### PR TITLE
feat(ot3): save pipette offset calibrations

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -42,7 +42,8 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
             sensor_threshold_pf=1.0,
         ),
         search_initial_tolerance_mm=5.0,
-        search_iteration_limit=10
+        search_iteration_limit=10,
+        nominal_center=(228, 150, 0),
     ),
     probe_length=34.5,
 )
@@ -356,6 +357,7 @@ def _build_default_edge_sense(
         search_iteration_limit=from_conf.get(
             "search_iteration_limit", default.search_iteration_limit
         ),
+        nominal_center=from_conf.get("nominal_center", default.nominal_center),
     )
 
 

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -20,7 +20,7 @@ DEFAULT_PIPETTE_OFFSET = [0.0, 0.0, 0.0]
 
 DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSettings(
     z_offset=ZSenseSettings(
-        point=(209, 170, 0),
+        point=(239, 160, 1),
         pass_settings=CapacitivePassSettings(
             prep_distance_mm=3,
             max_overrun_distance_mm=3,
@@ -29,10 +29,10 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
         ),
     ),
     edge_sense=EdgeSenseSettings(
-        plus_x_pos=(219, 150, 0),
-        minus_x_pos=(199, 150, 0),
-        plus_y_pos=(209, 160, 0),
-        minus_y_pos=(209, 140, 0),
+        plus_x_pos=(239, 140, 0),
+        minus_x_pos=(212, 140, 0),
+        plus_y_pos=(225, 160, 0),
+        minus_y_pos=(225, 135, 0),
         overrun_tolerance_mm=0.5,
         early_sense_tolerance_mm=0.2,
         pass_settings=CapacitivePassSettings(

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -29,10 +29,10 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
         ),
     ),
     edge_sense=EdgeSenseSettings(
-        plus_x_pos=(239, 140, 0),
-        minus_x_pos=(212, 140, 0),
-        plus_y_pos=(225, 160, 0),
-        minus_y_pos=(225, 135, 0),
+        plus_x_pos=(239, 150, 0),
+        minus_x_pos=(217, 150, 0),
+        plus_y_pos=(228, 161, 0),
+        minus_y_pos=(228, 139, 0),
         overrun_tolerance_mm=0.5,
         early_sense_tolerance_mm=0.2,
         pass_settings=CapacitivePassSettings(
@@ -42,7 +42,7 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
             sensor_threshold_pf=1.0,
         ),
         search_initial_tolerance_mm=5.0,
-        search_iteration_limit=10,
+        search_iteration_limit=10
     ),
     probe_length=34.5,
 )

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -44,6 +44,7 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
         search_initial_tolerance_mm=5.0,
         search_iteration_limit=10,
     ),
+    probe_length=34.5,
 )
 
 ROBOT_CONFIG_VERSION: Final = 1
@@ -366,6 +367,7 @@ def _build_default_calibration(
         edge_sense=_build_default_edge_sense(
             from_conf.get("edge_sense", {}), default.edge_sense
         ),
+        probe_length=from_conf.get("probe_length", default.probe_length),
     )
 
 

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -146,6 +146,7 @@ class EdgeSenseSettings:
     pass_settings: CapacitivePassSettings
     search_initial_tolerance_mm: float
     search_iteration_limit: int
+    nominal_center: Offset
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -152,6 +152,7 @@ class EdgeSenseSettings:
 class OT3CalibrationSettings:
     z_offset: ZSenseSettings
     edge_sense: EdgeSenseSettings
+    probe_length: float
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
@@ -10,6 +10,7 @@ from opentrons.calibration_storage import (
     helpers,
     load_tip_length_calibration,
     get_pipette_offset,
+    save_pipette_calibration,
 )
 from opentrons.hardware_control.types import OT3Mount
 
@@ -95,6 +96,25 @@ def load_pipette_offset(
                 ),
             )
     return pip_cal_obj
+
+
+def save_pipette_offset_calibration(
+    pip_id: typing.Optional[str],
+    mount: typing.Union[Mount, OT3Mount],
+    offset: Point,
+    tiprack_hash: str,
+    tiprack_uri: str,
+) -> None:
+    # TODO this can be removed once we switch to using
+    # ot3 pipette types in the ot3 hardware controller.
+    if isinstance(mount, OT3Mount):
+        checked_mount = mount.to_mount()
+    else:
+        checked_mount = mount
+    if pip_id:
+        save_pipette_calibration(
+            offset, pip_id, checked_mount, tiprack_hash, tiprack_uri
+        )
 
 
 # TODO (lc 09-26-2022) We should ensure that only LabwareDefinition models are passed

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -143,9 +143,12 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
         # Update the cached dict representation
         self._config_as_dict = asdict(self._config)
 
