### PR TITLE
fix(app): match module initial load info on resulting id

### DIFF
--- a/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
@@ -30,14 +30,14 @@ export function getLabwareLocationCombos(
           : appendLocationComboIfUniq(acc, {
               location: modLocation,
               definitionUri,
-              labwareId: command.params.labwareId,
+              labwareId: command.result.labwareId,
               moduleId,
             })
       } else {
         return appendLocationComboIfUniq(acc, {
           location: command.params.location,
           definitionUri,
-          labwareId: command.params.labwareId,
+          labwareId: command.result.labwareId,
         })
       }
     } else if (command.commandType === 'moveLabware') {

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getModuleInitialLoadInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getModuleInitialLoadInfo.test.ts
@@ -1,9 +1,7 @@
 import _protocolWithMagTempTC from '@opentrons/shared-data/protocol/fixtures/6/transferSettings.json'
-import _protocolWithMultipleTemps from '@opentrons/shared-data/protocol/fixtures/6/multipleTempModules.json'
-import _standardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
 import { getModuleInitialLoadInfo } from '../getModuleInitialLoadInfo'
 import { ProtocolAnalysisFile } from '@opentrons/shared-data'
-import { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+import type { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
 const protocolWithMagTempTC = (_protocolWithMagTempTC as unknown) as ProtocolAnalysisFile
 
@@ -12,24 +10,12 @@ describe('getModuleInitialLoadInfo', () => {
     const TC_ID: keyof typeof _protocolWithMagTempTC.modules =
       '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType'
 
-    const LOAD_TC_COMMAND = {
-      id: '4',
-      commandType: 'loadModule',
-      params: {
-        moduleId: '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType',
-        location: {
-          slotName: '7',
-        },
-      },
-      result: {
-        moduleId: '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType',
-      },
-    }
-
     expect(
       getModuleInitialLoadInfo(TC_ID, protocolWithMagTempTC.commands)
     ).toEqual({
-      location: LOAD_TC_COMMAND.params.location,
+      location: {
+        slotName: '7',
+      },
       protocolLoadOrder: 2,
     })
   })

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getModuleInitialLoadInfo.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getModuleInitialLoadInfo.test.ts
@@ -1,0 +1,54 @@
+import _protocolWithMagTempTC from '@opentrons/shared-data/protocol/fixtures/6/transferSettings.json'
+import _protocolWithMultipleTemps from '@opentrons/shared-data/protocol/fixtures/6/multipleTempModules.json'
+import _standardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
+import { getModuleInitialLoadInfo } from '../getModuleInitialLoadInfo'
+import { ProtocolAnalysisFile } from '@opentrons/shared-data'
+import { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+
+const protocolWithMagTempTC = (_protocolWithMagTempTC as unknown) as ProtocolAnalysisFile
+
+describe('getModuleInitialLoadInfo', () => {
+  it('should gather protocol module info for tc if id in params', () => {
+    const TC_ID: keyof typeof _protocolWithMagTempTC.modules =
+      '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType'
+
+    const LOAD_TC_COMMAND = {
+      id: '4',
+      commandType: 'loadModule',
+      params: {
+        moduleId: '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType',
+        location: {
+          slotName: '7',
+        },
+      },
+      result: {
+        moduleId: '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType',
+      },
+    }
+
+    expect(
+      getModuleInitialLoadInfo(TC_ID, protocolWithMagTempTC.commands)
+    ).toEqual({
+      location: LOAD_TC_COMMAND.params.location,
+      protocolLoadOrder: 2,
+    })
+  })
+  it('should gather protocol module info for tc if id not in params', () => {
+    const TC_ID: keyof typeof _protocolWithMagTempTC.modules =
+      '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType'
+
+    const LOAD_TC_COMMAND: LoadModuleRunTimeCommand = {
+      id: '4',
+      commandType: 'loadModule',
+      params: { location: { slotName: '7' } },
+      result: {
+        moduleId: '3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType',
+      },
+    } as any
+
+    expect(getModuleInitialLoadInfo(TC_ID, [LOAD_TC_COMMAND])).toEqual({
+      location: LOAD_TC_COMMAND.params.location,
+      protocolLoadOrder: 0,
+    })
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/utils/getModuleInitialLoadInfo.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getModuleInitialLoadInfo.ts
@@ -15,7 +15,7 @@ export const getModuleInitialLoadInfo = (
   const moduleLoadIndex = commands.findIndex(
     (command: RunTimeCommand): command is LoadModuleRunTimeCommand =>
       command.commandType === 'loadModule' &&
-      command.params.moduleId === moduleId
+      command.result.moduleId === moduleId
   )
 
   if (moduleLoadIndex === -1) {

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
@@ -59,7 +59,13 @@ export function getPrepCommands(
             ...acc,
             {
               ...command,
-              params: { ...command.params, location: 'offDeck' },
+              params: {
+                ...command.params,
+                location: 'offDeck',
+                // python protocols won't have labwareId in the params, we want to
+                // use the same labwareIds that came back as the result of analysis
+                labwareId: command.result.labwareId,
+              },
             },
           ]
         }

--- a/shared-data/protocol/fixtures/6/multipleTempModules.json
+++ b/shared-data/protocol/fixtures/6/multipleTempModules.json
@@ -4584,6 +4584,9 @@
         "location": {
           "slotName": "1"
         }
+      },
+      "result": {
+        "moduleId": "3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType"
       }
     },
     {
@@ -4594,6 +4597,9 @@
         "location": {
           "slotName": "3"
         }
+      },
+      "result": {
+        "moduleId": "3e0283e0-3412-11eb-ad93-ed232a2337cf:temperatureModuleType1"
       }
     },
     {
@@ -4604,6 +4610,9 @@
         "location": {
           "slotName": "7"
         }
+      },
+      "result": {
+        "moduleId": "3e039550-3412-11eb-ad93-ed232a2337cf:temperatureModuleType2"
       }
     },
     {


### PR DESCRIPTION
# Overview

Instead of matching modules from the top-level modules entity key by the moduleId within the params of a command, use the resulting id

Closes RAUT-273

# Review requests

- navigate to the Run Detail page for a python protocol  that includes usage of a module

# Risk assessment
low