### PR TITLE
feat(app): Thermocycler GEN1 and GEN2 lid status in_between wire up

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -118,5 +118,6 @@
   "module_name_error": "{{moduleName}} error",
   "view": "View",
   "error_details": "error details",
-  "module_error_contact_support": "Try powering the module off and on again. If the error persists, contact Opentrons Support."
+  "module_error_contact_support": "Try powering the module off and on again. If the error persists, contact Opentrons Support.",
+  "in_between": "in between"
 }

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -118,6 +118,5 @@
   "module_name_error": "{{moduleName}} error",
   "view": "View",
   "error_details": "error details",
-  "module_error_contact_support": "Try powering the module off and on again. If the error persists, contact Opentrons Support.",
-  "in_between": "in between"
+  "module_error_contact_support": "Try powering the module off and on again. If the error persists, contact Opentrons Support."
 }

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
@@ -87,11 +87,7 @@ export const ThermocyclerModuleData = (
         <Flex flexDirection={DIRECTION_ROW}>
           <Box marginRight={SPACING.spacing2}>
             <StatusLabel
-              status={
-                data.lidStatus === 'in_between'
-                  ? t('in_between')
-                  : data.lidStatus
-              }
+              status={data.lidStatus === 'in_between' ? 'open' : data.lidStatus}
               backgroundColor={COLORS.medGreyEnabled}
               textColor={COLORS.darkBlackEnabled}
               showIcon={false}

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
@@ -88,9 +88,9 @@ export const ThermocyclerModuleData = (
           <Box marginRight={SPACING.spacing2}>
             <StatusLabel
               status={
-                data.lidStatus === 'in_between' || data.lidStatus === 'open'
-                  ? 'open'
-                  : 'closed'
+                data.lidStatus === 'in_between'
+                  ? t('in_between')
+                  : data.lidStatus
               }
               backgroundColor={COLORS.medGreyEnabled}
               textColor={COLORS.darkBlackEnabled}

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleData.tsx
@@ -87,7 +87,11 @@ export const ThermocyclerModuleData = (
         <Flex flexDirection={DIRECTION_ROW}>
           <Box marginRight={SPACING.spacing2}>
             <StatusLabel
-              status={data.lidStatus}
+              status={
+                data.lidStatus === 'in_between' || data.lidStatus === 'open'
+                  ? 'open'
+                  : 'closed'
+              }
               backgroundColor={COLORS.medGreyEnabled}
               textColor={COLORS.darkBlackEnabled}
               showIcon={false}

--- a/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
@@ -204,13 +204,13 @@ describe('ThermocyclerModuleData', () => {
     )
   })
 
-  it('renders thermocycler lid status to say open even though the status is in_between', () => {
+  it('renders thermocycler lid status says in between when lid status is in_between', () => {
     props = {
       data: {
         lidStatus: 'in_between',
       } as ThermocyclerData,
     }
     const { getByTestId } = render(props)
-    getByTestId('status_label_open_lidStatus')
+    getByTestId('status_label_in between_lidStatus')
   })
 })

--- a/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
@@ -204,13 +204,13 @@ describe('ThermocyclerModuleData', () => {
     )
   })
 
-  it('renders thermocycler lid status says in between when lid status is in_between', () => {
+  it('renders thermocycler lid status to say open even though the status is in_between', () => {
     props = {
       data: {
         lidStatus: 'in_between',
       } as ThermocyclerData,
     }
     const { getByTestId } = render(props)
-    getByTestId('status_label_in between_lidStatus')
+    getByTestId('status_label_open_lidStatus')
   })
 })

--- a/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleData.test.tsx
@@ -203,4 +203,14 @@ describe('ThermocyclerModuleData', () => {
       'backgroundColor: C_SILVER_GRAY'
     )
   })
+
+  it('renders thermocycler lid status to say open even though the status is in_between', () => {
+    props = {
+      data: {
+        lidStatus: 'in_between',
+      } as ThermocyclerData,
+    }
+    const { getByTestId } = render(props)
+    getByTestId('status_label_open_lidStatus')
+  })
 })


### PR DESCRIPTION
closes RCORE-332

# Overview

when you first turn on the TC it doesn't know if the lid is opened or close, so it will default to saying `open` when the actual status is `in_between`

# Changelog

- add logic to `ThermocyclerModuleData` and add a test case

# Review requests

- should work on both TC GEN1 and TC GEN2. Turn either of them on and the status should say `open`

# Risk assessment

low