### PR TITLE
refactor(api): move thermocycler hardware interactions to core

### DIFF
--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -138,11 +138,11 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
     """Core control interface for an attached Thermocycler Module."""
 
     @abstractmethod
-    def open_lid(self) -> str:
+    def open_lid(self) -> ThermocyclerLidStatus:
         """Open the Thermocycler's lid."""
 
     @abstractmethod
-    def close_lid(self) -> str:
+    def close_lid(self) -> ThermocyclerLidStatus:
         """Close the Thermocycler's lid."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -1,6 +1,6 @@
 """Core module control interfaces."""
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Optional, TypeVar, List
+from typing import Any, Generic, List, Optional, TypeVar
 
 from opentrons.drivers.types import (
     HeaterShakerLabwareLatchStatus,
@@ -139,11 +139,11 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
 
     @abstractmethod
     def open_lid(self) -> str:
-        """Open the thermocycler's lid."""
+        """Open the Thermocycler's lid."""
 
     @abstractmethod
     def close_lid(self) -> str:
-        """Close the thermocycler's lid."""
+        """Close the Thermocycler's lid."""
 
     @abstractmethod
     def set_target_block_temperature(
@@ -154,22 +154,16 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
     ) -> None:
         """Set the target temperature for the well block, in °C.
 
-        Valid operational range yet to be determined.
-
-        :param celsius: The target temperature, in °C.
-        :param hold_time_seconds: The number of seconds to hold, after reaching
-                                  ``temperature``, before proceeding to the
-                                  next command. If `not specified, the
-                                  Thermocycler will proceed to the next
-                                  command after ``temperature`` is reached.
-        :param block_max_volume: The maximum volume of any individual well
-                                 of the loaded labware. If not supplied,
-                                 the thermocycler will default to 25µL/well.
-
-        .. note:
-
+        Note:
             If ``hold_time_seconds`` is not specified, the Thermocycler
             will proceed to the next command after ``temperature`` is reached.
+        Args:
+            celsius: The target temperature, in °C.
+            hold_time_seconds: The number of seconds to hold, after reaching
+                ``temperature``, before proceeding to the next command.
+            block_max_volume: The maximum volume of any individual well
+                of the loaded labware. If not supplied, the thermocycler
+                will default to 25µL/well.
         """
 
     @abstractmethod
@@ -191,25 +185,24 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
         repetitions: int,
         block_max_volume: Optional[float] = None,
     ) -> None:
-        """Execute a Thermocycler Profile defined as a cycle of
-        ``steps`` to repeat for a given number of ``repetitions``.
+        """Execute a Thermocycler Profile.
 
-        :param steps: List of unique steps that make up a single cycle.
-                      Each list item should be a dictionary that maps to
-                      the parameters of the :py:meth:`set_block_temperature`
-                      method with keys 'temperature', 'hold_time_seconds',
-                      and 'hold_time_minutes'.
-        :param repetitions: The number of times to repeat the cycled steps.
-        :param block_max_volume: The maximum volume of any individual well
-                                 of the loaded labware. If not supplied,
-                                 the thermocycler will default to 25µL/well.
+        Profile defined as a cycle of ``steps`` to repeat for a given number of ``repetitions``
 
-        .. note:
-
+        Note:
             Unlike the :py:meth:`set_block_temperature`, either or both of
             'hold_time_minutes' and 'hold_time_seconds' must be defined
             and finite for each step.
-
+        Args:
+            steps: List of unique steps that make up a single cycle.
+                Each list item should be a dictionary that maps to
+                the parameters of the :py:meth:`set_block_temperature`
+                method with keys 'temperature', 'hold_time_seconds',
+                and 'hold_time_minutes'.
+            repetitions: The number of times to repeat the cycled steps.
+            block_max_volume: The maximum volume of any individual well
+                of the loaded labware. If not supplied, the thermocycler
+                will default to 25µL/well.
         """
 
     @abstractmethod
@@ -226,35 +219,35 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
 
     @abstractmethod
     def get_lid_position(self) -> Optional[ThermocyclerLidStatus]:
-        """Get the thermocycler's lid position."""
+        """Get the Thermocycler's lid position."""
 
     @abstractmethod
     def get_block_temperature_status(self) -> TemperatureStatus:
-        """Get the thermocycler's block temperature status."""
+        """Get the Thermocycler's block temperature status."""
 
     @abstractmethod
     def get_lid_temperature_status(self) -> Optional[TemperatureStatus]:
-        """Get the thermocycler's lid temperature status."""
+        """Get the Thermocycler's lid temperature status."""
 
     @abstractmethod
     def get_block_temperature(self) -> Optional[float]:
-        """Get the thermocycler's current block temperature in °C."""
+        """Get the Thermocycler's current block temperature in °C."""
 
     @abstractmethod
     def get_block_target_temperature(self) -> Optional[float]:
-        """Get the thermocycler's target block temperature in °C."""
+        """Get the Thermocycler's target block temperature in °C."""
 
     @abstractmethod
     def get_lid_temperature(self) -> Optional[float]:
-        """Get the thermocycler's current lid temperature in °C."""
+        """Get the Thermocycler's current lid temperature in °C."""
 
     @abstractmethod
     def get_lid_target_temperature(self) -> Optional[float]:
-        """Get the thermocycler's target lid temperature in °C."""
+        """Get the Thermocycler's target lid temperature in °C."""
 
     @abstractmethod
     def get_ramp_rate(self) -> Optional[float]:
