### PR TITLE
fix(hardware-testing): Add gripper to sync-fw-ot3

### DIFF
--- a/hardware-testing/build_fw.sh
+++ b/hardware-testing/build_fw.sh
@@ -25,7 +25,7 @@ cmake --build --preset=gantry-y --target=gantry-y-rev1-flash || true
 cmake --build --preset=head --target=head-rev1-flash || true
 cmake --build --preset=pipettes-rev1 --target=pipettes-single-rev1-flash || true
 cmake --build --preset=pipettes-rev1 --target=pipettes-multi-rev1-flash || true
-cmake --build --preset=gripper-rev1 --target=gripper-rev1-flash || true
+cmake --build --preset=gripper --target=gripper-rev1-flash || true
 cd "$THIS_DIR" || exit
 
 # move all HEX files to temporary folder

--- a/hardware-testing/build_fw.sh
+++ b/hardware-testing/build_fw.sh
@@ -15,6 +15,7 @@ FW_PATH_GANTRY_Y="$REPO_DIR/build-cross/gantry/firmware/gantry-y-rev1.hex"
 FW_PATH_HEAD="$REPO_DIR/build-cross/head/firmware/head-rev1.hex"
 FW_PATH_PIPETTES_SINGLE="$REPO_DIR/build-cross/pipettes/firmware/pipettes-single-rev1.hex"
 FW_PATH_PIPETTES_MULTI="$REPO_DIR/build-cross/pipettes/firmware/pipettes-multi-rev1.hex"
+FW_PATH_GRIPPER="$REPO_DIR/build-cross/gripper/firmware/gripper-rev1.hex"
 
 # build all the firmware
 cd "$REPO_DIR" || cd "$THIS_DIR" || exit
@@ -24,6 +25,7 @@ cmake --build --preset=gantry-y --target=gantry-y-rev1-flash || true
 cmake --build --preset=head --target=head-rev1-flash || true
 cmake --build --preset=pipettes-rev1 --target=pipettes-single-rev1-flash || true
 cmake --build --preset=pipettes-rev1 --target=pipettes-multi-rev1-flash || true
+cmake --build --preset=gripper-rev1 --target=gripper-rev1-flash || true
 cd "$THIS_DIR" || exit
 
 # move all HEX files to temporary folder
@@ -34,6 +36,7 @@ cp "$FW_PATH_GANTRY_Y" "$TEMP_DIR_NAME/gantry-y-rev1.hex"
 cp "$FW_PATH_HEAD" "$TEMP_DIR_NAME/head-rev1.hex"
 cp "$FW_PATH_PIPETTES_SINGLE" "$TEMP_DIR_NAME/pipettes-single-rev1.hex"
 cp "$FW_PATH_PIPETTES_MULTI" "$TEMP_DIR_NAME/pipettes-multi-rev1.hex"
+cp "$FW_PATH_GRIPPER" "$TEMP_DIR_NAME/gripper-rev1.hex"
 
 # create a dummy file, simply named after the git hash
 touch "$TEMP_DIR_NAME/$GIT_HASH"

--- a/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
@@ -104,7 +104,7 @@ async def _main(directory: Path, is_simulating: bool) -> None:
                 is_simulating=is_simulating,
             )
     # flash the gripper
-    if has_gripper:
+    if has_gripper and FW_GRIPPER.path:
         _run_update_fw_command(
             path=FW_GRIPPER.path,
             target=FW_GRIPPER.target,

--- a/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
@@ -30,7 +30,8 @@ FW_PIP_SINGLE = HexPathAndTarget(
 FW_PIP_MULTI = HexPathAndTarget(
     name="pipettes-multi-rev1.hex", path=None, target="pipette-{mount}"
 )
-ALL_FW = [FW_GANTRY_X, FW_GANTRY_Y, FW_HEAD, FW_PIP_SINGLE, FW_PIP_MULTI]
+FW_GRIPPER = HexPathAndTarget(name="gripper-rev1.hex", path=None, target="gripper")
+ALL_FW = [FW_GANTRY_X, FW_GANTRY_Y, FW_HEAD, FW_PIP_SINGLE, FW_PIP_MULTI, FW_GRIPPER]
 
 
 def _gather_hex_files_from_directory(directory: Path) -> None:
@@ -104,7 +105,11 @@ async def _main(directory: Path, is_simulating: bool) -> None:
             )
     # flash the gripper
     if has_gripper:
-        raise RuntimeError("Gripper flashing is not yet implemented")
+        _run_update_fw_command(
+            path=FW_GRIPPER.path,
+            target=FW_GRIPPER.target,
+            is_simulating=is_simulating,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Adds ability to update gripper when running `make sync-ot3`

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
