### PR TITLE
refactor(api): add instruments with tip racks to engine PAPI core

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -4,6 +4,7 @@ from typing import Optional
 from opentrons.types import Location, Mount
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
 
 from ..instrument import AbstractInstrument
 from .well import WellCore
@@ -16,13 +17,14 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         pipette_id: ProtocolEngine ID of the loaded instrument.
     """
 
-    def __init__(self, pipette_id: str) -> None:
-        self._pipette_id = pipette_id
+    def __init__(self, pipette_id: str, engine_client: EngineClient) -> None:
+        self._id = pipette_id
+        self._engine_client = engine_client
 
     @property
     def pipette_id(self) -> str:
         """The instrument's unique ProtocolEngine ID."""
-        return self._pipette_id
+        return self._id
 
     def get_default_speed(self) -> float:
         raise NotImplementedError("InstrumentCore.get_default_speed not implemented")
@@ -79,11 +81,13 @@ class InstrumentCore(AbstractInstrument[WellCore]):
     def get_mount(self) -> Mount:
         raise NotImplementedError("InstrumentCore.get_mount not implemented")
 
-    def get_instrument_name(self) -> str:
-        raise NotImplementedError("InstrumentCore.get_instrument_name not implemented")
+    def get_pipette_load_name(self) -> str:
+        """Get the pipette's load name as a string.
 
-    def get_pipette_name(self) -> str:
-        raise NotImplementedError("InstrumentCore.get_pipette_name not implemented")
+        Will match the load name of the actually loaded pipette,
+        which may differ from the requested load name.
+        """
+        return self._engine_client.state.pipettes.get(self._id).pipetteName.value
 
     def get_model(self) -> str:
         raise NotImplementedError("InstrumentCore.get_model not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -18,13 +18,13 @@ class InstrumentCore(AbstractInstrument[WellCore]):
     """
 
     def __init__(self, pipette_id: str, engine_client: EngineClient) -> None:
-        self._id = pipette_id
+        self._pipette_id = pipette_id
         self._engine_client = engine_client
 
     @property
     def pipette_id(self) -> str:
         """The instrument's unique ProtocolEngine ID."""
-        return self._id
+        return self._pipette_id
 
     def get_default_speed(self) -> float:
         raise NotImplementedError("InstrumentCore.get_default_speed not implemented")
@@ -81,13 +81,15 @@ class InstrumentCore(AbstractInstrument[WellCore]):
     def get_mount(self) -> Mount:
         raise NotImplementedError("InstrumentCore.get_mount not implemented")
 
-    def get_pipette_load_name(self) -> str:
+    def get_pipette_name(self) -> str:
         """Get the pipette's load name as a string.
 
         Will match the load name of the actually loaded pipette,
         which may differ from the requested load name.
         """
-        return self._engine_client.state.pipettes.get(self._id).pipetteName.value
+        return self._engine_client.state.pipettes.get(
+            self._pipette_id
+        ).pipetteName.value
 
     def get_model(self) -> str:
         raise NotImplementedError("InstrumentCore.get_model not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -89,7 +89,7 @@ class ModuleCore(AbstractModuleCore[LabwareCore]):
 
     def add_labware_core(self, labware_core: LabwareCore) -> Labware:
         """Add a labware to the module."""
-        return Labware(implementation=labware_core, api_level=self._api_version)
+        return Labware(implementation=labware_core, api_version=self._api_version)
 
 
 class TemperatureModuleCore(ModuleCore, AbstractTemperatureModuleCore[LabwareCore]):

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -207,7 +207,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:
         """Get all loaded instruments by mount."""
-        raise NotImplementedError("ProtocolCore.add_labware_definition not implemented")
+        raise NotImplementedError("ProtocolCore.get_loaded_instruments not implemented")
 
     def pause(self, msg: Optional[str]) -> None:
         """Pause the protocol."""

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -59,6 +59,10 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         self._engine_client = engine_client
         self._api_version = api_version
         self._sync_hardware = sync_hardware
+        self._fixed_trash_core = LabwareCore(
+            labware_id=engine_client.state.labware.get_fixed_trash_id(),
+            engine_client=engine_client,
+        )
 
     @property
     def api_version(self) -> APIVersion:
@@ -196,7 +200,10 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         engine_mount = MountType[mount.name]
         load_result = self._engine_client.load_pipette(instrument_name, engine_mount)
 
-        return InstrumentCore(pipette_id=load_result.pipetteId)
+        return InstrumentCore(
+            pipette_id=load_result.pipetteId,
+            engine_client=self._engine_client,
+        )
 
     def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:
         """Get all loaded instruments by mount."""
@@ -228,7 +235,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def get_fixed_trash(self) -> DeckItem:
         """Get the fixed trash labware."""
-        raise NotImplementedError("ProtocolCore.get_fixed_trash not implemented")
+        return self._fixed_trash_core
 
     def set_rail_lights(self, on: bool) -> None:
         """Set the device's rail lights."""

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -1,8 +1,60 @@
 """ProtocolEngine-based Well core implementations."""
-
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocols.geometry.well_geometry import WellGeometry
 
 from ..well import AbstractWellCore
 
 
 class WellCore(AbstractWellCore):
-    """Well API core using a ProtocolEngine."""
+    """Well API core using a ProtocolEngine.
+
+    Args:
+        name: The well's name in the labware, e.g. `A1`.
+        labware_id: The ProtocolEngine ID of the well's parent labware.
+        engine_client: Synchronous ProtocolEngine client.
+    """
+
+    def __init__(self, name: str, labware_id: str, engine_client: EngineClient) -> None:
+        self._name = name
+        self._labware_id = labware_id
+        self._engine_client = engine_client
+        self._definition = engine_client.state.labware.get_well_definition(
+            labware_id=labware_id, well_name=name
+        )
+
+    @property
+    def labware_id(self) -> str:
+        """Get the ID of the well's parent labware."""
+        return self._labware_id
+
+    def has_tip(self) -> bool:
+        """Whether the well contains a tip."""
+        raise NotImplementedError("WellCore.has_tip not implemented")
+
+    def set_has_tip(self, value: bool) -> None:
+        """Set the well as containing or not containing a tip."""
+        raise NotImplementedError("WellCore.set_has_tip not implemented")
+
+    def get_display_name(self) -> str:
+        """Get the well's full display name."""
+        raise NotImplementedError("WellCore.get_display_name not implemented")
+
+    def get_name(self) -> str:
+        """Get the name of the well (e.g. "A1")."""
+        return self._name
+
+    def get_column_name(self) -> str:
+        """Get the column portion of the well name (e.g. "A")."""
+        raise NotImplementedError("WellCore.get_column_name not implemented")
+
+    def get_row_name(self) -> str:
+        """Get the row portion of the well name (e.g. "1")."""
+        raise NotImplementedError("WellCore.get_row_name not implemented")
+
+    def get_max_volume(self) -> float:
+        """Get the well's maximum liquid volume."""
+        return self._definition.totalLiquidVolume
+
+    def get_geometry(self) -> WellGeometry:
+        """Get the well's geometry information interface."""
+        raise NotImplementedError("WellCore.get_geometry not implemented")

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -77,7 +77,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def get_pipette_load_name(self) -> str:
+    def get_pipette_name(self) -> str:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -77,11 +77,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def get_instrument_name(self) -> str:
-        ...
-
-    @abstractmethod
-    def get_pipette_name(self) -> str:
+    def get_pipette_load_name(self) -> str:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -41,6 +41,10 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
 
     @abstractmethod
     def get_uri(self) -> str:
+        """Get the URI string string of the labware's definition.
+
+        The URI is unique for a given namespace, load name, and definition version.
+        """
         ...
 
     @abstractmethod
@@ -88,7 +92,8 @@ class AbstractLabware(DeckItem, ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def is_tiprack(self) -> bool:
+    def is_tip_rack(self) -> bool:
+        "Whether the labware is a tip rack."
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -208,7 +208,7 @@ class InstrumentContextImplementation(AbstractInstrument[WellImplementation]):
         """Get the instrument name."""
         return self._instrument_name
 
-    def get_pipette_load_name(self) -> str:
+    def get_pipette_name(self) -> str:
         """Get the pipette name."""
         return self.get_pipette()["name"]
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -208,7 +208,7 @@ class InstrumentContextImplementation(AbstractInstrument[WellImplementation]):
         """Get the instrument name."""
         return self._instrument_name
 
-    def get_pipette_name(self) -> str:
+    def get_pipette_load_name(self) -> str:
         """Get the pipette name."""
         return self.get_pipette()["name"]
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -109,7 +109,7 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
     def get_calibrated_offset(self) -> Point:
         return self._calibrated_offset
 
-    def is_tiprack(self) -> bool:
+    def is_tip_rack(self) -> bool:
         return self._parameters["isTiprack"]
 
     def get_tip_length(self) -> float:
@@ -119,7 +119,7 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
         self._parameters["tipLength"] = length
 
     def reset_tips(self) -> None:
-        if self.is_tiprack():
+        if self.is_tip_rack():
             for well in self._wells:
                 well.set_has_tip(True)
 
@@ -183,7 +183,7 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
                     parent_object=self,
                 ),
                 display_name="{} of {}".format(well, self._display_name),
-                has_tip=self.is_tiprack(),
+                has_tip=self.is_tip_rack(),
                 name=well,
             )
             for well in self._ordering

--- a/api/src/opentrons/protocol_api/core/protocol_api/well.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well.py
@@ -61,6 +61,10 @@ class WellImplementation(AbstractWellCore):
         """Get the row portion of the well name (e.g. "1")."""
         return self._row_name
 
+    def get_max_volume(self) -> float:
+        """Get the well's maximum liquid volume."""
+        return self._geometry.max_volume
+
     def get_geometry(self) -> WellGeometry:
         """Get the well's geometry information interface."""
         return self._geometry

--- a/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
@@ -142,10 +142,10 @@ class InstrumentContextSimulation(AbstractInstrument[WellImplementation]):
     def get_mount(self) -> types.Mount:
         return self._mount
 
-    def get_instrument_name(self) -> str:
+    def get_requested_as_name(self) -> str:
         return self._instrument_name
 
-    def get_pipette_name(self) -> str:
+    def get_pipette_load_name(self) -> str:
         return self._pipette_dict["name"]
 
     def get_model(self) -> str:

--- a/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
@@ -145,7 +145,7 @@ class InstrumentContextSimulation(AbstractInstrument[WellImplementation]):
     def get_requested_as_name(self) -> str:
         return self._instrument_name
 
-    def get_pipette_load_name(self) -> str:
+    def get_pipette_name(self) -> str:
         return self._pipette_dict["name"]
 
     def get_model(self) -> str:

--- a/api/src/opentrons/protocol_api/core/simulator/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/protocol_context.py
@@ -31,7 +31,7 @@ class ProtocolContextSimulation(
 
         if (
             existing_instrument
-            and existing_instrument.get_instrument_name() == instrument_name.value
+            and existing_instrument.get_requested_as_name() == instrument_name.value
         ):
             # Replacing with the exact same instrument name. Just return the
             # existing instrument instance.

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -40,6 +40,11 @@ class AbstractWellCore(ABC):
         ...
 
     @abstractmethod
+    def get_max_volume(self) -> float:
+        """Get the well's maximum liquid volume."""
+        ...
+
+    @abstractmethod
     def get_geometry(self) -> WellGeometry:
         """Get the well's geometry information interface."""
         ...

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -64,28 +64,22 @@ class InstrumentContext(publisher.CommandPublisher):
         implementation: InstrumentCore,
         ctx: ProtocolContext,
         broker: Broker,
-        at_version: APIVersion,
-        tip_racks: Optional[List[labware.Labware]] = None,
-        trash: Optional[labware.Labware] = None,
+        api_version: APIVersion,
+        tip_racks: List[labware.Labware],
+        trash: labware.Labware,
+        requested_as: str,
     ) -> None:
 
         super().__init__(broker)
-        self._api_version = at_version
+        self._api_version = api_version
         self._implementation = implementation
         self._ctx = ctx
-
-        self._tip_racks = tip_racks or list()
-        for tip_rack in self.tip_racks:
-            assert tip_rack.is_tiprack
-            instrument.validate_tiprack(self.name, tip_rack, logger)
-        if trash is None:
-            self.trash_container = self._ctx.fixed_trash
-        else:
-            self.trash_container = trash
-
+        self._tip_racks = tip_racks
         self._last_tip_picked_up_from: Union[labware.Well, None] = None
         self._starting_tip: Union[labware.Well, None] = None
-        self.requested_as = self._implementation.get_instrument_name()
+
+        self.trash_container = trash
+        self.requested_as = requested_as
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1381,7 +1375,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The name string for the pipette (e.g. 'p300_single')
         """
-        return self._implementation.get_pipette_name()
+        return self._implementation.get_pipette_load_name()
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1375,7 +1375,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The name string for the pipette (e.g. 'p300_single')
         """
-        return self._implementation.get_pipette_load_name()
+        return self._implementation.get_pipette_name()
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -500,7 +500,7 @@ class ProtocolContext(CommandPublisher):
 
         for tip_rack in tip_racks:
             instrument_support.validate_tiprack(
-                instrument_name=instrument_core.get_pipette_load_name(),
+                instrument_name=instrument_core.get_pipette_name(),
                 tip_rack=tip_rack,
                 log=logger,
             )

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -21,6 +21,7 @@ from opentrons.broker import Broker
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.commands import protocol_commands as cmds, types as cmd_types
 from opentrons.commands.publisher import CommandPublisher, publish
+from opentrons.protocols.api_support import instrument as instrument_support
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import (
     AxisMaxSpeeds,
@@ -478,7 +479,7 @@ class ProtocolContext(CommandPublisher):
 
         checked_mount = validation.ensure_mount(mount)
         checked_instrument_name = validation.ensure_pipette_name(instrument_name)
-
+        tip_racks = tip_racks or []
         existing_instrument = self._instruments[checked_mount]
 
         if existing_instrument is not None and not replace:
@@ -497,13 +498,21 @@ class ProtocolContext(CommandPublisher):
             mount=checked_mount,
         )
 
+        for tip_rack in tip_racks:
+            instrument_support.validate_tiprack(
+                instrument_name=instrument_core.get_pipette_load_name(),
+                tip_rack=tip_rack,
+                log=logger,
+            )
+
         instrument = InstrumentContext(
             ctx=self,
             broker=self._broker,
             implementation=instrument_core,
-            at_version=self._api_version,
-            # TODO(mc, 2022-08-25): test instrument tip racks
+            api_version=self._api_version,
             tip_racks=tip_racks,
+            trash=self.fixed_trash,
+            requested_as=instrument_name,
         )
 
         self._instruments[checked_mount] = instrument

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -436,3 +436,21 @@ class LabwareView(HasState[LabwareState]):
             ):
                 return candidate
         return None
