### PR TITLE
fix(api): fixed FF engined-based module loading failing in analysis

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -144,17 +144,14 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         self, serial_number: str, model: ModuleModel
     ) -> AbstractModule:
         """Resolve a module serial number to module hardware API."""
-        selected_hardware: AbstractModule
+        if self.is_simulating():
+            return self._sync_hardware.create_simulating_module(model)  # type: ignore[no-any-return]
+
         for module_hardware in self._sync_hardware.attached_modules:
             if serial_number == module_hardware.device_info["serial"]:
-                selected_hardware = module_hardware
-                break
-        else:
-            if self.is_simulating():
-                selected_hardware = self._sync_hardware.create_simulating_module(model)
-            else:
-                raise RuntimeError(f"Could not find specified module: {model.value}")
-        return selected_hardware
+                return module_hardware  # type: ignore[no-any-return]
+
+        raise RuntimeError(f"Could not find specified module: {model.value}")
 
     def load_module(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -7,6 +7,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
 from opentrons.types import Mount, MountType, Location, DeckSlotName
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
+from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import (
     ModuleModel,
     ModuleType,
@@ -100,7 +101,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def is_simulating(self) -> bool:
         """Get whether the protocol is being analyzed or actually run."""
-        raise NotImplementedError("ProtocolCore.is_simulating not implemented")
+        return self._sync_hardware.is_simulator  # type: ignore[no-any-return]
 
     def add_labware_definition(
         self,
@@ -139,6 +140,22 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
             engine_client=self._engine_client,
         )
 
+    def _resolve_module_hardware(
+        self, serial_number: str, model: ModuleModel
+    ) -> AbstractModule:
+        """Resolve a module serial number to module hardware API."""
+        selected_hardware: AbstractModule
+        for module_hardware in self._sync_hardware.attached_modules:
+            if serial_number == module_hardware.device_info["serial"]:
+                selected_hardware = module_hardware
+                break
+        else:
+            if self.is_simulating():
+                selected_hardware = self._sync_hardware.create_simulating_module(model)
+            else:
+                raise RuntimeError(f"Could not find specified module: {model.value}")
+        return selected_hardware
+
     def load_module(
         self,
         model: ModuleModel,
@@ -160,12 +177,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         )
         module_type = result.model.as_type()
 
-        for module_hardware in self._sync_hardware.attached_modules:
-            if result.serialNumber == module_hardware.device_info["serial"]:
-                selected_hardware = module_hardware
-                break
-        else:
-            raise RuntimeError(f"Could not find specified module: {model.value}")
+        selected_hardware = self._resolve_module_hardware(result.serialNumber, model)
 
         # TODO(mc, 2022-10-25): move to module core factory function
         module_core_cls: Type[ModuleCore] = ModuleCore


### PR DESCRIPTION
# Overview
Followup to PR #11619, part of RCORE-257.

Fixed issue where engine-based module loading was not handling simulating cases.

# Changelog
- Module Loading in engine-based PAPIv2 fixed

# Review requests
Test loading module on hardware, both analysis and protocol run.

# Risk assessment
Low, fixes bug in previous PR.