### PR TITLE
fix(engine): return highest 0 of zero if labware or modules not loaded

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -60,16 +60,23 @@ class GeometryView:
     # TODO(mc, 2022-06-24): rename this method
     def get_all_labware_highest_z(self) -> float:
         """Get the highest Z-point across all labware."""
-        return max(
-            *(
+        all_labware = self._labware.get_all()
+        all_modules = self._modules.get_all()
+        highest_labware_z = 0.0
+        highest_module_z = 0.0
+
+        if len(all_labware) > 0:
+            highest_labware_z = max(
                 self._get_highest_z_from_labware_data(lw_data)
-                for lw_data in self._labware.get_all()
-            ),
-            *(
-                self._modules.get_overall_height(module.id)
-                for module in self._modules.get_all()
-            ),
-        )
+                for lw_data in all_labware
+            )
+
+        if len(all_modules) > 0:
+            highest_module_z = max(
+                self._modules.get_overall_height(module.id) for module in all_modules
+            )
+
+        return max(highest_labware_z, highest_module_z)
 
     def get_labware_parent_position(self, labware_id: str) -> Point:
         """Get the position of the labware's parent slot (deck or module)."""

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -60,21 +60,21 @@ class GeometryView:
     # TODO(mc, 2022-06-24): rename this method
     def get_all_labware_highest_z(self) -> float:
         """Get the highest Z-point across all labware."""
-        all_labware = self._labware.get_all()
-        all_modules = self._modules.get_all()
-        highest_labware_z = 0.0
-        highest_module_z = 0.0
-
-        if len(all_labware) > 0:
-            highest_labware_z = max(
+        highest_labware_z = max(
+            (
                 self._get_highest_z_from_labware_data(lw_data)
-                for lw_data in all_labware
-            )
+                for lw_data in self._labware.get_all()
+            ),
+            default=0.0,
+        )
 
-        if len(all_modules) > 0:
-            highest_module_z = max(
-                self._modules.get_overall_height(module.id) for module in all_modules
-            )
+        highest_module_z = max(
+            (
+                self._modules.get_overall_height(module.id)
+                for module in self._modules.get_all()
+            ),
+            default=0.0,
+        )
 
         return max(highest_labware_z, highest_module_z)
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4,7 +4,6 @@ from decoy import Decoy
 from typing import cast
 
 from opentrons.calibration_storage.helpers import uri_from_details
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.types import Point, DeckSlotName
@@ -46,8 +45,6 @@ def subject(labware_view: LabwareView, module_view: ModuleView) -> GeometryView:
 
 def test_get_labware_parent_position(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
-    well_plate_def: LabwareDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -71,8 +68,6 @@ def test_get_labware_parent_position(
 
 def test_raise_error_for_off_deck_labware_parent(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
-    well_plate_def: LabwareDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -91,8 +86,6 @@ def test_raise_error_for_off_deck_labware_parent(
 
 def test_get_labware_parent_position_on_module(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
-    well_plate_def: LabwareDefinition,
     labware_view: LabwareView,
     module_view: ModuleView,
     subject: GeometryView,
@@ -124,7 +117,6 @@ def test_get_labware_parent_position_on_module(
 
 def test_get_labware_origin_position(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
     well_plate_def: LabwareDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
@@ -159,7 +151,6 @@ def test_get_labware_origin_position(
 
 def test_get_labware_highest_z(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
     well_plate_def: LabwareDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
@@ -191,7 +182,6 @@ def test_get_labware_highest_z(
 
 def test_get_module_labware_highest_z(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
     well_plate_def: LabwareDefinition,
     labware_view: LabwareView,
     module_view: ModuleView,
@@ -229,9 +219,23 @@ def test_get_module_labware_highest_z(
     assert highest_z == (well_plate_def.dimensions.zDimension + 3 + 3 + 6 + 0.5)
 
 
+def test_get_all_labware_highest_z_no_equipment(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    module_view: ModuleView,
+    subject: GeometryView,
+) -> None:
+    """It should return 0 if no loaded equipment."""
+    decoy.when(module_view.get_all()).then_return([])
+    decoy.when(labware_view.get_all()).then_return([])
+
+    result = subject.get_all_labware_highest_z()
+
+    assert result == 0
+
+
 def test_get_all_labware_highest_z(
     decoy: Decoy,
-    standard_deck_def: DeckDefinitionV3,
     well_plate_def: LabwareDefinition,
     reservoir_def: LabwareDefinition,
     labware_view: LabwareView,
@@ -310,7 +314,6 @@ def test_get_all_labware_highest_z_with_modules(
 def test_get_labware_position(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
-    standard_deck_def: DeckDefinitionV3,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -346,7 +349,6 @@ def test_get_labware_position(
 def test_get_well_position(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
-    standard_deck_def: DeckDefinitionV3,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -386,7 +388,6 @@ def test_get_well_position(
 def test_get_well_edges(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
-    standard_deck_def: DeckDefinitionV3,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -437,7 +438,6 @@ def test_get_well_edges(
 def test_get_module_labware_well_position(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
-    standard_deck_def: DeckDefinitionV3,
     labware_view: LabwareView,
     module_view: ModuleView,
     subject: GeometryView,
@@ -484,7 +484,6 @@ def test_get_module_labware_well_position(
 def test_get_well_position_with_top_offset(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
-    standard_deck_def: DeckDefinitionV3,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -531,7 +530,6 @@ def test_get_well_position_with_top_offset(
 def test_get_well_position_with_bottom_offset(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
-    standard_deck_def: DeckDefinitionV3,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -670,7 +668,6 @@ def test_get_nominal_tip_geometry_raises(
 
 def test_get_tip_drop_location(
     decoy: Decoy,
-    tip_rack_def: LabwareDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
@@ -709,11 +706,7 @@ def test_get_tip_drop_location_with_trash(
     assert location == WellLocation(offset=WellOffset(x=1, y=2, z=3))
 
 
-def test_get_tip_drop_invalid_origin(
-    decoy: Decoy,
-    labware_view: LabwareView,
-    subject: GeometryView,
-) -> None:
+def test_get_tip_drop_invalid_origin(subject: GeometryView) -> None:
     """It should raise if the given WellLocation is not WellOrigin.TOP."""
     pipette_config: PipetteDict = cast(PipetteDict, {"return_tip_height": 0.5})
 


### PR DESCRIPTION
## Overview

This PR fixes a bug in the `ProtocolEngine`'s geometry selectors that could cause an error to be raised if no modules or labware are loaded into the protocol.

Fixes RSS-129

## Changelog

- Fixed a misuse of `max` in the `GeometryView` that was introduced in #10902

## Review requests

- Unit test addition makes sense
- Repro case no long reproduces
    1. Load pipette
    2. Home
    3. Issue a `moveToCoordinates`

## Risk assessment

Low, tested bug fix
