### PR TITLE
fix(step-generation, shared-data): do not change liquid state of airGap command

### DIFF
--- a/shared-data/protocol/types/schemaV3.ts
+++ b/shared-data/protocol/types/schemaV3.ts
@@ -40,7 +40,9 @@ interface OffsetParams {
 export type AspDispAirgapParams = FlowRateParams &
   PipetteAccessParams &
   VolumeParams &
-  OffsetParams
+  OffsetParams & {
+    isAirGap?: boolean
+  }
 
 export type AspirateParams = AspDispAirgapParams
 export type DispenseParams = AspDispAirgapParams

--- a/shared-data/protocol/types/schemaV6/command/index.ts
+++ b/shared-data/protocol/types/schemaV6/command/index.ts
@@ -23,6 +23,7 @@ export interface CommonCommandRunTimeInfo {
 }
 export interface CommonCommandCreateInfo {
   key?: string
+  meta?: any
 }
 
 export type CreateCommand =

--- a/shared-data/protocol/types/schemaV6/command/index.ts
+++ b/shared-data/protocol/types/schemaV6/command/index.ts
@@ -23,7 +23,7 @@ export interface CommonCommandRunTimeInfo {
 }
 export interface CommonCommandCreateInfo {
   key?: string
-  meta?: any
+  meta?: { [key: string]: any }
 }
 
 export type CreateCommand =

--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -21,7 +21,7 @@ import {
   makeTouchTipHelper,
   pickUpTipHelper,
   SOURCE_LABWARE,
-  IS_AIR_GAP,
+  AIR_GAP_META,
 } from '../fixtures'
 import { DEST_WELL_BLOWOUT_DESTINATION } from '../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
@@ -1134,7 +1134,7 @@ describe('consolidate single-channel', () => {
         // Air Gap: after aspirating from A1
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1217,7 +1217,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A2
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1479,7 +1479,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A3
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1631,7 +1631,7 @@ describe('consolidate single-channel', () => {
         // Dispense > air gap in dest well
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1816,7 +1816,7 @@ describe('consolidate single-channel', () => {
         // Air Gap: after aspirating from A1
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1899,7 +1899,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A2
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2161,7 +2161,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A3
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2311,7 +2311,7 @@ describe('consolidate single-channel', () => {
         // Dispense > air gap in dest well
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2496,7 +2496,7 @@ describe('consolidate single-channel', () => {
         // Air Gap: after aspirating from A1
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2579,7 +2579,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A2
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2731,7 +2731,7 @@ describe('consolidate single-channel', () => {
         // Change tip is "always" so we can Dispense > Air Gap here
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2884,7 +2884,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A3
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3034,7 +3034,7 @@ describe('consolidate single-channel', () => {
         // Dispense > air gap in dest well
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',

--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -21,6 +21,7 @@ import {
   makeTouchTipHelper,
   pickUpTipHelper,
   SOURCE_LABWARE,
+  IS_AIR_GAP,
 } from '../fixtures'
 import { DEST_WELL_BLOWOUT_DESTINATION } from '../utils'
 import type { CreateCommand } from '@opentrons/shared-data'
@@ -1133,6 +1134,7 @@ describe('consolidate single-channel', () => {
         // Air Gap: after aspirating from A1
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1215,6 +1217,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A2
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1476,6 +1479,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A3
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1627,6 +1631,7 @@ describe('consolidate single-channel', () => {
         // Dispense > air gap in dest well
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1811,6 +1816,7 @@ describe('consolidate single-channel', () => {
         // Air Gap: after aspirating from A1
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1893,6 +1899,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A2
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2154,6 +2161,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A3
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2303,6 +2311,7 @@ describe('consolidate single-channel', () => {
         // Dispense > air gap in dest well
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2487,6 +2496,7 @@ describe('consolidate single-channel', () => {
         // Air Gap: after aspirating from A1
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2569,6 +2579,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A2
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2720,6 +2731,7 @@ describe('consolidate single-channel', () => {
         // Change tip is "always" so we can Dispense > Air Gap here
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2872,6 +2884,7 @@ describe('consolidate single-channel', () => {
         // Aspirate > air gap: after aspirating from A3
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3021,6 +3034,7 @@ describe('consolidate single-channel', () => {
         // Dispense > air gap in dest well
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -919,7 +919,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToTrash,
       ])
     })
-    it('should create commands in the expected order with expected params (blowout in trash, reuse tip', () => {
+    it('should create commands in the expected order with expected params (blowout in trash, reuse tip)', () => {
       const args = {
         ...allArgs,
         volume: 100,

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -919,7 +919,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToTrash,
       ])
     })
-    it('should create commands in the expected order with expected params (blowout in trash, reuse tip)', () => {
+    it('should create commands in the expected order with expected params (blowout in trash, reuse tip', () => {
       const args = {
         ...allArgs,
         volume: 100,

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -18,7 +18,7 @@ import {
   pickUpTipHelper,
   SOURCE_LABWARE,
   makeDispenseAirGapHelper,
-  IS_AIR_GAP,
+  AIR_GAP_META,
 } from '../fixtures'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
@@ -1148,7 +1148,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1174,7 +1174,7 @@ describe('advanced options', () => {
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1433,7 +1433,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1459,7 +1459,7 @@ describe('advanced options', () => {
         // dispense aspirate > air gap then liquid
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1811,7 +1811,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1837,7 +1837,7 @@ describe('advanced options', () => {
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2097,7 +2097,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             flowRate: 2.1,
@@ -2122,7 +2122,7 @@ describe('advanced options', () => {
         },
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             flowRate: 2.2,
@@ -2495,7 +2495,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2521,7 +2521,7 @@ describe('advanced options', () => {
         // dispense
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2781,7 +2781,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2807,7 +2807,7 @@ describe('advanced options', () => {
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3179,7 +3179,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3205,7 +3205,7 @@ describe('advanced options', () => {
         // dispense
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3506,7 +3506,7 @@ describe('advanced options', () => {
         {
           commandType: 'aspirate',
           key: expect.any(String),
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
@@ -3531,7 +3531,7 @@ describe('advanced options', () => {
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
-          meta: IS_AIR_GAP,
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -18,6 +18,7 @@ import {
   pickUpTipHelper,
   SOURCE_LABWARE,
   makeDispenseAirGapHelper,
+  IS_AIR_GAP,
 } from '../fixtures'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
@@ -724,7 +725,6 @@ describe('advanced options', () => {
         airGapHelper('A1', 5),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
-
         aspirateHelper('A1', 55),
         airGapHelper('A1', 5),
         dispenseAirGapHelper('B1', 5),
@@ -1148,6 +1148,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1173,6 +1174,7 @@ describe('advanced options', () => {
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1431,6 +1433,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1456,6 +1459,7 @@ describe('advanced options', () => {
         // dispense aspirate > air gap then liquid
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1807,6 +1811,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1832,6 +1837,7 @@ describe('advanced options', () => {
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2091,6 +2097,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             flowRate: 2.1,
@@ -2115,6 +2122,7 @@ describe('advanced options', () => {
         },
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             flowRate: 2.2,
@@ -2487,6 +2495,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2512,6 +2521,7 @@ describe('advanced options', () => {
         // dispense
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2771,6 +2781,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2796,6 +2807,7 @@ describe('advanced options', () => {
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3167,6 +3179,7 @@ describe('advanced options', () => {
         // aspirate > air gap
         {
           commandType: 'aspirate',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3192,6 +3205,7 @@ describe('advanced options', () => {
         // dispense
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3492,6 +3506,7 @@ describe('advanced options', () => {
         {
           commandType: 'aspirate',
           key: expect.any(String),
+          meta: IS_AIR_GAP,
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
@@ -3516,6 +3531,7 @@ describe('advanced options', () => {
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
+          meta: IS_AIR_GAP,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -22,7 +22,15 @@ export const aspirate: CommandCreator<AspirateParams> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipette, volume, labware, well, offsetFromBottomMm, flowRate } = args
+  const {
+    pipette,
+    volume,
+    labware,
+    well,
+    offsetFromBottomMm,
+    flowRate,
+    isAirGap,
+  } = args
   const actionName = 'aspirate'
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
@@ -167,6 +175,7 @@ export const aspirate: CommandCreator<AspirateParams> = (
   const commands: CreateCommand[] = [
     {
       commandType: 'aspirate',
+      meta: isAirGap,
       key: uuid(),
       params: {
         pipetteId: pipette,

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -175,7 +175,6 @@ export const aspirate: CommandCreator<AspirateParams> = (
   const commands: CreateCommand[] = [
     {
       commandType: 'aspirate',
-      meta: isAirGap,
       key: uuid(),
       params: {
         pipetteId: pipette,
@@ -190,6 +189,7 @@ export const aspirate: CommandCreator<AspirateParams> = (
         },
         flowRate,
       },
+      ...(isAirGap && { meta: { isAirGap } }),
     },
   ]
   return {

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -21,7 +21,15 @@ export const dispense: CommandCreator<DispenseParams> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipette, volume, labware, well, offsetFromBottomMm, flowRate } = args
+  const {
+    pipette,
+    volume,
+    labware,
+    well,
+    offsetFromBottomMm,
+    flowRate,
+    isAirGap,
+  } = args
   const actionName = 'dispense'
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
@@ -144,6 +152,7 @@ export const dispense: CommandCreator<DispenseParams> = (
   const commands: CreateCommand[] = [
     {
       commandType: 'dispense',
+      meta: isAirGap,
       key: uuid(),
       params: {
         pipetteId: pipette,

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -152,7 +152,6 @@ export const dispense: CommandCreator<DispenseParams> = (
   const commands: CreateCommand[] = [
     {
       commandType: 'dispense',
-      meta: isAirGap,
       key: uuid(),
       params: {
         pipetteId: pipette,
@@ -167,6 +166,7 @@ export const dispense: CommandCreator<DispenseParams> = (
         },
         flowRate,
       },
+      ...(isAirGap && { meta: { isAirGap } }),
     },
   ]
   return {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -107,6 +107,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                   well: sourceWell,
                   flowRate: aspirateFlowRateUlSec,
                   offsetFromBottomMm: airGapOffsetSourceWell,
+                  isAirGap: true,
                 }),
                 ...(aspirateDelay != null
                   ? [
@@ -272,6 +273,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                 well: args.destWell,
                 flowRate: aspirateFlowRateUlSec,
                 offsetFromBottomMm: airGapOffsetDestWell,
+                isAirGap: true,
               }),
               ...(aspirateDelay != null
                 ? [

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -137,6 +137,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               well: args.sourceWell,
               flowRate: aspirateFlowRateUlSec,
               offsetFromBottomMm: airGapOffsetSourceWell,
+              isAirGap: true,
             }),
             ...(aspirateDelay != null
               ? [
@@ -156,6 +157,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               well: firstDestWell,
               flowRate: dispenseFlowRateUlSec,
               offsetFromBottomMm: airGapOffsetDestWell,
+              isAirGap: true,
             }),
             ...(dispenseDelay != null
               ? [
@@ -257,6 +259,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                 well: dispenseAirGapWell,
                 flowRate: aspirateFlowRateUlSec,
                 offsetFromBottomMm: airGapOffsetDestWell,
+                isAirGap: true,
               }),
               ...(aspirateDelay != null
                 ? [

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -293,6 +293,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   well: sourceWell,
                   flowRate: aspirateFlowRateUlSec,
                   offsetFromBottomMm: airGapOffsetSourceWell,
+                  isAirGap: true,
                 }),
                 ...(aspirateDelay != null
                   ? [
@@ -312,6 +313,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   well: destWell,
                   flowRate: dispenseFlowRateUlSec,
                   offsetFromBottomMm: airGapOffsetDestWell,
+                  isAirGap: true,
                 }),
                 ...(dispenseDelay != null
                   ? [

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -94,7 +94,7 @@ export const SOURCE_LABWARE = 'sourcePlateId'
 export const DEST_LABWARE = 'destPlateId'
 export const TROUGH_LABWARE = 'troughId'
 export const DEFAULT_BLOWOUT_WELL = 'A1'
-export const IS_AIR_GAP = { isAirGap: true } // to differentiate if the aspirate or dispense command is an air gap or not
+export const AIR_GAP_META = { isAirGap: true } // to differentiate if the aspirate or dispense command is an air gap or not
 // =================
 type MakeAspDispHelper<P> = (
   bakedParams?: Partial<P>
@@ -142,7 +142,7 @@ export const makeAirGapHelper: MakeAirGapHelper<AspDispAirgapParams> = bakedPara
   params
 ) => ({
   commandType: 'aspirate',
-  meta: IS_AIR_GAP,
+  meta: AIR_GAP_META,
   key: expect.any(String),
   params: {
     ..._defaultAspirateParams,
@@ -214,7 +214,7 @@ export const makeDispenseAirGapHelper: MakeDispenseAirGapHelper<AspDispAirgapPar
     volume,
     ...params,
   },
-  meta: IS_AIR_GAP,
+  meta: AIR_GAP_META,
 })
 const _defaultTouchTipParams = {
   pipetteId: DEFAULT_PIPETTE,

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -94,7 +94,7 @@ export const SOURCE_LABWARE = 'sourcePlateId'
 export const DEST_LABWARE = 'destPlateId'
 export const TROUGH_LABWARE = 'troughId'
 export const DEFAULT_BLOWOUT_WELL = 'A1'
-
+export const IS_AIR_GAP = true // to differentiate if the aspirate command is an air gap or not
 // =================
 type MakeAspDispHelper<P> = (
   bakedParams?: Partial<P>
@@ -142,6 +142,7 @@ export const makeAirGapHelper: MakeAirGapHelper<AspDispAirgapParams> = bakedPara
   params
 ) => ({
   commandType: 'aspirate',
+  meta: IS_AIR_GAP,
   key: expect.any(String),
   params: {
     ..._defaultAspirateParams,
@@ -213,6 +214,7 @@ export const makeDispenseAirGapHelper: MakeDispenseAirGapHelper<AspDispAirgapPar
     volume,
     ...params,
   },
+  meta: IS_AIR_GAP,
 })
 const _defaultTouchTipParams = {
   pipetteId: DEFAULT_PIPETTE,

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -94,7 +94,7 @@ export const SOURCE_LABWARE = 'sourcePlateId'
 export const DEST_LABWARE = 'destPlateId'
 export const TROUGH_LABWARE = 'troughId'
 export const DEFAULT_BLOWOUT_WELL = 'A1'
-export const IS_AIR_GAP = true // to differentiate if the aspirate command is an air gap or not
+export const IS_AIR_GAP = true // to differentiate if the aspirate or dispense command is an air gap or not
 // =================
 type MakeAspDispHelper<P> = (
   bakedParams?: Partial<P>

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -94,7 +94,7 @@ export const SOURCE_LABWARE = 'sourcePlateId'
 export const DEST_LABWARE = 'destPlateId'
 export const TROUGH_LABWARE = 'troughId'
 export const DEFAULT_BLOWOUT_WELL = 'A1'
-export const IS_AIR_GAP = true // to differentiate if the aspirate or dispense command is an air gap or not
+export const IS_AIR_GAP = { isAirGap: true } // to differentiate if the aspirate or dispense command is an air gap or not
 // =================
 type MakeAspDispHelper<P> = (
   bakedParams?: Partial<P>

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -48,18 +48,22 @@ function _getNextRobotStateAndWarningsSingleCommand(
   assert(command, 'undefined command passed to getNextRobotStateAndWarning')
   switch (command.commandType) {
     case 'aspirate':
-      if (command.meta?.isAirGap === true) {
-        return
-      } else {
-        forAspirate(command.params, invariantContext, robotStateAndWarnings)
+      switch (command.meta) {
+        case undefined:
+          forAspirate(command.params, invariantContext, robotStateAndWarnings)
+          break
+        case 'isAirGap':
+          break
       }
       break
 
     case 'dispense':
-      if (command.meta?.isAirGap === true) {
-        return
-      } else {
-        forDispense(command.params, invariantContext, robotStateAndWarnings)
+      switch (command.meta) {
+        case undefined:
+          forDispense(command.params, invariantContext, robotStateAndWarnings)
+          break
+        case 'isAirGap':
+          break
       }
       break
 

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -46,14 +46,21 @@ function _getNextRobotStateAndWarningsSingleCommand(
   robotStateAndWarnings: RobotStateAndWarnings
 ): void {
   assert(command, 'undefined command passed to getNextRobotStateAndWarning')
-
   switch (command.commandType) {
     case 'aspirate':
-      forAspirate(command.params, invariantContext, robotStateAndWarnings)
+      if (command.meta?.isAirGap === true) {
+        return
+      } else {
+        forAspirate(command.params, invariantContext, robotStateAndWarnings)
+      }
       break
 
     case 'dispense':
-      forDispense(command.params, invariantContext, robotStateAndWarnings)
+      if (command.meta?.isAirGap === true) {
+        return
+      } else {
+        forDispense(command.params, invariantContext, robotStateAndWarnings)
+      }
       break
 
     case 'blowout':

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -48,22 +48,18 @@ function _getNextRobotStateAndWarningsSingleCommand(
   assert(command, 'undefined command passed to getNextRobotStateAndWarning')
   switch (command.commandType) {
     case 'aspirate':
-      switch (command.meta) {
-        case undefined:
-          forAspirate(command.params, invariantContext, robotStateAndWarnings)
-          break
-        case 'isAirGap':
-          break
+      if (command.meta?.isAirGap === true) {
+        break
+      } else {
+        forAspirate(command.params, invariantContext, robotStateAndWarnings)
       }
       break
 
     case 'dispense':
-      switch (command.meta) {
-        case undefined:
-          forDispense(command.params, invariantContext, robotStateAndWarnings)
-          break
-        case 'isAirGap':
-          break
+      if (command.meta?.isAirGap === true) {
+        break
+      } else {
+        forDispense(command.params, invariantContext, robotStateAndWarnings)
       }
       break
 


### PR DESCRIPTION

closes RAUT-247

# Overview

In the schema v6 migration, we changed `air_gap` to `aspirate`. This caused a bug in PD where `air_gap` volumes change the liquid state resulting in a warning saying you are out of liquid when you should have liquid left. To fix this, an optional `meta` key is added to `CommonCommandCreateInfo` and an optional `isAirGap` key is added to `AspDispAirgapParams`. When an air gap volume is added in `transfer`, `consolidate` or `distribute`, the `isAirGap` key is true, so when the `aspirate` command is created, it has a meta key to let you know if its an air gap or not.

# Changelog

- add `meta` key to `CommonCommandCreateInfo`
- add  `isAirGap` key is added to `AspDispAirgapParams`
- add logic for when an `aspirate` and `dispense` command is created telling you know if its an `air_gap` or not
- add logic to `transfer`, `consolidate` and `distribute`
- add logic to `getNextRobotStateAndWarnings`
- fix tests and fixtures

# Review requests

- follow the directions in the ticket - create a protocol with a liquid. Transfer the full amount of liquid to another well with an air gap. you should not see the warning banner. You can upload the protocol attached to the ticket too!
- test it out with consolidate and distribute
- `meta` key is type `any` - is this okay? Do we want it to be a different type?

# Risk assessment

low