### PR TITLE
feat(shared-data): add calibration commands to schemaV7

### DIFF
--- a/shared-data/protocol/index.ts
+++ b/shared-data/protocol/index.ts
@@ -16,4 +16,4 @@ export type JsonProtocolFile =
   | Readonly<ProtocolFileV4<{}>>
   | Readonly<ProtocolFileV5<{}>>
 
-export * from './types/schemaV7'
+export * from './types/schemaV6'

--- a/shared-data/protocol/index.ts
+++ b/shared-data/protocol/index.ts
@@ -16,4 +16,4 @@ export type JsonProtocolFile =
   | Readonly<ProtocolFileV4<{}>>
   | Readonly<ProtocolFileV5<{}>>
 
-export * from './types/schemaV6'
+export * from './types/schemaV7'

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -547,7 +547,7 @@
                 "pipetteId": { "type": "string" },
                 "deckSlot": {
                   "description": "Slot location to move to before starting calibration.",
-                  "enum": ["attach_or_detach", "probe_position"]
+                  "enum": ["attachOrDetach", "probePosition"]
                 }
               }
             }

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -527,9 +527,27 @@
               "commandType": { "enum": ["calibration/calibratePipette"] },
               "params": {
                 "required": ["mount"],
-                "labwareId": {
+                "mount": {
                   "enum": ["left", "right"],
                   "description": "Instrument mount to calibrate."
+                }
+              }
+            }
+          },
+
+          {
+            "description": "[This command is for internal use only and should NOT be used in protocols.] Move pipette to start position for attach/detach or calibration start.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["calibration/moveToLocation"] },
+              "params": {
+                "required": ["pipetteId", "deckSlot"],
+                "pipetteId": { "type": "string" },
+                "deckSlot": {
+                  "description": "Slot location to move to before starting calibration.",
+                  "enum": ["attach_or_detach", "probe_position"]
                 }
               }
             }

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -543,10 +543,10 @@
               "key": { "type": "string" },
               "commandType": { "enum": ["calibration/moveToLocation"] },
               "params": {
-                "required": ["pipetteId", "deckSlot"],
+                "required": ["pipetteId", "location"],
                 "pipetteId": { "type": "string" },
-                "deckSlot": {
-                  "description": "Slot location to move to before starting calibration.",
+                "location": {
+                  "description": "Location to move to before starting calibration.",
                   "enum": ["attachOrDetach", "probePosition"]
                 }
               }

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -519,6 +519,23 @@
           },
 
           {
+            "description": "[PROVISIONAL AND EXPERIMENTAL] Initiate automatic calibration of a pipette.",
+            "type": "object",
+            "required": ["commandType", "params"],
+            "properties": {
+              "key": { "type": "string" },
+              "commandType": { "enum": ["calibration/calibratePipette"] },
+              "params": {
+                "required": ["mount"],
+                "labwareId": {
+                  "enum": ["left", "right"],
+                  "description": "Instrument mount to calibrate."
+                }
+              }
+            }
+          },
+
+          {
             "description": "Save Position",
             "type": "object",
             "required": ["commandType", "params"],

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -519,7 +519,7 @@
           },
 
           {
-            "description": "[PROVISIONAL AND EXPERIMENTAL] Initiate automatic calibration of a pipette.",
+            "description": "[This command is for internal use only and should NOT be used in protocols.] Initiate automatic calibration of a pipette.",
             "type": "object",
             "required": ["commandType", "params"],
             "properties": {

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -5,14 +5,36 @@ export interface CalibratePipetteCreateCommand extends CommonCommandCreateInfo {
   commandType: 'calibration/calibratePipette'
   params: CalibratePipetteParams
 }
+
+export interface MoveToLocationCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'calibration/moveToLocation'
+  params: MoveToLocationParams
+}
+
 export interface CalibratePipetteRunTimeCommand
   extends CommonCommandRunTimeInfo,
     CalibratePipetteCreateCommand {
   result: CalibratePipetteResult
 }
 
-export type CalibrationRunTimeCommand = CalibratePipetteRunTimeCommand
-export type CalibrationCreateCommand = CalibratePipetteCreateCommand
+export interface MoveToLocationRunTimeCommand
+  extends MoveToLocationCreateCommand {
+  result: MoveToLocationResult
+}
+
+export type CalibrationRunTimeCommand =
+  | CalibratePipetteRunTimeCommand
+  | MoveToLocationRunTimeCommand
+
+export type CalibrationCreateCommand =
+  | CalibratePipetteCreateCommand
+  | MoveToLocationCreateCommand
+
+export const ATTACH_DETACH_POSITION = 'attach_or_detach'
+export const PROBE_POSITION = 'probe_position'
+export type SetupPosition =
+  | typeof ATTACH_DETACH_POSITION
+  | typeof PROBE_POSITION
 
 interface CalibratePipetteParams {
   mount: PipetteMount
@@ -20,4 +42,18 @@ interface CalibratePipetteParams {
 
 interface CalibratePipetteResult {
   pipetteOffset: LabwareOffset
+}
+
+interface MoveToLocationParams {
+  pipetteId: string
+  deckSlot: SetupPosition
+}
+
+interface MoveToLocationResult {
+  deckPoint: {
+    x: number
+    y: number
+    z: number
+  }
+  positionId: string
 }

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -1,0 +1,23 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { PipetteMount, LabwareOffset } from '../../../../js/types'
+
+export interface CalibratePipetteCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'calibration/calibratePipette'
+  params: CalibratePipetteParams
+}
+export interface CalibratePipetteRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    CalibratePipetteCreateCommand {
+  result: CalibratePipetteResult
+}
+
+export type CalibrationRunTimeCommand = CalibratePipetteRunTimeCommand
+export type CalibrationCreateCommand = CalibratePipetteCreateCommand
+
+interface CalibratePipetteParams {
+  mount: PipetteMount
+}
+
+interface CalibratePipetteResult {
+  pipetteOffset: LabwareOffset
+}

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -46,7 +46,7 @@ interface CalibratePipetteResult {
 
 interface MoveToLocationParams {
   pipetteId: string
-  deckSlot: SetupPosition
+  location: SetupPosition
 }
 
 interface MoveToLocationResult {
@@ -55,5 +55,4 @@ interface MoveToLocationResult {
     y: number
     z: number
   }
-  positionId: string
 }

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -1,6 +1,6 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
 import type { PipetteMount, LabwareOffset } from '../../../../js/types'
-
+// TODO (sb 10/26/22): Separate out calibration commands from protocol schema in RAUT-272
 export interface CalibratePipetteCreateCommand extends CommonCommandCreateInfo {
   commandType: 'calibration/calibratePipette'
   params: CalibratePipetteParams
@@ -30,8 +30,8 @@ export type CalibrationCreateCommand =
   | CalibratePipetteCreateCommand
   | MoveToLocationCreateCommand
 
-export const ATTACH_DETACH_POSITION = 'attach_or_detach'
-export const PROBE_POSITION = 'probe_position'
+export const ATTACH_DETACH_POSITION = 'attachOrDetach'
+export const PROBE_POSITION = 'probePosition'
 export type SetupPosition =
   | typeof ATTACH_DETACH_POSITION
   | typeof PROBE_POSITION

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -30,10 +30,10 @@ export type CalibrationCreateCommand =
   | CalibratePipetteCreateCommand
   | MoveToLocationCreateCommand
 
-export const ATTACH_DETACH_POSITION = 'attachOrDetach'
+export const ATTACH_OR_DETACH = 'attachOrDetach'
 export const PROBE_POSITION = 'probePosition'
-export type SetupPosition =
-  | typeof ATTACH_DETACH_POSITION
+export type CalibrationPosition =
+  | typeof ATTACH_OR_DETACH
   | typeof PROBE_POSITION
 
 interface CalibratePipetteParams {
@@ -46,7 +46,7 @@ interface CalibratePipetteResult {
 
 interface MoveToLocationParams {
   pipetteId: string
-  location: SetupPosition
+  location: CalibrationPosition
 }
 
 interface MoveToLocationResult {

--- a/shared-data/protocol/types/schemaV7/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV7/command/gantry.ts
@@ -1,0 +1,131 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { Coordinates, MotorAxis } from '../../../../js/types'
+
+export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'moveToSlot'
+  params: MoveToSlotParams
+}
+export interface MoveToSlotRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MoveToSlotCreateCommand {
+  result: {}
+}
+export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'moveToWell'
+  params: MoveToWellParams
+}
+export interface MoveToWellRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MoveToWellCreateCommand {
+  result: {}
+}
+export interface MoveToCoordinatesCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'moveToCoordinates'
+  params: MoveToCoordinatesParams
+}
+export interface MoveToCoordinatesRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MoveToCoordinatesCreateCommand {
+  result: {}
+}
+export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'moveRelative'
+  params: MoveRelativeParams
+}
+export interface MoveRelativeRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MoveRelativeCreateCommand {
+  result: {
+    position: Coordinates
+  }
+}
+export interface SavePositionCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'savePosition'
+  params: SavePositionParams
+}
+export interface SavePositionRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    SavePositionCreateCommand {
+  result: {
+    positionId: string
+    position: Coordinates
+  }
+}
+export interface HomeCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'home'
+  params: HomeParams
+}
+export interface HomeRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HomeCreateCommand {
+  result: {}
+}
+export type GantryRunTimeCommand =
+  | MoveToSlotRunTimeCommand
+  | MoveToWellRunTimeCommand
+  | MoveToCoordinatesRunTimeCommand
+  | MoveRelativeRunTimeCommand
+  | SavePositionRunTimeCommand
+  | HomeRunTimeCommand
+export type GantryCreateCommand =
+  | MoveToSlotCreateCommand
+  | MoveToWellCreateCommand
+  | MoveToCoordinatesCreateCommand
+  | MoveRelativeCreateCommand
+  | SavePositionCreateCommand
+  | HomeCreateCommand
+
+interface MoveToSlotParams {
+  pipetteId: string
+  slotName: string
+  offset?: {
+    x: number
+    y: number
+    z: number
+  }
+  minimumZHeight?: number
+  forceDirect?: boolean
+}
+
+export interface MoveToWellParams {
+  pipetteId: string
+  labwareId: string
+  wellName: string
+  wellLocation?: {
+    origin?: 'top' | 'bottom'
+    offset?: {
+      x?: number
+      y?: number
+      z?: number
+    }
+  }
+  minimumZHeight?: number
+  forceDirect?: boolean
+}
+
+interface MoveToCoordinatesParams {
+  pipetteId: string
+  coordinates: {
+    x: number
+    y: number
+    z: number
+  }
+  minimumZHeight?: number
+  forceDirect?: boolean
+}
+
+interface MoveRelativeParams {
+  pipetteId: string
+  axis: 'x' | 'y' | 'z'
+  distance: number
+}
+
+interface SavePositionParams {
+  pipetteId: string // pipette to use in measurement
+  positionId?: string // position ID, auto-assigned if left blank
+}
+
+interface HomeParams {
+  axes?: MotorAxis
+}

--- a/shared-data/protocol/types/schemaV7/command/index.ts
+++ b/shared-data/protocol/types/schemaV7/command/index.ts
@@ -1,0 +1,57 @@
+import type {
+  PipettingRunTimeCommand,
+  PipettingCreateCommand,
+} from './pipetting'
+import type { GantryRunTimeCommand, GantryCreateCommand } from './gantry'
+import type { ModuleRunTimeCommand, ModuleCreateCommand } from './module'
+import type { SetupRunTimeCommand, SetupCreateCommand } from './setup'
+import type { TimingRunTimeCommand, TimingCreateCommand } from './timing'
+import type {
+  CalibrationRunTimeCommand,
+  CalibrationCreateCommand,
+} from './calibration'
+
+// NOTE: these key/value pairs will only be present on commands at analysis/run time
+// they pertain only to the actual execution status of a command on hardware, as opposed to
+// the command's identity and parameters which can be known prior to runtime
+
+export type CommandStatus = 'queued' | 'running' | 'succeeded' | 'failed'
+export interface CommonCommandRunTimeInfo {
+  key?: string
+  id: string
+  status: CommandStatus
+  error: string | null
+  createdAt: string
+  startedAt: string | null
+  completedAt: string | null
+}
+export interface CommonCommandCreateInfo {
+  key?: string
+  meta?: { [key: string]: any }
+}
+
+export type CreateCommand =
+  | PipettingCreateCommand // involves the pipettes plunger motor
+  | GantryCreateCommand // movement that only effects the x,y,z position of the gantry/pipette
+  | ModuleCreateCommand // directed at a hardware module
+  | SetupCreateCommand // only effecting robot's equipment setup (pipettes, labware, modules, liquid), no hardware side-effects
+  | TimingCreateCommand // effecting the timing of command execution
+  | CalibrationCreateCommand // for automatic pipette calibration
+  | ({
+      commandType: 'custom'
+      params: { [key: string]: any }
+    } & CommonCommandCreateInfo) // allows for experimentation between schema versions with no expectation of system support
+
+// commands will be required to have a key, but will not be created with one
+export type RunTimeCommand =
+  | PipettingRunTimeCommand // involves the pipettes plunger motor
+  | GantryRunTimeCommand // movement that only effects the x,y,z position of the gantry/pipette
+  | ModuleRunTimeCommand // directed at a hardware module
+  | SetupRunTimeCommand // only effecting robot's equipment setup (pipettes, labware, modules, liquid), no hardware side-effects
+  | TimingRunTimeCommand // effecting the timing of command execution
+  | CalibrationRunTimeCommand // for automatic pipette calibration
+  | ({
+      commandType: 'custom'
+      params: { [key: string]: any }
+      result: any
+    } & CommonCommandRunTimeInfo) // allows for experimentation between schema versions with no expectation of system support

--- a/shared-data/protocol/types/schemaV7/command/index.ts
+++ b/shared-data/protocol/types/schemaV7/command/index.ts
@@ -36,6 +36,7 @@ export type CreateCommand =
   | ModuleCreateCommand // directed at a hardware module
   | SetupCreateCommand // only effecting robot's equipment setup (pipettes, labware, modules, liquid), no hardware side-effects
   | TimingCreateCommand // effecting the timing of command execution
+  // TODO (sb 10/26/22): Separate out calibration commands from protocol schema in RAUT-272
   | CalibrationCreateCommand // for automatic pipette calibration
   | ({
       commandType: 'custom'
@@ -49,6 +50,7 @@ export type RunTimeCommand =
   | ModuleRunTimeCommand // directed at a hardware module
   | SetupRunTimeCommand // only effecting robot's equipment setup (pipettes, labware, modules, liquid), no hardware side-effects
   | TimingRunTimeCommand // effecting the timing of command execution
+  // TODO (sb 10/26/22): Separate out calibration commands from protocol schema in RAUT-272
   | CalibrationRunTimeCommand // for automatic pipette calibration
   | ({
       commandType: 'custom'

--- a/shared-data/protocol/types/schemaV7/command/module.ts
+++ b/shared-data/protocol/types/schemaV7/command/module.ts
@@ -1,0 +1,301 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+
+export type ModuleRunTimeCommand =
+  | MagneticModuleEngageMagnetRunTimeCommand
+  | MagneticModuleDisengageRunTimeCommand
+  | TemperatureModuleSetTargetTemperatureRunTimeCommand
+  | TemperatureModuleDeactivateRunTimeCommand
+  | TemperatureModuleAwaitTemperatureRunTimeCommand
+  | TCSetTargetBlockTemperatureRunTimeCommand
+  | TCSetTargetLidTemperatureRunTimeCommand
+  | TCWaitForBlockTemperatureRunTimeCommand
+  | TCWaitForLidTemperatureRunTimeCommand
+  | TCOpenLidRunTimeCommand
+  | TCCloseLidRunTimeCommand
+  | TCDeactivateBlockRunTimeCommand
+  | TCDeactivateLidRunTimeCommand
+  | TCRunProfileRunTimeCommand
+  | TCAwaitProfileCompleteRunTimeCommand
+  | HeaterShakerStartSetTargetTemperatureRunTimeCommand
+  | HeaterShakerWaitForTemperatureRunTimeCommand
+  | HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
+  | HeaterShakerOpenLatchRunTimeCommand
+  | HeaterShakerCloseLatchRunTimeCommand
+  | HeaterShakerDeactivateHeaterRunTimeCommand
+  | HeaterShakerDeactivateShakerRunTimeCommand
+
+export type ModuleCreateCommand =
+  | MagneticModuleEngageMagnetCreateCommand
+  | MagneticModuleDisengageCreateCommand
+  | TemperatureModuleSetTargetTemperatureCreateCommand
+  | TemperatureModuleDeactivateCreateCommand
+  | TemperatureModuleAwaitTemperatureCreateCommand
+  | TCSetTargetBlockTemperatureCreateCommand
+  | TCSetTargetLidTemperatureCreateCommand
+  | TCWaitForBlockTemperatureCreateCommand
+  | TCWaitForLidTemperatureCreateCommand
+  | TCOpenLidCreateCommand
+  | TCCloseLidCreateCommand
+  | TCDeactivateBlockCreateCommand
+  | TCDeactivateLidCreateCommand
+  | TCRunProfileCreateCommand
+  | TCAwaitProfileCompleteCreateCommand
+  | HeaterShakerWaitForTemperatureCreateCommand
+  | HeaterShakerSetAndWaitForShakeSpeedCreateCommand
+  | HeaterShakerOpenLatchCreateCommand
+  | HeaterShakerCloseLatchCreateCommand
+  | HeaterShakerDeactivateHeaterCreateCommand
+  | HeaterShakerDeactivateShakerCreateCommand
+  | HeaterShakerStartSetTargetTemperatureCreateCommand
+
+export interface MagneticModuleEngageMagnetCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'magneticModule/engage'
+  params: EngageMagnetParams
+}
+export interface MagneticModuleEngageMagnetRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MagneticModuleEngageMagnetCreateCommand {
+  result: any
+}
+export interface MagneticModuleDisengageCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'magneticModule/disengage'
+  params: ModuleOnlyParams
+}
+export interface MagneticModuleDisengageRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MagneticModuleDisengageCreateCommand {
+  result: any
+}
+export interface TemperatureModuleSetTargetTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'temperatureModule/setTargetTemperature'
+  params: TemperatureParams
+}
+export interface TemperatureModuleSetTargetTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TemperatureModuleSetTargetTemperatureCreateCommand {
+  result: any
+}
+export interface TemperatureModuleDeactivateCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'temperatureModule/deactivate'
+  params: ModuleOnlyParams
+}
+export interface TemperatureModuleDeactivateRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TemperatureModuleDeactivateCreateCommand {
+  result: any
+}
+export interface TemperatureModuleAwaitTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'temperatureModule/waitForTemperature'
+  params: TemperatureParams
+}
+export interface TemperatureModuleAwaitTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TemperatureModuleAwaitTemperatureCreateCommand {
+  result: any
+}
+export interface TCSetTargetBlockTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/setTargetBlockTemperature'
+  params: ThermocyclerSetTargetBlockTemperatureParams
+}
+export interface TCSetTargetBlockTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCSetTargetBlockTemperatureCreateCommand {
+  result: any
+}
+export interface TCSetTargetLidTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/setTargetLidTemperature'
+  params: TemperatureParams
+}
+export interface TCSetTargetLidTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCSetTargetLidTemperatureCreateCommand {
+  result: any
+}
+export interface TCWaitForBlockTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/waitForBlockTemperature'
+  params: ModuleOnlyParams
+}
+export interface TCWaitForBlockTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCWaitForBlockTemperatureCreateCommand {
+  result: any
+}
+export interface TCWaitForLidTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/waitForLidTemperature'
+  params: ModuleOnlyParams
+}
+export interface TCWaitForLidTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCWaitForLidTemperatureCreateCommand {
+  result: any
+}
+export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/openLid'
+  params: ModuleOnlyParams
+}
+export interface TCOpenLidRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCOpenLidCreateCommand {
+  result: any
+}
+export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/closeLid'
+  params: ModuleOnlyParams
+}
+export interface TCCloseLidRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCCloseLidCreateCommand {
+  result: any
+}
+export interface TCDeactivateBlockCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/deactivateBlock'
+  params: ModuleOnlyParams
+}
+export interface TCDeactivateBlockRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCDeactivateBlockCreateCommand {
+  result: any
+}
+export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/deactivateLid'
+  params: ModuleOnlyParams
+}
+export interface TCDeactivateLidRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCDeactivateLidCreateCommand {
+  result: any
+}
+export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/runProfile'
+  params: TCProfileParams
+}
+export interface TCRunProfileRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCRunProfileCreateCommand {
+  result: any
+}
+export interface TCAwaitProfileCompleteCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'thermocycler/awaitProfileComplete'
+  params: ModuleOnlyParams
+}
+export interface TCAwaitProfileCompleteRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TCAwaitProfileCompleteCreateCommand {
+  result: any
+}
+export interface HeaterShakerStartSetTargetTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/setTargetTemperature'
+  params: TemperatureParams
+}
+export interface HeaterShakerStartSetTargetTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerStartSetTargetTemperatureCreateCommand {
+  result: any
+}
+export interface HeaterShakerWaitForTemperatureCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/waitForTemperature'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerWaitForTemperatureRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerWaitForTemperatureCreateCommand {
+  result: any
+}
+export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/setAndWaitForShakeSpeed'
+  params: ShakeSpeedParams
+}
+export interface HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
+  result: any
+}
+export interface HeaterShakerDeactivateHeaterCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/deactivateHeater'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerDeactivateHeaterRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerDeactivateHeaterCreateCommand {
+  result: any
+}
+export interface HeaterShakerOpenLatchCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/openLabwareLatch'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerOpenLatchRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerOpenLatchCreateCommand {
+  result: any
+}
+export interface HeaterShakerCloseLatchCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/closeLabwareLatch'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerCloseLatchRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerCloseLatchCreateCommand {
+  result: any
+}
+export interface HeaterShakerDeactivateShakerCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'heaterShaker/deactivateShaker'
+  params: ModuleOnlyParams
+}
+export interface HeaterShakerDeactivateShakerRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    HeaterShakerDeactivateShakerCreateCommand {
+  result: any
+}
+
+export interface EngageMagnetParams {
+  moduleId: string
+  height: number
+}
+
+export interface TemperatureParams {
+  moduleId: string
+  celsius: number
+}
+export interface ShakeSpeedParams {
+  moduleId: string
+  rpm: number
+}
+
+export interface AtomicProfileStep {
+  holdSeconds: number
+  celsius: number
+}
+
+export interface TCProfileParams {
+  moduleId: string
+  profile: AtomicProfileStep[]
+  blockMaxVolumeUl?: number
+}
+
+export interface ModuleOnlyParams {
+  moduleId: string
+}
+
+export interface ThermocyclerSetTargetBlockTemperatureParams {
+  moduleId: string
+  celsius: number
+  volume?: number
+}

