### PR TITLE
refactor(app, api-client): update stored protocol analysis to match schemaV6 adapter

### DIFF
--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -38,7 +38,7 @@ export function parseInitialPipetteNamesByMount(
 }
 
 export interface PipetteNamesById {
-  [pipetteId: string]: { name: PipetteName }
+  [pipetteId: string]: { pipetteName: PipetteName }
 }
 
 export function parseInitialPipetteNamesById(
@@ -57,7 +57,7 @@ export function parseInitialPipetteNamesById(
     rightPipette != null
       ? {
           [rightPipette.result.pipetteId]: {
-            name: rightPipette.params.pipetteName,
+            pipetteName: rightPipette.params.pipetteName,
           },
         }
       : {}
@@ -65,7 +65,7 @@ export function parseInitialPipetteNamesById(
     leftPipette != null
       ? {
           [leftPipette.result.pipetteId]: {
-            name: leftPipette.params.pipetteName,
+            pipetteName: leftPipette.params.pipetteName,
           },
         }
       : {}
@@ -152,7 +152,7 @@ export function parseInitialLoadedLabwareByModuleId(
 
 export interface LoadedLabwareById {
   [labwareId: string]: {
-    definitionId: string
+    definitionUri: string
     displayName?: string
   }
 }
@@ -179,12 +179,12 @@ export function parseInitialLoadedLabwareById(
         version,
         parameters: { loadName },
       } = command.result.definition
-      const definitionId = `${namespace}/${loadName}/${version}_id`
+      const definitionUri = `${namespace}/${loadName}/${version}`
 
       return {
         ...acc,
         [labwareId]: {
-          definitionId,
+          definitionUri,
           displayName: command.params.displayName,
         },
       }
@@ -194,7 +194,7 @@ export function parseInitialLoadedLabwareById(
 }
 
 export interface LoadedLabwareDefinitionsById {
-  [definitionId: string]: LabwareDefinition2
+  [definitionUri: string]: LabwareDefinition2
 }
 export function parseInitialLoadedLabwareDefinitionsById(
   commands: RunTimeCommand[]
@@ -215,11 +215,11 @@ export function parseInitialLoadedLabwareDefinitionsById(
       }
       const labwareDef: LabwareDefinition2 = command.result?.definition
       const labwareId = command.result?.labwareId ?? ''
-      const definitionId = labware[labwareId]?.definitionId
+      const definitionUri = labware[labwareId]?.definitionUri
 
       return {
         ...acc,
-        [definitionId]: labwareDef,
+        [definitionUri]: labwareDef,
       }
     },
     {}

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
@@ -56,6 +56,7 @@ export function SetupPipetteCalibration({
       </StyledText>
       {PipetteConstants.PIPETTE_MOUNTS.map((mount, index) => {
         const pipetteInfo = runPipetteInfoByMount[mount]
+        console.log(pipetteInfo)
         return pipetteInfo != null ? (
           <SetupPipetteCalibrationItem
             key={index}

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
@@ -56,7 +56,6 @@ export function SetupPipetteCalibration({
       </StyledText>
       {PipetteConstants.PIPETTE_MOUNTS.map((mount, index) => {
         const pipetteInfo = runPipetteInfoByMount[mount]
-        console.log(pipetteInfo)
         return pipetteInfo != null ? (
           <SetupPipetteCalibrationItem
             key={index}

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -11,7 +11,7 @@ import type { StoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 
 export const LABWARE_BY_ID: LoadedLabwareById = {
   'labware-0': {
-    definitionId: 'fakeLabwareDefinitionId',
+    definitionUri: 'fakeLabwareDefinitionUri',
     displayName: 'a fake labware',
   },
 }
@@ -22,7 +22,7 @@ export const MODULE_MODELS_BY_ID: ModuleModelsById = {
   'module-0': { model: 'thermocyclerModuleV1' },
 }
 export const PIPETTE_NAMES_BY_ID: PipetteNamesById = {
-  'pipette-0': { name: 'p10_single' },
+  'pipette-0': { pipetteName: 'p10_single' },
 }
 
 export const STORED_PROTOCOL_ANALYSIS = {

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
@@ -48,8 +48,8 @@ const RUN_ID = '1'
 const RUN_ID_2 = '2'
 
 const PIPETTES = {
-  left: { id: '1', name: 'testModelLeft' },
-  right: { id: '2', name: 'testModelRight' },
+  left: { id: '1', pipetteName: 'testModelLeft' },
+  right: { id: '2', pipetteName: 'testModelRight' },
 }
 const FORMATTED_PIPETTES = 'testModelLeft,testModelRight'
 const MODULES = {

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -89,6 +89,11 @@ const TIP_LENGTH_CALIBRATIONS = [
 const tiprack10ul = _tiprack10ul as LabwareDefinition2
 const modifiedSimpleV6Protocol = ({
   ..._uncastedModifiedSimpleV6Protocol,
+  pipettes: {
+    pipetteId: {
+      pipetteName: 'p10_single',
+    },
+  },
   labware: {
     trashId: {
       displayName: 'Trash',

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -51,6 +51,15 @@ const mockParseInitialPipetteNamesById = parseInitialPipetteNamesById as jest.Mo
 >
 const store: Store<any> = createStore(jest.fn(), {})
 
+const modifiedStoredProtocolData = {
+  ...storedProtocolData,
+  mostRecentAnalysis: {
+    commands: storedProtocolData?.mostRecentAnalysis?.commands,
+    liquids: storedProtocolData?.mostRecentAnalysis?.liquids,
+    errors: storedProtocolData?.mostRecentAnalysis?.errors,
+  },
+}
+
 const RUN_ID = 'the_run_id'
 const PROTOCOL_ID = 'the_protocol_id'
 const PROTOCOL_KEY = 'the_protocol_key'
@@ -133,7 +142,8 @@ describe('useStoredProtocolAnalysis hook', () => {
       } as UseQueryResult<Protocol>)
     when(mockGetStoredProtocol)
       .calledWith(undefined as any, PROTOCOL_KEY)
-      .mockReturnValue(storedProtocolData)
+      // @ts-expect-error
+      .mockReturnValue(modifiedStoredProtocolData)
 
     const { result } = renderHook(() => useStoredProtocolAnalysis(RUN_ID), {
       wrapper,

--- a/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
@@ -38,7 +38,7 @@ export const parseProtocolRunAnalyticsData = (
       protocolSource: protocolAnalysis?.metadata?.source ?? '',
       protocolName: protocolAnalysis?.metadata?.protocolName ?? '',
       pipettes: Object.values(protocolAnalysis?.pipettes ?? {})
-        .map(pipette => pipette.name)
+        .map(pipette => pipette.pipetteName)
         .join(','),
       modules: Object.values(protocolAnalysis?.modules ?? {})
         .map(module => module.model)

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -66,10 +66,9 @@ export function useRunPipetteInfoByMount(
     const loadCommand = loadPipetteCommands.find(
       command => command.result?.pipetteId === pipetteId
     )
-
     if (loadCommand != null) {
       const { mount } = loadCommand.params
-      const requestedPipetteName = pipette.name
+      const requestedPipetteName = pipette.pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
 
       if (pipetteSpecs != null) {
@@ -90,7 +89,7 @@ export function useRunPipetteInfoByMount(
 
         const attachedPipette = attachedPipettes[mount as Mount]
         const requestedPipetteMatch = getRequestedPipetteMatch(
-          pipette.name,
+          pipette.pipetteName,
           attachedPipette
         )
 

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -5,6 +5,7 @@ import {
   parseInitialLoadedLabwareDefinitionsById,
   parseInitialPipetteNamesById,
 } from '@opentrons/api-client'
+import { schemaV6Adapter } from '@opentrons/shared-data'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 
 import { getStoredProtocol } from '../../../redux/protocol-storage'
@@ -67,6 +68,8 @@ export function useStoredProtocolAnalysis(
   const storedProtocolAnalysis =
     useSelector((state: State) => getStoredProtocol(state, protocolKey))
       ?.mostRecentAnalysis ?? null
-
-  return parseProtocolAnalysisOutput(storedProtocolAnalysis)
+  // @ts-expect-error
+  return storedProtocolAnalysis != null && 'modules' in storedProtocolAnalysis
+    ? schemaV6Adapter(storedProtocolAnalysis)
+    : parseProtocolAnalysisOutput(storedProtocolAnalysis)
 }

--- a/app/src/redux/pipettes/__fixtures__/index.ts
+++ b/app/src/redux/pipettes/__fixtures__/index.ts
@@ -273,16 +273,16 @@ export const mockRightSpecs: any = {
   name: 'mock_right',
 }
 
-// NOTE: protocol pipettes use "name" for the exact "model" because reasons
+// NOTE: protocol pipettes use "pipetteName" for the exact "model" because reasons
 export const mockLeftProtoPipette: any = {
   mount: 'left',
-  name: 'mock_left_model',
+  pipetteName: 'mock_left_model',
   modelSpecs: mockLeftSpecs,
 }
 
 export const mockRightProtoPipette: any = {
   mount: 'right',
-  name: 'mock_right_model',
+  pipetteName: 'mock_right_model',
   modelSpecs: mockRightSpecs,
 }
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
We want the output of the useStoredProtocolAnalysis hook to mimic the output of the schemaV6Adapter so when we pull the most recent analysis it will have the same fields regardless of which analysis it is.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. If stored protocol analysis has been updated recently to have top level `modules`, `liquids`, `labware`, and `pipettes` keys, route response through the schemaV6Adapter
2. If it is not updated, route through current utils but update those utils to use `pipetteName` and `definitionUri` fields
3. Update a few missed places with new field names 

# Review requests
Smoke test running a protocol in the app, one that has been recently reanalyzed and one that hasn't
Check run setup to make sure all fields are present
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