-    def reset_pipette_offset(self, mount: MountType) -> None:
+    def reset_pipette_offset(self, mount: MountType, to_default: bool) -> None:
         """Reset the pipette offset to system defaults."""
-        self._pipette_offset = load_pipette_offset(pip_id=None, mount=mount)
+        if to_default:
+            self._pipette_offset = load_pipette_offset(pip_id=None, mount=mount)
+        else:
+            self._pipette_offset = load_pipette_offset(self._pipette_id, mount)
 
     def save_pipette_offset(self, mount: MountType, offset: Point) -> None:
         """Update the pipette offset to a new value."""

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -14,8 +14,13 @@ from opentrons.types import Point
 from opentrons.config import pipette_config, robot_configs, feature_flags
 from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.drivers.types import MoveSplit
+from opentrons.hardware_control.types import OT3Mount
 from ..instrument_abc import AbstractInstrument, MountType
-from ..ot3.instrument_calibration import save_pipette_offset_calibration
+from ..ot3.instrument_calibration import (
+    save_pipette_offset_calibration,
+    load_pipette_offset as ot3_pipette_offset,
+    PipetteOffsetByPipetteMount as OT3PipetteOffsetByPipetteMount,
+)
 from .instrument_calibration import (
     PipetteOffsetByPipetteMount,
     load_pipette_offset,
@@ -44,6 +49,13 @@ mod_log = logging.getLogger(__name__)
 
 INTERNOZZLE_SPACING_MM: Final[float] = 9
 
+# TODO (lc 11-1-2022) We need to separate out the pipette object
+# into a separate category for OT2 vs OT3 pipettes. At which point
+# this union will be unneccessary
+OffsetCalibrationType = Union[
+    PipetteOffsetByPipetteMount, OT3PipetteOffsetByPipetteMount
+]
+
 
 class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
     """A class to gather and track pipette state and configs.
@@ -58,7 +70,7 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
     def __init__(
         self,
         config: pipette_config.PipetteConfig,
-        pipette_offset_cal: PipetteOffsetByPipetteMount,
+        pipette_offset_cal: OffsetCalibrationType,
         pipette_id: Optional[str] = None,
     ) -> None:
         self._config = config
@@ -122,7 +134,7 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
         return self._nozzle_offset
 
     @property
-    def pipette_offset(self) -> PipetteOffsetByPipetteMount:
+    def pipette_offset(self) -> OffsetCalibrationType:
         return self._pipette_offset
 
     def update_config_item(self, elem_name: str, elem_val: Any) -> None:
@@ -140,8 +152,14 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
         # TODO (lc 10-31-2022) We should have this command be supported properly by
         # ot-3 and ot-2 when we split out the pipette class
         if feature_flags.enable_ot3_hardware_controller():
-            save_pipette_offset_calibration(self._pipette_id, mount, offset)
-        self._pipette_offset = load_pipette_offset(self._pipette_id, mount)
+            save_pipette_offset_calibration(
+                self._pipette_id, OT3Mount.from_mount(mount), offset
+            )
+            self._pipette_offset = ot3_pipette_offset(
+                self._pipette_id, OT3Mount.from_mount(mount)
+            )
+        else:
+            self._pipette_offset = load_pipette_offset(self._pipette_id, mount)
 
     @property
     def name(self) -> PipetteName:
@@ -371,7 +389,7 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
 def _reload_and_check_skip(
     new_config: pipette_config.PipetteConfig,
     attached_instr: Pipette,
-    pipette_offset: PipetteOffsetByPipetteMount,
+    pipette_offset: OffsetCalibrationType,
 ) -> Tuple[Pipette, bool]:
     # Once we have determined that the new and attached pipettes
     # are similar enough that we might skip, see if the configs
@@ -404,7 +422,7 @@ def load_from_config_and_check_skip(
     attached: Optional[Pipette],
     requested: Optional[PipetteName],
     serial: Optional[str],
-    pipette_offset: PipetteOffsetByPipetteMount,
+    pipette_offset: OffsetCalibrationType,
 ) -> Tuple[Optional[Pipette], bool]:
     """
     Given the pipette config for an attached pipette (if any) freshly read

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -128,6 +128,23 @@ class PipetteHandlerProvider(Generic[MountType]):
         else:
             _reset(mount)
 
+    def reset_instrument_offset(self, mount: MountType) -> None:
+        """
+        Tempoarily rest the pipette offset to default values.
+        :param mount: Modify the given mount.
+        """
+        pipette = self.get_pipette(mount)
+        pipette.reset_pipette_offset(mount)
+
+    def save_instrument_offset(self, mount: MountType, delta: top_types.Point) -> None:
+        """
+        Save a new instrument offset the pipette offset to a particular value.
+        :param mount: Modify the given mount.
+        :param delta: The offset to set for the pipette.
+        """
+        pipette = self.get_pipette(mount)
+        pipette.save_pipette_offset(mount, delta)
+
     # TODO(mc, 2022-01-11): change returned map value type to `Optional[PipetteDict]`
     # instead of potentially returning an empty dict
     def get_attached_instruments(self) -> Dict[MountType, PipetteDict]:

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -128,13 +128,13 @@ class PipetteHandlerProvider(Generic[MountType]):
         else:
             _reset(mount)
 
-    def reset_instrument_offset(self, mount: MountType) -> None:
+    def reset_instrument_offset(self, mount: MountType, to_default: bool) -> None:
         """
-        Tempoarily rest the pipette offset to default values.
+        Temporarily reset the pipette offset to default values.
         :param mount: Modify the given mount.
         """
         pipette = self.get_pipette(mount)
-        pipette.reset_pipette_offset(mount)
+        pipette.reset_pipette_offset(mount, to_default)
 
     def save_instrument_offset(self, mount: MountType, delta: top_types.Point) -> None:
         """

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -13,7 +13,11 @@ from opentrons.hardware_control.types import (
     GripperJawState,
     InvalidMoveError,
 )
-from .instrument_calibration import GripperCalibrationOffset
+from .instrument_calibration import (
+    GripperCalibrationOffset,
+    load_gripper_calibration_offset,
+    save_gripper_calibration_offset,
+)
 from ..instrument_abc import AbstractInstrument
 from opentrons.hardware_control.dev_types import AttachedGripper, GripperDict
 
@@ -94,10 +98,14 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
     def gripper_id(self) -> str:
         return self._gripper_id
 
-    def update_calibration_offset(self, cal_offset: GripperCalibrationOffset) -> None:
-        """Update gripper calibration offset."""
-        self._log.info(f"update gripper offset to: {cal_offset}")
-        self._calibration_offset = cal_offset
+    def reset_offset(self) -> None:
+        """Tempoarily reset the gripper offsets to default values."""
+        self._calibration_offset = load_gripper_calibration_offset(gripper_id=None)
+
+    def save_offset(self, delta: Point) -> None:
+        """Tempoarily reset the gripper offsets to default values."""
+        save_gripper_calibration_offset(self._gripper_id, delta)
+        self._calibration_offset = load_gripper_calibration_offset(self._gripper_id)
 
     def critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         """

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -98,9 +98,14 @@ class Gripper(AbstractInstrument[gripper_config.GripperConfig]):
     def gripper_id(self) -> str:
         return self._gripper_id
 
-    def reset_offset(self) -> None:
+    def reset_offset(self, to_default: bool) -> None:
         """Tempoarily reset the gripper offsets to default values."""
-        self._calibration_offset = load_gripper_calibration_offset(gripper_id=None)
+        if to_default:
+            self._calibration_offset = load_gripper_calibration_offset(gripper_id=None)
+        else:
+            self._calibration_offset = load_gripper_calibration_offset(
+                gripper_id=self._gripper_id
+            )
 
     def save_offset(self, delta: Point) -> None:
         """Tempoarily reset the gripper offsets to default values."""

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -60,6 +60,22 @@ class GripperHandler:
     def gripper(self, gripper: Optional[Gripper] = None) -> None:
         self._gripper = gripper
 
+    def reset_instrument_offset(self) -> None:
+        """
+        Tempoarily reset the gripper offsets to default values.
+        """
+        gripper = self.get_gripper()
+        gripper.reset_offset()
+
+    def save_instrument_offset(self, delta: Point) -> None:
+        """
+        Save a new instrument offset the pipette offset to a particular value.
+        :param mount: Modify the given mount.
+        :param delta: The offset to set for the pipette.
+        """
+        gripper = self.get_gripper()
+        gripper.save_offset(delta)
+
     def get_critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         if not self._gripper:
             raise GripperNotAttachedError()

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -60,12 +60,12 @@ class GripperHandler:
     def gripper(self, gripper: Optional[Gripper] = None) -> None:
         self._gripper = gripper
 
-    def reset_instrument_offset(self) -> None:
+    def reset_instrument_offset(self, to_default: bool) -> None:
         """
         Tempoarily reset the gripper offsets to default values.
         """
         gripper = self.get_gripper()
-        gripper.reset_offset()
+        gripper.reset_offset(to_default)
 
     def save_instrument_offset(self, delta: Point) -> None:
         """

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -6,7 +6,10 @@ from opentrons.config.robot_configs import (
     default_pipette_offset,
     default_gripper_calibration_offset,
 )
-from opentrons.types import Point
+from opentrons.types import Point, Mount
+
+# TODO change this when imports are fixed
+from opentrons.calibration_storage.ot3.pipette_offset import save_pipette_calibration
 from opentrons.calibration_storage import (
     types as cal_top_types,
     get_pipette_offset,
@@ -73,6 +76,19 @@ def load_pipette_offset(
     return pip_cal_obj
 
 
+def save_pipette_offset_calibration(
+    pip_id: typing.Optional[str], mount: typing.Union[Mount, OT3Mount], offset: Point
+) -> None:
+    # TODO this can be removed once we switch to using
+    # ot3 pipette types in the ot3 hardware controller.
+    if isinstance(mount, OT3Mount):
+        checked_mount = mount.to_mount()
+    else:
+        checked_mount = mount
+    if pip_id:
+        save_pipette_calibration(offset, pip_id, checked_mount)
+
+
 def load_gripper_calibration_offset(
     gripper_id: typing.Optional[str],
 ) -> GripperCalibrationOffset:
@@ -96,3 +112,10 @@ def load_gripper_calibration_offset(
                 ),
             )
     return grip_cal_obj
+
+
+def save_gripper_calibration_offset(
+    gripper_id: typing.Optional[str], delta: Point
+) -> None:
+    if gripper_id and ff.enable_ot3_hardware_controller():
+        ot3_gripper_offset.save_gripper_calibration(delta, gripper_id)

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -412,6 +412,7 @@ async def calibrate_mount(
     # also be used to baseline the edge detection points.
     # reset instrument offset
     await hcapi.reset_instrument_offset(mount)
+    await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
     z_pos = await find_deck_position(hcapi, mount)
     LOG.info(f"Found deck at {z_pos}mm")
 
@@ -429,4 +430,5 @@ async def calibrate_mount(
     # save new offset
     # reload
     await hcapi.save_instrument_offset(mount, center)
+    await hcapi.remove_tip(mount)
     return center

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -410,6 +410,8 @@ async def calibrate_mount(
     """
     # First, find the deck. This will become our z offset value, and will
     # also be used to baseline the edge detection points.
+    # reset instrument offset
+    await hcapi.reset_instrument_offset(mount)
     z_pos = await find_deck_position(hcapi, mount)
     LOG.info(f"Found deck at {z_pos}mm")
 
@@ -424,4 +426,7 @@ async def calibrate_mount(
     # the absolute sense value out-of-plane
     center = Point(x_center, y_center, z_pos)
     LOG.info(f"Found calibration value {center} for mount {mount.name}")
+    # save new offset
+    # reload
+    await hcapi.save_instrument_offset(mount, center)
     return center

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -427,8 +427,11 @@ async def calibrate_mount(
     # the absolute sense value out-of-plane
     center = Point(x_center, y_center, z_pos)
     LOG.info(f"Found calibration value {center} for mount {mount.name}")
+    instrument_offset = center - Point(
+        *hcapi.config.calibration.edge_sense.nominal_center
+    )
     # save new offset
     # reload
-    await hcapi.save_instrument_offset(mount, center)
+    await hcapi.save_instrument_offset(mount, instrument_offset)
     await hcapi.remove_tip(mount)
     return center

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -443,7 +443,7 @@ class OT3API(
             self._pipette_handler.hardware_instruments[mount],
             req_instr,
             pip_id,
-            pip_offset_cal,  # type: ignore[arg-type]
+            pip_offset_cal,
         )
         self._pipette_handler.hardware_instruments[mount] = p
         if req_instr and p:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1383,14 +1383,14 @@ class OT3API(
             self._pipette_handler.reset_instrument(checked_mount)
 
     async def reset_instrument_offset(
-        self, mount: Union[top_types.Mount, OT3Mount]
+        self, mount: Union[top_types.Mount, OT3Mount], to_default: bool = True
     ) -> None:
         """Reset the given instrument to system offsets."""
         checked_mount = OT3Mount.from_mount(mount)
         if checked_mount == OT3Mount.GRIPPER:
-            self._gripper_handler.reset_instrument_offset()
+            self._gripper_handler.reset_instrument_offset(to_default)
         else:
-            self._pipette_handler.reset_instrument_offset(checked_mount)
+            self._pipette_handler.reset_instrument_offset(checked_mount, to_default)
 
     async def save_instrument_offset(
         self, mount: Union[top_types.Mount, OT3Mount], delta: top_types.Point

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1382,6 +1382,26 @@ class OT3API(
         else:
             self._pipette_handler.reset_instrument(checked_mount)
 
+    async def reset_instrument_offset(
+        self, mount: Union[top_types.Mount, OT3Mount]
+    ) -> None:
+        """Reset the given instrument to system offsets."""
+        checked_mount = OT3Mount.from_mount(mount)
+        if checked_mount == OT3Mount.GRIPPER:
+            self._gripper_handler.reset_instrument_offset()
+        else:
+            self._pipette_handler.reset_instrument_offset(checked_mount)
+
+    async def save_instrument_offset(
+        self, mount: Union[top_types.Mount, OT3Mount], delta: top_types.Point
+    ) -> None:
+        """Save a new offset for a given instrument."""
+        checked_mount = OT3Mount.from_mount(mount)
+        if checked_mount == OT3Mount.GRIPPER:
+            self._gripper_handler.save_instrument_offset(delta)
+        else:
+            self._pipette_handler.save_instrument_offset(checked_mount, delta)
+
     def get_attached_pipette(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -437,7 +437,7 @@ class OT3API(
         """Set up pipette based on scanned information."""
         config = instrument_data.get("config")
         pip_id = instrument_data.get("id")
-        pip_offset_cal = load_pipette_offset(pip_id, mount.to_mount())  # type: ignore[arg-type]
+        pip_offset_cal = load_pipette_offset(pip_id, mount)
         p, may_skip = load_from_config_and_check_skip(
             config,
             self._pipette_handler.hardware_instruments[mount],

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -199,5 +199,6 @@ ot3_dummy_settings = {
             "search_initial_tolerance_mm": 18,
             "search_iteration_limit": 3,
         },
+        "probe_length": 40,
     },
 }

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -198,6 +198,7 @@ ot3_dummy_settings = {
             },
             "search_initial_tolerance_mm": 18,
             "search_iteration_limit": 3,
+            "nominal_center": [8, 8, 0],
         },
         "probe_length": 40,
     },

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1,10 +1,10 @@
 """ Tests for behaviors specific to the OT3 hardware controller.
 """
-from typing import cast, Iterator, Union, Dict
+from typing import cast, Iterator, Union, Dict, Tuple
 from typing_extensions import Literal
 from math import copysign
 import pytest
-from mock import AsyncMock, patch
+from mock import AsyncMock, patch, Mock
 from opentrons.config.types import GantryLoad, CapacitivePassSettings
 from opentrons.hardware_control.dev_types import (
     InstrumentDict,
@@ -12,7 +12,9 @@ from opentrons.hardware_control.dev_types import (
 )
 from opentrons.hardware_control.instruments.ot3.gripper_handler import (
     GripError,
+    GripperHandler,
 )
+from opentrons.hardware_control.instruments.ot2.pipette_handler import OT3PipetteHandler
 from opentrons.hardware_control.types import (
     OT3Mount,
     OT3Axis,
@@ -23,7 +25,7 @@ from opentrons.hardware_control.types import (
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control import ThreadManager
 from opentrons.hardware_control.backends.ot3utils import axis_to_node
-from opentrons.types import Point
+from opentrons.types import Point, Mount
 
 from opentrons.config import gripper_config as gc
 from opentrons_shared_data.gripper.dev_types import GripperModel
@@ -112,6 +114,20 @@ async def mock_backend_move(ot3_hardware: ThreadManager[OT3API]) -> Iterator[Asy
         AsyncMock(spec=ot3_hardware.managed_obj._backend.move),
     ) as mock_move:
         yield mock_move
+
+
+@pytest.fixture
+async def mock_instrument_handlers(
+    ot3_hardware: ThreadManager[OT3API],
+) -> Iterator[Tuple[Mock]]:
+    with patch.object(
+        ot3_hardware.managed_obj,
+        "_gripper_handler",
+        Mock(spec=GripperHandler),
+    ) as mock_gripper_handler, patch.object(
+        ot3_hardware.managed_obj, "_pipette_handler", Mock(spec=OT3PipetteHandler)
+    ) as mock_pipette_handler:
+        yield mock_gripper_handler, mock_pipette_handler
 
 
 @pytest.mark.parametrize(
@@ -519,3 +535,55 @@ async def test_gripper_move_to(
             OT3Axis.Y,
             OT3Axis.Z_G,
         ]
+
+
+@pytest.mark.parametrize(
+    "mount",
+    (
+        OT3Mount.RIGHT,
+        OT3Mount.LEFT,
+        OT3Mount.GRIPPER,
+        Mount.RIGHT,
+        Mount.LEFT,
+    ),
+)
+async def test_reset_instrument_offset(
+    ot3_hardware: ThreadManager[OT3API],
+    mount: Union[OT3Mount, Mount],
+    mock_instrument_handlers: Tuple[Mock],
+) -> None:
+    gripper_handler, pipette_handler = mock_instrument_handlers
+    await ot3_hardware.reset_instrument_offset(mount)
+    if mount == OT3Mount.GRIPPER:
+        gripper_handler.reset_instrument_offset.assert_called_once_with(True)
+    else:
+        converted_mount = OT3Mount.from_mount(mount)
+        pipette_handler.reset_instrument_offset.assert_called_once_with(
+            converted_mount, True
+        )
+
+
+@pytest.mark.parametrize(
+    "mount",
+    (
+        OT3Mount.RIGHT,
+        OT3Mount.LEFT,
+        OT3Mount.GRIPPER,
+        Mount.RIGHT,
+        Mount.LEFT,
+    ),
+)
+async def test_save_instrument_offset(
+    ot3_hardware: ThreadManager[OT3API],
+    mount: Union[OT3Mount, Mount],
+    mock_instrument_handlers: Tuple[Mock],
+) -> None:
+    gripper_handler, pipette_handler = mock_instrument_handlers
+    await ot3_hardware.save_instrument_offset(mount, Point(1, 1, 1))
+    if mount == OT3Mount.GRIPPER:
+        gripper_handler.save_instrument_offset.assert_called_once_with(Point(1, 1, 1))
+    else:
+        converted_mount = OT3Mount.from_mount(mount)
+        pipette_handler.save_instrument_offset.assert_called_once_with(
+            converted_mount, Point(1, 1, 1)
+        )

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -222,29 +222,37 @@ async def test_method_enum(ot3_hardware: ThreadManager[OT3API]) -> None:
         "opentrons.hardware_control.ot3_calibration.find_deck_position",
         AsyncMock(spec=find_deck_position),
     ) as find_deck, patch.object(
-        ot3_hardware.managed_obj, "_pipette_handler", Mock(spec=OT3PipetteHandler)
-    ):
+        ot3_hardware.managed_obj, "reset_instrument_offset", AsyncMock()
+    ) as reset_instrument_offset, patch.object(
+        ot3_hardware.managed_obj, "save_instrument_offset", AsyncMock()
+    ) as save_instrument_offset:
         find_deck.return_value = 10
         binary.return_value = (1.0, 2.0)
         noncontact.return_value = (3.0, 4.0)
         binval = await calibrate_mount(
             ot3_hardware, OT3Mount.RIGHT, CalibrationMethod.BINARY_SEARCH
         )
+        reset_instrument_offset.assert_called_once()
         find_deck.assert_called_once()
         binary.assert_called_once()
         noncontact.assert_not_called()
+        save_instrument_offset.assert_called_once()
         assert binval == Point(1.0, 2.0, 10)
 
+        reset_instrument_offset.reset_mock()
         find_deck.reset_mock()
         binary.reset_mock()
         noncontact.reset_mock()
+        save_instrument_offset.reset_mock()
 
         ncval = await calibrate_mount(
             ot3_hardware, OT3Mount.LEFT, CalibrationMethod.NONCONTACT_PASS
         )
+        reset_instrument_offset.assert_called_once()
         find_deck.assert_called_once()
         binary.assert_not_called()
         noncontact.assert_called_once()
+        save_instrument_offset.assert_called_once()
         assert ncval == Point(3.0, 4.0, 10)
 
 

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -11,6 +11,7 @@ from opentrons.hardware_control import ThreadManager
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.types import OT3Mount, OT3Axis
 from opentrons.config.types import OT3CalibrationSettings, Offset
+from opentrons.hardware_control.instruments.ot2.pipette_handler import OT3PipetteHandler
 from opentrons.hardware_control.ot3_calibration import (
     find_edge,
     find_axis_center,
@@ -220,7 +221,9 @@ async def test_method_enum(ot3_hardware: ThreadManager[OT3API]) -> None:
     ) as noncontact, patch(
         "opentrons.hardware_control.ot3_calibration.find_deck_position",
         AsyncMock(spec=find_deck_position),
-    ) as find_deck:
+    ) as find_deck, patch.object(
+        ot3_hardware.managed_obj, "_pipette_handler", Mock(spec=OT3PipetteHandler)
+    ):
         find_deck.return_value = 10
         binary.return_value = (1.0, 2.0)
         noncontact.return_value = (3.0, 4.0)

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -1,12 +1,12 @@
 import pytest
 from opentrons.calibration_storage import types as cal_types
-from opentrons.types import Point
+from opentrons.types import Point, Mount
 from opentrons.hardware_control.instruments.ot2 import pipette, instrument_calibration
 from opentrons.hardware_control import types
 from opentrons.config import pipette_config
 
 PIP_CAL = instrument_calibration.PipetteOffsetByPipetteMount(
-    offset=[0, 0, 0],
+    offset=Point(0, 0, 0),
     source=cal_types.SourceType.user,
     status=cal_types.CalibrationStatus(),
 )
@@ -117,6 +117,8 @@ def test_smoothie_config_update(monkeypatch):
 
 @pytest.mark.parametrize("config_model", pipette_config.config_models)
 def test_tip_overlap(config_model):
+    # TODO (lc 10-31-2022) We really shouldn't need to paramaterize over all of the
+    # config models to check that the config is loaded in properly.
     loaded = pipette_config.load(config_model)
     pip = pipette.Pipette(loaded, PIP_CAL, "testId")
     assert pip.config.tip_overlap == pipette_config.configs[config_model]["tipOverlap"]
@@ -161,3 +163,35 @@ def test_xy_center(config_model):
         loaded.nozzle_offset[1] - cp_y_offset,
         loaded.nozzle_offset[2],
     )
+
+
+def test_reset_instrument_offset():
+    # TODO (lc 10-31-2022) These tests would be much cleaner/easier to mock with
+    # an InstrumentCalibrationProvider class (like robot calibration provider)
+    # which should be done in a follow-up refactor.
+    temporary_calibration = instrument_calibration.PipetteOffsetByPipetteMount(
+        offset=Point(1, 1, 1),
+        source=cal_types.SourceType.user,
+        status=cal_types.CalibrationStatus(),
+    )
+
+    pip = pipette.Pipette(
+        pipette_config.load("p10_single_v1"), temporary_calibration, "testID"
+    )
+    assert pip.pipette_offset.offset == Point(1, 1, 1)
+    pip.reset_pipette_offset(Mount.LEFT)
+    assert pip.pipette_offset.offset == Point(0, 0, 0)
+
+
+@pytest.mark.xfail
+def test_save_instrument_offset():
+    # TODO (lc 10-31-2022) These tests would be much cleaner/easier to mock with
+    # an InstrumentCalibrationProvider class (like robot calibration provider)
+    # which should be done in a follow-up refactor.
+    pip = pipette.Pipette(pipette_config.load("p10_single_v1"), PIP_CAL, "testID")
+
+    assert pip.pipette_offset.offset == Point(0, 0, 0)
+    pip.save_pipette_offset(Mount.LEFT, Point(1.0, 2.0, 3.0))
+    # TODO (lc 10-31-2022) This assert should be easier to handle once we
+    # have the correct exports from calibration_storage
+    assert pip.pipette_offset.offset == Point(1.0, 2.0, 3.0)

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -179,7 +179,7 @@ def test_reset_instrument_offset():
         pipette_config.load("p10_single_v1"), temporary_calibration, "testID"
     )
     assert pip.pipette_offset.offset == Point(1, 1, 1)
-    pip.reset_pipette_offset(Mount.LEFT)
+    pip.reset_pipette_offset(Mount.LEFT, to_default=True)
     assert pip.pipette_offset.offset == Point(0, 0, 0)
 
 

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -17,7 +17,7 @@ def mock_pipette(decoy: Decoy) -> Pipette:
 
 @pytest.fixture
 def subject(decoy: Decoy, mock_pipette: Pipette) -> PipetteHandlerProvider:
-    inst_by_mount = {types.Mount.LEFT: mock_pipette}
+    inst_by_mount = {types.Mount.LEFT: mock_pipette, types.Mount.RIGHT: None}
     subject = PipetteHandlerProvider(attached_instruments=inst_by_mount)
     return subject
 
@@ -53,3 +53,8 @@ def test_plan_check_pick_up_tip_with_presses_argument(
     )
 
     assert len(spec.presses) == expected_array_length
+
+
+def test_get_pipette_fails(decoy: Decoy, subject: PipetteHandlerProvider):
+    with pytest.raises(types.PipetteNotAttachedError):
+        subject.get_pipette(types.Mount.RIGHT)

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -114,7 +114,7 @@ class DeckCalibrationUserFlow:
         self.hardware.set_robot_calibration(
             robot_cal.build_temporary_identity_calibration()
         )
-        self._hw_pipette.reset_pipette_offset(self._mount)
+        self._hw_pipette.reset_pipette_offset(self._mount, to_default=True)
         self._supported_commands = SupportedCommands(namespace="calibration")
         self._supported_commands.loadLabware = True
 

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -20,7 +20,6 @@ from opentrons.calibration_storage import (
 )
 from opentrons.hardware_control import robot_calibration as robot_cal
 from opentrons.hardware_control import HardwareControlAPI, CriticalPoint, Pipette
-from opentrons.hardware_control.instruments.ot2 import instrument_calibration
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location
@@ -115,9 +114,7 @@ class DeckCalibrationUserFlow:
         self.hardware.set_robot_calibration(
             robot_cal.build_temporary_identity_calibration()
         )
-        self._hw_pipette.update_pipette_offset(
-            instrument_calibration.load_pipette_offset(pip_id=None, mount=self._mount)
-        )
+        self._hw_pipette.reset_pipette_offset(self._mount)
         self._supported_commands = SupportedCommands(namespace="calibration")
         self._supported_commands.loadLabware = True
 

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -139,7 +139,7 @@ class PipetteOffsetCalibrationUserFlow:
             CalibrationCommand.invalidate_last_action: self.invalidate_last_action,
         }
 
-        self._hw_pipette.reset_pipette_offset(self._mount)
+        self._hw_pipette.reset_pipette_offset(self._mount, to_default=True)
         self._default_tipracks = util.get_default_tipracks(
             self.hw_pipette.config.default_tipracks
         )

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -21,7 +21,6 @@ from opentrons.calibration_storage.types import (
     TipLengthCalNotFound,
 )
 from opentrons.hardware_control import HardwareControlAPI, CriticalPoint, Pipette
-from opentrons.hardware_control.instruments.ot2 import instrument_calibration
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location
@@ -140,9 +139,7 @@ class PipetteOffsetCalibrationUserFlow:
             CalibrationCommand.invalidate_last_action: self.invalidate_last_action,
         }
 
-        self._hw_pipette.update_pipette_offset(
-            instrument_calibration.load_pipette_offset(pip_id=None, mount=self._mount)
-        )
+        self._hw_pipette.reset_pipette_offset(self._mount)
         self._default_tipracks = util.get_default_tipracks(
             self.hw_pipette.config.default_tipracks
         )


### PR DESCRIPTION
## Overview

Closes #RLIQ-78. We should reset the pipette offsets to zero during the calibrate_mount and then save the result of this function afterwards. **Note** there are some refactors that will make this work much nicer which will be addressed in follow-ups that I've listed below.

Refactors:
- Fix imports for calibration storage (in progress)
- Create an `InstrumentCalibrationProvider` class (similar to the `RobotCalibrationProvider`)
- Have the OT-2 user flows directly use `save_instrument_calibration` and `reset_instrument_calibration` through the api (low priority)
- Tease out the `Pipette` class to better differentiate between an OT2 or OT3 instrument (will be addressed in the next few weeks)

To-Do

- [x] Test on an OT-3
- [x] Test on an OT-2
