### PR TITLE
fix(api): do not trigger module attach on temporary device node paths

### DIFF
--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -250,6 +250,9 @@ class Controller:
             return
         if event is not None:
             if "ot_module" in event.name:
+                if ".tmp" in event.name:
+                    MODULE_LOG.warning(f"ignoring module tempnode {event.name}")
+                    return
                 event_name = event.name
                 flags = aionotify.Flags.parse(event.flags)
                 event_description = AionotifyEvent.build(event_name, flags)

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -250,9 +250,6 @@ class Controller:
             return
         if event is not None:
             if "ot_module" in event.name:
-                if ".tmp" in event.name:
-                    MODULE_LOG.warning(f"ignoring module tempnode {event.name}")
-                    return
                 event_name = event.name
                 flags = aionotify.Flags.parse(event.flags)
                 event_description = AionotifyEvent.build(event_name, flags)

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -249,10 +249,12 @@ class Controller:
             MODULE_LOG.warning("incomplete read error from watcher")
             return
         if event is not None:
-            MODULE_LOG.info(f"aionotify event on {event.name}: {event}")
+            flags = aionotify.Flags.parse(event.flags)
+            MODULE_LOG.info(
+                f"aionotify event on {event.name}: {event} with flags {flags}"
+            )
             if "ot_module" in event.name:
                 event_name = event.name
-                flags = aionotify.Flags.parse(event.flags)
                 event_description = AionotifyEvent.build(event_name, flags)
                 await self.module_controls.handle_module_appearance(event_description)
 

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -246,9 +246,10 @@ class Controller:
         try:
             event = await self._event_watcher.get_event()
         except asyncio.IncompleteReadError:
-            MODULE_LOG.debug("incomplete read error when quitting watcher")
+            MODULE_LOG.warning("incomplete read error from watcher")
             return
         if event is not None:
+            MODULE_LOG.info(f'aionotify event on {event.name}: {event}')
             if "ot_module" in event.name:
                 event_name = event.name
                 flags = aionotify.Flags.parse(event.flags)

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -249,7 +249,7 @@ class Controller:
             MODULE_LOG.warning("incomplete read error from watcher")
             return
         if event is not None:
