### PR TITLE
feat(app, protocol-designer): remove Thermocycler Gen2 feature flags

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -86,7 +86,6 @@
   "__dev_internal__enableChangePipetteWizard": "Enable Change Pipette Wizard",
   "__dev_internal__enableCalibrationWizards": "Enable Re-skinned Calibration Wizards",
   "__dev_internal__enableManualDeckStateModification": "Enable Manual Deck State Modification",
-  "__dev_internal__enableThermocyclerGen2": "Enable Thermocycler Module GEN2 App Support",
   "__dev_internal__enableExtendedHardware": "Enable Extended Hardware",
   "override_path_to_python": "Override Path to Python",
   "opentrons_app_will_use_interpreter": "If specified, the Opentrons App will use the Python interpreter at this path instead of the default bundled Python interpreter.",

--- a/app/src/molecules/DeckThumbnail/index.tsx
+++ b/app/src/molecules/DeckThumbnail/index.tsx
@@ -38,8 +38,6 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
   const deckDef = React.useMemo(() => getDeckDefinitions().ot2_standard, [])
   const { commands, liquids } = props
   const liquidSetupEnabled = useFeatureFlag('enableLiquidSetup')
-  const enableThermocyclerGen2 = useFeatureFlag('enableThermocyclerGen2')
-
   const initialLoadedLabwareBySlot = parseInitialLoadedLabwareBySlot(commands)
   const initialLoadedModulesBySlot = parseInitialLoadedModulesBySlot(commands)
   const initialLoadedLabwareByModuleId = parseInitialLoadedLabwareByModuleId(
@@ -91,11 +89,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
               : null
           return (
             <React.Fragment key={slotId}>
-              {/* TODO(jr, 9/28/22): revert this logic to only moduleInSlot != null when we remove the enableThermocyclerGen2 FF */}
-              {(moduleInSlot != null && enableThermocyclerGen2) ||
-              (moduleInSlot != null &&
-                !enableThermocyclerGen2 &&
-                moduleInSlot.params.model !== 'thermocyclerModuleV2') ? (
+              {moduleInSlot != null ? (
                 <Module
                   x={slot.position[0]}
                   y={slot.position[1]}

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -31,7 +31,6 @@ import {
   getRobotModelByName,
 } from '../../redux/discovery'
 import { ModuleIcon } from '../../molecules/ModuleIcon'
-import { useFeatureFlag } from '../../redux/config'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
 import { UpdateRobotBanner } from '../UpdateRobotBanner'
@@ -161,7 +160,6 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
   const { robotName } = props
   const { t } = useTranslation('devices_landing')
   const attachedModules = useAttachedModules()
-  const enableThermocyclerGen2 = useFeatureFlag('enableThermocyclerGen2')
 
   return attachedModules.length > 0 ? (
     <Box
@@ -178,20 +176,15 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
         {t('modules')}
       </StyledText>
       <Flex>
-        {attachedModules.map((module, i) =>
-          //  TODO(jr, 9/28/22): remove this logic when we remove enableThermocyclerGen2 FF
-          enableThermocyclerGen2 ||
-          (!enableThermocyclerGen2 &&
-            module.moduleModel !== 'thermocyclerModuleV2') ? (
-            <ModuleIcon
-              key={`${module.moduleModel}_${i}_${robotName}`}
-              tooltipText={t('this_robot_has_connected_and_power_on_module', {
-                moduleName: getModuleDisplayName(module.moduleModel),
-              })}
-              module={module}
-            />
-          ) : null
-        )}
+        {attachedModules.map((module, i) => (
+          <ModuleIcon
+            key={`${module.moduleModel}_${i}_${robotName}`}
+            tooltipText={t('this_robot_has_connected_and_power_on_module', {
+              moduleName: getModuleDisplayName(module.moduleModel),
+            })}
+            module={module}
+          />
+        ))}
       </Flex>
     </Box>
   ) : (

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -31,7 +31,6 @@ import {
   useAttachedPipettes,
   useProtocolDetailsForRun,
 } from '../hooks'
-import { useFeatureFlag } from '../../../redux/config'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../../organisms/RunTimeControl/hooks'
 import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
@@ -49,7 +48,6 @@ jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../hooks')
 jest.mock('../../UpdateRobotBanner')
 jest.mock('../../ChooseProtocolSlideout')
-jest.mock('../../../redux/config')
 
 const OT2_PNG_FILE_NAME = 'OT2-R_HERO.png'
 const OT3_PNG_FILE_NAME = 'OT3.png'
@@ -122,9 +120,6 @@ const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.
 const mockGetRobotModelByName = getRobotModelByName as jest.MockedFunction<
   typeof getRobotModelByName
 >
-const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
-  typeof useFeatureFlag
->
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as ProtocolAnalysisFile<{}>
 const PROTOCOL_DETAILS = {
@@ -150,7 +145,6 @@ describe('RobotCard', () => {
 
   beforeEach(() => {
     props = { robot: mockConnectableRobot }
-    mockUseFeatureFlag.mockReturnValue(false)
     mockUseAttachedModules.mockReturnValue(
       mockFetchModulesSuccessActionPayloadModules
     )

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -8,7 +8,6 @@ import {
   getModuleType,
   getPipetteNameSpecs,
   ProtocolAnalysisOutput,
-  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import {
   Box,
@@ -33,7 +32,6 @@ import {
   parseAllRequiredModuleModels,
 } from '@opentrons/api-client'
 
-import { useFeatureFlag } from '../../redux/config'
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 import { InstrumentContainer } from '../../atoms/InstrumentContainer'
 import { StyledText } from '../../atoms/text'
@@ -115,7 +113,6 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
     modified,
   } = props
   const { t } = useTranslation(['protocol_list', 'shared'])
-  const enableThermocyclerGen2 = useFeatureFlag('enableThermocyclerGen2')
   const analysisStatus = getAnalysisStatus(isAnalyzing, mostRecentAnalysis)
 
   const { left: leftMountPipetteName, right: rightMountPipetteName } =
@@ -126,11 +123,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
     mostRecentAnalysis != null ? mostRecentAnalysis.commands : []
   )
 
-  const requiredModuleModelsWithFF = enableThermocyclerGen2
-    ? requiredModuleModels
-    : requiredModuleModels.filter(mod => mod !== THERMOCYCLER_MODULE_V2)
-
-  const requiredModuleTypes = requiredModuleModelsWithFF.map(getModuleType)
+  const requiredModuleTypes = requiredModuleModels.map(getModuleType)
 
   return (
     <Flex

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -9,7 +9,6 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'enableLiquidSetup',
   'enableManualDeckStateModification',
   'enableCalibrationWizards',
-  'enableThermocyclerGen2',
   'enableExtendedHardware',
 ]
 

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -13,7 +13,6 @@ export type DevInternalFlag =
   | 'enableLiquidSetup'
   | 'enableManualDeckStateModification'
   | 'enableCalibrationWizards'
-  | 'enableThermocyclerGen2'
   | 'enableExtendedHardware'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>

--- a/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
@@ -81,13 +81,14 @@ describe('Protocols with Modules', () => {
 
       // Re-add thermocycler
       cy.get(addThermocycler).click()
-      cy.get('button')
-        .contains('save', { matchCase: false })
-        .click({ force: true })
+      cy.get(editModuleModal).within(() => {
+        cy.get(moduleModelDropdown).select('GEN1')
+        cy.get('button').contains('save', { matchCase: false }).click()
+      })
     })
 
     it('adds one liquid', () => {
-      cy.get('button').contains('Continue to Liquids').click({ force: true })
+      cy.get('button').contains('Continue to Liquids').click()
       cy.addLiquid('Water', 'pure H2O', true)
     })
 
@@ -257,7 +258,10 @@ describe('Protocols with Modules', () => {
       cy.get(slotSeven).contains('Delete').click()
       cy.openFilePage()
       cy.get(addThermocycler).click()
-      cy.get('button').contains('save', { matchCase: false }).click()
+      cy.get(editModuleModal).within(() => {
+        cy.get(moduleModelDropdown).select('GEN1')
+        cy.get('button').contains('save', { matchCase: false }).click()
+      })
       cy.openDesignPage()
       cy.get('[class*="alert_title"]').should('not.exist')
       cy.get('[class*="error_icon"]').should('not.exist')

--- a/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
@@ -81,11 +81,13 @@ describe('Protocols with Modules', () => {
 
       // Re-add thermocycler
       cy.get(addThermocycler).click()
-      cy.get('button').contains('save', { matchCase: false }).click()
+      cy.get('button')
+        .contains('save', { matchCase: false })
+        .click({ force: true })
     })
 
-    it('adds two liquids', () => {
-      cy.get('button').contains('Continue to Liquids').click()
+    it('adds one liquid', () => {
+      cy.get('button').contains('Continue to Liquids').click({ force: true })
       cy.addLiquid('Water', 'pure H2O', true)
     })
 

--- a/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
@@ -66,13 +66,11 @@ describe('Protocols with Modules', () => {
         cy.contains('Slot 7').should('exist')
       })
 
-      // Edit Thermocycler module (should not have slot option and not have another gen)
-      //  TODO(jr, 9/23/22): remove line 75 and replace with line 74 when we remove the TC gen2 FF
+      // Edit Thermocycler module (should not have slot option but have another gen)
       cy.get(editThermocycler).click()
       cy.get(editModuleModal).within(() => {
         cy.contains('Position').should('not.exist')
-        // cy.get(moduleModelDropdown).contains('GEN2').should('exist')
-        cy.get(moduleModelDropdown).contains('GEN2').should('not.exist')
+        cy.get(moduleModelDropdown).contains('GEN2').should('exist')
         cy.get('button').contains('cancel', { matchCase: false }).click()
       })
 

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
@@ -29,7 +29,6 @@ import {
 } from '../../../../step-forms/utils'
 import * as moduleData from '../../../../modules/moduleData'
 import { MODELS_FOR_MODULE_TYPE } from '../../../../constants'
-import { getEnabledThermocyclerGen2 } from '../../../../feature-flags/selectors'
 import { selectors as featureSelectors } from '../../../../feature-flags'
 import { getLabwareIsCompatible } from '../../../../utils/labwareModuleCompatibility'
 import { isModuleWithCollisionIssue } from '../../../modules/utils'
@@ -52,7 +51,6 @@ jest.mock('../../../../step-forms/selectors')
 jest.mock('../../../modules/utils')
 jest.mock('../../../../step-forms/utils')
 jest.mock('../form-state')
-jest.mock('../../../../feature-flags/selectors')
 
 const MODEL_FIELD = 'selectedModel'
 const SLOT_FIELD = 'selectedSlot'
@@ -75,13 +73,10 @@ const getLabwareOnSlotMock: jest.MockedFunction<any> = getLabwareOnSlot
 
 const getIsLabwareAboveHeightMock: jest.MockedFunction<any> = getIsLabwareAboveHeight
 
-const getEnabledThermocyclerGen2Mock: jest.MockedFunction<any> = getEnabledThermocyclerGen2
-
 describe('Edit Modules Modal', () => {
   let mockStore: any
   let props: EditModulesModalProps
   beforeEach(() => {
-    getEnabledThermocyclerGen2Mock.mockReturnValue(false)
     getInitialDeckSetupMock.mockReturnValue(getMockDeckSetup())
     getSlotsBlockedBySpanningMock.mockReturnValue([])
     getLabwareOnSlotMock.mockReturnValue({})

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -18,7 +18,6 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   ModuleType,
   ModuleModel,
-  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import {
@@ -36,10 +35,7 @@ import {
   getAllModuleSlotsByType,
 } from '../../../modules/moduleData'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
-import {
-  MODELS_FOR_MODULE_TYPE,
-  MODELS_FOR_MODULE_TYPE_NO_FF,
-} from '../../../constants'
+import { MODELS_FOR_MODULE_TYPE } from '../../../constants'
 import { PDAlert } from '../../alerts/PDAlert'
 import { isModuleWithCollisionIssue } from '../../modules'
 import modalStyles from '../modal.css'
@@ -79,9 +75,6 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
     onCloseClick,
     moduleOnDeck,
   } = props
-  const enableThermocyclerGen2 = useSelector(
-    featureFlagSelectors.getEnabledThermocyclerGen2
-  )
   const supportedModuleSlot = SUPPORTED_MODULE_SLOTS[moduleType][0].value
   const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const dispatch = useDispatch()
@@ -104,19 +97,10 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
     return !isLabwareCompatible
   }
 
-  const moduleIsThermocycler = moduleType === THERMOCYCLER_MODULE_TYPE
-
-  const initialValues = moduleIsThermocycler
-    ? {
-        selectedSlot: moduleOnDeck?.slot || supportedModuleSlot,
-        selectedModel: enableThermocyclerGen2
-          ? moduleOnDeck?.model || null
-          : THERMOCYCLER_MODULE_V1,
-      }
-    : {
-        selectedSlot: moduleOnDeck?.slot || supportedModuleSlot,
-        selectedModel: moduleOnDeck?.model || null,
-      }
+  const initialValues = {
+    selectedSlot: moduleOnDeck?.slot || supportedModuleSlot,
+    selectedModel: moduleOnDeck?.model || null,
+  }
 
   const validator = ({
     selectedModel,
@@ -232,10 +216,6 @@ const EditModulesModalComponent = (
   const { moduleType, onCloseClick, supportedModuleSlot } = props
   const { values, errors, isValid } = useFormikContext<EditModulesFormValues>()
   const { selectedModel } = values
-  const enableThermocyclerGen2 = useSelector(
-    featureFlagSelectors.getEnabledThermocyclerGen2
-  )
-
   const disabledModuleRestriction = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
@@ -283,11 +263,7 @@ const EditModulesModalComponent = (
               <ModelDropdown
                 fieldName={'selectedModel'}
                 tabIndex={0}
-                options={
-                  enableThermocyclerGen2
-                    ? MODELS_FOR_MODULE_TYPE[moduleType]
-                    : MODELS_FOR_MODULE_TYPE_NO_FF[moduleType]
-                }
+                options={MODELS_FOR_MODULE_TYPE[moduleType]}
               />
             </FormGroup>
             {showSlotOption && (

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react'
 import { CheckboxField, DropdownField, FormGroup } from '@opentrons/components'
-import { useSelector } from 'react-redux'
 import { i18n } from '../../../localization'
 import {
   DEFAULT_MODEL_FOR_MODULE_TYPE,
   MODELS_FOR_MODULE_TYPE,
-  MODELS_FOR_MODULE_TYPE_NO_FF,
 } from '../../../constants'
 import { FormModulesByType } from '../../../step-forms'
-import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { ModuleDiagram } from '../../modules'
 import styles from './FilePipettesModal.css'
 import type { ModuleType } from '@opentrons/shared-data'
@@ -66,10 +63,6 @@ export function ModuleFields(props: ModuleFieldsProps): JSX.Element {
     errors,
     touched,
   } = props
-
-  const enableThermocyclerGen2 = useSelector(
-    featureFlagSelectors.getEnabledThermocyclerGen2
-  )
 
   // @ts-expect-error(sa, 2021-6-21): Object.keys not smart enough to take the keys of FormModulesByType
   const modules: ModuleType[] = Object.keys(values)
@@ -130,11 +123,7 @@ export function ModuleFields(props: ModuleFieldsProps): JSX.Element {
                     }
                     tabIndex={i}
                     name={`${moduleTypeAccessor}.model`}
-                    options={
-                      enableThermocyclerGen2
-                        ? MODELS_FOR_MODULE_TYPE[moduleType]
-                        : MODELS_FOR_MODULE_TYPE_NO_FF[moduleType]
-                    }
+                    options={MODELS_FOR_MODULE_TYPE[moduleType]}
                     value={selectedModel}
                     onChange={onFieldChange}
                     onBlur={onBlur}

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.tsx
@@ -10,14 +10,9 @@ import {
   THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import { CheckboxField } from '@opentrons/components'
-import { getEnabledThermocyclerGen2 } from '../../../../feature-flags/selectors'
 import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../../../constants'
 import { ModuleDiagram } from '../../../modules'
 import { ModuleFields, ModuleFieldsProps } from '../ModuleFields'
-
-jest.mock('../../../../feature-flags/selectors')
-
-const getEnabledThermocyclerGen2Mock: jest.MockedFunction<any> = getEnabledThermocyclerGen2
 
 describe('ModuleFields', () => {
   let magnetModuleOnDeck,
@@ -27,7 +22,6 @@ describe('ModuleFields', () => {
   let props: ModuleFieldsProps
   let store: any
   beforeEach(() => {
-    getEnabledThermocyclerGen2Mock.mockReturnValue(false)
     store = {
       dispatch: jest.fn(),
       subscribe: jest.fn(),
@@ -180,8 +174,7 @@ describe('ModuleFields', () => {
     })
   })
 
-  it('displays Thermocycler gen2 module img when model has been selected and FF is turned on', () => {
-    getEnabledThermocyclerGen2Mock.mockReturnValue(true)
+  it('displays Thermocycler gen2 module img when model has been selected', () => {
     props.values[THERMOCYCLER_MODULE_TYPE].model = THERMOCYCLER_MODULE_V2
 
     const wrapper = render(props)

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -130,48 +130,6 @@ export const MODELS_FOR_MODULE_TYPE: Record<
   ],
 }
 
-export const MODELS_FOR_MODULE_TYPE_NO_FF: Record<
-  ModuleType,
-  Array<{
-    name: string
-    value: ModuleModel
-    disabled?: boolean
-  }>
-> = {
-  [MAGNETIC_MODULE_TYPE]: [
-    {
-      name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V1}`),
-      value: MAGNETIC_MODULE_V1,
-    },
-    {
-      name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V2}`),
-      value: MAGNETIC_MODULE_V2,
-    },
-  ],
-  [TEMPERATURE_MODULE_TYPE]: [
-    {
-      name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V1}`),
-      value: TEMPERATURE_MODULE_V1,
-    },
-    {
-      name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V2}`),
-      value: TEMPERATURE_MODULE_V2,
-    },
-  ],
-  [THERMOCYCLER_MODULE_TYPE]: [
-    {
-      name: i18n.t(`modules.model_display_name.${THERMOCYCLER_MODULE_V1}`),
-      value: THERMOCYCLER_MODULE_V1,
-    },
-  ],
-  [HEATERSHAKER_MODULE_TYPE]: [
-    {
-      name: i18n.t(`modules.model_display_name.${HEATERSHAKER_MODULE_V1}`),
-      value: HEATERSHAKER_MODULE_V1,
-    },
-  ],
-}
-
 export const DEFAULT_MODEL_FOR_MODULE_TYPE: Record<ModuleType, ModuleModel> = {
   [MAGNETIC_MODULE_TYPE]: MAGNETIC_MODULE_V1,
   [TEMPERATURE_MODULE_TYPE]: TEMPERATURE_MODULE_V1,

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -21,8 +21,6 @@ const initialFlags: Flags = {
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
   OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS:
     process.env.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS === '1' || false,
-  OT_PD_ENABLE_THERMOCYCLER_GEN_2:
-    process.env.OT_PD_ENABLE_THERMOCYCLER_GEN_2 === '1' || false,
   OT_PD_ENABLE_OT_3: process.env.OT_PD_ENABLE_OT_3 === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -19,11 +19,6 @@ export const getEnabledLiquidColorEnhancements: Selector<boolean> = createSelect
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS ?? false
 )
-export const getEnabledThermocyclerGen2: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_THERMOCYCLER_GEN_2 ?? false
-)
-
 export const getEnabledOT3: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_OT_3 ?? false

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -17,13 +17,13 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_BATCH_EDIT_MIX',
   'OT_PD_ENABLE_SCHEMA_V6',
   'OT_PD_ENABLE_HEATER_SHAKER',
+  'OT_PD_ENABLE_THERMOCYCLER_GEN_2',
 ]
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS'
-  | 'OT_PD_ENABLE_THERMOCYCLER_GEN_2'
   | 'OT_PD_ENABLE_OT_3'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [


### PR DESCRIPTION
closes RCORE-316

# Overview

Removes the Thermocycler Gen2 feature flags: 1 in the app, 1 in PD

# Changelog

- deprecate `enableThermocyclerGen2` in PD ffs, remove logic added to `ModuleFields` and `EditModulesModal`, fix tests
- delete protocol-designer constant `MODELS_FOR_MODULE_TYPE_NO_FF` that was created specifically for the TC GEN2 ff
- remove  `enableThermocyclerGen2` in app ffs, remove logic added to `Thumbnail`, `RobotCard` and `ProtocolCard`. Fix tests
- fix `newProtocolWithTC` cypress test

# Review requests

- launch Protocol designer. You should be able to select TC GEN2 from the `EditModulesModal` and when you select to edit it, GEN2 should be an option.
- launch the app. If you have a TC GEN2 attached, the RobotCard should work as expected. If you upload a protocol with the TC GEN2, you should see it properly render in the thumbnail and protocol card.

All the rest of PD and app functionality should work as expected for the TC GEN2! 

# Risk assessment

low