### PR TITLE
refactor(api): engine based thermocycler module core

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -517,12 +517,11 @@ class Thermocycler(mod_abc.AbstractModule):
         temperature = step.get("temperature")
         hold_time_minutes = step.get("hold_time_minutes", None)
         hold_time_seconds = step.get("hold_time_seconds", None)
-        ramp_rate = step.get("ramp_rate", None)
         await self._set_temperature_no_pause(
             temperature=temperature,  # type: ignore
             hold_time_minutes=hold_time_minutes,
             hold_time_seconds=hold_time_seconds,
-            ramp_rate=ramp_rate,
+            ramp_rate=None,
             volume=volume,
         )
 

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -24,7 +24,15 @@ if TYPE_CHECKING:
         HeaterShakerModuleType,
     )
 
-ThermocyclerStep = Dict[str, float]
+
+class ThermocyclerStepBase(TypedDict):
+    temperature: float
+
+
+class ThermocyclerStep(ThermocyclerStepBase, total=False):
+    hold_time_seconds: float
+    hold_time_minutes: float
+
 
 UploadFunction = Callable[[str, str, Dict[str, Any]], Awaitable[Tuple[bool, str]]]
 

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -288,7 +288,10 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
 
     def get_current_cycle_index(self) -> Optional[int]:
         """Get index of the current set cycle repetition."""
-        return None if self._repetitions is None else self._repetitions + 1
+        if self._repetitions is None:
+            return None
+        step_index = self._sync_module_hardware.current_step_index
+        return (step_index - 1) // self._step_count + 1  # type: ignore[no-any-return]
 
     def get_total_step_count(self) -> Optional[int]:
         """Get number of steps within the current cycle."""
@@ -296,7 +299,10 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
 
     def get_current_step_index(self) -> Optional[int]:
         """Get the index of the current step within the current cycle."""
-        return None if self._step_count is None else self._step_count + 1
+        if self._step_count is None:
+            return None
+        step_index = self._sync_module_hardware.current_step_index
+        return (step_index - 1) % self._step_count + 1  # type: ignore[no-any-return]
 
     def _clear_cycle_counters(self) -> None:
         """Clear core-tracked cycle counters."""

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -178,11 +178,13 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
 
     def open_lid(self) -> ThermocyclerLidStatus:
         """Open the Thermocycler's lid."""
-        raise NotImplementedError("open_lid not implemeted")
+        self._engine_client.thermocycler_open_lid(module_id=self.module_id)
+        return ThermocyclerLidStatus.OPEN
 
     def close_lid(self) -> ThermocyclerLidStatus:
         """Close the Thermocycler's lid."""
-        raise NotImplementedError("close_lid not implemented")
+        self._engine_client.thermocycler_close_lid(module_id=self.module_id)
+        return ThermocyclerLidStatus.CLOSED
 
     def set_target_block_temperature(
         self,
@@ -190,32 +192,28 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
         hold_time_seconds: Optional[float] = None,
         block_max_volume: Optional[float] = None,
     ) -> None:
-        """Set the target temperature for the well block, in °C.
-
-        Note:
-            If ``hold_time_seconds`` is not specified, the Thermocycler
-            will proceed to the next command after ``temperature`` is reached.
-        Args:
-            celsius: The target temperature, in °C.
-            hold_time_seconds: The number of seconds to hold, after reaching
-                ``temperature``, before proceeding to the next command.
-            block_max_volume: The maximum volume of any individual well
-                of the loaded labware. If not supplied, the thermocycler
-                will default to 25µL/well.
-        """
-        raise NotImplementedError("set_target_block_temperature not implemented")
+        """Set the target temperature for the well block, in °C."""
+        self._engine_client.thermocycler_set_target_block_temperature(
+            module_id=self.module_id, celsius=celsius, block_max_volume=block_max_volume
+        )
 
     def wait_for_block_temperature(self) -> None:
         """Wait for target block temperature to be reached."""
-        raise NotImplementedError("wait_for_block_temperature not implemented")
+        self._engine_client.thermocycler_wait_for_block_temperature(
+            module_id=self.module_id
+        )
 
     def set_target_lid_temperature(self, celsius: float) -> None:
         """Set the target temperature for the heated lid, in °C."""
-        raise NotImplementedError("set_target_lid_temperature not implemented")
+        self._engine_client.thermocycler_set_target_lid_temperature(
+            module_id=self.module_id, celsius=celsius
+        )
 
     def wait_for_lid_temperature(self) -> None:
         """Wait for target lid temperature to be reached."""
-        raise NotImplementedError("wait_for_lid_temperature not implemented")
+        self._engine_client.thermocycler_wait_for_lid_temperature(
+            module_id=self.module_id
+        )
 
     def execute_profile(
         self,
@@ -223,90 +221,75 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
         repetitions: int,
         block_max_volume: Optional[float] = None,
     ) -> None:
-        """Execute a Thermocycler Profile.
-
-        Profile defined as a cycle of ``steps`` to repeat for a given number of ``repetitions``
-
-        Note:
-            Unlike the :py:meth:`set_block_temperature`, either or both of
-            'hold_time_minutes' and 'hold_time_seconds' must be defined
-            and finite for each step.
-        Args:
-            steps: List of unique steps that make up a single cycle.
-                Each list item should be a dictionary that maps to
-                the parameters of the :py:meth:`set_block_temperature`
-                method with keys 'temperature', 'hold_time_seconds',
-                and 'hold_time_minutes'.
-            repetitions: The number of times to repeat the cycled steps.
-            block_max_volume: The maximum volume of any individual well
-                of the loaded labware. If not supplied, the thermocycler
-                will default to 25µL/well.
-        """
-        raise NotImplementedError("execute_profile not implemented")
+        """Execute a Thermocycler Profile."""
+        self._engine_client.thermocycler_run_profile(
+            module_id=self.module_id, steps=steps, block_max_volume=block_max_volume
+        )
 
     def deactivate_lid(self) -> None:
         """Turn off the heated lid."""