-            MODULE_LOG.info(f'aionotify event on {event.name}: {event}')
+            MODULE_LOG.info(f"aionotify event on {event.name}: {event}")
             if "ot_module" in event.name:
                 event_name = event.name
                 flags = aionotify.Flags.parse(event.flags)

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -34,12 +34,12 @@ _MODULE_SYMLINK_NAME_SUBRE = (
 # to create a "tmpnode", a dev node with the guaranteed-unique name "NAME.tmp-cMAJ:MIN". this
 # device only exists until the rest of the nodes and symlinks are established, and cannot be
 # used after udev finishes processing. we'll pick it up from inotify, but by the time we try
-# to open it it'll be gone and we'll error - so ignore it. to get this to work, we need an
-# end-of-line anchor so that the search() can't just terminate early, so make sure this is
-# called on a stripped line.
-_MODULE_IGNORE_TMPNODE_SUBRE = r"(?!tmp\d+:\d+)$"
+# to open it it'll be gone and we'll error - so we need to separately capture the temp node
+# so we can just pay attention to the module symlink part. Make sure this is called on a
+# stripped line since it uses an EOL anchor.
+_MODULE_OPTIONAL_TMPNODE_SUBRE = r"(?:.tmp-c\d+:\d+)?$"
 MODULE_PORT_REGEX = re.compile(
-    _MODULE_SYMLINK_NAME_SUBRE + _MODULE_IGNORE_TMPNODE_SUBRE, re.I
+    _MODULE_SYMLINK_NAME_SUBRE + _MODULE_OPTIONAL_TMPNODE_SUBRE, re.I
 )
 
 

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -31,7 +31,8 @@ _MODULE_SYMLINK_NAME_SUBRE = (
 )
 
 # when connecting a module, regardless of what udev rules exist the kernel + udev conspire
-# to create a "tmpnode", a dev node with the guaranteed-unique name "NAME.tmp-cMAJ:MIN". this
+# to create a "tmpnode", a dev node with the guaranteed-unique name "NAME.tmp-cMAJ:MIN",
+# for instance /dev/ot_module_tempdeck0.tmp-c229:1 . this
 # device only exists until the rest of the nodes and symlinks are established, and cannot be
 # used after udev finishes processing. we'll pick it up from inotify, but by the time we try
 # to open it it'll be gone and we'll error - so we need to separately capture the temp node

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -20,18 +20,24 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# All names joined with alternators in a non-capturing group (just so the alternation works)
-_MODULE_NAME_SUBRE = r"(?:" + r"|".join(modules.MODULE_HW_BY_NAME.keys()) + r")"
+# All names joined with alternators in a named group for later access
+_MODULE_NAME_SUBRE = (
+    r"(?P<module_name>" + r"|".join(modules.MODULE_HW_BY_NAME.keys()) + r")"
+)
 # group that requires a module name (non-capturing) and a number (non-zero if more than one of the same
 # module is connected) and bundles the whole thing into a named capture
-_MODULE_SYMLINK_NAME_SUBRE = r"(?P<symlink_name>" + _MODULE_NAME_SUBRE + r"\d+)"
+_MODULE_SYMLINK_NAME_SUBRE = (
+    r"(?P<symlink_name>ot_module_" + _MODULE_NAME_SUBRE + r"\d+\d*)"
+)
 
 # when connecting a module, regardless of what udev rules exist the kernel + udev conspire
 # to create a "tmpnode", a dev node with the guaranteed-unique name "NAME.tmp-cMAJ:MIN". this
 # device only exists until the rest of the nodes and symlinks are established, and cannot be
 # used after udev finishes processing. we'll pick it up from inotify, but by the time we try
-# to open it it'll be gone and we'll error - so ignore it.
-_MODULE_IGNORE_TMPNODE_SUBRE = r"(?!.tmp)"
+# to open it it'll be gone and we'll error - so ignore it. to get this to work, we need an
+# end-of-line anchor so that the search() can't just terminate early, so make sure this is
+# called on a stripped line.
+_MODULE_IGNORE_TMPNODE_SUBRE = r"(?!tmp\d+:\d+)$"
 MODULE_PORT_REGEX = re.compile(
     _MODULE_SYMLINK_NAME_SUBRE + _MODULE_IGNORE_TMPNODE_SUBRE, re.I
 )
@@ -239,13 +245,18 @@ class AttachedModulesControl:
         """Given a port, returns either a ModuleAtPort
         if it is a recognized module, or None if not recognized.
         """
-        match = MODULE_PORT_REGEX.search(port)
+        log.info(f"Checking port {port}")
+        match = MODULE_PORT_REGEX.search(port.strip())
         if match:
-            name = match.group("symlink_name").lower()
+            name = match.group("module_name").lower()
+            log.info(f"matched module {name} from {port}")
             if name not in modules.MODULE_HW_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None
-            return modules.ModuleAtPort(port=f"/dev/{port}", name=name)
+            symlink_name = match.group("symlink_name")
+            return modules.ModuleAtPort(port=f"/dev/{symlink_name}", name=name)
+        else:
+            log.info(f"discarding non-matching module {port}")
         return None
 
     async def handle_module_appearance(self, event: AionotifyEvent) -> None:

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -21,18 +21,20 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # All names joined with alternators in a non-capturing group (just so the alternation works)
-_MODULE_NAME_SUBRE = r'(?:' + r"|".join(modules.MODULE_HW_BY_NAME.keys()) + r')'
+_MODULE_NAME_SUBRE = r"(?:" + r"|".join(modules.MODULE_HW_BY_NAME.keys()) + r")"
 # group that requires a module name (non-capturing) and a number (non-zero if more than one of the same
 # module is connected) and bundles the whole thing into a named capture
-_MODULE_SYMLINK_NAME_SUBRE = r'(?P<symlink_name>' + _MODULE_NAME_SUBRE + '\d+)'
+_MODULE_SYMLINK_NAME_SUBRE = r"(?P<symlink_name>" + _MODULE_NAME_SUBRE + r"\d+)"
 
 # when connecting a module, regardless of what udev rules exist the kernel + udev conspire
 # to create a "tmpnode", a dev node with the guaranteed-unique name "NAME.tmp-cMAJ:MIN". this
 # device only exists until the rest of the nodes and symlinks are established, and cannot be
 # used after udev finishes processing. we'll pick it up from inotify, but by the time we try
 # to open it it'll be gone and we'll error - so ignore it.
-_MODULE_IGNORE_TMPNODE_SUBRE = r'(?!.tmp)'
-MODULE_PORT_REGEX = re.compile(_MODULE_SYMLINK_NAME_SUBRE + _MODULE_IGNORE_TMPNODE_SUBRE, re.I)
+_MODULE_IGNORE_TMPNODE_SUBRE = r"(?!.tmp)"
+MODULE_PORT_REGEX = re.compile(
+    _MODULE_SYMLINK_NAME_SUBRE + _MODULE_IGNORE_TMPNODE_SUBRE, re.I
+)
 
 
 class AttachedModulesControl:
@@ -239,7 +241,7 @@ class AttachedModulesControl:
         """
         match = MODULE_PORT_REGEX.search(port)
         if match:
-            name = match.group('symlink_name').lower()
+            name = match.group("symlink_name").lower()
             if name not in modules.MODULE_HW_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -20,7 +20,19 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-MODULE_PORT_REGEX = re.compile("|".join(modules.MODULE_HW_BY_NAME.keys()), re.I)
+# All names joined with alternators in a non-capturing group (just so the alternation works)
+_MODULE_NAME_SUBRE = r'(?:' + r"|".join(modules.MODULE_HW_BY_NAME.keys()) + r')'
+# group that requires a module name (non-capturing) and a number (non-zero if more than one of the same
+# module is connected) and bundles the whole thing into a named capture
+_MODULE_SYMLINK_NAME_SUBRE = r'(?P<symlink_name>' + _MODULE_NAME_SUBRE + '\d+)'
+
+# when connecting a module, regardless of what udev rules exist the kernel + udev conspire
+# to create a "tmpnode", a dev node with the guaranteed-unique name "NAME.tmp-cMAJ:MIN". this
+# device only exists until the rest of the nodes and symlinks are established, and cannot be
+# used after udev finishes processing. we'll pick it up from inotify, but by the time we try
+# to open it it'll be gone and we'll error - so ignore it.
+_MODULE_IGNORE_TMPNODE_SUBRE = r'(?!.tmp)'
+MODULE_PORT_REGEX = re.compile(_MODULE_SYMLINK_NAME_SUBRE + _MODULE_IGNORE_TMPNODE_SUBRE, re.I)
 
 
 class AttachedModulesControl:
@@ -227,7 +239,7 @@ class AttachedModulesControl:
         """
         match = MODULE_PORT_REGEX.search(port)
         if match:
-            name = match.group().lower()
+            name = match.group('symlink_name').lower()
             if name not in modules.MODULE_HW_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -139,7 +139,10 @@ async def test_register_modules_sort(
             "ot_module_magdeck0",
             ModuleAtPort(port="/dev/ot_module_magdeck0", name="magdeck"),
         ),
-        ("ot_module_magdeck0.tmp-c166:0", None),
+        (
+            "ot_module_magdeck0.tmp-c166:0",
+            ModuleAtPort(port="/dev/ot_module_magdeck0", name="magdeck"),
+        ),
         (
             "ot_module_thermocycler2",
             ModuleAtPort(port="/dev/ot_module_thermocycler2", name="thermocycler"),
@@ -149,7 +152,10 @@ async def test_register_modules_sort(
             "ot_module_heatershaker29",
             ModuleAtPort(port="/dev/ot_module_heatershaker29", name="heatershaker"),
         ),
-        ("ot_module_tempdeck1000.tmp-c166:0", None),
+        (
+            "ot_module_tempdeck1000.tmp-c166:0",
+            ModuleAtPort(port="/dev/ot_module_tempdeck1000", name="tempdeck"),
+        ),
         (
             "ot_module_tempdeck1000",
             ModuleAtPort(port="/dev/ot_module_tempdeck1000", name="tempdeck"),
@@ -158,7 +164,10 @@ async def test_register_modules_sort(
             "/dev/ot_module_tempdeck999",
             ModuleAtPort(port="/dev/ot_module_tempdeck999", name="tempdeck"),
         ),
-        ("/dev/ot_module_heatershaker0.tmp-c166:0", None),
+        (
+            "/dev/ot_module_heatershaker0.tmp-c166:0",
+            ModuleAtPort(port="/dev/ot_module_heatershaker0", name="heatershaker"),
+        ),
     ],
 )
 def test_port_filtering(portname: str, result: Optional[ModuleAtPort]) -> None:

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -1,7 +1,7 @@
 """Tests for opentrons.hardware_control.module_control."""
 import pytest
 from decoy import Decoy, matchers
-from typing import Awaitable, Callable, cast
+from typing import Awaitable, Callable, cast, Optional
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.rpi_drivers.interfaces import USBDriverInterface
@@ -130,3 +130,31 @@ async def test_register_modules_sort(
     result = subject.available_modules
 
     assert result == [module_2, module_1, module_4, module_3]
+
+
+@pytest.mark.parametrize(
+    "portname,result",
+    [
+        (
+            "ot_module_magdeck0",
+            ModuleAtPort(port="/dev/ot_module_magdeck0", name="magdeck"),
+        ),
+        ("ot_module_magdeck0.tmp-c166:0", None),
+        (
+            "ot_module_thermocycler2",
+            ModuleAtPort(port="/dev/ot_module_thermocycler2", name="thermocycler"),
+        ),
+        ("/dev/asdasfasd", None),
+        (
+            "ot_module_heatershaker29",
+            ModuleAtPort(port="/dev/ot_module_heatershaker29", name="heatershaker"),
+        ),
+        ("ot_module_tempdeck1000.tmp-c166:0", None),
+        (
+            "ot_module_tempdeck1000",
+            ModuleAtPort(port="/dev/ot_module_tempdeck1000", name="tempdeck"),
+        ),
+    ],
+)
+def test_port_filtering(portname: str, result: Optional[ModuleAtPort]) -> None:
+    assert AttachedModulesControl.get_module_at_port(portname) == result

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -154,6 +154,11 @@ async def test_register_modules_sort(
             "ot_module_tempdeck1000",
             ModuleAtPort(port="/dev/ot_module_tempdeck1000", name="tempdeck"),
         ),
+        (
+            "/dev/ot_module_tempdeck999",
+            ModuleAtPort(port="/dev/ot_module_tempdeck999", name="tempdeck"),
+        ),
+        ("/dev/ot_module_heatershaker0.tmp-c166:0", None),
     ],
 )
 def test_port_filtering(portname: str, result: Optional[ModuleAtPort]) -> None:

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -17,7 +17,7 @@ scp -i $(2) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
 ssh -i $(2) $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
