### PR TITLE
docs(api): hide certain private methods

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -11,7 +11,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.ProtocolContext
    :members:
-   :exclude-members: location_cache, _hw_manager
+   :exclude-members: location_cache, _hw_manager, cleanup, clear_commands, commands
 
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:
@@ -30,20 +30,22 @@ Modules
 -------
 .. autoclass:: opentrons.protocol_api.TemperatureModuleContext
    :members:
-   :exclude-members: start_set_temperature
+   :exclude-members: start_set_temperature, broker, geometry
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.MagneticModuleContext
    :members:
+   :exclude-members: broker, geometry
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.ThermocyclerContext
    :members:
-   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, flag_unsafe_move
+   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, flag_unsafe_move, broker, geometry
    :inherited-members:
    
 .. autoclass:: opentrons.protocol_api.HeaterShakerContext
    :members:
+   :exclude-members: broker, geometry
    :inherited-members:
 
 

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -40,7 +40,7 @@ Modules
 
 .. autoclass:: opentrons.protocol_api.ThermocyclerContext
    :members:
-   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, flag_unsafe_move, broker, geometry
+   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, broker, geometry
    :inherited-members:
    
 .. autoclass:: opentrons.protocol_api.HeaterShakerContext

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -15,6 +15,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:
+   :exclude-members: delay
 
 .. _protocol-api-labware:
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Hides a number of methods and parameters that aren't intended for (and likely aren't useful to) API users.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Adds `:exclude-members:` entries to the API reference page.
- Does not use `:meta private:` in source docstrings because this is [not yet supported by autosummary](https://github.com/sphinx-doc/sphinx/issues/8922).

# Review requests

<!--
Describe any requests for your reviewers here.
-->

[Sandbox link](http://sandbox.docs.opentrons.com/RTC-40-hide-private-methods/v2/new_protocol_api.html)
- Check that all the methods that should be hidden are hidden.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

v low