### PR TITLE
refactor(api): consolidate abstract core interface exports

### DIFF
--- a/api/src/opentrons/protocol_api/core/common.py
+++ b/api/src/opentrons/protocol_api/core/common.py
@@ -1,19 +1,22 @@
-"""Convenience type aliases for ProtocolContext tests."""
-from opentrons.protocol_api.core.protocol import AbstractProtocol
-from opentrons.protocol_api.core.instrument import AbstractInstrument
-from opentrons.protocol_api.core.labware import AbstractLabware
-from opentrons.protocol_api.core.module import (
+"""Common APIs for protocol core interfaces."""
+
+# TODO(mc, 2022-08-22): move to __init__ when dependency cycles are resolved
+from .instrument import AbstractInstrument
+from .labware import AbstractLabware
+from .module import (
     AbstractModuleCore,
     AbstractTemperatureModuleCore,
     AbstractMagneticModuleCore,
     AbstractThermocyclerCore,
     AbstractHeaterShakerCore,
 )
-from opentrons.protocol_api.core.well import AbstractWellCore
+from .protocol import AbstractProtocol
+from .well import AbstractWellCore
 
 
-InstrumentCore = AbstractInstrument[AbstractWellCore]
-LabwareCore = AbstractLabware[AbstractWellCore]
+WellCore = AbstractWellCore
+LabwareCore = AbstractLabware[WellCore]
+InstrumentCore = AbstractInstrument[WellCore]
 ModuleCore = AbstractModuleCore[LabwareCore]
 TemperatureModuleCore = AbstractTemperatureModuleCore[LabwareCore]
 MagneticModuleCore = AbstractMagneticModuleCore[LabwareCore]

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -25,19 +25,19 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         return self._pipette_id
 
     def get_default_speed(self) -> float:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_default_speed not implemented")
 
     def set_default_speed(self, speed: float) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.set_default_speed not implemented")
 
     def aspirate(self, volume: float, rate: float) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.aspirate not implemented")
 
     def dispense(self, volume: float, rate: float) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.dispense not implemented")
 
     def blow_out(self) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.blow_out not implemented")
 
     def touch_tip(
         self,
@@ -46,7 +46,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         v_offset: float,
         speed: float,
     ) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.touch_tip not implemented")
 
     def pick_up_tip(
         self,
@@ -56,16 +56,16 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         increment: Optional[float],
         prep_after: bool,
     ) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.pick_up_tip not implemented")
 
     def drop_tip(self, home_after: bool) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.drop_tip not implemented")
 
     def home(self) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.home not implemented")
 
     def home_plunger(self) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.home_plunger not implemented")
 
     def move_to(
         self,
@@ -74,58 +74,60 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         minimum_z_height: Optional[float],
         speed: Optional[float],
     ) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.move_to not implemented")
 
     def get_mount(self) -> Mount:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_mount not implemented")
 
     def get_instrument_name(self) -> str:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_instrument_name not implemented")
 
     def get_pipette_name(self) -> str:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_pipette_name not implemented")
 
     def get_model(self) -> str:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_model not implemented")
 
     def get_min_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_min_volume not implemented")
 
     def get_max_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_max_volume not implemented")
 
     def get_current_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_current_volume not implemented")
 
     def get_available_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_available_volume not implemented")
 
     def get_pipette(self) -> PipetteDict:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_pipette not implemented")
 
     def get_channels(self) -> int:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_channels not implemented")
 
     def has_tip(self) -> bool:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.has_tip not implemented")
 
     def is_ready_to_aspirate(self) -> bool:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.is_ready_to_aspirate not implemented")
 
     def prepare_for_aspirate(self) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.prepare_for_aspirate not implemented")
 
     def get_return_height(self) -> float:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_return_height not implemented")
 
     def get_well_bottom_clearance(self) -> Clearances:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError(
+            "InstrumentCore.get_well_bottom_clearance not implemented"
+        )
 
     def get_speed(self) -> PlungerSpeeds:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_speed not implemented")
 
     def get_flow_rate(self) -> FlowRates:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.get_flow_rate not implemented")
 
     def set_flow_rate(
         self,
@@ -133,7 +135,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         dispense: Optional[float] = None,
         blow_out: Optional[float] = None,
     ) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.set_flow_rate not implemented")
 
     def set_pipette_speed(
         self,
@@ -141,4 +143,4 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         dispense: Optional[float] = None,
         blow_out: Optional[float] = None,
     ) -> None:
-        raise NotImplementedError("InstrumentCore not implemented")
+        raise NotImplementedError("InstrumentCore.set_pipette_speed not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -38,18 +38,18 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     @property
     def highest_z(self) -> float:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.highest_z not implemented")
 
     @property
     def separate_calibration(self) -> bool:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.separate_calibration not implemented")
 
     @property
     def load_name(self) -> str:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.load_name not implemented")
 
     def get_uri(self) -> str:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_uri not implemented")
 
     def get_load_params(self) -> LabwareLoadParams:
         return LabwareLoadParams(
@@ -60,63 +60,65 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     def get_display_name(self) -> str:
         """Get a display name for the labware, falling back to the definition."""
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_display_name not implemented")
 
     def get_user_display_name(self) -> Optional[str]:
         """Get the user-specified display name of the labware, if set."""
         return self._user_display_name
 
     def get_name(self) -> str:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_name not implemented")
 
     def set_name(self, new_name: str) -> None:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.set_name not implemented")
 
     def get_definition(self) -> LabwareDefinitionDict:
         """Get the labware's definition as a plain dictionary."""
         return cast(LabwareDefinitionDict, self._definition.dict(exclude_none=True))
 
     def get_parameters(self) -> LabwareParameters:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_parameters not implemented")
 
     def get_quirks(self) -> List[str]:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_quirks not implemented")
 
     def set_calibration(self, delta: Point) -> None:
         # TODO(jbl 2022-09-01): implement set calibration through the engine
         pass
 
     def get_calibrated_offset(self) -> Point:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_calibrated_offset not implemented")
 
     def is_tiprack(self) -> bool:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.is_tiprack not implemented")
 
     def get_tip_length(self) -> float:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_tip_length not implemented")
 
     def set_tip_length(self, length: float) -> None:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.set_tip_length not implemented")
 
     def reset_tips(self) -> None:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.reset_tips not implemented")
 
     def get_tip_tracker(self) -> TipTracker:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_tip_tracker not implemented")
 
     def get_well_grid(self) -> WellGrid:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_well_grid not implemented")
 
     def get_wells(self) -> List[WellCore]:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_wells not implemented")
 
     def get_wells_by_name(self) -> Dict[str, WellCore]:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_wells_by_name not implemented")
 
     def get_geometry(self) -> LabwareGeometry:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError("LabwareCore.get_geometry not implemented")
 
     def get_default_magnet_engage_height(
         self, preserve_half_mm: bool = False
     ) -> Optional[float]:
-        raise NotImplementedError("LabwareCore not implemented")
+        raise NotImplementedError(
+            "LabwareCore.get_default_magnet_engage_height not implemented"
+        )

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -70,25 +70,25 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
         Deprecated method for past experiment with ZIP protocols.
         """
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_bundled_data not implemented")
 
     def get_bundled_labware(self) -> Optional[Dict[str, LabwareDefDict]]:
         """Get a map of labware names to definition dicts.
 
         Deprecated method used for past experiment with ZIP protocols.
         """
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_bundled_labware not implemented")
 
     def get_extra_labware(self) -> Optional[Dict[str, LabwareDefDict]]:
         """Get a map of extra labware names to definition dicts.
 
         Used to assist load custom labware definitions.
         """
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_extra_labware not implemented")
 
     def get_max_speeds(self) -> AxisMaxSpeeds:
         """Get a control interface for maximum move speeds."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_max_speeds not implemented")
 
     def get_hardware(self) -> SyncHardwareAPI:
         """Get direct access to a hardware control interface."""
@@ -96,7 +96,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def is_simulating(self) -> bool:
         """Get whether the protocol is being analyzed or actually run."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.is_simulating not implemented")
 
     def add_labware_definition(
         self,
@@ -200,54 +200,54 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:
         """Get all loaded instruments by mount."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.add_labware_definition not implemented")
 
     def pause(self, msg: Optional[str]) -> None:
         """Pause the protocol."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.pause not implemented")
 
     def resume(self) -> None:
         """Resume the protocol."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.resume not implemented")
 
     def comment(self, msg: str) -> None:
         """Create a comment in the protocol to be shown in the log."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.comment not implemented")
 
     def delay(self, seconds: float, msg: Optional[str]) -> None:
         """Wait for a period of time before proceeding."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.delay not implemented")
 
     def home(self) -> None:
         """Move all axes to their home positions."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.home not implemented")
 
     def get_deck(self) -> Deck:
         """Get an interface to get and modify the deck layout."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_deck not implemented")
 
     def get_fixed_trash(self) -> DeckItem:
         """Get the fixed trash labware."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_fixed_trash not implemented")
 
     def set_rail_lights(self, on: bool) -> None:
         """Set the device's rail lights."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.set_rail_lights not implemented")
 
     def get_rail_lights_on(self) -> bool:
         """Get whether the device's rail lights are on."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_rail_lights_on not implemented")
 
     def door_closed(self) -> bool:
         """Get whether the device's front door is closed."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.door_closed not implemented")
 
     def get_last_location(
         self,
         mount: Optional[Mount] = None,
     ) -> Optional[Location]:
         """Get the last accessed location."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.get_last_location not implemented")
 
     def set_last_location(
         self,
@@ -255,4 +255,4 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         mount: Optional[Mount] = None,
     ) -> None:
         """Set the last accessed location."""
-        raise NotImplementedError("ProtocolEngine PAPI core not implemented")
+        raise NotImplementedError("ProtocolCore.set_last_location not implemented")

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -1,6 +1,8 @@
 """Core module control interfaces."""
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Generic, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, List, Optional, TypeVar
 
 from opentrons.drivers.types import (
     HeaterShakerLabwareLatchStatus,
@@ -16,9 +18,11 @@ from opentrons.hardware_control.modules.types import (
 )
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.types import DeckSlotName
-from opentrons.protocol_api.labware import Labware
 
 from .labware import LabwareCoreType
+
+if TYPE_CHECKING:
+    from opentrons.protocol_api.labware import Labware
 
 
 class AbstractModuleCore(ABC, Generic[LabwareCoreType]):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -24,8 +24,7 @@ from opentrons.protocols.api_support.util import (
     APIVersionError,
 )
 
-from .core.instrument import AbstractInstrument
-from .core.well import AbstractWellCore
+from .core.common import InstrumentCore
 from .module_contexts import ThermocyclerContext, HeaterShakerContext
 from . import labware
 
@@ -62,7 +61,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
     def __init__(
         self,
-        implementation: AbstractInstrument[AbstractWellCore],
+        implementation: InstrumentCore,
         ctx: ProtocolContext,
         broker: Broker,
         at_version: APIVersion,

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -31,8 +31,6 @@ from opentrons.protocols.labware import (  # noqa: F401
 )
 
 from .core.labware import AbstractLabware
-from .core.well import AbstractWellCore
-
 from .core.protocol_api.labware import LabwareImplementation
 
 if TYPE_CHECKING:
@@ -43,6 +41,7 @@ if TYPE_CHECKING:
         LabwareDefinition,
         LabwareParameters,
     )
+    from .core.common import LabwareCore, WellCore
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -66,7 +65,7 @@ class Well:
 
     def __init__(
         self,
-        well_implementation: AbstractWellCore,
+        well_implementation: WellCore,
         api_level: Optional[APIVersion] = None,
     ):
         """
