### PR TITLE
feat(hardware-testing): Adds argument to set which pipette models to simulate

### DIFF
--- a/hardware-testing/hardware_testing/scripts/test_pipette.py
+++ b/hardware-testing/hardware_testing/scripts/test_pipette.py
@@ -22,11 +22,13 @@ MAX_SPEED_PIP = 20
 
 
 async def _main(is_simulating: bool) -> None:
-    api = await build_async_ot3_hardware_api(is_simulating=is_simulating)
-    await api.set_gantry_load(gantry_load=LOAD)
-
-    attached_pips = api.get_attached_pipettes()
-    assert attached_pips[MOUNT.to_mount()]
+    api = await build_async_ot3_hardware_api(
+        is_simulating=is_simulating,
+        pipette_left="p1000_single_v3.3",
+        pipette_right="p50_single_v4.3",
+    )
+    assert api.hardware_pipettes[OT3Mount.LEFT.to_mount()], "No pipette on the left!"
+    assert api.hardware_pipettes[OT3Mount.RIGHT.to_mount()], "No pipette on the right!"
 
     await home_ot3(api, [OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L, OT3Axis.Z_R])
     await api.home_plunger(mount=MOUNT)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds two new arguments when creating the `OT3API` instance to specify which pipette model to simulate on which mount.

Should work for any pipette model, as long as it is present in the `pipetteModelConfigs.json`

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
