### PR TITLE
refactor(api): engine based heater-shaker module core

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -316,56 +316,60 @@ class HeaterShakerModuleCore(ModuleCore, AbstractHeaterShakerCore[LabwareCore]):
 
     def set_target_temperature(self, celsius: float) -> None:
         """Set the labware plate's target temperature in °C."""
-        raise NotImplementedError("set_target_temperature not implemented")
+        self._engine_client.heater_shaker_set_target_temperature(
+            module_id=self.module_id, celsius=celsius
+        )
 
     def wait_for_target_temperature(self) -> None:
         """Wait for the labware plate's target temperature to be reached."""
-        raise NotImplementedError("wait_for_target_temperature not implemented")
+        self._engine_client.heater_shaker_wait_for_temperature(module_id=self.module_id)
 
     def set_and_wait_for_shake_speed(self, rpm: int) -> None:
         """Set the shaker's target shake speed and wait for it to spin up."""
-        raise NotImplementedError("set_and_wait_for_shake_speed not implemented")
+        self._engine_client.heater_shaker_set_and_wait_for_shake_speed(
+            module_id=self.module_id, rpm=rpm
+        )
 
     def open_labware_latch(self) -> None:
         """Open the labware latch."""
-        raise NotImplementedError("open_labware_latch not implemented")
+        self._engine_client.heater_shaker_open_labware_latch(module_id=self.module_id)
 
     def close_labware_latch(self) -> None:
         """Close the labware latch."""
-        raise NotImplementedError("close_labware_latch not implemented")
+        self._engine_client.heater_shaker_close_labware_latch(module_id=self.module_id)
 
     def deactivate_shaker(self) -> None:
         """Stop shaking."""
-        raise NotImplementedError("deactivate_shaker not implemented")
+        self._engine_client.heater_shaker_deactivate_shaker(module_id=self.module_id)
 
     def deactivate_heater(self) -> None:
         """Stop heating."""
-        raise NotImplementedError("deactivate_heater not implemented")
+        self._engine_client.heater_shaker_deactivate_heater(module_id=self.module_id)
 
     def get_current_temperature(self) -> float:
         """Get the labware plate's current temperature in °C."""
-        raise NotImplementedError("not implemented")
+        return self._sync_module_hardware.temperature  # type: ignore[no-any-return]
 
     def get_target_temperature(self) -> Optional[float]:
         """Get the labware plate's target temperature in °C, if set."""
-        raise NotImplementedError("get_current_temperature not implemented")
+        return self._sync_module_hardware.target_temperature  # type: ignore[no-any-return]
 
     def get_current_speed(self) -> int:
         """Get the shaker's current speed in RPM."""
-        raise NotImplementedError("get_current_speed not implemented")
+        return self._sync_module_hardware.speed  # type: ignore[no-any-return]
 
     def get_target_speed(self) -> Optional[int]:
         """Get the shaker's target speed in RPM, if set."""
-        raise NotImplementedError("get_target_speed not implemented")
+        return self._sync_module_hardware.target_speed  # type: ignore[no-any-return]
 
     def get_temperature_status(self) -> TemperatureStatus:
         """Get the module's heater status."""
-        raise NotImplementedError("get_temperature_status not implemented")
+        return self._sync_module_hardware.temperature_status  # type: ignore[no-any-return]
 
     def get_speed_status(self) -> SpeedStatus:
         """Get the module's heater status."""
-        raise NotImplementedError("get_speed_status not implemented")
+        return self._sync_module_hardware.speed_status  # type: ignore[no-any-return]
 
     def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
         """Get the module's labware latch status."""
-        raise NotImplementedError("get_labware_latch_status not implemented")
+        return self._sync_module_hardware.labware_latch_status  # type: ignore[no-any-return]

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -280,3 +280,80 @@ class SyncClient:
         )
         result = self._transport.execute_command(request=request)
         return cast(commands.thermocycler.CloseLidResult, result)
