### PR TITLE
fix(api): ensure module polling waits for full poll to notify

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -48,7 +48,7 @@ class SimulatingDriver(AbstractThermocyclerDriver):
     ) -> None:
         self._plate_temperature.target = temp
         self._plate_temperature.current = temp
-        self._plate_temperature.hold = hold_time
+        self._plate_temperature.hold = 0
 
     async def get_plate_temperature(self) -> PlateTemperature:
         return self._plate_temperature

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -279,7 +279,7 @@ class HeaterShaker(mod_abc.AbstractModule):
     async def await_temperature(self, awaiting_temperature: float) -> None:
         """Await temperature in degreess Celsius.
 
-        Polls the Temperature Module's current temperature until
+        Polls the Heater-Shaker's current temperature until
         the specified temperature is reached. If `awaiting_temperature`
         is different than the current target temperature,
         the resulting behavior may be unpredictable.

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -1,15 +1,17 @@
+from __future__ import annotations
+
 import asyncio
 import logging
-from dataclasses import dataclass
 from typing import Optional, Mapping
 from typing_extensions import Final
+
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.heater_shaker.driver import HeaterShakerDriver
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 from opentrons.hardware_control.execution_manager import ExecutionManager
-from opentrons.hardware_control.poller import Reader, WaitableListener, Poller
+from opentrons.hardware_control.poller import Reader, Poller
 from opentrons.hardware_control.modules import mod_abc, update
 from opentrons.hardware_control.modules.types import (
     ModuleType,
@@ -73,16 +75,20 @@ class HeaterShaker(mod_abc.AbstractModule):
             driver = SimulatingDriver()
             polling_period = SIMULATING_POLL_PERIOD
 
-        mod = cls(
+        device_info = await driver.get_device_info()
+        reader = HeaterShakerReader(driver=driver)
+        poller = Poller(reader=reader, interval=polling_period)
+
+        return cls(
             port=port,
             usb_port=usb_port,
+            device_info=device_info,
             execution_manager=execution_manager,
             driver=driver,
-            device_info=await driver.get_device_info(),
+            reader=reader,
+            poller=poller,
             loop=loop,
-            polling_period=polling_period,
         )
-        return mod
 
     def __init__(
         self,
@@ -90,8 +96,9 @@ class HeaterShaker(mod_abc.AbstractModule):
         usb_port: USBPort,
         execution_manager: ExecutionManager,
         driver: AbstractHeaterShakerDriver,
+        reader: HeaterShakerReader,
+        poller: Poller,
         device_info: Mapping[str, str],
-        polling_period: float,
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         super().__init__(
@@ -99,16 +106,12 @@ class HeaterShaker(mod_abc.AbstractModule):
         )
         self._device_info = device_info
         self._driver = driver
-        self._listener = HeaterShakerListener(loop=loop)
-        self._poller = Poller(
-            reader=PollerReader(driver=self._driver),
-            interval_seconds=polling_period,
-            listener=self._listener,
-        )
+        self._reader = reader
+        self._poller = poller
 
     async def cleanup(self) -> None:
         """Stop the poller task"""
-        await self._poller.stop_and_wait()
+        await self._poller.stop()
 
     @classmethod
     def name(cls) -> str:
@@ -176,9 +179,10 @@ class HeaterShaker(mod_abc.AbstractModule):
     def bootloader(self) -> UploadFunction:
         return update.upload_via_dfu
 
+    # TODO(mc, 2022-10-08): not publicly used; remove
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete."""
-        await self._listener.wait_next_poll()
+        await self._poller.wait_next_poll()
 
     @property
     def device_info(self) -> Mapping[str, str]:
@@ -197,44 +201,44 @@ class HeaterShaker(mod_abc.AbstractModule):
                 "targetTemp": self.target_temperature,
                 "currentSpeed": self.speed,
                 "targetSpeed": self.target_speed,
-                "errorDetails": self._listener.state.error,
+                "errorDetails": self._reader.error,
             },
         }
 
     @property
     def temperature(self) -> float:
-        return self._listener.state.temperature.current
+        return self._reader.temperature.current
 
     @property
     def target_temperature(self) -> Optional[float]:
-        return self._listener.state.temperature.target
+        return self._reader.temperature.target
 
     @property
     def speed(self) -> int:
-        return self._listener.state.rpm.current
+        return self._reader.rpm.current
 
     @property
     def target_speed(self) -> Optional[int]:
-        return self._listener.state.rpm.target
+        return self._reader.rpm.target
 
     @property
     def temperature_status(self) -> TemperatureStatus:
-        return self._get_temperature_status(self._listener.state.temperature)
+        return self._get_temperature_status(self._reader.temperature)
 
     @property
     def speed_status(self) -> SpeedStatus:
-        return self._get_speed_status(self._listener.state.rpm)
+        return self._get_speed_status(self._reader.rpm)
 
     @property
     def labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