+
+    def get_fixed_trash_id(self) -> str:
+        """Get the identifier of labware loaded into the fixed trash location.
+
+        Raises:
+            LabwareNotLoadedError: a fixed trash was not loaded by the deck definition
+                that is currently in use for the protocol run.
+        """
+        for labware in self._state.labware_by_id.values():
+            if (
+                isinstance(labware.location, DeckSlotLocation)
+                and labware.location.slotName == DeckSlotName.FIXED_TRASH
+            ):
+                return labware.id
+
+        raise errors.LabwareNotLoadedError(
+            "No labware loaded into fixed trash location by this deck type."
+        )

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -74,18 +74,21 @@ VALID_PIP_TIPRACK_VOL = {
 
 
 def validate_tiprack(
-    instrument_name: str, tiprack: Labware, log: logging.Logger
+    instrument_name: str, tip_rack: Labware, log: logging.Logger
 ) -> None:
     """Validate a tiprack logging a warning message."""
+    if not tip_rack.is_tiprack:
+        raise ValueError(f"Labware {tip_rack.load_name} is not a tip rack.")
+
     # TODO AA 2020-06-24 - we should instead add the acceptable Opentrons
     #  tipracks to the pipette as a refactor
-    if tiprack._implementation.get_definition()["namespace"] == "opentrons":
-        tiprack_vol = tiprack.wells()[0].max_volume
+    if tip_rack.uri.startswith("opentrons/"):
+        tiprack_vol = tip_rack.wells()[0].max_volume
         valid_vols = VALID_PIP_TIPRACK_VOL[instrument_name.split("_")[0]]
         if tiprack_vol not in valid_vols:
             log.warning(
-                f"The pipette {instrument_name} and its tiprack "
-                f"{tiprack.load_name} in slot {tiprack.parent} appear to "
+                f"The pipette {instrument_name} and its tip rack "
+                f"{tip_rack.load_name} in slot {tip_rack.parent} appear to "
                 "be mismatched. Please check your protocol before running "
                 "on the robot."
             )

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -1,0 +1,39 @@
+"""Test for the ProtocolEngine-based instrument API core."""
+import pytest
+from decoy import Decoy
+
+from opentrons_shared_data.pipette.dev_types import PipetteNameType
+
+from opentrons.protocol_engine import LoadedPipette
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_api.core.engine import InstrumentCore
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+@pytest.fixture
+def subject(mock_engine_client: EngineClient) -> InstrumentCore:
+    """Get a InstrumentCore test subject with its dependencies mocked out."""
+    return InstrumentCore(pipette_id="abc123", engine_client=mock_engine_client)
+
+
+def test_pipette_id(subject: InstrumentCore) -> None:
+    """It should have a ProtocolEngine ID."""
+    assert subject.pipette_id == "abc123"
+
+
+def test_get_pipette_load_name(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: InstrumentCore
+) -> None:
+    """It should get the pipette's load name."""
+    decoy.when(mock_engine_client.state.pipettes.get("abc123")).then_return(
+        LoadedPipette.construct(pipetteName=PipetteNameType.P300_SINGLE)  # type: ignore[call-arg]
+    )
+
+    result = subject.get_pipette_load_name()
+
+    assert result == "p300_single"

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -26,7 +26,7 @@ def test_pipette_id(subject: InstrumentCore) -> None:
     assert subject.pipette_id == "abc123"
 
 
-def test_get_pipette_load_name(
+def test_get_pipette_name(
     decoy: Decoy, mock_engine_client: EngineClient, subject: InstrumentCore
 ) -> None:
     """It should get the pipette's load name."""
@@ -34,6 +34,6 @@ def test_get_pipette_load_name(
         LoadedPipette.construct(pipetteName=PipetteNameType.P300_SINGLE)  # type: ignore[call-arg]
     )
 
-    result = subject.get_pipette_load_name()
+    result = subject.get_pipette_name()
 
     assert result == "p300_single"

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -14,13 +14,27 @@ from opentrons.types import Point
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 
 from opentrons.protocol_api.core.labware import LabwareLoadParams
-from opentrons.protocol_api.core.engine import LabwareCore
+from opentrons.protocol_api.core.engine import LabwareCore, WellCore
 
 
 @pytest.fixture
-def mock_engine_client(decoy: Decoy) -> EngineClient:
+def labware_definition() -> LabwareDefinition:
+    """Get a LabwareDefinition value object to use in tests."""
+    return LabwareDefinition.construct(ordering=[])  # type: ignore[call-arg]
+
+
+@pytest.fixture
+def mock_engine_client(
+    decoy: Decoy, labware_definition: LabwareDefinition
+) -> EngineClient:
     """Get a mock ProtocolEngine synchronous client."""
-    return decoy.mock(cls=EngineClient)
+    engine_client = decoy.mock(cls=EngineClient)
+
+    decoy.when(engine_client.state.labware.get_definition("cool-labware")).then_return(
+        labware_definition
+    )
+
+    return engine_client
 
 
 def test_get_load_params(decoy: Decoy, mock_engine_client: EngineClient) -> None:
@@ -29,6 +43,7 @@ def test_get_load_params(decoy: Decoy, mock_engine_client: EngineClient) -> None
         namespace="hello",
         version=42,
         parameters=LabwareDefinitionParameters.construct(loadName="world"),  # type: ignore[call-arg]
+        ordering=[],
     )
 
     decoy.when(
@@ -49,7 +64,7 @@ def test_set_calibration(mock_engine_client: EngineClient) -> None:
 
 def test_get_definition(decoy: Decoy, mock_engine_client: EngineClient) -> None:
     """It should get the labware's definition as a dictionary."""
-    labware_definition = LabwareDefinition.construct(namespace="hello")  # type: ignore[call-arg]
+    labware_definition = LabwareDefinition.construct(namespace="hello", ordering=[])  # type: ignore[call-arg]
 
     decoy.when(
         mock_engine_client.state.labware.get_definition("cool-labware")
@@ -58,7 +73,7 @@ def test_get_definition(decoy: Decoy, mock_engine_client: EngineClient) -> None:
     subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
     result = subject.get_definition()
 
-    assert result == cast(LabwareDefDict, {"namespace": "hello"})
+    assert result == cast(LabwareDefDict, {"namespace": "hello", "ordering": []})
 
 
 def test_get_user_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:
@@ -71,3 +86,50 @@ def test_get_user_display_name(decoy: Decoy, mock_engine_client: EngineClient) -
     result = subject.get_user_display_name()
 
     assert result == "Cool Label"
+
+
+def test_is_tip_rack(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should know whether it's a tip rack."""
+    labware_definition = LabwareDefinition.construct(  # type: ignore[call-arg]
+        ordering=[],
+        parameters=LabwareDefinitionParameters.construct(isTiprack=True),  # type: ignore[call-arg]
+    )
+
+    decoy.when(
+        mock_engine_client.state.labware.get_definition("cool-labware")
+    ).then_return(labware_definition)
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    result = subject.is_tip_rack()
+
+    assert result is True
+
+
+def test_get_wells(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get a wells list in order, from the definition."""
+    labware_definition = LabwareDefinition.construct(  # type: ignore[call-arg]
+        ordering=[["A1", "B1"], ["A2", "B2"]],
+    )
+
+    decoy.when(
+        mock_engine_client.state.labware.get_definition("cool-labware")
+    ).then_return(labware_definition)
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    result = subject.get_wells()
+
+    assert len(result) == 4
+    assert all(isinstance(wc, WellCore) for wc in result)
+    assert list(wc.get_name() for wc in result) == ["A1", "B1", "A2", "B2"]
+
+
+def test_get_uri(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get a labware's URI from the core."""
+    decoy.when(
+        mock_engine_client.state.labware.get_definition_uri("cool-labware")
+    ).then_return("great/uri/42")
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+    result = subject.get_uri()
+
+    assert result == "great/uri/42"

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -1,0 +1,50 @@
+"""Test for the ProtocolEngine-based well API core."""
+import pytest
+from decoy import Decoy
+
+from opentrons_shared_data.labware.labware_definition import WellDefinition
+
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocols.api_support.types import APIVersion
+
+from opentrons.protocol_api.core.engine import WellCore
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+@pytest.fixture
+def api_version() -> APIVersion:
+    """Get an API version to apply to the interface."""
+    return MAX_SUPPORTED_VERSION
+
+
+def test_name(mock_engine_client: EngineClient) -> None:
+    """It should have a name and labware ID."""
+    subject = WellCore(
+        name="Gene", labware_id="Wilder", engine_client=mock_engine_client
+    )
+
+    assert subject.get_name() == "Gene"
+    assert subject.labware_id == "Wilder"
+
+
+def test_max_volume(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should have a max volume."""
+    decoy.when(
+        mock_engine_client.state.labware.get_well_definition(
+            labware_id="labware-id", well_name="well-name"
+        )
+    ).then_return(
+        WellDefinition.construct(totalLiquidVolume=101)  # type: ignore[call-arg]
+    )
+
+    subject = WellCore(
+        name="well-name", labware_id="labware-id", engine_client=mock_engine_client
+    )
+
+    assert subject.get_max_volume() == 101

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1,0 +1,94 @@
+"""Tests for the InstrumentContext public interface."""
+import pytest
+from decoy import Decoy
+
+from opentrons.broker import Broker
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_api import (
+    MAX_SUPPORTED_VERSION,
+    ProtocolContext,
+    InstrumentContext,
+    Labware,
+)
+from opentrons.protocol_api.core.common import InstrumentCore
+
+
+@pytest.fixture
+def mock_instrument_core(decoy: Decoy) -> InstrumentCore:
+    """Get a mock instrument implementation core."""
+    return decoy.mock(cls=InstrumentCore)
+
+
+# TODO(mc, 2022-10-25): this will be replaced by a protocol core, instead
+@pytest.fixture
+def mock_protocol_context(decoy: Decoy) -> ProtocolContext:
+    """Get a mock ProtocolContext."""
+    return decoy.mock(cls=ProtocolContext)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> Broker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def mock_trash(decoy: Decoy) -> Broker:
+    """Get a mock fixed-trash labware."""
+    return decoy.mock(cls=Broker)
+
+
+@pytest.fixture
+def api_version() -> APIVersion:
+    """Get the API version to test at."""
+    return MAX_SUPPORTED_VERSION
+
+
+@pytest.fixture
+def subject(
+    mock_instrument_core: InstrumentCore,
+    mock_protocol_context: ProtocolContext,
+    mock_broker: Broker,
+    mock_trash: Labware,
+    api_version: APIVersion,
+) -> InstrumentContext:
+    """Get a ProtocolContext test subject with its dependencies mocked out."""
+    return InstrumentContext(
+        implementation=mock_instrument_core,
+        ctx=mock_protocol_context,
+        broker=mock_broker,
+        api_version=api_version,
+        tip_racks=[],
+        trash=mock_trash,
+        requested_as="requested-pipette-name",
+    )
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 0), APIVersion(2, 1)])
+def test_api_version(api_version: APIVersion, subject: InstrumentContext) -> None:
+    """It should have an api_version property."""
+    assert subject.api_version == api_version
+
+
+def test_trash_container(
+    decoy: Decoy,
+    mock_trash: Labware,
+    subject: InstrumentContext,
+) -> None:
+    """It should have a settable trash_container property."""
+    assert subject.trash_container is mock_trash
+
+    other_trash = decoy.mock(cls=Labware)
+    subject.trash_container = other_trash
+
+    assert subject.trash_container is other_trash
+
+
+def test_tip_racks(decoy: Decoy, subject: InstrumentContext) -> None:
+    """It should have a settable tip_racks property."""
+    assert subject.tip_racks == []
+
+    tip_racks = [decoy.mock(cls=Labware), decoy.mock(cls=Labware)]
+    subject.tip_racks = tip_racks
+
+    assert subject.tip_racks == tip_racks

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -1,0 +1,76 @@
+"""Tests for the InstrumentContext public interface."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, Labware, Well
+from opentrons.protocol_api.core.common import LabwareCore, WellCore
+
+
+@pytest.fixture
+def mock_labware_core(decoy: Decoy) -> LabwareCore:
+    """Get a mock labware implementation core."""
+    return decoy.mock(cls=LabwareCore)
+
+
+@pytest.fixture
+def api_version() -> APIVersion:
+    """Get the API version to test at."""
+    return MAX_SUPPORTED_VERSION
+
+
+@pytest.fixture
+def subject(mock_labware_core: LabwareCore, api_version: APIVersion) -> Labware:
+    """Get a ProtocolContext test subject with its dependencies mocked out."""
+    return Labware(implementation=mock_labware_core, api_version=api_version)
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 0), APIVersion(2, 1)])
+def test_api_version(api_version: APIVersion, subject: Labware) -> None:
+    """It should have an api_version property."""
+    assert subject.api_version == api_version
+
+
+def test_is_tiprack(
+    decoy: Decoy, mock_labware_core: LabwareCore, subject: Labware
+) -> None:
+    """It should report if it's a tip rack."""
+    decoy.when(mock_labware_core.is_tip_rack()).then_return(True)
+    assert subject.is_tiprack is True
+
+    decoy.when(mock_labware_core.is_tip_rack()).then_return(False)
+    assert subject.is_tiprack is False
+
+
+def test_wells(decoy: Decoy, mock_labware_core: LabwareCore, subject: Labware) -> None:
+    """It should return a list of wells."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+
+    decoy.when(mock_labware_core.get_wells()).then_return(
+        [mock_well_core_1, mock_well_core_2]
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("Z42")
+    decoy.when(mock_well_core_1.get_max_volume()).then_return(100)
+    decoy.when(mock_well_core_2.get_name()).then_return("X1")
+    decoy.when(mock_well_core_1.get_max_volume()).then_return(1000)
+
+    result = subject.wells()
+
+    assert len(result) == 2
+    assert isinstance(result[0], Well)
+    assert result[0].well_name == "Z42"
+    assert isinstance(result[1], Well)
+    assert result[1].well_name == "X1"
+
+
+def test_well_max_volume(
+    decoy: Decoy, mock_labware_core: LabwareCore, subject: Labware
+) -> None:
+    """It should get the well's max volume from the core."""
+    mock_well_core = decoy.mock(cls=WellCore)
+
+    decoy.when(mock_labware_core.get_wells()).then_return([mock_well_core])
+    decoy.when(mock_well_core.get_max_volume()).then_return(101)
+
+    assert subject.wells()[0].max_volume == 101

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -90,9 +90,7 @@ def test_load_instrument(
         )
     ).then_return(mock_instrument_core)
 
-    decoy.when(mock_instrument_core.get_pipette_load_name()).then_return(
-        "Gandalf the Grey"
-    )
+    decoy.when(mock_instrument_core.get_pipette_name()).then_return("Gandalf the Grey")
 
     result = subject.load_instrument(
         instrument_name="gandalf", mount="shadowfax", tip_racks=mock_tip_racks
@@ -135,7 +133,7 @@ def test_load_instrument_replace(
             mount=matchers.IsA(Mount),
         )
     ).then_return(mock_instrument_core)
-    decoy.when(mock_instrument_core.get_pipette_load_name()).then_return("Ada Lovelace")
+    decoy.when(mock_instrument_core.get_pipette_name()).then_return("Ada Lovelace")
 
     pipette_1 = subject.load_instrument(instrument_name="ada", mount=Mount.RIGHT)
     assert subject.loaded_instruments["right"] is pipette_1

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -10,13 +10,14 @@ from opentrons_shared_data.labware.dev_types import LabwareDefinition as Labware
 
 from opentrons.types import Mount, DeckSlotName
 from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
+from opentrons.protocols.api_support import instrument as mock_instrument_support
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     ProtocolContext,
     InstrumentContext,
     ModuleContext,
     Labware,
-    validation,
+    validation as mock_validation,
 )
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.common import (
@@ -29,8 +30,16 @@ from opentrons.protocol_api.core.common import (
 
 @pytest.fixture(autouse=True)
 def _mock_validation_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
-    for name, func in inspect.getmembers(validation, inspect.isfunction):
-        monkeypatch.setattr(validation, name, decoy.mock(func=func))
+    for name, func in inspect.getmembers(mock_validation, inspect.isfunction):
+        monkeypatch.setattr(mock_validation, name, decoy.mock(func=func))
+
+
+@pytest.fixture(autouse=True)
+def _mock_instrument_support_module(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name, func in inspect.getmembers(mock_instrument_support, inspect.isfunction):
+        monkeypatch.setattr(mock_instrument_support, name, decoy.mock(func=func))
 
 
 @pytest.fixture
@@ -48,6 +57,18 @@ def subject(mock_core: ProtocolCore) -> ProtocolContext:
     )
 
 
+def test_fixed_trash(
+    decoy: Decoy, mock_core: ProtocolCore, subject: ProtocolContext
+) -> None:
+    """It should get the fixed trash labware from the core."""
+    mock_labware = decoy.mock(cls=Labware)
+    decoy.when(mock_core.get_fixed_trash()).then_return(mock_labware)
+
+    result = subject.fixed_trash
+
+    assert result is mock_labware
+
+
 def test_load_instrument(
     decoy: Decoy,
     mock_core: ProtocolCore,
@@ -55,10 +76,10 @@ def test_load_instrument(
 ) -> None:
     """It should create a instrument using its execution core."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
+    mock_tip_racks = [decoy.mock(cls=Labware), decoy.mock(cls=Labware)]
 
-    decoy.when(validation.ensure_mount("shadowfax")).then_return(Mount.LEFT)
-
-    decoy.when(validation.ensure_pipette_name("gandalf")).then_return(
+    decoy.when(mock_validation.ensure_mount("shadowfax")).then_return(Mount.LEFT)
+    decoy.when(mock_validation.ensure_pipette_name("gandalf")).then_return(
         PipetteNameType.P300_SINGLE
     )
 
@@ -69,16 +90,31 @@ def test_load_instrument(
         )
     ).then_return(mock_instrument_core)
 
-    decoy.when(mock_instrument_core.get_pipette_name()).then_return("Gandalf the Grey")
+    decoy.when(mock_instrument_core.get_pipette_load_name()).then_return(
+        "Gandalf the Grey"
+    )
 
     result = subject.load_instrument(
-        instrument_name="gandalf",
-        mount="shadowfax",
+        instrument_name="gandalf", mount="shadowfax", tip_racks=mock_tip_racks
     )
 
     assert isinstance(result, InstrumentContext)
     assert result.name == "Gandalf the Grey"
+    assert result.requested_as == "gandalf"
     assert subject.loaded_instruments["left"] is result
+
+    decoy.verify(
+        mock_instrument_support.validate_tiprack(
+            instrument_name="Gandalf the Grey",
+            tip_rack=mock_tip_racks[0],
+            log=matchers.Anything(),
+        ),
+        mock_instrument_support.validate_tiprack(
+            instrument_name="Gandalf the Grey",
+            tip_rack=mock_tip_racks[1],
+            log=matchers.Anything(),
+        ),
+    )
 
 
 def test_load_instrument_replace(
@@ -87,8 +123,10 @@ def test_load_instrument_replace(
     """It should allow/disallow pipette replacement."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
 
-    decoy.when(validation.ensure_mount(matchers.IsA(Mount))).then_return(Mount.RIGHT)
-    decoy.when(validation.ensure_pipette_name(matchers.IsA(str))).then_return(
+    decoy.when(mock_validation.ensure_mount(matchers.IsA(Mount))).then_return(
+        Mount.RIGHT
+    )
+    decoy.when(mock_validation.ensure_pipette_name(matchers.IsA(str))).then_return(
         PipetteNameType.P300_SINGLE
     )
     decoy.when(
@@ -97,7 +135,7 @@ def test_load_instrument_replace(
             mount=matchers.IsA(Mount),
         )
     ).then_return(mock_instrument_core)
-    decoy.when(mock_instrument_core.get_pipette_name()).then_return("Ada Lovelace")
+    decoy.when(mock_instrument_core.get_pipette_load_name()).then_return("Ada Lovelace")
 
     pipette_1 = subject.load_instrument(instrument_name="ada", mount=Mount.RIGHT)
     assert subject.loaded_instruments["right"] is pipette_1
@@ -119,7 +157,7 @@ def test_load_labware(
     """It should create a labware using its execution core."""
     mock_labware_core = decoy.mock(cls=LabwareCore)
 
-    decoy.when(validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_5)
+    decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_5)
 
     decoy.when(
         mock_core.load_labware(
@@ -156,7 +194,7 @@ def test_load_labware_from_definition(
     labware_definition_dict = cast(LabwareDefDict, {"labwareDef": True})
     labware_load_params = LabwareLoadParams("you", "are", 1337)
 
-    decoy.when(validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_1)
+    decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_1)
     decoy.when(mock_core.add_labware_definition(labware_definition_dict)).then_return(
         labware_load_params
     )
@@ -193,10 +231,10 @@ def test_load_module(
     mock_module_core = cast(
         TemperatureModuleCore, decoy.mock(cls=TemperatureModuleCore.__origin__)  # type: ignore[attr-defined]
     )
-    decoy.when(validation.ensure_module_model("spline reticulator")).then_return(
+    decoy.when(mock_validation.ensure_module_model("spline reticulator")).then_return(
         TemperatureModuleModel.TEMPERATURE_V1
     )
-    decoy.when(validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_3)
+    decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_3)
 
     decoy.when(
         mock_core.load_module(
@@ -229,7 +267,7 @@ def test_load_module_default_location(
         TemperatureModuleCore, decoy.mock(cls=TemperatureModuleCore.__origin__)  # type: ignore[attr-defined]
     )
 
-    decoy.when(validation.ensure_module_model("spline reticulator")).then_return(
+    decoy.when(mock_validation.ensure_module_model("spline reticulator")).then_return(
         TemperatureModuleModel.TEMPERATURE_V1
     )
 

--- a/api/tests/opentrons/protocol_api_old/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_instrument_context.py
@@ -78,16 +78,24 @@ def mock_labware(decoy: Decoy) -> Labware:
 
 
 @pytest.fixture
+def mock_trash(decoy: Decoy) -> Labware:
+    return decoy.mock(cls=Labware)
+
+
+@pytest.fixture
 def subject(
     mock_instrument_implementation: AbstractInstrument[AbstractWellCore],
     mock_protocol_context: ProtocolContext,
+    mock_trash: Labware,
 ) -> InstrumentContext:
-
     subject = InstrumentContext(
         implementation=mock_instrument_implementation,
         ctx=mock_protocol_context,
         broker=Broker(),
-        at_version=APIVersion(2, 0),
+        api_version=APIVersion(2, 0),
+        tip_racks=[],
+        trash=mock_trash,
+        requested_as="some-pipette-name",
     )
 
     return subject

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -414,7 +414,7 @@ def test_select_next_tip(
             definition=opentrons_96_tiprack_300ul_def,
             parent=Location(Point(0, 0, 0), "Test Slot"),
         ),
-        api_level=APIVersion(2, 1),
+        api_version=APIVersion(2, 1),
     )
     early_tr.use_tips(well_list[0])
     with pytest.raises(AssertionError):
@@ -587,7 +587,7 @@ def test_labware_hash_func_same_implementation(minimal_labware_def) -> None:
         minimal_labware_def, Location(Point(0, 0, 0), "Test Slot")
     )
     s = set(
-        labware.Labware(implementation=impl, api_level=APIVersion(2, 3))
+        labware.Labware(implementation=impl, api_version=APIVersion(2, 3))
         for i in range(10)
     )
     assert len(s) == 1
@@ -602,8 +602,8 @@ def test_labware_hash_func_same_implementation_different_version(
         minimal_labware_def, Location(Point(0, 0, 0), "Test Slot")
     )
 
-    l1 = labware.Labware(implementation=impl, api_level=APIVersion(2, 3))
-    l2 = labware.Labware(implementation=impl, api_level=APIVersion(2, 4))
+    l1 = labware.Labware(implementation=impl, api_version=APIVersion(2, 3))
+    l2 = labware.Labware(implementation=impl, api_version=APIVersion(2, 4))
 
     assert len({l1, l2}) == 2
 
@@ -620,8 +620,8 @@ def test_labware_hash_func_diff_implementation_same_version(
         minimal_labware_def, Location(Point(0, 0, 0), "Test Slot2")
     )
 
-    l1 = labware.Labware(implementation=impl1, api_level=APIVersion(2, 3))
-    l2 = labware.Labware(implementation=impl2, api_level=APIVersion(2, 3))
+    l1 = labware.Labware(implementation=impl1, api_version=APIVersion(2, 3))
+    l2 = labware.Labware(implementation=impl2, api_version=APIVersion(2, 3))
 
     assert len({l1, l2}) == 2
 
@@ -634,6 +634,8 @@ def test_set_offset(decoy: Decoy) -> None:
     subject.set_offset(x=1.1, y=2.2, z=3.3)
     decoy.verify(labware_impl.set_calibration(Point(1.1, 2.2, 3.3)))
 
-    subject = labware.Labware(implementation=labware_impl, api_level=APIVersion(2, 11))
+    subject = labware.Labware(
+        implementation=labware_impl, api_version=APIVersion(2, 11)
+    )
     with pytest.raises(APIVersionError):
         subject.set_offset(x=4.4, y=5.5, z=6.6)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -628,3 +628,37 @@ def test_get_display_name() -> None:
 
     assert subject.get_display_name("plate_with_display_name") == "Fancy Plate Name"
     assert subject.get_display_name("reservoir_without_display_name") is None
+
+
+def test_get_fixed_trash_id() -> None:
+    """It should return the ID of the labware loaded into the fixed trash slot."""
+    subject = get_labware_view(
+        labware_by_id={
+            "abc123": LoadedLabware(
+                id="abc123",
+                loadName="trash-load-name",
+                location=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
+                definitionUri="trash-definition-uri",
+                offsetId=None,
+                displayName=None,
+            )
+        },
+    )
+
+    assert subject.get_fixed_trash_id() == "abc123"
+
+    subject = get_labware_view(
+        labware_by_id={
+            "abc123": LoadedLabware(
+                id="abc123",
+                loadName="trash-load-name",
+                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+                definitionUri="trash-definition-uri",
+                offsetId=None,
+                displayName=None,
+            )
+        },
+    )
+
+    with pytest.raises(errors.LabwareNotLoadedError):
+        subject.get_fixed_trash_id()


### PR DESCRIPTION
## Overview

This PR adds enough to the engine core to allow a pipette to be loaded with assigned tip racks.

Part of RCORE-247.

## Changelog

The following items were needed in the ProtocolEngine cores to get instrument loading fully working:

- Removed confusing "instrument name" (requested load name) from InstrumentCore
    - Replaced it with a simple init arg at the `InstrumentContext` level
- Reworked `InstrumentContext` init args for clarity and to remove side-effects 
- Added fixed trash support to `ProtocolCore`
- Added URI and "is tip rack?" support to `LabwareCore`
- Added `WellCore` construction to `LabwareCore`
- Added name and max volume support to `WellCore`

## Review requests

Testing protocol loads a tip rack and then loads a pipette that uses that tip rack. Protocol should analyze and "run" with the PAPI engine core feature flag on.

```shell
make -C robot-server dev OT_API_FF_enableProtocolEnginePAPICore=1
```

```python
from opentrons import protocol_api, types

metadata = {
    "apiLevel": "2.13",
}


def run(ctx: protocol_api.ProtocolContext) -> None:
    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", location="1")
    right = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tip_rack])

```

In addition, standard protocol smoke tests with the feature flag off are probably prudent.

## Risk assessment

Low. This shuffles some stuff around in the non-engine PAPI core, but in areas that are very well covered by automated acceptance tests like the G-Code regression suite.