+
+    def heater_shaker_set_target_temperature(
+        self, module_id: str, celsius: float
+    ) -> commands.heater_shaker.SetTargetTemperatureResult:
+        """Execute a `heaterShaker/setTargetTemperature` command and return the result."""
+        request = commands.heater_shaker.SetTargetTemperatureCreate(
+            params=commands.heater_shaker.SetTargetTemperatureParams(
+                moduleId=module_id, celsius=celsius
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.SetTargetTemperatureResult, result)
+
+    def heater_shaker_wait_for_temperature(
+        self,
+        module_id: str,
+    ) -> commands.heater_shaker.WaitForTemperatureResult:
+        """Execute a `heaterShaker/waitForTemperature` command and return the result."""
+        request = commands.heater_shaker.WaitForTemperatureCreate(
+            params=commands.heater_shaker.WaitForTemperatureParams(
+                moduleId=module_id,
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.WaitForTemperatureResult, result)
+
+    def heater_shaker_set_and_wait_for_shake_speed(
+        self, module_id: str, rpm: float
+    ) -> commands.heater_shaker.SetAndWaitForShakeSpeedResult:
+        """Execute a `heaterShaker/setAndWaitForShakeSpeed` command and return the result."""
+        request = commands.heater_shaker.SetAndWaitForShakeSpeedCreate(
+            params=commands.heater_shaker.SetAndWaitForShakeSpeedParams(
+                moduleId=module_id, rpm=rpm
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.SetAndWaitForShakeSpeedResult, result)
+
+    def heater_shaker_open_labware_latch(
+        self, module_id: str
+    ) -> commands.heater_shaker.OpenLabwareLatchResult:
+        """Execute a `heaterShaker/openLabwareLatch` command and return the result."""
+        request = commands.heater_shaker.OpenLabwareLatchCreate(
+            params=commands.heater_shaker.OpenLabwareLatchParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.OpenLabwareLatchResult, result)
+
+    def heater_shaker_close_labware_latch(
+        self, module_id: str
+    ) -> commands.heater_shaker.CloseLabwareLatchResult:
+        """Execute a `heaterShaker/closeLabwareLatch` command and return the result."""
+        request = commands.heater_shaker.CloseLabwareLatchCreate(
+            params=commands.heater_shaker.CloseLabwareLatchParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.CloseLabwareLatchResult, result)
+
+    def heater_shaker_deactivate_shaker(
+        self, module_id: str
+    ) -> commands.heater_shaker.DeactivateShakerResult:
+        """Execute a `heaterShaker/deactivateShaker` command and return the result."""
+        request = commands.heater_shaker.DeactivateShakerCreate(
+            params=commands.heater_shaker.DeactivateShakerParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.DeactivateShakerResult, result)
+
+    def heater_shaker_deactivate_heater(
+        self, module_id: str
+    ) -> commands.heater_shaker.DeactivateHeaterResult:
+        """Execute a `heaterShaker/deactivateHeater` command and return the result."""
+        request = commands.heater_shaker.DeactivateHeaterCreate(
+            params=commands.heater_shaker.DeactivateHeaterParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.heater_shaker.DeactivateHeaterResult, result)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
@@ -70,7 +70,7 @@ class CloseLabwareLatch(BaseCommand[CloseLabwareLatchParams, CloseLabwareLatchRe
 class CloseLabwareLatchCreate(BaseCommandCreate[CloseLabwareLatchParams]):
     """A request to create a Heater-Shaker's close latch command."""
 
-    commandType: CloseLabwareLatchCommandType
+    commandType: CloseLabwareLatchCommandType = "heaterShaker/closeLabwareLatch"
     params: CloseLabwareLatchParams
 
     _CommandCls: Type[CloseLabwareLatch] = CloseLabwareLatch

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -69,7 +69,7 @@ class DeactivateHeater(BaseCommand[DeactivateHeaterParams, DeactivateHeaterResul
 class DeactivateHeaterCreate(BaseCommandCreate[DeactivateHeaterParams]):
     """A request to create a Heater-Shaker's deactivate heater command."""
 
-    commandType: DeactivateHeaterCommandType
+    commandType: DeactivateHeaterCommandType = "heaterShaker/deactivateHeater"
     params: DeactivateHeaterParams
 
     _CommandCls: Type[DeactivateHeater] = DeactivateHeater

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
@@ -69,7 +69,7 @@ class DeactivateShaker(BaseCommand[DeactivateShakerParams, DeactivateShakerResul
 class DeactivateShakerCreate(BaseCommandCreate[DeactivateShakerParams]):
     """A request to create a Heater-Shaker's deactivate shaker command."""
 
-    commandType: DeactivateShakerCommandType
+    commandType: DeactivateShakerCommandType = "heaterShaker/deactivateShaker"
     params: DeactivateShakerParams
 
     _CommandCls: Type[DeactivateShaker] = DeactivateShaker

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -98,7 +98,7 @@ class OpenLabwareLatch(BaseCommand[OpenLabwareLatchParams, OpenLabwareLatchResul
 class OpenLabwareLatchCreate(BaseCommandCreate[OpenLabwareLatchParams]):
     """A request to create a Heater-Shaker's open labware latch command."""
 
-    commandType: OpenLabwareLatchCommandType
+    commandType: OpenLabwareLatchCommandType = "heaterShaker/openLabwareLatch"
     params: OpenLabwareLatchParams
 
     _CommandCls: Type[OpenLabwareLatch] = OpenLabwareLatch

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -20,8 +20,6 @@ class SetAndWaitForShakeSpeedParams(BaseModel):
     """Input parameters to set and wait for a shake speed for a Heater-Shaker Module."""
 
     moduleId: str = Field(..., description="Unique ID of the Heater-Shaker Module.")
-    # TODO(mc, 2022-02-24): for set temperature we use `temperature` (not `celsius`)
-    # but for shake we use `rpm` (not `speed`). This is inconsistent
     rpm: float = Field(..., description="Target speed in rotations per minute.")
 
 
@@ -111,7 +109,9 @@ class SetAndWaitForShakeSpeed(
 class SetAndWaitForShakeSpeedCreate(BaseCommandCreate[SetAndWaitForShakeSpeedParams]):
     """A request to create a Heater-Shaker's set and wait for shake speed command."""
 
-    commandType: SetAndWaitForShakeSpeedCommandType
+    commandType: SetAndWaitForShakeSpeedCommandType = (
+        "heaterShaker/setAndWaitForShakeSpeed"
+    )
     params: SetAndWaitForShakeSpeedParams
 
     _CommandCls: Type[SetAndWaitForShakeSpeed] = SetAndWaitForShakeSpeed

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -79,7 +79,7 @@ class SetTargetTemperature(
 class SetTargetTemperatureCreate(BaseCommandCreate[SetTargetTemperatureParams]):
     """A request to create a Heater-Shaker's set temperature command."""
 
-    commandType: SetTargetTemperatureCommandType
+    commandType: SetTargetTemperatureCommandType = "heaterShaker/setTargetTemperature"
     params: SetTargetTemperatureParams
 
     _CommandCls: Type[SetTargetTemperature] = SetTargetTemperature

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
@@ -87,7 +87,7 @@ class WaitForTemperature(
 class WaitForTemperatureCreate(BaseCommandCreate[WaitForTemperatureParams]):
     """A request to create a Heater-Shaker's wait for temperature command."""
 
-    commandType: WaitForTemperatureCommandType
+    commandType: WaitForTemperatureCommandType = "heaterShaker/waitForTemperature"
     params: WaitForTemperatureParams
 
     _CommandCls: Type[WaitForTemperature] = WaitForTemperature

--- a/api/tests/opentrons/protocol_api/core/engine/test_heater_shaker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_heater_shaker_core.py
@@ -1,0 +1,221 @@
+"""Tests for the engine based Protocol API module core implementations."""
+import pytest
+from decoy import Decoy
+
+from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import HeaterShaker
+from opentrons.hardware_control.modules.types import TemperatureStatus, SpeedStatus
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_api.core.engine.module_core import HeaterShakerModuleCore
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION
+
+SyncHeaterShakerHardware = SynchronousAdapter[HeaterShaker]
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SyncHeaterShakerHardware:
+    """Get a mock synchronous module hardware."""
+    return decoy.mock(name="SyncHeaterShakerHardware")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def subject(
+    mock_engine_client: EngineClient,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+) -> HeaterShakerModuleCore:
+    """Get a HeaterShakerModuleCore test subject."""
+    return HeaterShakerModuleCore(
+        module_id="1234",
+        engine_client=mock_engine_client,
+        api_version=MAX_SUPPORTED_VERSION,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+
+def test_create(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+) -> None:
+    """It should be able to create a heater shaker module core."""
+    result = HeaterShakerModuleCore(
+        module_id="1234",
+        engine_client=mock_engine_client,
+        api_version=MAX_SUPPORTED_VERSION,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+    assert result.module_id == "1234"
+
+
+def test_set_target_temperature(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should set the target temperature with the engine client."""
+    subject.set_target_temperature(celsius=42.0)
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_set_target_temperature(
+            module_id="1234", celsius=42.0
+        ),
+        times=1,
+    )
+
+
+def test_wait_for_target_temperature(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should wait for the target temperature with the engine client."""
+    subject.wait_for_target_temperature()
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_wait_for_temperature(module_id="1234"), times=1
+    )
+
+
+def test_set_and_wait_for_shake_speed(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should set and wait for shake speed with the engine client."""
+    subject.set_and_wait_for_shake_speed(rpm=1337)
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_set_and_wait_for_shake_speed(
+            module_id="1234", rpm=1337
+        ),
+        times=1,
+    )
+
+
+def test_open_labware_latch(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should open the labware latch with the engine client."""
+    subject.open_labware_latch()
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_open_labware_latch(module_id="1234"), times=1
+    )
+
+
+def test_close_labware_latch(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should close the labware latch with the engine client."""
+    subject.close_labware_latch()
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_close_labware_latch(module_id="1234"), times=1
+    )
+
+
+def test_deactivate_shaker(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should deactivate the shaker with the engine client."""
+    subject.deactivate_shaker()
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_deactivate_shaker(module_id="1234"), times=1
+    )
+
+
+def test_deactivate_heater(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: HeaterShakerModuleCore
+) -> None:
+    """It should deactivate the heater with the engine client."""
+    subject.deactivate_heater()
+
+    decoy.verify(
+        mock_engine_client.heater_shaker_deactivate_heater(module_id="1234"), times=1
+    )
+
+
+def test_get_current_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the current temperature."""
+    decoy.when(mock_sync_module_hardware.temperature).then_return(42.0)
+    result = subject.get_current_temperature()
+    assert result == 42.0
+
+
+def test_get_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the target temperature."""
+    decoy.when(mock_sync_module_hardware.target_temperature).then_return(42.0)
+    result = subject.get_target_temperature()
+    assert result == 42.0
+
+
+def test_get_temperature_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the temperature status."""
+    decoy.when(mock_sync_module_hardware.temperature_status).then_return(
+        TemperatureStatus.COOLING
+    )
+    result = subject.get_temperature_status()
+    assert result == TemperatureStatus.COOLING
+
+
+def test_get_current_speed(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the current speed."""
+    decoy.when(mock_sync_module_hardware.speed).then_return(321)
+    result = subject.get_current_speed()
+    assert result == 321
+
+
+def test_get_target_speed(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the target speed."""
+    decoy.when(mock_sync_module_hardware.target_speed).then_return(321)
+    result = subject.get_target_speed()
+    assert result == 321
+
+
+def test_get_speed_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the speed status."""
+    decoy.when(mock_sync_module_hardware.speed_status).then_return(
+        SpeedStatus.ACCELERATING
+    )
+    result = subject.get_speed_status()
+    assert result == SpeedStatus.ACCELERATING
+
+
+def test_get_labware_latch_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncHeaterShakerHardware,
+    subject: HeaterShakerModuleCore,
+) -> None:
+    """It should report the labware latch status."""
+    decoy.when(mock_sync_module_hardware.labware_latch_status).then_return(
+        HeaterShakerLabwareLatchStatus.OPENING
+    )
+    result = subject.get_labware_latch_status()
+    assert result == HeaterShakerLabwareLatchStatus.OPENING

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -442,3 +442,125 @@ def test_blow_out(
     )
 
     assert result == response
+
+
+def test_heater_shaker_set_target_temperature(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's set target temperature command."""
+    request = commands.heater_shaker.SetTargetTemperatureCreate(
+        params=commands.heater_shaker.SetTargetTemperatureParams(
+            moduleId="module-id", celsius=42.0
+        )
+    )
+    response = commands.heater_shaker.SetTargetTemperatureResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_set_target_temperature(
+        module_id="module-id", celsius=42.0
+    )
+
+    assert result == response
+
+
+def test_heater_shaker_wait_for_temperature(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's wait for temperature command."""
+    request = commands.heater_shaker.WaitForTemperatureCreate(
+        params=commands.heater_shaker.WaitForTemperatureParams(moduleId="module-id")
+    )
+    response = commands.heater_shaker.WaitForTemperatureResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_wait_for_temperature(module_id="module-id")
+
+    assert result == response
+
+
+def test_heater_shaker_set_and_wait_for_shake_speed(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's set and wait for shake speed command."""
+    request = commands.heater_shaker.SetAndWaitForShakeSpeedCreate(
+        params=commands.heater_shaker.SetAndWaitForShakeSpeedParams(
+            moduleId="module-id", rpm=1337
+        )
+    )
+    response = commands.heater_shaker.SetAndWaitForShakeSpeedResult(
+        pipetteRetracted=False
+    )
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_set_and_wait_for_shake_speed(
+        module_id="module-id", rpm=1337
+    )
+
+    assert result == response
+
+
+def test_heater_shaker_open_labware_latch(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's open labware latch command."""
+    request = commands.heater_shaker.OpenLabwareLatchCreate(
+        params=commands.heater_shaker.OpenLabwareLatchParams(moduleId="module-id")
+    )
+    response = commands.heater_shaker.OpenLabwareLatchResult(pipetteRetracted=False)
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_open_labware_latch(module_id="module-id")
+
+    assert result == response
+
+
+def test_heater_shaker_close_labware_latch(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's close labware latch command."""
+    request = commands.heater_shaker.CloseLabwareLatchCreate(
+        params=commands.heater_shaker.CloseLabwareLatchParams(moduleId="module-id")
+    )
+    response = commands.heater_shaker.CloseLabwareLatchResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_close_labware_latch(module_id="module-id")
+
+    assert result == response
+
+
+def test_heater_shaker_deactivate_shaker(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's deactivate shaker command."""
+    request = commands.heater_shaker.DeactivateShakerCreate(
+        params=commands.heater_shaker.DeactivateShakerParams(moduleId="module-id")
+    )
+    response = commands.heater_shaker.DeactivateShakerResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_deactivate_shaker(module_id="module-id")
+
+    assert result == response
+
+
+def test_heater_shaker_deactivate_heater(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Heater-Shaker's deactivate heater command."""
+    request = commands.heater_shaker.DeactivateHeaterCreate(
+        params=commands.heater_shaker.DeactivateHeaterParams(moduleId="module-id")
+    )
+    response = commands.heater_shaker.DeactivateHeaterResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.heater_shaker_deactivate_heater(module_id="module-id")
+
+    assert result == response


### PR DESCRIPTION
# Overview
Addresses the heater shaker portion of RCORE-257.

Adds engine-based heater-shaker module core, using the sync client for all non-read methods of the heater-shaker. All read methods use the hardware API for the present moment. Relevant methods have been added to the sync client for heater-shaker.

# Changelog
- Implements all methods of the engine-based `HeaterShakerModuleCore`
- Adds relevant heater-shaker methods to the `SyncClient`
- Fixes missing `commandType` defaults for heater-shaker command create classes

# Review requests
Regression testing with hardware for all heater-shaker methods with the feature flag on.
`make -C robot-server dev OT_API_FF_enableProtocolEnginePAPICore=1`

# Risk assessment
Low-ish, this only touches heater-shaker module interactions with the feature flag on, uses existing methods, and is well-covered by tests.