--- a/shared-data/protocol/types/schemaV7/command/pipetting.ts
+++ b/shared-data/protocol/types/schemaV7/command/pipetting.ts
@@ -1,0 +1,113 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+export type PipettingRunTimeCommand =
+  | AspirateRunTimeCommand
+  | DispenseRunTimeCommand
+  | BlowoutRunTimeCommand
+  | TouchTipRunTimeCommand
+  | PickUpTipRunTimeCommand
+  | DropTipRunTimeCommand
+export type PipettingCreateCommand =
+  | AspirateCreateCommand
+  | DispenseCreateCommand
+  | BlowoutCreateCommand
+  | TouchTipCreateCommand
+  | PickUpTipCreateCommand
+  | DropTipCreateCommand
+
+export interface AspirateCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'aspirate'
+  params: AspDispAirgapParams
+}
+export interface AspirateRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    AspirateCreateCommand {
+  result: BasicLiquidHandlingResult
+}
+export interface DispenseCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'dispense'
+  params: AspDispAirgapParams
+}
+export interface DispenseRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    DispenseCreateCommand {
+  result: BasicLiquidHandlingResult
+}
+export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'blowout'
+  params: BlowoutParams
+}
+export interface BlowoutRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    BlowoutCreateCommand {
+  result: BasicLiquidHandlingResult
+}
+export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'touchTip'
+  params: TouchTipParams
+}
+export interface TouchTipRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    TouchTipCreateCommand {
+  result: BasicLiquidHandlingResult
+}
+export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'pickUpTip'
+  params: PickUpTipParams
+}
+export interface PickUpTipRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    PickUpTipCreateCommand {
+  result: any
+}
+export interface DropTipCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'dropTip'
+  params: DropTipParams
+}
+export interface DropTipRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    DropTipCreateCommand {
+  result: any
+}
+
+export type AspDispAirgapParams = FlowRateParams &
+  PipetteAccessParams &
+  VolumeParams &
+  WellLocationParam
+export type BlowoutParams = FlowRateParams &
+  PipetteAccessParams &
+  WellLocationParam
+export type TouchTipParams = PipetteAccessParams & WellLocationParam
+export type DropTipParams = TouchTipParams
+export type PickUpTipParams = TouchTipParams
+
+interface FlowRateParams {
+  flowRate: number // µL/s
+}
+
+interface PipetteAccessParams {
+  pipetteId: string
+  labwareId: string
+  wellName: string
+}
+
+interface VolumeParams {
+  volume: number // µL
+}
+
+interface WellLocationParam {
+  wellLocation?: {
+    // default value is 'top'
+    origin?: 'top' | 'bottom'
+    offset?: {
+      // mm
+      // all values default to 0
+      x?: number
+      y?: number
+      z?: number
+    }
+  }
+}
+
+interface BasicLiquidHandlingResult {
+  volume: number // Amount of liquid in uL handled in the operation
+}

