### PR TITLE
docs(api): Thermocycler GEN2 in Python API

### DIFF
--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -408,7 +408,7 @@ If you only specify a ``temperature`` in °C, the Thermocycler will hold this te
 Hold Time
 ---------
 
-You can optionally instruct the Thermocycler to hold its block temperature for a specific amount of time. You can specify ``hold_time_minutes``, ``hold_time_seconds``, or both (in which case they will be added). For example, this will set the block to 4 °C for 4 minutes and 15 seconds:
+You can optionally instruct the Thermocycler to hold its block temperature for a specific amount of time. You can specify ``hold_time_minutes``, ``hold_time_seconds``, or both (in which case they will be added together). For example, this will set the block to 4 °C for 4 minutes and 15 seconds:
 
 .. code-block:: python
 
@@ -482,103 +482,14 @@ However, this code would generate 60 lines in the protocol's run log, while exec
 
 .. versionadded:: 2.0
 
-Thermocycler Status
-===================
-
-Throughout your protocol, you may want particular information on the current status of your Thermocycler. Below are
-a few methods that allow you to do that.
-
-Basic Status
-------------
-
-..
-    TODO(mm, 2021-09-30): We should be able to cross-reference to ThermocyclerContext.status, but it appears to not actually exist?
-
-The ``ThermocyclerContext.status`` property is one of the strings ``‘holding at target’``, ``‘cooling’``, ``‘heating’``, or ``‘idle’``.
-
-.. code-block:: python
-
-    tc_mod.status
-
-.. versionadded:: 2.0
-
-Lid Position
-------------
-
-The current status of the lid position. It can be one of the strings ``'open'``, ``'closed'`` or ``'in_between'``.
-
-.. code-block:: python
-
-    tc_mod.lid_position
-
-.. versionadded:: 2.0
-
-Heated Lid Temperature Status
------------------------------
-
-The current status of the heated lid temperature controller. It can be one of the strings ``'holding at target'``, ``'heating'``, ``'idle'``,  or ``'error'``.
-
-.. code-block:: python
-
-    tc_mod.lid_temperature_status
-
-.. versionadded:: 2.0
-
-Block Temperature Status
-------------------------
-
-The current status of the well block temperature controller. It can be one of the strings ``'holding at target'``, ``'cooling'``, ``'heating'``, ``'idle'``, or ``'error'``.
-
-.. code-block:: python
-
-    tc_mod.block_temperature_status
-
-.. versionadded:: 2.0
-
-.. _thermocycler-deactivation:
-
-Thermocycler Deactivate
-=======================
-
-At some points in your protocol, you may want to deactivate specific temperature controllers of your Thermocycler. This can be done with three methods,
-:py:meth:`.ThermocyclerContext.deactivate`, :py:meth:`.ThermocyclerContext.deactivate_lid`, :py:meth:`.ThermocyclerContext.deactivate_block`.
-
-Deactivate
-----------
-
-This deactivates both the well block and the heated lid of the Thermocycler.
-
-.. code-block:: python
-
-  tc_mod.deactivate()
-
-Deactivate Lid
---------------
-
-This deactivates only the heated lid of the Thermocycler.
-
-.. code-block:: python
-
-  tc_mod.deactivate_lid()
-
-.. versionadded:: 2.0
-
-Deactivate Block
-----------------
-
-This deactivates only the well block of the Thermocycler.
-
-.. code-block:: python
-
-  tc_mod.deactivate_block()
-
-.. versionadded:: 2.0
-
 
 Changes with the GEN2 Thermocycler Module
 =========================================
 
-TK
+All methods of :py:class:`.ThermocyclerContext` work with both the GEN1 and GEN2 Thermocycler. One difference is that the GEN2 module has an automatic plate lift feature. When executing :py:meth:`~.ThermocyclerContext.open_lid`,  the GEN2 module physically moves the loaded plate upward to make it easier to remove the plate from the module.
+
+.. versionchanged: 2.14
+
 
 .. _heater-shaker-module:
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -412,7 +412,8 @@ You can optionally instruct the Thermocycler to hold its block temperature for a
 
 .. code-block:: python
 
-        tc_mod.set_block_temperature(temperature=4, hold_time_minutes=4,  hold_time_seconds=15)
+        tc_mod.set_block_temperature(temperature=4, hold_time_minutes=4,
+                                     hold_time_seconds=15)
 
 .. note ::
 
