### PR TITLE
refactor(app): make WizardRequiredEquipment generic

### DIFF
--- a/app/src/molecules/WizardRequiredEquipmentList/equipmentImages.ts
+++ b/app/src/molecules/WizardRequiredEquipmentList/equipmentImages.ts
@@ -1,0 +1,6 @@
+// images by equipment load name
+
+export const equipmentImages = {
+  //  TODO(jt, 10/24/22): add equipment images for required equipment in calibration flows
+  //  should be similar to labwareImages.ts
+}

--- a/app/src/molecules/WizardRequiredEquipmentList/equipmentImages.ts
+++ b/app/src/molecules/WizardRequiredEquipmentList/equipmentImages.ts
@@ -1,6 +1,6 @@
 // images by equipment load name
 
 export const equipmentImages = {
-  //  TODO(jt, 10/24/22): add equipment images for required equipment in calibration flows
+  //  TODO(jr, 10/24/22): add equipment images for required equipment in calibration flows
   //  should be similar to labwareImages.ts
 }

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -16,7 +16,7 @@ import {
 import { StyledText } from '../../atoms/text'
 import { Divider } from '../../atoms/structure'
 import { labwareImages } from '../../organisms/CalibrationPanels/labwareImages'
-import { equipmentImages } from './EquipmentImages'
+import { equipmentImages } from './equipmentImages'
 
 interface WizardRequiredEquipmentListProps {
   equipmentList: Array<React.ComponentProps<typeof RequiredEquipmentCard>>

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -62,9 +62,9 @@ function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
 
   let imageSrc: string = labwareImages.generic_custom_tiprack
   if (loadName in labwareImages) {
-    src = labwareImages[loadName as keyof typeof labwareImages]
+    imageSrc = labwareImages[loadName as keyof typeof labwareImages]
   } else if (loadName in equipmentImages) {
-    src = equipmentImages[loadName as keyof typeof equipmentImages]
+    imageSrc = equipmentImages[loadName as keyof typeof equipmentImages]
   }
 
   return (

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -52,15 +52,15 @@ export function WizardRequiredEquipmentList(
 }
 
 interface RequiredEquipmentCardProps {
-  displayName: string
   loadName: string
+  displayName: string
   subtitle?: string
 }
 
 function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
   const { loadName, displayName, subtitle } = props
 
-  let src: string = labwareImages.generic_custom_tiprack
+  let imageSrc: string = labwareImages.generic_custom_tiprack
   if (loadName in labwareImages) {
     src = labwareImages[loadName as keyof typeof labwareImages]
   } else if (loadName in equipmentImages) {
@@ -88,7 +88,7 @@ function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
               flex: 0 1 5rem;
               display: block;
             `}
-            src={src}
+            src={imageSrc}
           />
         </Flex>
         <Flex

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -16,13 +16,14 @@ import {
 import { StyledText } from '../../atoms/text'
 import { Divider } from '../../atoms/structure'
 import { labwareImages } from '../../organisms/CalibrationPanels/labwareImages'
+import { equipmentImages } from './EquipmentImages'
 
-interface WizardRequiredLabwareListProps {
-  equipmentList: Array<React.ComponentProps<typeof RequiredLabwareCard>>
+interface WizardRequiredEquipmentListProps {
+  equipmentList: Array<React.ComponentProps<typeof RequiredEquipmentCard>>
   footer: string
 }
-export function WizardRequiredLabwareList(
-  props: WizardRequiredLabwareListProps
+export function WizardRequiredEquipmentList(
+  props: WizardRequiredEquipmentListProps
 ): JSX.Element {
   const { t } = useTranslation('robot_calibration')
   const { equipmentList, footer } = props
@@ -33,10 +34,10 @@ export function WizardRequiredLabwareList(
         {t('you_will_need')}
       </StyledText>
       <Divider />
-      {equipmentList.map(requiredLabwareProps => (
-        <RequiredLabwareCard
-          key={requiredLabwareProps.loadName}
-          {...requiredLabwareProps}
+      {equipmentList.map(requiredEquipmentProps => (
+        <RequiredEquipmentCard
+          key={requiredEquipmentProps.loadName}
+          {...requiredEquipmentProps}
         />
       ))}
       <StyledText
@@ -50,18 +51,21 @@ export function WizardRequiredLabwareList(
   )
 }
 
-interface RequiredLabwareCardProps {
-  loadName: string
+interface RequiredEquipmentCardProps {
   displayName: string
+  loadName: string
   subtitle?: string
 }
 
-function RequiredLabwareCard(props: RequiredLabwareCardProps): JSX.Element {
+function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
   const { loadName, displayName, subtitle } = props
-  const imageSrc =
-    loadName in labwareImages
-      ? labwareImages[loadName as keyof typeof labwareImages]
-      : labwareImages.generic_custom_tiprack
+
+  let src: string = labwareImages.generic_custom_tiprack
+  if (loadName in labwareImages) {
+    src = labwareImages[loadName as keyof typeof labwareImages]
+  } else if (loadName in equipmentImages) {
+    src = equipmentImages[loadName as keyof typeof equipmentImages]
+  }
 
   return (
     <>
@@ -84,7 +88,7 @@ function RequiredLabwareCard(props: RequiredLabwareCardProps): JSX.Element {
               flex: 0 1 5rem;
               display: block;
             `}
-            src={imageSrc}
+            src={src}
           />
         </Flex>
         <Flex

--- a/app/src/organisms/CalibrationPanels/Introduction/index.tsx
+++ b/app/src/organisms/CalibrationPanels/Introduction/index.tsx
@@ -16,7 +16,7 @@ import { NeedHelpLink } from '../NeedHelpLink'
 import { ChooseTipRack } from '../ChooseTipRack'
 
 import { TRASH_BIN_LOAD_NAME } from '../constants'
-import { WizardRequiredLabwareList } from '../../../molecules/WizardRequiredLabwareList'
+import { WizardRequiredEquipmentList } from '../../../molecules/WizardRequiredEquipmentList'
 import { Body } from './Body'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -135,7 +135,7 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
           <Body sessionType={sessionType} />
         </Flex>
         <Flex flex="1">
-          <WizardRequiredLabwareList
+          <WizardRequiredEquipmentList
             equipmentList={equipmentList}
             footer={
               sessionType === Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK


### PR DESCRIPTION
closes RLIQ-216

# Overview

renames `labware` to `equipment` in `WizardRequiredEquipement` to make it more generic for usage through the attach/detach pipette flow and calibration flow

# Changelog

- change `WizardRequiredEquipement`
- create `equipmentImages`

# Review requests

- does this make sense in making this component more generic for usage with other equipment lists that are not labware?

# Risk assessment

low