### PR TITLE
fix(app): prevent white screen in protocols with liquids on nested labware

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
@@ -2,18 +2,12 @@ import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { SPACING } from '@opentrons/components'
-import {
-  getModuleDisplayName,
-  getLabwareDisplayName,
-} from '@opentrons/shared-data'
+import { getModuleDisplayName } from '@opentrons/shared-data'
+import { getSlotLabwareName } from './utils/getSlotLabwareName'
 import { parseLiquidsInLoadOrder } from '@opentrons/api-client'
 
 import { StyledText } from '../../../atoms/text'
-import {
-  useProtocolDetailsForRun,
-  useRunPipetteInfoByMount,
-  useLabwareRenderInfoForRunById,
-} from '../hooks'
+import { useProtocolDetailsForRun, useRunPipetteInfoByMount } from '../hooks'
 
 import type { RunCommandSummary } from '@opentrons/api-client'
 import type { Mount } from '@opentrons/components'
@@ -34,7 +28,6 @@ export const RunLogProtocolSetupInfo = ({
   const { t } = useTranslation('run_details')
   const { protocolData } = useProtocolDetailsForRun(runId)
   const protocolPipetteData = useRunPipetteInfoByMount(robotName, runId)
-  const labwareRenderInfoById = useLabwareRenderInfoForRunById(runId)
 
   if (protocolData == null) return null
   if (setupCommand === undefined) return null
@@ -147,9 +140,8 @@ export const RunLogProtocolSetupInfo = ({
         i18nKey={'load_liquids_info_protocol_setup'}
         values={{
           liquid: liquidDisplayName ?? 'liquid',
-          labware: getLabwareDisplayName(
-            labwareRenderInfoById[labwareId].labwareDef
-          ),
+          labware: getSlotLabwareName(labwareId, protocolData.commands)
+            .labwareName,
         }}
       />
     )

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -15,13 +15,11 @@ import {
   TYPOGRAPHY,
   LabwareRender,
 } from '@opentrons/components'
-import {
-  useProtocolDetailsForRun,
-  useLabwareRenderInfoForRunById,
-} from '../../../Devices/hooks'
+import { useProtocolDetailsForRun } from '../../../Devices/hooks'
 import { Modal } from '../../../../molecules/Modal'
 import { StyledText } from '../../../../atoms/text'
 import { getSlotLabwareName } from '../utils/getSlotLabwareName'
+import { getSlotLabwareDefinition } from '../utils/getSlotLabwareDefinition'
 import { LiquidDetailCard } from './LiquidDetailCard'
 import {
   getLiquidsByIdForLabware,
@@ -43,7 +41,6 @@ export const LiquidsLabwareDetailsModal = (
   const { liquidId, labwareId, runId, closeModal } = props
   const { t } = useTranslation('protocol_setup')
   const currentLiquidRef = React.useRef<HTMLDivElement>(null)
-  const labwareRenderInfo = useLabwareRenderInfoForRunById(runId)[labwareId]
   const protocolData = useProtocolDetailsForRun(runId).protocolData
   const commands = protocolData?.commands ?? []
   const liquids = parseLiquidsInLoadOrder(
@@ -79,6 +76,8 @@ export const LiquidsLabwareDetailsModal = (
       display: none;
     }
   `
+  if (protocolData == null) return null
+
   const liquidIds = filteredLiquidsInLoadOrder.map(liquid => liquid.id)
   const disabledLiquidIds = liquidIds.filter(id => id !== selectedValue)
 
@@ -177,7 +176,10 @@ export const LiquidsLabwareDetailsModal = (
             <Flex flex="1 1 30rem" flexDirection={DIRECTION_COLUMN}>
               <svg viewBox="0 -10 130 100" transform="scale(1, -1)">
                 <LabwareRender
-                  definition={labwareRenderInfo.labwareDef}
+                  definition={getSlotLabwareDefinition(
+                    labwareId,
+                    protocolData.commands
+                  )}
                   wellFill={wellFill}
                   wellLabelOption="SHOW_LABEL_INSIDE"
                   highlightedWells={

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
@@ -9,13 +9,17 @@ import {
 } from '@opentrons/components'
 import { parseLiquidsInLoadOrder } from '@opentrons/api-client'
 import { getSlotLabwareName } from '../../utils/getSlotLabwareName'
+import { getSlotLabwareDefinition } from '../../utils/getSlotLabwareDefinition'
 import { getLiquidsByIdForLabware, getWellFillFromLabwareId } from '../utils'
 import {
   useLabwareRenderInfoForRunById,
   useProtocolDetailsForRun,
 } from '../../../../Devices/hooks'
+import { mockDefinition } from '../../../../../redux/custom-labware/__fixtures__'
 import { LiquidsLabwareDetailsModal } from '../LiquidsLabwareDetailsModal'
 import { LiquidDetailCard } from '../LiquidDetailCard'
+
+import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
 
 jest.mock('@opentrons/components', () => {
   const actualComponents = jest.requireActual('@opentrons/components')
@@ -26,6 +30,7 @@ jest.mock('@opentrons/components', () => {
 })
 jest.mock('@opentrons/api-client')
 jest.mock('../../utils/getSlotLabwareName')
+jest.mock('../../utils/getSlotLabwareDefinition')
 jest.mock('../utils')
 jest.mock('../LiquidDetailCard')
 jest.mock('../../../../Devices/hooks')
@@ -35,6 +40,9 @@ const mockLiquidDetailCard = LiquidDetailCard as jest.MockedFunction<
 >
 const mockGetSlotLabwareName = getSlotLabwareName as jest.MockedFunction<
   typeof getSlotLabwareName
+>
+const mockGetSlotLabwareDefinition = getSlotLabwareDefinition as jest.MockedFunction<
+  typeof getSlotLabwareDefinition
 >
 const mockGetLiquidsByIdForLabware = getLiquidsByIdForLabware as jest.MockedFunction<
   typeof getLiquidsByIdForLabware
@@ -76,6 +84,7 @@ describe('LiquidsLabwareDetailsModal', () => {
       labwareName: 'mock labware name',
       slotName: '5',
     })
+    mockGetSlotLabwareDefinition.mockReturnValue(mockDefinition)
     mockGetLiquidsByIdForLabware.mockReturnValue({
       '4': [
         {
@@ -108,7 +117,11 @@ describe('LiquidsLabwareDetailsModal', () => {
         labwareDef: {},
       },
     } as any)
-    mockUseProtocolDetailsForRun.mockReturnValue({} as any)
+    mockUseProtocolDetailsForRun.mockReturnValue({
+      displayName: null,
+      protocolData: {} as ProtocolAnalysisFile<{}>,
+      protocolKey: null,
+    } as any)
 
     when(mockLabwareRender)
       .mockReturnValue(<div></div>) // this (default) empty div will be returned when LabwareRender isn't called with expected props

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getSlotLabwareDefinition.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getSlotLabwareDefinition.test.ts
@@ -1,0 +1,34 @@
+import { RunTimeCommand } from '@opentrons/shared-data'
+import { mockDefinition } from '../../../../../redux/custom-labware/__fixtures__'
+import { getSlotLabwareDefinition } from '../getSlotLabwareDefinition'
+
+const LABWARE_ID =
+  '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1'
+
+const MOCK_LOAD_LABWARE_COMMANDS = [
+  {
+    commandType: 'loadLabware',
+    params: {
+      location: {
+        slotName: '5',
+      },
+    },
+    result: {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      definition: mockDefinition,
+    },
+  },
+]
+
+describe('getSlotLabwareDefinition', () => {
+  it('returns labware definition for labwareId', () => {
+    const expected = mockDefinition
+    expect(
+      getSlotLabwareDefinition(
+        LABWARE_ID,
+        MOCK_LOAD_LABWARE_COMMANDS as RunTimeCommand[]
+      )
+    ).toEqual(expected)
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/utils/getSlotLabwareDefinition.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getSlotLabwareDefinition.ts
@@ -1,0 +1,15 @@
+import { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+
+export function getSlotLabwareDefinition(
+  labwareId: string,
+  commands?: RunTimeCommand[]
+): LabwareDefinition2 {
+  const loadLabwareCommands = commands?.filter(
+    command => command.commandType === 'loadLabware'
+  )
+  const loadLabwareCommand = loadLabwareCommands?.find(
+    command => command.result.labwareId === labwareId
+  )
+
+  return loadLabwareCommand?.result.definition
+}


### PR DESCRIPTION


# Overview

This PR fixes the white screen issues in the liquids setup section and run log when a protocol has liquids nested on module.

Paired with @smb2268 

# Changelog

- Utilize `getSlotLabwareName`
- Implement `getSlotLabwareDefinition` utility
- Update tests

# Review requests

- Currently in `edge` if you upload a protocol containing liquids nested on a module, the app will white screen if you visit the Run Log OR open the Liquid Details modal in the liquid setup step.
- In this branch, try uploading the same protocol and ensure the white screen no longer persists.

# Risk assessment

low