### PR TITLE
feat: Allow for custom naming of dev robot

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -119,7 +119,10 @@ def name() -> str:
         return result[:-1]
 
     else:
-        return "opentrons-dev"
+        robot_name = "opentrons-dev"
+        if "DEV_ROBOT_NAME" in os.environ.keys():
+            robot_name = os.environ["DEV_ROBOT_NAME"]
+        return robot_name
 
 
 class ConfigElementType(enum.Enum):

--- a/robot-server/dev.env
+++ b/robot-server/dev.env
@@ -3,3 +3,4 @@
 ENABLE_VIRTUAL_SMOOTHIE=true
 OT_ROBOT_SERVER_persistence_directory=automatically_make_temporary
 OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test.json
+DEV_ROBOT_NAME=opentrons-dev


### PR DESCRIPTION
# Overview

Allow for defining of custom robot name through environment variable `DEV_ROBOT_NAME`

# Changelog

- When determining the name of the robot, if `DEV_ROBOT_NAME` is specified use that name, otherwise use default.

# Review requests

I ran all the tests and everything passed. But could this break anything else? 

# Risk assessment

Low, I think. 
Going to include people more knowledgeable than myself to see if this has any unexpected ramifications.