### PR TITLE
feat(protocol-designer): bump up PD version  in settings to 6.0.1

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -58,7 +58,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       title:
         'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 6.0.x, schema v6',
       importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
-      expectedExportFixture: '../../fixtures/protocol/6/mix_6_0_0.json',
+      expectedExportFixture: '../../fixtures/protocol/6/mix_6_0_1.json',
       migrationModal: 'noBehaviorChange',
       unusedPipettes: false,
     },

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -58,7 +58,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       title:
         'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 6.0.x, schema v6',
       importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
-      expectedExportFixture: '../../fixtures/protocol/6/mix_6_0_1.json',
+      expectedExportFixture: '../../fixtures/protocol/6/mix_6_0_0.json',
       migrationModal: 'noBehaviorChange',
       unusedPipettes: false,
     },

--- a/protocol-designer/fixtures/protocol/6/mix_6_0_0.json
+++ b/protocol-designer/fixtures/protocol/6/mix_6_0_0.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "data": {
       "_internalAppBuildDate": "Wed, 06 Jul 2022 19:10:55 GMT",
       "defaultValues": {

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '6.0.0'
+const OT_PD_VERSION = '6.0.1'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.tsx')


### PR DESCRIPTION
closes RAUT-264

# Overview

In settings, the PD version should now say `6.0.1`

<img width="229" alt="Screen Shot 2022-10-18 at 3 13 38 PM" src="https://user-images.githubusercontent.com/66035149/196522872-0f5fac58-97c4-4aab-b0d5-85eeb6b41b74.png">


# Changelog

bump up PD version in `webpack.config`
fix e2e test `migrations.spec.js`

# Review requests

- look at the PD version in settings in PD, should see correct version
# Risk assessment

low