### PR TITLE
feat(calibration): add the calibration probe length

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -44,6 +44,7 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
         search_initial_tolerance_mm=5.0,
         search_iteration_limit=10,
     ),
+    probe_length=34.5,
 )
 
 ROBOT_CONFIG_VERSION: Final = 1
@@ -366,6 +367,7 @@ def _build_default_calibration(
         edge_sense=_build_default_edge_sense(
             from_conf.get("edge_sense", {}), default.edge_sense
         ),
+        probe_length=from_conf.get("probe_length", default.probe_length),
     )
 
 

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -152,6 +152,7 @@ class EdgeSenseSettings:
 class OT3CalibrationSettings:
     z_offset: ZSenseSettings
     edge_sense: EdgeSenseSettings
+    probe_length: float
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -412,6 +412,7 @@ async def calibrate_mount(
     # also be used to baseline the edge detection points.
     # reset instrument offset
     await hcapi.reset_instrument_offset(mount)
+    await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
     z_pos = await find_deck_position(hcapi, mount)
     LOG.info(f"Found deck at {z_pos}mm")
 
@@ -429,4 +430,5 @@ async def calibrate_mount(
     # save new offset
     # reload
     await hcapi.save_instrument_offset(mount, center)
+    await hcapi.remove_tip(mount)
     return center

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -199,6 +199,6 @@ ot3_dummy_settings = {
             "search_initial_tolerance_mm": 18,
             "search_iteration_limit": 3,
         },
-        "probe_length": 40
+        "probe_length": 40,
     },
 }

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -199,5 +199,6 @@ ot3_dummy_settings = {
             "search_initial_tolerance_mm": 18,
             "search_iteration_limit": 3,
         },
+        "probe_length": 40
     },
 }


### PR DESCRIPTION
We should add the correct calibration probe length before beginning the probe. It can be treated like a tip.
