### PR TITLE
refactor(robot-server): Safely unpickle renamed types

### DIFF
--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -15,10 +15,6 @@ from opentrons.hardware_control.modules import ModuleType as ModuleType
 from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
     # convenience re-export of LabwareUri type
     LabwareUri as LabwareUri,
-    # TODO(mc, 2022-09-01): re-consider pickle usage in robot-server.
-    # This re-export of PipetteName prevents pickle breakage
-    # https://opentrons.atlassian.net/browse/RSS-94
-    PipetteNameType as PipetteName,
 )
 
 

--- a/robot-server/robot_server/persistence/legacy_pickle.py
+++ b/robot-server/robot_server/persistence/legacy_pickle.py
@@ -1,0 +1,189 @@
+"""Safely unpickle objects stored in the database by older robot-server versions."""
+
+
+from dataclasses import dataclass
+from io import BytesIO
+from logging import getLogger
+from pickle import (  # noqa: F401
+    Unpickler,
+    # Re-export `dumps()` to allow this module to be used as a drop-in replacement
+    # for the `pickle` module, which is useful for `sqlalchemy.PickleType`.
+    #
+    # TODO(mm, 2022-10-13): Transition to JSON and remove this after we've stopped
+    # new objects. Or, wrap this with validation to stop us from accidentally pickling
+    # unknown types.
+    dumps as dumps,
+)
+from typing import Dict, List
+
+
+_log = getLogger(__name__)
+
+
+@dataclass
+class _LegacyTypeInfo:
+    """Information about a Python type that older robot-server versions pickled."""
+
+    original_name: str
+    """The Python source name that the type had in older robot-server versions.
+
+    Should not include the name of the containing module.
+    """
+
+    current_type: type
+    """The Python type as it exists today.
+
+    Legacy objects whose type name matches `original_name` will be unpickled
+    into this type.
+
+    The current type is allowed to have a different source name or be defined in a
+    different module from the original. But it must otherwise be pickle-compatible
+    with the original.
+    """
+
+
+# fmt: off
+
+_legacy_ot_types: List[_LegacyTypeInfo] = []
+"""All Opentrons-defined Python types that were pickled by older robot-server versions.
+
+NOTE: After adding a type to this list, its `original_name` should never change.
+Even if the `current_type` gets renamed.
+"""
+
+from robot_server.protocols.analysis_models import AnalysisResult  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="AnalysisResult", current_type=AnalysisResult)
+)
+
+from robot_server.protocols.analysis_models import AnalysisStatus  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="AnalysisStatus", current_type=AnalysisStatus)
+)
+
+from opentrons.protocol_engine.commands import CommandIntent  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="CommandIntent", current_type=CommandIntent)
+)
+
+from opentrons.protocol_engine.commands import CommandStatus  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="CommandStatus", current_type=CommandStatus)
+)
+
+from opentrons.types import DeckSlotName  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="DeckSlotName", current_type=DeckSlotName)
+)
+
+from opentrons_shared_data.labware.labware_definition import DisplayCategory  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="DisplayCategory", current_type=DisplayCategory)
+)
+
+from opentrons.protocol_engine import EngineStatus  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="EngineStatus", current_type=EngineStatus)
+)
+
+from opentrons.protocol_engine import ModuleModel  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="ModuleModel", current_type=ModuleModel)
+)
+
+from opentrons.hardware_control.modules.types import ModuleType  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="ModuleType", current_type=ModuleType)
+)
+
+from opentrons.protocol_engine.types import MotorAxis  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="MotorAxis", current_type=MotorAxis)
+)
+
+from opentrons.types import MountType  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="MountType", current_type=MountType)
+)
+
+from opentrons.protocol_engine.types import MovementAxis  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="MovementAxis", current_type=MovementAxis)
+)
+
+from opentrons_shared_data.pipette.dev_types import PipetteNameType  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="PipetteName", current_type=PipetteNameType)
+)
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="PipetteNameType", current_type=PipetteNameType)
+)
+
+from opentrons.protocol_engine import WellOrigin  # noqa: E402
+_legacy_ot_types.append(
+    _LegacyTypeInfo(original_name="WellOrigin", current_type=WellOrigin)
+)
+
+# fmt: on
+
+
+_current_types_by_legacy_name: Dict[str, type] = {}
+for legacy_type in _legacy_ot_types:
+    assert (
+        legacy_type.original_name not in _current_types_by_legacy_name
+    ), "LegacyUnpickler assumes the original names are unique."
+    _current_types_by_legacy_name[legacy_type.original_name] = legacy_type.current_type
+
+
+class LegacyUnpickler(Unpickler):
+    """A custom unpickler to safely handle legacy Opentrons types.
+
+    The standard library's default unpickler is sensitive to import paths.
+    If you pickle an object, and then refactor your code to move or rename that object's
+    type, you'll get a "class not found" error when you try to unpickle it later.
+
+    This class lets us unpickle objects stored by older robot-server versions
+    even if we've moved or renamed their types.
+    """
+
+    def find_class(self, module: str, name: str) -> object:  # noqa: D102
+        try:
+            # We match purely on the type name, ignoring the name of the containing
+            # module. This is to avoid potential confusion and false negatives
+            # with types that could be imported through multiple paths.
+            return _current_types_by_legacy_name[name]
+
+        except KeyError:
+            # The type of the object that we're unpickling doesn't appear to be an
+            # Opentrons-defined type. Is it something else that we know about?
+
+            if module == "" and name in {"int", "str"}:
+                known_type = True
+
+            elif module == "datetime":
+                # `datetime.datetime`s and their attributes, like `datetime.timezone`.
+                known_type = True
+
+            elif module == "numpy" or module.startswith("numpy."):
+                # `numpy.dtype` and `numpy.core.multiarray.scalar` (and possibly others)
+                # are present.
+                known_type = True
+
+            else:
+                known_type = False
+
+            if not known_type:
+                raise NotImplementedError
+                _log.warning(
+                    f'Unpickling unknown type "{name}" from module "{module}".'
+                    f" This may cause problems with reading records created by"
+                    f" older versions of this robot software."
+                    f" This should be reported to Opentrons and investigated."
+                )
+
+            return super().find_class(module, name)
+
+
+def loads(data: bytes) -> object:
+    """Drop-in replacement for `pickle.loads` that uses our custom unpickler."""
+    return LegacyUnpickler(BytesIO(data)).load()