-        return self._listener.state.labware_latch
+        return self._reader.labware_latch
 
     @property
     def status(self) -> HeaterShakerStatus:
         """Module status or error state details."""
         # TODO (spp, 2022-2-22): Does this make sense as the overarching 'status'?
         #  Or maybe consolidate the above 3 statuses into this one?
-        if self._listener.state.error:
+        if self._reader.error:
             return HeaterShakerStatus.ERROR
         elif (
             self.temperature_status == TemperatureStatus.IDLE
@@ -250,7 +254,7 @@ class HeaterShaker(mod_abc.AbstractModule):
 
     async def start_set_temperature(self, celsius: float) -> None:
         """
-        Set temperature in degree Celsius
+        Set temperature in degrees Celsius
 
         Range: Room temperature to 90 degree Celsius
                Any temperature above the value will be clipped to
@@ -267,20 +271,15 @@ class HeaterShaker(mod_abc.AbstractModule):
 
         """
         await self.wait_for_is_running()
-
-        # TODO(mc, 2022-06-14); this common "set and wait for the next poll" pattern
-        # exists so `self.target_...`  immediately after a `_driver.set_...` works.
-        # This is fraught, and probably still open to race conditions.
-        # Re-think this pattern, potentially even at the driver/firmware level
         await self._driver.set_temperature(celsius)
-        await self.wait_next_poll()
+        await self._reader.read_temperature()
 
     # TODO(mc, 2022-10-10): remove `awaiting_temperature` argument,
     # and instead, wait until status is holding
     async def await_temperature(self, awaiting_temperature: float) -> None:
-        """Await temperature in degrees Celsius.
+        """Await temperature in degreess Celsius.
 
-        Polls temperature module's current temperature until
+        Polls the Temperature Module's current temperature until
         the specified temperature is reached. If `awaiting_temperature`
         is different than the current target temperature,
         the resulting behavior may be unpredictable.
@@ -289,15 +288,18 @@ class HeaterShaker(mod_abc.AbstractModule):
             return
 
         await self.wait_for_is_running()
-        await self.wait_next_poll()
+        await self._reader.read_temperature()
 
         async def _await_temperature() -> None:
-            if self.temperature_status == TemperatureStatus.HEATING:
+            if awaiting_temperature is None:
+                while self.temperature_status != TemperatureStatus.HOLDING:
+                    await self._poller.wait_next_poll()
+            elif self.temperature_status == TemperatureStatus.HEATING:
                 while self.temperature < awaiting_temperature:
-                    await self.wait_next_poll()
+                    await self._poller.wait_next_poll()
             elif self.temperature_status == TemperatureStatus.COOLING:
                 while self.temperature > awaiting_temperature:
-                    await self.wait_next_poll()
+                    await self._poller.wait_next_poll()
 
         t = self._loop.create_task(_await_temperature())
         self.make_cancellable(t)
@@ -316,12 +318,12 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_rpm(rpm)
-        await self.wait_next_poll()
+        await self._reader.read_rpm()
 
         async def _wait() -> None:
             # Wait until we reach the target speed.
             while self.speed_status != SpeedStatus.HOLDING:
-                await self.wait_next_poll()
+                await self._poller.wait_next_poll()
 
         task = self._loop.create_task(_wait())
         self.make_cancellable(task)
@@ -332,12 +334,12 @@ class HeaterShaker(mod_abc.AbstractModule):
     ) -> None:
         """Wait until the hardware reports the labware latch status matches."""
         while self.labware_latch_status != status:
-            await self.wait_next_poll()
+            await self._poller.wait_next_poll()
 
     async def _wait_for_shake_deactivation(self) -> None:
         """Wait until hardware reports that module has stopped shaking and has homed."""
         while self.speed_status != SpeedStatus.IDLE:
-            await self.wait_next_poll()
+            await self._poller.wait_next_poll()
 
     async def deactivate(self) -> None:
         """Stop heating/cooling; stop shaking and home the plate"""
@@ -348,7 +350,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """Stop heating/cooling"""
         await self.wait_for_is_running()
         await self._driver.deactivate_heater()
-        await self.wait_next_poll()
+        await self._reader.read_temperature()
 
     async def deactivate_shaker(self) -> None:
         """Stop shaking and home the plate"""
@@ -367,77 +369,48 @@ class HeaterShaker(mod_abc.AbstractModule):
         await self._wait_for_labware_latch(HeaterShakerLabwareLatchStatus.IDLE_CLOSED)
 
     async def prep_for_update(self) -> str:
-        await self._poller.stop_and_wait()
+        await self._poller.stop()
         await self._driver.enter_programming_mode()
         dfu_info = await update.find_dfu_device(pid=DFU_PID, expected_device_count=2)
         return dfu_info
 
 
-@dataclass
-class PollResult:
+class HeaterShakerReader(Reader):
     temperature: Temperature
     rpm: RPM
     labware_latch: HeaterShakerLabwareLatchStatus
-
-
-@dataclass
-class ListenerState(PollResult):
     error: Optional[str]
 
