### PR TITLE
fix(api): Fix LabwareNotOnDeckError when unrelated labware are off-deck

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -64,6 +64,7 @@ class GeometryView:
             (
                 self._get_highest_z_from_labware_data(lw_data)
                 for lw_data in self._labware.get_all()
+                if lw_data.location != OFF_DECK_LOCATION
             ),
             default=0.0,
         )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -238,6 +238,7 @@ def test_get_all_labware_highest_z(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
     reservoir_def: LabwareDefinition,
+    falcon_tuberack_def: LabwareDefinition,
     labware_view: LabwareView,
     module_view: ModuleView,
     subject: GeometryView,
@@ -250,7 +251,7 @@ def test_get_all_labware_highest_z(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         offsetId="plate-offset-id",
     )
-    off_deck_plate = LoadedLabware(
+    off_deck_lw = LoadedLabware(
         id="off-deck-plate-id",
         loadName="off-deck-plate-load-name",
         definitionUri="off-deck-plate-definition-uri",
@@ -266,19 +267,19 @@ def test_get_all_labware_highest_z(
     )
 
     plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
-    off_deck_plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    off_deck_lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
 
     decoy.when(module_view.get_all()).then_return([])
 
-    decoy.when(labware_view.get_all()).then_return([plate, off_deck_plate, reservoir])
+    decoy.when(labware_view.get_all()).then_return([plate, off_deck_lw, reservoir])
     decoy.when(labware_view.get("plate-id")).then_return(plate)
-    decoy.when(labware_view.get("off-deck-plate-id")).then_return(off_deck_plate)
+    decoy.when(labware_view.get("off-deck-plate-id")).then_return(off_deck_lw)
     decoy.when(labware_view.get("reservoir-id")).then_return(reservoir)
 
     decoy.when(labware_view.get_definition("plate-id")).then_return(well_plate_def)
     decoy.when(labware_view.get_definition("off-deck-plate-id")).then_return(
-        well_plate_def
+        falcon_tuberack_def  # Something tall.
     )
     decoy.when(labware_view.get_definition("reservoir-id")).then_return(reservoir_def)
 
@@ -286,7 +287,7 @@ def test_get_all_labware_highest_z(
         plate_offset
     )
     decoy.when(labware_view.get_labware_offset_vector("off-deck-plate-id")).then_return(
-        off_deck_plate_offset
+        off_deck_lw_offset
     )
     decoy.when(labware_view.get_labware_offset_vector("reservoir-id")).then_return(
         reservoir_offset

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -250,6 +250,13 @@ def test_get_all_labware_highest_z(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         offsetId="plate-offset-id",
     )
+    off_deck_plate = LoadedLabware(
+        id="off-deck-plate-id",
+        loadName="off-deck-plate-load-name",
+        definitionUri="off-deck-plate-definition-uri",
+        location=OFF_DECK_LOCATION,
+        offsetId="plate-offset-id",
+    )
     reservoir = LoadedLabware(
         id="reservoir-id",
         loadName="reservoir-load-name",
@@ -259,19 +266,27 @@ def test_get_all_labware_highest_z(
     )
 
     plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    off_deck_plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
 
     decoy.when(module_view.get_all()).then_return([])
 
-    decoy.when(labware_view.get_all()).then_return([plate, reservoir])
+    decoy.when(labware_view.get_all()).then_return([plate, off_deck_plate, reservoir])
     decoy.when(labware_view.get("plate-id")).then_return(plate)
+    decoy.when(labware_view.get("off-deck-plate-id")).then_return(off_deck_plate)
     decoy.when(labware_view.get("reservoir-id")).then_return(reservoir)
 
     decoy.when(labware_view.get_definition("plate-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_definition("off-deck-plate-id")).then_return(
+        well_plate_def
+    )
     decoy.when(labware_view.get_definition("reservoir-id")).then_return(reservoir_def)
 
     decoy.when(labware_view.get_labware_offset_vector("plate-id")).then_return(
         plate_offset
+    )
+    decoy.when(labware_view.get_labware_offset_vector("off-deck-plate-id")).then_return(
+        off_deck_plate_offset
     )
     decoy.when(labware_view.get_labware_offset_vector("reservoir-id")).then_return(
         reservoir_offset
@@ -288,6 +303,7 @@ def test_get_all_labware_highest_z(
     reservoir_z = subject.get_labware_highest_z("reservoir-id")
     all_z = subject.get_all_labware_highest_z()
 
+    # Should exclude the off-deck plate.
     assert all_z == max(plate_z, reservoir_z)
 
 


### PR DESCRIPTION
Fixes a silly bug, RLAB-139. Please see that ticket for details and steps to reproduce.