@@ -436,20 +437,6 @@ If the Thermocycler assumes these samples are 25 µL, it may not cool them to 4 
 
 .. versionadded:: 2.0
 
-Ramp Rate
----------
-
-Lastly, you can modify the ``ramp_rate`` in °C/sec for a given ``temperature``.
-
-.. code-block:: python
-
-        tc_mod.set_block_temperature(4, hold_time_seconds=60, ramp_rate=0.5)
-
-.. warning::
-
-  Do not modify the ``ramp_rate`` unless you know what you're doing.
-
-.. versionadded:: 2.0
 
 .. _thermocycler-profiles:
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -369,9 +369,9 @@ Lid Control
 
 The Thermocycler can control the position and temperature of its lid. 
 
-To change the lid position, use :py:meth:`~.ThermocyclerContext.open_lid` and :py:meth:`~.ThermocyclerContext.close_lid`  When the lid is open, the pipettes can access the loaded labware. 
+To change the lid position, use :py:meth:`~.ThermocyclerContext.open_lid` and :py:meth:`~.ThermocyclerContext.close_lid`. When the lid is open, the pipettes can access the loaded labware. 
 
-You can also control the target temperature of the lid. Acceptable target temperatures are between 37 and 110 °C. To set the lid temperature, use :py:meth:`~.ThermocyclerContext.set_lid_temperature`, which takes one parameter: the target ``temperature`` (in degrees Celsius) as an integer. For example, to set the lid to 50 °C:
+You can also control the temperature of the lid. Acceptable target temperatures are between 37 and 110 °C. Use :py:meth:`~.ThermocyclerContext.set_lid_temperature`, which takes one parameter: the target ``temperature`` (in degrees Celsius) as an integer. For example, to set the lid to 50 °C:
 
 .. code-block:: python
 
@@ -395,13 +395,13 @@ The Thermocycler can control its block temperature, including holding at a tempe
 Temperature
 -----------
 
-To set the block temperature inside the Thermocycler, use :py:meth:`.ThermocyclerContext.set_block_temperature`. At minimum you have to specify a ``temperature`` in degrees Celsius:
+To set the block temperature inside the Thermocycler, use :py:meth:`~.ThermocyclerContext.set_block_temperature`. At minimum you have to specify a ``temperature`` in degrees Celsius:
 
 .. code-block:: python
 
         tc_mod.set_block_temperature(temperature=4)
         
-If you only specify a ``temperature`` in °C, the Thermocycler will hold this temperature until a new temperature is set, :py:meth:`~.ThermocyclerContext.deactivate_block` is called, or the module is powered off.
+If you don't specify any other parameters, the Thermocycler will hold this temperature until a new temperature is set, :py:meth:`~.ThermocyclerContext.deactivate_block` is called, or the module is powered off.
 
 .. versionadded:: 2.0
 
@@ -417,7 +417,7 @@ You can optionally instruct the Thermocycler to hold its block temperature for a
 
 .. note ::
 
