### PR TITLE
refactor(hardware): increase interrupts_per_sec

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/constants.py
+++ b/hardware/opentrons_hardware/hardware_control/constants.py
@@ -4,5 +4,5 @@ from typing_extensions import Final
 brushed_motor_interrupts_per_sec: Final = 32000
 """The number of gripper motor interrupts per second."""
 
-interrupts_per_sec: Final = 100000
+interrupts_per_sec: Final = 200000
 """The number of motor interrupts per second."""


### PR DESCRIPTION
This confirms to recent changes in firmware and will let us specify moves at the same speeds we currently use, while being able to increase the microstep ratio for quieter and smoother motion.

This PR must only be used in combination with https://github.com/Opentrons/ot3-firmware/pull/464 . If the firmware PR is missing, motors will move twice as fast as they should.