--- a/shared-data/protocol/types/schemaV7/command/setup.ts
+++ b/shared-data/protocol/types/schemaV7/command/setup.ts
@@ -1,0 +1,118 @@
+import type {
+  CommonCommandRunTimeInfo,
+  CommonCommandCreateInfo,
+  LabwareDefinition2,
+  LabwareOffset,
+  PipetteName,
+  ModuleModel,
+} from '../../../../js'
+
+export interface LoadPipetteCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'loadPipette'
+  params: LoadPipetteParams
+}
+export interface LoadPipetteRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    Omit<LoadPipetteCreateCommand, 'params'> {
+  params: LoadPipetteParams & {
+    pipetteName: PipetteName
+  }
+  result: LoadPipetteResult
+}
+export interface LoadLabwareCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'loadLabware'
+  params: LoadLabwareParams
+}
+export interface LoadLabwareRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    LoadLabwareCreateCommand {
+  result: LoadLabwareResult
+}
+export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'moveLabware'
+  params: MoveLabwareParams
+}
+export interface MoveLabwareRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MoveLabwareCreateCommand {
+  result: MoveLabwareResult
+}
+export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'loadModule'
+  params: LoadModuleParams
+}
+export interface LoadModuleRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    Omit<LoadModuleCreateCommand, 'params'> {
+  params: LoadModuleParams & {
+    model: ModuleModel
+  }
+  result: LoadModuleResult
+}
+export interface LoadLiquidCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'loadLiquid'
+  params: LoadLiquidParams
+}
+export interface LoadLiquidRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    LoadLiquidCreateCommand {
+  result: LoadLiquidResult
+}
+
+export type SetupRunTimeCommand =
+  | LoadPipetteRunTimeCommand
+  | LoadLabwareRunTimeCommand
+  | LoadModuleRunTimeCommand
+  | LoadLiquidRunTimeCommand
+  | MoveLabwareRunTimeCommand
+export type SetupCreateCommand =
+  | LoadPipetteCreateCommand
+  | LoadLabwareCreateCommand
+  | LoadModuleCreateCommand
+  | LoadLiquidCreateCommand
+  | MoveLabwareCreateCommand
+
+export type LabwareLocation = { slotName: string } | { moduleId: string }
+
+export interface ModuleLocation {
+  slotName: string
+}
+interface LoadPipetteParams {
+  pipetteId: string
+  mount: 'left' | 'right'
+}
+interface LoadPipetteResult {
+  pipetteId: string
+}
+interface LoadLabwareParams {
+  labwareId: string
+  location: LabwareLocation
+  displayName?: string
+}
+interface LoadLabwareResult {
+  labwareId: string
+  definition: LabwareDefinition2
+  offset: LabwareOffset
+}
+interface MoveLabwareParams {
+  labwareId: string
+  newLocation: LabwareLocation
+}
+interface MoveLabwareResult {
+  offsetId: string
+}
+interface LoadModuleParams {
+  moduleId: string
+  location: ModuleLocation
+}
+interface LoadModuleResult {
+  moduleId: string
+}
+interface LoadLiquidParams {
+  liquidId: string
+  labwareId: string
+  volumeByWell: { [wellName: string]: number }
+}
+interface LoadLiquidResult {
+  liquidId: string
+}

