### PR TITLE
fix(api): allow relative threshold value to be set for capacitive probe

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -18,7 +18,7 @@ from typing import (
     TypeVar,
     Iterator,
 )
-from opentrons.config.types import OT3Config, GantryLoad
+from opentrons.config.types import OT3Config, GantryLoad, CapacitivePassSettings
 from opentrons.config import pipette_config, gripper_config
 from .ot3utils import (
     axis_convert,
@@ -770,14 +770,15 @@ class OT3Controller:
         mount: OT3Mount,
         moving: OT3Axis,
         distance_mm: float,
-        speed_mm_per_s: float,
+        capacitive_settings: CapacitivePassSettings,
     ) -> None:
         pos, _ = await capacitive_probe(
             self._messenger,
             sensor_node_for_mount(mount),
             axis_to_node(moving),
             distance_mm,
-            speed_mm_per_s,
+            capacitive_settings.speed_mm_per_s,
+            relative_threshold_pf=capacitive_settings.sensor_threshold_pf,
             log_sensor_values=True,
         )
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -18,7 +18,7 @@ from typing import (
     TypeVar,
     Iterator,
 )
-from opentrons.config.types import OT3Config, GantryLoad, CapacitivePassSettings
+from opentrons.config.types import OT3Config, GantryLoad
 from opentrons.config import pipette_config, gripper_config
 from .ot3utils import (
     axis_convert,
@@ -770,15 +770,16 @@ class OT3Controller:
         mount: OT3Mount,
         moving: OT3Axis,
         distance_mm: float,
-        capacitive_settings: CapacitivePassSettings,
+        speed_mm_per_s: float,
+        sensor_threshold_pf: float,
     ) -> None:
         pos, _ = await capacitive_probe(
             self._messenger,
             sensor_node_for_mount(mount),
             axis_to_node(moving),
             distance_mm,
-            capacitive_settings.speed_mm_per_s,
-            relative_threshold_pf=capacitive_settings.sensor_threshold_pf,
+            speed_mm_per_s,
+            relative_threshold_pf=sensor_threshold_pf,
             log_sensor_values=True,
         )
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -17,7 +17,7 @@ from typing import (
     Mapping,
 )
 
-from opentrons.config.types import OT3Config, GantryLoad
+from opentrons.config.types import OT3Config, GantryLoad, CapacitivePassSettings
 from opentrons.config import pipette_config, gripper_config
 from opentrons_shared_data.pipette import dummy_model_for_name
 from .ot3utils import (
@@ -479,7 +479,7 @@ class OT3Simulator:
         mount: OT3Mount,
         moving: OT3Axis,
         distance_mm: float,
-        speed_mm_per_s: float,
+        capacitive_settings: CapacitivePassSettings,
     ) -> None:
         self._position[axis_to_node(moving)] += distance_mm
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -17,7 +17,7 @@ from typing import (
     Mapping,
 )
 
-from opentrons.config.types import OT3Config, GantryLoad, CapacitivePassSettings
+from opentrons.config.types import OT3Config, GantryLoad
 from opentrons.config import pipette_config, gripper_config
 from opentrons_shared_data.pipette import dummy_model_for_name
 from .ot3utils import (
@@ -479,7 +479,8 @@ class OT3Simulator:
         mount: OT3Mount,
         moving: OT3Axis,
         distance_mm: float,
-        capacitive_settings: CapacitivePassSettings,
+        speed_mm_per_s: float,
+        sensor_threshold_pf: float,
     ) -> None:
         self._position[axis_to_node(moving)] += distance_mm
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1506,7 +1506,6 @@ class OT3API(
                 pass_settings.prep_distance_mm + pass_settings.max_overrun_distance_mm
             )
         else:
-
             pass_start = target_pos + pass_settings.prep_distance_mm
             pass_distance = -1.0 * (
                 pass_settings.prep_distance_mm + pass_settings.max_overrun_distance_mm
@@ -1520,10 +1519,7 @@ class OT3API(
         pass_start_pos = moving_axis.set_in_point(here, pass_start)
         await self.move_to(mount, pass_start_pos)
         await self._backend.capacitive_probe(
-            mount,
-            moving_axis,
-            machine_pass_distance,
-            pass_settings.speed_mm_per_s,
+            mount, moving_axis, machine_pass_distance, pass_settings
         )
         end_pos = await self.gantry_position(mount, refresh=True)
         await self.move_to(mount, pass_start_pos)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1519,7 +1519,11 @@ class OT3API(
         pass_start_pos = moving_axis.set_in_point(here, pass_start)
         await self.move_to(mount, pass_start_pos)
         await self._backend.capacitive_probe(
-            mount, moving_axis, machine_pass_distance, pass_settings
+            mount,
+            moving_axis,
+            machine_pass_distance,
+            pass_settings.speed_mm_per_s,
+            pass_settings.sensor_threshold_pf,
         )
         end_pos = await self.gantry_position(mount, refresh=True)
         await self.move_to(mount, pass_start_pos)

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -159,7 +159,11 @@ def mock_backend_capacitive_probe(
     ) as mock_probe:
 
         def _update_position(
-            mount: OT3Mount, moving: OT3Axis, distance_mm: float, speed_mm_per_s: float
+            mount: OT3Mount,
+            moving: OT3Axis,
+            distance_mm: float,
+            speed_mm_per_s: float,
+            threshold_pf: float,
         ) -> None:
             ot3_hardware._backend._position[axis_to_node(moving)] += distance_mm / 2
 
@@ -218,9 +222,7 @@ async def test_capacitive_probe(
 
     # This is a negative probe because the current position is the home position
     # which is very large.
-    mock_backend_capacitive_probe.assert_called_once_with(
-        mount, moving, 3.0, fake_settings
-    )
+    mock_backend_capacitive_probe.assert_called_once_with(mount, moving, 3.0, 4, 1.0)
 
     original = moving.set_in_point(here, 0)
     for call in mock_move_to.call_args_list:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -218,7 +218,9 @@ async def test_capacitive_probe(
 
     # This is a negative probe because the current position is the home position
     # which is very large.
-    mock_backend_capacitive_probe.assert_called_once_with(mount, moving, 3, 4)
+    mock_backend_capacitive_probe.assert_called_once_with(
+        mount, moving, 3.0, fake_settings
+    )
 
     original = moving.set_in_point(here, 0)
     for call in mock_move_to.call_args_list:


### PR DESCRIPTION
## Overview
We may want to adjust the relative threshold, and so we should allow the api to actually do that.