### PR TITLE
refactor(api,shared-data): Type-check more strictly in opentrons.protocols.types & .parse

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -15,7 +15,7 @@ warn_untyped_fields = True
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
 
-# ~240 errors
+# ~157 errors
 [mypy-opentrons.protocols.*]
 disallow_any_generics = False
 disallow_untyped_defs = False

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -24,6 +24,22 @@ disallow_incomplete_defs = False
 no_implicit_optional = False
 warn_return_any = False
 
+[mypy-opentrons.protocols.parse]
+disallow_any_generics = True
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+no_implicit_optional = True
+warn_return_any = True
+
+[mypy-opentrons.protocols.types]
+disallow_any_generics = True
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+no_implicit_optional = True
+warn_return_any = True
+
 # ~30 errors
 [mypy-tests.opentrons.drivers.*]
 disallow_untyped_defs = False

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -67,7 +67,7 @@ This function is not present in the current protocol and must be added.
 
 PYTHON_API_VERSION_DEPRECATED = """
 
-The python protocol you uploaded has the Python API Version {0}.  Robot server version 4.0.0 is
+The Python protocol you uploaded has the Python API Version {0}.  Robot server version 4.0.0 is
 the official end of life of Python API Version {0}. The minimum supported Python API Version is {1}. This means that this protocol
 will not run in robot server version 4.0.0 and above.
 Please downgrade your robot server version if you wish to run this protocol. Otherwise, please upgrade this
@@ -82,14 +82,14 @@ through the downgrade process.
 
 
 class MalformedProtocolError(Exception):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.message = message
         super().__init__(message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message + PROTOCOL_MALFORMED
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}: {}>".format(self.__class__.__name__, self.message)
 
 
@@ -98,8 +98,8 @@ class ApiDeprecationError(Exception):
         self.version = version
         super().__init__(version)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return PYTHON_API_VERSION_DEPRECATED.format(self.version, MIN_SUPPORTED_VERSION)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}: {}>".format(self.__class__.__name__, self.version)

--- a/shared-data/python/opentrons_shared_data/protocol/__init__.py
+++ b/shared-data/python/opentrons_shared_data/protocol/__init__.py
@@ -10,4 +10,4 @@ Schema = NewType("Schema", Dict[str, Any])
 
 
 def load_schema(version: int) -> "Schema":
-    return json.loads(load_shared_data(f"protocol/schema/{version}.json"))
+    return json.loads(load_shared_data(f"protocol/schemas/{version}.json"))


### PR DESCRIPTION
# Overview

Some non-behavioral changes to bring some of our older code up to more modern type-checking standards. This will help with RSS-127.

# Changelog

* Enable strict mypy type-checking in `opentrons/protocols/parse.py` and `opentrons/protocols/types.py`. This carves out an exception from an exception. Our general rule is to do strict type-checking everywhere, but `opentrons/protocols/` has been looser as a special case.
* Fix up mypy errors, which were mostly easy things, like missing obvious type annotations.
* Change some things in `parse.py` to use the official load functions from `opentrons_shared_data` instead of implementing loading themselves. This lets us avoid some typecasting.
    * This revealed a silly typo bug in `opentrons_shared_data.protocol.load_schema()`, which was apparently formerly unused and uncovered by tests. Fix the bug.
* Reindent `"""`-strings in `test_parse.py`, for readability.


# Review requests

Read the code and double-check that this has no behavioral changes.

# Risk assessment

Low.
