### PR TITLE
fix(app): fix displaying a wrong image when a robot is unavailable

### DIFF
--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -8,9 +8,7 @@ import {
   useInterval,
   ALIGN_CENTER,
   ALIGN_START,
-  C_MED_LIGHT_GRAY,
   COLORS,
-  C_WHITE,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   JUSTIFY_SPACE_BETWEEN,
@@ -81,8 +79,8 @@ export function RobotOverview({
   return robot != null ? (
     <Flex
       alignItems={ALIGN_START}
-      backgroundColor={C_WHITE}
-      borderBottom={`1px solid ${C_MED_LIGHT_GRAY}`}
+      backgroundColor={COLORS.white}
+      borderBottom={`1px solid ${COLORS.medGreyEnabled}`}
       flexDirection={DIRECTION_ROW}
       marginBottom={SPACING.spacing4}
       padding={SPACING.spacing3}

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -243,6 +243,6 @@ export const getRobotModelByName = (
   state: State,
   robotName: string
 ): string | null => {
-  const robot = getRobotByName(state, robotName)
+  const robot = getDiscoverableRobotByName(state, robotName)
   return robot != null ? getRobotModel(robot)?.split(/\s/)[0] : null
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Issue: when an OT-2 become unavailable, the app shows the OT-3 image instead of the OT-2.
https://opentrons.slack.com/archives/C03QBAEPD62/p1666286926417419

This issue happens because `getRobotModelByName` used `getRobotByName` that  returns `ViewableRobot` so that `getRobotModelByName` always returns `null` when a robot is unavailable. As a result, `RobotCard` and `RobotOverview` use the OT-3 image.

In addition, noticed that RobotOverview used the previous color constants. Updated them.

This will close RCORE-289
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- update `getRobotModelByName` (getRobotByName --> getDiscoverableRobotByName )
- update colors in RobotOverView
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] When an OT-2 is unavailable, the app shows the OT-2 image
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