@@ -276,7 +275,7 @@ class Labware(DeckItem):
                 f"version or update your robot."
             )
         self._api_version = api_level
-        self._implementation: AbstractLabware[AbstractWellCore] = implementation
+        self._implementation: LabwareCore = implementation
 
     @property
     def separate_calibration(self) -> bool:
@@ -698,7 +697,7 @@ class Labware(DeckItem):
         if self._is_tiprack:
             self._implementation.reset_tips()
 
-    def _well_from_impl(self, well: AbstractWellCore) -> Well:
+    def _well_from_impl(self, well: WellCore) -> Well:
         return Well(well_implementation=well, api_level=self._api_version)
 
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -21,17 +21,14 @@ from opentrons.protocols.geometry.module_geometry import (
     HeaterShakerGeometry,
 )
 
-from .core.protocol import AbstractProtocol
-from .core.instrument import AbstractInstrument
-from .core.labware import AbstractLabware
-from .core.module import (
-    AbstractModuleCore,
-    AbstractTemperatureModuleCore,
-    AbstractMagneticModuleCore,
-    AbstractThermocyclerCore,
-    AbstractHeaterShakerCore,
+from .core.common import (
+    ProtocolCore,
+    ModuleCore,
+    TemperatureModuleCore,
+    MagneticModuleCore,
+    ThermocyclerCore,
+    HeaterShakerCore,
 )
-from .core.well import AbstractWellCore
 
 from .module_validation_and_errors import (
     validate_heater_shaker_temperature,
@@ -47,11 +44,6 @@ ENGAGE_HEIGHT_UNIT_CNV = 2
 _log = logging.getLogger(__name__)
 
 GeometryType = TypeVar("GeometryType", bound=ModuleGeometry)
-
-InstrumentCore = AbstractInstrument[AbstractWellCore]
-LabwareCore = AbstractLabware[AbstractWellCore]
-ModuleCore = AbstractModuleCore[LabwareCore]
-ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]
 
 
 class ModuleContext(CommandPublisher, Generic[GeometryType]):
@@ -256,7 +248,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
 
     """
 
-    _core: AbstractTemperatureModuleCore[AbstractLabware[AbstractWellCore]]
+    _core: TemperatureModuleCore
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 0)
@@ -329,7 +321,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     .. versionadded:: 2.0
     """
 
-    _core: AbstractMagneticModuleCore[AbstractLabware[AbstractWellCore]]
+    _core: MagneticModuleCore
 
     @publish(command=cmds.magdeck_calibrate)
     @requires_version(2, 0)
@@ -436,7 +428,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     .. versionadded:: 2.0
     """
 
-    _core: AbstractThermocyclerCore[AbstractLabware[AbstractWellCore]]
+    _core: ThermocyclerCore
 
     def flag_unsafe_move(
         self, to_loc: types.Location, from_loc: types.Location
@@ -658,7 +650,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     .. versionadded:: 2.13
     """
 
-    _core: AbstractHeaterShakerCore[AbstractLabware[AbstractWellCore]]
+    _core: HeaterShakerCore
 
     @property  # type: ignore[misc]
     @requires_version(2, 13)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -31,17 +31,14 @@ from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
-from .core.instrument import AbstractInstrument
+from .core.common import ModuleCore, ProtocolCore
 from .core.labware import AbstractLabware
 from .core.module import (
-    AbstractModuleCore,
     AbstractTemperatureModuleCore,
     AbstractMagneticModuleCore,
     AbstractThermocyclerCore,
     AbstractHeaterShakerCore,
 )
-from .core.protocol import AbstractProtocol
-from .core.well import AbstractWellCore
 
 from . import validation
 from .instrument_context import InstrumentContext
@@ -63,12 +60,6 @@ ModuleTypes = Union[
     ThermocyclerContext,
     HeaterShakerContext,
 ]
-
-
-InstrumentCore = AbstractInstrument[AbstractWellCore]
-LabwareCore = AbstractLabware[AbstractWellCore]
-ModuleCore = AbstractModuleCore[LabwareCore]
-ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]
 
 
 class HardwareManager(NamedTuple):