--- a/shared-data/protocol/types/schemaV7/command/timing.ts
+++ b/shared-data/protocol/types/schemaV7/command/timing.ts
@@ -1,0 +1,58 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+
+export type TimingCreateCommand =
+  | WaitForResumeCreateCommand
+  | WaitForDurationCreateCommand
+  | DeprecatedDelayCreateCommand
+
+export type TimingRunTimeCommand =
+  | WaitForResumeRunTimeCommand
+  | WaitForDurationRunTimeCommand
+  | DeprecatedDelayRunTimeCommand
+
+export interface WaitForResumeCreateCommand extends CommonCommandCreateInfo {
+  // NOTE: `pause` accepted for backwards compatibility
+  commandType: 'waitForResume' | 'pause'
+  params: WaitForResumeParams
+}
+
+export interface WaitForResumeRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    WaitForResumeCreateCommand {
+  result: any
+}
+
+interface WaitForResumeParams {
+  message?: string
+}
+
+export interface WaitForDurationCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'waitForDuration'
+  params: WaitForDurationParams
+}
+
+export interface WaitForDurationRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    WaitForDurationCreateCommand {
+  result: any
+}
+
+interface WaitForDurationParams {
+  seconds: number
+  message?: string
+}
+
+export interface DeprecatedDelayCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'delay'
+  params: DeprecatedDelayParams
+}
+
+export interface DeprecatedDelayRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    DeprecatedDelayCreateCommand {
+  result: {}
+}
+
+type DeprecatedDelayParams =
+  | { waitForResume: true; message?: string }
+  | { seconds: number; message?: string }

