### PR TITLE
fix(hardware-testing): Increase XY speed during homing

### DIFF
--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -1,12 +1,10 @@
 """Opentrons helper methods."""
-import asyncio
 from dataclasses import dataclass, replace
 from datetime import datetime
 from subprocess import run
 from typing import List, Optional, Dict, Tuple
 
 from opentrons.config.robot_configs import build_config_ot3, load_ot3 as load_ot3_config
-from opentrons.config.defaults_ot3 import DEFAULT_MAX_SPEED_DISCONTINUITY
 from opentrons.hardware_control.instruments.pipette import Pipette
 from opentrons.hardware_control.ot3api import OT3API
 
@@ -194,17 +192,17 @@ async def set_gantry_load_per_axis_settings_ot3(
 
 async def home_ot3(api: OT3API, axes: Optional[List[OT3Axis]] = None) -> None:
     """Home OT3 gantry."""
-    default_home_speed = 10
-    default_home_speed_xy = 40
+    default_home_speed = 10.0
+    default_home_speed_xy = 40.0
 
-    homing_speeds = {
+    homing_speeds: Dict[OT3Axis, float] = {
         OT3Axis.X: default_home_speed_xy,
         OT3Axis.Y: default_home_speed_xy,
         OT3Axis.Z_L: default_home_speed,
         OT3Axis.Z_R: default_home_speed,
         OT3Axis.Z_G: default_home_speed,
         OT3Axis.P_L: default_home_speed,
-        OT3Axis.P_R: default_home_speed
+        OT3Axis.P_R: default_home_speed,
     }
 
     # save our current script's settings


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Increased homing speed for XY axes on OT-3.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
