### PR TITLE
refactor(shared-data): add off deck to python v6 schema file as param

### DIFF
--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -38,7 +38,7 @@ class Params(BaseModel):
     pipetteId: Optional[str]
     mount: Optional[str]
     moduleId: Optional[str]
-    location: Union[Optional[Location], Literal['offDeck']]
+    location: Optional[Union[Location, Literal["offDeck"]]]
     labwareId: Optional[str]
     displayName: Optional[str]
     liquidId: Optional[str]

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -67,7 +67,7 @@ class Params(BaseModel):
     # there is moveLabware support in PAPIv2, this is only to unblock
     # internal testing of LPC with JSON protocols that include
     # 'moveLabware' commands in the meantime
-    newLocation: Union[Optional[Location], Literal['offDeck']]
+    newLocation: Optional[Union[Location, Literal["offDeck"]]]
     strategy: Optional[str]
 
 

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, validator
-from typing import Any, List, Optional, Dict
+from typing import Any, List, Optional, Dict, Union
 from typing_extensions import Literal
 from enum import Enum
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
@@ -38,7 +38,7 @@ class Params(BaseModel):
     pipetteId: Optional[str]
     mount: Optional[str]
     moduleId: Optional[str]
-    location: Optional[Location]
+    location: Union[Optional[Location], Literal['offDeck']]
     labwareId: Optional[str]
     displayName: Optional[str]
     liquidId: Optional[str]
@@ -67,7 +67,7 @@ class Params(BaseModel):
     # there is moveLabware support in PAPIv2, this is only to unblock
     # internal testing of LPC with JSON protocols that include
     # 'moveLabware' commands in the meantime
-    newLocation: Optional[Location]
+    newLocation: Union[Optional[Location], Literal['offDeck']]
     strategy: Optional[str]
 
 


### PR DESCRIPTION
# Overview

As a short term shim to allow internal JSON protocols to take advantage of the new `offDeck`  Location param, this updates the protocol schema v6 spec in python to reflect that addition.