--- a/robot-server/robot_server/persistence/tables.py
+++ b/robot-server/robot_server/persistence/tables.py
@@ -1,5 +1,7 @@
 """SQLite table schemas."""
 import sqlalchemy
+
+from . import legacy_pickle
 from .utc_datetime import UTCDateTime
 
 _metadata = sqlalchemy.MetaData()
@@ -81,9 +83,17 @@ run_table = sqlalchemy.Table(
         nullable=True,
     ),
     # column added in schema v1
-    sqlalchemy.Column("state_summary", sqlalchemy.PickleType, nullable=True),
+    sqlalchemy.Column(
+        "state_summary",
+        sqlalchemy.PickleType(pickler=legacy_pickle),
+        nullable=True,
+    ),
     # column added in schema v1
-    sqlalchemy.Column("commands", sqlalchemy.PickleType, nullable=True),
+    sqlalchemy.Column(
+        "commands",
+        sqlalchemy.PickleType(pickler=legacy_pickle),
+        nullable=True,
+    ),
     # column added in schema v1
     sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
     # column added in schema v1

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -1,7 +1,6 @@
 """Protocol analysis storage."""
 from __future__ import annotations
 
-import pickle
 from dataclasses import dataclass
 from logging import getLogger
 from typing import Dict, List, Optional
@@ -18,6 +17,7 @@ from opentrons.protocol_engine import (
 )
 
 from robot_server.persistence import analysis_table, sqlite_rowid
+from robot_server.persistence import legacy_pickle
 
 from .analysis_models import (
     AnalysisSummary,
@@ -294,7 +294,7 @@ class _CompletedAnalysisResource:
         """
 
         def serialize_completed_analysis() -> bytes:
-            return pickle.dumps(self.completed_analysis.dict())
+            return legacy_pickle.dumps(self.completed_analysis.dict())
 
         serialized_completed_analysis = await anyio.to_thread.run_sync(
             serialize_completed_analysis,
@@ -336,7 +336,9 @@ class _CompletedAnalysisResource:
         assert isinstance(protocol_id, str)
 
         def parse_completed_analysis() -> CompletedAnalysis:
-            return CompletedAnalysis.parse_obj(pickle.loads(sql_row.completed_analysis))
+            return CompletedAnalysis.parse_obj(
+                legacy_pickle.loads(sql_row.completed_analysis)
+            )
 
         completed_analysis = await anyio.to_thread.run_sync(
             parse_completed_analysis,


### PR DESCRIPTION
# Overview

This PR mitigates a source of fragility in `robot-server`'s database. It lets `robot-server` unpickle objects created by prior versions of itself, even if the object's Python class has been moved or renamed in the meantime. Formerly, if the class were moved or renamed, it would cause "class not found" errors.

This work goes towards RSS-98. See that ticket for more background.

# Changelog

* Hard-code a list of all Python types that `robot-server` has been pickling in its database. This list is intended to be exhaustive. I generated it with the help of a script that recursively scans our Pydantic models and outputs every field type that it encounters: [dump_leaf_types.py](https://gist.github.com/SyntaxColoring/03833754fd6faba6f0036ef347a86fb5)
* When unpickling a type from that list, map it to its modern equivalent. The mapping is hard-coded, but it should be easy for us to adapt as we move and rename things in the future.
* Apply this mapping to all pickle columns in `robot-server`'s database: `analysis.completed_analysis`, `run.state_summary`, and `run.commands`.

# Review requests

* Does the way I've written the mapping look maintainable? I'm a little worried about a future find+replace accidentally changing an `original_name` string without us noticing. Does anyone have ideas to make it more foolproof, or make it stick out more in code review?
* I didn't add unit tests for the custom unpickler because it's already covered by integration tests such as [these](https://github.com/Opentrons/opentrons/blob/1a5707def27bf041d066aa32017063c3912fc82c/robot-server/tests/integration/http_api/persistence/test_compatibility.py#L35). But I could add them without too much trouble. Do we want that?
* Do we want to check my `dump_leaf_types.py` script in to this repo somewhere?

# Risk assessment

Alone, this PR is low-risk. It's well-covered by existing integration tests, and it's written to fall back to prior behavior in case it encounters an unexpected type.

# Next steps

This PR isn't sufficient to close RSS-98 because it remains easy for us to accidentally pickle something not included in the `_legacy_ot_types` list. As discussed in that ticket, we want to migrate entirely off of pickles and use JSON instead. There's a `# TODO` for this in the code.