--- a/api/tests/opentrons/protocol_api/test_heater_shaker_context.py
+++ b/api/tests/opentrons/protocol_api/test_heater_shaker_context.py
@@ -7,8 +7,7 @@ from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
 from opentrons.hardware_control.modules import TemperatureStatus, SpeedStatus
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, HeaterShakerContext
-
-from .types import ProtocolCore, HeaterShakerCore
+from opentrons.protocol_api.core.common import ProtocolCore, HeaterShakerCore
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -6,8 +6,7 @@ from opentrons.broker import Broker
 from opentrons.hardware_control.modules import MagneticStatus
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MagneticModuleContext
-
-from .types import ProtocolCore, MagneticModuleCore
+from opentrons.protocol_api.core.common import ProtocolCore, MagneticModuleCore
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -9,10 +9,8 @@ from opentrons_shared_data.labware.dev_types import LabwareDefinition as Labware
 from opentrons.broker import Broker
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, ModuleContext, Labware
+from opentrons.protocol_api.core.common import LabwareCore, ModuleCore, ProtocolCore
 from opentrons.protocol_api.core.labware import LabwareLoadParams
-
-
-from .types import LabwareCore, ModuleCore, ProtocolCore
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -19,8 +19,7 @@ from opentrons.protocol_api import (
     validation,
 )
 from opentrons.protocol_api.core.labware import LabwareLoadParams
-
-from .types import (
+from opentrons.protocol_api.core.common import (
     InstrumentCore,
     LabwareCore,
     ProtocolCore,

--- a/api/tests/opentrons/protocol_api/test_temperature_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_temperature_module_context.py
@@ -7,8 +7,7 @@ from opentrons.hardware_control.modules import TemperatureStatus
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, TemperatureModuleContext
-
-from .types import ProtocolCore, TemperatureModuleCore
+from opentrons.protocol_api.core.common import ProtocolCore, TemperatureModuleCore
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -7,8 +7,7 @@ from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.hardware_control.modules import TemperatureStatus
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, ThermocyclerContext
-
-from .types import ProtocolCore, ThermocyclerCore
+from opentrons.protocol_api.core.common import ProtocolCore, ThermocyclerCore
 
 
 @pytest.fixture


### PR DESCRIPTION
## Overview

This PR splits some test and type interface cleanup out of #11622 to make reviewing easier.

Part of RCORE-247.

## Changelog

- Consolidate abstract core interface aliases to reduce busy work
- Improve `NotImplementedError` messages in PE cores

## Review requests

Core review only. Any testing that would be required here will be required later in the stack

## Risk assessment

Very low