-        raise NotImplementedError("deactivate_lid not implemented")
+        self._engine_client.thermocycler_deactivate_lid(module_id=self.module_id)
 
     def deactivate_block(self) -> None:
         """Turn off the well block temperature controller"""
-        raise NotImplementedError("deactivate_block not implemented")
+        self._engine_client.thermocycler_deactivate_block(module_id=self.module_id)
 
     def deactivate(self) -> None:
         """Turn off the well block temperature controller, and heated lid"""
-        raise NotImplementedError("deactivate not implemented")
+        self._engine_client.thermocycler_deactivate_block(module_id=self.module_id)
+        self._engine_client.thermocycler_deactivate_lid(module_id=self.module_id)
 
     def get_lid_position(self) -> Optional[ThermocyclerLidStatus]:
         """Get the thermocycler's lid position."""
-        raise NotImplementedError("get_lid_position not implemented")
+        return self._sync_module_hardware.lid_status  # type: ignore[no-any-return]
 
     def get_block_temperature_status(self) -> TemperatureStatus:
         """Get the thermocycler's block temperature status."""
-        raise NotImplementedError("get_block_temperature_status not implemented")
+        return self._sync_module_hardware.status  # type: ignore[no-any-return]
 
     def get_lid_temperature_status(self) -> Optional[TemperatureStatus]:
         """Get the thermocycler's lid temperature status."""
-        raise NotImplementedError("get_lid_temperature_status not implemented")
+        return self._sync_module_hardware.lid_temp_status  # type: ignore[no-any-return]
 
     def get_block_temperature(self) -> Optional[float]:
         """Get the thermocycler's current block temperature in °C."""
-        raise NotImplementedError("get_block_temperature not implemented")
+        return self._sync_module_hardware.temperature  # type: ignore[no-any-return]
 
     def get_block_target_temperature(self) -> Optional[float]:
         """Get the thermocycler's target block temperature in °C."""
-        raise NotImplementedError("get_block_target_temperature not implemented")
+        return self._sync_module_hardware.target  # type: ignore[no-any-return]
 
     def get_lid_temperature(self) -> Optional[float]:
         """Get the thermocycler's current lid temperature in °C."""
-        raise NotImplementedError("get_lid_temperature not implemented")
+        return self._sync_module_hardware.lid_temp  # type: ignore[no-any-return]
 
     def get_lid_target_temperature(self) -> Optional[float]:
         """Get the thermocycler's target lid temperature in °C."""
-        raise NotImplementedError("get_lid_target_temperature not implemented")
+        return self._sync_module_hardware.lid_target  # type: ignore[no-any-return]
 
     def get_ramp_rate(self) -> Optional[float]:
-        """Get the thermocycler's current rampe rate in °C/sec."""
-        raise NotImplementedError("get_ramp_rate not implemented")
+        """Get the thermocycler's current ramp rate in °C/sec."""
+        return self._sync_module_hardware.ramp_rate  # type: ignore[no-any-return]
 
     def get_hold_time(self) -> Optional[float]:
         """Get the remaining hold time in seconds."""
-        raise NotImplementedError("get_hold_time not implemented")
+        return self._sync_module_hardware.hold_time  # type: ignore[no-any-return]
 
     def get_total_cycle_count(self) -> Optional[int]:
         """Get number of repetitions for current set cycle."""
-        raise NotImplementedError("get_total_cycle_count not implemented")
+        return self._sync_module_hardware.total_cycle_count  # type: ignore[no-any-return]
 
     def get_current_cycle_index(self) -> Optional[int]:
         """Get index of the current set cycle repetition."""
-        raise NotImplementedError("get_current_cycle_index not implemented")
+        return self._sync_module_hardware.current_cycle_index  # type: ignore[no-any-return]
 
     def get_total_step_count(self) -> Optional[int]:
         """Get number of steps within the current cycle."""
-        raise NotImplementedError("get_total_step_count not implemented")
+        return self._sync_module_hardware.total_step_count  # type: ignore[no-any-return]
 
     def get_current_step_index(self) -> Optional[int]:
         """Get the index of the current step within the current cycle."""
-        raise NotImplementedError("get_current_step_index not implemented")
+        return self._sync_module_hardware.current_step_index  # type: ignore[no-any-return]
 
 
 class HeaterShakerModuleCore(ModuleCore, AbstractHeaterShakerCore[LabwareCore]):

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -291,6 +291,8 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
         if self._repetitions is None:
             return None
         step_index = self._sync_module_hardware.current_step_index
+        # TODO(jbl 2022-10-31) this is intended to work even if execute profile is non-blocking, but it is blocking so
+        #   this is not guaranteed to be accurate
         return (step_index - 1) // self._step_count + 1  # type: ignore[no-any-return]
 
     def get_total_step_count(self) -> Optional[int]:
@@ -302,6 +304,8 @@ class ThermocyclerModuleCore(ModuleCore, AbstractThermocyclerCore[LabwareCore]):
         if self._step_count is None:
             return None
         step_index = self._sync_module_hardware.current_step_index
+        # TODO(jbl 2022-10-31) this is intended to work even if execute profile is non-blocking, but it is blocking so
+        #   this is not guaranteed to be accurate
         return (step_index - 1) % self._step_count + 1  # type: ignore[no-any-return]
 
     def _clear_cycle_counters(self) -> None:

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -287,18 +287,6 @@ class LegacyThermocyclerCore(
         block_max_volume: Optional[float] = None,
     ) -> None:
         """Execute a Thermocycler Profile."""
