### PR TITLE
fix(api): Reduce Z axis max speed to 65 mm/sec on EVT units

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -63,48 +63,47 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
     none={
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
-        OT3AxisKind.Z: 200,
+        OT3AxisKind.Z: 65,
         OT3AxisKind.P: 45,
         OT3AxisKind.Z_G: 100,
     },
     high_throughput={
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
-        OT3AxisKind.Z: 200,
+        OT3AxisKind.Z: 35,
         OT3AxisKind.P: 45,
     },
     low_throughput={
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
-        OT3AxisKind.Z: 200,
+        OT3AxisKind.Z: 65,
         OT3AxisKind.P: 45,
     },
     two_low_throughput={
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
     },
-    gripper={OT3AxisKind.Z: 200},
+    gripper={OT3AxisKind.Z: 65},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
         OT3AxisKind.X: 1000,
         OT3AxisKind.Y: 1000,
-        OT3AxisKind.Z: 500,
+        OT3AxisKind.Z: 100,
         OT3AxisKind.P: 50,
-        OT3AxisKind.Z_G: 100,
         OT3AxisKind.Z_G: 20,
     },
     high_throughput={
         OT3AxisKind.X: 1000,
         OT3AxisKind.Y: 1000,
-        OT3AxisKind.Z: 500,
+        OT3AxisKind.Z: 100,
         OT3AxisKind.P: 50,
     },
     low_throughput={
         OT3AxisKind.X: 1000,
         OT3AxisKind.Y: 1000,
-        OT3AxisKind.Z: 500,
+        OT3AxisKind.Z: 100,
         OT3AxisKind.P: 50,
     },
     two_low_throughput={
@@ -112,7 +111,7 @@ DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryL
         OT3AxisKind.Y: 1000,
     },
     gripper={
-        OT3AxisKind.Z: 500,
+        OT3AxisKind.Z: 100,
     },
 )
 
@@ -120,10 +119,10 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
     ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 90,
-        OT3AxisKind.Y: 90,
-        OT3AxisKind.Z: 40,
-        OT3AxisKind.Z_G: 15,
+        OT3AxisKind.X: 10,
+        OT3AxisKind.Y: 10,
+        OT3AxisKind.Z: 10,
+        OT3AxisKind.Z_G: 10,
         OT3AxisKind.P: 10,
     },
     high_throughput={


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

EVT units have a geared-up Z axis. So we slowed it down.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