-
-class PollerReader(Reader[PollResult]):
-    """Polled data reader."""
-
     def __init__(self, driver: AbstractHeaterShakerDriver) -> None:
-        """Constructor."""
+        self.temperature = Temperature(current=25, target=None)
+        self.rpm = RPM(current=0, target=None)
+        self.labware_latch = HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN
+        self.error: Optional[str] = None
         self._driver = driver
 
-    async def read(self) -> PollResult:
-        """Poll the heater-shaker."""
+    async def read(self) -> None:
+        await self.read_temperature()
+        await self.read_rpm()
+        await self.read_labware_latch()
+        self._set_error(None)
 
-        return PollResult(
-            temperature=await self._driver.get_temperature(),
-            rpm=await self._driver.get_rpm(),
-            labware_latch=await self._driver.get_labware_latch_status(),
-        )
+    def on_error(self, exception: Exception) -> None:
+        self._set_error(exception)
 
+    async def read_temperature(self) -> None:
+        self.temperature = await self._driver.get_temperature()
 
-class HeaterShakerListener(WaitableListener[PollResult]):
-    """Heater-Shaker state listener."""
+    async def read_rpm(self) -> None:
+        self.rpm = await self._driver.get_rpm()
 
-    def __init__(
-        self,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-    ) -> None:
-        """Constructor."""
-        super().__init__(loop=loop)
-        self._state = ListenerState(
-            temperature=Temperature(current=25, target=None),
-            rpm=RPM(current=0, target=None),
-            labware_latch=HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN,
-            error=None,
-        )
+    async def read_labware_latch(self) -> None:
+        self.labware_latch = await self._driver.get_labware_latch_status()
 
-    @staticmethod
-    def _exc_to_errorstr(exc: Exception) -> str:
-        try:
-            return str(exc.args[0])
-        except Exception:
-            return repr(exc)
-
-    @property
-    def state(self) -> ListenerState:
-        return self._state
-
-    def on_poll(self, result: PollResult) -> None:
-        """On new poll."""
-        self._state.temperature = result.temperature
-        self._state.rpm = result.rpm
-        self._state.labware_latch = result.labware_latch
-        self._state.error = None
-        return super().on_poll(result)
-
-    def on_error(self, exc: Exception) -> None:
-        """On error."""
-        self._state.error = self._exc_to_errorstr(exc)
-        super().on_error(exc)
+    def _set_error(self, exception: Optional[Exception]) -> None:
+        if exception is None:
+            self.error = None
+        else:
+            try:
+                self.error = str(exception.args[0])
+            except Exception:
+                self.error = repr(exception)

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -277,7 +277,7 @@ class HeaterShaker(mod_abc.AbstractModule):
     # TODO(mc, 2022-10-10): remove `awaiting_temperature` argument,
     # and instead, wait until status is holding
     async def await_temperature(self, awaiting_temperature: float) -> None:
-        """Await temperature in degreess Celsius.
+        """Await temperature in degrees Celsius.
 
         Polls the Heater-Shaker's current temperature until
         the specified temperature is reached. If `awaiting_temperature`

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -291,10 +291,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         await self._reader.read_temperature()
 
         async def _await_temperature() -> None:
-            if awaiting_temperature is None:
-                while self.temperature_status != TemperatureStatus.HOLDING:
-                    await self._poller.wait_next_poll()
-            elif self.temperature_status == TemperatureStatus.HEATING:
+            if self.temperature_status == TemperatureStatus.HEATING:
                 while self.temperature < awaiting_temperature:
                     await self._poller.wait_next_poll()
             elif self.temperature_status == TemperatureStatus.COOLING:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -369,18 +369,11 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         await self._reader.read_block_temperature()
 
-        # if self.is_simulated:
-        #     return
-
         while self._reader.block_temperature_status != TemperatureStatus.HOLDING:
             await self.wait_next_poll()
 
         while self.hold_time is not None and self.hold_time > 0:
-            if self.hold_time < self._poller.interval:
-                await asyncio.sleep(self.hold_time)
-                await self._reader.read_block_temperature()
-            else:
-                await self.wait_next_poll()
+            await self.wait_next_poll()
 
     async def _wait_for_lid_status(self, status: ThermocyclerLidStatus) -> None:
         """Wait for lid status to be status."""
@@ -389,6 +382,7 @@ class Thermocycler(mod_abc.AbstractModule):
         while self.lid_status != status:
             await self.wait_next_poll()
 
