### PR TITLE
refactor(app): setupLabwareList labwareId logic refactor

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
@@ -70,6 +70,7 @@ export function SetupLabwareList(
   const { t } = useTranslation('protocol_setup')
   if (protocolData == null) return null
   const labwareIdsInOrder = getAllLabwareAndTiprackIdsInOrder(
+    // @ts-expect-error this type will match once we retype the output of the adapter
     protocolData.labware,
     protocolData.labwareDefinitions,
     protocolData.commands

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/utils.test.ts
@@ -1,75 +1,77 @@
 import _protocolWithMagTempTC from '@opentrons/shared-data/protocol/fixtures/6/transferSettings.json'
 import { getAllLabwareAndTiprackIdsInOrder } from '../utils'
-import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
+import type {
+  ProtocolAnalysisFile,
+  LoadedLabware,
+} from '@opentrons/shared-data'
 
-const protocolWithMagTempTC = ({
-  ..._protocolWithMagTempTC,
-  labware: [
-    {
-      id: 'fixedTrash',
-      loadName: 'opentrons_1_trash_1100ml_fixed',
-      displayName: 'Trash',
-      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
-    },
-    {
-      id:
-        '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1',
-      displayName: 'Opentrons 96 Tip Rack 1000 µL',
-      loadName: 'opentrons_96_tiprack_1000ul',
-      definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
-    },
-    {
-      id:
-        '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
-      displayName: 'NEST 1 Well Reservoir 195 mL',
-      definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
-      loadName: 'nest_1_reservoir_195ml',
-    },
-    {
-      id:
-        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
-      displayName: 'Corning 24 Well Plate 3.4 mL Flat',
-      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
-      loadName: 'corning_24_wellplate_3.4ml_flat',
-    },
-    {
-      id:
-        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
-      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
-      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
-      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
-    },
-    {
-      id:
-        'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
-      displayName:
-        'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
-      definitionUri:
-        'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
-      loadName: 'opentrons_96_aluminumblock_generic_pcr_strip_200ul',
-    },
-    {
-      id:
-        'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
-      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
-      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
-      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
-    },
-    {
-      id:
-        'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1',
-      displayName: 'Opentrons 96 Tip Rack 20 µL',
-      definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
-      loadName: 'opentrons_96_tiprack_20ul',
-    },
-    {
-      id: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
-      displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
-      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
-      loadName: 'corning_24_wellplate_3.4ml_flat',
-    },
-  ],
-} as unknown) as ProtocolAnalysisFile
+const labware = [
+  {
+    id: 'fixedTrash',
+    loadName: 'opentrons_1_trash_1100ml_fixed',
+    displayName: 'Trash',
+    definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+  },
+  {
+    id:
+      '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1',
+    displayName: 'Opentrons 96 Tip Rack 1000 µL',
+    loadName: 'opentrons_96_tiprack_1000ul',
+    definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+  },
+  {
+    id:
+      '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
+    displayName: 'NEST 1 Well Reservoir 195 mL',
+    definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
+    loadName: 'nest_1_reservoir_195ml',
+  },
+  {
+    id:
+      '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+    displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+    definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    loadName: 'corning_24_wellplate_3.4ml_flat',
+  },
+  {
+    id:
+      'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+    definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+  },
+  {
+    id:
+      'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+    displayName:
+      'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
+    definitionUri:
+      'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+    loadName: 'opentrons_96_aluminumblock_generic_pcr_strip_200ul',
+  },
+  {
+    id:
+      'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
+    definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+    loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+  },
+  {
+    id:
+      'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1',
+    displayName: 'Opentrons 96 Tip Rack 20 µL',
+    definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+    loadName: 'opentrons_96_tiprack_20ul',
+  },
+  {
+    id: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
+    displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
+    definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+    loadName: 'corning_24_wellplate_3.4ml_flat',
+  },
+] as LoadedLabware[]
+
+const protocolWithMagTempTC = (_protocolWithMagTempTC as unknown) as ProtocolAnalysisFile
 
 describe('getAllLabwareAndTiprackIdsInOrder', () => {
   it('should get all the labware and tiprack ids in order', () => {
@@ -85,7 +87,7 @@ describe('getAllLabwareAndTiprackIdsInOrder', () => {
     ]
     expect(
       getAllLabwareAndTiprackIdsInOrder(
-        protocolWithMagTempTC.labware,
+        labware,
         protocolWithMagTempTC.labwareDefinitions,
         protocolWithMagTempTC.commands
       )

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/utils.test.ts
@@ -2,7 +2,74 @@ import _protocolWithMagTempTC from '@opentrons/shared-data/protocol/fixtures/6/t
 import { getAllLabwareAndTiprackIdsInOrder } from '../utils'
 import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
-const protocolWithMagTempTC = (_protocolWithMagTempTC as unknown) as ProtocolAnalysisFile
+const protocolWithMagTempTC = ({
+  ..._protocolWithMagTempTC,
+  labware: [
+    {
+      id: 'fixedTrash',
+      loadName: 'opentrons_1_trash_1100ml_fixed',
+      displayName: 'Trash',
+      definitionUri: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+    },
+    {
+      id:
+        '3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1',
+      displayName: 'Opentrons 96 Tip Rack 1000 µL',
+      loadName: 'opentrons_96_tiprack_1000ul',
+      definitionUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+    },
+    {
+      id:
+        '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
+      displayName: 'NEST 1 Well Reservoir 195 mL',
+      definitionUri: 'opentrons/nest_1_reservoir_195ml/1',
+      loadName: 'nest_1_reservoir_195ml',
+    },
+    {
+      id:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+      loadName: 'corning_24_wellplate_3.4ml_flat',
+    },
+    {
+      id:
+        'aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+    },
+    {
+      id:
+        'ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+      displayName:
+        'Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL',
+      definitionUri:
+        'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1',
+      loadName: 'opentrons_96_aluminumblock_generic_pcr_strip_200ul',
+    },
+    {
+      id:
+        'b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt (1)',
+      definitionUri: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+      loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+    },
+    {
+      id:
+        'faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1',
+      displayName: 'Opentrons 96 Tip Rack 20 µL',
+      definitionUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+      loadName: 'opentrons_96_tiprack_20ul',
+    },
+    {
+      id: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
+      displayName: 'Corning 24 Well Plate 3.4 mL Flat (1)',
+      definitionUri: 'opentrons/corning_24_wellplate_3.4ml_flat/1',
+      loadName: 'corning_24_wellplate_3.4ml_flat',
+    },
+  ],
+} as unknown) as ProtocolAnalysisFile
 
 describe('getAllLabwareAndTiprackIdsInOrder', () => {
   it('should get all the labware and tiprack ids in order', () => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/utils.ts
@@ -15,18 +15,18 @@ export const getAllLabwareAndTiprackIdsInOrder = (
   labwareDefinitions: Record<string, LabwareDefinition2>,
   commands: RunTimeCommand[]
 ): string[] => {
-  const unorderedLabware = labware.reduce<LabwareToOrder[]>(
-    (unorderedLabware, currentLabware) => {
+  const orderedLabware = labware.reduce<LabwareToOrder[]>(
+    (orderedLabware, currentLabware) => {
       const labwareDef = labwareDefinitions[currentLabware.definitionUri]
       const slotName = getSlotLabwareName(currentLabware.id, commands).slotName
 
       if (
         !getSlotHasMatingSurfaceUnitVector(standardDeckDef as any, slotName)
       ) {
-        return [...unorderedLabware]
+        return [...orderedLabware]
       }
       return [
-        ...unorderedLabware,
+        ...orderedLabware,
         {
           definition: labwareDef,
           labwareId: currentLabware.id,
@@ -36,7 +36,7 @@ export const getAllLabwareAndTiprackIdsInOrder = (
     },
     []
   )
-  const orderedLabwareIds = unorderedLabware
+  const orderedLabwareIds = orderedLabware
     .sort(orderBySlot)
     .map(({ labwareId }) => labwareId)
 

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/utils.ts
@@ -19,16 +19,22 @@ export const getAllLabwareAndTiprackIdsInOrder = (
 ): string[] => {
   const unorderedLabware = reduce<typeof labware, LabwareToOrder[]>(
     labware,
-    (unorderedLabware, currentLabware, labwareId) => {
-      const labwareDef = labwareDefinitions[currentLabware.definitionId]
-      const labwareLocation = getLabwareLocation(labwareId, commands)
+    (unorderedLabware, currentLabware, labwareIndex) => {
+      //  @ts-expect-error: definitionUri will exist when we remove the schemaV6Adapter
+      const labwareDef = labwareDefinitions[currentLabware.definitionUri]
+      const labwareLocation = getLabwareLocation(
+        //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+        labware[labwareIndex].id,
+        commands
+      )
 
       if ('moduleId' in labwareLocation) {
         return [
           ...unorderedLabware,
           {
             definition: labwareDef,
-            labwareId: labwareId,
+            //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+            labwareId: labware[labwareIndex].id,
             slot: getModuleInitialLoadInfo(labwareLocation.moduleId, commands)
               .location.slotName,
           },
@@ -47,7 +53,8 @@ export const getAllLabwareAndTiprackIdsInOrder = (
         ...unorderedLabware,
         {
           definition: labwareDef,
-          labwareId: labwareId,
+          //  @ts-expect-error: id will exist when we remove the schemaV6Adapter
+          labwareId: labware[labwareIndex].id,
           slot: labwareLocation.slotName,
         },
       ]

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -73,6 +73,7 @@ export function useStoredProtocolAnalysis(
 
   // @ts-expect-error
   return storedProtocolAnalysis != null && 'modules' in storedProtocolAnalysis
-    ? schemaV6Adapter(storedProtocolAnalysis)
+    ? // @ts-expect-error
+      schemaV6Adapter(storedProtocolAnalysis)
     : parseProtocolAnalysisOutput(storedProtocolAnalysis)
 }

--- a/app/src/organisms/LabwarePositionCheck/utils/getOnePipettePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getOnePipettePositionCheckSteps.ts
@@ -29,14 +29,15 @@ export const getOnePipettePositionCheckSteps = (args: {
   } = args
 
   const orderedTiprackIds = getTiprackIdsInOrder(
+    // @ts-expect-error these types will match once schemaV6 output is updated
     labware,
     labwareDefinitions,
     commands
   )
   const orderedLabwareIds = getLabwareIdsInOrder(
+    // @ts-expect-error these types will match once schemaV6 output is updated
     labware,
     labwareDefinitions,
-    modules,
     commands
   )
   const moveToTiprackSteps = getMoveToTiprackSteps(

--- a/app/src/organisms/LabwarePositionCheck/utils/getTwoPipettePositionCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getTwoPipettePositionCheckSteps.ts
@@ -32,6 +32,7 @@ export const getTwoPipettePositionCheckSteps = (args: {
   const orderedTiprackIdsThatSecondaryPipetteUses = getAllTipracksIdsThatPipetteUsesInOrder(
     secondaryPipetteId,
     commands,
+    // @ts-expect-error these types will match once schemaV6 output is updated
     labware,
     labwareDefinitions
   )
@@ -39,6 +40,7 @@ export const getTwoPipettePositionCheckSteps = (args: {
   const orderedTiprackIdsThatPrimaryPipetteUses = getAllTipracksIdsThatPipetteUsesInOrder(
     primaryPipetteId,
     commands,
+    // @ts-expect-error these types will match once schemaV6 output is updated
     labware,
     labwareDefinitions
   )
@@ -53,9 +55,9 @@ export const getTwoPipettePositionCheckSteps = (args: {
   )
 
   const orderedLabwareIds = getLabwareIdsInOrder(
+    // @ts-expect-error these types will match once schemaV6 output is updated
     labware,
     labwareDefinitions,
-    modules,
     commands
   )
 

--- a/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json
+++ b/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json
@@ -3057,7 +3057,7 @@
       },
       "result": {
         "labwareId": "fixedTrash",
-        "labwareDefinition": {
+        "definition": {
           "ordering": [["A1"]],
           "metadata": {
             "displayCategory": "trash",
@@ -3113,7 +3113,7 @@
       },
       "result": {
         "labwareId": "50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1",
-        "labwareDefinition": {
+        "definition": {
           "ordering": [
             ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
             ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
@@ -4141,7 +4141,7 @@
       },
       "result": {
         "labwareId": "9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1",
-        "labwareDefinition": {
+        "definition": {
           "ordering": [
             ["A1"],
             ["A2"],
@@ -4338,7 +4338,7 @@
       },
       "result": {
         "labwareId": "e24818a0-0042-11ec-8258-f7ffdf5ad45a",
-        "labwareDefinition": {
+        "definition": {
           "ordering": [
             ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
             ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
@@ -5366,7 +5366,7 @@
       },
       "result": {
         "labwareId": "1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-        "labwareDefinition": {
+        "definition": {
           "ordering": [
             ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
             ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],


### PR DESCRIPTION
closes RAUT-270


# Overview

the `SetupLabwareList` component had some logic that needed to be refactored to match the labware key/value structure

# Changelog

- change logic in `getAllLabwareAndTiprackIdsInOrder` and fix test

# Review requests

- smoke test to make sure everything works as expected and there is no whitescreen. Smoke test: protocol setup, run protocol, and LPC

# Risk assessment

low