--- a/shared-data/protocol/types/schemaV7/index.ts
+++ b/shared-data/protocol/types/schemaV7/index.ts
@@ -1,0 +1,117 @@
+import {
+  LoadedPipette,
+  LoadedLabware,
+  LoadedModule,
+  Liquid,
+  PipetteName,
+} from '../../../js'
+import type { CreateCommand, RunTimeCommand } from './command'
+import type { LabwareDefinition2, ModuleModel } from '../../../js/types'
+
+export * from './command'
+
+// NOTE: must be kept in sync with '../schemas/7.json'
+export interface ProtocolFile<DesignerApplicationData = {}> {
+  $otSharedSchema: '#/protocol/schemas/7'
+  schemaVersion: 7
+  metadata: {
+    protocolName?: string
+    author?: string
+    description?: string | null | undefined
+    created?: number
+    lastModified?: number | null | undefined
+    category?: string | null | undefined
+    subcategory?: string | null | undefined
+    tags?: string[]
+  }
+  designerApplication?: {
+    name?: string
+    version?: string
+    data?: DesignerApplicationData
+  }
+  robot: {
+    model: 'OT-2 Standard' | 'OT-3 Standard'
+    deckId: 'ot2_standard' | 'ot2_short_trash' | 'ot3_standard'
+  }
+  pipettes: {
+    [pipetteId: string]: { name: PipetteName }
+  }
+  labwareDefinitions: {
+    [definitionId: string]: LabwareDefinition2
+  }
+  labware: {
+    [labwareId: string]: {
+      definitionId: string
+      displayName?: string
+    }
+  }
+  modules: {
+    [moduleId: string]: {
+      model: ModuleModel
+    }
+  }
+  liquids: {
+    [liquidId: string]: {
+      displayName: string
+      description: string
+      displayColor?: string
+    }
+  }
+  commands: CreateCommand[]
+  commandAnnotations?: {
+    commandIds: string[]
+    annotationType: string
+    params?: { [key: string]: any }
+  }
+}
+
+/**
+ * This type should not be used, any time you want a function/hook/component to take in
+ * a protocol file with run time commands, split your function signature to take in each param
+ * separately, and import the RunTimeCommand type separately. RunTimeCommand is a server concept
+ * and should not be mixed with our Protocol types
+ * @deprecated Use {@link ProtocolFile}
+ */
+export interface ProtocolAnalysisFile<DesignerApplicationData = {}>
+  extends Omit<ProtocolFile<DesignerApplicationData>, 'commands'> {
+  commands: RunTimeCommand[]
+}
+
+/**
+ * This type interface is represents the output of the opentrons analyze cli tool
+ * which contains the protocol analysis engine
+ * TODO: reconcile this type with that of the analysis returned from
+ * the protocols record endpoints on the robot-server
+ */
+export interface ProtocolAnalysisOutput {
+  createdAt: string
+  files: AnalysisSourceFile[]
+  config: JsonConfig | PythonConfig
+  metadata: { [key: string]: any }
+  commands: RunTimeCommand[]
+  labware: LoadedLabware[]
+  pipettes: LoadedPipette[]
+  modules: LoadedModule[]
+  liquids: Liquid[]
+  errors: AnalysisError[]
+}
+
+interface AnalysisSourceFile {
+  name: string
+  role: 'main' | 'labware'
+}
+export interface JsonConfig {
+  protocolType: 'json'
+  schemaVersion: number
+}
+export interface PythonConfig {
+  protocolType: 'python'
+  apiVersion: [major: number, minor: number]
+}
+
+interface AnalysisError {
+  id: string
+  errorType: string
+  createdAt: string
+  detail: string
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
This PR adds the `calibration/calibratePipette` and `calibration/moveToLocation` commands and schemaV7 command types
# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. Copy all schemaV6 types to a new schemaV7 type folder
2. Create new `calibration.ts` file with `calibration/calibratePipette` and `calibration/moveToLocation` commands
3. Add these commands and to `7-draft.json` with a warning that they shouldn't be used in protocols

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Verify that the command type, params, and result align with what was added in https://github.com/Opentrons/opentrons/pull/11482 and https://github.com/Opentrons/opentrons/pull/11478/files

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low