+    # TODO(mc, 2022-10-08): not publicly used; remove
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete."""
         try:
@@ -398,7 +392,7 @@ class Thermocycler(mod_abc.AbstractModule):
 
     @property
     def lid_target(self) -> Optional[float]:
-        return self._reader.lid_temperature.target if self._reader else None
+        return self._reader.lid_temperature.target
 
     # TODO(mc, 2022-10-10): update type signature to non-optional
     @property

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -320,7 +320,7 @@ class Thermocycler(mod_abc.AbstractModule):
         await task
 
     async def wait_for_lid_target(self) -> None:
-        """Set the lid temperature in degres Celsius"""
+        """Set the lid temperature in degrees Celsius"""
         await self.wait_for_is_running()
 
         task = self._loop.create_task(self._wait_for_lid_target())

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -1,155 +1,74 @@
 import asyncio
-from abc import abstractmethod, ABC
-from collections import deque
-from typing import TypeVar, Generic, Deque, Optional
 import logging
+from abc import ABC, abstractmethod
+from typing import List
 
-DataT = TypeVar("DataT")
+
 log = logging.getLogger(__name__)
 
 
-class Reader(ABC, Generic[DataT]):
-    """Interface of poller target."""
-
+class Reader(ABC):
     @abstractmethod
-    async def read(self) -> DataT:
-        """
-        Read a new poll sample.
+    async def read(self) -> None:
+        """Read some data from an external source."""
 
-        Returns: The next poll result.
-        """
-        ...
-
-
-class Listener(ABC, Generic[DataT]):
-    """Interface of poller listener"""
-
-    @abstractmethod
-    def on_poll(self, result: DataT) -> None:
-        """
-        Called by poller notifying result of new poll.
-
-        Args:
-            result: The latest poll result.
-
-        Returns: None
-        """
-        ...
-
-    @abstractmethod
     def on_error(self, exception: Exception) -> None:
-        """
-        Called by poller to notify of a poll error.
-
-        Args:
-            exception: The raised exception
-
-        Returns: None
-        """
-        ...
-
-    @abstractmethod
-    def on_terminated(self) -> None:
-        """
-        Called by poller when it is terminating.
-
-        Returns: None
-        """
-        ...
+        """Handle an error from calling `read`."""
 
 
-class WaitableListener(Listener[DataT]):
-    """A listener that can be waited on."""
+class Poller:
+    """A poller to call a given reader on an interval.
 
-    def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
-        """Constructor."""
-        self._loop = loop or asyncio.get_running_loop()
-        self._futures: Deque["asyncio.Future[DataT]"] = deque()
+    Args:
+        reader: An interface to read data.
+        interval: The poll interval, in seconds.
+        on_error: An optional callback to trigger if a poll raises an error.
+    """
 
-    async def wait_next_poll(self) -> DataT:
-        """
-        Wait for the next poll.
+    interval: float
 
-        Returns: The next poll result.
-        """
-        f: "asyncio.Future[DataT]" = self._loop.create_future()
-        self._futures.append(f)
-        return await f
-
-    def on_poll(self, result: DataT) -> None:
-        """Handle a new poll"""
-        self._notify(result)
-
-    def on_error(self, exc: Exception) -> None:
-        """Handle a poller error."""
-        self._cancel(exc)
-
-    def on_terminated(self) -> None:
-        """Handle the poller finishing up."""
-        self._cancel(Exception("Poller has terminated."))
-
-    def _notify(self, val: DataT) -> None:
-        """Notify all futures of a new poll result."""
-        while self._futures:
-            f = self._futures.popleft()
-            if not f.done():
-                f.set_result(val)
-
-    def _cancel(self, exc: Exception) -> None:
-        """Notify all futures of an error."""
-        while self._futures:
-            f = self._futures.popleft()
-            if not f.done():
-                f.set_exception(exc)
-
-
-class Poller(Generic[DataT]):
-    """Asyncio poller."""
-
-    def __init__(
-        self,
-        interval_seconds: float,
-        reader: Reader[DataT],
-        listener: Listener[DataT],
-    ) -> None:
-        """
-        Constructor.
-
-        Args:
-            interval_seconds: time in between polls.
-            reader: The data reader.
-            listener: event listener.
-        """
-        self._shutdown_event = asyncio.Event()
-        self._interval = interval_seconds
-        self._listener = listener
+    def __init__(self, reader: Reader, interval: float) -> None:
+        self.interval = interval
         self._reader = reader
-        self._task = asyncio.create_task(self._poller())
+        self._poll_waiters: List["asyncio.Future[None]"] = []
+        self._poll_forever_task = asyncio.create_task(self._poll_forever())
 
-    def stop(self) -> None:
-        """Signal poller to stop."""
-        self._shutdown_event.set()
+    async def stop(self) -> None:
+        """Stop polling."""
+        self._poll_forever_task.cancel()
+        await asyncio.gather(self._poll_forever_task, return_exceptions=True)
 
-    async def stop_and_wait(self) -> None:
-        """Stop poller and wait for it to terminate."""
-        self.stop()
-        await self._task
+    async def wait_next_poll(self) -> None:
+        """Wait for the next poll to complete.
 
