### PR TITLE
refactor(labware-library, shared-data): copy changes to Labware Creator and deep well displayName

### DIFF
--- a/labware-library/src/labware-creator/components/IntroCopy.tsx
+++ b/labware-library/src/labware-creator/components/IntroCopy.tsx
@@ -20,8 +20,8 @@ export const IntroCopy = (): JSX.Element => (
     </LinkOut>
     <p>
       This tool will allow you to create definitions for well plates,
-      reservoirs, tubes in tube racks, and plates/tubes in Opentrons aluminum
-      blocks that do not already exist on the{' '}
+      reservoirs, tubes in tube racks, plates/tubes in Opentrons aluminum
+      blocks, and tip racks that do not already exist on the{' '}
       <Link to={LINK_LABWARE_LIBRARY} className={styles.link}>
         Labware Library
       </Link>

--- a/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
@@ -50,7 +50,7 @@ describe('Export', () => {
 
     screen.getByText(
       'Your file will be exported with a protocol that will help you test and troubleshoot your labware definition on the robot. ' +
-        'The protocol requires a Single or Eight-Channel pipette on the right mount of your robot.'
+        'The protocol requires a Single or 8-Channel pipette on the right mount of your robot.'
     )
 
     screen.getByText(/test pipette/i)

--- a/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
@@ -50,7 +50,7 @@ describe('Export', () => {
 
     screen.getByText(
       'Your file will be exported with a protocol that will help you test and troubleshoot your labware definition on the robot. ' +
-        'The protocol requires a Single Channel pipette on the right mount of your robot.'
+        'The protocol requires a Single or Eight-Channel pipette on the right mount of your robot.'
     )
 
     screen.getByText(/test pipette/i)

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -59,7 +59,7 @@ export const Export = (props: ExportProps): JSX.Element | null => {
           <p>
             Your file will be exported with a protocol that will help you test
             and troubleshoot your labware definition on the robot. The protocol
-            requires a Single Channel pipette on the right mount of your robot.
+            requires a Single or Eight-Channel pipette on the right mount of your robot.
           </p>
         </div>
         <div className={styles.pipette_field_wrapper}>

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -59,7 +59,7 @@ export const Export = (props: ExportProps): JSX.Element | null => {
           <p>
             Your file will be exported with a protocol that will help you test
             and troubleshoot your labware definition on the robot. The protocol
-            requires a Single or Eight-Channel pipette on the right mount of
+            requires a Single or 8-Channel pipette on the right mount of
             your robot.
           </p>
         </div>

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -59,8 +59,8 @@ export const Export = (props: ExportProps): JSX.Element | null => {
           <p>
             Your file will be exported with a protocol that will help you test
             and troubleshoot your labware definition on the robot. The protocol
-            requires a Single or 8-Channel pipette on the right mount of
-            your robot.
+            requires a Single or 8-Channel pipette on the right mount of your
+            robot.
           </p>
         </div>
         <div className={styles.pipette_field_wrapper}>

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -59,7 +59,8 @@ export const Export = (props: ExportProps): JSX.Element | null => {
           <p>
             Your file will be exported with a protocol that will help you test
             and troubleshoot your labware definition on the robot. The protocol
-            requires a Single or Eight-Channel pipette on the right mount of your robot.
+            requires a Single or Eight-Channel pipette on the right mount of
+            your robot.
           </p>
         </div>
         <div className={styles.pipette_field_wrapper}>

--- a/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/1.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/1.json
@@ -19,7 +19,7 @@
     "links": ["http://www.cell-nest.com/page94?product_id=101&_l=en"]
   },
   "metadata": {
-    "displayName": "NEST 96 Deepwell Plate 2mL",
+    "displayName": "NEST 96 Deep Well Plate 2mL",
     "displayCategory": "wellPlate",
     "displayVolumeUnits": "µL",
     "tags": []
@@ -994,7 +994,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "NEST 96 Deepwell Plate 2mL",
+        "displayName": "NEST 96 Deep well Plate 2mL",
         "displayCategory": "wellPlate",
         "wellBottomShape": "v"
       },

--- a/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/1.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/1.json
@@ -994,7 +994,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "NEST 96 Deep well Plate 2mL",
+        "displayName": "NEST 96 Deep Well Plate 2mL",
         "displayCategory": "wellPlate",
         "wellBottomShape": "v"
       },


### PR DESCRIPTION
closes RAUT-201 and RAUT-203

# Overview

1. A few copy changes to the heading and the test pipette text - see ticket for more info.
2. update labware definition `displayName` for NEST 96 deep well 2ml

# Changelog

- change `Export` and test file
- change `IntroCopy`
- change labware definition file `displayName` in both areas (`displayName` and `metadata/displayName`)

# Review requests

- run `make -C labware-library dev` and navigate to Custom Labware Creator
- in the heading, you should see `tip racks` included
- create a new definition. Scroll down to `Labware Test Protocol` and the text should include `Eight-Channel`
- look at `Labware LIbrary` and navigate to the NEST 96 deep well plate. make sure the display name is correct (The change will also be reflected in the app > labware tab and anytime the display name is being shown such as in protocol details)

# Risk assessment

low