### PR TITLE
feat(shared_data): update OT-3 deck def dimensions and slot positions

### DIFF
--- a/shared-data/deck/definitions/3/ot3_standard.json
+++ b/shared-data/deck/definitions/3/ot3_standard.json
@@ -30,7 +30,7 @@
       },
       {
         "id": "2",
-        "position": [145.0, 0.0, 0.0],
+        "position": [164.0, 0.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
@@ -46,7 +46,7 @@
       },
       {
         "id": "3",
-        "position": [290.0, 0.0, 0.0],
+        "position": [328.0, 0.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
@@ -78,7 +78,7 @@
       },
       {
         "id": "5",
-        "position": [145.0, 107, 0.0],
+        "position": [164.0, 107, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
@@ -94,7 +94,7 @@
       },
       {
         "id": "6",
-        "position": [290.0, 107, 0.0],
+        "position": [328.0, 107, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
@@ -127,7 +127,7 @@
       },
       {
         "id": "8",
-        "position": [145.0, 214.0, 0.0],
+        "position": [164.0, 214.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
@@ -143,7 +143,7 @@
       },
       {
         "id": "9",
-        "position": [290.0, 214.0, 0.0],
+        "position": [328.0, 214.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
@@ -191,7 +191,7 @@
       },
       {
         "id": "12",
-        "position": [290.0, 321.0, 0.0],
+        "position": [328.0, 321.0, 0.0],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,

--- a/shared-data/deck/definitions/3/ot3_standard.json
+++ b/shared-data/deck/definitions/3/ot3_standard.json
@@ -1,7 +1,7 @@
 {
   "otId": "ot3_standard",
   "schemaVersion": 3,
-  "cornerOffsetFromOrigin": [ -194.69, -75.59, 0],
+  "cornerOffsetFromOrigin": [ -204.31, -76.59, 0],
   "dimensions": [854.995, 581.740, 0],
   "metadata": {
     "displayName": "OT-3 Standard Deck",

--- a/shared-data/deck/definitions/3/ot3_standard.json
+++ b/shared-data/deck/definitions/3/ot3_standard.json
@@ -1,8 +1,8 @@
 {
   "otId": "ot3_standard",
   "schemaVersion": 3,
-  "cornerOffsetFromOrigin": [ -204.31, -76.59, 0],
-  "dimensions": [854.995, 581.740, 0],
+  "cornerOffsetFromOrigin": [-204.31, -76.59, 0],
+  "dimensions": [854.995, 581.74, 0],
   "metadata": {
     "displayName": "OT-3 Standard Deck",
     "tags": ["ot3", "12 slots", "standard"]

--- a/shared-data/deck/definitions/3/ot3_standard.json
+++ b/shared-data/deck/definitions/3/ot3_standard.json
@@ -1,8 +1,8 @@
 {
   "otId": "ot3_standard",
   "schemaVersion": 3,
-  "cornerOffsetFromOrigin": [-115.65, -68.03, 0],
-  "dimensions": [580, 430, 0],
+  "cornerOffsetFromOrigin": [ -194.69, -75.59, 0],
+  "dimensions": [854.995, 581.740, 0],
   "metadata": {
     "displayName": "OT-3 Standard Deck",
     "tags": ["ot3", "12 slots", "standard"]
@@ -175,7 +175,7 @@
       },
       {
         "id": "11",
-        "position": [145.0, 321.0, 0.0],
+        "position": [164.0, 321.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,


### PR DESCRIPTION
# Overview

OT-3 deck dimensions + slot positions have not been updated since May... this PR updates the deck dimensions and slot positions with values I got from hardware.

# Changelog

- Update OT-3 deck dimensions and slot positions


# Review requests

@sfoster1 @andySigler double check these changes are legit (I used [this sheet](https://docs.google.com/spreadsheets/d/12fcm5NeNBA2P_qvL7jtHyek7GoX7NyG19H2OpSI6wFU/edit#gid=1591524405))

For app & ui folks, confirm that [storybook](https://s3-us-west-2.amazonaws.com/opentrons-components/shared_data-update-ot3-deck-dimensions/index.html?path=/story/library-molecules-simulation-deck--deck&args=deckDef:ot3_standard) looks like it should!
# Risk assessment

Med
