### PR TITLE
fix(api): ensure passed in pipette and labware names are lowercased

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -297,6 +297,7 @@ class ProtocolContext(CommandPublisher):
         :param int version: The version of the labware definition. If
             unspecified, will use version 1.
         """
+        load_name = validation.ensure_lowercase_name(load_name)
         deck_slot = validation.ensure_deck_slot(location)
 
         labware_core = self._implementation.load_labware(
@@ -523,7 +524,7 @@ class ProtocolContext(CommandPublisher):
                              `mount` (if such an instrument exists) should be
                              replaced by `instrument_name`.
         """
-
+        instrument_name = validation.ensure_lowercase_name(instrument_name)
         checked_mount = validation.ensure_mount(mount)
         checked_instrument_name = validation.ensure_pipette_name(instrument_name)
         tip_racks = tip_racks or []

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -37,6 +37,8 @@ def ensure_mount(mount: Union[str, Mount]) -> Mount:
 
 def ensure_pipette_name(pipette_name: str) -> PipetteNameType:
     """Ensure that an input value represents a valid pipette name."""
+    pipette_name = ensure_lowercase_name(pipette_name)
+
     try:
         return PipetteNameType(pipette_name)
     except ValueError as e:
@@ -54,6 +56,14 @@ def ensure_deck_slot(deck_slot: Union[int, str]) -> DeckSlotName:
         return DeckSlotName(str(deck_slot))
     except ValueError as e:
         raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e
+
+
+def ensure_lowercase_name(name: str) -> str:
+    """Ensure that a given name string is all lowercase."""
+    if not isinstance(name, str):
+        raise TypeError(f"Value must be a string, but got {name}")
+
+    return name.lower()
 
 
 _MODULE_ALIASES: Dict[str, ModuleModel] = {

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -82,6 +82,7 @@ def test_load_instrument(
     mock_tip_racks = [decoy.mock(cls=Labware), decoy.mock(cls=Labware)]
 
     decoy.when(mock_validation.ensure_mount("shadowfax")).then_return(Mount.LEFT)
+    decoy.when(mock_validation.ensure_lowercase_name("Gandalf")).then_return("gandalf")
     decoy.when(mock_validation.ensure_pipette_name("gandalf")).then_return(
         PipetteNameType.P300_SINGLE
     )
@@ -96,7 +97,7 @@ def test_load_instrument(
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("Gandalf the Grey")
 
     result = subject.load_instrument(
-        instrument_name="gandalf", mount="shadowfax", tip_racks=mock_tip_racks
+        instrument_name="Gandalf", mount="shadowfax", tip_racks=mock_tip_racks
     )
 
     assert isinstance(result, InstrumentContext)
@@ -124,6 +125,7 @@ def test_load_instrument_replace(
     """It should allow/disallow pipette replacement."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
 
+    decoy.when(mock_validation.ensure_lowercase_name("ada")).then_return("ada")
     decoy.when(mock_validation.ensure_mount(matchers.IsA(Mount))).then_return(
         Mount.RIGHT
     )
@@ -158,11 +160,14 @@ def test_load_labware(
     """It should create a labware using its execution core."""
     mock_labware_core = decoy.mock(cls=LabwareCore)
 
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
+        "lowercase_labware"
+    )
     decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_5)
 
     decoy.when(
         mock_core.load_labware(
-            load_name="some_labware",
+            load_name="lowercase_labware",
             location=DeckSlotName.SLOT_5,
             label="some_display_name",
             namespace="some_namespace",
@@ -173,7 +178,7 @@ def test_load_labware(
     decoy.when(mock_labware_core.get_name()).then_return("Full Name")
 
     result = subject.load_labware(
-        load_name="some_labware",
+        load_name="UPPERCASE_LABWARE",
         location=42,
         label="some_display_name",
         namespace="some_namespace",
@@ -195,6 +200,7 @@ def test_load_labware_from_definition(
     labware_definition_dict = cast(LabwareDefDict, {"labwareDef": True})
     labware_load_params = LabwareLoadParams("you", "are", 1337)
 
+    decoy.when(mock_validation.ensure_lowercase_name("are")).then_return("are")
     decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_1)
     decoy.when(mock_core.add_labware_definition(labware_definition_dict)).then_return(
         labware_load_params

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -41,10 +41,17 @@ def test_ensure_mount_input_invalid() -> None:
         subject.ensure_mount(42)  # type: ignore[arg-type]
 
 
-def test_ensure_pipette_name() -> None:
+@pytest.mark.parametrize(
+    ["input_value", "expected"],
+    [
+        ("p300_single", PipetteNameType.P300_SINGLE),
+        ("P300_muLTI_gen2", PipetteNameType.P300_MULTI_GEN2),
+    ],
+)
+def test_ensure_pipette_name(input_value: str, expected: PipetteNameType) -> None:
     """It should properly map strings and PipetteNameType enums."""
-    result = subject.ensure_pipette_name("p300_single")
-    assert result == PipetteNameType.P300_SINGLE
+    result = subject.ensure_pipette_name(input_value)
+    assert result == expected
 
 
 def test_ensure_pipette_input_invalid() -> None:
@@ -78,6 +85,18 @@ def test_ensure_deck_slot_invalid() -> None:
 
     with pytest.raises(TypeError, match="must be a string or integer"):
         subject.ensure_deck_slot(1.23)  # type: ignore[arg-type]
+
+
+def test_ensure_lowercase_name() -> None:
+    """It should properly map strings and PipetteNameType enums."""
+    result = subject.ensure_lowercase_name("aBcDeFg")
+    assert result == "abcdefg"
+
+
+def test_ensure_lowercase_name_invalid() -> None:
+    """It should raise a ValueError if given an invalid name."""
+    with pytest.raises(TypeError, match="must be a string"):
+        subject.ensure_lowercase_name(101)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview

This PR fixes a little bug with the Protocol API that prevents proper interaction with the ProtocolEngine when using the PE cores: load strings are assumed to be lowercase rather than force to be lowercase. This PR fixes that issue at the Protocol API level.

The ProtocolEngine commands will need to enforce this, too, to account for HTTP commands, but I'm leaving that for a separate PR.

Ref: RSS-136

## Changelog

- fix(api): ensure passed in pipette and labware names are lowercased

## Review requests

This one is straightforward; code review should be all we need on this one

## Risk assessment

Very low
