### PR TITLE
feat(hardware-controller): initialize nsync to high on HC initialization

### DIFF
--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -6,6 +6,7 @@ from logging import getLogger
 
 CONSUMER_NAME_DEFAULT: Final[str] = "opentrons"
 ESTOP_OUT_GPIO_NAME: Final[str] = "SODIMM_210"
+NSYNC_OUT_GPIO_NAME: Final[str] = "SODIMM_206"
 
 LOG = getLogger(__name__)
 
@@ -40,7 +41,12 @@ class OT3GPIO:
         self._estop_out_line.request(
             self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
         )
+        self._nsync_out_line = self._gpiod.find_line(NSYNC_OUT_GPIO_NAME)
+        self._nsync_out_line.request(
+            self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
+        )
         self.deactivate_estop()
+        self.deactivate_nsync_out()
 
     def activate_estop(self) -> None:
         """Assert the emergency stop, which will disable all motors."""
@@ -53,3 +59,15 @@ class OT3GPIO:
         again.
         """
         self._estop_out_line.set_value(1)
+
+    def activate_nsync_out(self) -> None:
+        """Assert the emergency stop, which will disable all motors."""
+        self._nsync_out_line.set_value(0)
+
+    def deactivate_nsync_out(self) -> None:
+        """Stop asserting the emergency stop.
+
+        If no other node is asserting estop, then motors can be enabled
+        again.
+        """
+        self._nsync_out_line.set_value(1)

--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -61,13 +61,9 @@ class OT3GPIO:
         self._estop_out_line.set_value(1)
 
     def activate_nsync_out(self) -> None:
-        """Assert the emergency stop, which will disable all motors."""
+        """Assert the nsync out line."""
         self._nsync_out_line.set_value(0)
 
     def deactivate_nsync_out(self) -> None:
-        """Stop asserting the emergency stop.
-
-        If no other node is asserting estop, then motors can be enabled
-        again.
-        """
+        """Stop asserting the nsync out line."""
         self._nsync_out_line.set_value(1)


### PR DESCRIPTION
We need to make sure the sync line is set high across the system.

## TODO

- [x] Test on a robot