-    async def _poller(self) -> None:
-        """Poll task entrypoint."""
+        If called in the middle of a read, it will not return until
+        the next complete read. If a read raises an exception,
+        it will be passed through to `wait_next_poll`.
+        """
+        poll_future = asyncio.get_running_loop().create_future()
+        self._poll_waiters.append(poll_future)
+        await poll_future
+
+    async def _poll_forever(self) -> None:
+        """Polling loop."""
         while True:
-            try:
-                poll = await self._reader.read()
-                self._listener.on_poll(poll)
-            except Exception as e:
-                log.exception("Polling exception")
-                self._listener.on_error(e)
+            await self._poll_once()
+            await asyncio.sleep(self.interval)
 
-            try:
-                await asyncio.wait_for(self._shutdown_event.wait(), self._interval)
-            except asyncio.TimeoutError:
-                pass
-            else:
-                break
+    async def _poll_once(self) -> None:
+        """Trigger a single read, notifying listeners of success or error."""
+        previous_waiters = self._poll_waiters
+        self._poll_waiters = []
 
-        self._listener.on_terminated()
+        try:
+            await self._reader.read()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.exception("Polling exception")
+            self._reader.on_error(e)
+            for waiter in previous_waiters:
+                waiter.set_exception(e)
+        else:
+            for waiter in previous_waiters:
+                waiter.set_result(None)

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -22,7 +22,6 @@ class Poller:
     Args:
         reader: An interface to read data.
         interval: The poll interval, in seconds.
-        on_error: An optional callback to trigger if a poll raises an error.
     """
 
     interval: float

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
@@ -52,14 +52,14 @@ class WaitForBlockTemperatureImpl(
         )
 
         # Raises error if no target temperature
-        target_temperature = thermocycler_state.get_target_block_temperature()
+        thermocycler_state.get_target_block_temperature()
 
         thermocycler_hardware = self._equipment.get_module_hardware_api(
             thermocycler_state.module_id
         )
 
         if thermocycler_hardware is not None:
-            await thermocycler_hardware.wait_for_block_temperature(target_temperature)
+            await thermocycler_hardware.wait_for_block_target()
 
         return WaitForBlockTemperatureResult()
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
@@ -52,14 +52,14 @@ class WaitForLidTemperatureImpl(
         )
 
         # Raises error if no target temperature
-        target_temperature = thermocycler_state.get_target_lid_temperature()
+        thermocycler_state.get_target_lid_temperature()
 
         thermocycler_hardware = self._equipment.get_module_hardware_api(
             thermocycler_state.module_id
         )
 
         if thermocycler_hardware is not None:
-            await thermocycler_hardware.wait_for_lid_temperature(target_temperature)
+            await thermocycler_hardware.wait_for_lid_target()
 
         return WaitForLidTemperatureResult()
 

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -95,9 +95,8 @@ async def test_start_set_temperature_heat(tempdeck: TempDeck) -> None:
 async def test_deactivate(tempdeck: TempDeck) -> None:
     """It should deactivate and move to room temperature"""
     await tempdeck.deactivate()
-
-    # Wait for temperature to be reached
     await tempdeck.await_temperature(awaiting_temperature=23)
