### PR TITLE
fix(api): thermocycler test merge conflict

### DIFF
--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -181,7 +181,7 @@ async def subject_mocked_driver(
             "model": "dummyModelTC",
             "version": "dummyVersionTC",
         },
-        loop=asyncio.get_running_loop(),
+        hw_control_loop=asyncio.get_running_loop(),
         polling_interval_sec=SIMULATING_POLL_PERIOD,
     )
     try:


### PR DESCRIPTION
Whatever commit introduced this didn't update the argument name of the asyncio loop for the hardware module.
