### PR TITLE
fix(labware-library, shared-data): block OT-3 trash defs

### DIFF
--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -32,6 +32,7 @@ export const LABWAREV2_DO_NOT_LIST = [
   'tipone_96_tiprack_200ul',
   'opentrons_1_trash_850ml_fixed',
   'opentrons_1_trash_1100ml_fixed',
+  'opentrons_1_trash_3200ml_fixed',
   'eppendorf_96_tiprack_1000ul_eptips',
   'eppendorf_96_tiprack_10ul_eptips',
   'opentrons_calibrationblock_short_side_left',


### PR DESCRIPTION
# Overview
After we added the OT-3 trash def to shared data we forgot to add it to our block list. This PR does that so it doesn't show up in LL

closes RAUT-204


# Changelog

- Block OT-3 trash def

# Review requests

run LL locally and make sure the trash def does not show up
# Risk assessment

Low
