### PR TITLE
feat(engine): implement slot-to-slot labware movement using gripper

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1401,6 +1401,9 @@ class OT3API(
     def attached_gripper(self) -> Optional[GripperDict]:
         return self._gripper_handler.get_gripper_dict()
 
+    def has_gripper(self) -> bool:
+        return self._gripper_handler.has_gripper()
+
     def calibrate_plunger(
         self,
         mount: Union[top_types.Mount, OT3Mount],

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
@@ -8,7 +8,7 @@ from ..command import (
     BaseCommand,
     BaseCommandCreate,
 )
-from ..validation import ensure_ot3_hardware
+from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import OT3Mount
@@ -46,7 +46,9 @@ class CalibratePipetteImplementation(
     async def execute(self, params: CalibratePipetteParams) -> CalibratePipetteResult:
         """Execute calibrate-pipette command."""
         # TODO (tz, 20-9-22): Add a better solution to determine if a command can be executed on an OT-3/OT-2
-        ot3_api = ensure_ot3_hardware(self._hardware_api)
+        ot3_api = ensure_ot3_hardware(
+            self._hardware_api,
+        )
         ot3_mount = OT3Mount.from_mount(params.mount)
 
         pipette_offset = await calibration.calibrate_mount(

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -163,6 +163,7 @@ class AbstractCommandImpl(
         hardware_api: HardwareControlAPI,
         equipment: execution.EquipmentHandler,
         movement: execution.MovementHandler,
+        labware_movement: execution.LabwareMovementHandler,
         pipetting: execution.PipettingHandler,
         run_control: execution.RunControlHandler,
         rail_lights: execution.RailLightsHandler,

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -87,7 +87,7 @@ class MoveLabwareImplementation(
             await self._labware_movement.move_labware_with_gripper(
                 labware_id=params.labwareId,
                 current_location=from_location,
-                new_location=params.newLocation
+                new_location=params.newLocation,
             )
         else:
             # Pause to allow for manual labware movement

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -21,7 +21,7 @@ class MoveLabwareParams(BaseModel):
 
     labwareId: str = Field(..., description="The ID of the labware to move.")
     newLocation: LabwareLocation = Field(..., description="Where to move the labware.")
-    use_gripper: Optional[bool] = Field(
+    useGripper: Optional[bool] = Field(
         False, description="Whether to use the gripper to perform the labware movement."
     )
 
@@ -71,7 +71,7 @@ class MoveLabwareImplementation(
             labware_definition_uri=definition_uri, labware_location=params.newLocation
         )
 
-        if params.use_gripper:
+        if params.useGripper:
             await self._equipment.move_labware_with_gripper(
                 labware_id=params.labwareId, new_location=params.newLocation
             )

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -9,7 +9,8 @@ from ..types import LabwareLocation
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
-    from ..execution import EquipmentHandler
+    from ..execution import EquipmentHandler, RunControlHandler
+    from ..state import StateView
 
 
 MoveLabwareCommandType = Literal["moveLabware"]
@@ -20,6 +21,9 @@ class MoveLabwareParams(BaseModel):
 
     labwareId: str = Field(..., description="The ID of the labware to move.")
     newLocation: LabwareLocation = Field(..., description="Where to move the labware.")
+    use_gripper: Optional[bool] = Field(
+        False, description="Whether to use the gripper to perform the labware movement."
+    )
 
 
 class MoveLabwareResult(BaseModel):
@@ -45,15 +49,36 @@ class MoveLabwareImplementation(
 ):
     """The execution implementation for ``moveLabware`` commands."""
 
-    def __init__(self, equipment: EquipmentHandler, **kwargs: object) -> None:
+    def __init__(
+        self,
+        state_view: StateView,
+        equipment: EquipmentHandler,
+        run_control: RunControlHandler,
+        **kwargs: object,
+    ) -> None:
         self._equipment = equipment
+        self._state_view = state_view
+        self._run_control = run_control
 
     async def execute(self, params: MoveLabwareParams) -> MoveLabwareResult:
         """Move a loaded labware to a new location."""
-        new_offset_id = self._equipment.move_labware(
-            labware_id=params.labwareId,
-            new_location=params.newLocation,
+        # Allow propagation of LabwareNotLoadedError.
+        current_labware = self._state_view.labware.get(labware_id=params.labwareId)
+        definition_uri = current_labware.definitionUri
+
+        # Allow propagation of ModuleNotLoadedError.
+        new_offset_id = self._equipment.find_applicable_labware_offset_id(
+            labware_definition_uri=definition_uri, labware_location=params.newLocation
         )
+
+        if params.use_gripper:
+            await self._equipment.move_labware_with_gripper(
+                labware_id=params.labwareId, new_location=params.newLocation
+            )
+        else:
+            # Pause to allow for manual labware movement
+            await self._run_control.wait_for_resume()
+
         return MoveLabwareResult(offsetId=new_offset_id)
 
 

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -40,6 +40,7 @@ from .exceptions import (
     PauseNotAllowedError,
     ProtocolCommandFailedError,
     GripperNotAttachedError,
+    HardwareNotSupportedError,
     UnsupportedLabwareMovement,
 )
 
@@ -86,6 +87,7 @@ __all__ = [
     "PauseNotAllowedError",
     "ProtocolCommandFailedError",
     "GripperNotAttachedError",
+    "HardwareNotSupportedError",
     "UnsupportedLabwareMovement",
     # error occurrence models
     "ErrorOccurrence",

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -41,7 +41,7 @@ from .exceptions import (
     ProtocolCommandFailedError,
     GripperNotAttachedError,
     HardwareNotSupportedError,
-    UnsupportedLabwareMovement,
+    UnsupportedLabwareMovementError,
 )
 
 from .error_occurrence import ErrorOccurrence
@@ -88,7 +88,7 @@ __all__ = [
     "ProtocolCommandFailedError",
     "GripperNotAttachedError",
     "HardwareNotSupportedError",
-    "UnsupportedLabwareMovement",
+    "UnsupportedLabwareMovementError",
     # error occurrence models
     "ErrorOccurrence",
 ]

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -39,6 +39,8 @@ from .exceptions import (
     CannotPerformModuleAction,
     PauseNotAllowedError,
     ProtocolCommandFailedError,
+    GripperNotAttachedError,
+    UnsupportedLabwareMovement,
 )
 
 from .error_occurrence import ErrorOccurrence
@@ -83,6 +85,8 @@ __all__ = [
     "CannotPerformModuleAction",
     "PauseNotAllowedError",
     "ProtocolCommandFailedError",
+    "GripperNotAttachedError",
+    "UnsupportedLabwareMovement",
     # error occurrence models
     "ErrorOccurrence",
 ]

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -181,5 +181,5 @@ class GripperNotAttachedError(ProtocolEngineError):
     """An error raised when executing a gripper action without an attached gripper."""
 
 
-class UnsupportedLabwareMovement(ProtocolEngineError):
+class UnsupportedLabwareMovementError(ProtocolEngineError):
     """An error raised when attempting an illegal labware movement."""

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -175,3 +175,11 @@ class ProtocolCommandFailedError(ProtocolEngineError):
 
 class HardwareNotSupportedError(ProtocolEngineError):
     """An error raised when executing a command on the wrong hardware."""
+
+
+class GripperNotAttachedError(ProtocolEngineError):
+    """An error raised when executing a gripper action without an attached gripper."""
+
+
+class UnsupportedLabwareMovement(ProtocolEngineError):
+    """An error raised when attempting an illegal labware movement."""

--- a/api/src/opentrons/protocol_engine/execution/__init__.py
+++ b/api/src/opentrons/protocol_engine/execution/__init__.py
@@ -9,6 +9,7 @@ from .equipment import (
     LoadedModuleData,
 )
 from .movement import MovementHandler, MoveRelativeData, SavedPositionData
+from .labware_movement import LabwareMovementHandler
 from .pipetting import PipettingHandler
 from .queue_worker import QueueWorker
 from .rail_lights import RailLightsHandler
@@ -30,6 +31,7 @@ __all__ = [
     "MoveRelativeData",
     "SavedPositionData",
     "PipettingHandler",
+    "LabwareMovementHandler",
     "QueueWorker",
     "RunControlHandler",
     "HardwareStopper",

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -11,6 +11,7 @@ from ..actions import ActionDispatcher, UpdateCommandAction, FailCommandAction
 from ..errors import ProtocolEngineError, UnexpectedProtocolError
 from .equipment import EquipmentHandler
 from .movement import MovementHandler
+from .labware_movement import LabwareMovementHandler
 from .pipetting import PipettingHandler
 from .run_control import RunControlHandler
 from .rail_lights import RailLightsHandler
@@ -33,6 +34,7 @@ class CommandExecutor:
         action_dispatcher: ActionDispatcher,
         equipment: EquipmentHandler,
         movement: MovementHandler,
+        labware_movement: LabwareMovementHandler,
         pipetting: PipettingHandler,
         run_control: RunControlHandler,
         rail_lights: RailLightsHandler,
@@ -44,6 +46,7 @@ class CommandExecutor:
         self._action_dispatcher = action_dispatcher
         self._equipment = equipment
         self._movement = movement
+        self._labware_movement = labware_movement
         self._pipetting = pipetting
         self._run_control = run_control
         self._rail_lights = rail_lights
@@ -62,6 +65,7 @@ class CommandExecutor:
             hardware_api=self._hardware_api,
             equipment=self._equipment,
             movement=self._movement,
+            labware_movement=self._labware_movement,
             pipetting=self._pipetting,
             run_control=self._run_control,
             rail_lights=self._rail_lights,

--- a/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
@@ -6,6 +6,7 @@ from ..state import StateStore
 from ..actions import ActionDispatcher
 from .equipment import EquipmentHandler
 from .movement import MovementHandler
+from .labware_movement import LabwareMovementHandler
 from .pipetting import PipettingHandler
 from .run_control import RunControlHandler
 from .command_executor import CommandExecutor
@@ -34,6 +35,11 @@ def create_queue_worker(
         state_store=state_store,
     )
 
+    labware_movement_handler = LabwareMovementHandler(
+        hardware_api=hardware_api,
+        state_store=state_store,
+    )
+
     pipetting_handler = PipettingHandler(
         hardware_api=hardware_api,
         state_store=state_store,
@@ -54,6 +60,7 @@ def create_queue_worker(
         action_dispatcher=action_dispatcher,
         equipment=equipment_handler,
         movement=movement_handler,
+        labware_movement=labware_movement_handler,
         pipetting=pipetting_handler,
         run_control=run_control_handler,
         rail_lights=rail_lights_handler,

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -1,14 +1,12 @@
 """Equipment command side-effect logic."""
 from dataclasses import dataclass
-from typing import Optional, overload, Union, List
+from typing import Optional, overload
 
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.config import feature_flags
-from opentrons.types import MountType, Point
+from opentrons.types import MountType
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.types import OT3Mount, OT3Axis
 from opentrons.hardware_control.modules import (
     AbstractModule,
     MagDeck,
@@ -26,8 +24,6 @@ from ..errors import (
     FailedToLoadPipetteError,
     LabwareDefinitionDoesNotExistError,
     ModuleNotAttachedError,
-    GripperNotAttachedError,
-    UnsupportedLabwareMovement,
 )
 from ..resources import LabwareDataProvider, ModuleDataProvider, ModelUtils
 from ..state import StateStore, HardwareModule
@@ -38,12 +34,7 @@ from ..types import (
     LabwareOffsetLocation,
     ModuleModel,
     ModuleDefinition,
-    OFF_DECK_LOCATION,
 )
-
-# TODO: remove once hardware control is able to calibrate & handle the offsets
-GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
-GRIP_FORCE = 20  # Newtons
 
 
 @dataclass(frozen=True)
@@ -149,103 +140,6 @@ class EquipmentHandler:
         return LoadedLabwareData(
             labware_id=labware_id, definition=definition, offsetId=offset_id
         )
-
-    async def move_labware_with_gripper(
-        self, labware_id: str, new_location: LabwareLocation
-    ) -> None:
-        """Move a loaded labware from one location to another."""
-        if not feature_flags.enable_ot3_hardware_controller():
-            raise UnsupportedLabwareMovement(
-                "Labware movement w/ gripper is only available on the OT3"
-            )
-        from opentrons.hardware_control.ot3api import OT3API
-
-        assert isinstance(
-            self._hardware_api, OT3API
-        ), "Gripper is only available on the OT3"
-
-        if self._hardware_api.attached_gripper is None:
-            raise GripperNotAttachedError(
-                "No gripper found in order to perform labware movement with."
-            )
-
-        from_location = self._state_store.labware.get_location(labware_id=labware_id)
-        assert isinstance(
-            from_location, (DeckSlotLocation, ModuleLocation)
-        ), "Off-deck labware movements are not supported using the gripper."
-        assert isinstance(
-            new_location, (DeckSlotLocation, ModuleLocation)
-        ), "Off-deck labware movements are not supported using the gripper."
-
-        gripper_mount = OT3Mount.GRIPPER
-
-        # Retract all mounts
-        await self._hardware_api.home(axes=[OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.Z_G])
-        # TODO: reset well location cache upon completion of command execution
-        await self._hardware_api.home_gripper_jaw()
-
-        gripper_homed_position = await self._hardware_api.gantry_position(
-            mount=gripper_mount
-        )
-        waypoints_to_labware = self._get_gripper_movement_waypoints(
-            labware_id=labware_id,
-            location=from_location,
-            current_position=await self._hardware_api.gantry_position(
-                mount=gripper_mount
-            ),
-            gripper_home_z=gripper_homed_position.z,
-        )
-        for waypoint in waypoints_to_labware:
-            await self._hardware_api.move_to(mount=gripper_mount, abs_position=waypoint)
-
-        await self._hardware_api.grip(force_newtons=GRIP_FORCE)
-
-        waypoints_to_new_location = self._get_gripper_movement_waypoints(
-            labware_id=labware_id,
-            location=new_location,
-            current_position=waypoints_to_labware[-1],
-            gripper_home_z=gripper_homed_position.z,
-        )
-        for waypoint in waypoints_to_new_location:
-            await self._hardware_api.move_to(mount=gripper_mount, abs_position=waypoint)
-
-        await self._hardware_api.ungrip()
-        await self._hardware_api.move_to(
-            mount=OT3Mount.GRIPPER,
-            abs_position=Point(
-                waypoints_to_new_location[-1].x,
-                waypoints_to_new_location[-1].y,
-                gripper_homed_position.z,
-            ),
-        )
-
-    def _get_gripper_movement_waypoints(
-        self,
-        labware_id: str,
-        location: Union[DeckSlotLocation, ModuleLocation],
-        current_position: Point,
-        gripper_home_z: float,
-    ) -> List[Point]:
-        """Get waypoints for gripper to move to a specified location."""
-        # TODO: remove this after support for module locations is added
-        assert isinstance(
-            location, DeckSlotLocation
-        ), "Moving labware to & from modules with a gripper is not implemented yet."
-
-        # Keeping grip height as half of overall height of labware
-        grip_height = (
-            self._state_store.labware.get_dimensions(labware_id=labware_id).z / 2
-        )
-        slot_loc = (
-            self._state_store.labware.get_slot_center_position(location.slotName)
-            + GRIPPER_OFFSET
-        )
-        waypoints: List[Point] = [
-            Point(current_position.x, current_position.y, gripper_home_z),
-            Point(slot_loc.x, slot_loc.y, gripper_home_z),
-            Point(slot_loc.x, slot_loc.y, grip_height),
-        ]
-        return waypoints
 
     async def load_pipette(
         self,
@@ -385,6 +279,7 @@ class EquipmentHandler:
             f' for module ID "{module_id}".'
         )
 
+    # TODO (spp, 2022-10-18): move this to labware state view
     def find_applicable_labware_offset_id(
         self, labware_definition_uri: str, labware_location: LabwareLocation
     ) -> Optional[str]:

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -279,7 +279,6 @@ class EquipmentHandler:
             f' for module ID "{module_id}".'
         )
 
-    # TODO (spp, 2022-10-18): move this to labware state view
     def find_applicable_labware_offset_id(
         self, labware_definition_uri: str, labware_location: LabwareLocation
     ) -> Optional[str]:

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -117,9 +117,12 @@ class LabwareMovementHandler:
     ) -> List[Point]:
         """Get waypoints for gripper to move to a specified location."""
         # TODO: remove this after support for module locations is added
-        assert isinstance(
+        if not isinstance(
             location, DeckSlotLocation
-        ), "Moving labware to & from modules with a gripper is not implemented yet."
+        ):
+            raise NotImplementedError(
+                "Moving labware to & from modules with a gripper is not implemented yet."
+            )
 
         # Keeping grip height as half of overall height of labware
         grip_height = (

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -22,6 +22,8 @@ GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
 GRIP_FORCE = 20  # Newtons
 
 
+# TODO (spp, 2022-10-20): name this GripperMovementHandler if it doesn't handle
+#  any non-gripper implementations
 class LabwareMovementHandler:
     """Implementation logic for labware movement."""
 
@@ -117,9 +119,7 @@ class LabwareMovementHandler:
     ) -> List[Point]:
         """Get waypoints for gripper to move to a specified location."""
         # TODO: remove this after support for module locations is added
-        if not isinstance(
-            location, DeckSlotLocation
-        ):
+        if not isinstance(location, DeckSlotLocation):
             raise NotImplementedError(
                 "Moving labware to & from modules with a gripper is not implemented yet."
             )
@@ -150,6 +150,7 @@ class LabwareMovementHandler:
         ]
         return waypoints
 
+    # TODO (spp, 2022-10-20): move to labware view
     @staticmethod
     def ensure_valid_gripper_location(
         location: LabwareLocation,

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -1,0 +1,135 @@
+"""Labware movement command handling."""
+from typing import Optional, Union, List
+
+# from opentrons.config import feature_flags
+from opentrons.types import Point
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.ot3api import OT3API
+from opentrons.hardware_control.types import OT3Mount, OT3Axis
+from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.protocol_engine.state import StateStore
+
+from ..errors import (
+    GripperNotAttachedError,
+    # UnsupportedLabwareMovement,
+)
+
+from ..types import (
+    DeckSlotLocation,
+    ModuleLocation,
+)
+
+
+# TODO: remove once hardware control is able to calibrate & handle the offsets
+GRIPPER_OFFSET = Point(0.0, 1.0, 0.0)
+GRIP_FORCE = 20  # Newtons
+
+
+class LabwareMovementHandler:
+    """Implementation logic for labware movement."""
+
+    _hardware_api: HardwareControlAPI
+    _state_store: StateStore
+    _model_utils: ModelUtils
+
+    def __init__(
+            self,
+            hardware_api: HardwareControlAPI,
+            state_store: StateStore,
+            model_utils: Optional[ModelUtils] = None,
+    ) -> None:
+        """Initialize a LabwareMovementHandler instance."""
+        self._hardware_api = hardware_api
+        self._state_store = state_store
+        self._model_utils = model_utils or ModelUtils()
+
+    async def move_labware_with_gripper(
+        self,
+        labware_id: str,
+        current_location: Union[DeckSlotLocation, ModuleLocation],
+        new_location: Union[DeckSlotLocation, ModuleLocation],
+    ) -> None:
+        """Move a loaded labware from one location to another."""
+        # if not feature_flags.enable_ot3_hardware_controller():
+        #     raise UnsupportedLabwareMovement(
+        #         "Labware movement w/ gripper is only available on the OT3"
+        #     )
+
+        assert isinstance(
+            self._hardware_api, OT3API
+        ), "Gripper is only available on the OT3"
+
+        if self._hardware_api.attached_gripper is None:
+            raise GripperNotAttachedError(
+                "No gripper found in order to perform labware movement with."
+            )
+
+        gripper_mount = OT3Mount.GRIPPER
+
+        # Retract all mounts
+        await self._hardware_api.home(axes=[OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.Z_G])
+        # TODO: reset well location cache upon completion of command execution
+        await self._hardware_api.home_gripper_jaw()
+
+        gripper_homed_position = await self._hardware_api.gantry_position(
+            mount=gripper_mount
+        )
+        waypoints_to_labware = self._get_gripper_movement_waypoints(
+            labware_id=labware_id,
+            location=current_location,
+            current_position=await self._hardware_api.gantry_position(
+                mount=gripper_mount
+            ),
+            gripper_home_z=gripper_homed_position.z,
+        )
+        for waypoint in waypoints_to_labware:
+            await self._hardware_api.move_to(mount=gripper_mount, abs_position=waypoint)
+
+        await self._hardware_api.grip(force_newtons=GRIP_FORCE)
+
+        waypoints_to_new_location = self._get_gripper_movement_waypoints(
+            labware_id=labware_id,
+            location=new_location,
+            current_position=waypoints_to_labware[-1],
+            gripper_home_z=gripper_homed_position.z,
+        )
+        for waypoint in waypoints_to_new_location:
+            await self._hardware_api.move_to(mount=gripper_mount, abs_position=waypoint)
+
+        await self._hardware_api.ungrip()
+        await self._hardware_api.move_to(
+            mount=OT3Mount.GRIPPER,
+            abs_position=Point(
+                waypoints_to_new_location[-1].x,
+                waypoints_to_new_location[-1].y,
+                gripper_homed_position.z,
+            ),
+        )
+
+    def _get_gripper_movement_waypoints(
+        self,
+        labware_id: str,
+        location: Union[DeckSlotLocation, ModuleLocation],
+        current_position: Point,
+        gripper_home_z: float,
+    ) -> List[Point]:
+        """Get waypoints for gripper to move to a specified location."""
+        # TODO: remove this after support for module locations is added
+        assert isinstance(
+            location, DeckSlotLocation
+        ), "Moving labware to & from modules with a gripper is not implemented yet."
+
+        # Keeping grip height as half of overall height of labware
+        grip_height = (
+            self._state_store.labware.get_dimensions(labware_id=labware_id).z / 2
+        )
+        slot_loc = (
+            self._state_store.labware.get_slot_center_position(location.slotName)
+            + GRIPPER_OFFSET
+        )
+        waypoints: List[Point] = [
+            Point(current_position.x, current_position.y, gripper_home_z),
+            Point(slot_loc.x, slot_loc.y, gripper_home_z),
+            Point(slot_loc.x, slot_loc.y, grip_height),
+        ]
+        return waypoints

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -1,7 +1,6 @@
 """Labware movement command handling."""
 from typing import Optional, Union, List
 
-# from opentrons.config import feature_flags
 from opentrons.types import Point
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.ot3api import OT3API
@@ -11,7 +10,7 @@ from opentrons.protocol_engine.state import StateStore
 
 from ..errors import (
     GripperNotAttachedError,
-    # UnsupportedLabwareMovement,
+    HardwareNotSupportedError,
 )
 
 from ..types import (
@@ -33,10 +32,10 @@ class LabwareMovementHandler:
     _model_utils: ModelUtils
 
     def __init__(
-            self,
-            hardware_api: HardwareControlAPI,
-            state_store: StateStore,
-            model_utils: Optional[ModelUtils] = None,
+        self,
+        hardware_api: HardwareControlAPI,
+        state_store: StateStore,
+        model_utils: Optional[ModelUtils] = None,
     ) -> None:
         """Initialize a LabwareMovementHandler instance."""
         self._hardware_api = hardware_api
@@ -50,18 +49,12 @@ class LabwareMovementHandler:
         new_location: Union[DeckSlotLocation, ModuleLocation],
     ) -> None:
         """Move a loaded labware from one location to another."""
-        # if not feature_flags.enable_ot3_hardware_controller():
-        #     raise UnsupportedLabwareMovement(
-        #         "Labware movement w/ gripper is only available on the OT3"
-        #     )
-
-        assert isinstance(
-            self._hardware_api, OT3API
-        ), "Gripper is only available on the OT3"
+        if not isinstance(self._hardware_api, OT3API):
+            raise HardwareNotSupportedError("Gripper is only available on the OT3")
 
         if self._hardware_api.attached_gripper is None:
             raise GripperNotAttachedError(
-                "No gripper found in order to perform labware movement with."
+                "No gripper found for performing labware movements."
             )
 
         gripper_mount = OT3Mount.GRIPPER

--- a/api/src/opentrons/protocol_engine/resources/ot3_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/ot3_validation.py
@@ -1,23 +1,28 @@
 """Validation file for protocol engine commandsot."""
 from __future__ import annotations
-from typing import TYPE_CHECKING
-
-from opentrons.hardware_control.protocols import HardwareControlAPI
+from typing import TYPE_CHECKING, Optional
 
 from opentrons.protocol_engine.errors.exceptions import HardwareNotSupportedError
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
+    from opentrons.hardware_control.protocols import HardwareControlAPI
 
 
-def ensure_ot3_hardware(hardware_api: HardwareControlAPI) -> OT3API:
+def ensure_ot3_hardware(
+    hardware_api: HardwareControlAPI, error_msg: Optional[str] = None
+) -> OT3API:
     """Validate that the HardwareControlAPI is of OT-3 instance."""
     try:
         from opentrons.hardware_control.ot3api import OT3API
     except ImportError:
-        raise HardwareNotSupportedError("This command is supported by OT-3 only.")
+        raise HardwareNotSupportedError(
+            error_msg or "This command is supported by OT-3 only."
+        )
 
     if not isinstance(hardware_api, OT3API):
-        raise HardwareNotSupportedError("This command is supported by OT-3 only.")
+        raise HardwareNotSupportedError(
+            error_msg or "This command is supported by OT-3 only."
+        )
 
     return hardware_api

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -176,6 +176,12 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(command.result, (MoveLabwareResult, MoveLabwareOffDeckResult)):
             moved_labware_id = command.params.labwareId
             if (
+                isinstance(command.result, MoveLabwareResult)
+                and command.params.useGripper
+            ):
+                # All mounts will have been retracted.
+                self._state.current_well = None
+            elif (
                 self._state.current_well is not None
                 and self._state.current_well.labware_id == moved_labware_id
             ):

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -374,6 +374,17 @@ async def test_cache_gripper(ot3_hardware: ThreadManager[OT3API]) -> None:
     assert ot3_hardware.attached_gripper["gripper_id"] == "g12345"
 
 
+async def test_has_gripper(
+    ot3_hardware: ThreadManager[OT3API],
+) -> None:
+    """It should return whether the robot has a gripper attached."""
+    assert ot3_hardware.has_gripper() is False
+    gripper_config = gc.load(GripperModel.V1, "g12345")
+    instr_data = AttachedGripper(config=gripper_config, id="g12345")
+    await ot3_hardware.cache_gripper(instr_data)
+    assert ot3_hardware.has_gripper() is True
+
+
 async def test_gripper_action(
     ot3_hardware: ThreadManager[OT3API],
     mock_grip: AsyncMock,

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -13,6 +13,7 @@ from opentrons.protocol_engine.execution import (
     PipettingHandler,
     RunControlHandler,
     RailLightsHandler,
+    LabwareMovementHandler,
 )
 from opentrons.protocol_engine.state import StateView
 
@@ -61,6 +62,12 @@ def equipment(decoy: Decoy) -> EquipmentHandler:
 def movement(decoy: Decoy) -> MovementHandler:
     """Get a mocked out MovementHandler."""
     return decoy.mock(cls=MovementHandler)
+'' \
+''
+@pytest.fixture
+def labware_movement(decoy: Decoy) -> LabwareMovementHandler:
+    """Get a mocked out LabwareMovementHandler."""
+    return decoy.mock(cls=LabwareMovementHandler)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -62,8 +62,11 @@ def equipment(decoy: Decoy) -> EquipmentHandler:
 def movement(decoy: Decoy) -> MovementHandler:
     """Get a mocked out MovementHandler."""
     return decoy.mock(cls=MovementHandler)
-'' \
-''
+
+
+"" ""
+
+
 @pytest.fixture
 def labware_movement(decoy: Decoy) -> LabwareMovementHandler:
     """Get a mocked out LabwareMovementHandler."""

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for protocol engine command tests."""
 from __future__ import annotations
-from typing import TYPE_CHECKING
 
 import pytest
 from decoy import Decoy
@@ -17,9 +16,6 @@ from opentrons.protocol_engine.execution import (
 )
 from opentrons.protocol_engine.state import StateView
 
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
-
 
 @pytest.fixture
 def state_view(decoy: Decoy) -> StateView:
@@ -31,19 +27,6 @@ def state_view(decoy: Decoy) -> StateView:
 def hardware_api(decoy: Decoy) -> HardwareControlAPI:
     """Get a mocked out HardwareControlAPI."""
     return decoy.mock(cls=HardwareControlAPI)
-
-
-@pytest.mark.ot3_only
-@pytest.fixture
-def ot3_hardware_api(decoy: Decoy) -> OT3API:
-    """Get a mocked out OT3API."""
-    try:
-        from opentrons.hardware_control.ot3api import OT3API
-
-        return decoy.mock(cls=OT3API)
-    except ImportError:
-        # TODO (tz, 9-23-22) Figure out a better way to use this fixture with OT-3 api only.
-        return None  # type: ignore[return-value]
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -64,9 +64,6 @@ def movement(decoy: Decoy) -> MovementHandler:
     return decoy.mock(cls=MovementHandler)
 
 
-"" ""
-
-
 @pytest.fixture
 def labware_movement(decoy: Decoy) -> LabwareMovementHandler:
     """Get a mocked out LabwareMovementHandler."""

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -1,9 +1,16 @@
 """Test the ``moveLabware`` command."""
+import pytest
 from decoy import Decoy
 
 from opentrons.types import DeckSlotName
-from opentrons.protocol_engine.types import DeckSlotLocation
-from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine import errors
+from opentrons.protocol_engine.types import (
+    DeckSlotLocation,
+    ModuleLocation,
+    LoadedLabware,
+)
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.execution import EquipmentHandler, RunControlHandler
 
 from opentrons.protocol_engine.commands.move_labware import (
     MoveLabwareParams,
@@ -12,27 +19,140 @@ from opentrons.protocol_engine.commands.move_labware import (
 )
 
 
-async def test_move_labware_implementation(
+async def test_manual_move_labware_implementation(
     decoy: Decoy,
     equipment: EquipmentHandler,
+    state_view: StateView,
+    run_control: RunControlHandler,
 ) -> None:
-    """It should delegate to the equipment handler and return the new offset."""
-    subject = MoveLabwareImplementation(equipment=equipment)
+    """It should execute a pause and return the new offset."""
+    subject = MoveLabwareImplementation(
+        equipment=equipment,
+        state_view=state_view,
+        run_control=run_control,
+    )
 
     data = MoveLabwareParams(
         labwareId="my-cool-labware-id",
         newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+        use_gripper=False,
+    )
+
+    decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
+        LoadedLabware(
+            id="my-cool-labware-id",
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            offsetId=None,
+        )
     )
 
     decoy.when(
-        equipment.move_labware(
-            labware_id="my-cool-labware-id",
-            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+        equipment.find_applicable_labware_offset_id(
+            labware_definition_uri="opentrons-test/load-name/1",
+            labware_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
         )
     ).then_return("wowzers-a-new-offset-id")
 
     result = await subject.execute(data)
-
+    decoy.verify(await run_control.wait_for_resume(), times=1)
     assert result == MoveLabwareResult(
         offsetId="wowzers-a-new-offset-id",
     )
+
+
+async def test_gripper_move_labware_implementation(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+    run_control: RunControlHandler,
+) -> None:
+    """It should delegate to the equipment handler and return the new offset."""
+    subject = MoveLabwareImplementation(
+        equipment=equipment,
+        state_view=state_view,
+        run_control=run_control,
+    )
+
+    data = MoveLabwareParams(
+        labwareId="my-cool-labware-id",
+        newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+        use_gripper=True,
+    )
+
+    decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
+        LoadedLabware(
+            id="my-cool-labware-id",
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            offsetId=None,
+        )
+    )
+
+    decoy.when(
+        equipment.find_applicable_labware_offset_id(
+            labware_definition_uri="opentrons-test/load-name/1",
+            labware_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+        )
+    ).then_return("wowzers-a-new-offset-id")
+
+    result = await subject.execute(data)
+    decoy.verify(
+        equipment.move_labware_with_gripper(
+            labware_id="my-cool-labware-id",
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+        ),
+        times=1,
+    )
+    assert result == MoveLabwareResult(
+        offsetId="wowzers-a-new-offset-id",
+    )
+
+
+async def test_move_labware_raises(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    run_control: RunControlHandler,
+    state_view: StateView,
+) -> None:
+    """It should raise an error when specified labware/ module is not found."""
+    subject = MoveLabwareImplementation(
+        state_view=state_view,
+        run_control=run_control,
+        equipment=equipment,
+    )
+    move_non_existent_labware_params = MoveLabwareParams(
+        labwareId="my-cool-labware-id",
+        newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
+    )
+    decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_raise(
+        errors.LabwareNotLoadedError("Woops!")
+    )
+
+    with pytest.raises(errors.LabwareNotLoadedError):
+        await subject.execute(move_non_existent_labware_params)
+
+    move_labware_from_questionable_module_params = MoveLabwareParams(
+        labwareId="real-labware-id",
+        newLocation=ModuleLocation(moduleId="imaginary-module-id"),
+    )
+    decoy.when(state_view.labware.get(labware_id="real-labware-id")).then_return(
+        LoadedLabware(
+            id="real-labware-id",
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=ModuleLocation(moduleId="imaginary-module-id"),
+            offsetId=None,
+        )
+    )
+    decoy.when(
+        equipment.find_applicable_labware_offset_id(
+            labware_definition_uri="opentrons-test/load-name/1",
+            labware_location=ModuleLocation(moduleId="imaginary-module-id"),
+        )
+    ).then_raise(errors.ModuleNotLoadedError("Woops 2.0!"))
+
+    with pytest.raises(errors.ModuleNotLoadedError):
+        await subject.execute(move_labware_from_questionable_module_params)

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -35,7 +35,7 @@ async def test_manual_move_labware_implementation(
     data = MoveLabwareParams(
         labwareId="my-cool-labware-id",
         newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
-        use_gripper=False,
+        useGripper=False,
     )
 
     decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
@@ -78,7 +78,7 @@ async def test_gripper_move_labware_implementation(
     data = MoveLabwareParams(
         labwareId="my-cool-labware-id",
         newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
-        use_gripper=True,
+        useGripper=True,
     )
 
     decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
@@ -100,7 +100,7 @@ async def test_gripper_move_labware_implementation(
 
     result = await subject.execute(data)
     decoy.verify(
-        equipment.move_labware_with_gripper(
+        await equipment.move_labware_with_gripper(
             labware_id="my-cool-labware-id",
             new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
         ),

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -107,19 +107,21 @@ async def test_gripper_move_labware_implementation(
         )
     ).then_return("wowzers-a-new-offset-id")
 
+    validated_from_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_6)
+    validated_new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_7)
     decoy.when(
         labware_movement.ensure_valid_gripper_location(from_location)
-    ).then_return(from_location)
+    ).then_return(validated_from_location)
     decoy.when(
         labware_movement.ensure_valid_gripper_location(new_location)
-    ).then_return(new_location)
+    ).then_return(validated_new_location)
 
     result = await subject.execute(data)
     decoy.verify(
         await labware_movement.move_labware_with_gripper(
             labware_id="my-cool-labware-id",
-            current_location=from_location,
-            new_location=new_location,
+            current_location=validated_from_location,
+            new_location=validated_new_location,
             new_offset_id="wowzers-a-new-offset-id",
         ),
         times=1,

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -1,5 +1,9 @@
 """ProtocolEngine shared test fixtures."""
+from __future__ import annotations
+
 import pytest
+from typing import TYPE_CHECKING
+from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.deck import load as load_deck
@@ -11,6 +15,22 @@ from opentrons.protocols.api_support.constants import (
     SHORT_TRASH_DECK,
 )
 from opentrons.protocol_engine.types import ModuleDefinition
+
+if TYPE_CHECKING:
+    from opentrons.hardware_control.ot3api import OT3API
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
+def ot3_hardware_api(decoy: Decoy) -> OT3API:
+    """Get a mocked out OT3API."""
+    try:
+        from opentrons.hardware_control.ot3api import OT3API
+
+        return decoy.mock(cls=OT3API)
+    except ImportError:
+        # TODO (tz, 9-23-22) Figure out a better way to use this fixture with OT-3 api only.
+        return None  # type: ignore[return-value]
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -27,6 +27,7 @@ from opentrons.protocol_engine.execution import (
     CommandExecutor,
     EquipmentHandler,
     MovementHandler,
+    LabwareMovementHandler,
     PipettingHandler,
     RunControlHandler,
     RailLightsHandler,
@@ -64,6 +65,12 @@ def movement(decoy: Decoy) -> MovementHandler:
 
 
 @pytest.fixture
+def labware_movement(decoy: Decoy) -> LabwareMovementHandler:
+    """Get a mocked out LabwareMovementHandler."""
+    return decoy.mock(cls=LabwareMovementHandler)
+
+
+@pytest.fixture
 def pipetting(decoy: Decoy) -> PipettingHandler:
     """Get a mocked out PipettingHandler."""
     return decoy.mock(cls=PipettingHandler)
@@ -94,6 +101,7 @@ def subject(
     action_dispatcher: ActionDispatcher,
     equipment: EquipmentHandler,
     movement: MovementHandler,
+    labware_movement: LabwareMovementHandler,
     pipetting: PipettingHandler,
     run_control: RunControlHandler,
     rail_lights: RailLightsHandler,
@@ -106,6 +114,7 @@ def subject(
         action_dispatcher=action_dispatcher,
         equipment=equipment,
         movement=movement,
+        labware_movement=labware_movement,
         pipetting=pipetting,
         run_control=run_control,
         model_utils=model_utils,
@@ -133,13 +142,14 @@ async def test_execute(
     action_dispatcher: ActionDispatcher,
     equipment: EquipmentHandler,
     movement: MovementHandler,
+    labware_movement: LabwareMovementHandler,
     pipetting: PipettingHandler,
     run_control: RunControlHandler,
     rail_lights: RailLightsHandler,
     model_utils: ModelUtils,
     subject: CommandExecutor,
 ) -> None:
-    """It should be able execute a command."""
+    """It should be able to execute a command."""
     TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
     command_impl = decoy.mock(cls=_TestCommandImpl)
 
@@ -202,6 +212,7 @@ async def test_execute(
             hardware_api=hardware_api,
             equipment=equipment,
             movement=movement,
+            labware_movement=labware_movement,
             pipetting=pipetting,
             run_control=run_control,
             rail_lights=rail_lights,
@@ -245,6 +256,7 @@ async def test_execute_raises_protocol_engine_error(
     action_dispatcher: ActionDispatcher,
     equipment: EquipmentHandler,
     movement: MovementHandler,
+    labware_movement: LabwareMovementHandler,
     pipetting: PipettingHandler,
     run_control: RunControlHandler,
     rail_lights: RailLightsHandler,
@@ -301,6 +313,7 @@ async def test_execute_raises_protocol_engine_error(
             hardware_api=hardware_api,
             equipment=equipment,
             movement=movement,
+            labware_movement=labware_movement,
             pipetting=pipetting,
             run_control=run_control,
             rail_lights=rail_lights,

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -15,7 +15,6 @@ from opentrons.hardware_control.modules import (
     HeaterShaker,
     AbstractModule,
 )
-from opentrons.hardware_control.dev_types import GripperDict
 from opentrons.protocols.models import LabwareDefinition
 
 from opentrons.protocol_engine import errors
@@ -43,9 +42,6 @@ from opentrons.protocol_engine.execution.equipment import (
     LoadedPipetteData,
     LoadedModuleData,
 )
-
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
 
 
 @pytest.fixture
@@ -109,24 +105,6 @@ def subject(
     """Get an EquipmentHandler test subject with its dependencies mocked out."""
     return EquipmentHandler(
         hardware_api=hardware_api,
-        state_store=state_store,
-        labware_data_provider=labware_data_provider,
-        module_data_provider=module_data_provider,
-        model_utils=model_utils,
-    )
-
-
-@pytest.mark.ot3_only
-def ot3_subject(
-    ot3_hardware_api: HardwareControlAPI,
-    state_store: StateStore,
-    labware_data_provider: LabwareDataProvider,
-    module_data_provider: ModuleDataProvider,
-    model_utils: ModelUtils,
-) -> EquipmentHandler:
-    """Get EquipmentHandler test subject for OT3, with its dependencies mocked out."""
-    return EquipmentHandler(
-        hardware_api=ot3_hardware_api,
         state_store=state_store,
         labware_data_provider=labware_data_provider,
         module_data_provider=module_data_provider,
@@ -688,24 +666,3 @@ def test_get_module_hardware_api_missing(
 
     with pytest.raises(errors.ModuleNotAttachedError):
         subject.get_module_hardware_api(cast(Any, "module-id"))
-
-
-@pytest.mark.ot3_only
-async def test_move_labware_with_gripper(
-    decoy: Decoy,
-    state_store: StateStore,
-    ot3_hardware_api: OT3API,
-    subject: EquipmentHandler,
-) -> None:
-    """It should perform a labware movement with gripper by delegating to OT3API."""
-    decoy.when(ot3_hardware_api.attached_gripper).then_return(GripperDict(
-        name="gripper", display_name="abc", model=GripperModel("abc"), state=0, gripper_id="123"
-    ))
-
-    decoy.when(state_store.labware.get_location(labware_id="my-teleporting-labware"))
-
-    await subject.move_labware_with_gripper(
-        labware_id="my-teleporting-labware",
-        new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
-    )
-    # TODO: complete this test

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -669,10 +669,9 @@ def test_get_module_hardware_api_missing(
 
 
 def test_move_labware_with_gripper(
-        decoy: Decoy,
-        state_store: StateStore,
-        hardware_api: HardwareControlAPI,
-        subject: EquipmentHandler,
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareControlAPI,
+    subject: EquipmentHandler,
 ) -> None:
     """It should perform a labware movement with gripper by delegating to OT3API."""
-    

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -2,7 +2,7 @@
 import pytest
 from datetime import datetime
 from decoy import Decoy, matchers
-from typing import Any, cast, TYPE_CHECKING
+from typing import Any, cast
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -49,7 +49,7 @@ def subject(
     state_store: StateStore,
     model_utils: ModelUtils,
 ) -> LabwareMovementHandler:
-    """Get EquipmentHandler test subject for OT3, with its dependencies mocked out."""
+    """Get LabwareMovementHandler for OT3, with its dependencies mocked out."""
     return LabwareMovementHandler(
         hardware_api=ot3_hardware_api,
         state_store=state_store,

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -1,0 +1,116 @@
+"""Test labware movement command execution side effects."""
+import pytest
+from decoy import Decoy
+
+# from opentrons.hardware_control import HardwareControlAPI
+from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.types import DeckSlotName, Point
+# from opentrons.config import feature_flags
+from opentrons_shared_data.gripper.dev_types import GripperModel
+from opentrons.hardware_control.dev_types import GripperDict
+from opentrons.hardware_control.types import GripperJawState, OT3Mount, OT3Axis
+from opentrons.hardware_control.ot3api import OT3API
+
+from opentrons.protocol_engine.types import DeckSlotLocation, Dimensions
+from opentrons.protocol_engine.execution.labware_movement import (
+    LabwareMovementHandler,
+    GRIPPER_OFFSET,
+)
+from opentrons.protocol_engine.state import StateStore
+
+
+@pytest.fixture
+def state_store(decoy: Decoy) -> StateStore:
+    """Get a mocked out StateStore instance."""
+    return decoy.mock(cls=StateStore)
+
+
+@pytest.fixture
+def model_utils(decoy: Decoy) -> ModelUtils:
+    """Get a mocked out ModelUtils instance."""
+    return decoy.mock(cls=ModelUtils)
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
+def subject(
+    ot3_hardware_api: OT3API,
+    state_store: StateStore,
+    model_utils: ModelUtils,
+) -> LabwareMovementHandler:
+    """Get EquipmentHandler test subject for OT3, with its dependencies mocked out."""
+    return LabwareMovementHandler(
+        hardware_api=ot3_hardware_api,
+        state_store=state_store,
+        model_utils=model_utils,
+    )
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
+def ot3_hardware_api(decoy: Decoy) -> OT3API:
+    """Get a mocked out OT3API."""
+    return decoy.mock(cls=OT3API)
+
+
+# TODO (spp, 2022-10-18): Should write an acceptance test for this too
+@pytest.mark.ot3_only
+async def test_move_labware_with_gripper(
+    decoy: Decoy,
+    state_store: StateStore,
+    ot3_hardware_api: OT3API,
+    subject: LabwareMovementHandler,
+) -> None:
+    """It should perform a labware movement with gripper by delegating to OT3API."""
+    # decoy.when(feature_flags.enable_ot3_hardware_controller()).then_return(True)
+    decoy.when(ot3_hardware_api.attached_gripper).then_return(GripperDict(
+        name="gripper",
+        display_name="abc",
+        model=GripperModel.V1,
+        state=GripperJawState.HOMED_READY,
+        gripper_id="123",
+    ))
+
+    decoy.when(await ot3_hardware_api.gantry_position(mount=OT3Mount.GRIPPER)
+               ).then_return(Point(x=777, y=888, z=999))
+    decoy.when(state_store.labware.get_dimensions(
+        labware_id="my-teleporting-labware")
+    ).then_return(Dimensions(x=11, y=22, z=33))
+
+    decoy.when(state_store.labware.get_slot_center_position(
+        DeckSlotName.SLOT_1)
+    ).then_return(Point(x=101, y=102, z=103))
+
+    decoy.when(state_store.labware.get_slot_center_position(
+        DeckSlotName.SLOT_3
+    )).then_return(Point(x=201, y=202, z=203))
+
+    await subject.move_labware_with_gripper(
+        labware_id="my-teleporting-labware",
+        current_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+    )
+
+    expected_moves = [
+        Point(777, 888, 999),   # gripper retract at current location
+        Point(101, 102+GRIPPER_OFFSET.y, 999),   # move to above slot 1
+        Point(101, 102+GRIPPER_OFFSET.y, 16.5),  # move to labware on slot 1
+        Point(101, 102+GRIPPER_OFFSET.y, 999),   # gripper retract at current location
+        Point(201, 202+GRIPPER_OFFSET.y, 999),   # move to above slot 3
+        Point(201, 202+GRIPPER_OFFSET.y, 16.5),  # move down to labware drop height on slot 3
+        Point(201, 202+GRIPPER_OFFSET.y, 999),   # retract in place
+    ]
+
+    decoy.verify(
+        await ot3_hardware_api.home(axes=[OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.Z_G]),
+        await ot3_hardware_api.home_gripper_jaw(),
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[0]),
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[1]),
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[2]),
+        await ot3_hardware_api.grip(force_newtons=20),  # TODO: replace this once we have this spec in hardware control
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[3]),
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[4]),
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[5]),
+        await ot3_hardware_api.ungrip(),
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[6])
+    )

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -2,10 +2,10 @@
 import pytest
 from decoy import Decoy
 
-# from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.types import DeckSlotName, Point
-# from opentrons.config import feature_flags
+
 from opentrons_shared_data.gripper.dev_types import GripperModel
 from opentrons.hardware_control.dev_types import GripperDict
 from opentrons.hardware_control.types import GripperJawState, OT3Mount, OT3Axis
@@ -15,6 +15,10 @@ from opentrons.protocol_engine.types import DeckSlotLocation, Dimensions
 from opentrons.protocol_engine.execution.labware_movement import (
     LabwareMovementHandler,
     GRIPPER_OFFSET,
+)
+from opentrons.protocol_engine.errors import (
+    HardwareNotSupportedError,
+    GripperNotAttachedError,
 )
 from opentrons.protocol_engine.state import StateStore
 
@@ -33,6 +37,13 @@ def model_utils(decoy: Decoy) -> ModelUtils:
 
 @pytest.mark.ot3_only
 @pytest.fixture
+def ot3_hardware_api(decoy: Decoy) -> OT3API:
+    """Get a mocked out OT3API."""
+    return decoy.mock(cls=OT3API)
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
 def subject(
     ot3_hardware_api: OT3API,
     state_store: StateStore,
@@ -46,14 +57,7 @@ def subject(
     )
 
 
-@pytest.mark.ot3_only
-@pytest.fixture
-def ot3_hardware_api(decoy: Decoy) -> OT3API:
-    """Get a mocked out OT3API."""
-    return decoy.mock(cls=OT3API)
-
-
-# TODO (spp, 2022-10-18): Should write an acceptance test for this too
+# TODO (spp, 2022-10-18): Should write an acceptance test w/ real labware on ot3 deck
 @pytest.mark.ot3_only
 async def test_move_labware_with_gripper(
     decoy: Decoy,
@@ -62,28 +66,30 @@ async def test_move_labware_with_gripper(
     subject: LabwareMovementHandler,
 ) -> None:
     """It should perform a labware movement with gripper by delegating to OT3API."""
-    # decoy.when(feature_flags.enable_ot3_hardware_controller()).then_return(True)
-    decoy.when(ot3_hardware_api.attached_gripper).then_return(GripperDict(
-        name="gripper",
-        display_name="abc",
-        model=GripperModel.V1,
-        state=GripperJawState.HOMED_READY,
-        gripper_id="123",
-    ))
+    decoy.when(ot3_hardware_api.attached_gripper).then_return(
+        GripperDict(
+            name="gripper",
+            display_name="abc",
+            model=GripperModel.V1,
+            state=GripperJawState.HOMED_READY,
+            gripper_id="123",
+        )
+    )
 
-    decoy.when(await ot3_hardware_api.gantry_position(mount=OT3Mount.GRIPPER)
-               ).then_return(Point(x=777, y=888, z=999))
-    decoy.when(state_store.labware.get_dimensions(
-        labware_id="my-teleporting-labware")
+    decoy.when(
+        await ot3_hardware_api.gantry_position(mount=OT3Mount.GRIPPER)
+    ).then_return(Point(x=777, y=888, z=999))
+    decoy.when(
+        state_store.labware.get_dimensions(labware_id="my-teleporting-labware")
     ).then_return(Dimensions(x=11, y=22, z=33))
 
-    decoy.when(state_store.labware.get_slot_center_position(
-        DeckSlotName.SLOT_1)
+    decoy.when(
+        state_store.labware.get_slot_center_position(DeckSlotName.SLOT_1)
     ).then_return(Point(x=101, y=102, z=103))
 
-    decoy.when(state_store.labware.get_slot_center_position(
-        DeckSlotName.SLOT_3
-    )).then_return(Point(x=201, y=202, z=203))
+    decoy.when(
+        state_store.labware.get_slot_center_position(DeckSlotName.SLOT_3)
+    ).then_return(Point(x=201, y=202, z=203))
 
     await subject.move_labware_with_gripper(
         labware_id="my-teleporting-labware",
@@ -92,25 +98,67 @@ async def test_move_labware_with_gripper(
     )
 
     expected_moves = [
-        Point(777, 888, 999),   # gripper retract at current location
-        Point(101, 102+GRIPPER_OFFSET.y, 999),   # move to above slot 1
-        Point(101, 102+GRIPPER_OFFSET.y, 16.5),  # move to labware on slot 1
-        Point(101, 102+GRIPPER_OFFSET.y, 999),   # gripper retract at current location
-        Point(201, 202+GRIPPER_OFFSET.y, 999),   # move to above slot 3
-        Point(201, 202+GRIPPER_OFFSET.y, 16.5),  # move down to labware drop height on slot 3
-        Point(201, 202+GRIPPER_OFFSET.y, 999),   # retract in place
+        Point(777, 888, 999),  # gripper retract at current location
+        Point(101, 102 + GRIPPER_OFFSET.y, 999),  # move to above slot 1
+        Point(101, 102 + GRIPPER_OFFSET.y, 16.5),  # move to labware on slot 1
+        Point(101, 102 + GRIPPER_OFFSET.y, 999),  # gripper retract at current location
+        Point(201, 202 + GRIPPER_OFFSET.y, 999),  # move to above slot 3
+        Point(
+            201, 202 + GRIPPER_OFFSET.y, 16.5
+        ),  # move down to labware drop height on slot 3
+        Point(201, 202 + GRIPPER_OFFSET.y, 999),  # retract in place
     ]
 
+    gripper = OT3Mount.GRIPPER
     decoy.verify(
         await ot3_hardware_api.home(axes=[OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.Z_G]),
         await ot3_hardware_api.home_gripper_jaw(),
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[0]),
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[1]),
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[2]),
-        await ot3_hardware_api.grip(force_newtons=20),  # TODO: replace this once we have this spec in hardware control
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[3]),
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[4]),
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[5]),
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[0]),
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[1]),
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[2]),
+        await ot3_hardware_api.grip(
+            force_newtons=20
+        ),  # TODO: replace this once we have this spec in hardware control
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[3]),
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[4]),
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[5]),
         await ot3_hardware_api.ungrip(),
-        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER, abs_position=expected_moves[6])
+        await ot3_hardware_api.move_to(mount=gripper, abs_position=expected_moves[6]),
     )
+
+
+async def test_labware_movement_raises_on_ot2(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareControlAPI,
+    model_utils: ModelUtils,
+) -> None:
+    """It should raise an error when attempting a gripper movement on a non-OT3 bot."""
+    subject = LabwareMovementHandler(
+        hardware_api=hardware_api,
+        state_store=state_store,
+        model_utils=model_utils,
+    )
+
+    with pytest.raises(HardwareNotSupportedError):
+        await subject.move_labware_with_gripper(
+            labware_id="labware-id",
+            current_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        )
+
+
+async def test_labware_movement_raises_without_gripper(
+    decoy: Decoy,
+    state_store: StateStore,
+    ot3_hardware_api: OT3API,
+    subject: LabwareMovementHandler,
+) -> None:
+    """It should raise an error when attempting a gripper movement without a gripper."""
+    decoy.when(ot3_hardware_api.attached_gripper).then_return(None)
+    with pytest.raises(GripperNotAttachedError):
+        await subject.move_labware_with_gripper(
+            labware_id="labware-id",
+            current_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        )

--- a/api/tests/opentrons/protocol_engine/resources/test_ot3_validation.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_ot3_validation.py
@@ -2,7 +2,7 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine.commands.validation import ensure_ot3_hardware
+from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons.protocol_engine.errors.exceptions import HardwareNotSupportedError
 
 from opentrons.hardware_control.api import API
@@ -16,7 +16,9 @@ def test_ensure_ot3_hardware(decoy: Decoy) -> None:
         from opentrons.hardware_control.ot3api import OT3API
 
         ot_3_hardware_api = decoy.mock(cls=OT3API)
-        result = ensure_ot3_hardware(ot_3_hardware_api)
+        result = ensure_ot3_hardware(
+            ot_3_hardware_api,
+        )
         assert result == ot_3_hardware_api
     except ImportError:
         pass
@@ -27,4 +29,6 @@ def test_ensure_ot3_hardware_raises_error(decoy: Decoy) -> None:
     """Should raise a HardwareNotSupportedError exception."""
     ot_2_hardware_api = decoy.mock(cls=API)
     with pytest.raises(HardwareNotSupportedError):
-        ensure_ot3_hardware(ot_2_hardware_api)
+        ensure_ot3_hardware(
+            ot_2_hardware_api,
+        )

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -340,11 +340,13 @@ def create_move_labware_command(
     new_location: LabwareLocation,
     labware_id: str = "labware-id",
     offset_id: Optional[str] = None,
+    use_gripper: Optional[bool] = False,
 ) -> cmd.MoveLabware:
     """Get a completed MoveLabware command."""
     params = cmd.MoveLabwareParams(
         labwareId=labware_id,
         newLocation=new_location,
+        useGripper=use_gripper,
     )
     result = cmd.MoveLabwareResult(offsetId=offset_id)
 

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -431,18 +431,31 @@ def test_heater_shaker_command_without_movement(
             # because MoveLabwareOffDeck command had "matching-labware-id".
             None,
         ),
+        (
+            create_move_labware_command(
+                labware_id="non-matching-labware-id",
+                new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+                use_gripper=True,
+                offset_id=None,
+            ),
+            # Current well IS cleared,
+            # because MoveLabware command used gripper.
+            None,
+        ),
     ),
 )
-def test_move_labware_clears_current_well_if_belonged_to_moved_labware(
+def test_move_labware_clears_current_well(
     subject: PipetteStore,
     move_labware_command: Union[cmd.MoveLabware, cmd.MoveLabwareOffDeck],
     expected_current_well: Optional[CurrentWell],
 ) -> None:
     """Labware movement commands should sometimes clear the current well.
 
-    * When the current well belongs to the labware that was moved,
-      it should be cleared.
-    * Otherwise, it should be left alone.
+    It should be cleared when-
+    * the current well belongs to the labware that was moved,
+    * or gripper was used to move labware
+
+    Otherwise, it should be left alone.
     """
     load_pipette_command = create_load_pipette_command(
         pipette_id="pipette-id",

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -107,6 +107,10 @@
               "type": "string"
             }
           }
+        },
+        {
+          "const": "offDeck",
+          "description": "String literal 'offDeck'. Used to load a labware without placing it on the deck"
         }
       ]
     }

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -475,6 +475,11 @@
                 "newLocation": {
                   "$ref": "#/definitions/labwareLocation",
                   "description": "Where to move the labware."
+                },
+                "useGripper": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to use the gripper to move the labware. Gripper is only available on the OT3."
                 }
               }
             }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Closes RLAB-136, closes RLAB-135

This PR adds gripper movement capability to the protocol engine. It implements slot-to-slot labware movements using a gripper on the OT3.

# Changelog

- added a `useGripper` param to `moveLabware` command
- updated `moveLabware` execution to either pause for manual DSM or perform the gripper movement
- added `LabwareMovementHandler` (~will be renaming this to `GripperMovementHandler` shortly. Raise your voice if anyone is against this~ I am keeping it as is for now. Will reconsider renaming if it still makes sense after all labware movement functionality is implemented) which interfaces with the OT3 hardware control API and uses simple and conservative motion planning steps to move a labware from a slot to another one using the gripper as described in the ticket.
- updated SchemaV7 draft 

Things not changed here and will be addressed later:
1. moving labware to & from modules
2. consolidating `moveLabwareOffDeck` command into `moveLabware`
3. if required- a way for LPC to use `moveLabware` for manual DSM (it can't right now because of the auto-pause behavior)

# Review requests

- Make sure code looks good and there's enough test coverage
- I've done some refactoring since testing on the OT3 so if you have access to a *POC* OT3 with a gripper, would be good to re-test but not absolutely necessary
- Make sure I'm not forgetting to account for any side effects of moving labware with a gripper

# Risk assessment

Low. Still very restricted to labware movements which is not yet user-facing.