-        """Get the thermocycler's current rampe rate in °C/sec."""
+        """Get the Thermocycler's current ramp rate in °C/sec."""
 
     @abstractmethod
     def get_hold_time(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -146,12 +146,10 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
         """Close the thermocycler's lid."""
 
     @abstractmethod
-    def set_block_temperature(
+    def set_target_block_temperature(
         self,
         celsius: float,
         hold_time_seconds: Optional[float] = None,
-        hold_time_minutes: Optional[float] = None,
-        ramp_rate: Optional[float] = None,
         block_max_volume: Optional[float] = None,
     ) -> None:
         """Set the target temperature for the well block, in °C.
@@ -159,36 +157,35 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
         Valid operational range yet to be determined.
 
         :param celsius: The target temperature, in °C.
-        :param hold_time_minutes: The number of minutes to hold, after reaching
-                                  ``temperature``, before proceeding to the
-                                  next command.
         :param hold_time_seconds: The number of seconds to hold, after reaching
                                   ``temperature``, before proceeding to the
-                                  next command. If ``hold_time_minutes`` and
-                                  ``hold_time_seconds`` are not specified,
-                                  the Thermocycler will proceed to the next
+                                  next command. If `not specified, the
+                                  Thermocycler will proceed to the next
                                   command after ``temperature`` is reached.
-        :param ramp_rate: The target rate of temperature change, in °C/sec.
-                          If ``ramp_rate`` is not specified, it will default
-                          to the maximum ramp rate as defined in the device
-                          configuration.
         :param block_max_volume: The maximum volume of any individual well
                                  of the loaded labware. If not supplied,
                                  the thermocycler will default to 25µL/well.
 
         .. note:
 
-            If ``hold_time_minutes`` and ``hold_time_seconds`` are not
-            specified, the Thermocycler will proceed to the next command
-            after ``temperature`` is reached.
+            If ``hold_time_seconds`` is not specified, the Thermocycler
+            will proceed to the next command after ``temperature`` is reached.
         """
 
     @abstractmethod
-    def set_lid_temperature(self, celsius: float) -> None:
+    def wait_for_block_temperature(self) -> None:
+        """Wait for target block temperature to be reached."""
+
+    @abstractmethod
+    def set_target_lid_temperature(self, celsius: float) -> None:
         """Set the target temperature for the heated lid, in °C."""
 
     @abstractmethod
-    def execute_profile(  # TODO name it this or cycle_temperatures?
+    def wait_for_lid_temperature(self) -> None:
+        """Wait for target lid temperature to be reached."""
+
+    @abstractmethod
+    def execute_profile(
         self,
         steps: List[ThermocyclerStep],
         repetitions: int,
@@ -224,20 +221,20 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
         """Turn off the well block temperature controller"""
 
     @abstractmethod
-    def deactivate(self) -> None:  # TODO do we need this in addition to the above two?
+    def deactivate(self) -> None:
         """Turn off the well block temperature controller, and heated lid"""
 
     @abstractmethod
     def get_lid_position(self) -> Optional[ThermocyclerLidStatus]:
-        """Get the thermoycler's lid position."""
+        """Get the thermocycler's lid position."""
 
     @abstractmethod
     def get_block_temperature_status(self) -> TemperatureStatus:
-        """Get the thermoycler's block temperature status."""
+        """Get the thermocycler's block temperature status."""
 
     @abstractmethod
     def get_lid_temperature_status(self) -> Optional[TemperatureStatus]:
-        """Get the thermoycler's lid temperature status."""
+        """Get the thermocycler's lid temperature status."""
 
     @abstractmethod
     def get_block_temperature(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -138,11 +138,11 @@ class AbstractThermocyclerCore(AbstractModuleCore[LabwareCoreType]):
     """Core control interface for an attached Thermocycler Module."""
 
     @abstractmethod
-    def open_lid(self) -> None:
+    def open_lid(self) -> str:
         """Open the thermocycler's lid."""
 
     @abstractmethod
-    def close_lid(self) -> None:
+    def close_lid(self) -> str:
         """Close the thermocycler's lid."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -34,9 +34,7 @@ from ..module import (
     AbstractHeaterShakerCore,
 )
 
-# TODO I hate this
 from .labware import LabwareImplementation
-from ..labware import AbstractLabware
 from ...labware import Labware
 
 if TYPE_CHECKING:
@@ -363,7 +361,7 @@ class LegacyThermocyclerCore(
     def _get_fixed_trash(self) -> Labware:
         trash = self._protocol_core.get_fixed_trash()
 
-        if isinstance(trash, AbstractLabware):
+        if isinstance(trash, LabwareImplementation):
             trash = Labware(implementation=trash)
 
         return cast(Labware, trash)

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -238,13 +238,13 @@ class LegacyThermocyclerCore(
     _sync_module_hardware: SynchronousAdapter[hw_modules.Thermocycler]
     _geometry: ThermocyclerGeometry
 
-    def open_lid(self) -> str:
+    def open_lid(self) -> ThermocyclerLidStatus:
         """Open the thermocycler's lid."""
         self._prepare_for_lid_move()
         self._geometry.lid_status = self._sync_module_hardware.open()
         return self._geometry.lid_status
 
-    def close_lid(self) -> str:
+    def close_lid(self) -> ThermocyclerLidStatus:
         """Close the thermocycler's lid."""
         self._prepare_for_lid_move()
         self._geometry.lid_status = self._sync_module_hardware.close()

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -258,7 +258,7 @@ class LegacyThermocyclerCore(
     ) -> None:
         """Set the target temperature for the well block, in °C."""
         self._sync_module_hardware.set_target_block_temperature(
-            temperature=celsius,
+            celsius=celsius,
             hold_time_seconds=hold_time_seconds,
             volume=block_max_volume,
         )
@@ -269,7 +269,7 @@ class LegacyThermocyclerCore(
 
     def set_target_lid_temperature(self, celsius: float) -> None:
         """Set the target temperature for the heated lid, in °C."""
-        self._sync_module_hardware.set_target_lid_temperature(temperature=celsius)
+        self._sync_module_hardware.set_target_lid_temperature(celsius=celsius)
 
     def wait_for_lid_temperature(self) -> None:
         """Wait for target lid temperature to be reached."""

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -250,26 +250,30 @@ class LegacyThermocyclerCore(
         self._geometry.lid_status = self._sync_module_hardware.close()
         return self._geometry.lid_status
 
-    def set_block_temperature(
+    def set_target_block_temperature(
         self,
         celsius: float,
         hold_time_seconds: Optional[float] = None,
-        hold_time_minutes: Optional[float] = None,
-        ramp_rate: Optional[float] = None,
         block_max_volume: Optional[float] = None,
     ) -> None:
         """Set the target temperature for the well block, in °C."""
-        self._sync_module_hardware.set_temperature(
+        self._sync_module_hardware.set_target_block_temperature(
             temperature=celsius,
             hold_time_seconds=hold_time_seconds,
-            hold_time_minutes=hold_time_minutes,
-            ramp_rate=ramp_rate,
             volume=block_max_volume,
         )
 
-    def set_lid_temperature(self, celsius: float) -> None:
+    def wait_for_block_temperature(self) -> None:
+        """Wait for target block temperature to be reached."""
+        self._sync_module_hardware.wait_for_block_target()
+
+    def set_target_lid_temperature(self, celsius: float) -> None:
         """Set the target temperature for the heated lid, in °C."""
-        self._sync_module_hardware.set_lid_temperature(temperature=celsius)
+        self._sync_module_hardware.set_target_lid_temperature(temperature=celsius)
+
+    def wait_for_lid_temperature(self) -> None:
+        """Wait for target lid temperature to be reached."""
+        self._sync_module_hardware.wait_for_lid_target()
 
     def execute_profile(
         self,

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -455,13 +455,13 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def open_lid(self) -> str:
         """Opens the lid"""
-        return self._core.open_lid()
+        return self._core.open_lid().value
 
     @publish(command=cmds.thermocycler_close)
     @requires_version(2, 0)
     def close_lid(self) -> str:
         """Closes the lid"""
-        return self._core.close_lid()
+        return self._core.close_lid().value
 
     @publish(command=cmds.thermocycler_set_block_temp)
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -29,6 +29,7 @@ from .core.module import (
     AbstractModuleCore,
     AbstractTemperatureModuleCore,
     AbstractMagneticModuleCore,
+    AbstractThermocyclerCore,
     AbstractHeaterShakerCore,
 )
 from .core.well import AbstractWellCore
@@ -446,6 +447,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     # TODO(mc, 2022-02-05): this type annotation is misleading;
     # a SynchronousAdapter wrapper is actually passed in
     _module: modules.thermocycler.Thermocycler  # type: ignore[assignment]
+    _core: AbstractThermocyclerCore[AbstractLabware[AbstractWellCore]]
 
     def _get_fixed_trash(self) -> Labware:
         trash = self._protocol_core.get_fixed_trash()
@@ -633,77 +635,79 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def lid_position(self) -> Optional[str]:
         """Lid open/close status string"""
-        return self._module.lid_status
+        return self._core.get_lid_position()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def block_temperature_status(self) -> str:
-        return self._module.status
+        """Block temperature status string"""
+        return self._core.get_block_temperature_status()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_temperature_status(self) -> Optional[str]:
-        return self._module.lid_temp_status
+        """Lod temperature status string"""
+        return self._core.get_lid_temperature_status()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def block_temperature(self) -> Optional[float]:
         """Current temperature in degrees C"""
-        return self._module.temperature
+        return self._core.get_block_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def block_target_temperature(self) -> Optional[float]:
         """Target temperature in degrees C"""
-        return self._module.target
+        return self._core.get_block_target_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_temperature(self) -> Optional[float]:
         """Current temperature in degrees C"""
-        return self._module.lid_temp
+        return self._core.get_lid_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_target_temperature(self) -> Optional[float]:
         """Target temperature in degrees C"""
-        return self._module.lid_target
+        return self._core.get_lid_target_temperature()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def ramp_rate(self) -> Optional[float]:
         """Current ramp rate in degrees C/sec"""
-        return self._module.ramp_rate
+        return self._core.get_ramp_rate()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def hold_time(self) -> Optional[float]:
         """Remaining hold time in sec"""
-        return self._module.hold_time
+        return self._core.get_hold_time()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def total_cycle_count(self) -> Optional[int]:
         """Number of repetitions for current set cycle"""
-        return self._module.total_cycle_count
+        return self._core.get_total_cycle_count()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def current_cycle_index(self) -> Optional[int]:
         """Index of the current set cycle repetition"""
-        return self._module.current_cycle_index
+        return self._core.get_current_cycle_index()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def total_step_count(self) -> Optional[int]:
         """Number of steps within the current cycle"""
-        return self._module.total_step_count
+        return self._core.get_total_step_count()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def current_step_index(self) -> Optional[int]:
         """Index of the current step within the current cycle"""
-        return self._module.current_step_index
+        return self._core.get_current_step_index()
 
 
 class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -38,6 +38,7 @@ from .module_validation_and_errors import (
     validate_heater_shaker_speed,
 )
 from .labware import Labware
+from . import validation
 
 
 ENGAGE_HEIGHT_UNIT_CNV = 2
@@ -443,8 +444,6 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     .. versionadded:: 2.0
     """
 
-    # TODO(mc, 2022-02-05): this type annotation is misleading;
-    # a SynchronousAdapter wrapper is actually passed in
     _core: AbstractThermocyclerCore[AbstractLabware[AbstractWellCore]]
 
     def flag_unsafe_move(
@@ -502,13 +501,16 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             specified, the Thermocycler will proceed to the next command
             after ``temperature`` is reached.
         """
-        if hold_time_minutes is not None:
-            if hold_time_seconds is None:
-                hold_time_seconds = 0
-            hold_time_seconds += hold_time_minutes * 60
+        seconds = validation.ensure_hold_time_seconds(
+            seconds=hold_time_seconds, minutes=hold_time_minutes
+        )
+        # if hold_time_minutes is not None:
+        #     if hold_time_seconds is None:
+        #         hold_time_seconds = 0
+        #     hold_time_seconds += hold_time_minutes * 60
         self._core.set_target_block_temperature(
             celsius=temperature,
-            hold_time_seconds=hold_time_seconds,
+            hold_time_seconds=seconds,
             block_max_volume=block_max_volume,
         )
         self._core.wait_for_block_temperature()

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -504,10 +504,6 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         seconds = validation.ensure_hold_time_seconds(
             seconds=hold_time_seconds, minutes=hold_time_minutes
         )
-        # if hold_time_minutes is not None:
-        #     if hold_time_seconds is None:
-        #         hold_time_seconds = 0
-        #     hold_time_seconds += hold_time_minutes * 60
         self._core.set_target_block_temperature(
             celsius=temperature,
             hold_time_seconds=seconds,

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -595,7 +595,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_temperature_status(self) -> Optional[str]:
-        """Lod temperature status string"""
+        """Lid temperature status string"""
         return self._core.get_lid_temperature_status()
 
     @property  # type: ignore[misc]

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -502,13 +502,16 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             specified, the Thermocycler will proceed to the next command
             after ``temperature`` is reached.
         """
-        self._core.set_block_temperature(
+        if hold_time_minutes is not None:
+            if hold_time_seconds is None:
+                hold_time_seconds = 0
+            hold_time_seconds += hold_time_minutes * 60
+        self._core.set_target_block_temperature(
             celsius=temperature,
             hold_time_seconds=hold_time_seconds,
-            hold_time_minutes=hold_time_minutes,
-            ramp_rate=ramp_rate,
             block_max_volume=block_max_volume,
         )
+        self._core.wait_for_block_temperature()
 
     @publish(command=cmds.thermocycler_set_lid_temperature)
     @requires_version(2, 0)
@@ -524,7 +527,8 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             ``temperature`` has been reached.
 
         """
-        self._core.set_lid_temperature(celsius=42.0)
+        self._core.set_target_lid_temperature(celsius=42.0)
+        self._core.wait_for_lid_temperature()
 
     @publish(command=cmds.thermocycler_execute_profile)
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -527,7 +527,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             ``temperature`` has been reached.
 
         """
-        self._core.set_target_lid_temperature(celsius=42.0)
+        self._core.set_target_lid_temperature(celsius=temperature)
         self._core.wait_for_lid_temperature()
 
     @publish(command=cmds.thermocycler_execute_profile)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -10,7 +10,6 @@ from opentrons.broker import Broker
 from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
 from opentrons.hardware_control import SynchronousAdapter, modules
 from opentrons.hardware_control.modules import ModuleModel, types as module_types
-from opentrons.hardware_control.types import Axis
 from opentrons.commands import module_commands as cmds
 from opentrons.commands.publisher import CommandPublisher, publish
 from opentrons.protocols.api_support.types import APIVersion
@@ -446,45 +445,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
 
     # TODO(mc, 2022-02-05): this type annotation is misleading;
     # a SynchronousAdapter wrapper is actually passed in
-    _module: modules.thermocycler.Thermocycler  # type: ignore[assignment]
     _core: AbstractThermocyclerCore[AbstractLabware[AbstractWellCore]]
-
-    def _get_fixed_trash(self) -> Labware:
-        trash = self._protocol_core.get_fixed_trash()
-
-        if isinstance(trash, AbstractLabware):
-            trash = Labware(implementation=trash)
-
-        return cast(Labware, trash)
-
-    def _prepare_for_lid_move(self) -> None:
-        loaded_instruments = [
-            instr
-            for mount, instr in self._protocol_core.get_loaded_instruments().items()
-            if instr is not None
-        ]
-        try:
-            instr_impl = loaded_instruments[0]
-        except IndexError:
-            _log.warning(
-                "Cannot assure a safe gantry position to avoid colliding"
-                " with the lid of the Thermocycler Module."
-            )
-        else:
-            ctx_impl = self._protocol_core
-            hardware = ctx_impl.get_hardware()
-            hardware.retract(instr_impl.get_mount())
-            high_point = hardware.current_position(instr_impl.get_mount())
-            trash_top = self._get_fixed_trash().wells()[0].top()
-            safe_point = trash_top.point._replace(
-                z=high_point[Axis.by_mount(instr_impl.get_mount())]
-            )
-            instr_impl.move_to(
-                types.Location(safe_point, None),
-                force_direct=True,
-                minimum_z_height=None,
-                speed=None,
-            )
 
     def flag_unsafe_move(
         self, to_loc: types.Location, from_loc: types.Location
@@ -495,17 +456,13 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def open_lid(self) -> str:
         """Opens the lid"""
-        self._prepare_for_lid_move()
-        self.geometry.lid_status = self._module.open()  # type: ignore[assignment]
-        return self.geometry.lid_status
+        return self._core.open_lid()
 
     @publish(command=cmds.thermocycler_close)
     @requires_version(2, 0)
     def close_lid(self) -> str:
         """Closes the lid"""
-        self._prepare_for_lid_move()
-        self.geometry.lid_status = self._module.close()  # type: ignore[assignment]
-        return self.geometry.lid_status
+        return self._core.close_lid()
 
     @publish(command=cmds.thermocycler_set_block_temp)
     @requires_version(2, 0)
@@ -545,12 +502,12 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             specified, the Thermocycler will proceed to the next command
             after ``temperature`` is reached.
         """
-        self._module.set_temperature(
-            temperature=temperature,
+        self._core.set_block_temperature(
+            celsius=temperature,
             hold_time_seconds=hold_time_seconds,
             hold_time_minutes=hold_time_minutes,
             ramp_rate=ramp_rate,
-            volume=block_max_volume,
+            block_max_volume=block_max_volume,
         )
 
     @publish(command=cmds.thermocycler_set_lid_temperature)
@@ -567,7 +524,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             ``temperature`` has been reached.
 
         """
-        self._module.set_lid_temperature(temperature)
+        self._core.set_lid_temperature(celsius=42.0)
 
     @publish(command=cmds.thermocycler_execute_profile)
     @requires_version(2, 0)
@@ -597,39 +554,27 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             and finite for each step.
 
         """
-        if repetitions <= 0:
-            raise ValueError("repetitions must be a positive integer")
-        for step in steps:
-            if step.get("temperature") is None:
-                raise ValueError("temperature must be defined for each step in cycle")
-            hold_mins = step.get("hold_time_minutes")
-            hold_secs = step.get("hold_time_seconds")
-            if hold_mins is None and hold_secs is None:
-                raise ValueError(
-                    "either hold_time_minutes or hold_time_seconds must be"
-                    "defined for each step in cycle"
-                )
-        self._module.cycle_temperatures(
-            steps=steps, repetitions=repetitions, volume=block_max_volume
+        self._core.execute_profile(
+            steps=steps, repetitions=repetitions, block_max_volume=block_max_volume
         )
 
     @publish(command=cmds.thermocycler_deactivate_lid)
     @requires_version(2, 0)
     def deactivate_lid(self) -> None:
         """Turn off the heated lid"""
-        self._module.deactivate_lid()
+        self._core.deactivate_lid()
 
     @publish(command=cmds.thermocycler_deactivate_block)
     @requires_version(2, 0)
     def deactivate_block(self) -> None:
         """Turn off the well block temperature controller"""
-        self._module.deactivate_block()
+        self._core.deactivate_block()
 
     @publish(command=cmds.thermocycler_deactivate)
     @requires_version(2, 0)
     def deactivate(self) -> None:
         """Turn off the well block temperature controller, and heated lid"""
-        self._module.deactivate()
+        self._core.deactivate()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
@@ -96,3 +96,14 @@ def ensure_module_model(load_name: str) -> ModuleModel:
         )
 
     return model
+
+
+def ensure_hold_time_seconds(
+    seconds: Optional[float], minutes: Optional[float]
+) -> Optional[float]:
+    """Ensure that hold time is expressed in seconds, if seconds and/or minutes are provided."""
+    if minutes is not None:
+        if seconds is None:
+            seconds = 0
+        seconds += minutes * 60
+    return seconds

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -101,9 +101,9 @@ def ensure_module_model(load_name: str) -> ModuleModel:
 def ensure_hold_time_seconds(
     seconds: Optional[float], minutes: Optional[float]
 ) -> Optional[float]:
-    """Ensure that hold time is expressed in seconds, if seconds and/or minutes are provided."""
+    """Ensure that hold time is expressed in seconds."""
+    if seconds is None:
+        seconds = 0
     if minutes is not None:
-        if seconds is None:
-            seconds = 0
         seconds += minutes * 60
     return seconds

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -100,7 +100,7 @@ def ensure_module_model(load_name: str) -> ModuleModel:
 
 def ensure_hold_time_seconds(
     seconds: Optional[float], minutes: Optional[float]
-) -> Optional[float]:
+) -> float:
     """Ensure that hold time is expressed in seconds."""
     if seconds is None:
         seconds = 0

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -22,6 +22,7 @@ from opentrons.motion_planning.adjacent_slots_getters import (
     get_adjacent_slots,
 )
 
+from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.hardware_control.modules.types import (
     ModuleModel,
     ModuleType,
@@ -219,7 +220,7 @@ class ThermocyclerGeometry(ModuleGeometry):
             parent,
         )
         self._lid_height = lid_height
-        self._lid_status = "open"  # Needs to reflect true status
+        self._lid_status = ThermocyclerLidStatus.OPEN  # Needs to reflect true status
         self._configuration = configuration
         if self.is_semi_configuration:
             self._offset = self._offset + Point(-23.28, 0, 0)
@@ -238,7 +239,7 @@ class ThermocyclerGeometry(ModuleGeometry):
         return super().highest_z
 
     @property
-    def lid_status(self) -> str:
+    def lid_status(self) -> ThermocyclerLidStatus:
         return self._lid_status
 
     @lid_status.setter

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -335,30 +335,37 @@ def test_close_lid(
     assert result == "close"
 
 
-def test_set_block_temperature(
+def test_set_target_block_temperature(
     decoy: Decoy,
     mock_sync_module_hardware: SyncThermocyclerHardware,
     subject: LegacyThermocyclerCore,
 ) -> None:
     """It should set the block temperature with the hardware."""
-    subject.set_block_temperature(
+    subject.set_target_block_temperature(
         celsius=42.0,
         hold_time_seconds=1.2,
-        hold_time_minutes=3.4,
-        ramp_rate=5.6,
         block_max_volume=7.8,
     )
 
     decoy.verify(
-        mock_sync_module_hardware.set_temperature(
+        mock_sync_module_hardware.set_target_block_temperature(
             temperature=42.0,
             hold_time_seconds=1.2,
-            hold_time_minutes=3.4,
-            ramp_rate=5.6,
             volume=7.8,
         ),
         times=1,
     )
+
+
+def test_wait_for_block_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should wait for the block temperature with the hardware."""
+    subject.wait_for_block_temperature()
+
+    decoy.verify(mock_sync_module_hardware.wait_for_block_target(), times=1)
 
 
 def test_set_lid_temperature(
@@ -367,9 +374,20 @@ def test_set_lid_temperature(
     subject: LegacyThermocyclerCore,
 ) -> None:
     """It should set the lid temperature with the hardware."""
-    subject.set_lid_temperature(celsius=42.0)
+    subject.set_target_lid_temperature(celsius=42.0)
 
-    decoy.verify(mock_sync_module_hardware.set_lid_temperature(temperature=42.0))
+    decoy.verify(mock_sync_module_hardware.set_target_lid_temperature(temperature=42.0))
+
+
+def test_wait_for_lid_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should wait for the lid temperature with the hardware."""
+    subject.wait_for_lid_temperature()
+
+    decoy.verify(mock_sync_module_hardware.wait_for_lid_target(), times=1)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -344,14 +344,14 @@ def test_set_target_block_temperature(
     subject.set_target_block_temperature(
         celsius=42.0,
         hold_time_seconds=1.2,
-        block_max_volume=7.8,
+        block_max_volume=3.4,
     )
 
     decoy.verify(
         mock_sync_module_hardware.set_target_block_temperature(
-            temperature=42.0,
+            celsius=42.0,
             hold_time_seconds=1.2,
-            volume=7.8,
+            volume=3.4,
         ),
         times=1,
     )
@@ -368,7 +368,7 @@ def test_wait_for_block_temperature(
     decoy.verify(mock_sync_module_hardware.wait_for_block_target(), times=1)
 
 
-def test_set_lid_temperature(
+def test_set_target_lid_temperature(
     decoy: Decoy,
     mock_sync_module_hardware: SyncThermocyclerHardware,
     subject: LegacyThermocyclerCore,
@@ -376,7 +376,7 @@ def test_set_lid_temperature(
     """It should set the lid temperature with the hardware."""
     subject.set_target_lid_temperature(celsius=42.0)
 
-    decoy.verify(mock_sync_module_hardware.set_target_lid_temperature(temperature=42.0))
+    decoy.verify(mock_sync_module_hardware.set_target_lid_temperature(celsius=42.0))
 
 
 def test_wait_for_lid_temperature(

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -1,0 +1,218 @@
+"""Tests for the legacy Protocol API module core implementations."""
+import pytest
+from decoy import Decoy
+
+from opentrons.drivers.types import ThermocyclerLidStatus
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import Thermocycler, TemperatureStatus
+from opentrons.hardware_control.modules.types import (
+    ThermocyclerModuleModel,
+)
+from opentrons.protocols.geometry.module_geometry import ThermocyclerGeometry
+
+from opentrons.protocol_api.core.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
+from opentrons.protocol_api.core.protocol_api.legacy_module_core import (
+    LegacyThermocyclerCore,
+    create_module_core,
+)
+
+SyncThermocyclerHardware = SynchronousAdapter[Thermocycler]
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolContextImplementation:
+    """Get a mock protocol context implementation core."""
+    return decoy.mock(cls=ProtocolContextImplementation)
+
+
+@pytest.fixture
+def mock_geometry(decoy: Decoy) -> ThermocyclerGeometry:
+    """Get a mock thermocycler geometry."""
+    return decoy.mock(cls=ThermocyclerGeometry)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SyncThermocyclerHardware:
+    """Get a mock module hardware control interface."""
+    return decoy.mock(name="SyncThermocyclerHardware")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def subject(
+    mock_geometry: ThermocyclerGeometry,
+    mock_protocol_core: ProtocolContextImplementation,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+) -> LegacyThermocyclerCore:
+    """Get a legacy module implementation core with mocked out dependencies."""
+    return LegacyThermocyclerCore(
+        requested_model=ThermocyclerModuleModel.THERMOCYCLER_V1,
+        protocol_core=mock_protocol_core,
+        geometry=mock_geometry,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+
+def test_create(
+    decoy: Decoy,
+    mock_geometry: ThermocyclerGeometry,
+    mock_protocol_core: ProtocolContextImplementation,
+) -> None:
+    """It should be able to create a thermocycler module core."""
+    mock_module_hardware_api = decoy.mock(cls=Thermocycler)
+    result = create_module_core(
+        geometry=mock_geometry,
+        protocol_core=mock_protocol_core,
+        module_hardware_api=mock_module_hardware_api,
+        requested_model=ThermocyclerModuleModel.THERMOCYCLER_V1,
+    )
+
+    assert isinstance(result, LegacyThermocyclerCore)
+
+
+def test_get_lid_position(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current lid position."""
+    decoy.when(mock_sync_module_hardware.lid_status).then_return(
+        ThermocyclerLidStatus.OPEN
+    )
+    result = subject.get_lid_position()
+    assert result == "open"
+
+
+def test_get_block_temperature_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current block temperature status."""
+    decoy.when(mock_sync_module_hardware.status).then_return(TemperatureStatus.IDLE)
+    result = subject.get_block_temperature_status()
+    assert result == "idle"
+
+
+def test_get_lid_temperature_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current lid temperature status."""
+    decoy.when(mock_sync_module_hardware.lid_temp_status).then_return(
+        TemperatureStatus.IDLE
+    )
+    result = subject.get_lid_temperature_status()
+    assert result == "idle"
+
+
+def test_get_block_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current block temperature."""
+    decoy.when(mock_sync_module_hardware.temperature).then_return(12.3)
+    result = subject.get_block_temperature()
+    assert result == 12.3
+
+
+def test_get_block_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the target block temperature."""
+    decoy.when(mock_sync_module_hardware.target).then_return(12.3)
+    result = subject.get_block_target_temperature()
+    assert result == 12.3
+
+
+def test_get_lid_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current lid temperature."""
+    decoy.when(mock_sync_module_hardware.lid_temp).then_return(42.0)
+    result = subject.get_lid_temperature()
+    assert result == 42.0
+
+
+def test_get_lid_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current lid temperature."""
+    decoy.when(mock_sync_module_hardware.lid_target).then_return(42.0)
+    result = subject.get_lid_target_temperature()
+    assert result == 42.0
+
+
+def test_get_ramp_rate(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the ramp rate."""
+    decoy.when(mock_sync_module_hardware.ramp_rate).then_return(1.23)
+    result = subject.get_ramp_rate()
+    assert result == 1.23
+
+
+def test_get_hold_time(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the hold time."""
+    decoy.when(mock_sync_module_hardware.hold_time).then_return(13.37)
+    result = subject.get_hold_time()
+    assert result == 13.37
+
+
+def test_get_total_cycle_count(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the total cycle count."""
+    decoy.when(mock_sync_module_hardware.total_cycle_count).then_return(321)
+    result = subject.get_total_cycle_count()
+    assert result == 321
+
+
+def test_get_current_cycle_index(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current cycle index."""
+    decoy.when(mock_sync_module_hardware.current_cycle_index).then_return(123)
+    result = subject.get_current_cycle_index()
+    assert result == 123
+
+
+def test_get_total_step_count(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the total step count."""
+    decoy.when(mock_sync_module_hardware.total_step_count).then_return(1337)
+    result = subject.get_total_step_count()
+    assert result == 1337
+
+
+def test_get_current_step_index(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should report the current step index."""
+    decoy.when(mock_sync_module_hardware.current_step_index).then_return(42)
+    result = subject.get_current_step_index()
+    assert result == 42

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -118,7 +118,7 @@ def test_get_lid_position(
         ThermocyclerLidStatus.OPEN
     )
     result = subject.get_lid_position()
-    assert result == "open"
+    assert result == ThermocyclerLidStatus.OPEN
 
 
 def test_get_block_temperature_status(
@@ -129,7 +129,7 @@ def test_get_block_temperature_status(
     """It should report the current block temperature status."""
     decoy.when(mock_sync_module_hardware.status).then_return(TemperatureStatus.IDLE)
     result = subject.get_block_temperature_status()
-    assert result == "idle"
+    assert result == TemperatureStatus.IDLE
 
 
 def test_get_lid_temperature_status(
@@ -142,7 +142,7 @@ def test_get_lid_temperature_status(
         TemperatureStatus.IDLE
     )
     result = subject.get_lid_temperature_status()
-    assert result == "idle"
+    assert result == TemperatureStatus.IDLE
 
 
 def test_get_block_temperature(
@@ -261,6 +261,7 @@ def test_open_lid(
     mock_sync_hardware_api: SyncHardwareAPI,
     mock_protocol_core: ProtocolContextImplementation,
     mock_instrument_core: InstrumentContextImplementation,
+    mock_geometry: ThermocyclerGeometry,
     mock_labware: Labware,
     mock_well: Well,
     subject: LegacyThermocyclerCore,
@@ -291,6 +292,7 @@ def test_open_lid(
             minimum_z_height=None,
             speed=None,
         ),
+        decoy.prop(mock_geometry.lid_status).set("open"),
     )
     assert result == "open"
 
@@ -301,6 +303,7 @@ def test_close_lid(
     mock_sync_hardware_api: SyncHardwareAPI,
     mock_protocol_core: ProtocolContextImplementation,
     mock_instrument_core: InstrumentContextImplementation,
+    mock_geometry: ThermocyclerGeometry,
     mock_labware: Labware,
     mock_well: Well,
     subject: LegacyThermocyclerCore,
@@ -319,7 +322,7 @@ def test_close_lid(
         Location(point=Point(x=1, y=2, z=3), labware=mock_well)
     )
 
-    decoy.when(mock_sync_module_hardware.close()).then_return("close")
+    decoy.when(mock_sync_module_hardware.close()).then_return("closed")
 
     result = subject.close_lid()
 
@@ -331,8 +334,9 @@ def test_close_lid(
             minimum_z_height=None,
             speed=None,
         ),
+        decoy.prop(mock_geometry.lid_status).set("closed"),
     )
-    assert result == "close"
+    assert result == "closed"
 
 
 def test_set_target_block_temperature(

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -2,14 +2,20 @@
 import pytest
 from decoy import Decoy
 
+from typing import List
+
+from opentrons.types import Mount, Location, Point
 from opentrons.drivers.types import ThermocyclerLidStatus
-from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control import SynchronousAdapter, SyncHardwareAPI
+from opentrons.hardware_control.types import Axis
 from opentrons.hardware_control.modules import Thermocycler, TemperatureStatus
 from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,
+    ThermocyclerStep,
 )
 from opentrons.protocols.geometry.module_geometry import ThermocyclerGeometry
 
+from opentrons.protocol_api.labware import Labware, Well
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
 )
@@ -17,14 +23,27 @@ from opentrons.protocol_api.core.protocol_api.legacy_module_core import (
     LegacyThermocyclerCore,
     create_module_core,
 )
+from opentrons.protocol_api.core.protocol_api.instrument_context import (
+    InstrumentContextImplementation,
+)
 
 SyncThermocyclerHardware = SynchronousAdapter[Thermocycler]
 
 
 @pytest.fixture
-def mock_protocol_core(decoy: Decoy) -> ProtocolContextImplementation:
-    """Get a mock protocol context implementation core."""
-    return decoy.mock(cls=ProtocolContextImplementation)
+def mock_sync_hardware_api(decoy: Decoy) -> SyncHardwareAPI:
+    """Get a mock sync hardware API."""
+    return decoy.mock(cls=SyncHardwareAPI)
+
+
+@pytest.fixture
+def mock_protocol_core(
+    decoy: Decoy, mock_sync_hardware_api: SyncHardwareAPI
+) -> ProtocolContextImplementation:
+    """Get a mock protocol core."""
+    mock_protocol_core = decoy.mock(cls=ProtocolContextImplementation)
+    decoy.when(mock_protocol_core.get_hardware()).then_return(mock_sync_hardware_api)
+    return mock_protocol_core
 
 
 @pytest.fixture
@@ -37,6 +56,24 @@ def mock_geometry(decoy: Decoy) -> ThermocyclerGeometry:
 def mock_sync_module_hardware(decoy: Decoy) -> SyncThermocyclerHardware:
     """Get a mock module hardware control interface."""
     return decoy.mock(name="SyncThermocyclerHardware")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def mock_instrument_core(decoy: Decoy) -> InstrumentContextImplementation:
+    """Get a mock instrument core."""
+    return decoy.mock(cls=InstrumentContextImplementation)
+
+
+@pytest.fixture
+def mock_labware(decoy: Decoy) -> Labware:
+    """Get a mock labware."""
+    return decoy.mock(cls=Labware)
+
+
+@pytest.fixture
+def mock_well(decoy: Decoy) -> Well:
+    """Get a mock well."""
+    return decoy.mock(cls=Well)
 
 
 @pytest.fixture
@@ -216,3 +253,207 @@ def test_get_current_step_index(
     decoy.when(mock_sync_module_hardware.current_step_index).then_return(42)
     result = subject.get_current_step_index()
     assert result == 42
+
+
+def test_open_lid(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    mock_sync_hardware_api: SyncHardwareAPI,
+    mock_protocol_core: ProtocolContextImplementation,
+    mock_instrument_core: InstrumentContextImplementation,
+    mock_labware: Labware,
+    mock_well: Well,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should open the lid with the hardware."""
+    decoy.when(mock_protocol_core.get_loaded_instruments()).then_return(
+        {Mount.RIGHT: mock_instrument_core}
+    )
+    decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
+    decoy.when(mock_sync_hardware_api.current_position(Mount.RIGHT)).then_return(
+        {Axis.A: 4}
+    )
+    decoy.when(subject._get_fixed_trash()).then_return(mock_labware)
+    decoy.when(mock_labware.wells()).then_return([mock_well])
+    decoy.when(mock_well.top()).then_return(
+        Location(point=Point(x=1, y=2, z=3), labware=mock_well)
+    )
+
+    decoy.when(mock_sync_module_hardware.open()).then_return("open")
+
+    result = subject.open_lid()
+
+    decoy.verify(
+        mock_sync_hardware_api.retract(Mount.RIGHT),
+        mock_instrument_core.move_to(
+            Location(Point(x=1, y=2, z=4), None),
+            force_direct=True,
+            minimum_z_height=None,
+            speed=None,
+        ),
+    )
+    assert result == "open"
+
+
+def test_close_lid(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    mock_sync_hardware_api: SyncHardwareAPI,
+    mock_protocol_core: ProtocolContextImplementation,
+    mock_instrument_core: InstrumentContextImplementation,
+    mock_labware: Labware,
+    mock_well: Well,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should close the lid with the hardware."""
+    decoy.when(mock_protocol_core.get_loaded_instruments()).then_return(
+        {Mount.LEFT: mock_instrument_core}
+    )
+    decoy.when(mock_instrument_core.get_mount()).then_return(Mount.LEFT)
+    decoy.when(mock_sync_hardware_api.current_position(Mount.LEFT)).then_return(
+        {Axis.Z: 4}
+    )
+    decoy.when(subject._get_fixed_trash()).then_return(mock_labware)
+    decoy.when(mock_labware.wells()).then_return([mock_well])
+    decoy.when(mock_well.top()).then_return(
+        Location(point=Point(x=1, y=2, z=3), labware=mock_well)
+    )
+
+    decoy.when(mock_sync_module_hardware.close()).then_return("close")
+
+    result = subject.close_lid()
+
+    decoy.verify(
+        mock_sync_hardware_api.retract(Mount.LEFT),
+        mock_instrument_core.move_to(
+            Location(Point(x=1, y=2, z=4), None),
+            force_direct=True,
+            minimum_z_height=None,
+            speed=None,
+        ),
+    )
+    assert result == "close"
+
+
+def test_set_block_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should set the block temperature with the hardware."""
+    subject.set_block_temperature(
+        celsius=42.0,
+        hold_time_seconds=1.2,
+        hold_time_minutes=3.4,
+        ramp_rate=5.6,
+        block_max_volume=7.8,
+    )
+
+    decoy.verify(
+        mock_sync_module_hardware.set_temperature(
+            temperature=42.0,
+            hold_time_seconds=1.2,
+            hold_time_minutes=3.4,
+            ramp_rate=5.6,
+            volume=7.8,
+        ),
+        times=1,
+    )
+
+
+def test_set_lid_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should set the lid temperature with the hardware."""
+    subject.set_lid_temperature(celsius=42.0)
+
+    decoy.verify(mock_sync_module_hardware.set_lid_temperature(temperature=42.0))
+
+
+@pytest.mark.parametrize(
+    "steps",
+    [
+        [{"temperature": 42.0, "hold_time_minutes": 12.3, "hold_time_seconds": 45.6}],
+        [{"temperature": 42.0, "hold_time_seconds": 45.6}],
+        [{"temperature": 42.0, "hold_time_minutes": 12.3}],
+        [],
+    ],
+)
+def test_execute_profile(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    steps: List[ThermocyclerStep],
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should execute a valid profile with the hardware."""
+    subject.execute_profile(steps=steps, repetitions=12, block_max_volume=34.5)
+
+    decoy.verify(
+        mock_sync_module_hardware.cycle_temperatures(
+            steps=steps, repetitions=12, volume=34.5
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "repetitions",
+    [0, -1, -999],
+)
+def test_execute_profile_invalid_repetitions_raises(
+    repetitions: int,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should raise a ValueError when given non-positive repetition value."""
+    with pytest.raises(ValueError):
+        subject.execute_profile(steps=[], repetitions=repetitions)
+
+
+@pytest.mark.parametrize(
+    "steps",
+    [
+        [{"hold_time_minutes": 12.3, "hold_time_seconds": 45.6}],
+        [{"temperature": 42.0}],
+    ],
+)
+def test_execute_profile_invalid_steps_raises(
+    steps: List[ThermocyclerStep],
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should raise a ValueError when given invalid thermocycler profile steps."""
+    with pytest.raises(ValueError):
+        subject.execute_profile(steps=steps, repetitions=1)
+
+
+def test_deactivate_lid(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should turn off the heated lid with the hardware."""
+    subject.deactivate_lid()
+
+    decoy.verify(mock_sync_module_hardware.deactivate_lid(), times=1)
+
+
+def test_deactivate_block(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should turn off the well block temperature controller with the hardware."""
+    subject.deactivate_block()
+
+    decoy.verify(mock_sync_module_hardware.deactivate_block(), times=1)
+
+
+def test_deactivate(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: LegacyThermocyclerCore,
+) -> None:
+    """It should turn off the well block and lid temperature with the hardware."""
+    subject.deactivate()
+
+    decoy.verify(mock_sync_module_hardware.deactivate(), times=1)

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -292,9 +292,9 @@ def test_open_lid(
             minimum_z_height=None,
             speed=None,
         ),
-        decoy.prop(mock_geometry.lid_status).set("open"),
+        decoy.prop(mock_geometry.lid_status).set(ThermocyclerLidStatus.OPEN),
     )
-    assert result == "open"
+    assert result == ThermocyclerLidStatus.OPEN
 
 
 def test_close_lid(
@@ -334,9 +334,9 @@ def test_close_lid(
             minimum_z_height=None,
             speed=None,
         ),
-        decoy.prop(mock_geometry.lid_status).set("closed"),
+        decoy.prop(mock_geometry.lid_status).set(ThermocyclerLidStatus.CLOSED),
     )
-    assert result == "closed"
+    assert result == ThermocyclerLidStatus.CLOSED
 
 
 def test_set_target_block_temperature(

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -1,0 +1,172 @@
+"""Tests for Protocol API thermocycler module contexts."""
+import pytest
+from decoy import Decoy
+
+from opentrons.broker import Broker
+from opentrons.drivers.types import ThermocyclerLidStatus
+from opentrons.hardware_control.modules import TemperatureStatus
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, ThermocyclerContext
+
+from .types import ProtocolCore, ThermocyclerCore
+
+
+@pytest.fixture
+def mock_core(decoy: Decoy) -> ThermocyclerCore:
+    """Get a mock module implementation core."""
+    return decoy.mock(cls=ThermocyclerCore)
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol implementation core."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> Broker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def api_version() -> APIVersion:
+    """Get an API version to apply to the interface."""
+    return MAX_SUPPORTED_VERSION
+
+
+@pytest.fixture
+def subject(
+    api_version: APIVersion,
+    mock_core: ThermocyclerCore,
+    mock_protocol_core: ProtocolCore,
+    mock_broker: Broker,
+) -> ThermocyclerContext:
+    """Get a thermocycler module context with its dependencies mocked out."""
+    return ThermocyclerContext(
+        core=mock_core,
+        protocol_core=mock_protocol_core,
+        broker=mock_broker,
+        api_version=api_version,
+    )
+
+
+def test_get_lid_position(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the lid position status from the core."""
+    decoy.when(mock_core.get_lid_position()).then_return(ThermocyclerLidStatus.OPEN)
+    result = subject.lid_position
+    assert result == "open"
+
+
+def test_get_block_temperature_status(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the block temperature status from the core."""
+    decoy.when(mock_core.get_block_temperature_status()).then_return(
+        TemperatureStatus.IDLE
+    )
+    result = subject.block_temperature_status
+    assert result == "idle"
+
+
+def test_get_lid_temperature_status(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the lid temperature status from the core."""
+    decoy.when(mock_core.get_lid_temperature_status()).then_return(
+        TemperatureStatus.IDLE
+    )
+    result = subject.lid_temperature_status
+    assert result == "idle"
+
+
+def test_get_block_temperature(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the current block temperature from the core."""
+    decoy.when(mock_core.get_block_temperature()).then_return(12.3)
+    result = subject.block_temperature
+    assert result == 12.3
+
+
+def test_get_block_target_temperature(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the target block temperature from the core."""
+    decoy.when(mock_core.get_block_target_temperature()).then_return(12.3)
+    result = subject.block_target_temperature
+    assert result == 12.3
+
+
+def test_get_lid_temperature(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the current lid temperature from the core."""
+    decoy.when(mock_core.get_lid_temperature()).then_return(42.0)
+    result = subject.lid_temperature
+    assert result == 42.0
+
+
+def test_get_lid_target_temperature(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the target lid temperature from the core."""
+    decoy.when(mock_core.get_lid_target_temperature()).then_return(42.0)
+    result = subject.lid_target_temperature
+    assert result == 42.0
+
+
+def test_get_ramp_rate(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the current ramp rate from the core."""
+    decoy.when(mock_core.get_ramp_rate()).then_return(1.23)
+    result = subject.ramp_rate
+    assert result == 1.23
+
+
+def test_get_hold_time(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the current hold time from the core."""
+    decoy.when(mock_core.get_hold_time()).then_return(13.37)
+    result = subject.hold_time
+    assert result == 13.37
+
+
+def test_get_total_cycle_count(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the total cycle count from the core."""
+    decoy.when(mock_core.get_total_cycle_count()).then_return(321)
+    result = subject.total_cycle_count
+    assert result == 321
+
+
+def test_get_current_cycle_index(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the current cycle index from the core."""
+    decoy.when(mock_core.get_current_cycle_index()).then_return(123)
+    result = subject.current_cycle_index
+    assert result == 123
+
+
+def test_get_total_step_count(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the total step count from the core."""
+    decoy.when(mock_core.get_total_step_count()).then_return(1337)
+    result = subject.total_step_count
+    assert result == 1337
+
+
+def test_get_current_step_index(
+    decoy: Decoy, mock_core: ThermocyclerCore, subject: ThermocyclerContext
+) -> None:
+    """It should get the current step index from the core."""
+    decoy.when(mock_core.get_current_step_index()).then_return(42)
+    result = subject.current_step_index
+    assert result == 42

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -179,7 +179,7 @@ def test_open_lid(
     subject: ThermocyclerContext,
 ) -> None:
     """It should open the lid via the core."""
-    decoy.when(mock_core.open_lid()).then_return("open")
+    decoy.when(mock_core.open_lid()).then_return(ThermocyclerLidStatus.OPEN)
 
     result = subject.open_lid()
 
@@ -208,7 +208,7 @@ def test_close_lid(
     subject: ThermocyclerContext,
 ) -> None:
     """It should close the lid via the core."""
-    decoy.when(mock_core.close_lid()).then_return("closed")
+    decoy.when(mock_core.close_lid()).then_return(ThermocyclerLidStatus.CLOSED)
 
     result = subject.close_lid()
 

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -208,7 +208,7 @@ def test_close_lid(
     subject: ThermocyclerContext,
 ) -> None:
     """It should close the lid via the core."""
-    decoy.when(mock_core.close_lid()).then_return("close")
+    decoy.when(mock_core.close_lid()).then_return("closed")
 
     result = subject.close_lid()
 
@@ -227,7 +227,7 @@ def test_close_lid(
             matchers.DictMatching({"$": "after"}),
         ),
     )
-    assert result == "close"
+    assert result == "closed"
 
 
 def test_set_block_temperature(

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -258,13 +258,12 @@ def test_set_block_temperature(
                 }
             ),
         ),
-        mock_core.set_block_temperature(
+        mock_core.set_target_block_temperature(
             celsius=42.0,
-            hold_time_seconds=1.2,
-            hold_time_minutes=3.4,
-            ramp_rate=5.6,
+            hold_time_seconds=205.2,
             block_max_volume=7.8,
         ),
+        mock_core.wait_for_block_temperature(),
         mock_broker.publish(
             "command",
             matchers.DictMatching(
@@ -298,7 +297,8 @@ def test_set_lid_temperature(
                 }
             ),
         ),
-        mock_core.set_lid_temperature(celsius=42.0),
+        mock_core.set_target_lid_temperature(celsius=42.0),
+        mock_core.wait_for_lid_temperature(),
         mock_broker.publish(
             "command",
             matchers.DictMatching({"$": "after"}),

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -128,7 +128,7 @@ def test_ensure_module_model_invalid() -> None:
     ],
 )
 def test_ensure_hold_time_seconds(
-    seconds: Optional[float], minutes: Optional[float], expected: Optional[float]
+    seconds: Optional[float], minutes: Optional[float], expected: float
 ) -> None:
     """It should ensure hold time is in seconds only."""
     result = subject.ensure_hold_time_seconds(seconds=seconds, minutes=minutes)

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -124,12 +124,12 @@ def test_ensure_module_model_invalid() -> None:
         (42.42, None, 42.42),
         (None, 1.2, 72.0),
         (42.42, 1.2, 114.42),
-        (None, None, None),
+        (None, None, 0),
     ],
 )
 def test_ensure_hold_time_seconds(
     seconds: Optional[float], minutes: Optional[float], expected: Optional[float]
 ) -> None:
-    """It should ensure hold time is in seconds only if seconds and/or minutes are provided."""
+    """It should ensure hold time is in seconds only."""
     result = subject.ensure_hold_time_seconds(seconds=seconds, minutes=minutes)
     assert result == expected

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -1,5 +1,5 @@
 """Tests for Protocol API input validation."""
-from typing import List, Union
+from typing import List, Union, Optional
 
 import pytest
 
@@ -116,3 +116,20 @@ def test_ensure_module_model_invalid() -> None:
 
     with pytest.raises(TypeError, match="must be a string"):
         subject.ensure_module_model(42)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ["seconds", "minutes", "expected"],
+    [
+        (42.42, None, 42.42),
+        (None, 1.2, 72.0),
+        (42.42, 1.2, 114.42),
+        (None, None, None),
+    ],
+)
+def test_ensure_hold_time_seconds(
+    seconds: Optional[float], minutes: Optional[float], expected: Optional[float]
+) -> None:
+    """It should ensure hold time is in seconds only if seconds and/or minutes are provided."""
+    result = subject.ensure_hold_time_seconds(seconds=seconds, minutes=minutes)
+    assert result == expected

--- a/api/tests/opentrons/protocol_api/types.py
+++ b/api/tests/opentrons/protocol_api/types.py
@@ -6,6 +6,7 @@ from opentrons.protocol_api.core.module import (
     AbstractModuleCore,
     AbstractTemperatureModuleCore,
     AbstractMagneticModuleCore,
+    AbstractThermocyclerCore,
     AbstractHeaterShakerCore,
 )
 from opentrons.protocol_api.core.well import AbstractWellCore
@@ -16,5 +17,6 @@ LabwareCore = AbstractLabware[AbstractWellCore]
 ModuleCore = AbstractModuleCore[LabwareCore]
 TemperatureModuleCore = AbstractTemperatureModuleCore[LabwareCore]
 MagneticModuleCore = AbstractMagneticModuleCore[LabwareCore]
+ThermocyclerCore = AbstractThermocyclerCore[LabwareCore]
 HeaterShakerCore = AbstractHeaterShakerCore[LabwareCore]
 ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -981,8 +981,8 @@ def test_order_of_module_load():
     temp1 = ctx1.load_module("tempdeck", 4)
     ctx1.load_module("thermocycler")
     temp2 = ctx1.load_module("tempdeck", 1)
-    async_temp1 = temp1._module._obj_to_adapt  # type: ignore[union-attr]
-    async_temp2 = temp2._module._obj_to_adapt  # type: ignore[union-attr]
+    async_temp1 = temp1._module._obj_to_adapt
+    async_temp2 = temp2._module._obj_to_adapt
 
     assert id(async_temp1) == id(hw_temp1)
     assert id(async_temp2) == id(hw_temp2)
@@ -999,8 +999,8 @@ def test_order_of_module_load():
     temp1 = ctx2.load_module("tempdeck", 1)
     temp2 = ctx2.load_module("tempdeck", 4)
 
-    async_temp1 = temp1._module._obj_to_adapt  # type: ignore[union-attr]
-    async_temp2 = temp2._module._obj_to_adapt  # type: ignore[union-attr]
+    async_temp1 = temp1._module._obj_to_adapt
+    async_temp2 = temp2._module._obj_to_adapt
     assert id(async_temp1) == id(hw_temp1)
     assert id(async_temp2) == id(hw_temp2)
 

--- a/g-code-testing/g_code_test_data/http/modules/tempdeck.py
+++ b/g-code-testing/g_code_test_data/http/modules/tempdeck.py
@@ -16,19 +16,6 @@ TEMPDECK_DEACTIVATE = HTTPGCodeConfirmConfig(
     settings=HTTP_SETTINGS,
 )
 
-TEMPDECK_SET_TEMPERATURE = HTTPGCodeConfirmConfig(
-    name='tempdeck_set_temperature',
-    executable=partial(
-        post_serial_command,
-        # Keep the args at a low value because the temp starts and 0.0 and only
-        # changes 0.25 degrees every second
-        command=SerialCommand(command_type='set_temperature', args=[2.0]),
-        serial=HTTP_SETTINGS.tempdeck.serial_number,
-        requested_version=2
-    ),
-    settings=HTTP_SETTINGS,
-)
-
 TEMPDECK_START_SET_TEMPERATURE = HTTPGCodeConfirmConfig(
     name='tempdeck_start_set_temperature',
     executable=partial(
@@ -44,6 +31,5 @@ TEMPDECK_START_SET_TEMPERATURE = HTTPGCodeConfirmConfig(
 
 TEMPDECK_CONFIGURATIONS = [
     TEMPDECK_DEACTIVATE,
-    TEMPDECK_SET_TEMPERATURE,
     TEMPDECK_START_SET_TEMPERATURE,
 ]

--- a/g-code-testing/tests/test_cli.py
+++ b/g-code-testing/tests/test_cli.py
@@ -25,7 +25,6 @@ from g_code_test_data.http.modules.magdeck import (
 
 from g_code_test_data.http.modules.tempdeck import (
     TEMPDECK_DEACTIVATE,
-    TEMPDECK_SET_TEMPERATURE,
     TEMPDECK_START_SET_TEMPERATURE,
 )
 
@@ -49,7 +48,6 @@ ALL_MAGDECK_CONFIGS = {
 }
 ALL_TEMPDECK_CONFIGS = {
     RunnableConfiguration(TEMPDECK_DEACTIVATE, None),
-    RunnableConfiguration(TEMPDECK_SET_TEMPERATURE, None),
     RunnableConfiguration(TEMPDECK_START_SET_TEMPERATURE, None),
 }
 ALL_MODULE_CONFIGS = ALL_MAGDECK_CONFIGS.union(ALL_TEMPDECK_CONFIGS)
@@ -99,7 +97,6 @@ MOCK_CONFIGURATIONS_DICT: Dict[
     "http/magdeck_deactivate": MAGDECK_DEACTIVATE,
     "http/magdeck_engage": MAGDECK_ENGAGE,
     "http/tempdeck_deactivate": TEMPDECK_DEACTIVATE,
-    "http/tempdeck_set_temperature": TEMPDECK_SET_TEMPERATURE,
     "http/tempdeck_start_set_temperature": TEMPDECK_START_SET_TEMPERATURE,
     "protocols/2_modules/2.12": TWO_MODULES,
     "protocols/2_modules/2.13": TWO_MODULES,


### PR DESCRIPTION
# Overview
Thermocycler portion of RCORE-103

# Changelog
- Move thermocycler hardware interactions to `LegacyThermocyclerCore`
- Split `module_context` `set_block_temperature` and `set_lid_temperature` into two separate set and wait calls

# Review requests
Tests run on hardware using PAPIv2 protocol, with all thermocycler commands working as expected.

# Risk assessment
Medium, changes are isolated to just thermocycler functionality, but `set_block_temperature` and `set_lid_temperature` now call different hardware API methods.