### PR TITLE
fix(api): refresh the current position in capacitive probe

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1501,7 +1501,7 @@ class OT3API(
                 " tool"
             )
 
-        here = await self.gantry_position(mount)
+        here = await self.gantry_position(mount, refresh=True)
         origin_pos = moving_axis.of_point(here)
         if origin_pos < target_pos:
             pass_start = target_pos - pass_settings.prep_distance_mm


### PR DESCRIPTION
We need to refresh the current position to ensure that we have the correct current position before moving to safe z height in the capacitive probe.