### PR TITLE
feat(hardware-testing): Simple jog function

### DIFF
--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -277,20 +277,18 @@ async def move_plunger_absolute_ot3(
     if not api.hardware_pipettes[mount.to_mount()]:
         raise PipetteNotAttachedError(f"No pipette found on mount: {mount}")
     plunger_axis = OT3Axis.of_main_tool_actuator(mount)
+    _move_coro = api._move(
+        target_position={plunger_axis: position},  # type: ignore[arg-type]
+        speed=speed,
+    )
     if motor_current is None:
-        await api._move(
-            target_position={plunger_axis: position},  # type: ignore[arg-type]
-            speed=speed,
-        )
+        await _move_coro
     else:
         async with api._backend.restore_current():
             await api._backend.set_active_current(
                 {OT3Axis.of_main_tool_actuator(mount): motor_current}  # type: ignore[dict-item]
             )
-            await api._move(
-                target_position={plunger_axis: position},  # type: ignore[arg-type]
-                speed=speed,
-            )
+            await _move_coro
 
 
 async def move_plunger_relative_ot3(

--- a/hardware-testing/hardware_testing/scripts/test_jogging.py
+++ b/hardware-testing/hardware_testing/scripts/test_jogging.py
@@ -10,7 +10,6 @@ MOUNT = types.OT3Mount.RIGHT
 
 async def _main(is_simulating: bool) -> None:
     api = await helpers_ot3.build_async_ot3_hardware_api(is_simulating=is_simulating)
-    print(api.hardware_pipettes)
     await api.home()
     final_position = await helpers_ot3.jog_mount_ot3(api, MOUNT)
     print(f"Jogged the mount to deck coordinate: {final_position}")

--- a/hardware-testing/hardware_testing/scripts/test_jogging.py
+++ b/hardware-testing/hardware_testing/scripts/test_jogging.py
@@ -1,0 +1,23 @@
+"""Test Jogging."""
+import argparse
+import asyncio
+
+from hardware_testing.opentrons_api import types
+from hardware_testing.opentrons_api import helpers_ot3
+
+MOUNT = types.OT3Mount.RIGHT
+
+
+async def _main(is_simulating: bool) -> None:
+    api = await helpers_ot3.build_async_ot3_hardware_api(is_simulating=is_simulating)
+    print(api.hardware_pipettes)
+    await api.home()
+    final_position = await helpers_ot3.jog_mount_ot3(api, MOUNT)
+    print(f"Jogged the mount to deck coordinate: {final_position}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulate", action="store_true")
+    args = parser.parse_args()
+    asyncio.run(_main(args.simulate))


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

A simple function `jog_mount_ot3()`, which gives a minimal interface to jog an OT3 mount using CLI.

### Example Commands:

|command|description|
|--|--|
|`x1`| jog +1 mm along X axis|
|`x-1`|jog -1 mm along X axis|
|`y-2.345`|jog -2.345 mm along Y axis|
|`z-10`|jog -10 mm along Z axis (depends on mount)|
|`p3`|jog +3 mm along Plunger axis|
|`<ENTER-KEY>`|jog again, using the previously set axis/distance|
|`stop`|stop jogging|

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
