### PR TITLE
feat(engine): add virtual gripper config to protocol engine

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -91,12 +91,14 @@ class MoveLabwareImplementation(
             validated_new_loc = self._labware_movement.ensure_valid_gripper_location(
                 empty_new_location,
             )
-            await self._labware_movement.move_labware_with_gripper(
-                labware_id=params.labwareId,
-                current_location=validated_current_loc,
-                new_location=validated_new_loc,
-                new_offset_id=new_offset_id,
-            )
+            use_virtual_gripper = self._state_view.config.use_virtual_gripper
+            if not use_virtual_gripper:
+                await self._labware_movement.move_labware_with_gripper(
+                    labware_id=params.labwareId,
+                    current_location=validated_current_loc,
+                    new_location=validated_new_loc,
+                    new_offset_id=new_offset_id,
+                )
         elif params.strategy == LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE:
             # Pause to allow for manual labware movement
             await self._run_control.wait_for_resume()

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -91,14 +91,14 @@ class MoveLabwareImplementation(
             validated_new_loc = self._labware_movement.ensure_valid_gripper_location(
                 empty_new_location,
             )
-            use_virtual_gripper = self._state_view.config.use_virtual_gripper
-            if not use_virtual_gripper:
-                await self._labware_movement.move_labware_with_gripper(
-                    labware_id=params.labwareId,
-                    current_location=validated_current_loc,
-                    new_location=validated_new_loc,
-                    new_offset_id=new_offset_id,
-                )
+
+            # Skips gripper moves when using virtual gripper
+            await self._labware_movement.move_labware_with_gripper(
+                labware_id=params.labwareId,
+                current_location=validated_current_loc,
+                new_location=validated_new_loc,
+                new_offset_id=new_offset_id,
+            )
         elif params.strategy == LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE:
             # Pause to allow for manual labware movement
             await self._run_control.wait_for_resume()

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -70,6 +70,9 @@ class LabwareMovementHandler:
         new_offset_id: Optional[str],
     ) -> None:
         """Move a loaded labware from one location to another."""
+        use_virtual_gripper = self._state_store.config.use_virtual_gripper
+        if use_virtual_gripper:
+            return
         ot3api = ensure_ot3_hardware(
             hardware_api=self._hardware_api,
             error_msg="Gripper is only available on the OT-3",

--- a/api/src/opentrons/protocol_engine/state/config.py
+++ b/api/src/opentrons/protocol_engine/state/config.py
@@ -11,10 +11,13 @@ class Config:
             for pauses and delays to complete.
         use_virtual_modules: The engine should no-op instead of calling
             modules' hardware control API.
+        use_virtual_gripper: The engine should no-op instead of calling
+            gripper hardware control API.
         block_on_door_open: Protocol execution should pause if the
             front door is opened.
     """
 
     ignore_pause: bool = False
     use_virtual_modules: bool = False
+    use_virtual_gripper: bool = False
     block_on_door_open: bool = False

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -52,6 +52,7 @@ async def create_simulating_runner() -> ProtocolRunner:
         config=ProtocolEngineConfig(
             ignore_pause=True,
             use_virtual_modules=True,
+            use_virtual_gripper=True,
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -134,6 +134,7 @@ async def test_gripper_move_labware_implementation(
         labware_movement.ensure_valid_gripper_location(new_location)
     ).then_return(validated_new_location)
 
+    decoy.when(state_view.config.use_virtual_gripper).then_return(False)
     result = await subject.execute(data)
     decoy.verify(
         await labware_movement.move_labware_with_gripper(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -134,7 +134,6 @@ async def test_gripper_move_labware_implementation(
         labware_movement.ensure_valid_gripper_location(new_location)
     ).then_return(validated_new_location)
 
-    decoy.when(state_view.config.use_virtual_gripper).then_return(False)
     result = await subject.execute(data)
     decoy.verify(
         await labware_movement.move_labware_with_gripper(

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -220,6 +220,7 @@ async def test_labware_movement_raises_on_ot2(
         )
 
 
+@pytest.mark.ot3_only
 async def test_labware_movement_skips_for_virtual_gripper(
     decoy: Decoy,
     state_store: StateStore,

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -114,6 +114,7 @@ async def test_move_labware_with_gripper(
     to_location: Union[DeckSlotLocation, ModuleLocation],
 ) -> None:
     """It should perform a labware movement with gripper by delegating to OT3API."""
+    decoy.when(state_store.config.use_virtual_gripper).then_return(False)
     decoy.when(ot3_hardware_api.has_gripper()).then_return(True)
 
     decoy.when(
@@ -203,6 +204,7 @@ async def test_labware_movement_raises_on_ot2(
     model_utils: ModelUtils,
 ) -> None:
     """It should raise an error when attempting a gripper movement on a non-OT3 bot."""
+    decoy.when(state_store.config.use_virtual_gripper).then_return(False)
     subject = LabwareMovementHandler(
         hardware_api=hardware_api,
         state_store=state_store,
@@ -218,6 +220,28 @@ async def test_labware_movement_raises_on_ot2(
         )
 
 
+async def test_labware_movement_skips_for_virtual_gripper(
+    decoy: Decoy,
+    state_store: StateStore,
+    ot3_hardware_api: OT3API,
+    subject: LabwareMovementHandler,
+    model_utils: ModelUtils,
+) -> None:
+    """It should neither raise error nor move gripper when using virtual gripper."""
+    decoy.when(state_store.config.use_virtual_gripper).then_return(True)
+    await subject.move_labware_with_gripper(
+        labware_id="labware-id",
+        current_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        new_offset_id=None,
+    )
+    decoy.verify(
+        await ot3_hardware_api.move_to(mount=OT3Mount.GRIPPER),  # type: ignore[call-arg]
+        times=0,
+        ignore_extra_args=True,
+    )
+
+
 @pytest.mark.ot3_only
 async def test_labware_movement_raises_without_gripper(
     decoy: Decoy,
@@ -226,6 +250,7 @@ async def test_labware_movement_raises_without_gripper(
     subject: LabwareMovementHandler,
 ) -> None:
     """It should raise an error when attempting a gripper movement without a gripper."""
+    decoy.when(state_store.config.use_virtual_gripper).then_return(False)
     decoy.when(ot3_hardware_api.has_gripper()).then_return(False)
     with pytest.raises(GripperNotAttachedError):
         await subject.move_labware_with_gripper(


### PR DESCRIPTION
Closes RLAB-190

# Overview

Adds virtual gripper config so that analysis skips any calls to the gripper hardware control API.

# Changelog

- added `use_virtual_gripper` config
- added check for virtual gripper in `move_labware_with_gripper` 

# Review requests

- I added the check for virtual gripper inside `move_labware_with_gripper` instead of in `moveLabware`'s execute method because it made testing easier. Does that make sense?

# Risk assessment

Low. Adds a check to allow analysis to pass