-    Holding at a temperature will block execution of later commands in your protocol. Further commands will proceed once the hold time has elapsed.(If you don't specify a hold time, the protocol will proceed as soon as the target temperature is reached.)
+    Your protocol will not proceed to further commands while holding at a temperature. If you don't specify a hold time, the protocol will proceed as soon as the target temperature is reached.
 
 .. versionadded:: 2.0
 
@@ -443,7 +443,9 @@ If the Thermocycler assumes these samples are 25 µL, it may not cool them to 4 
 Thermocycler Profiles
 =====================
 
-In addition to executing individual temperature commands, the Thermocycler can automatically cycle through a sequence of block temperatures to perform heat-sensitive reactions. These sequences are called *profiles*, which are defined in the Protocol API as lists of dicts. Each dict should have a ``temperature`` key, which specifies the temperature of a profile step, and either or both of ``hold_time_seconds`` or ``hold_time_minutes``, which specify the duration of the step. For instance, this profile commands the Thermocycler to reach 10 °C and hold for 30 seconds, and then to reach 60 °C and hold for 45 seconds:
+In addition to executing individual temperature commands, the Thermocycler can automatically cycle through a sequence of block temperatures to perform heat-sensitive reactions. These sequences are called *profiles*, which are defined in the Protocol API as lists of dicts. Each dict should have a ``temperature`` key, which specifies the temperature of the step, and either or both of ``hold_time_seconds`` and ``hold_time_minutes``, which specify the duration of the step. 
+
+For example, this profile commands the Thermocycler to reach 10 °C and hold for 30 seconds, and then to reach 60 °C and hold for 45 seconds:
 
 .. code-block:: python
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -63,7 +63,10 @@ Some modules were added to the Protocol API later than others, and some modules 
    | GEN2               |                               |                     |
    +--------------------+-------------------------------+---------------------+
    | Thermocycler       | ``thermocycler module``       | 2.0                 |
-   | Module             | or ``thermocycler``           |                     |
+   | Module GEN1        | or ``thermocycler``           |                     |
+   +--------------------+-------------------------------+---------------------+
+   | Thermocycler       | ``thermocycler module gen2``  | 2.14                |
+   | Module GEN2        | or ``thermocyclerModuleV2``   |                     |
    +--------------------+-------------------------------+---------------------+
    | Heater-Shaker      | ``heaterShakerModuleV1``      | 2.13                |
    | Module             |                               |                     |
@@ -319,7 +322,7 @@ Changes with the GEN2 Magnetic Module
 The GEN2 Magnetic Module uses smaller magnets than the GEN1 version.
 This mitigates an issue where beads would be attracted even when the magnets were retracted.
 
-This means it will take longer for the GEN2 module to attract beads.
+This means it will take longer for the GEN2 module to attract beads. If you need additional strength for your application, use the available `Adapter Magnets <https://support.opentrons.com/s/article/Adapter-magnets>`_.
 
 Recommended Magnetic Module GEN2 bead attraction time:
     - Total liquid volume <= 50 uL: 5 minutes
@@ -333,34 +336,33 @@ Using a Thermocycler Module
 ***************************
 
 
-The Thermocycler Module allows users to perform complete experiments that require temperature sensitive reactions such as PCR.
+The Thermocycler Module provides on-deck, fully automated thermocycling and can heat and cool very quickly during operation. The module's block can heat and cool between 4 °C and 99 °C, and the module's lid can heat up to 110 °C.
 
-There are two heating mechanisms in the Thermocycler. One is the block in which samples are located; the other is the lid heating pad.
+The Thermocycler is represented in code by a :py:class:`.ThermocyclerContext` object, which has methods for controlling the lid, controlling the block, and setting *profiles* — timed heating and cooling routines that can be automatically repeated. 
 
-The block can control its temperature between 4 °C and 99 °C to the nearest 1 °C.
-
-The lid can control its temperature between 37 °C to 110 °C. Please see our `support article <https://support.opentrons.com/en/articles/3469797-thermocycler-module>`_ on controlling the Thermocycler in the Opentrons App.
-
-For the purposes of this section, assume we have the following already:
+The examples in this section will use a Thermocycler loaded as follows:
 
 .. code-block:: python
     :substitutions:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
-        tc_mod = protocol.load_module('Thermocycler Module')
+        tc_mod = protocol.load_module('thermocyclerModuleV2')
         plate = tc_mod.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
+        
+The ``location`` parameter of :py:meth:`.load_module` isn't required for the Thermocycler, since it only has one valid deck location, which covers slots 7, 8, 10, and 11. Attempting to load any other modules or labware in these four slots will raise a ``DeckConflictError``. 
 
 .. note::
 
-    When loading the Thermocycler, it is not necessary to specify a slot.
-    This is because the Thermocycler has a default position that covers Slots 7, 8, 10, and 11.
-    This is the only valid location for the Thermocycler on the OT-2 deck.
+    If you want to specify a slot for the Thermocycler (for parallelism with other ``load_module()`` calls in your protocol), you can do so: the only accepted value is ``7``.
 
 .. versionadded:: 2.0
+.. versionchanged:: 2.14
+   Added support for Thermocycler Module GEN2.
+
 
 Lid Motor Control
 =================
@@ -594,6 +596,11 @@ This deactivates only the well block of the Thermocycler.
 
 .. versionadded:: 2.0
 
+
+Changes with the GEN2 Magnetic Module
+=====================================
+
+TK
 
 .. _heater-shaker-module:
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -364,50 +364,29 @@ The ``location`` parameter of :py:meth:`.load_module` isn't required for the The
    Added support for Thermocycler Module GEN2.
 
 
-Lid Motor Control
-=================
+Lid Control
+===========
 
-The Thermocycler can control its temperature with the lid open or closed. When the lid of the Thermocycler is open, the pipettes can access the loaded labware. You can control the lid position with the methods below.
+The Thermocycler can control the position and temperature of its lid. 
 
-Open Lid
---------
+To change the lid position, use :py:meth:`~.ThermocyclerContext.open_lid` and :py:meth:`~.ThermocyclerContext.close_lid`  When the lid is open, the pipettes can access the loaded labware. 
 
-.. code-block:: python
-
-    tc_mod.open_lid()
-
-
-.. versionadded:: 2.0
-
-Close Lid
----------
+You can also control the target temperature of the lid. Acceptable target temperatures are between 37 and 110 °C. To set the lid temperature, use :py:meth:`~.ThermocyclerContext.set_lid_temperature`, which takes one parameter: the target ``temperature`` (in degrees Celsius) as an integer. For example, to set the lid to 50 °C:
 
 .. code-block:: python
 
-    tc_mod.close_lid()
+    tc_mod.set_lid_temperature(50)
+
+The protocol will only proceed once the lid temperature reaches 50 °C. This is the case whether the previous temperature was lower than 50 °C (in which case the lid will actively heat) or higher than 50 °C (in which case the lid will passively cool).
+
+.. note::
+
+    Lid temperature is not affected by Thermocycler profiles. Therefore you should set an appropriate lid temperature to hold during your profile *before* executing it. See :ref:`thermocycler-profiles` for more information on defining and executing profiles.
 
 .. versionadded:: 2.0
 
-Lid Temperature Control
-=======================
-
-You can control when a lid temperature is set. It is recommended that you set
-the lid temperature before executing a Thermocycler profile (see :ref:`thermocycler-profiles`). The range of the Thermocycler lid is
-37 °C to 110 °C.
-
-Set Lid Temperature
--------------------
-
-:py:meth:`.ThermocyclerContext.set_lid_temperature` takes one parameter: the ``temperature`` you wish the lid to be set to. The protocol will only proceed once the lid temperature has been reached.
-
-.. code-block:: python
-
-    tc_mod.set_lid_temperature(temperature)
-
-.. versionadded:: 2.0
-
-Block Temperature Control
-=========================
+Block Control
+=============
 
 To set the block temperature inside the Thermocycler, you can use the method :py:meth:`.ThermocyclerContext.set_block_temperature`. It takes five parameters:
 ``temperature``, ``hold_time_seconds``, ``hold_time_minutes``, ``ramp_rate`` and ``block_max_volume``. Only ``temperature`` is required; the two ``hold_time`` parameters, ``ramp_rate``, and ``block_max_volume`` are optional.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -577,6 +577,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def lid_position(self) -> Optional[str]:
         """One of these possible lid statuses:
+
         - ``closed``: The lid is closed.
         - ``in_between``: The lid is neither open nor closed.
         - ``open``: The lid is open.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -530,14 +530,14 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         repetitions: int,
         block_max_volume: Optional[float] = None,
     ) -> None:
-        """Execute a Thermocycler Profile defined as a cycle of
-        ``steps`` to repeat for a given number of ``repetitions``.
+        """Execute a Thermocycler profile, defined as a cycle of
+        ``steps``, for a given number of ``repetitions``.
 
         :param steps: List of unique steps that make up a single cycle.
                       Each list item should be a dictionary that maps to
                       the parameters of the :py:meth:`set_block_temperature`
-                      method with keys ``temperature``, ``hold_time_seconds``,
-                      and ``hold_time_minutes``.
+                      method with a ``temperature`` key, and either or both of
+                      ``hold_time_seconds`` and ``hold_time_minutes``.
         :param repetitions: The number of times to repeat the cycled steps.
         :param block_max_volume: The greatest volume of liquid contained in any
                                  individual well of the loaded labware, in µL.
@@ -572,15 +572,15 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         """Turn off both the well block temperature controller and the lid heater."""
         self._core.deactivate()
 
+    # TODO(ec, 2022-10-31): what the `max` value means
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_position(self) -> Optional[str]:
-        """One of five possible lid statuses:
+        """One of these possible lid statuses:
         - ``closed``: The lid is closed.
         - ``in_between``: The lid is neither open nor closed.
         - ``open``: The lid is open.
-        - ``unknown``: The status can't be determined.
-        # - ``max``: TODO what MAX means
+        - ``unknown``: The lid position can't be determined.
         """
         return self._core.get_lid_position()
 
@@ -589,12 +589,11 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def block_temperature_status(self) -> str:
         """One of five possible temperature statuses:
 
-        - ``holding at target``: The module has reached its target temperature
+        - ``holding at target``: The block has reached its target temperature
             and is actively maintaining that temperature.
-        - ``cooling``: The module has previously heated and is now passively cooling.
-            `The Heater-Shaker does not have active cooling.`
-        - ``heating``: The module is heating to a target temperature.
-        - ``idle``: The module has not heated since the beginning of the protocol.
+        - ``cooling``: The block is cooling to a target temperature.
+        - ``heating``: The block is heating to a target temperature.
+        - ``idle``: The block has not heated or cooled since the beginning of the protocol.
         - ``error``: The temperature status can't be determined.
         """
         return self._core.get_block_temperature_status()
@@ -604,12 +603,12 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def lid_temperature_status(self) -> Optional[str]:
         """One of five possible temperature statuses:
 
-        - ``holding at target``: The module has reached its target temperature
+        - ``holding at target``: The lid has reached its target temperature
             and is actively maintaining that temperature.
-        - ``cooling``: The module has previously heated and is now passively cooling.
-            `The Heater-Shaker does not have active cooling.`
-        - ``heating``: The module is heating to a target temperature.
-        - ``idle``: The module has not heated since the beginning of the protocol.
+        - ``cooling``: The lid has previously heated and is now passively cooling.
+            `The Thermocycler lid does not have active cooling.`
+        - ``heating``: The lid is heating to a target temperature.
+        - ``idle``: The lid has not heated since the beginning of the protocol.
         - ``error``: The temperature status can't be determined.
         """
         return self._core.get_lid_temperature_status()

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -475,7 +475,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     ) -> None:
         """Set the target temperature for the well block, in °C.
 
-        :param temperature: A value between 4 and 99, representing the target 
+        :param temperature: A value between 4 and 99, representing the target
                             temperature in °C.
         :param hold_time_minutes: The number of minutes to hold, after reaching
                                   ``temperature``, before proceeding to the
@@ -485,8 +485,8 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
                                   ``temperature``, before proceeding to the
                                   next command. If ``hold_time_minutes`` is also
                                   specified, the times are added together.
-        :param block_max_volume: The greatest volume of liquid contained in any 
-                                 individual well of the loaded labware, in µL. 
+        :param block_max_volume: The greatest volume of liquid contained in any
+                                 individual well of the loaded labware, in µL.
                                  If not specified, the default is 25 µL.
 
         .. note:
@@ -510,7 +510,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def set_lid_temperature(self, temperature: float) -> None:
         """Set the target temperature for the heated lid, in °C.
 