+
     assert tempdeck.live_data == {
         "status": "idle",
         "data": {"currentTemp": 23, "targetTemp": None},

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -129,8 +129,8 @@ async def test_wait_for_temperatures(thermocycler: Thermocycler) -> None:
     """It should wait for temperature and be at holding status"""
     await thermocycler.set_target_block_temperature(40.0)
     await thermocycler.set_target_lid_temperature(50.0)
-    await thermocycler.wait_for_block_temperature(temperature=40.0)
-    await thermocycler.wait_for_lid_temperature(temperature=50.0)
+    await thermocycler.wait_for_block_target()
+    await thermocycler.wait_for_lid_target()
     assert thermocycler.status == TemperatureStatus.HOLDING
     assert thermocycler.lid_temp_status == TemperatureStatus.HOLDING
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -5,7 +5,8 @@ import pytest
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.temp_deck import AbstractTempDeckDriver
-from opentrons.hardware_control import modules, ExecutionManager
+from opentrons.hardware_control import modules, poller, ExecutionManager
+from opentrons.hardware_control.modules.tempdeck import TempDeckReader
 
 
 @pytest.fixture
@@ -77,16 +78,18 @@ async def test_revision_model_parsing(subject: modules.AbstractModule):
 
 async def test_poll_error(usb_port: USBPort) -> None:
     mock_driver = AsyncMock(spec=AbstractTempDeckDriver)
-    mock_driver.get_temperature.side_effect = ValueError("hello!")
+    mock_reader = AsyncMock(spec=TempDeckReader)
+    mock_reader.read.side_effect = ValueError("hello!")
 
     tempdeck = modules.TempDeck(
         port="",
         usb_port=usb_port,
         execution_manager=AsyncMock(spec=ExecutionManager),
         driver=mock_driver,
+        reader=mock_reader,
+        poller=poller.Poller(reader=mock_reader, interval=0.1),
         device_info={},
         loop=asyncio.get_running_loop(),
-        polling_frequency=1,
     )
     with pytest.raises(ValueError, match="hello!"):
         await tempdeck.wait_next_poll()

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -42,19 +42,15 @@ async def test_sim_initialization(subject: modules.Thermocycler) -> None:
 
 async def test_lid(subject: modules.Thermocycler) -> None:
     await subject.open()
-    await subject.wait_next_poll()
     assert subject.lid_status == "open"
 
     await subject.close()
-    await subject.wait_next_poll()
     assert subject.lid_status == "closed"
 
     await subject.close()
-    await subject.wait_next_poll()
     assert subject.lid_status == "closed"
 
     await subject.open()
-    await subject.wait_next_poll()
     assert subject.lid_status == "open"
 
 
@@ -75,7 +71,6 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
     await subject.set_temperature(
         temperature=10, hold_time_seconds=None, hold_time_minutes=None, volume=50
     )
-    await subject.wait_next_poll()
     assert subject.temperature == 10
     assert subject.target == 10
     assert subject.status == "holding at target"
@@ -91,7 +86,6 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
     assert subject.lid_target == 80
 
     await subject.deactivate_lid()
-    await subject.wait_next_poll()
     assert subject.lid_temp == 23
     assert subject.lid_target is None
 
@@ -102,7 +96,6 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
     assert subject.lid_temp == 70
     assert subject.lid_target == 70
     await subject.deactivate()
-    await subject.wait_next_poll()
     assert subject.temperature == 23
     assert subject.target is None
     assert subject.status == "idle"
@@ -145,7 +138,7 @@ async def set_temperature_subject(
 ) -> AsyncGenerator[modules.Thermocycler, None]:
     """Fixture that spys on set_plate_temperature"""
     reader = ThermocyclerReader(driver=simulator_set_plate_spy)
-    poller = Poller(reader=reader, interval=0.1)
+    poller = Poller(reader=reader, interval=0.01)
 
     hw_tc = modules.Thermocycler(
         port="/dev/ot_module_sim_thermocycler0",
@@ -196,20 +189,6 @@ async def test_set_temperature_just_minutes_hold(
     just minutes."""
     await set_temperature_subject.set_temperature(40, hold_time_minutes=5.5)
     set_plate_temp_spy.assert_called_once_with(temp=40, hold_time=330, volume=None)
-
-
-async def test_set_temperature_fuzzy(
-    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
-) -> None:
-    """ "It should call set_plate_temperature with passed in hold time when under
-    fuzzy seconds."""
-    # Test hold_time < _hold_time_fuzzy_seconds. Here we know
-    # that wait_for_hold will be called with the direct hold
-    # time rather than increments of 0.1
-    set_temperature_subject._wait_for_hold = mock.AsyncMock()  # type: ignore[assignment]
-    await set_temperature_subject.set_temperature(40, hold_time_seconds=2)
-    set_temperature_subject._wait_for_hold.assert_called_once_with(2)
-    set_plate_temp_spy.assert_called_once_with(temp=40, hold_time=2, volume=None)
 
 
 async def test_cycle_temperature(

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -1,87 +1,33 @@
-import asyncio
-from typing import Callable
-
 import pytest
-from mock import AsyncMock, MagicMock
-from opentrons.hardware_control.poller import Poller, Listener, Reader, WaitableListener
+from decoy import Decoy, matchers
+from opentrons.hardware_control.poller import Poller, Reader
 
 
-async def test_poll_error() -> None:
-    """It should call error callback on error."""
-    exc = AssertionError()
-
-    async def raiser() -> None:
-        raise exc
-
-    reader = AsyncMock(spec=Reader)
-    reader.read.side_effect = raiser
-    listener = MagicMock(spec=Listener)
-
-    p: Poller[int] = Poller(interval_seconds=0.01, reader=reader, listener=listener)
-    await p.stop_and_wait()
-
-    listener.on_error.assert_called_once_with(exc)
-    listener.on_terminated.assert_called_once()
+@pytest.fixture
+def mock_reader(decoy: Decoy) -> Reader:
+    return decoy.mock(cls=Reader)
 
 
-async def test_notify() -> None:
-    """It should call on_poll with new result."""
-    reader = AsyncMock(spec=Reader)
-    reader.read.return_value = 23
-    listener = MagicMock(spec=Listener)
+async def test_poller(decoy: Decoy, mock_reader: Reader) -> None:
+    subject = Poller(reader=mock_reader, interval=0.1)
 
-    p: Poller[int] = Poller(interval_seconds=0.01, reader=reader, listener=listener)
-    await p.stop_and_wait()
+    await subject.wait_next_poll()
+    decoy.verify(await mock_reader.read(), times=1)
 
-    listener.on_poll.assert_called_once_with(23)
-    listener.on_terminated.assert_called_once()
+    await subject.wait_next_poll()
+    decoy.verify(await mock_reader.read(), times=2)
 
 
-async def test_await_poll_error() -> None:
-    """It should raise in wait_next_poll if reader raises."""
-    exc = AssertionError()
+async def test_poller_error(decoy: Decoy, mock_reader: Reader) -> None:
+    """It should raise if read errors"""
+    decoy.when(await mock_reader.read()).then_raise(RuntimeError("oh no"))
 
-    async def raiser() -> None:
-        raise exc
+    subject = Poller(reader=mock_reader, interval=0.1)
 
-    reader = AsyncMock(spec=Reader)
-    reader.read.side_effect = raiser
-    listener = WaitableListener[int]()
+    with pytest.raises(RuntimeError, match="oh no"):
+        await subject.wait_next_poll()
 
-    p: Poller[int] = Poller(interval_seconds=0.01, reader=reader, listener=listener)
-    with pytest.raises(exc.__class__):
-        await listener.wait_next_poll()
-    await p.stop_and_wait()
-
-
-@pytest.mark.parametrize(
-    argnames=["func"],
-    argvalues=[
-        [
-            # Notifies that a poll is complete
-            lambda x: x.on_poll(1)
-        ],
-        [
-            # Notifies that an error occurred
-            lambda x: x.on_error(ValueError("Hi!"))
-        ],
-        [
-            # Notifies poller terminated
-            lambda x: x.on_terminated()
-        ],
-    ],
-)
-async def test_on_poll_canceled_future(
-    func: Callable[[WaitableListener[int]], None]
-) -> None:
-    """It should ignore canceled futures"""
-    listener = WaitableListener[int]()
-    # Create a task that waits for a poll
-    task = asyncio.create_task(listener.wait_next_poll())
-    # Let it start
-    await asyncio.sleep(0.001)
-    # Cancel the task
-    task.cancel()
-    # Notify.
-    func(listener)
-    # There should be no exception
+    decoy.verify(
+        mock_reader.on_error(matchers.ErrorMatching(RuntimeError, match="oh no")),
+        times=1,
+    )

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -1,6 +1,12 @@
+import asyncio
+from typing import AsyncGenerator, Tuple
+
 import pytest
 from decoy import Decoy, matchers
 from opentrons.hardware_control.poller import Poller, Reader
+
+
+POLLING_INTERVAL = 0.1
 
 
 @pytest.fixture
@@ -8,21 +14,72 @@ def mock_reader(decoy: Decoy) -> Reader:
     return decoy.mock(cls=Reader)
 
 
-async def test_poller(decoy: Decoy, mock_reader: Reader) -> None:
-    subject = Poller(reader=mock_reader, interval=0.1)
+@pytest.fixture
+async def mock_reader_flow_control(
+    decoy: Decoy, mock_reader: Reader
+) -> Tuple[asyncio.Event, asyncio.Event]:
+    read_started_event = asyncio.Event()
+    ok_to_finish_read_event = asyncio.Event()
 
-    await subject.wait_next_poll()
+    async def _mock_read() -> None:
+        read_started_event.set()
+        ok_to_finish_read_event.clear()
+        await ok_to_finish_read_event.wait()
+
+    decoy.when(await mock_reader.read()).then_do(_mock_read)
+
+    return (read_started_event, ok_to_finish_read_event)
+
+
+@pytest.fixture
+async def subject(mock_reader: Reader) -> AsyncGenerator[Poller, None]:
+    """Create a poller, kicking off the interval and the first read."""
+    poller = Poller(reader=mock_reader, interval=POLLING_INTERVAL)
+    yield poller
+    await poller.stop()
+
+
+async def test_poller(decoy: Decoy, mock_reader: Reader, subject: Poller) -> None:
     decoy.verify(await mock_reader.read(), times=1)
 
     await subject.wait_next_poll()
     decoy.verify(await mock_reader.read(), times=2)
 
+    await subject.wait_next_poll()
+    decoy.verify(await mock_reader.read(), times=3)
 
-async def test_poller_error(decoy: Decoy, mock_reader: Reader) -> None:
+
+async def test_poller_concurrency(
+    mock_reader_flow_control: Tuple[asyncio.Event, asyncio.Event],
+    subject: Poller,
+) -> None:
+    """It should wait for a full poll before notifying."""
+    read_started_event, ok_to_finish_read_event = mock_reader_flow_control
+
+    # wait for the first read to start, then subscribe in the middle of the first read
+    await read_started_event.wait()
+    poll_notification = asyncio.create_task(subject.wait_next_poll())
+
+    # allow the first read to finish, then wait for the second read to start
+    read_started_event.clear()
+    ok_to_finish_read_event.set()
+    await read_started_event.wait()
+
+    # verify that our wait isn't done, because it was kicked off after the first read started
+    assert poll_notification.done() is False
+
+    # allow the second read to complete and wait for the third read to start
+    read_started_event.clear()
+    ok_to_finish_read_event.set()
+    await read_started_event.wait()
+
+    # verify the waiter has now been notified since it's been through the full second read
+    assert poll_notification.done() is True
+
+
+async def test_poller_error(decoy: Decoy, mock_reader: Reader, subject: Poller) -> None:
     """It should raise if read errors"""
     decoy.when(await mock_reader.read()).then_raise(RuntimeError("oh no"))
-
-    subject = Poller(reader=mock_reader, interval=0.1)
 
     with pytest.raises(RuntimeError, match="oh no"):
         await subject.wait_next_poll()

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -45,7 +45,7 @@ async def test_with_thermocycler():
             "currentCycleIndex": None,
             "currentStepIndex": None,
             "currentTemp": 3,
-            "holdTime": 121,
+            "holdTime": 0,
             "lid": "open",
             "lidTarget": None,
             "lidTemp": 23,
@@ -55,7 +55,7 @@ async def test_with_thermocycler():
             "totalCycleCount": None,
             "totalStepCount": None,
         },
-        "status": "heating",
+        "status": "holding at target",
     }
 
 

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_block_temperature.py
@@ -35,7 +35,6 @@ async def test_set_target_block_temperature(
         state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
     ).then_return(tc_module_substate)
 
-    decoy.when(tc_module_substate.get_target_block_temperature()).then_return(76.6)
     decoy.when(tc_module_substate.module_id).then_return(
         ThermocyclerModuleId("thermocycler-id")
     )
@@ -48,6 +47,7 @@ async def test_set_target_block_temperature(
     result = await subject.execute(data)
 
     decoy.verify(
-        await tc_hardware.wait_for_block_temperature(temperature=76.6), times=1
+        tc_module_substate.get_target_block_temperature(),
+        await tc_hardware.wait_for_block_target(),
     )
     assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_lid_temperature.py
@@ -35,7 +35,6 @@ async def test_set_target_block_temperature(
         state_view.modules.get_thermocycler_module_substate("input-thermocycler-id")
     ).then_return(tc_module_substate)
 
-    decoy.when(tc_module_substate.get_target_lid_temperature()).then_return(76.6)
     decoy.when(tc_module_substate.module_id).then_return(
         ThermocyclerModuleId("thermocycler-id")
     )
@@ -47,5 +46,8 @@ async def test_set_target_block_temperature(
 
     result = await subject.execute(data)
 
-    decoy.verify(await tc_hardware.wait_for_lid_temperature(temperature=76.6), times=1)
+    decoy.verify(
+        tc_module_substate.get_target_lid_temperature(),
+        await tc_hardware.wait_for_lid_target(),
+    )
     assert result == expected_result

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -105,8 +105,8 @@ class LidStatusAndRaiseSpec(NamedTuple):
             expected_raise_cm=pytest.raises(ThermocyclerNotOpenError),
         ),
         LidStatusAndRaiseSpec(
-            lid_status=None,
-            expected_raise_cm=pytest.raises(AssertionError),
+            lid_status=ThermocyclerLidStatus.UNKNOWN,
+            expected_raise_cm=pytest.raises(ThermocyclerNotOpenError),
         ),
         LidStatusAndRaiseSpec(
             lid_status=ThermocyclerLidStatus.OPEN,
@@ -115,7 +115,7 @@ class LidStatusAndRaiseSpec(NamedTuple):
     ],
 )
 async def test_raises_depending_on_thermocycler_hardware_lid_status(
-    lid_status: Optional[ThermocyclerLidStatus],
+    lid_status: ThermocyclerLidStatus,
     expected_raise_cm: ContextManager[Any],
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,


### PR DESCRIPTION
## Overview

This PR makes changes to how the HW API polls modules and updates its own state tracking of the hardware itself to remove concurrency bugs, increase responsiveness, and remove unnecessary code complexity. Resolves RET-1259

### Items investigated during development

- [x] Improve "disconnect on error" behavior of TC HW API
    - [x] Investigate why we disconnect driver and poller on error in existing code. Is it even necessary? (@pmoegenburg)
        - **Conclusion:** necessary for GEN1, not necessary for GEN2 (RET-1263)
- [x] (Maybe) rewrite some of the HW API unit tests to be strictly isolated unit tests rather than quasi-integration tests with partial mocking
    - **Conclusion:** not worth the effort, save this for a complete re-write
- [x] Validate that set and read is guaranteed to return the just-set value at a firmware level (@pmoegenburg)
    - [x] Heater-Shaker
    - [x] Temperature module
    - [x] Thermocycler gen1
    - [x] Thermocycler gen2
        - **Conclusion:** firmware behaves as expected: values are set immediately

## Changelog

- Calling `wait_next_poll` will now wait for the next _complete_ poll to finish
    - If `wait_next_poll` is called with a `read` is ongoing, it will be subscribed to the _next_ call to `read` rather than the current call 
- All module setters refactored to be more responsive and remove unnecessary complexity
    - Before: "set a target value and wait up to 1 second for the next poll to complete to update HW API state"
    - After: "set a target value and immediately read that value to update HW state"

## Review requests

We've been smoke testing this heavily on real hardware. The focus is on making sure all module reads and writes behave as expected. Pay special attention to any potential regression of #6392.

See ticket for a testing protocol written in Jupyter Notebook.

## Risk assessment

Medium, mitigated by:

- Thorough on-hardware testing
- The fact that this PR fixes removes code and complexity to fix the issue rather than adding code

**This PR will change the G-code that gets sent to modules.** Specifically, while write calls will remain unchanged, there will be slightly more read calls because, in addition to the poller, the HW API will now explicitly request at least one read per write 