-        if repetitions <= 0:
-            raise ValueError("repetitions must be a positive integer")
-        for step in steps:
-            if step.get("temperature") is None:
-                raise ValueError("temperature must be defined for each step in cycle")
-            hold_mins = step.get("hold_time_minutes")
-            hold_secs = step.get("hold_time_seconds")
-            if hold_mins is None and hold_secs is None:
-                raise ValueError(
-                    "either hold_time_minutes or hold_time_seconds must be"
-                    "defined for each step in cycle"
-                )
         self._sync_module_hardware.cycle_temperatures(
             steps=steps, repetitions=repetitions, volume=block_max_volume
         )
@@ -316,15 +304,15 @@ class LegacyThermocyclerCore(
         self._sync_module_hardware.deactivate()
 
     def get_lid_position(self) -> Optional[ThermocyclerLidStatus]:
-        """Get the thermoycler's lid position."""
+        """Get the thermocycler's lid position."""
         return self._sync_module_hardware.lid_status  # type: ignore[no-any-return]
 
     def get_block_temperature_status(self) -> TemperatureStatus:
-        """Get the thermoycler's block temperature status."""
+        """Get the thermocycler's block temperature status."""
         return self._sync_module_hardware.status  # type: ignore[no-any-return]
 
     def get_lid_temperature_status(self) -> Optional[TemperatureStatus]:
-        """Get the thermoycler's lid temperature status."""
+        """Get the thermocycler's lid temperature status."""
         return self._sync_module_hardware.lid_temp_status  # type: ignore[no-any-return]
 
     def get_block_temperature(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -540,8 +540,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             and finite for each step.
 
         """
-        if repetitions <= 0:
-            raise ValueError("repetitions must be a positive integer")
+        repetitions = validation.ensure_thermocycler_repetition_count(repetitions)
         validated_steps = validation.ensure_thermocycler_profile_steps(steps)
         self._core.execute_profile(
             steps=validated_steps,

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -540,8 +540,13 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             and finite for each step.
 
         """
+        if repetitions <= 0:
+            raise ValueError("repetitions must be a positive integer")
+        validated_steps = validation.ensure_thermocycler_profile_steps(steps)
         self._core.execute_profile(
-            steps=steps, repetitions=repetitions, block_max_volume=block_max_volume
+            steps=validated_steps,
+            repetitions=repetitions,
+            block_max_volume=block_max_volume,
         )
 
     @publish(command=cmds.thermocycler_deactivate_lid)

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -110,6 +110,13 @@ def ensure_hold_time_seconds(
     return seconds
 
 
+def ensure_thermocycler_repetition_count(repetitions: int) -> int:
+    """Ensure thermocycler repetitions is a positive integer."""
+    if repetitions <= 0:
+        raise ValueError("repetitions must be a positive integer")
+    return repetitions
+
+
 def ensure_thermocycler_profile_steps(
     steps: List[ThermocyclerStep],
 ) -> List[ThermocyclerStep]:

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -128,6 +128,8 @@ def ensure_thermocycler_profile_steps(
             )
         validated_seconds = ensure_hold_time_seconds(hold_secs, hold_mins)
         validated_steps.append(
-            {"temperature": temperature, "hold_time_seconds": validated_seconds}
+            ThermocyclerStep(
+                temperature=temperature, hold_time_seconds=validated_seconds
+            )
         )
     return validated_steps

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Optional
+from typing import List, Dict, Union, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
@@ -9,6 +9,7 @@ from opentrons.hardware_control.modules.types import (
     TemperatureModuleModel,
     ThermocyclerModuleModel,
     HeaterShakerModuleModel,
+    ThermocyclerStep,
 )
 
 
@@ -107,3 +108,26 @@ def ensure_hold_time_seconds(
     if minutes is not None:
         seconds += minutes * 60
     return seconds
+
+
+def ensure_thermocycler_profile_steps(
+    steps: List[ThermocyclerStep],
+) -> List[ThermocyclerStep]:
+    """Ensure thermocycler steps are valid and hold time is expressed in seconds only."""
+    validated_steps = []
+    for step in steps:
+        temperature = step.get("temperature")
+        hold_mins = step.get("hold_time_minutes")
+        hold_secs = step.get("hold_time_seconds")
+        if temperature is None:
+            raise ValueError("temperature must be defined for each step in cycle")
+        if hold_mins is None and hold_secs is None:
+            raise ValueError(
+                "either hold_time_minutes or hold_time_seconds must be"
+                "defined for each step in cycle"
+            )
+        validated_seconds = ensure_hold_time_seconds(hold_secs, hold_mins)
+        validated_steps.append(
+            {"temperature": temperature, "hold_time_seconds": validated_seconds}
+        )
+    return validated_steps

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -1,11 +1,12 @@
 """Synchronous ProtocolEngine client module."""
-from typing import cast, Optional
+from typing import cast, List, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.types import MountType
+from opentrons.hardware_control.modules.types import ThermocyclerStep
 
 from .. import commands
 from ..state import StateView
@@ -257,6 +258,75 @@ class SyncClient:
         )
         result = self._transport.execute_command(request=request)
         return cast(commands.magnetic_module.EngageResult, result)
+
+    def thermocycler_set_target_lid_temperature(
+        self, module_id: str, celsius: float
+    ) -> commands.thermocycler.SetTargetLidTemperatureResult:
+        """Execute a `thermocycler/setTargetLidTemperature` command and return the result."""
+        request = commands.thermocycler.SetTargetLidTemperatureCreate(
+            params=commands.thermocycler.SetTargetLidTemperatureParams(
+                moduleId=module_id, celsius=celsius
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.SetTargetLidTemperatureResult, result)
+
+    def thermocycler_set_target_block_temperature(
+        self, module_id: str, celsius: float, block_max_volume: Optional[float]
+    ) -> commands.thermocycler.SetTargetBlockTemperatureResult:
+        """Execute a `thermocycler/setTargetLidTemperature` command and return the result."""
+        request = commands.thermocycler.SetTargetBlockTemperatureCreate(
+            params=commands.thermocycler.SetTargetBlockTemperatureParams(
+                moduleId=module_id, celsius=celsius, blockMaxVolumeUl=block_max_volume
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.SetTargetBlockTemperatureResult, result)
+
+    def thermocycler_wait_for_lid_temperature(
+        self, module_id: str
+    ) -> commands.thermocycler.WaitForLidTemperatureResult:
+        """Execute a `thermocycler/waitForLidTemperature` command and return the result."""
+        request = commands.thermocycler.WaitForLidTemperatureCreate(
+            params=commands.thermocycler.WaitForLidTemperatureParams(moduleId=module_id)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.WaitForLidTemperatureResult, result)
+
+    def thermocycler_wait_for_block_temperature(
+        self, module_id: str
+    ) -> commands.thermocycler.WaitForBlockTemperatureResult:
+        """Execute a `thermocycler/waitForBlockTemperature` command and return the result."""
+        request = commands.thermocycler.WaitForBlockTemperatureCreate(
+            params=commands.thermocycler.WaitForBlockTemperatureParams(
+                moduleId=module_id
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.WaitForBlockTemperatureResult, result)
+
+    def thermocycler_run_profile(
+        self,
+        module_id: str,
+        steps: List[ThermocyclerStep],
+        block_max_volume: Optional[float],
+    ) -> commands.thermocycler.RunProfileResult:
+        """Execute a `thermocycler/runProfile` command and return the result."""
+        request = commands.thermocycler.RunProfileCreate(
+            params=commands.thermocycler.RunProfileParams(
+                moduleId=module_id,
+                profile=[
+                    commands.thermocycler.RunProfileStepParams(
+                        celsius=step["temperature"],
+                        holdSeconds=step["hold_time_seconds"],
+                    )
+                    for step in steps
+                ],
+                blockMaxVolumeUl=block_max_volume,
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.thermocycler.RunProfileResult, result)
 
     def thermocycler_deactivate_block(
         self, module_id: str

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
@@ -5,6 +5,8 @@ from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
+from opentrons.hardware_control.modules.types import ThermocyclerStep
+
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -65,12 +67,12 @@ class RunProfileImpl(AbstractCommandImpl[RunProfileParams, RunProfileResult]):
         )
 
         steps = [
-            {
-                "temperature": thermocycler_state.validate_target_block_temperature(
+            ThermocyclerStep(
+                temperature=thermocycler_state.validate_target_block_temperature(
                     profile_step.celsius
                 ),
-                "hold_time_seconds": profile_step.holdSeconds,
-            }
+                hold_time_seconds=profile_step.holdSeconds,
+            )
             for profile_step in params.profile
         ]
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -106,7 +106,9 @@ class SetTargetBlockTemperatureCreate(
 ):
     """A request to create a Thermocycler's set block temperature command."""
 
-    commandType: SetTargetBlockTemperatureCommandType
+    commandType: SetTargetBlockTemperatureCommandType = (
+        "thermocycler/setTargetBlockTemperature"
+    )
     params: SetTargetBlockTemperatureParams
 
     _CommandCls: Type[SetTargetBlockTemperature] = SetTargetBlockTemperature

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -83,7 +83,9 @@ class SetTargetLidTemperature(
 class SetTargetLidTemperatureCreate(BaseCommandCreate[SetTargetLidTemperatureParams]):
     """A request to create a Thermocycler's set lid temperature command."""
 
-    commandType: SetTargetLidTemperatureCommandType
+    commandType: SetTargetLidTemperatureCommandType = (
+        "thermocycler/setTargetLidTemperature"
+    )
     params: SetTargetLidTemperatureParams
 
     _CommandCls: Type[SetTargetLidTemperature] = SetTargetLidTemperature

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
@@ -81,7 +81,9 @@ class WaitForBlockTemperature(
 class WaitForBlockTemperatureCreate(BaseCommandCreate[WaitForBlockTemperatureParams]):
     """A request to create Thermocycler's wait for block temperature command."""
 
-    commandType: WaitForBlockTemperatureCommandType
+    commandType: WaitForBlockTemperatureCommandType = (
+        "thermocycler/waitForBlockTemperature"
+    )
     params: WaitForBlockTemperatureParams
 
     _CommandCls: Type[WaitForBlockTemperature] = WaitForBlockTemperature

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
@@ -79,7 +79,7 @@ class WaitForLidTemperature(
 class WaitForLidTemperatureCreate(BaseCommandCreate[WaitForLidTemperatureParams]):
     """A request to create Thermocycler's wait for lid temperature command."""
 
-    commandType: WaitForLidTemperatureCommandType
+    commandType: WaitForLidTemperatureCommandType = "thermocycler/waitForLidTemperature"
     params: WaitForLidTemperatureParams
 
     _CommandCls: Type[WaitForLidTemperature] = WaitForLidTemperature

--- a/api/src/opentrons/protocols/execution/execute_json_v4.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v4.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Dict, List, TYPE_CHECKING, Union
+from opentrons.hardware_control.modules.types import ThermocyclerStep
 from opentrons.protocol_api import (
     ProtocolContext,
     MagneticModuleContext,
@@ -164,7 +165,7 @@ def _thermocycler_run_profile(
 ) -> None:
     volume = params["volume"]
     profile = [
-        {"temperature": p["temperature"], "hold_time_seconds": p["holdTime"]}
+        ThermocyclerStep(temperature=p["temperature"], hold_time_seconds=p["holdTime"])
         for p in params["profile"]
     ]
     module.execute_profile(steps=profile, block_max_volume=volume, repetitions=1)

--- a/api/tests/opentrons/protocol_api/core/engine/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_thermocycler_core.py
@@ -1,0 +1,323 @@
+"""Tests for the engine based Protocol API module core implementations."""
+import pytest
+from decoy import Decoy
+
+from opentrons.drivers.types import ThermocyclerLidStatus
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import Thermocycler, TemperatureStatus
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_api.core.engine.module_core import ThermocyclerModuleCore
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION
+
+SyncThermocyclerHardware = SynchronousAdapter[Thermocycler]
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SyncThermocyclerHardware:
+    """Get a mock synchronous module hardware."""
+    return decoy.mock(name="SyncThermocyclerHardware")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def subject(
+    mock_engine_client: EngineClient,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+) -> ThermocyclerModuleCore:
+    """Get a HeaterShakerModuleCore test subject."""
+    return ThermocyclerModuleCore(
+        module_id="1234",
+        engine_client=mock_engine_client,
+        api_version=MAX_SUPPORTED_VERSION,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+
+def test_create(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+) -> None:
+    """It should be able to create a thermocycler module core."""
+    result = ThermocyclerModuleCore(
+        module_id="1234",
+        engine_client=mock_engine_client,
+        api_version=MAX_SUPPORTED_VERSION,
+        sync_module_hardware=mock_sync_module_hardware,
+    )
+
+    assert result.module_id == "1234"
+
+
+def test_open_lid(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should open the lid with the engine client."""
+    result = subject.open_lid()
+
+    decoy.verify(mock_engine_client.thermocycler_open_lid(module_id="1234"), times=1)
+    assert result == ThermocyclerLidStatus.OPEN
+
+
+def test_close_lid(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should close the lid with the engine client."""
+    result = subject.close_lid()
+
+    decoy.verify(mock_engine_client.thermocycler_close_lid(module_id="1234"), times=1)
+    assert result == ThermocyclerLidStatus.CLOSED
+
+
+def test_set_target_block_temperature(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should set the block temperature with the engine client."""
+    subject.set_target_block_temperature(
+        celsius=42.0,
+        hold_time_seconds=1.2,
+        block_max_volume=3.4,
+    )
+
+    decoy.verify(
+        mock_engine_client.thermocycler_set_target_block_temperature(
+            module_id="1234",
+            celsius=42.0,
+            block_max_volume=3.4,
+        ),
+        times=1,
+    )
+
+
+def test_wait_for_block_temperature(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should wait for the block temperature with the engine client."""
+    subject.wait_for_block_temperature()
+
+    decoy.verify(
+        mock_engine_client.thermocycler_wait_for_block_temperature(module_id="1234"),
+        times=1,
+    )
+
+
+def test_set_target_lid_temperature(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should set the lid temperature with the engine client."""
+    subject.set_target_lid_temperature(celsius=42.0)
+
+    decoy.verify(
+        mock_engine_client.thermocycler_set_target_lid_temperature(
+            module_id="1234", celsius=42.0
+        ),
+        times=1,
+    )
+
+
+def test_wait_for_lid_temperature(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should wait for the lid temperature with the engine client."""
+    subject.wait_for_lid_temperature()
+
+    decoy.verify(
+        mock_engine_client.thermocycler_wait_for_lid_temperature(module_id="1234"),
+        times=1,
+    )
+
+
+def test_execute_profile(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should run a thermocycler profile with the engine client."""
+    subject.execute_profile(
+        steps=[{"temperature": 45.6, "hold_time_seconds": 12.3}],
+        repetitions=2,
+        block_max_volume=78.9,
+    )
+
+    decoy.verify(
+        mock_engine_client.thermocycler_run_profile(
+            module_id="1234",
+            steps=[{"temperature": 45.6, "hold_time_seconds": 12.3}],
+            block_max_volume=78.9,
+        )
+    )
+
+
+def test_deactivate_lid(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should turn of the heated lid with the engine client."""
+    subject.deactivate_lid()
+
+    decoy.verify(
+        mock_engine_client.thermocycler_deactivate_lid(module_id="1234"), times=1
+    )
+
+
+def test_deactivate_block(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should turn of the well block temperature controller with the engine client."""
+    subject.deactivate_block()
+
+    decoy.verify(
+        mock_engine_client.thermocycler_deactivate_block(module_id="1234"), times=1
+    )
+
+
+def test_deactivate(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ThermocyclerModuleCore
+) -> None:
+    """It should turn of the well block temperature controller with the engine client."""
+    subject.deactivate()
+
+    decoy.verify(
+        mock_engine_client.thermocycler_deactivate_block(module_id="1234"),
+        mock_engine_client.thermocycler_deactivate_lid(module_id="1234"),
+    )
+
+
+def test_get_lid_position(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current lid position."""
+    decoy.when(mock_sync_module_hardware.lid_status).then_return(
+        ThermocyclerLidStatus.OPEN
+    )
+    result = subject.get_lid_position()
+    assert result == ThermocyclerLidStatus.OPEN
+
+
+def test_get_block_temperature_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current block temperature status."""
+    decoy.when(mock_sync_module_hardware.status).then_return(TemperatureStatus.IDLE)
+    result = subject.get_block_temperature_status()
+    assert result == TemperatureStatus.IDLE
+
+
+def test_get_lid_temperature_status(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current lid temperature status."""
+    decoy.when(mock_sync_module_hardware.lid_temp_status).then_return(
+        TemperatureStatus.IDLE
+    )
+    result = subject.get_lid_temperature_status()
+    assert result == TemperatureStatus.IDLE
+
+
+def test_get_block_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current block temperature."""
+    decoy.when(mock_sync_module_hardware.temperature).then_return(12.3)
+    result = subject.get_block_temperature()
+    assert result == 12.3
+
+
+def test_get_block_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the target block temperature."""
+    decoy.when(mock_sync_module_hardware.target).then_return(12.3)
+    result = subject.get_block_target_temperature()
+    assert result == 12.3
+
+
+def test_get_lid_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current lid temperature."""
+    decoy.when(mock_sync_module_hardware.lid_temp).then_return(42.0)
+    result = subject.get_lid_temperature()
+    assert result == 42.0
+
+
+def test_get_lid_target_temperature(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current lid temperature."""
+    decoy.when(mock_sync_module_hardware.lid_target).then_return(42.0)
+    result = subject.get_lid_target_temperature()
+    assert result == 42.0
+
+
+def test_get_ramp_rate(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the ramp rate."""
+    decoy.when(mock_sync_module_hardware.ramp_rate).then_return(1.23)
+    result = subject.get_ramp_rate()
+    assert result == 1.23
+
+
+def test_get_hold_time(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the hold time."""
+    decoy.when(mock_sync_module_hardware.hold_time).then_return(13.37)
+    result = subject.get_hold_time()
+    assert result == 13.37
+
+
+def test_get_total_cycle_count(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the total cycle count."""
+    decoy.when(mock_sync_module_hardware.total_cycle_count).then_return(321)
+    result = subject.get_total_cycle_count()
+    assert result == 321
+
+
+def test_get_current_cycle_index(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the current cycle index."""
+    decoy.when(mock_sync_module_hardware.current_cycle_index).then_return(123)
+    result = subject.get_current_cycle_index()
+    assert result == 123
+
+
+def test_get_total_step_count(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
+    subject: ThermocyclerModuleCore,
+) -> None:
+    """It should report the total step count."""
+    decoy.when(mock_sync_module_hardware.total_step_count).then_return(1337)
+    result = subject.get_total_step_count()
+    assert result == 1337

--- a/api/tests/opentrons/protocol_api/core/engine/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_thermocycler_core.py
@@ -294,6 +294,8 @@ def test_get_hold_time(
 
 
 def test_cycle_counting(
+    decoy: Decoy,
+    mock_sync_module_hardware: SyncThermocyclerHardware,
     subject: ThermocyclerModuleCore,
 ) -> None:
     """It should keep track of cycle and step counts and indices."""
@@ -304,10 +306,13 @@ def test_cycle_counting(
         ],
         repetitions=3,
     )
+
+    decoy.when(mock_sync_module_hardware.current_step_index).then_return(6)
+
     assert subject.get_total_cycle_count() == 3
-    assert subject.get_current_cycle_index() == 4
+    assert subject.get_current_cycle_index() == 3
     assert subject.get_total_step_count() == 2
-    assert subject.get_current_step_index() == 3
+    assert subject.get_current_step_index() == 2
 
     subject.deactivate_block()
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -2,8 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from typing import List
-
 from opentrons.types import Mount, Location, Point
 from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.hardware_control import SynchronousAdapter, SyncHardwareAPI
@@ -11,7 +9,6 @@ from opentrons.hardware_control.types import Axis
 from opentrons.hardware_control.modules import Thermocycler, TemperatureStatus
 from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,
-    ThermocyclerStep,
 )
 from opentrons.protocols.geometry.module_geometry import ThermocyclerGeometry
 
@@ -394,58 +391,25 @@ def test_wait_for_lid_temperature(
     decoy.verify(mock_sync_module_hardware.wait_for_lid_target(), times=1)
 
 
-@pytest.mark.parametrize(
-    "steps",
-    [
-        [{"temperature": 42.0, "hold_time_minutes": 12.3, "hold_time_seconds": 45.6}],
-        [{"temperature": 42.0, "hold_time_seconds": 45.6}],
-        [{"temperature": 42.0, "hold_time_minutes": 12.3}],
-        [],
-    ],
-)
 def test_execute_profile(
     decoy: Decoy,
     mock_sync_module_hardware: SyncThermocyclerHardware,
-    steps: List[ThermocyclerStep],
     subject: LegacyThermocyclerCore,
 ) -> None:
     """It should execute a valid profile with the hardware."""
-    subject.execute_profile(steps=steps, repetitions=12, block_max_volume=34.5)
+    subject.execute_profile(
+        steps=[{"temperature": 42.0, "hold_time_seconds": 45.6}],
+        repetitions=12,
+        block_max_volume=34.5,
+    )
 
     decoy.verify(
         mock_sync_module_hardware.cycle_temperatures(
-            steps=steps, repetitions=12, volume=34.5
+            steps=[{"temperature": 42.0, "hold_time_seconds": 45.6}],
+            repetitions=12,
+            volume=34.5,
         )
     )
-
-
-@pytest.mark.parametrize(
-    "repetitions",
-    [0, -1, -999],
-)
-def test_execute_profile_invalid_repetitions_raises(
-    repetitions: int,
-    subject: LegacyThermocyclerCore,
-) -> None:
-    """It should raise a ValueError when given non-positive repetition value."""
-    with pytest.raises(ValueError):
-        subject.execute_profile(steps=[], repetitions=repetitions)
-
-
-@pytest.mark.parametrize(
-    "steps",
-    [
-        [{"hold_time_minutes": 12.3, "hold_time_seconds": 45.6}],
-        [{"temperature": 42.0}],
-    ],
-)
-def test_execute_profile_invalid_steps_raises(
-    steps: List[ThermocyclerStep],
-    subject: LegacyThermocyclerCore,
-) -> None:
-    """It should raise a ValueError when given invalid thermocycler profile steps."""
-    with pytest.raises(ValueError):
-        subject.execute_profile(steps=steps, repetitions=1)
 
 
 def test_deactivate_lid(

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -1,4 +1,5 @@
 """Tests for Protocol API thermocycler module contexts."""
+import inspect
 import pytest
 from decoy import Decoy, matchers
 
@@ -6,8 +7,18 @@ from opentrons.broker import Broker
 from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.hardware_control.modules import TemperatureStatus
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION, ThermocyclerContext
+from opentrons.protocol_api import (
+    MAX_SUPPORTED_VERSION,
+    ThermocyclerContext,
+    validation as mock_validation,
+)
 from opentrons.protocol_api.core.common import ProtocolCore, ThermocyclerCore
+
+
+@pytest.fixture(autouse=True)
+def _mock_validation_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, func in inspect.getmembers(mock_validation, inspect.isfunction):
+        monkeypatch.setattr(mock_validation, name, decoy.mock(func=func))
 
 
 @pytest.fixture
@@ -236,6 +247,10 @@ def test_set_block_temperature(
     subject: ThermocyclerContext,
 ) -> None:
     """It should set the block temperature via the core."""
+    decoy.when(
+        mock_validation.ensure_hold_time_seconds(seconds=1.2, minutes=3.4)
+    ).then_return(5.6)
+
     subject.set_block_temperature(
         temperature=42.0,
         hold_time_seconds=1.2,
@@ -259,7 +274,7 @@ def test_set_block_temperature(
         ),
         mock_core.set_target_block_temperature(
             celsius=42.0,
-            hold_time_seconds=205.2,
+            hold_time_seconds=5.6,
             block_max_volume=7.8,
         ),
         mock_core.wait_for_block_temperature(),
@@ -312,11 +327,26 @@ def test_execute_profile(
     subject: ThermocyclerContext,
 ) -> None:
     """It should execute a thermocycler profile via the core."""
+    decoy.when(mock_validation.ensure_thermocycler_repetition_count(123)).then_return(
+        321
+    )
+    decoy.when(
+        mock_validation.ensure_thermocycler_profile_steps(
+            [
+                {
+                    "temperature": 12.3,
+                    "hold_time_minutes": 12.3,
+                    "hold_time_seconds": 45.6,
+                }
+            ]
+        )
+    ).then_return([{"temperature": 42.0, "hold_time_seconds": 123.456}])
+
     subject.execute_profile(
         steps=[
-            {"temperature": 42.0, "hold_time_minutes": 12.3, "hold_time_seconds": 45.6}
+            {"temperature": 12.3, "hold_time_minutes": 12.3, "hold_time_seconds": 45.6}
         ],
-        repetitions=12,
+        repetitions=123,
         block_max_volume=34.5,
     )
 
@@ -331,7 +361,7 @@ def test_execute_profile(
                         {
                             "steps": [
                                 {
-                                    "temperature": 42.0,
+                                    "temperature": 12.3,
                                     "hold_time_minutes": 12.3,
                                     "hold_time_seconds": 45.6,
                                 }
@@ -345,10 +375,10 @@ def test_execute_profile(
             steps=[
                 {
                     "temperature": 42.0,
-                    "hold_time_seconds": 783.6,
+                    "hold_time_seconds": 123.456,
                 }
             ],
-            repetitions=12,
+            repetitions=321,
             block_max_volume=34.5,
         ),
         mock_broker.publish(
@@ -360,7 +390,7 @@ def test_execute_profile(
                         {
                             "steps": [
                                 {
-                                    "temperature": 42.0,
+                                    "temperature": 12.3,
                                     "hold_time_minutes": 12.3,
                                     "hold_time_seconds": 45.6,
                                 }
@@ -369,28 +399,6 @@ def test_execute_profile(
                     ),
                 }
             ),
-        ),
-    )
-
-
-@pytest.mark.parametrize(
-    "repetitions",
-    [0, -1, -999],
-)
-def test_execute_profile_invalid_repetitions_raises(
-    decoy: Decoy,
-    repetitions: int,
-    mock_broker: Broker,
-    subject: ThermocyclerContext,
-) -> None:
-    """It should raise if given an invalid amount of repetitions."""
-    with pytest.raises(ValueError) as exc_info:
-        subject.execute_profile(steps=[], repetitions=repetitions)
-
-    decoy.verify(
-        mock_broker.publish(
-            "command",
-            matchers.DictMatching({"$": "after", "error": exc_info.value}),
         ),
     )
 

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -345,8 +345,7 @@ def test_execute_profile(
             steps=[
                 {
                     "temperature": 42.0,
-                    "hold_time_minutes": 12.3,
-                    "hold_time_seconds": 45.6,
+                    "hold_time_seconds": 783.6,
                 }
             ],
             repetitions=12,
@@ -370,6 +369,28 @@ def test_execute_profile(
                     ),
                 }
             ),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "repetitions",
+    [0, -1, -999],
+)
+def test_execute_profile_invalid_repetitions_raises(
+    decoy: Decoy,
+    repetitions: int,
+    mock_broker: Broker,
+    subject: ThermocyclerContext,
+) -> None:
+    """It should raise if given an invalid amount of repetitions."""
+    with pytest.raises(ValueError) as exc_info:
+        subject.execute_profile(steps=[], repetitions=repetitions)
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching({"$": "after", "error": exc_info.value}),
         ),
     )
 

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -137,6 +137,20 @@ def test_ensure_hold_time_seconds(
 
 
 @pytest.mark.parametrize(
+    ["repetitions", "expected"],
+    [
+        (1, 1),
+        (2, 2),
+        (999, 999),
+    ],
+)
+def test_ensure_thermocycler_repetition_count(repetitions: int, expected: int) -> None:
+    """It should return a given positive integer."""
+    result = subject.ensure_thermocycler_repetition_count(repetitions)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     "repetitions",
     [
         0,
@@ -170,6 +184,16 @@ def test_ensure_thermocycler_repetition_count_raises(repetitions: int) -> None:
         (
             [{"temperature": 42.0, "hold_time_minutes": 12.3}],
             [{"temperature": 42.0, "hold_time_seconds": 738.0}],
+        ),
+        (
+            [
+                {"temperature": 42.0, "hold_time_seconds": 12.3},
+                {"temperature": 52.0, "hold_time_minutes": 12.3},
+            ],
+            [
+                {"temperature": 42.0, "hold_time_seconds": 12.3},
+                {"temperature": 52.0, "hold_time_seconds": 738.0},
+            ],
         ),
         ([], []),
     ],

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -137,6 +137,20 @@ def test_ensure_hold_time_seconds(
 
 
 @pytest.mark.parametrize(
+    "repetitions",
+    [
+        0,
+        -1,
+        -999,
+    ],
+)
+def test_ensure_thermocycler_repetition_count_raises(repetitions: int) -> None:
+    """It should raise if repetitions is zero or negative."""
+    with pytest.raises(ValueError):
+        subject.ensure_thermocycler_repetition_count(repetitions)
+
+
+@pytest.mark.parametrize(
     ["steps", "expected"],
     [
         (

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -350,6 +350,110 @@ def test_magnetic_module_engage(
     assert result == response
 
 
+def test_thermocycler_set_target_lid_temperature(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's set target lid temperature command."""
+    request = commands.thermocycler.SetTargetLidTemperatureCreate(
+        params=commands.thermocycler.SetTargetLidTemperatureParams(
+            moduleId="module-id", celsius=45.6
+        )
+    )
+    response = commands.thermocycler.SetTargetLidTemperatureResult(
+        targetLidTemperature=45.6
+    )
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_set_target_lid_temperature(
+        module_id="module-id", celsius=45.6
+    )
+
+    assert result == response
+
+
+def test_thermocycler_set_target_block_temperature(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's set target block temperature command."""
+    request = commands.thermocycler.SetTargetBlockTemperatureCreate(
+        params=commands.thermocycler.SetTargetBlockTemperatureParams(
+            moduleId="module-id", celsius=45.6, blockMaxVolumeUl=12.3
+        )
+    )
+    response = commands.thermocycler.SetTargetBlockTemperatureResult(
+        targetBlockTemperature=45.6
+    )
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_set_target_block_temperature(
+        module_id="module-id", celsius=45.6, block_max_volume=12.3
+    )
+
+    assert result == response
+
+
+def test_thermocycler_wait_for_lid_temperature(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's wait for lid temperature command."""
+    request = commands.thermocycler.WaitForLidTemperatureCreate(
+        params=commands.thermocycler.WaitForLidTemperatureParams(moduleId="module-id")
+    )
+    response = commands.thermocycler.WaitForLidTemperatureResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_wait_for_lid_temperature(module_id="module-id")
+
+    assert result == response
+
+
+def test_thermocycler_wait_for_block_temperature(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's wait for block temperature command."""
+    request = commands.thermocycler.WaitForBlockTemperatureCreate(
+        params=commands.thermocycler.WaitForBlockTemperatureParams(moduleId="module-id")
+    )
+    response = commands.thermocycler.WaitForBlockTemperatureResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_wait_for_block_temperature(module_id="module-id")
+
+    assert result == response
+
+
+def test_thermocycler_run_profile(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a Thermocycler's run profile command."""
+    request = commands.thermocycler.RunProfileCreate(
+        params=commands.thermocycler.RunProfileParams(
+            moduleId="module-id",
+            profile=[
+                commands.thermocycler.RunProfileStepParams(
+                    celsius=42.0, holdSeconds=12.3
+                )
+            ],
+            blockMaxVolumeUl=45.6,
+        )
+    )
+    response = commands.thermocycler.RunProfileResult()
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+    result = subject.thermocycler_run_profile(
+        module_id="module-id",
+        steps=[{"temperature": 42.0, "hold_time_seconds": 12.3}],
+        block_max_volume=45.6,
+    )
+
+    assert result == response
+
+
 def test_thermocycler_deactivate_block(
     decoy: Decoy,
     transport: AbstractSyncTransport,


### PR DESCRIPTION
# Overview
Addresses the thermocycler portion of RCORE-257.

Adds engine-based thermocycler module core, using the sync client for all non-read methods of the thermocycler. All read methods use the hardware API for the present moment. Relevant methods have been added to the sync client for thermocycler.

# Changelog
- Implements all methods of the engine-based `ThermocyclerModuleCore`
- Adds relevant thermocycler methods to the `SyncClient`
- Refactored thermocycler profile step validation
- Fixes missing `commandType` defaults for thermocycler command create classes

# Review requests
Regression testing with hardware for all thermocycler methods with the feature flag on.
`make -C robot-server dev OT_API_FF_enableProtocolEnginePAPICore=1`

# Risk assessment
Low, this only touches thermocycler module interactions with the feature flag on (besides simple refactor to execute profile), uses existing methods, and is well-covered by tests.