-        :param temperature: A value between 37 and 110, representing the target 
+        :param temperature: A value between 37 and 110, representing the target
                             temperature in °C.
 
         .. note:
@@ -539,8 +539,8 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
                       method with keys ``temperature``, ``hold_time_seconds``,
                       and ``hold_time_minutes``.
         :param repetitions: The number of times to repeat the cycled steps.
-        :param block_max_volume: The greatest volume of liquid contained in any 
-                                 individual well of the loaded labware, in µL. 
+        :param block_max_volume: The greatest volume of liquid contained in any
+                                 individual well of the loaded labware, in µL.
                                  If not specified, the default is 25 µL.
 
         .. note:
@@ -588,7 +588,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def block_temperature_status(self) -> str:
         """One of five possible temperature statuses:
-        
+
         - ``holding at target``: The module has reached its target temperature
             and is actively maintaining that temperature.
         - ``cooling``: The module has previously heated and is now passively cooling.
@@ -603,7 +603,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def lid_temperature_status(self) -> Optional[str]:
         """One of five possible temperature statuses:
-        
+
         - ``holding at target``: The module has reached its target temperature
             and is actively maintaining that temperature.
         - ``cooling``: The module has previously heated and is now passively cooling.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -572,7 +572,6 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         """Turn off both the well block temperature controller and the lid heater."""
         self._core.deactivate()
 
-    # TODO(ec, 2022-10-31): what the `max` value means
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_position(self) -> Optional[str]:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Adding info on the Thermocycler GEN2 to the Python API docs.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Full edit of the Thermocycler section on the Hardware Modules page.
- Copy pass on docstrings for `ThermocyclerContext`

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Sandbox links: [Hardware Modules section](http://sandbox.docs.opentrons.com/docs-tcgen2/v2/new_modules.html#thermocycler-module), [API reference section](http://sandbox.docs.opentrons.com/docs-tcgen2/v2/new_protocol_api.html#opentrons.protocol_api.ThermocyclerContext)

Are all descriptions of GEN2 behavior accurate? Is anything missing?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Docs only.