### PR TITLE
fix(hardware-testing): Ensure new motion-settings are being set immediately

### DIFF
--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -186,7 +186,7 @@ async def home_ot3(api: OT3API, axes: Optional[List[OT3Axis]] = None) -> None:
         set_gantry_load_per_axis_motion_settings_ot3(
             api, ax, max_speed_discontinuity=val
         )
-    await api.engage_axes(which=axes)
+    await api.engage_axes(which=axes)  # type: ignore[arg-type]
     await asyncio.sleep(0.5)
     await api.home(axes=axes)
     for ax, val in cached_discontinuities.items():

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -1,4 +1,5 @@
 """Opentrons helper methods."""
+import asyncio
 from dataclasses import dataclass, replace
 from subprocess import run
 from typing import List, Optional, Dict, Tuple
@@ -133,7 +134,7 @@ class GantryLoadSettings:
     run_current: float  # amps
 
 
-def set_gantry_load_per_axis_settings_ot3(
+async def set_gantry_load_per_axis_settings_ot3(
     api: OT3API,
     settings: Dict[OT3Axis, GantryLoadSettings],
     load: Optional[GantryLoad] = None,
@@ -154,6 +155,8 @@ def set_gantry_load_per_axis_settings_ot3(
         set_gantry_load_per_axis_current_settings_ot3(
             api, ax, load, hold_current=stg.hold_current, run_current=stg.run_current
         )
+    if load == api.gantry_load:
+        await api.set_gantry_load(gantry_load=load)
 
 
 async def home_ot3(api: OT3API, axes: Optional[List[OT3Axis]] = None) -> None:
@@ -183,6 +186,8 @@ async def home_ot3(api: OT3API, axes: Optional[List[OT3Axis]] = None) -> None:
         set_gantry_load_per_axis_motion_settings_ot3(
             api, ax, max_speed_discontinuity=val
         )
+    await api.engage_axes(which=axes)
+    await asyncio.sleep(0.5)
     await api.home(axes=axes)
     for ax, val in cached_discontinuities.items():
         set_gantry_load_per_axis_motion_settings_ot3(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Small PR to make sure any updates to axes motion settings are immediately applied.

Also adds an explicit call to `api.engage_axes()` before homing, to avoid bugs seen in other testing.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
