### PR TITLE
refactor(api): add hardware api to module engine cores

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1,6 +1,7 @@
 """Protocol API module implementation logic."""
 from typing import Optional, List
 
+from opentrons.hardware_control import SynchronousAdapter, modules as hw_modules
 from opentrons.hardware_control.modules.types import (
     ModuleModel,
     ModuleType,
@@ -41,10 +42,12 @@ class ModuleCore(AbstractModuleCore[LabwareCore]):
         module_id: str,
         engine_client: ProtocolEngineClient,
         api_version: APIVersion,
+        sync_module_hardware: SynchronousAdapter[hw_modules.AbstractModule],
     ) -> None:
         self._module_id = module_id
         self._engine_client = engine_client
         self._api_version = api_version
+        self._sync_module_hardware = sync_module_hardware
 
     @property
     def api_version(self) -> APIVersion:
@@ -92,6 +95,8 @@ class ModuleCore(AbstractModuleCore[LabwareCore]):
 class TemperatureModuleCore(ModuleCore, AbstractTemperatureModuleCore[LabwareCore]):
     """Temperature Module core logic implementation for Python protocols."""
 
+    _sync_module_hardware: SynchronousAdapter[hw_modules.TempDeck]
+
     def set_target_temperature(self, celsius: float) -> None:
         """Set the Temperature Module's target temperature in °C."""
         raise NotImplementedError("set_target_temperature not implemented")
@@ -123,6 +128,8 @@ class TemperatureModuleCore(ModuleCore, AbstractTemperatureModuleCore[LabwareCor
 
 class MagneticModuleCore(ModuleCore, AbstractMagneticModuleCore[LabwareCore]):
     """Magnetic Module control interface via a ProtocolEngine."""
+
+    _sync_module_hardware: SynchronousAdapter[hw_modules.MagDeck]
 
     def engage(
         self,
@@ -166,6 +173,8 @@ class MagneticModuleCore(ModuleCore, AbstractMagneticModuleCore[LabwareCore]):
 
 class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
     """Core control interface for an attached Thermocycler Module."""
+
+    _sync_module_hardware: SynchronousAdapter[hw_modules.Thermocycler]
 
     def open_lid(self) -> ThermocyclerLidStatus:
         """Open the Thermocycler's lid."""
@@ -302,6 +311,8 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
 
 class HeaterShakerModuleCore(ModuleCore, AbstractHeaterShakerCore[LabwareCore]):
     """Core control interface for an attached Heater-Shaker Module."""
+
+    _sync_module_hardware: SynchronousAdapter[hw_modules.HeaterShaker]
 
     def set_target_temperature(self, celsius: float) -> None:
         """Set the labware plate's target temperature in °C."""

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -93,7 +93,11 @@ def create_protocol_context(
             engine=protocol_engine, loop=protocol_engine_loop
         )
         engine_client = SyncClient(transport=engine_client_transport)
-        core = ProtocolCore(engine_client=engine_client, api_version=api_version)
+        core = ProtocolCore(
+            engine_client=engine_client,
+            api_version=api_version,
+            sync_hardware=sync_hardware,
+        )
 
     # TODO(mc, 2022-8-22): remove `disable_fast_protocol_upload`
     elif use_simulating_core and not feature_flags.disable_fast_protocol_upload():

--- a/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
@@ -2,6 +2,8 @@
 import pytest
 from decoy import Decoy
 
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import AbstractModule
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocol_api.core.engine.module_core import ModuleCore
 from opentrons.protocol_api.core.engine.labware import LabwareCore
@@ -26,12 +28,23 @@ def mock_engine_client(decoy: Decoy) -> EngineClient:
 
 
 @pytest.fixture
-def subject(mock_engine_client: EngineClient, api_version: APIVersion) -> ModuleCore:
+def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[AbstractModule]:
+    """Get a mock synchronous module hardware."""
+    return decoy.mock(name="SynchronousAdapter[AbstractModule]")  # type: ignore[no-any-return]
+
+
+@pytest.fixture()
+def subject(
+    mock_engine_client: EngineClient,
+    api_version: APIVersion,
+    mock_sync_module_hardware: SynchronousAdapter[AbstractModule],
+) -> ModuleCore:
     """Get a ModuleCore test subject."""
     return ModuleCore(
         module_id="1234",
         engine_client=mock_engine_client,
         api_version=api_version,
+        sync_module_hardware=mock_sync_module_hardware,
     )
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
@@ -33,7 +33,7 @@ def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[AbstractModule
     return decoy.mock(name="SynchronousAdapter[AbstractModule]")  # type: ignore[no-any-return]
 
 
-@pytest.fixture()
+@pytest.fixture
 def subject(
     mock_engine_client: EngineClient,
     api_version: APIVersion,


### PR DESCRIPTION
# Overview
Part of RCORE-257

Adds synchronous hardware api adaptor to the engine based module cores, for usage in read-only methods. This will be further refactored in later work once that hardware control is on its own dedicated process.

# Changelog
- adds `SyncHardwareApi` to engine-based protocol core
- result of sync client `load_module` used to find matching hardware api
- `SynchronousAdapter` added to base `ModuleCore`

# Review requests
Basic smoke testing.

# Risk assessment
Low, small PR that only adds to work in progress module cores.