### PR TITLE
refactor(app, api-client): remove dependence on key/value structure for labware key

### DIFF
--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import {
   parseInitialPipetteNamesByMount,
   parseAllRequiredModuleModels,
   parseAllRequiredModuleModelsById,
-  parseLoadedLabwareById,
+  parseInitialLoadedLabwareEntity,
   parseInitialLoadedLabwareBySlot,
   parseInitialLoadedLabwareByModuleId,
   parseInitialLoadedLabwareDefinitionsById,
@@ -227,7 +227,9 @@ describe('parseInitialLoadedLabwareById', () => {
           'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap',
       },
     ]
-    expect(parseLoadedLabwareById(mockRunTimeCommands)).toEqual(expected)
+    expect(parseInitialLoadedLabwareEntity(mockRunTimeCommands)).toEqual(
+      expected
+    )
   })
 })
 describe('parseInitialLoadedLabwareDefinitionsById', () => {

--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import {
   parseInitialPipetteNamesByMount,
   parseAllRequiredModuleModels,
   parseAllRequiredModuleModelsById,
-  parseInitialLoadedLabwareById,
+  parseLoadedLabwareEntity,
   parseInitialLoadedLabwareBySlot,
   parseInitialLoadedLabwareByModuleId,
   parseInitialLoadedLabwareDefinitionsById,
@@ -227,7 +227,7 @@ describe('parseInitialLoadedLabwareById', () => {
           'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap',
       },
     ]
-    expect(parseInitialLoadedLabwareById(mockRunTimeCommands)).toEqual(expected)
+    expect(parseLoadedLabwareEntity(mockRunTimeCommands)).toEqual(expected)
   })
 })
 describe('parseInitialLoadedLabwareDefinitionsById', () => {

--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import {
   parseInitialPipetteNamesByMount,
   parseAllRequiredModuleModels,
   parseAllRequiredModuleModelsById,
-  parseLoadedLabwareEntity,
+  parseLoadedLabwareById,
   parseInitialLoadedLabwareBySlot,
   parseInitialLoadedLabwareByModuleId,
   parseInitialLoadedLabwareDefinitionsById,
@@ -227,7 +227,7 @@ describe('parseInitialLoadedLabwareById', () => {
           'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap',
       },
     ]
-    expect(parseLoadedLabwareEntity(mockRunTimeCommands)).toEqual(expected)
+    expect(parseLoadedLabwareById(mockRunTimeCommands)).toEqual(expected)
   })
 })
 describe('parseInitialLoadedLabwareDefinitionsById', () => {

--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -205,22 +205,28 @@ describe('parseInitialLoadedLabwareByModuleId', () => {
 })
 describe('parseInitialLoadedLabwareById', () => {
   it('returns labware loaded by id', () => {
-    const expected = {
-      'labware-1': {
+    const expected = [
+      {
+        id: 'labware-1',
+        loadName: 'opentrons_96_tiprack_300ul',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
       },
-      'labware-2': {
+      {
+        id: 'labware-2',
+        loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
         definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
         displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
       },
-      'labware-3': {
+      {
+        id: 'labware-3',
+        loadName: 'opentrons_24_aluminumblock_generic_2ml_screwcap',
         definitionUri:
           'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1',
         displayName:
           'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap',
       },
-    }
+    ]
     expect(parseInitialLoadedLabwareById(mockRunTimeCommands)).toEqual(expected)
   })
 })

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -155,16 +155,16 @@ export function parseInitialLoadedLabwareByModuleId(
   )
 }
 
-export interface LoadedLabwareEntity {
+export interface LoadedLabwareById {
   id: string
   loadName: string
   definitionUri: string
   displayName?: string
 }
 
-export function parseLoadedLabwareEntity(
+export function parseLoadedLabwareById(
   commands: RunTimeCommand[]
-): LoadedLabwareEntity[] {
+): LoadedLabwareById[] {
   const loadLabwareCommands = commands.filter(
     (command): command is LoadLabwareRunTimeCommand =>
       command.commandType === 'loadLabware'
@@ -195,7 +195,7 @@ export interface LoadedLabwareDefinitionsById {
 export function parseInitialLoadedLabwareDefinitionsById(
   commands: RunTimeCommand[]
 ): LoadedLabwareDefinitionsById {
-  const labware = parseLoadedLabwareEntity(commands)
+  const labware = parseLoadedLabwareById(commands)
   const loadLabwareCommandsReversed = commands
     .filter(
       (command): command is LoadLabwareRunTimeCommand =>

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -155,21 +155,20 @@ export function parseInitialLoadedLabwareByModuleId(
   )
 }
 
-export interface LoadedLabwareById {
+export interface LoadedLabwareEntity {
   id: string
   loadName: string
   definitionUri: string
   displayName?: string
 }
 
-export function parseInitialLoadedLabwareById(
+export function parseLoadedLabwareEntity(
   commands: RunTimeCommand[]
-): LoadedLabwareById[] {
+): LoadedLabwareEntity[] {
   const loadLabwareCommands = commands.filter(
     (command): command is LoadLabwareRunTimeCommand =>
       command.commandType === 'loadLabware'
   )
-
   const filterOutTrashCommands = loadLabwareCommands.filter(
     command => command.result.definition.metadata.displayCategory !== 'trash'
   )
@@ -196,7 +195,7 @@ export interface LoadedLabwareDefinitionsById {
 export function parseInitialLoadedLabwareDefinitionsById(
   commands: RunTimeCommand[]
 ): LoadedLabwareDefinitionsById {
-  const labware = parseInitialLoadedLabwareById(commands)
+  const labware = parseLoadedLabwareEntity(commands)
   const loadLabwareCommandsReversed = commands
     .filter(
       (command): command is LoadLabwareRunTimeCommand =>

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -155,16 +155,16 @@ export function parseInitialLoadedLabwareByModuleId(
   )
 }
 
-export interface LoadedLabwareById {
+export interface LoadedLabwareEntity {
   id: string
   loadName: string
   definitionUri: string
   displayName?: string
 }
 
-export function parseLoadedLabwareById(
+export function parseInitialLoadedLabwareEntity(
   commands: RunTimeCommand[]
-): LoadedLabwareById[] {
+): LoadedLabwareEntity[] {
   const loadLabwareCommands = commands.filter(
     (command): command is LoadLabwareRunTimeCommand =>
       command.commandType === 'loadLabware'
@@ -195,7 +195,7 @@ export interface LoadedLabwareDefinitionsById {
 export function parseInitialLoadedLabwareDefinitionsById(
   commands: RunTimeCommand[]
 ): LoadedLabwareDefinitionsById {
-  const labware = parseLoadedLabwareById(commands)
+  const labware = parseInitialLoadedLabwareEntity(commands)
   const loadLabwareCommandsReversed = commands
     .filter(
       (command): command is LoadLabwareRunTimeCommand =>

--- a/app/src/molecules/PythonLabwareOffsetSnippet/__tests__/createSnippet.test.ts
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/__tests__/createSnippet.test.ts
@@ -4,46 +4,71 @@ import { ModuleModel, ProtocolAnalysisFile } from '@opentrons/shared-data'
 
 const protocolWithMagTempTC = ({
   ..._protocolWithMagTempTC,
-  labware: {
-    fixedTrash: {
+  labware: [
+    {
+      id: 'fixedTrash',
+      loadName: 'opentrons_1_trash_1100ml_fixed',
       displayName: 'Trash',
       definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
     },
-    '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1': {
+    {
+      id:
+        '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1',
       displayName: 'Opentrons 96 Tip Rack 1000 µL',
+      loadName: 'opentrons_96_tiprack_1000ul',
       definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
     },
-    '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1': {
+    {
+      id:
+        '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
       displayName: 'NEST 1 Well Reservoir 195 mL',
       definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
+      loadName: 'nest_1_reservoir_195ml',
     },
-    '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1': {
+    {
+      id:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
       displayName: 'Corning 24 Well Plate 3.4 mL Flat',
       definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+      loadName: 'corning_24_wellplate_3.4ml_flat',
     },
-    'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+    {
+      id:
+        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
       displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
       definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
     },
-    'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1': {
+    {
+      id:
+        'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
       displayName:
         'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
       definitionUri:
         'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+      loadName: 'opentrons_96_aluminumblock_generic_pcr_strip_200ul',
     },
-    'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+    {
+      id:
+        'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
       displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
       definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
     },
-    'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1': {
+    {
+      id:
+        'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1',
       displayName: 'Opentrons 96 Tip Rack 20 µL',
       definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+      loadName: 'opentrons_96_tiprack_20ul',
     },
-    '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b': {
+    {
+      id: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
       displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
       definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+      loadName: 'corning_24_wellplate_3.4ml_flat',
     },
-  },
+  ],
 } as unknown) as ProtocolAnalysisFile
 
 // module ids come from the fixture protocol, they are just here for readability

--- a/app/src/molecules/PythonLabwareOffsetSnippet/createSnippet.ts
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/createSnippet.ts
@@ -22,10 +22,13 @@ export function createSnippet(
       let addendum = null
       if (command.commandType === 'loadLabware') {
         labwareCount = labwareCount + 1
-        const loadedLabware = protocol.labware[command.result.labwareId]
+        //  @ts-expect-error
+        const loadedLabware = protocol.labware.find(
+          //  @ts-expect-error
+          item => item.id === command.result.labwareId
+        )
         if (loadedLabware == null) return acc
         const { loadName } = protocol.labwareDefinitions[
-          //  @ts-expect-error
           loadedLabware.definitionUri
         ].parameters
         if ('slotName' in command.params.location) {

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -47,6 +47,7 @@ export function StepText(props: Props): JSX.Element | null {
     )
     return null
   }
+
   // params will not exist on command summaries
   switch (displayCommand.commandType) {
     case 'delay': {
@@ -66,6 +67,11 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dropTip': {
       const { wellName, labwareId } = displayCommand.params
+      //  @ts-expect-error
+      const matchingLabware = protocolData.labware.find(
+        //  @ts-expect-error
+        item => item.id === labwareId
+      )
       const labwareLocation = getLabwareLocation(
         labwareId,
         protocolData.commands
@@ -79,10 +85,7 @@ export function StepText(props: Props): JSX.Element | null {
           labwareId === TRASH_ID
             ? 'Opentrons Fixed Trash'
             : getLabwareDisplayName(
-                protocolData.labwareDefinitions[
-                  //  @ts-expect-error
-                  protocolData.labware[labwareId].definitionUri
-                ]
+                protocolData.labwareDefinitions[matchingLabware.definitionUri]
               ),
         labware_location: labwareLocation.slotName,
       })

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareDefinitionUri.test.ts
@@ -16,12 +16,15 @@ describe('getLabwareDefinitionUri', () => {
   })
   it('should return the definition uri of a given labware', () => {
     const MOCK_LABWARE_ID = 'some_labware'
-    const mockLabware = {
-      [MOCK_LABWARE_ID]: {
+    const mockLabware = [
+      {
+        id: MOCK_LABWARE_ID,
+        loadName: 'some loadname',
         definitionUri: MOCK_DEFINITION_URI,
         displayName: 'some dope labware',
       },
-    }
+    ]
+
     const mockLabwareDefinitions = {
       [MOCK_DEFINITION_URI]: MOCK_DEF,
     }

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
@@ -4,8 +4,124 @@ import _standardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_stan
 import { getProtocolModulesInfo } from '../getProtocolModulesInfo'
 import { getModuleDef2, ProtocolAnalysisFile } from '@opentrons/shared-data'
 
-const protocolWithMagTempTC = (_protocolWithMagTempTC as unknown) as ProtocolAnalysisFile
-const protocolWithMultipleTemps = (_protocolWithMultipleTemps as unknown) as ProtocolAnalysisFile
+const protocolWithMagTempTC = ({
+  ..._protocolWithMagTempTC,
+  labware: [
+    {
+      id: 'fixedTrash',
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    {
+      id:
+        '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1',
+      displayName: 'Opentrons 96 Tip Rack 1000 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+    },
+    {
+      id:
+        '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
+      displayName: 'NEST 1 Well Reservoir 195 mL',
+      definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
+    },
+    {
+      id:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    },
+    {
+      id:
+        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    },
+    {
+      id:
+        'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+      displayName:
+        'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
+      definitionUri:
+        'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+    },
+    {
+      id:
+        'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    },
+    {
+      id:
+        'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1',
+      displayName: 'Opentrons 96 Tip Rack 20 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+    },
+    {
+      id: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    },
+  ],
+} as unknown) as ProtocolAnalysisFile
+const protocolWithMultipleTemps = ({
+  ..._protocolWithMultipleTemps,
+  labware: [
+    {
+      id: 'fixedTrash',
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    {
+      id:
+        '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1',
+      displayName: 'Opentrons 96 Tip Rack 1000 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+    },
+    {
+      id:
+        '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
+      displayName: 'NEST 1 Well Reservoir 195 mL',
+      definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
+    },
+    {
+      id:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    },
+    {
+      id:
+        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    },
+    {
+      id:
+        'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+      displayName:
+        'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
+      definitionUri:
+        'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+    },
+    {
+      id:
+        'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    },
+    {
+      id:
+        'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1',
+      displayName: 'Opentrons 96 Tip Rack 20 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+    },
+    {
+      id: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    },
+  ],
+} as unknown) as ProtocolAnalysisFile
 const standardDeckDef = _standardDeckDef as any
 
 describe('getProtocolModulesInfo', () => {
@@ -24,11 +140,11 @@ describe('getProtocolModulesInfo', () => {
     const TC_ID: keyof typeof _protocolWithMagTempTC.modules =
       '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType'
 
-    const MAG_LW_ID: keyof typeof _protocolWithMagTempTC.labware =
+    const MAG_LW_ID =
       'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
-    const TEMP_LW_ID: keyof typeof _protocolWithMagTempTC.labware =
+    const TEMP_LW_ID =
       'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1'
-    const TC_LW_ID: keyof typeof _protocolWithMagTempTC.labware =
+    const TC_LW_ID =
       'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
 
     const expectedInfo = [
@@ -40,15 +156,10 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('magneticModuleV2'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMagTempTC.labware[MAG_LW_ID]
-              //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+            'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
           ],
         nestedLabwareId: MAG_LW_ID,
-        nestedLabwareDisplayName:
-          _protocolWithMultipleTemps.labware[MAG_LW_ID].displayName,
+        nestedLabwareDisplayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
         protocolLoadOrder: 0,
         slotName: '1',
       },
@@ -60,15 +171,11 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('temperatureModuleV2'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMagTempTC.labware[TEMP_LW_ID]
-               //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+            'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1'
           ],
         nestedLabwareId: TEMP_LW_ID,
         nestedLabwareDisplayName:
-          _protocolWithMultipleTemps.labware[TEMP_LW_ID].displayName,
+          'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
         protocolLoadOrder: 1,
         slotName: '3',
       },
@@ -80,15 +187,11 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('thermocyclerModuleV1'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMagTempTC.labware[TC_LW_ID]
-              //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+            'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
           ],
         nestedLabwareId: TC_LW_ID,
         nestedLabwareDisplayName:
-          _protocolWithMultipleTemps.labware[TC_LW_ID].displayName,
+          'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
         protocolLoadOrder: 2,
         slotName: '7',
       },
@@ -113,11 +216,11 @@ describe('getProtocolModulesInfo', () => {
     const TEMP_MOD_TWO_ID: keyof typeof _protocolWithMultipleTemps.modules =
       '3e039550-3412-11eb-ad93-ed232a2337cf:temperatureModuleType2'
 
-    const MAG_LW_ID: keyof typeof _protocolWithMultipleTemps.labware =
+    const MAG_LW_ID =
       'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
-    const TEMP_ONE_LW_ID: keyof typeof _protocolWithMultipleTemps.labware =
+    const TEMP_ONE_LW_ID =
       'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1'
-    const TEMP_TWO_LW_ID: keyof typeof _protocolWithMultipleTemps.labware =
+    const TEMP_TWO_LW_ID =
       'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
 
     const expectedInfo = [
@@ -129,15 +232,10 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('magneticModuleV2'),
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMultipleTemps.labware[MAG_LW_ID]
-              //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
+            'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
           ],
         nestedLabwareId: MAG_LW_ID,
-        nestedLabwareDisplayName:
-          _protocolWithMultipleTemps.labware[MAG_LW_ID].displayName,
+        nestedLabwareDisplayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
         protocolLoadOrder: 0,
         slotName: '1',
       },
@@ -149,15 +247,11 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('temperatureModuleV2'),
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMultipleTemps.labware[TEMP_ONE_LW_ID]
-              //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
+            'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1'
           ],
         nestedLabwareId: TEMP_ONE_LW_ID,
         nestedLabwareDisplayName:
-          _protocolWithMultipleTemps.labware[TEMP_ONE_LW_ID].displayName,
+          'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
         protocolLoadOrder: 1,
         slotName: '3',
       },
@@ -169,15 +263,11 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('temperatureModuleV2'),
         nestedLabwareDef:
           _protocolWithMultipleTemps.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMultipleTemps.labware[TEMP_TWO_LW_ID]
-              //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMultipleTemps.labwareDefinitions
+            'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
           ],
         nestedLabwareId: TEMP_TWO_LW_ID,
         nestedLabwareDisplayName:
-          _protocolWithMultipleTemps.labware[TEMP_TWO_LW_ID].displayName,
+          'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
         protocolLoadOrder: 2,
         slotName: '7',
       },
@@ -192,9 +282,8 @@ describe('getProtocolModulesInfo', () => {
     // mag mod is in deck slot 1 which has [x,y] coordinate [0,0,0]
     const SLOT_1_COORDS = [0, 0, 0]
     // these ids come from the protocol fixture
-    const MAG_MOD_ID: keyof typeof _protocolWithMagTempTC.modules =
-      '3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType'
-    const MAG_LW_ID: keyof typeof _protocolWithMagTempTC.labware =
+    const MAG_MOD_ID = '3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType'
+    const MAG_LW_ID =
       'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
     const stubDisplayName = 'custom display name'
 
@@ -207,11 +296,7 @@ describe('getProtocolModulesInfo', () => {
         moduleDef: getModuleDef2('magneticModuleV2'),
         nestedLabwareDef:
           _protocolWithMagTempTC.labwareDefinitions[
-            // prettier-ignore
-            /* eslint-disable */
-            _protocolWithMagTempTC.labware[MAG_LW_ID]
-              //  @ts-expect-error
-              .definitionUri as keyof typeof _protocolWithMagTempTC.labwareDefinitions
+            'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
           ],
         nestedLabwareId: MAG_LW_ID,
         nestedLabwareDisplayName: stubDisplayName,
@@ -225,12 +310,15 @@ describe('getProtocolModulesInfo', () => {
         {
           ...protocolWithMagTempTC,
           modules: { [MAG_MOD_ID]: protocolWithMagTempTC.modules[MAG_MOD_ID] },
-          labware: {
-            [MAG_LW_ID]: {
-              ...protocolWithMagTempTC.labware[MAG_LW_ID],
+          labware: [
+            //  @ts-expect-error
+            {
+              definitionUri:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              id: MAG_LW_ID,
               displayName: stubDisplayName,
             },
-          },
+          ],
         },
         standardDeckDef
       )

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getProtocolModulesInfo.test.ts
@@ -311,8 +311,8 @@ describe('getProtocolModulesInfo', () => {
           ...protocolWithMagTempTC,
           modules: { [MAG_MOD_ID]: protocolWithMagTempTC.modules[MAG_MOD_ID] },
           labware: [
-            //  @ts-expect-error
             {
+              //  @ts-expect-error
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               id: MAG_LW_ID,

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareDefinitionUri.ts
@@ -8,7 +8,8 @@ export function getLabwareDefinitionUri(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): string {
   //  @ts-expect-error
-  const labwareDefinitionUri = labware[labwareId].definitionUri
+  const labwareDefinitionUri = labware.find(item => item.id === labwareId)
+    .definitionUri
   if (labwareDefinitionUri == null) {
     throw new Error(
       'expected to be able to find labware definition uri for labware, but could not'

--- a/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
@@ -47,14 +47,21 @@ export const getProtocolModulesInfo = (
                 'moduleId' in command.params.location &&
                 command.params.location.moduleId === moduleId
             )?.result?.labwareId ?? null
-        const nestedLabware =
+        //  @ts-expect-error
+        const nestedLabware = protocolData.labware.filter(
           //  @ts-expect-error
-          nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null
+          item => nestedLabwareId != null && item.id === nestedLabwareId
+        )
         const nestedLabwareDef =
           nestedLabware != null
-            ? protocolData.labwareDefinitions[nestedLabware.definitionUri]
+            ? protocolData.labwareDefinitions[
+                //  @ts-expect-error
+                nestedLabware.map(item => item.definitionUri)
+              ]
             : null
-        const nestedLabwareDisplayName = nestedLabware?.displayName ?? null
+        const nestedLabwareDisplayName =
+          //  @ts-expect-error
+          nestedLabware.map(item => item.displayName).toString() ?? null
         const moduleInitialLoadInfo = getModuleInitialLoadInfo(
           moduleId,
           protocolData.commands

--- a/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
@@ -47,9 +47,8 @@ export const getProtocolModulesInfo = (
                 'moduleId' in command.params.location &&
                 command.params.location.moduleId === moduleId
             )?.result?.labwareId ?? null
-
         const nestedLabware =
-        //  @ts-expect-error
+          //  @ts-expect-error
           nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null
         const nestedLabwareDef =
           nestedLabware != null

--- a/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo.ts
@@ -49,11 +49,11 @@ export const getProtocolModulesInfo = (
             )?.result?.labwareId ?? null
 
         const nestedLabware =
+        //  @ts-expect-error
           nestedLabwareId != null ? protocolData.labware[nestedLabwareId] : null
         const nestedLabwareDef =
           nestedLabware != null
-            ? //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-              protocolData.labwareDefinitions[nestedLabware.definitionUri]
+            ? protocolData.labwareDefinitions[nestedLabware.definitionUri]
             : null
         const nestedLabwareDisplayName = nestedLabware?.displayName ?? null
         const moduleInitialLoadInfo = getModuleInitialLoadInfo(

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -10,10 +10,10 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 
 export const LABWARE_BY_ID: LoadedLabwareById = {
-  'labware-0': {
-    definitionUri: 'fakeLabwareDefinitionUri',
-    displayName: 'a fake labware',
-  },
+  id: 'labware-0',
+  loadName: 'fakeLoadName',
+  definitionUri: 'fakeLabwareDefinitionUri',
+  displayName: 'a fake labware',
 }
 export const LABWARE_DEFINITIONS: LoadedLabwareDefinitionsById = {
   fakeLabwareDefinitionId: {} as LabwareDefinition2,
@@ -29,7 +29,7 @@ export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
 export const STORED_PROTOCOL_ANALYSIS = {
   ...storedProtocolData.mostRecentAnalysis,
   modules: MODULE_MODELS_BY_ID,
-  labware: LABWARE_BY_ID,
+  labware: [LABWARE_BY_ID],
   labwareDefinitions: LABWARE_DEFINITIONS,
   pipettes: [PIPETTE_NAME_BY_ID],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -1,7 +1,7 @@
 import { storedProtocolData } from '../../../../redux/protocol-storage/__fixtures__'
 
 import type {
-  LoadedLabwareEntity,
+  LoadedLabwareById,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
@@ -9,7 +9,7 @@ import type {
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 
-export const LABWARE: LoadedLabwareEntity = {
+export const LABWARE_BY_ID: LoadedLabwareById = {
   id: 'labware-0',
   loadName: 'fakeLoadName',
   definitionUri: 'fakeLabwareDefinitionUri',
@@ -29,7 +29,7 @@ export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
 export const STORED_PROTOCOL_ANALYSIS = {
   ...storedProtocolData.mostRecentAnalysis,
   modules: MODULE_MODELS_BY_ID,
-  labware: [LABWARE],
+  labware: [LABWARE_BY_ID],
   labwareDefinitions: LABWARE_DEFINITIONS,
   pipettes: [PIPETTE_NAME_BY_ID],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -1,7 +1,7 @@
 import { storedProtocolData } from '../../../../redux/protocol-storage/__fixtures__'
 
 import type {
-  LoadedLabwareById,
+  LoadedLabwareEntity,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
@@ -9,7 +9,7 @@ import type {
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 
-export const LABWARE_BY_ID: LoadedLabwareById = {
+export const LABWARE: LoadedLabwareEntity = {
   id: 'labware-0',
   loadName: 'fakeLoadName',
   definitionUri: 'fakeLabwareDefinitionUri',
@@ -29,7 +29,7 @@ export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
 export const STORED_PROTOCOL_ANALYSIS = {
   ...storedProtocolData.mostRecentAnalysis,
   modules: MODULE_MODELS_BY_ID,
-  labware: [LABWARE_BY_ID],
+  labware: [LABWARE],
   labwareDefinitions: LABWARE_DEFINITIONS,
   pipettes: [PIPETTE_NAME_BY_ID],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -1,7 +1,7 @@
 import { storedProtocolData } from '../../../../redux/protocol-storage/__fixtures__'
 
 import type {
-  LoadedLabwareById,
+  LoadedLabwareEntity,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
@@ -9,7 +9,7 @@ import type {
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 
-export const LABWARE_BY_ID: LoadedLabwareById = {
+export const LABWARE_ENTITY: LoadedLabwareEntity = {
   id: 'labware-0',
   loadName: 'fakeLoadName',
   definitionUri: 'fakeLabwareDefinitionUri',
@@ -29,7 +29,7 @@ export const PIPETTE_NAME_BY_ID: PipetteNamesById = {
 export const STORED_PROTOCOL_ANALYSIS = {
   ...storedProtocolData.mostRecentAnalysis,
   modules: MODULE_MODELS_BY_ID,
-  labware: [LABWARE_BY_ID],
+  labware: [LABWARE_ENTITY],
   labwareDefinitions: LABWARE_DEFINITIONS,
   pipettes: [PIPETTE_NAME_BY_ID],
 } as StoredProtocolAnalysis

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -89,24 +89,32 @@ const TIP_LENGTH_CALIBRATIONS = [
 const tiprack10ul = _tiprack10ul as LabwareDefinition2
 const modifiedSimpleV6Protocol = ({
   ..._uncastedModifiedSimpleV6Protocol,
-  labware: {
-    trashId: {
+  labware: [
+    {
+      id: ' trashId',
       displayName: 'Trash',
       definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+      loadName: 'opentrons_1_trash_1100ml_fixed',
     },
-    tipRackId: {
+    {
+      id: 'tipRackId',
       displayName: 'Opentrons 96 Tip Rack 10 µL',
       definitionUri: 'opentrons/opentrons_96_tiprack_10ul/1',
+      loadName: 'opentrons_96_tiprack_10ul',
     },
-    sourcePlateId: {
+    {
+      id: 'sourcePlateId',
       displayName: 'Source Plate',
       definitionUri: 'example/plate/1',
+      loadName: 'plate',
     },
-    destPlateId: {
+    {
+      id: 'destPlateId',
       displayName: 'Sample Collection Plate',
       definitionUri: 'example/plate/1',
+      loadName: 'plate',
     },
-  },
+  ],
   pipettes: [
     {
       id: 'pipetteId',

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -7,7 +7,7 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import {
   parseAllRequiredModuleModelsById,
-  parseLoadedLabwareById,
+  parseInitialLoadedLabwareEntity,
   parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
@@ -17,7 +17,7 @@ import { storedProtocolData } from '../../../../redux/protocol-storage/__fixture
 import { getStoredProtocol } from '../../../../redux/protocol-storage'
 import { useStoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 import {
-  LABWARE_BY_ID,
+  LABWARE_ENTITY,
   LABWARE_DEFINITIONS,
   MODULE_MODELS_BY_ID,
   PIPETTE_NAME_BY_ID,
@@ -40,8 +40,8 @@ const mockGetStoredProtocol = getStoredProtocol as jest.MockedFunction<
 const mockParseAllRequiredModuleModelsById = parseAllRequiredModuleModelsById as jest.MockedFunction<
   typeof parseAllRequiredModuleModelsById
 >
-const mockParseLoadedLabwareById = parseLoadedLabwareById as jest.MockedFunction<
-  typeof parseLoadedLabwareById
+const mockParseInitialLoadedLabwareEntity = parseInitialLoadedLabwareEntity as jest.MockedFunction<
+  typeof parseInitialLoadedLabwareEntity
 >
 const mockParseInitialLoadedLabwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById as jest.MockedFunction<
   typeof parseInitialLoadedLabwareDefinitionsById
@@ -88,7 +88,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseAllRequiredModuleModelsById).mockReturnValue(
       MODULE_MODELS_BY_ID
     )
-    when(mockParseLoadedLabwareById).mockReturnValue([LABWARE_BY_ID])
+    when(mockParseInitialLoadedLabwareEntity).mockReturnValue([LABWARE_ENTITY])
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -88,7 +88,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseAllRequiredModuleModelsById).mockReturnValue(
       MODULE_MODELS_BY_ID
     )
-    when(mockParseInitialLoadedLabwareById).mockReturnValue(LABWARE_BY_ID)
+    when(mockParseInitialLoadedLabwareById).mockReturnValue([LABWARE_BY_ID])
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -7,7 +7,7 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import {
   parseAllRequiredModuleModelsById,
-  parseLoadedLabwareEntity,
+  parseLoadedLabwareById,
   parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
@@ -17,7 +17,7 @@ import { storedProtocolData } from '../../../../redux/protocol-storage/__fixture
 import { getStoredProtocol } from '../../../../redux/protocol-storage'
 import { useStoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 import {
-  LABWARE,
+  LABWARE_BY_ID,
   LABWARE_DEFINITIONS,
   MODULE_MODELS_BY_ID,
   PIPETTE_NAME_BY_ID,
@@ -40,8 +40,8 @@ const mockGetStoredProtocol = getStoredProtocol as jest.MockedFunction<
 const mockParseAllRequiredModuleModelsById = parseAllRequiredModuleModelsById as jest.MockedFunction<
   typeof parseAllRequiredModuleModelsById
 >
-const mockParseLoadedLabwareEntity = parseLoadedLabwareEntity as jest.MockedFunction<
-  typeof parseLoadedLabwareEntity
+const mockParseLoadedLabwareById = parseLoadedLabwareById as jest.MockedFunction<
+  typeof parseLoadedLabwareById
 >
 const mockParseInitialLoadedLabwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById as jest.MockedFunction<
   typeof parseInitialLoadedLabwareDefinitionsById
@@ -88,7 +88,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseAllRequiredModuleModelsById).mockReturnValue(
       MODULE_MODELS_BY_ID
     )
-    when(mockParseLoadedLabwareEntity).mockReturnValue([LABWARE])
+    when(mockParseLoadedLabwareById).mockReturnValue([LABWARE_BY_ID])
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -7,7 +7,7 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import {
   parseAllRequiredModuleModelsById,
-  parseInitialLoadedLabwareById,
+  parseLoadedLabwareEntity,
   parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
@@ -17,7 +17,7 @@ import { storedProtocolData } from '../../../../redux/protocol-storage/__fixture
 import { getStoredProtocol } from '../../../../redux/protocol-storage'
 import { useStoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 import {
-  LABWARE_BY_ID,
+  LABWARE,
   LABWARE_DEFINITIONS,
   MODULE_MODELS_BY_ID,
   PIPETTE_NAME_BY_ID,
@@ -40,8 +40,8 @@ const mockGetStoredProtocol = getStoredProtocol as jest.MockedFunction<
 const mockParseAllRequiredModuleModelsById = parseAllRequiredModuleModelsById as jest.MockedFunction<
   typeof parseAllRequiredModuleModelsById
 >
-const mockParseInitialLoadedLabwareById = parseInitialLoadedLabwareById as jest.MockedFunction<
-  typeof parseInitialLoadedLabwareById
+const mockParseLoadedLabwareEntity = parseLoadedLabwareEntity as jest.MockedFunction<
+  typeof parseLoadedLabwareEntity
 >
 const mockParseInitialLoadedLabwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById as jest.MockedFunction<
   typeof parseInitialLoadedLabwareDefinitionsById
@@ -88,7 +88,7 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockParseAllRequiredModuleModelsById).mockReturnValue(
       MODULE_MODELS_BY_ID
     )
-    when(mockParseInitialLoadedLabwareById).mockReturnValue([LABWARE_BY_ID])
+    when(mockParseLoadedLabwareEntity).mockReturnValue([LABWARE])
     when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
       LABWARE_DEFINITIONS
     )

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -39,7 +39,6 @@ export function useProtocolDetailsForRun(
   )
 
   const mostRecentAnalysis = last(protocolAnalyses?.data ?? []) ?? null
-
   React.useEffect(() => {
     if (mostRecentAnalysis?.status === 'completed') {
       setIsPollingProtocolAnalyses(false)

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -39,6 +39,7 @@ export function useProtocolDetailsForRun(
   )
 
   const mostRecentAnalysis = last(protocolAnalyses?.data ?? []) ?? null
+
   React.useEffect(() => {
     if (mostRecentAnalysis?.status === 'completed') {
       setIsPollingProtocolAnalyses(false)

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -81,7 +81,7 @@ export function useRunPipetteInfoByMount(
             //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
             const tipRack = labware.find(
               //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-              index => index.id === command.params?.labwareId
+              item => item.id === command.params?.labwareId
             )
             const tipRackDefinition = labwareDefinitions[tipRack.definitionUri]
 

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -78,8 +78,11 @@ export function useRunPipetteInfoByMount(
           LabwareDefinition2[]
         >((acc, command) => {
           if (pipetteId === command.params?.pipetteId) {
-            const tipRack = labware[command.params?.labwareId]
             //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+            const tipRack = labware.find(
+              //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
+              index => index.id === command.params?.labwareId
+            )
             const tipRackDefinition = labwareDefinitions[tipRack.definitionUri]
 
             if (tipRackDefinition != null && !acc.includes(tipRackDefinition)) {

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux'
 import {
   parseAllRequiredModuleModelsById,
-  parseInitialLoadedLabwareById,
+  parseLoadedLabwareEntity,
   parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
@@ -11,7 +11,7 @@ import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { getStoredProtocol } from '../../../redux/protocol-storage'
 
 import type {
-  LoadedLabwareById,
+  LoadedLabwareEntity,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
@@ -22,7 +22,7 @@ import type { State } from '../../../redux/types'
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
   pipettes: PipetteNamesById[]
   modules: ModuleModelsById
-  labware: LoadedLabwareById[]
+  labware: LoadedLabwareEntity[]
   labwareDefinitions: LoadedLabwareDefinitionsById
 }
 
@@ -35,7 +35,7 @@ export const parseProtocolAnalysisOutput = (
   const moduleModelsById = parseAllRequiredModuleModelsById(
     storedProtocolAnalysis?.commands ?? []
   )
-  const labwareById = parseInitialLoadedLabwareById(
+  const labwareById = parseLoadedLabwareEntity(
     storedProtocolAnalysis?.commands ?? []
   )
   const labwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById(

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux'
 import {
   parseAllRequiredModuleModelsById,
-  parseLoadedLabwareById,
+  parseInitialLoadedLabwareEntity,
   parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
@@ -11,7 +11,7 @@ import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { getStoredProtocol } from '../../../redux/protocol-storage'
 
 import type {
-  LoadedLabwareById,
+  LoadedLabwareEntity,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
@@ -22,7 +22,7 @@ import type { State } from '../../../redux/types'
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
   pipettes: PipetteNamesById[]
   modules: ModuleModelsById
-  labware: LoadedLabwareById[]
+  labware: LoadedLabwareEntity[]
   labwareDefinitions: LoadedLabwareDefinitionsById
 }
 
@@ -35,7 +35,7 @@ export const parseProtocolAnalysisOutput = (
   const moduleModelsById = parseAllRequiredModuleModelsById(
     storedProtocolAnalysis?.commands ?? []
   )
-  const labwareById = parseLoadedLabwareById(
+  const labwareById = parseInitialLoadedLabwareEntity(
     storedProtocolAnalysis?.commands ?? []
   )
   const labwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById(

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux'
 import {
   parseAllRequiredModuleModelsById,
-  parseLoadedLabwareEntity,
+  parseLoadedLabwareById,
   parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
@@ -11,7 +11,7 @@ import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { getStoredProtocol } from '../../../redux/protocol-storage'
 
 import type {
-  LoadedLabwareEntity,
+  LoadedLabwareById,
   LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
@@ -22,7 +22,7 @@ import type { State } from '../../../redux/types'
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
   pipettes: PipetteNamesById[]
   modules: ModuleModelsById
-  labware: LoadedLabwareEntity[]
+  labware: LoadedLabwareById[]
   labwareDefinitions: LoadedLabwareDefinitionsById
 }
 
@@ -35,7 +35,7 @@ export const parseProtocolAnalysisOutput = (
   const moduleModelsById = parseAllRequiredModuleModelsById(
     storedProtocolAnalysis?.commands ?? []
   )
-  const labwareById = parseLoadedLabwareEntity(
+  const labwareById = parseLoadedLabwareById(
     storedProtocolAnalysis?.commands ?? []
   )
   const labwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById(

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -22,7 +22,7 @@ import type { State } from '../../../redux/types'
 export interface StoredProtocolAnalysis extends ProtocolAnalysisOutput {
   pipettes: PipetteNamesById[]
   modules: ModuleModelsById
-  labware: LoadedLabwareById
+  labware: LoadedLabwareById[]
   labwareDefinitions: LoadedLabwareDefinitionsById
 }
 
@@ -41,7 +41,6 @@ export const parseProtocolAnalysisOutput = (
   const labwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById(
     storedProtocolAnalysis?.commands ?? []
   )
-
   return storedProtocolAnalysis != null
     ? {
         ...storedProtocolAnalysis,
@@ -68,6 +67,7 @@ export function useStoredProtocolAnalysis(
   const storedProtocolAnalysis =
     useSelector((state: State) => getStoredProtocol(state, protocolKey))
       ?.mostRecentAnalysis ?? null
+
   // @ts-expect-error
   return storedProtocolAnalysis != null && 'modules' in storedProtocolAnalysis
     ? schemaV6Adapter(storedProtocolAnalysis)

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedLabwarePositionCheckStepDetail.tsx
@@ -90,7 +90,8 @@ export const DeprecatedLabwarePositionCheckStepDetail = (
 
   if (protocolData == null) return null
   //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-  const labwareDefUri = protocolData.labware[labwareId].definitionUri
+  const labwareDefUri = protocolData.labware.find(item => item.id === labwareId)
+    .definitionUri
   const labwareDef = protocolData.labwareDefinitions[labwareDefUri]
   // filter out the TC open lid command as it does not have an associated pipette id
   const stepMovementCommands = selectedStep.commands.filter(

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedStepDetailText.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedStepDetailText.tsx
@@ -36,7 +36,8 @@ export const DeprecatedStepDetailText = (
   ] = React.useState<boolean>(false)
   if (protocolData == null) return null
   //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-  const labwareDefId = protocolData.labware[labwareId].definitionUri
+  const labwareDefId = protocolData.labware.find(item => item.id === labwareId)
+    .definitionUri
   const labwareDef = protocolData.labwareDefinitions[labwareDefId]
   const { displayName } = labwareDef.metadata
   const { isTiprack } = labwareDef.parameters

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedSummaryScreen.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedSummaryScreen.tsx
@@ -40,6 +40,7 @@ export const DeprecatedSummaryScreen = (props: {
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
   const { protocolData } = useProtocolDetailsForRun(runId)
+  console.log(protocolData)
   const trackEvent = useTrackEvent()
   useLabwareOffsets(
     savePositionCommandData,
@@ -58,7 +59,6 @@ export const DeprecatedSummaryScreen = (props: {
   //  @ts-expect-error
   const labwareIds = protocolData.labware.map(item => item.id)
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
-
   const applyLabwareOffsets = (): void => {
     trackEvent({ name: 'applyLabwareOffsetData', properties: {} })
     if (labwareOffsets.length > 0) {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedSummaryScreen.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedSummaryScreen.tsx
@@ -40,7 +40,6 @@ export const DeprecatedSummaryScreen = (props: {
   const { t } = useTranslation('labware_position_check')
   const introInfo = useIntroInfo()
   const { protocolData } = useProtocolDetailsForRun(runId)
-  console.log(protocolData)
   const trackEvent = useTrackEvent()
   useLabwareOffsets(
     savePositionCommandData,

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedSummaryScreen.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/DeprecatedSummaryScreen.tsx
@@ -55,7 +55,8 @@ export const DeprecatedSummaryScreen = (props: {
   const { setIsShowingLPCSuccessToast } = useLPCSuccessToast()
 
   if (runId == null || introInfo == null || protocolData == null) return null
-  const labwareIds = Object.keys(protocolData.labware)
+  //  @ts-expect-error
+  const labwareIds = protocolData.labware.map(item => item.id)
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
 
   const applyLabwareOffsets = (): void => {

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedLabwarePositionCheckStepDetail.test.tsx
@@ -165,13 +165,15 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
         protocolData: {
-          labware: {
-            [mockLabwarePositionCheckStepTipRack.labwareId]: {
+          labware: [
+            {
+              id: mockLabwarePositionCheckStepTipRack.labwareId,
               slot: '1',
               displayName: 'someDislpayName',
               definitionUri: LABWARE_DEF_URI,
+              loadName: 'someLoadName',
             },
-          },
+          ],
           labwareDefinitions: {
             [LABWARE_DEF_URI]: LABWARE_DEF,
           },
@@ -246,13 +248,15 @@ describe('DeprecatedLabwarePositionCheckStepDetail', () => {
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
         protocolData: {
-          labware: {
-            [mockLabwarePositionCheckStepTipRack.labwareId]: {
+          labware: [
+            {
+              id: mockLabwarePositionCheckStepTipRack.labwareId,
               slot: '1',
               displayName: 'someDislpayName',
-              definitionUri: TIPRACK_DEF_URI,
+              definitionUri: LABWARE_DEF_URI,
+              loadName: 'someLoadName',
             },
-          },
+          ],
           labwareDefinitions: {
             [TIPRACK_DEF_URI]: LABWARE_DEF,
           },

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedStepDetailText.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedStepDetailText.test.tsx
@@ -88,32 +88,43 @@ describe('DeprecatedStepDetailText', () => {
       .mockReturnValue({
         protocolData: {
           ...withSinglechannelProtocol,
-          labware: {
-            trashId: {
+          labware: [
+            {
+              id: 'trashId',
               slot: '12',
               displayName: 'Trash',
               definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+              loadName: 'opentrons_1_trash_1100ml_fixed',
             },
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '2',
               displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
               definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+              loadName: 'opentrons_96_filtertiprack_200ul',
             },
-            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+            {
+              id:
+                '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
               displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
             },
-            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+            {
+              id:
+                '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
               slot:
                 '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
               displayName:
                 'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
               definitionUri:
                 'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+              loadName: 'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
             },
-          },
+          ],
         },
       } as any)
   })
@@ -175,32 +186,43 @@ describe('DeprecatedStepDetailText', () => {
       .mockReturnValue({
         protocolData: {
           ...withMultiChannelProtocol,
-          labware: {
-            trashId: {
+          labware: [
+            {
+              id: 'trashId',
               slot: '12',
               displayName: 'Trash',
               definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+              loadName: 'opentrons_1_trash_1100ml_fixed',
             },
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '2',
               displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
               definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+              loadName: 'opentrons_96_filtertiprack_200ul',
             },
-            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+            {
+              id:
+                '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
               displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
             },
-            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+            {
+              id:
+                '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
               slot:
                 '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
               displayName:
                 'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
               definitionUri:
                 'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+              loadName: 'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
             },
-          },
+          ],
         },
       } as any)
 
@@ -224,32 +246,43 @@ describe('DeprecatedStepDetailText', () => {
       .mockReturnValue({
         protocolData: {
           ...withMultiChannelProtocol,
-          labware: {
-            trashId: {
+          labware: [
+            {
+              id: 'trashId',
               slot: '12',
               displayName: 'Trash',
               definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+              loadName: 'opentrons_1_trash_1100ml_fixed',
             },
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '2',
               displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
               definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+              loadName: 'opentrons_96_filtertiprack_200ul',
             },
-            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+            {
+              id:
+                '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
               displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
             },
-            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+            {
+              id:
+                '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
               slot:
                 '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
               displayName:
                 'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
               definitionUri:
                 'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+              loadName: 'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
             },
-          },
+          ],
         },
       } as any)
 

--- a/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedSummaryScreen.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/DeprecatedComponents/__tests__/DeprecatedSummaryScreen.test.tsx
@@ -6,6 +6,7 @@ import { useTrackEvent } from '../../../../redux/analytics'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { useProtocolDetailsForRun } from '../../../Devices/hooks'
+import { useLPCSuccessToast } from '../../../ProtocolSetup/hooks'
 import { useCurrentRunId } from '../../../ProtocolUpload/hooks'
 import { DeprecatedSectionList } from '../DeprecatedSectionList'
 import { DeprecatedDeckMap } from '../DeprecatedDeckMap'
@@ -13,7 +14,6 @@ import { DeprecatedSummaryScreen } from '../DeprecatedSummaryScreen'
 import { DeprecatedLabwareOffsetsSummary } from '../DeprecatedLabwareOffsetsSummary'
 import { useIntroInfo, useLabwareOffsets } from '../../hooks'
 import { Section } from '../types'
-import { useLPCSuccessToast } from '../../../ProtocolSetup/hooks'
 
 jest.mock('../../../../redux/analytics')
 jest.mock('../../../ProtocolUpload/hooks')
@@ -98,13 +98,16 @@ describe('DeprecatedSummaryScreen', () => {
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
         protocolData: {
-          labware: {
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+          labware: [
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '1',
               displayName: 'someDisplayName',
               definitionId: LABWARE_DEF_ID,
+              loadName: 'someLoadName',
             },
-          },
+          ],
           labwareDefinitions: {
             [LABWARE_DEF_ID]: LABWARE_DEF,
           },

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckStepDetail.tsx
@@ -85,7 +85,8 @@ export const LabwarePositionCheckStepDetail = (
 
   if (protocolData == null) return null
   //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-  const labwareDefUri = protocolData.labware[labwareId].definitionUri
+  const labwareDefUri = protocolData.labware.find(item => item.id === labwareId)
+    .definitionUri
   const labwareDef = protocolData.labwareDefinitions[labwareDefUri]
   // filter out the TC open lid command as it does not have an associated pipette id
   const stepMovementCommands = selectedStep.commands.filter(

--- a/app/src/organisms/LabwarePositionCheck/StepDetailText.tsx
+++ b/app/src/organisms/LabwarePositionCheck/StepDetailText.tsx
@@ -31,7 +31,8 @@ export const StepDetailText = (
   ] = React.useState<boolean>(false)
   if (protocolData == null) return null
   //   @ts-expect-error: when we remove schemav6Adapter, defintiionUri will be correct
-  const labwareDefId = protocolData.labware[labwareId].definitionUri
+  const labwareDefId = protocolData.labware.find(item => item.id === labwareId)
+    .definitionUri
   const labwareDef = protocolData.labwareDefinitions[labwareDefId]
   const { displayName } = labwareDef.metadata
   const { isTiprack } = labwareDef.parameters

--- a/app/src/organisms/LabwarePositionCheck/StepDetailText.tsx
+++ b/app/src/organisms/LabwarePositionCheck/StepDetailText.tsx
@@ -31,9 +31,9 @@ export const StepDetailText = (
   ] = React.useState<boolean>(false)
   if (protocolData == null) return null
   //   @ts-expect-error: when we remove schemav6Adapter, defintiionUri will be correct
-  const labwareDefId = protocolData.labware.find(item => item.id === labwareId)
+  const labwareDefUri = protocolData.labware.find(item => item.id === labwareId)
     .definitionUri
-  const labwareDef = protocolData.labwareDefinitions[labwareDefId]
+  const labwareDef = protocolData.labwareDefinitions[labwareDefUri]
   const { displayName } = labwareDef.metadata
   const { isTiprack } = labwareDef.parameters
 

--- a/app/src/organisms/LabwarePositionCheck/SummaryScreen.tsx
+++ b/app/src/organisms/LabwarePositionCheck/SummaryScreen.tsx
@@ -51,7 +51,8 @@ export const SummaryScreen = (props: {
   const { setIsShowingLPCSuccessToast } = useLPCSuccessToast()
 
   if (runId == null || introInfo == null || protocolData == null) return null
-  const labwareIds = Object.keys(protocolData.labware)
+  //  @ts-expect-error
+  const labwareIds = protocolData.labware.map(item => item.id)
   const { sections, primaryPipetteMount, secondaryPipetteMount } = introInfo
 
   const applyLabwareOffsets = (): void => {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/LabwarePositionCheckStepDetail.test.tsx
@@ -160,13 +160,15 @@ describe('LabwarePositionCheckStepDetail', () => {
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
         protocolData: {
-          labware: {
-            [mockLabwarePositionCheckStepTipRack.labwareId]: {
+          labware: [
+            {
+              id: mockLabwarePositionCheckStepTipRack.labwareId,
               slot: '1',
               displayName: 'someDislpayName',
               definitionUri: LABWARE_DEF_URI,
+              loadName: 'someLoadName',
             },
-          },
+          ],
           labwareDefinitions: {
             [LABWARE_DEF_URI]: LABWARE_DEF,
           },
@@ -241,13 +243,15 @@ describe('LabwarePositionCheckStepDetail', () => {
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
         protocolData: {
-          labware: {
-            [mockLabwarePositionCheckStepTipRack.labwareId]: {
+          labware: [
+            {
+              id: mockLabwarePositionCheckStepTipRack.labwareId,
               slot: '1',
               displayName: 'someDislpayName',
-              definitionUri: TIPRACK_DEF_URI,
+              definitionUri: LABWARE_DEF_URI,
+              loadName: 'someLoadName',
             },
-          },
+          ],
           labwareDefinitions: {
             [TIPRACK_DEF_URI]: LABWARE_DEF,
           },

--- a/app/src/organisms/LabwarePositionCheck/__tests__/StepDetailText.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/StepDetailText.test.tsx
@@ -86,32 +86,43 @@ describe('StepDetailText', () => {
       .mockReturnValue({
         protocolData: {
           ...withSinglechannelProtocol,
-          labware: {
-            trashId: {
+          labware: [
+            {
+              id: 'trashId',
               slot: '12',
               displayName: 'Trash',
               definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+              loadName: 'opentrons_1_trash_1100ml_fixed',
             },
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '2',
               displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
               definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+              loadName: 'opentrons_96_filtertiprack_200ul',
             },
-            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+            {
+              id:
+                '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
               displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
             },
-            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+            {
+              id:
+                '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
               slot:
                 '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
               displayName:
                 'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
               definitionUri:
                 'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+              loadName: 'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
             },
-          },
+          ],
         },
       } as any)
   })
@@ -173,32 +184,43 @@ describe('StepDetailText', () => {
       .mockReturnValue({
         protocolData: {
           ...withMultiChannelProtocol,
-          labware: {
-            trashId: {
+          labware: [
+            {
+              id: 'trashId',
               slot: '12',
               displayName: 'Trash',
               definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+              loadName: 'opentrons_1_trash_1100ml_fixed',
             },
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '2',
               displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
               definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+              loadName: 'opentrons_96_filtertiprack_200ul',
             },
-            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+            {
+              id:
+                '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
               displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
             },
-            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+            {
+              id:
+                '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
               slot:
                 '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
               displayName:
                 'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
               definitionUri:
                 'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+              loadName: 'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
             },
-          },
+          ],
         },
       } as any)
 
@@ -222,32 +244,43 @@ describe('StepDetailText', () => {
       .mockReturnValue({
         protocolData: {
           ...withMultiChannelProtocol,
-          labware: {
-            trashId: {
+          labware: [
+            {
+              id: 'trashId',
               slot: '12',
               displayName: 'Trash',
               definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+              loadName: 'opentrons_1_trash_1100ml_fixed',
             },
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '2',
               displayName: 'Opentrons 96 Filter Tip Rack 200 µL',
               definitionUri: 'opentrons/opentrons_96_filtertiprack_200ul/1',
+              loadName: 'opentrons_96_filtertiprack_200ul',
             },
-            '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+            {
+              id:
+                '24274d20-67ad-11ea-9f8b-3b50068bd62d:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
               slot: '1d57adf0-67ad-11ea-9f8b-3b50068bd62d:magneticModuleType',
               displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
               definitionUri:
                 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+              loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
             },
-            '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1': {
+            {
+              id:
+                '269518d0-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
               slot:
                 '1d57d500-67ad-11ea-9f8b-3b50068bd62d:temperatureModuleType',
               displayName:
                 'Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap',
               definitionUri:
                 'opentrons/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1',
+              loadName: 'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
             },
-          },
+          ],
         },
       } as any)
 

--- a/app/src/organisms/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/SummaryScreen.test.tsx
@@ -7,13 +7,13 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { useProtocolDetailsForRun } from '../../Devices/hooks'
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
+import { useLPCSuccessToast } from '../../ProtocolSetup/hooks'
 import { SectionList } from '../SectionList'
 import { DeckMap } from '../DeckMap'
 import { SummaryScreen } from '../SummaryScreen'
 import { LabwareOffsetsSummary } from '../LabwareOffsetsSummary'
 import { useIntroInfo, useLabwareOffsets } from '../hooks'
 import { Section } from '../types'
-import { useLPCSuccessToast } from '../../ProtocolSetup/hooks'
 
 jest.mock('../../../redux/analytics')
 jest.mock('../../ProtocolUpload/hooks')
@@ -92,13 +92,16 @@ describe('SummaryScreen', () => {
       .calledWith(MOCK_RUN_ID)
       .mockReturnValue({
         protocolData: {
-          labware: {
-            '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1': {
+          labware: [
+            {
+              id:
+                '1d57fc10-67ad-11ea-9f8b-3b50068bd62d:opentrons/opentrons_96_filtertiprack_200ul/1',
               slot: '1',
               displayName: 'someDisplayName',
               definitionId: LABWARE_DEF_ID,
+              loadName: 'someLoadName',
             },
-          },
+          ],
           labwareDefinitions: {
             [LABWARE_DEF_ID]: LABWARE_DEF,
           },

--- a/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -136,11 +136,39 @@ describe('getLabwarePositionCheckSteps', () => {
 
     const protocolWithUnusedTipRack = {
       ...protocolWithOnePipette,
-      labware: {
-        ...protocolWithOnePipette.labware,
-        id: 'unusedTipRackId',
-        definitionUri: 'bogusDefinitionUri',
-      },
+      labware: [
+        {
+          id: 'fixedTrash',
+          loadName: 'opentrons_1_trash_1100ml_fixed',
+          displayName: 'Trash',
+          definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        },
+        {
+          id:
+            '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
+          loadName: 'opentrons_96_tiprack_300ul',
+          displayName: 'Opentrons 96 Tip Rack 300 µL',
+          definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        },
+        {
+          id:
+            '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
+          loadName: 'nest_12_reservoir_15ml',
+          displayName: 'NEST 12 Well Reservoir 15 mL',
+          definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+        },
+        {
+          id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
+          loadName: 'opentrons_96_tiprack_300ul',
+          displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
+          definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        },
+        {
+          id: 'unusedTipRackId',
+          definitionUri: 'bogusDefinitionUri',
+          loadName: 'someLoadname',
+        },
+      ],
       labwareDefinitions: {
         ...protocolWithOnePipette.labwareDefinitions,
         bogusDefinitionId: { parameters: { isTiprack: true } } as any,

--- a/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/getLabwarePositionCheckSteps.test.ts
@@ -9,24 +9,34 @@ import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
 const protocolWithOnePipette = ({
   ..._uncasted_v6ProtocolWithTwoPipettes,
-  labware: {
-    fixedTrash: {
+  labware: [
+    {
+      id: 'fixedTrash',
+      loadName: 'opentrons_1_trash_1100ml_fixed',
       displayName: 'Trash',
       definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
     },
-    '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+    {
+      id:
+        '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
+      loadName: 'opentrons_96_tiprack_300ul',
       displayName: 'Opentrons 96 Tip Rack 300 µL',
       definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
     },
-    '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+    {
+      id:
+        '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
+      loadName: 'nest_12_reservoir_15ml',
       displayName: 'NEST 12 Well Reservoir 15 mL',
       definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
     },
-    'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+    {
+      id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
+      loadName: 'opentrons_96_tiprack_300ul',
       displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
       definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
     },
-  },
+  ],
   pipettes: [
     {
       pipetteName: 'p300_single_gen2',
@@ -46,24 +56,34 @@ const protocolWithTwoPipettes = ({
       id: 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a',
     },
   ],
-  labware: {
-    fixedTrash: {
+  labware: [
+    {
+      id: 'fixedTrash',
+      loadName: 'opentrons_1_trash_1100ml_fixed',
       displayName: 'Trash',
       definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
     },
-    '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+    {
+      id:
+        '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
+      loadName: 'opentrons_96_tiprack_300ul',
       displayName: 'Opentrons 96 Tip Rack 300 µL',
       definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
     },
-    '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+    {
+      id:
+        '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
+      loadName: 'nest_12_reservoir_15ml',
       displayName: 'NEST 12 Well Reservoir 15 mL',
       definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
     },
-    'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+    {
+      id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
+      loadName: 'opentrons_96_tiprack_300ul',
       displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
       definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
     },
-  },
+  ],
 } as unknown) as ProtocolAnalysisFile
 
 jest.mock('../utils/getPrimaryPipetteId')
@@ -118,9 +138,8 @@ describe('getLabwarePositionCheckSteps', () => {
       ...protocolWithOnePipette,
       labware: {
         ...protocolWithOnePipette.labware,
-        unusedTipRackId: {
-          definitionUri: 'bogusDefinitionUri',
-        },
+        id: 'unusedTipRackId',
+        definitionUri: 'bogusDefinitionUri',
       },
       labwareDefinitions: {
         ...protocolWithOnePipette.labwareDefinitions,

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -27,21 +27,19 @@ export const getLabwarePositionCheckSteps = (
     )
     //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
     const pipetteNames = pipettes.map(({ pipetteName }) => pipetteName)
-    const labware = Object.values(
-      omitBy(
-        protocolData.labware,
-        labware =>
-          //  @ts-expect-error
-          protocolData.labwareDefinitions[labware.definitionUri]?.parameters
-            .isTiprack &&
-          !protocolData.commands.some(
-            command =>
-              command.commandType === 'pickUpTip' &&
-              //  @ts-expect-error
-              command.params.labwareId === labware.id
-          )
-      )
+    //  @ts-expect-error
+    const labware = protocolData.labware.filter(
+      //  @ts-expect-error
+      labware =>
+        protocolData.labwareDefinitions[labware.definitionUri]?.parameters
+          .isTiprack ||
+        !protocolData.commands.some(
+          command =>
+            command.commandType === 'pickUpTip' &&
+            command.params.labwareId === labware.id
+        )
     )
+
     const modules: ProtocolAnalysisFile['modules'] = protocolData.modules
     const labwareDefinitions = protocolData.labwareDefinitions
     const commands: RunTimeCommand[] = protocolData.commands
@@ -49,7 +47,6 @@ export const getLabwarePositionCheckSteps = (
     const pipetteWorkflow = getPipetteWorkflow({
       pipetteNames,
       primaryPipetteId,
-      //  @ts-expect-error
       labware,
       labwareDefinitions,
       commands,
@@ -57,7 +54,6 @@ export const getLabwarePositionCheckSteps = (
     if (pipetteWorkflow === 1) {
       return getOnePipettePositionCheckSteps({
         primaryPipetteId,
-        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,
@@ -73,7 +69,6 @@ export const getLabwarePositionCheckSteps = (
       return getTwoPipettePositionCheckSteps({
         primaryPipetteId,
         secondaryPipetteId,
-        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -10,6 +10,8 @@ import type {
 } from '@opentrons/shared-data/protocol/types/schemaV6'
 import type { LabwarePositionCheckStep } from './types'
 
+const TRASH_ID = 'fixedTrash'
+
 export const getLabwarePositionCheckSteps = (
   protocolData: ProtocolAnalysisFile
 ): LabwarePositionCheckStep[] => {
@@ -29,16 +31,21 @@ export const getLabwarePositionCheckSteps = (
     const pipetteNames = values(pipettes).map(({ pipetteName }) => pipetteName)
     const labware = omitBy(
       protocolData.labware,
-      (labware, id) =>
-        //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-        protocolData.labwareDefinitions[labware.definitionUri]?.parameters
+      item =>
+        //  @ts-expect-error
+        (protocolData.labwareDefinitions[item.definitionUri]?.parameters
           .isTiprack &&
-        !protocolData.commands.some(
-          command =>
-            command.commandType === 'pickUpTip' &&
-            command.params.labwareId === id
-        )
+          !protocolData.commands.some(
+            command =>
+              command.commandType === 'pickUpTip' &&
+              //  @ts-expect-error
+              command.params.labwareId === item.definitionUri
+          )) ||
+        //  @ts-expect-error
+        item.id === TRASH_ID
     )
+
+    console.log(labware)
     const modules: ProtocolAnalysisFile['modules'] = protocolData.modules
     const labwareDefinitions = protocolData.labwareDefinitions
     const commands: RunTimeCommand[] = protocolData.commands

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -10,8 +10,6 @@ import type {
 } from '@opentrons/shared-data/protocol/types/schemaV6'
 import type { LabwarePositionCheckStep } from './types'
 
-const TRASH_ID = 'fixedTrash'
-
 export const getLabwarePositionCheckSteps = (
   protocolData: ProtocolAnalysisFile
 ): LabwarePositionCheckStep[] => {
@@ -28,24 +26,22 @@ export const getLabwarePositionCheckSteps = (
         )
     )
     //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-    const pipetteNames = values(pipettes).map(({ pipetteName }) => pipetteName)
-    const labware = omitBy(
-      protocolData.labware,
-      item =>
-        //  @ts-expect-error
-        (protocolData.labwareDefinitions[item.definitionUri]?.parameters
-          .isTiprack &&
+    const pipetteNames = pipettes.map(({ pipetteName }) => pipetteName)
+    const labware = Object.values(
+      omitBy(
+        protocolData.labware,
+        labware =>
+          //  @ts-expect-error
+          protocolData.labwareDefinitions[labware.definitionUri]?.parameters
+            .isTiprack &&
           !protocolData.commands.some(
             command =>
               command.commandType === 'pickUpTip' &&
               //  @ts-expect-error
-              command.params.labwareId === item.definitionUri
-          )) ||
-        //  @ts-expect-error
-        item.id === TRASH_ID
+              command.params.labwareId === labware.id
+          )
+      )
     )
-
-    console.log(labware)
     const modules: ProtocolAnalysisFile['modules'] = protocolData.modules
     const labwareDefinitions = protocolData.labwareDefinitions
     const commands: RunTimeCommand[] = protocolData.commands
@@ -53,6 +49,7 @@ export const getLabwarePositionCheckSteps = (
     const pipetteWorkflow = getPipetteWorkflow({
       pipetteNames,
       primaryPipetteId,
+      //  @ts-expect-error
       labware,
       labwareDefinitions,
       commands,
@@ -60,6 +57,7 @@ export const getLabwarePositionCheckSteps = (
     if (pipetteWorkflow === 1) {
       return getOnePipettePositionCheckSteps({
         primaryPipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,
@@ -75,6 +73,7 @@ export const getLabwarePositionCheckSteps = (
       return getTwoPipettePositionCheckSteps({
         primaryPipetteId,
         secondaryPipetteId,
+        //  @ts-expect-error
         labware,
         labwareDefinitions,
         modules,

--- a/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/getLabwarePositionCheckSteps.ts
@@ -26,18 +26,20 @@ export const getLabwarePositionCheckSteps = (
         )
     )
     //  @ts-expect-error: pipetteName should be name until we remove the schemaV6Adapter
-    const pipetteNames = pipettes.map(({ pipetteName }) => pipetteName)
+    const pipetteNames = values(pipettes).map(({ pipetteName }) => pipetteName)
     //  @ts-expect-error
     const labware = protocolData.labware.filter(
       //  @ts-expect-error
       labware =>
-        protocolData.labwareDefinitions[labware.definitionUri]?.parameters
+        !protocolData.labwareDefinitions[labware.definitionUri]?.parameters
           .isTiprack ||
-        !protocolData.commands.some(
-          command =>
-            command.commandType === 'pickUpTip' &&
-            command.params.labwareId === labware.id
-        )
+        (protocolData.labwareDefinitions[labware.definitionUri]?.parameters
+          .isTiprack &&
+          protocolData.commands.some(
+            command =>
+              command.commandType === 'pickUpTip' &&
+              command.params.labwareId === labware.id
+          ))
     )
 
     const modules: ProtocolAnalysisFile['modules'] = protocolData.modules

--- a/app/src/organisms/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/hooks/__tests__/useLabwarePositionCheck.test.tsx
@@ -10,6 +10,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 import { useTrackEvent } from '../../../../redux/analytics'
+import { LARGE_STEP_SIZE_MM } from '../../../../molecules/JogControls'
 import {
   useCurrentRunId,
   useCurrentRunCommands,
@@ -25,7 +26,6 @@ import { useLabwarePositionCheck } from '../useLabwarePositionCheck'
 
 import type { HostConfig } from '@opentrons/api-client'
 import type { LabwarePositionCheckStep } from '../../types'
-import { LARGE_STEP_SIZE_MM } from '../../../../molecules/JogControls'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../../redux/analytics')

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwareOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwareOffsets.ts
@@ -84,8 +84,11 @@ export const useLabwareOffsets = (
         protocolData.labware,
         protocolData.labwareDefinitions
       )
-      //   @ts-expect-error: when we remove schemav6Adapter, defintiionUri will be correct
-      const { definitionUri } = protocolData.labware[labwareId]
+      //   @ts-expect-error: when we remove schemav6Adapter, this logic will be correct
+      const { definitionUri } = protocolData.labware.find(
+        //   @ts-expect-error: when we remove schemav6Adapter, this logic will be correct
+        item => item.id === labwareId
+      ).definitionUri
       const displayName = getLabwareDisplayName(
         protocolData.labwareDefinitions[definitionUri]
       )

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwareOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwareOffsets.ts
@@ -85,7 +85,7 @@ export const useLabwareOffsets = (
         protocolData.labwareDefinitions
       )
       //   @ts-expect-error: when we remove schemav6Adapter, this logic will be correct
-      const { definitionUri } = protocolData.labware.find(
+      const definitionUri = protocolData.labware.find(
         //   @ts-expect-error: when we remove schemav6Adapter, this logic will be correct
         item => item.id === labwareId
       ).definitionUri

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLabwarePositionCheck.ts
@@ -177,7 +177,8 @@ export const useTitleText = (
     if (labware == null || labwareDefinitions == null) return ''
 
     //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-    const labwareDefId = labware[labwareId].definitionUri
+    const labwareDefId = labware.find(item => item.id === labwareId)
+      .definitionUri
     const labwareDisplayName = getLabwareDisplayName(
       labwareDefinitions[labwareDefId]
     )

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/doesPipetteVisitAllTipracks.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/doesPipetteVisitAllTipracks.test.ts
@@ -7,24 +7,34 @@ import type { RunTimeCommand } from '@opentrons/shared-data/protocol/types/schem
 // TODO: update these fixtures to be v6 protocols
 const protocolMultipleTipracks = (_uncastedProtocolMultipleTipracks as unknown) as ProtocolAnalysisFile
 const protocolOneTiprack = (_uncastedProtocolOneTiprack as unknown) as ProtocolAnalysisFile
-const labwareWithDefinitionUri = {
-  fixedTrash: {
+const labwareWithDefinitionUri = [
+  {
+    id: 'fixedTrash',
     displayName: 'Trash',
     definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    loadName: 'opentrons_1_trash_1100ml_fixed',
   },
-  '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+  {
+    id:
+      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
     displayName: 'Opentrons 96 Tip Rack 300 µL',
     definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+    loadName: 'opentrons_96_tiprack_300ul',
   },
-  '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+  {
+    id:
+      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
     displayName: 'NEST 12 Well Reservoir 15 mL',
     definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+    loadName: 'nest_12_reservoir_15ml',
   },
-  'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+  {
+    id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
     displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
     definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+    loadName: 'opentrons_96_tiprack_300ul',
   },
-}
+]
 
 describe('doesPipetteVisitAllTipracks', () => {
   it('should return true when the pipette visits both tipracks', () => {
@@ -61,24 +71,32 @@ describe('doesPipetteVisitAllTipracks', () => {
   })
   it('should return true when there is only one tiprack and pipette visits it', () => {
     const pipetteId = 'pipetteId' // this is just taken from the protocol fixture
-    const labware = {
-      fixedTrash: {
+    const labware = [
+      {
+        id: 'fixedTrash',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
       },
-      tiprackId: {
+      {
+        id: 'tiprackId',
         displayName: 'Opentrons 96 Tip Rack 10 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_10ul/1',
+        loadName: 'opentrons_96_tiprack_10ul',
       },
-      sourcePlateId: {
+      {
+        id: 'sourcePlateId',
         displayName: 'Source Plate',
         definitionUri: 'example/plate/1',
+        loadName: 'plate',
       },
-      destPlateId: {
+      {
+        id: 'destPlateId',
         displayName: 'Dest Plate',
         definitionUri: 'example/plate/1',
+        loadName: 'plate',
       },
-    }
+    ]
     const labwareDefinitions = protocolOneTiprack.labwareDefinitions
     const commands: RunTimeCommand[] = protocolOneTiprack.commands
 

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/getOnePipettePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/getOnePipettePositionCheckSteps.test.ts
@@ -12,24 +12,34 @@ const protocolWithTC = (_uncastedProtocolWithTC as unknown) as ProtocolAnalysisF
 describe('getOnePipettePositionCheckSteps', () => {
   it('should check all tipracks, pick up a tip at the final tiprack, move to all remaining labware, and drop the tip', () => {
     const primaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
-    const labware = {
-      fixedTrash: {
+    const labware = [
+      {
+        id: 'fixedTrash',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
       },
-      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      {
+        id:
+          '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      {
+        id:
+          '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
         displayName: 'NEST 12 Well Reservoir 15 mL',
         definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+        loadName: 'nest_12_reservoir_15ml',
       },
-      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      {
+        id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
         displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-    }
+    ]
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
     const modules = protocolMultipleTipracks.modules
 
@@ -134,28 +144,41 @@ describe('getOnePipettePositionCheckSteps', () => {
   })
   it('should check tiprack, pick up a tip at the final tiprack, move to all remaining labware (and open TC lid), and drop the tip', () => {
     const primaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
-    const labware = {
-      fixedTrash: {
+    const labware = [
+      {
+        id: 'fixedTrash',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
       },
-      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      {
+        id:
+          '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      {
+        id:
+          '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
         displayName: 'NEST 12 Well Reservoir 15 mL',
         definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+        loadName: 'nest_12_reservoir_15ml',
       },
-      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      {
+        id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
         displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+      {
+        id:
+          '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
         displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
         definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+        loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
       },
-    }
+    ]
     const labwareDefinitions = protocolWithTC.labwareDefinitions
     const modules = protocolWithTC.modules
 

--- a/app/src/organisms/LabwarePositionCheck/utils/__tests__/getTwoPipettePositionCheckSteps.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/__tests__/getTwoPipettePositionCheckSteps.test.ts
@@ -13,24 +13,34 @@ describe('getTwoPipettePositionCheckSteps', () => {
   it('should move to all tipracks that the secondary pipette uses, move to all tipracks with that the primary pipette uses, pick up a tip at the final tiprack that the primary pipette uses, move to all remaining labware, and drop the tip back in the tiprack that the primary pipette uses', () => {
     const primaryPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
     const secondaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
-    const labware = {
-      fixedTrash: {
+    const labware = [
+      {
+        id: 'fixedTrash',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
       },
-      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      {
+        id:
+          '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      {
+        id:
+          '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
         displayName: 'NEST 12 Well Reservoir 15 mL',
         definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+        loadName: 'nest_12_reservoir_15ml',
       },
-      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      {
+        id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
         displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-    }
+    ]
     const labwareDefinitions = protocolMultipleTipracks.labwareDefinitions
     const modules = protocolMultipleTipracks.modules
     const commands = protocolMultipleTipracks.commands
@@ -138,28 +148,41 @@ describe('getTwoPipettePositionCheckSteps', () => {
   it('should move to all tipracks that the secondary pipette uses, move to all tipracks with the primary pipette uses, pick up a tip at the final tiprack that the primary pipette uses, move to all remaining labware (and open TC lid), and drop the tip back in the tiprack that the primary pipette uses', () => {
     const primaryPipetteId = '50d23e00-0042-11ec-8258-f7ffdf5ad45a' // this is just taken from the protocol fixture
     const secondaryPipetteId = 'c235a5a0-0042-11ec-8258-f7ffdf5ad45a'
-    const labware = {
-      fixedTrash: {
+    const labware = [
+      {
+        id: 'fixedTrash',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
       },
-      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      {
+        id:
+          '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      {
+        id:
+          '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
         displayName: 'NEST 12 Well Reservoir 15 mL',
         definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+        loadName: 'nest_12_reservoir_15ml',
       },
-      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      {
+        id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
         displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+      {
+        id:
+          '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
         displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
         definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+        loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
       },
-    }
+    ]
     const labwareDefinitions = protocolWithTC.labwareDefinitions
     const modules = protocolWithTC.modules
     const commands = protocolWithTC.commands

--- a/app/src/organisms/LabwarePositionCheck/utils/doesPipetteVisitAllTipracks.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/doesPipetteVisitAllTipracks.ts
@@ -23,7 +23,6 @@ export const doesPipetteVisitAllTipracks = (
     },
     0
   )
-
   const pickUpTipCommandsWithPipette = getPickUpTipCommandsWithPipette(
     commands,
     pipetteId

--- a/app/src/organisms/LabwarePositionCheck/utils/getOnePipettePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getOnePipettePositionCheckSteps.ts
@@ -33,14 +33,12 @@ export const getOnePipettePositionCheckSteps = (args: {
     labwareDefinitions,
     commands
   )
-
   const orderedLabwareIds = getLabwareIdsInOrder(
     labware,
     labwareDefinitions,
     modules,
     commands
   )
-
   const moveToTiprackSteps = getMoveToTiprackSteps(
     orderedTiprackIds,
     primaryPipetteId,

--- a/app/src/organisms/LabwarePositionCheck/utils/getPipetteWorkflow.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getPipetteWorkflow.ts
@@ -21,6 +21,7 @@ export const getPipetteWorkflow = (args: {
     labwareDefinitions,
     commands,
   } = args
+
   const uniquePipetteNames = uniq(pipetteNames)
   if (uniquePipetteNames.length === 1) {
     return 1

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useClearAllOffsetsForCurrentRun.test.tsx
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useClearAllOffsetsForCurrentRun.test.tsx
@@ -33,28 +33,41 @@ const mockProtocolDetails: ProtocolDetails = {
   protocolData: {
     commands: protocolWithTC.commands,
     modules: protocolWithTC.modules,
-    labware: {
-      fixedTrash: {
+    labware: [
+      {
+        id: 'fixedTrash',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
       },
-      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      {
+        id:
+          '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
       },
-      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      {
+        id:
+          '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
+        loadName: 'nest_12_reservoir_15ml',
         displayName: 'NEST 12 Well Reservoir 15 mL',
         definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
       },
-      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      {
+        id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
+        loadName: 'opentrons_96_tiprack_300ul',
         displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
       },
-      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+      {
+        id:
+          '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+        loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
         displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
         definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
       },
-    },
+    ],
     labwareDefinitions: protocolWithTC.labwareDefinitions,
   } as any,
   displayName: 'fake protocol name',

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useOffsetCandidatesForCurrentRun.test.tsx
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/__tests__/useOffsetCandidatesForCurrentRun.test.tsx
@@ -35,28 +35,41 @@ const mockProtocolDetails: ProtocolDetails = {
   protocolData: {
     commands: protocolWithTC.commands,
     modules: protocolWithTC.modules,
-    labware: {
-      fixedTrash: {
+    labware: [
+      {
+        id: 'fixedTrash',
         displayName: 'Trash',
         definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+        loadName: 'opentrons_1_trash_1100ml_fixed',
       },
-      '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1': {
+      {
+        id:
+          '50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1',
         displayName: 'Opentrons 96 Tip Rack 300 µL',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1': {
+      {
+        id:
+          '9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1',
         displayName: 'NEST 12 Well Reservoir 15 mL',
         definitionUri: 'opentrons/nest_12_reservoir_15ml/1',
+        loadName: 'nest_12_reservoir_15ml',
       },
-      'e24818a0-0042-11ec-8258-f7ffdf5ad45a': {
+      {
+        id: 'e24818a0-0042-11ec-8258-f7ffdf5ad45a',
         displayName: 'Opentrons 96 Tip Rack 300 µL (1)',
         definitionUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+        loadName: 'opentrons_96_tiprack_300ul',
       },
-      '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': {
+      {
+        id:
+          '1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
         displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
         definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+        loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
       },
-    },
+    ],
     labwareDefinitions: protocolWithTC.labwareDefinitions,
   } as any,
   displayName: 'fake protocol name',

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/useClearAllOffsetsForCurrentRun.ts
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/useClearAllOffsetsForCurrentRun.ts
@@ -12,17 +12,18 @@ export function useClearAllOffsetsForCurrentRun(): () => void {
 
   return () => {
     if (currentRunId == null || protocolData == null) return
-    Object.keys(protocolData.labware).forEach(labwareId => {
+    //  @ts-expect-error
+    protocolData.labware.forEach(item => {
       createLabwareOffset({
         runId: currentRunId,
         data: {
           definitionUri: getLabwareDefinitionUri(
-            labwareId,
+            item.id,
             protocolData.labware,
             protocolData.labwareDefinitions
           ),
           location: getLabwareOffsetLocation(
-            labwareId,
+            item.id,
             protocolData.commands,
             protocolData.modules
           ),

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
@@ -38,15 +38,17 @@ export function useOffsetCandidatesForCurrentRun(): OffsetCandidate[] {
   )
     return []
 
-  return Object.keys(protocolData.labware).reduce<OffsetCandidate[]>(
-    (acc: OffsetCandidate[], labwareId: string) => {
+  //  @ts-expect-error
+  return protocolData.labware.reduce<OffsetCandidate[]>(
+    //  @ts-expect-error
+    (acc: OffsetCandidate[], item) => {
       const location = getLabwareOffsetLocation(
-        labwareId,
+        item.id,
         protocolData.commands,
         protocolData.modules
       )
       const definition = getLabwareDefinition(
-        labwareId,
+        item.id,
         protocolData.labware,
         protocolData.labwareDefinitions
       )
@@ -81,7 +83,8 @@ function getLabwareDefinition(
   labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
 ): ProtocolFile<{}>['labwareDefinitions'][string] {
   //  @ts-expect-error: will be an error until we remove the schemaV6Adapter
-  const labwareDefinitionId = labware[labwareId].definitionUri
+  const labwareDefinitionId = labware.find(item => item.id === labwareId)
+    .definitionUri
   if (labwareDefinitionId == null) {
     throw new Error(
       'expected to be able to find labware definition id for labware, but could not'

--- a/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
+++ b/app/src/organisms/ReapplyOffsetsModal/hooks/useOffsetCandidatesForCurrentRun.ts
@@ -38,42 +38,46 @@ export function useOffsetCandidatesForCurrentRun(): OffsetCandidate[] {
   )
     return []
 
-  //  @ts-expect-error
-  return protocolData.labware.reduce<OffsetCandidate[]>(
-    //  @ts-expect-error
-    (acc: OffsetCandidate[], item) => {
-      const location = getLabwareOffsetLocation(
-        item.id,
-        protocolData.commands,
-        protocolData.modules
-      )
-      const definition = getLabwareDefinition(
-        item.id,
-        protocolData.labware,
-        protocolData.labwareDefinitions
-      )
-      const defUri = getLabwareDefURI(definition)
-      const labwareDisplayName = getLabwareDisplayName(definition)
+  return (
+    protocolData.labware
+      //  @ts-expect-error
+      .filter(labware => labware.id !== 'fixedTrash')
+      .reduce<OffsetCandidate[]>(
+        //  @ts-expect-error
+        (acc: OffsetCandidate[], item) => {
+          const location = getLabwareOffsetLocation(
+            item.id,
+            protocolData.commands,
+            protocolData.modules
+          )
+          const definition = getLabwareDefinition(
+            item.id,
+            protocolData.labware,
+            protocolData.labwareDefinitions
+          )
+          const defUri = getLabwareDefURI(definition)
+          const labwareDisplayName = getLabwareDisplayName(definition)
 
-      const offsetMatch = allHistoricOffsets.find(
-        ({ offset }) =>
-          !isEqual(offset.vector, { x: 0, y: 0, z: 0 }) &&
-          isEqual(offset.location, location) &&
-          offset.definitionUri === defUri
-      )
+          const offsetMatch = allHistoricOffsets.find(
+            ({ offset }) =>
+              !isEqual(offset.vector, { x: 0, y: 0, z: 0 }) &&
+              isEqual(offset.location, location) &&
+              offset.definitionUri === defUri
+          )
 
-      return offsetMatch == null
-        ? acc
-        : [
-            ...acc,
-            {
-              ...offsetMatch.offset,
-              runCreatedAt: offsetMatch.runCreatedAt,
-              labwareDisplayName,
-            },
-          ]
-    },
-    []
+          return offsetMatch == null
+            ? acc
+            : [
+                ...acc,
+                {
+                  ...offsetMatch.offset,
+                  runCreatedAt: offsetMatch.runCreatedAt,
+                  labwareDisplayName,
+                },
+              ]
+        },
+        []
+      )
   )
 }
 

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -20,12 +20,12 @@ export const schemaV6Adapter = (
   protocolAnalysis: PendingProtocolAnalysis | CompletedProtocolAnalysis
 ): ProtocolAnalysisFile<{}> | null => {
   if (protocolAnalysis != null && protocolAnalysis.status === 'completed') {
-    const labware: {
+    const labware: Array<{
       id: string
       loadName: string
       definitionUri: string
       displayName?: string
-    }[] = protocolAnalysis.labware.map(labware => {
+    }> = protocolAnalysis.labware.map(labware => {
       const labwareId = labware.id
       //  TODO(jr, 10/6/22): this logic can be removed when protocol analysis includes displayName
       const loadCommand: LoadLabwareRunTimeCommand | null =


### PR DESCRIPTION
closes RAUT-245

# Overview

This changes the key/value structure for labware key, to eventually remove the `schemaV6Adapter`: We are waiting on backend to add `displayName`

# Changelog

- changes in `SchemaV6Adapter`
- touched a bunch of components and their tests:
1. `createSnippet`
4. `StepText`
5. `getLabwareDefinitionUri`
6. `useRunPipettesInfoByMount`
7. `DeprecatedLabwarePositionCheckStepDetail` and `LabwarePositionCheckStepDetail`
8. `DeprecatedStepDetailText` and `StepDetailText`
9. `getLabwarePositionCheckStep`
10. `useLabwarePositionCheck`
11. `useLabwareOffsets`
12. `doesPipetteVisitAllTipracks`
13. `getOnePipettePositionCheckSteps`
14. `getPipetteWorkflow`
15. `labware`
16. `useOffsetCandidatesForCurrentRun`
17. `useClearAllOffsetsForCurrentRun`
18. `summaryScreen` and `DeprecatedSummaryScreen`

# Review requests

- smoke test in the app including LPC, creating a snippet, applying and deleting offset data

# Risk assessment

low