-cd /usr/lib/python3.7/site-packages &&\
+cd /usr/lib/python3.10/site-packages &&\
 unzip -o /data/$(notdir $(4)) && cleanup || cleanup"
 endef
 


### PR DESCRIPTION
On the buildroot update, inotify now gives us notifications for kernel-created "tempnode" variants of the serial `/dev` entries that we normally bind to modules. These are meant to exist to give userspace a chance to handle new devices before the kernel does and before other udev rules fire. Unfortunately, they're named by just appending `.tmp-{TYPE}{MAJOR}:{MINOR}` to whatever is about to be created, so when we try and create e.g. `/dev/ot_module_magdeck0` udev will helpfully first create `/dev/ot_module_magdeck0.tmp-c122:0`, which inotify sees and tells us about, and which matches our module regex, so we try to create a module on it. Unfortunately, that device only exists for an _extremely_ short period of time, and by the time we try and create the module (which we shouldn't be doing anyway) it's gone and we get an exception.

The fix for this is to add the capability for the module parser to recognize these tempnode paths and discard the extension. Since tempnodes get created just ahead of the actual symlink, we can rely on the matching symlink to be present.

# Changelog
- Add an extra recognizer for the tepmpnode to our module recognition regex
- Add tests for the module recognition regexp
- Update `push` makescript to push to `/usr/lib/python3.10` instead of `/usr/lib/python3.7` so you can actually push things

# Review requests

- [ ] Is this enough comments for the regex?
- [x] Does this now allow modules to actually connect on buildroot-update machines?


# Risk assessment

Medium - should be pretty straightforward and fix an exception that wasn't previously there, so pretty hard to cause a regression

Closes RQA-296