### PR TITLE
fix(api): ensure first module read completes during HW API build

### DIFF
--- a/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
+++ b/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
@@ -120,12 +120,10 @@ async def wait_emulators(
             m: Message = await client.read()
             if m.status == "dump" or m.status == "connected":
                 for c in m.connections:
-                    if c.module_type in module_set:
-                        module_set.remove(c.module_type)
+                    module_set.discard(c.module_type)
             elif m.status == "disconnected":
                 for c in m.connections:
-                    if c.module_type not in module_set:
-                        module_set.add(c.module_type)
+                    module_set.add(c.module_type)
 
             log.debug(f"after message: {m}, awaiting module set is: {module_set}")
 

--- a/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
+++ b/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
@@ -124,7 +124,7 @@ async def wait_emulators(
                         module_set.remove(c.module_type)
             elif m.status == "disconnected":
                 for c in m.connections:
-                    if c.module_type in module_set:
+                    if c.module_type not in module_set:
                         module_set.add(c.module_type)
 
             log.debug(f"after message: {m}, awaiting module set is: {module_set}")

--- a/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
+++ b/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
@@ -111,11 +111,13 @@ async def wait_emulators(
         asyncio.TimeoutError on timeout.
     """
 
-    async def _wait_modules(cl: ModuleStatusClient, module_set: Set[str]) -> None:
+    async def _wait_modules() -> None:
         """Read messages from module server waiting for modules in module_set to
         be connected."""
+        module_set: Set[str] = set(modules)
+
         while module_set:
-            m: Message = await cl.read()
+            m: Message = await client.read()
             if m.status == "dump" or m.status == "connected":
                 for c in m.connections:
                     if c.module_type in module_set:
@@ -127,7 +129,4 @@ async def wait_emulators(
 
             log.debug(f"after message: {m}, awaiting module set is: {module_set}")
 
-    await asyncio.wait_for(
-        _wait_modules(cl=client, module_set=set(n.value for n in modules)),
-        timeout=timeout,
-    )
+    await asyncio.wait_for(_wait_modules(), timeout=timeout)

--- a/api/src/opentrons/hardware_control/emulation/proxy.py
+++ b/api/src/opentrons/hardware_control/emulation/proxy.py
@@ -219,13 +219,14 @@ class Proxy:
         while True:
             try:
                 d = await in_connection.reader.read(1)
+                out_connection.writer.write(d)
+
                 if not d:
                     log.info(
                         f"{in_connection.writer.transport.get_extra_info('socket')} "
                         f"disconnected."
                     )
                     break
-                out_connection.writer.write(d)
             except ConnectionError:
                 log.exception("connection error in data router")
                 break

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -77,7 +77,7 @@ class AttachedModulesControl:
             usb_port=usb_port,
             type=type,
             simulating=self._api.is_simulator,
-            loop=self._api.loop,
+            hw_control_loop=self._api.loop,
             execution_manager=self._api._execution_manager,
             sim_model=sim_model,
         )
@@ -100,11 +100,11 @@ class AttachedModulesControl:
                 self._available_modules.remove(removed_mod)
             except ValueError:
                 log.exception(
-                    f"Removed Module {removed_mod} not" " found in attached modules"
+                    f"Removed Module {removed_mod} not found in attached modules"
                 )
         for removed_mod in removed_modules:
             log.info(
-                f"Module {removed_mod.name()} detached" f" from port {removed_mod.port}"
+                f"Module {removed_mod.name()} detached from port {removed_mod.port}"
             )
             await removed_mod.cleanup()
         self._available_modules = sorted(

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -45,10 +45,10 @@ class HeaterShaker(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
         sim_model: Optional[str] = None,
-        **kwargs: float,
     ) -> "HeaterShaker":
         """
         Build a HeaterShaker
@@ -57,26 +57,25 @@ class HeaterShaker(mod_abc.AbstractModule):
             port: The port to connect to
             usb_port: USB Port
             execution_manager: Execution manager.
+            hw_control_loop: The event loop running in the hardware control thread.
+            poll_interval_seconds: Poll interval override.
             simulating: whether to build a simulating driver
             loop: Loop
             sim_model: The model name used by simulator
-            polling_period: the polling period in seconds
-            kwargs: further kwargs are in starargs because of inheritance rules.
-            possible values include polling_period: float, a time in seconds to poll
 
         Returns:
             HeaterShaker instance
         """
         driver: AbstractHeaterShakerDriver
         if not simulating:
-            driver = await HeaterShakerDriver.create(port=port, loop=loop)
-            polling_period = kwargs.get("polling_period", POLL_PERIOD)
+            driver = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
+            poll_interval_seconds = poll_interval_seconds or POLL_PERIOD
         else:
             driver = SimulatingDriver()
-            polling_period = SIMULATING_POLL_PERIOD
+            poll_interval_seconds = poll_interval_seconds or SIMULATING_POLL_PERIOD
 
         reader = HeaterShakerReader(driver=driver)
-        poller = Poller(reader=reader, interval=polling_period)
+        poller = Poller(reader=reader, interval=poll_interval_seconds)
         module = cls(
             port=port,
             usb_port=usb_port,
@@ -85,7 +84,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            loop=loop,
+            hw_control_loop=hw_control_loop,
         )
 
         try:
@@ -104,10 +103,13 @@ class HeaterShaker(mod_abc.AbstractModule):
         reader: HeaterShakerReader,
         poller: Poller,
         device_info: Mapping[str, str],
-        loop: Optional[asyncio.AbstractEventLoop] = None,
+        hw_control_loop: asyncio.AbstractEventLoop,
     ):
         super().__init__(
-            port=port, usb_port=usb_port, loop=loop, execution_manager=execution_manager
+            port=port,
+            usb_port=usb_port,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
         )
         self._device_info = device_info
         self._driver = driver
@@ -117,6 +119,7 @@ class HeaterShaker(mod_abc.AbstractModule):
     async def cleanup(self) -> None:
         """Stop the poller task"""
         await self._poller.stop()
+        await self._driver.disconnect()
 
     @classmethod
     def name(cls) -> str:

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -49,23 +49,23 @@ class MagDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
         sim_model: Optional[str] = None,
-        **kwargs: float,
     ) -> "MagDeck":
         """Factory function."""
         driver: AbstractMagDeckDriver
         if not simulating:
-            driver = await MagDeckDriver.create(port=port, loop=loop)
+            driver = await MagDeckDriver.create(port=port, loop=hw_control_loop)
         else:
             driver = SimulatingDriver(sim_model=sim_model)
 
         mod = cls(
             port=port,
             usb_port=usb_port,
-            loop=loop,
             execution_manager=execution_manager,
+            hw_control_loop=hw_control_loop,
             device_info=await driver.get_device_info(),
             driver=driver,
         )
@@ -76,13 +76,16 @@ class MagDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
+        hw_control_loop: asyncio.AbstractEventLoop,
         driver: AbstractMagDeckDriver,
         device_info: Mapping[str, str],
-        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         """Constructor"""
         super().__init__(
-            port=port, usb_port=usb_port, loop=loop, execution_manager=execution_manager
+            port=port,
+            usb_port=usb_port,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
         )
         self._device_info = device_info
         self._driver = driver

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -4,9 +4,10 @@ import logging
 import re
 from pkg_resources import parse_version
 from typing import ClassVar, Mapping, Optional, cast, TypeVar
+
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
-from opentrons.hardware_control.util import use_or_initialize_loop
 from opentrons.drivers.rpi_drivers.types import USBPort
+
 from ..execution_manager import ExecutionManager
 from .types import BundledFirmware, UploadFunction, LiveData, ModuleType
 
@@ -27,30 +28,27 @@ class AbstractModule(abc.ABC):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
         sim_model: Optional[str] = None,
-        **kwargs: float,
     ) -> "AbstractModule":
         """Modules should always be created using this factory.
 
         This lets the (perhaps blocking) work of connecting to and initializing
         a module be in a place that can be async.
         """
-        pass
 
     def __init__(
         self,
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
-        simulating: bool = False,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-        sim_model: Optional[str] = None,
+        hw_control_loop: asyncio.AbstractEventLoop,
     ) -> None:
         self._port = port
         self._usb_port = usb_port
-        self._loop = use_or_initialize_loop(loop)
+        self._loop = hw_control_loop
         self._execution_manager = execution_manager
         self._bundled_fw: Optional[BundledFirmware] = self.get_bundled_fw()
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -35,10 +35,10 @@ class TempDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         execution_manager: ExecutionManager,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
         sim_model: Optional[str] = None,
-        **kwargs: float,
     ) -> "TempDeck":
         """
         Build a TempDeck
@@ -47,27 +47,24 @@ class TempDeck(mod_abc.AbstractModule):
             port: The port to connect to
             usb_port: USB Port
             execution_manager: Execution manager.
+            hw_control_loop: The event loop running in the hardware control thread.
+            poll_interval_seconds: Poll interval override.
             simulating: whether to build a simulating driver
-            loop: Loop
             sim_model: The model name used by simulator
-            **kwargs: Module specific values.
-                can be 'polling_frequency' to specify the polling frequency in
-                seconds
 
         Returns:
             Tempdeck instance
         """
-        polling_frequency = kwargs.get("polling_frequency")
         driver: AbstractTempDeckDriver
         if not simulating:
-            driver = await TempDeckDriver.create(port=port, loop=loop)
-            polling_frequency = polling_frequency or TEMP_POLL_INTERVAL_SECS
+            driver = await TempDeckDriver.create(port=port, loop=hw_control_loop)
+            poll_interval_seconds = poll_interval_seconds or TEMP_POLL_INTERVAL_SECS
         else:
             driver = SimulatingDriver(sim_model=sim_model)
-            polling_frequency = polling_frequency or SIM_TEMP_POLL_INTERVAL_SECS
+            poll_interval_seconds = poll_interval_seconds or SIM_TEMP_POLL_INTERVAL_SECS
 
         reader = TempDeckReader(driver=driver)
-        poller = Poller(reader=reader, interval=polling_frequency)
+        poller = Poller(reader=reader, interval=poll_interval_seconds)
         module = cls(
             port=port,
             usb_port=usb_port,
@@ -76,7 +73,7 @@ class TempDeck(mod_abc.AbstractModule):
             reader=reader,
             poller=poller,
             device_info=await driver.get_device_info(),
-            loop=loop,
+            hw_control_loop=hw_control_loop,
         )
 
         try:
@@ -95,11 +92,14 @@ class TempDeck(mod_abc.AbstractModule):
         reader: TempDeckReader,
         poller: Poller,
         device_info: Mapping[str, str],
-        loop: Optional[asyncio.AbstractEventLoop] = None,
+        hw_control_loop: asyncio.AbstractEventLoop,
     ) -> None:
         """Constructor"""
         super().__init__(
-            port=port, usb_port=usb_port, loop=loop, execution_manager=execution_manager
+            port=port,
+            usb_port=usb_port,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
         )
         self._device_info = device_info
         self._driver = driver

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -39,7 +39,7 @@ async def build(
     type: ModuleType,
     simulating: bool,
     usb_port: USBPort,
-    loop: asyncio.AbstractEventLoop,
+    hw_control_loop: asyncio.AbstractEventLoop,
     execution_manager: ExecutionManager,
     sim_model: Optional[str] = None,
 ) -> AbstractModule:
@@ -47,7 +47,7 @@ async def build(
         port=port,
         usb_port=usb_port,
         simulating=simulating,
-        loop=loop,
+        hw_control_loop=hw_control_loop,
         execution_manager=execution_manager,
         sim_model=sim_model,
     )

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -47,8 +47,7 @@ class Poller:
 
         async with self._use_read_lock():
             task.cancel()
-
-        await asyncio.gather(task, return_exceptions=True)
+            await asyncio.gather(task, return_exceptions=True)
 
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete.

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -61,5 +61,5 @@ async def build_module(
             _log.warning(f"Module build attempt {retry_attempt} failed.", exc_info=e)
             retry_attempt += 1
 
-    assert module is not None, f"Failed to build module after {retry_attempt} attempts."
+    assert module is not None, f"Failed to build module after {_CONNECT_RETRIES} tries."
     return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -8,6 +8,8 @@ from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import AbstractModule
 
 
+_CONNECT_RETRIES = 3
+
 _log = logging.getLogger(__name__)
 
 ModuleType = TypeVar("ModuleType", bound=AbstractModule)
@@ -22,6 +24,12 @@ async def build_module(
 ) -> ModuleType:
     """Build a module emulator.
 
+    This factory will retry the build if it fails.
+    This is to account for the fact that the network-based serial connections
+    used by the emulators cannot always close and re-open a socket immediately.
+
+    See https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports.
+
     Args:
         module_cls: The module to build.
         port: The TCP port to connect on.
@@ -32,18 +40,26 @@ async def build_module(
         The module's hardware control interface.
 
     Raises:
-        Exception: The module was not able to be built.
+        AssertionError: The module was not able to be built, even after retries.
     """
-    try:
-        module = await module_cls.build(
-            port=f"socket://127.0.0.1:{port}",
-            execution_manager=execution_manager,
-            usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-            hw_control_loop=asyncio.get_running_loop(),
-            poll_interval_seconds=poll_interval_seconds,
-        )
-    except Exception as e:
-        _log.warn("Failed to build module", exc_info=e)
-        raise
+    module = None
+    retry_attempt = 1
 
+    # Closing and re-opening network-based serial connections does not always work
+    # Attempt to connect to the driver several times to prevent test flakiness
+    # https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports
+    while module is None and retry_attempt <= _CONNECT_RETRIES:
+        try:
+            module = await module_cls.build(
+                port=f"socket://127.0.0.1:{port}",
+                execution_manager=execution_manager,
+                usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
+                hw_control_loop=asyncio.get_running_loop(),
+                poll_interval_seconds=poll_interval_seconds,
+            )
+        except Exception as e:
+            _log.warning(f"Module build attempt {retry_attempt} failed.", exc_info=e)
+            retry_attempt += 1
+
+    assert module is not None, f"Failed to build module after {retry_attempt} attempts."
     return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -1,16 +1,10 @@
 """Build a module emulator for integration tests."""
 import asyncio
-import logging
 from typing import Optional, Type, TypeVar, cast
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import AbstractModule
-
-
-_CONNECT_RETRIES = 3
-
-_log = logging.getLogger(__name__)
 
 ModuleType = TypeVar("ModuleType", bound=AbstractModule)
 
@@ -22,13 +16,7 @@ async def build_module(
     execution_manager: ExecutionManager,
     poll_interval_seconds: Optional[float] = None,
 ) -> ModuleType:
-    """Build a module emulator.
-
-    This factory will retry the build if it fails.
-    This is to account for the fact that the network-based serial connections
-    used by the emulators cannot always close and re-open a socket immediately.
-
-    See https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports.
+    """Build a module emulator connected to a RFC-2217 network serial port.
 
     Args:
         module_cls: The module to build.
@@ -38,28 +26,13 @@ async def build_module(
 
     Returns:
         The module's hardware control interface.
-
-    Raises:
-        AssertionError: The module was not able to be built, even after retries.
     """
-    module = None
-    retry_attempt = 1
+    module = await module_cls.build(
+        port=f"socket://127.0.0.1:{port}",
+        execution_manager=execution_manager,
+        usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
+        hw_control_loop=asyncio.get_running_loop(),
+        poll_interval_seconds=poll_interval_seconds,
+    )
 
-    # Closing and re-opening network-based serial connections does not always work
-    # Attempt to connect to the driver several times to prevent test flakiness
-    # https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports
-    while module is None and retry_attempt <= _CONNECT_RETRIES:
-        try:
-            module = await module_cls.build(
-                port=f"socket://127.0.0.1:{port}",
-                execution_manager=execution_manager,
-                usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-                hw_control_loop=asyncio.get_running_loop(),
-                poll_interval_seconds=poll_interval_seconds,
-            )
-        except Exception as e:
-            _log.warning(f"Module build attempt {retry_attempt} failed.", exc_info=e)
-            retry_attempt += 1
-
-    assert module is not None, f"Failed to build module after {_CONNECT_RETRIES} tries."
     return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -1,0 +1,65 @@
+"""Build a module emulator for integration tests."""
+import asyncio
+import logging
+from typing import Optional, Type, TypeVar, cast
+
+from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.hardware_control import ExecutionManager
+from opentrons.hardware_control.modules import AbstractModule
+
+
+_CONNECT_RETRIES = 3
+
+_log = logging.getLogger(__name__)
+
+ModuleType = TypeVar("ModuleType", bound=AbstractModule)
+
+
+async def build_module(
+    module_cls: Type[ModuleType],
+    *,
+    port: int,
+    execution_manager: ExecutionManager,
+    poll_interval_seconds: Optional[float] = None,
+) -> ModuleType:
+    """Build a module emulator.
+
+    This factory will retry the build if it fails.
+    This is to account for the fact that the network-based serial connections
+    used by the emulators cannot always close and re-open a socket immediately.
+
+    See https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports.
+
+    Args:
+        module_cls: The module to build.
+        port: The TCP port to connect on.
+        execution_manager: Passed through to module builder.
+        poll_interval_seconds: Passed through to module builder.
+
+    Returns:
+        The module's hardware control interface.
+
+    Raises:
+        AssertionError: The module was not able to be built, even after retries.
+    """
+    module = None
+    retry_attempt = 1
+
+    # Closing and re-opening network-based serial connections does not always work
+    # Attempt to connect to the driver several times to prevent test flakiness
+    # https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports
+    while module is None and retry_attempt <= _CONNECT_RETRIES:
+        try:
+            module = await module_cls.build(
+                port=f"socket://127.0.0.1:{port}",
+                execution_manager=execution_manager,
+                usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
+                hw_control_loop=asyncio.get_running_loop(),
+                poll_interval_seconds=poll_interval_seconds,
+            )
+        except Exception as e:
+            _log.warn(f"Module build attempt {retry_attempt} failed.", exc_info=e)
+            retry_attempt += 1
+
+    assert module is not None, f"Failed to build module after {retry_attempt} attempts."
+    return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -8,8 +8,6 @@ from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import AbstractModule
 
 
-_CONNECT_RETRIES = 3
-
 _log = logging.getLogger(__name__)
 
 ModuleType = TypeVar("ModuleType", bound=AbstractModule)
@@ -24,12 +22,6 @@ async def build_module(
 ) -> ModuleType:
     """Build a module emulator.
 
-    This factory will retry the build if it fails.
-    This is to account for the fact that the network-based serial connections
-    used by the emulators cannot always close and re-open a socket immediately.
-
-    See https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports.
-
     Args:
         module_cls: The module to build.
         port: The TCP port to connect on.
@@ -40,26 +32,18 @@ async def build_module(
         The module's hardware control interface.
 
     Raises:
-        AssertionError: The module was not able to be built, even after retries.
+        Exception: The module was not able to be built.
     """
-    module = None
-    retry_attempt = 1
+    try:
+        module = await module_cls.build(
+            port=f"socket://127.0.0.1:{port}",
+            execution_manager=execution_manager,
+            usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
+            hw_control_loop=asyncio.get_running_loop(),
+            poll_interval_seconds=poll_interval_seconds,
+        )
+    except Exception as e:
+        _log.warn("Failed to build module", exc_info=e)
+        raise
 
-    # Closing and re-opening network-based serial connections does not always work
-    # Attempt to connect to the driver several times to prevent test flakiness
-    # https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rfc-2217-network-ports
-    while module is None and retry_attempt <= _CONNECT_RETRIES:
-        try:
-            module = await module_cls.build(
-                port=f"socket://127.0.0.1:{port}",
-                execution_manager=execution_manager,
-                usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-                hw_control_loop=asyncio.get_running_loop(),
-                poll_interval_seconds=poll_interval_seconds,
-            )
-        except Exception as e:
-            _log.warn(f"Module build attempt {retry_attempt} failed.", exc_info=e)
-            retry_attempt += 1
-
-    assert module is not None, f"Failed to build module after {retry_attempt} attempts."
     return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -82,4 +82,4 @@ async def execution_manager() -> AsyncGenerator[ExecutionManager, None]:
 @pytest.fixture
 def poll_interval_seconds() -> float:
     """The polling interval used for the module tests."""
-    return 0.01
+    return 0.05

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -86,4 +86,4 @@ def poll_interval_seconds() -> float:
     If too fast, tests may fail due to stale data in the serial buffers.
     If too slow, tests will take too long and may time out.
     """
-    return 0.01
+    return 0.1

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -81,5 +81,9 @@ async def execution_manager() -> AsyncGenerator[ExecutionManager, None]:
 
 @pytest.fixture
 def poll_interval_seconds() -> float:
-    """The polling interval used for the module tests."""
-    return 0.05
+    """The polling interval used for the module tests.
+
+    If too fast, tests may fail due to stale data in the serial buffers.
+    If too slow, tests will take too long and may time out.
+    """
+    return 0.1

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -86,4 +86,4 @@ def poll_interval_seconds() -> float:
     If too fast, tests may fail due to stale data in the serial buffers.
     If too slow, tests will take too long and may time out.
     """
-    return 0.1
+    return 0.01

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -1,9 +1,10 @@
-from typing import Iterator
+import asyncio
 import threading
+from typing import AsyncGenerator, Iterator
 
 import pytest
-import asyncio
 
+from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.module_server import ModuleStatusClient
 from opentrons.hardware_control.emulation.module_server.helpers import wait_emulators
 from opentrons.hardware_control.emulation.scripts import run_app, run_smoothie
@@ -69,3 +70,16 @@ def emulation_app(emulator_settings: Settings) -> Iterator[None]:
     ready_proc.join()
 
     yield
+
+
+@pytest.fixture
+async def execution_manager() -> AsyncGenerator[ExecutionManager, None]:
+    em = ExecutionManager()
+    yield em
+    await em.cancel()
+
+
+@pytest.fixture
+def poll_interval_seconds() -> float:
+    """The polling interval used for the module tests."""
+    return 0.01

--- a/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
@@ -1,13 +1,12 @@
-import asyncio
 from typing import AsyncGenerator
 
 import pytest
-from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.emulation.util import TEMPERATURE_ROOM
-
 from opentrons.hardware_control.modules import HeaterShaker
+
+from .build_module import build_module
 
 TEMP_ROOM_LOW = TEMPERATURE_ROOM - 0.7
 TEMP_ROOM_HIGH = TEMPERATURE_ROOM + 0.7
@@ -20,11 +19,10 @@ async def heatershaker(
     execution_manager: ExecutionManager,
     poll_interval_seconds: float,
 ) -> AsyncGenerator[HeaterShaker, None]:
-    module = await HeaterShaker.build(
-        port=f"socket://127.0.0.1:{emulator_settings.heatershaker_proxy.driver_port}",
+    module = await build_module(
+        HeaterShaker,
+        port=emulator_settings.heatershaker_proxy.driver_port,
         execution_manager=execution_manager,
-        usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-        hw_control_loop=asyncio.get_running_loop(),
         poll_interval_seconds=poll_interval_seconds,
     )
     yield module

--- a/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
@@ -23,7 +23,7 @@ async def heatershaker(
         execution_manager=AsyncMock(),
         usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
         loop=asyncio.get_running_loop(),
-        polling_period=0.5,
+        polling_period=0.01,
     )
     yield module
     await module.cleanup()
@@ -40,7 +40,6 @@ def test_device_info(heatershaker: HeaterShaker):
 
 async def test_latch_status(heatershaker: HeaterShaker) -> None:
     """It should run open and close latch."""
-    await heatershaker.wait_next_poll()
     assert heatershaker.labware_latch_status.value == "idle_open"
 
     await heatershaker.close_labware_latch()
@@ -53,7 +52,6 @@ async def test_latch_status(heatershaker: HeaterShaker) -> None:
 async def test_speed(heatershaker: HeaterShaker) -> None:
     """It should speed up, then slow down."""
 
-    await heatershaker.wait_next_poll()
     await heatershaker.set_speed(550)
     assert heatershaker.target_speed == 550
 
@@ -64,7 +62,6 @@ async def test_speed(heatershaker: HeaterShaker) -> None:
 async def test_deactivate_shaker(heatershaker: HeaterShaker) -> None:
     """It should speed up, then slow down."""
 
-    await heatershaker.wait_next_poll()
     await heatershaker.set_speed(150)
     assert heatershaker.target_speed == 150
 
@@ -75,7 +72,6 @@ async def test_deactivate_shaker(heatershaker: HeaterShaker) -> None:
 
 
 async def test_deactivate_heater(heatershaker: HeaterShaker) -> None:
-    await heatershaker.wait_next_poll()
     await heatershaker.start_set_temperature(30.0)
     await heatershaker.await_temperature(30.0)
     assert heatershaker.target_temperature == 30.0
@@ -89,8 +85,6 @@ async def test_deactivate_heater(heatershaker: HeaterShaker) -> None:
 async def test_temp(heatershaker: HeaterShaker) -> None:
     """Test setting temp"""
 
-    # Have to wait for next poll because target temp will not update until then
-    await heatershaker.wait_next_poll()
     await heatershaker.start_set_temperature(50.0)
     assert heatershaker.target_temperature == 50.0
     assert heatershaker.temperature != 50.0

--- a/api/tests/opentrons/hardware_control/integration/test_magdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_magdeck.py
@@ -17,7 +17,7 @@ async def magdeck(
         port=f"socket://127.0.0.1:{emulator_settings.magdeck_proxy.driver_port}",
         execution_manager=AsyncMock(),
         usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
     )
     yield module
     await module.cleanup()

--- a/api/tests/opentrons/hardware_control/integration/test_magdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_magdeck.py
@@ -1,29 +1,30 @@
-import asyncio
 from typing import AsyncIterator, Iterator
 
 import pytest
-from mock import AsyncMock
-from opentrons.drivers.rpi_drivers.types import USBPort
+
+from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.modules import MagDeck
+
+from .build_module import build_module
 
 
 @pytest.fixture
 async def magdeck(
     emulation_app: Iterator[None],
     emulator_settings: Settings,
+    execution_manager: ExecutionManager,
 ) -> AsyncIterator[MagDeck]:
-    module = await MagDeck.build(
-        port=f"socket://127.0.0.1:{emulator_settings.magdeck_proxy.driver_port}",
-        execution_manager=AsyncMock(),
-        usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-        hw_control_loop=asyncio.get_running_loop(),
+    module = await build_module(
+        MagDeck,
+        port=emulator_settings.magdeck_proxy.driver_port,
+        execution_manager=execution_manager,
     )
     yield module
     await module.cleanup()
 
 
-def test_device_info(magdeck: MagDeck):
+def test_device_info(magdeck: MagDeck) -> None:
     assert magdeck.device_info == {
         "model": "mag_deck_v20",
         "serial": "magnetic_emulator",
@@ -31,7 +32,7 @@ def test_device_info(magdeck: MagDeck):
     }
 
 
-async def test_engage_cycle(magdeck: MagDeck):
+async def test_engage_cycle(magdeck: MagDeck) -> None:
     """It should cycle engage and disengage"""
     await magdeck.engage(1)
     assert magdeck.current_height == 1
@@ -48,7 +49,7 @@ async def test_engage_cycle(magdeck: MagDeck):
     }
 
 
-async def test_engage_from_base_cycle(magdeck: MagDeck):
+async def test_engage_from_base_cycle(magdeck: MagDeck) -> None:
     """It should cycle engage/disengage, taking the offset from base into account."""
     await magdeck.engage(height_from_base=1)
     assert magdeck.current_height == 3.5

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Iterator
+from typing import AsyncGenerator
 
 import pytest
 from opentrons.drivers.rpi_drivers.types import USBPort
@@ -11,18 +11,19 @@ from opentrons.hardware_control.modules import TempDeck
 @pytest.fixture
 async def tempdeck(
     emulator_settings: Settings,
-    emulation_app: Iterator[None],
-) -> TempDeck:
+    emulation_app: None,
+    execution_manager: ExecutionManager,
+    poll_interval_seconds: float,
+) -> AsyncGenerator[TempDeck, None]:
     execution_manager = ExecutionManager()
     module = await TempDeck.build(
         port=f"socket://127.0.0.1:{emulator_settings.temperature_proxy.driver_port}",
         execution_manager=execution_manager,
         usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-        loop=asyncio.get_running_loop(),
-        polling_frequency=0.01,
+        hw_control_loop=asyncio.get_running_loop(),
+        poll_interval_seconds=poll_interval_seconds,
     )
     yield module
-    await execution_manager.cancel()
     await module.cleanup()
 
 

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -58,7 +58,7 @@ async def test_start_set_temperature_cool(tempdeck: TempDeck) -> None:
     await tempdeck.start_set_temperature(new_temp)
     assert tempdeck.live_data == {
         "status": "cooling",
-        "data": {"currentTemp": current, "targetTemp": new_temp},
+        "data": {"currentTemp": pytest.approx(current, abs=5), "targetTemp": new_temp},
     }
 
     # Wait for temperature to be reached
@@ -77,7 +77,7 @@ async def test_start_set_temperature_heat(tempdeck: TempDeck) -> None:
     await tempdeck.start_set_temperature(new_temp)
     assert tempdeck.live_data == {
         "status": "heating",
-        "data": {"currentTemp": current, "targetTemp": new_temp},
+        "data": {"currentTemp": pytest.approx(current, abs=5), "targetTemp": new_temp},
     }
 
     # Wait for temperature to be reached

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -1,11 +1,11 @@
-import asyncio
 from typing import AsyncGenerator
 
 import pytest
-from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.modules import TempDeck
+
+from .build_module import build_module
 
 
 @pytest.fixture
@@ -15,12 +15,10 @@ async def tempdeck(
     execution_manager: ExecutionManager,
     poll_interval_seconds: float,
 ) -> AsyncGenerator[TempDeck, None]:
-    execution_manager = ExecutionManager()
-    module = await TempDeck.build(
-        port=f"socket://127.0.0.1:{emulator_settings.temperature_proxy.driver_port}",
+    module = await build_module(
+        TempDeck,
+        port=emulator_settings.temperature_proxy.driver_port,
         execution_manager=execution_manager,
-        usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-        hw_control_loop=asyncio.get_running_loop(),
         poll_interval_seconds=poll_interval_seconds,
     )
     yield module

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -37,7 +37,6 @@ def test_device_info(tempdeck: TempDeck) -> None:
 
 async def test_set_temperature(tempdeck: TempDeck) -> None:
     """It should set the temperature and return when target is reached."""
-    await tempdeck.wait_next_poll()
     assert tempdeck.live_data == {
         "status": "idle",
         "data": {"currentTemp": 0, "targetTemp": None},
@@ -54,7 +53,6 @@ async def test_set_temperature(tempdeck: TempDeck) -> None:
 
 async def test_start_set_temperature_cool(tempdeck: TempDeck) -> None:
     """It should set the temperature and return and wait for temperature."""
-    await tempdeck.wait_next_poll()
     current = tempdeck.temperature
     new_temp = current - 20
 
@@ -74,7 +72,6 @@ async def test_start_set_temperature_cool(tempdeck: TempDeck) -> None:
 
 async def test_start_set_temperature_heat(tempdeck: TempDeck) -> None:
     """It should set the temperature and return and wait for temperature."""
-    await tempdeck.wait_next_poll()
     current = tempdeck.temperature
     new_temp = current + 20
 

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -129,6 +129,7 @@ async def test_wait_for_temperatures(thermocycler: Thermocycler) -> None:
 # TODO(mm, 2022-07-01): This test is a flakiness hazard because it's sensitive to
 # timing and async task scheduling.
 async def test_cycle_cannot_be_interrupted_by_pause(
+    poll_interval_seconds: int,
     thermocycler: Thermocycler,
     execution_manager: ExecutionManager,
 ) -> None:
@@ -150,11 +151,10 @@ async def test_cycle_cannot_be_interrupted_by_pause(
     # in the middle of it, but not so long that makes the test take a disruptively
     # long time.
     steps = [
-        *[
-            {"temperature": temp_1},
-            {"temperature": temp_2},
-        ]
-        * 5,
+        {"temperature": temp_1, "hold_time_seconds": poll_interval_seconds * 2},
+        {"temperature": temp_2, "hold_time_seconds": poll_interval_seconds * 2},
+        {"temperature": temp_1, "hold_time_seconds": poll_interval_seconds * 2},
+        {"temperature": temp_2, "hold_time_seconds": poll_interval_seconds * 2},
         {"temperature": final_temp},
     ]
 

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -47,7 +47,6 @@ def test_device_info(thermocycler: Thermocycler) -> None:
 
 async def test_lid_status(thermocycler: Thermocycler) -> None:
     """It should run open and close lid."""
-    await thermocycler.wait_next_poll()
     assert thermocycler.lid_status == "open"
 
     await thermocycler.close()
@@ -66,7 +65,6 @@ async def test_lid_temperature(thermocycler: Thermocycler) -> None:
     assert thermocycler.lid_target == 40
 
     await thermocycler.deactivate_lid()
-    await thermocycler.wait_next_poll()
     assert thermocycler.lid_target is None
 
 
@@ -82,7 +80,6 @@ async def test_plate_temperature(thermocycler: Thermocycler) -> None:
     assert thermocycler.temperature == 80
 
     await thermocycler.deactivate_block()
-    await thermocycler.wait_next_poll()
     assert thermocycler.target is None
 
 

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from typing import AsyncGenerator
 
 import anyio
@@ -127,7 +128,10 @@ async def test_wait_for_temperatures(thermocycler: Thermocycler) -> None:
 
 
 # TODO(mm, 2022-07-01): This test is a flakiness hazard because it's sensitive to
-# timing and async task scheduling.
+# timing and async task scheduling. Move to an isolated unit test, instead
+@pytest.mark.xfail(
+    condition=(sys.platform == "darwin"), reason="Timing flakiness on macOS"
+)
 async def test_cycle_cannot_be_interrupted_by_pause(
     poll_interval_seconds: int,
     thermocycler: Thermocycler,

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -4,11 +4,12 @@ from typing import AsyncGenerator
 import anyio
 import pytest
 
-from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.modules import Thermocycler
 from opentrons.hardware_control.modules.types import TemperatureStatus
+
+from .build_module import build_module
 
 
 @pytest.fixture
@@ -19,11 +20,10 @@ async def thermocycler(
     poll_interval_seconds: float,
 ) -> AsyncGenerator[Thermocycler, None]:
     """Return a Thermocycler test subject."""
-    module = await Thermocycler.build(
-        port=f"socket://127.0.0.1:{emulator_settings.thermocycler_proxy.driver_port}",
+    module = await build_module(
+        Thermocycler,
+        port=emulator_settings.thermocycler_proxy.driver_port,
         execution_manager=execution_manager,
-        usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
-        hw_control_loop=asyncio.get_running_loop(),
         poll_interval_seconds=poll_interval_seconds,
     )
     yield module

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -28,7 +28,7 @@ async def simulating_module(usb_port):
         usb_port=usb_port,
         type=modules.ModuleType.HEATER_SHAKER,
         simulating=True,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     assert isinstance(module, modules.AbstractModule)

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -22,7 +22,7 @@ async def test_sim_initialization(usb_port):
         usb_port=usb_port,
         type=modules.ModuleType.MAGNETIC,
         simulating=True,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     assert isinstance(mag, modules.AbstractModule)
@@ -34,7 +34,7 @@ async def test_sim_data(usb_port):
         usb_port=usb_port,
         type=modules.ModuleType.MAGNETIC,
         simulating=True,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     assert mag.status == "disengaged"
@@ -52,7 +52,7 @@ async def test_sim_state_update(usb_port):
         usb_port=usb_port,
         type=modules.ModuleType.MAGNETIC,
         simulating=True,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     await mag.calibrate()
@@ -69,7 +69,7 @@ async def test_revision_model_parsing(usb_port):
         type=modules.ModuleType.MAGNETIC,
         simulating=True,
         usb_port=usb_port,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     mag._device_info["model"] = "mag_deck_v1.1"

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -24,7 +24,7 @@ async def subject(usb_port: USBPort) -> modules.AbstractModule:
         usb_port=usb_port,
         type=modules.ModuleType.TEMPERATURE,
         simulating=True,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     yield temp

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -1,12 +1,9 @@
 import asyncio
-from mock import AsyncMock
 
 import pytest
 
 from opentrons.drivers.rpi_drivers.types import USBPort
-from opentrons.drivers.temp_deck import AbstractTempDeckDriver
-from opentrons.hardware_control import modules, poller, ExecutionManager
-from opentrons.hardware_control.modules.tempdeck import TempDeckReader
+from opentrons.hardware_control import modules, ExecutionManager
 
 
 @pytest.fixture
@@ -39,7 +36,6 @@ async def test_sim_initialization(subject: modules.AbstractModule):
 
 
 async def test_sim_state(subject: modules.AbstractModule):
-    await subject.wait_next_poll()
     assert subject.temperature == 0
     assert subject.target is None
     assert subject.status == "idle"
@@ -74,24 +70,3 @@ async def test_revision_model_parsing(subject: modules.AbstractModule):
     assert subject.model() == "temperatureModuleV1"
     subject._device_info["model"] = "temp_deck_v1.1"
     assert subject.model() == "temperatureModuleV1"
-
-
-async def test_poll_error(usb_port: USBPort) -> None:
-    mock_driver = AsyncMock(spec=AbstractTempDeckDriver)
-    mock_reader = AsyncMock(spec=TempDeckReader)
-    mock_reader.read.side_effect = ValueError("hello!")
-
-    tempdeck = modules.TempDeck(
-        port="",
-        usb_port=usb_port,
-        execution_manager=AsyncMock(spec=ExecutionManager),
-        driver=mock_driver,
-        reader=mock_reader,
-        poller=poller.Poller(reader=mock_reader, interval=0.1),
-        device_info={},
-        loop=asyncio.get_running_loop(),
-    )
-    with pytest.raises(ValueError, match="hello!"):
-        await tempdeck.wait_next_poll()
-
-    await tempdeck.cleanup()

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -29,7 +29,7 @@ async def subject(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, Non
         usb_port=usb_port,
         type=modules.ModuleType.THERMOCYCLER,
         simulating=True,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     yield cast(modules.Thermocycler, therm)
@@ -142,7 +142,7 @@ async def set_temperature_subject(
     hw_tc = modules.Thermocycler(
         port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
         driver=simulator_set_plate_spy,
         reader=reader,

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -76,7 +76,6 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
     assert subject.status == "holding at target"
 
     await subject.deactivate_block()
-    await subject.wait_next_poll()
     assert subject.temperature == 23
     assert subject.target is None
     assert subject.status == "idle"
@@ -150,6 +149,8 @@ async def set_temperature_subject(
         poller=poller,
         device_info={},
     )
+
+    await poller.start()
     yield hw_tc
     await hw_tc.cleanup()
 

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -107,8 +107,6 @@ async def test_create_simulating_module(
 async def mod_tempdeck():
     from opentrons.hardware_control import modules
 
-    loop = asyncio.get_running_loop()
-
     usb_port = USBPort(
         name="",
         hub=None,
@@ -121,7 +119,7 @@ async def mod_tempdeck():
         usb_port=usb_port,
         type=ModuleType.TEMPERATURE,
         simulating=True,
-        loop=loop,
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
         sim_model="temperatureModuleV2",
     )
@@ -132,8 +130,6 @@ async def mod_tempdeck():
 @pytest.fixture
 async def mod_magdeck():
     from opentrons.hardware_control import modules
-
-    loop = asyncio.get_running_loop()
 
     usb_port = USBPort(
         name="",
@@ -147,7 +143,7 @@ async def mod_magdeck():
         usb_port=usb_port,
         type=ModuleType.MAGNETIC,
         simulating=True,
-        loop=loop,
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     yield magdeck
@@ -158,8 +154,6 @@ async def mod_magdeck():
 async def mod_thermocycler():
     from opentrons.hardware_control import modules
 
-    loop = asyncio.get_running_loop()
-
     usb_port = USBPort(
         name="",
         hub=None,
@@ -172,7 +166,7 @@ async def mod_thermocycler():
         usb_port=usb_port,
         type=ModuleType.THERMOCYCLER,
         simulating=True,
-        loop=loop,
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     yield thermocycler
@@ -183,8 +177,6 @@ async def mod_thermocycler():
 async def mod_thermocycler_gen2():
     from opentrons.hardware_control import modules
 
-    loop = asyncio.get_running_loop()
-
     usb_port = USBPort(
         name="",
         hub=None,
@@ -197,7 +189,7 @@ async def mod_thermocycler_gen2():
         usb_port=usb_port,
         type=ModuleType.THERMOCYCLER,
         simulating=True,
-        loop=loop,
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
         sim_model="thermocyclerModuleV2",
     )
@@ -208,8 +200,6 @@ async def mod_thermocycler_gen2():
 @pytest.fixture
 async def mod_heatershaker():
     from opentrons.hardware_control import modules
-
-    loop = asyncio.get_running_loop()
 
     usb_port = USBPort(
         name="",
@@ -223,7 +213,7 @@ async def mod_heatershaker():
         usb_port=usb_port,
         type=ModuleType.HEATER_SHAKER,
         simulating=True,
-        loop=loop,
+        hw_control_loop=asyncio.get_running_loop(),
         execution_manager=ExecutionManager(),
     )
     yield heatershaker

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -78,7 +78,7 @@ async def test_poller_concurrency(
     """It should wait for a full poll before notifying."""
     # wait for the first read to start
     asyncio.create_task(subject.start())
-    await asyncio.wait_for(read_started_event.wait(), timeout=2 * subject.interval)
+    await asyncio.wait_for(read_started_event.wait(), timeout=4 * subject.interval)
 
     # subscribe in the middle of the first read
     poll_notification = asyncio.create_task(subject.wait_next_poll())
@@ -86,7 +86,7 @@ async def test_poller_concurrency(
     # allow the first read to finish, then wait for the second read to start
     read_started_event.clear()
     ok_to_finish_read_event.set()
-    await asyncio.wait_for(read_started_event.wait(), timeout=2 * subject.interval)
+    await asyncio.wait_for(read_started_event.wait(), timeout=4 * subject.interval)
 
     # verify that our wait isn't done, because it was kicked off after the first read started
     assert poll_notification.done() is False
@@ -94,7 +94,7 @@ async def test_poller_concurrency(
     # allow the second read to complete and wait for the third read to start
     read_started_event.clear()
     ok_to_finish_read_event.set()
-    await asyncio.wait_for(read_started_event.wait(), timeout=2 * subject.interval)
+    await asyncio.wait_for(read_started_event.wait(), timeout=4 * subject.interval)
 
     # verify the waiter has now been notified since it's been through the full second read
     assert poll_notification.done() is True
@@ -108,15 +108,15 @@ async def test_poller_stop_waits_for_poll(
 ) -> None:
     # wait for the first read to start
     asyncio.create_task(subject.start())
-    await asyncio.wait_for(read_started_event.wait(), timeout=2 * subject.interval)
+    await asyncio.wait_for(read_started_event.wait(), timeout=4 * subject.interval)
 
     # request a stop in the middle of the first read
     stop_request = asyncio.create_task(subject.stop())
-    await asyncio.sleep(2 * subject.interval)
+    await asyncio.sleep(4 * subject.interval)
     assert stop_request.done() is False
 
     ok_to_finish_read_event.set()
-    await asyncio.sleep(subject.interval)
+    await asyncio.sleep(2 * subject.interval)
     assert stop_request.done() is True
 
 

--- a/api/tests/opentrons/hardware_control/test_thread_manager.py
+++ b/api/tests/opentrons/hardware_control/test_thread_manager.py
@@ -1,7 +1,9 @@
 import asyncio
+import weakref
+from typing import Any
 
 import pytest
-import weakref
+
 from opentrons.hardware_control.modules import ModuleAtPort
 from opentrons.hardware_control.thread_manager import (
     ThreadManagerException,
@@ -10,17 +12,17 @@ from opentrons.hardware_control.thread_manager import (
 from opentrons.hardware_control.api import API
 
 
+async def _raise_exception() -> Any:
+    raise Exception("oh no")
+
+
 def test_build_fail_raises_exception():
     """
     Test that a builder that raises an exception raises
     a ThreadManagerException
     """
-
-    def f():
-        raise Exception()
-
     with pytest.raises(ThreadManagerException):
-        ThreadManager(f)
+        ThreadManager(_raise_exception)
 
 
 def test_module_cache_add_entry():

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -30,7 +30,7 @@ async def magdeck():
         type=ModuleType.MAGNETIC,
         simulating=True,
         execution_manager=ExecutionManager(),
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
     )
     MagDeck.current_height = PropertyMock(return_value=321)
 
@@ -53,7 +53,7 @@ async def tempdeck():
         type=ModuleType.TEMPERATURE,
         simulating=True,
         execution_manager=ExecutionManager(),
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
     )
     TempDeck.temperature = PropertyMock(return_value=123.0)
     TempDeck.target = PropertyMock(return_value=321.0)
@@ -77,7 +77,7 @@ async def thermocycler():
         type=ModuleType.THERMOCYCLER,
         simulating=True,
         execution_manager=ExecutionManager(),
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
     )
 
     Thermocycler.lid_status = PropertyMock(return_value="open")
@@ -111,7 +111,7 @@ async def heater_shaker():
         type=ModuleType.HEATER_SHAKER,
         simulating=True,
         execution_manager=ExecutionManager(),
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
     )
 
     HeaterShaker.live_data = PropertyMock(


### PR DESCRIPTION
## Overview

This PR makes several changes to the module HW APIs and integration tests to improve the reliability of the module APIs in a way that also reduces flakiness of the integration tests.

Fundamentally, most of the flakiness is caused by this order of events occurring:

0. Some test starts, module HW API built and connected
    - To build module HW API, device info is queried from module
    - Emulator sees "get device info" G-Code and responds accordingly
1. Test runs to completion
2. Poller kicks off a poll
3. "Read data" G-Codes sent over network to module emulator
4. Test fixture cleanup runs, poller cancelled, driver disconnected
5. "Read data" response G-Code sent back by module emulator
    - Response gets buffered somewhere but never hits the driver, because it disconnected
    - Probably buffered in the network proxy, not 100% sure
6. New test starts
7. New HW API is built, device info queried
    - Emulator sees "get device info" G-Code and responds accordingly
9. Driver sees previously buffered response instead of the latest response to "get device info"
10. Driver errors out trying to parse the wrong thing as a device info response
    - e.g. `KeyError: "model"`

## Changelog

Most important changes:

- **Reduce likelihood of stale module responses getting buffered in the emulator's serial proxy**
    - I had good results with this change locally on macOS
    - Not enough to prevent failures in CI, though
- **Wait for any in-progress poll to complete in the poller before cancelling.**
    - This drastically lowers the risk of poller cancellation / driver disconnection happening in the middle of a G-Code read/response cycle

Other minor changes:

- Ensure a module's poller completes its first read before returning a built module HW API
- Remove `wait_next_poll` as a public method of the modules' HW APIs to force other methods to behave predictably
- Clean up module build signature to:
    - Avoid `kwargs` for better type checking
    - Rename / make explicit a `hw_control_loop` parameter of module construction, to reduce the risk of future threading bugs caused by implicit asyncio loop creation
- Remove inappropriate mocks from module integration tests, which were causing warnings 
- `xfail` a known flakey Thermocycler test on macOS, where it seems to fail the most in CI
    - Test can/should be replaced with an isolated unit test, eventually

## Review requests

Check that the tests pass for you locally. I'm re-running CI repeatedly to try to get a sense of how much this PR actually reduces flakiness:

1. ⚠️ [Attempt 1](https://github.com/Opentrons/opentrons/actions/runs/3292542507/attempts/1)
    - All runners ✅ except...
    - macOS, which froze inside `tests/opentrons/hardware_control/emulation`
2. ✅ [Attempt 2](https://github.com/Opentrons/opentrons/actions/runs/3292542507/attempts/2)
3. ✅ [Attempt 3](https://github.com/Opentrons/opentrons/actions/runs/3292542507/attempts/3)
4. ✅ [Attempt 4](https://github.com/Opentrons/opentrons/actions/runs/3292542507/attempts/4)
5. ✅ [Attempt 5](https://github.com/Opentrons/opentrons/actions/runs/3292542507/attempts/5)

## Risk assessment

Low, especially given the amount of module smoke testing that will happen on this branch and in subsequent PRs. Module integration tests, when they're not flaking out, give us a lot of confidence in the system