### PR TITLE
feat(protocol-designer): bump PD version up to 6.1.0

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -13,7 +13,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
   const testCases = [
     {
       title:
-        'preFlexGrandfatheredProtocol 1.0.0 (schema 1, PD version pre-1) -> PD 6.0.x, schema 6',
+        'preFlexGrandfatheredProtocol 1.0.0 (schema 1, PD version pre-1) -> PD 6.1.x, schema 6',
       importFixture:
         '../../fixtures/protocol/1/preFlexGrandfatheredProtocol.json',
       expectedExportFixture:
@@ -22,7 +22,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'newLabwareDefs',
     },
     {
-      title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 6.0.x, schema 6',
+      title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 6.1.x, schema 6',
       importFixture: '../../fixtures/protocol/1/example_1_1_0.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/example_1_1_0MigratedFromV1_0_0.json',
@@ -30,7 +30,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'newLabwareDefs',
     },
     {
-      title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 6.0.x, schema 6',
+      title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 6.1.x, schema 6',
       importFixture: '../../fixtures/protocol/4/doItAllV3.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/doItAllV3MigratedToV6.json',
@@ -38,7 +38,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'noBehaviorChange',
     },
     {
-      title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 6.0.x, schema 6',
+      title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 6.1.x, schema 6',
       importFixture: '../../fixtures/protocol/4/doItAllV4.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/doItAllV4MigratedToV6.json',
@@ -47,7 +47,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
     },
     {
       title:
-        'doItAllV6 (schema 6, PD version 6.0.0) -> import and re-export should preserve data',
+        'doItAllV6 (schema 6, PD version 6.1.0) -> import and re-export should preserve data',
       importFixture: '../../fixtures/protocol/6/doItAllV4MigratedToV6.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/doItAllV4MigratedToV6.json',
@@ -56,7 +56,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
     },
     {
       title:
-        'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 6.0.x, schema v6',
+        'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 6.1.x, schema v6',
       importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
       expectedExportFixture: '../../fixtures/protocol/6/mix_6_0_0.json',
       migrationModal: 'noBehaviorChange',
@@ -144,8 +144,8 @@ describe('Protocol fixtures migrate and match snapshots', () => {
 
               assert.match(
                 savedFile.designerApplication.version,
-                /^6\.0\.\d+$/,
-                'designerApplication.version is 6.0.x'
+                /^6\.1\.\d+$/,
+                'designerApplication.version is 6.1.x'
               )
               ;[savedFile, expectedFile].forEach(f => {
                 // Homogenize fields we don't want to compare

--- a/protocol-designer/fixtures/protocol/6/doItAllV3MigratedToV6.json
+++ b/protocol-designer/fixtures/protocol/6/doItAllV3MigratedToV6.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "data": {
       "_internalAppBuildDate": "Wed, 06 Jul 2022 19:10:55 GMT",
       "defaultValues": {

--- a/protocol-designer/fixtures/protocol/6/doItAllV4MigratedToV6.json
+++ b/protocol-designer/fixtures/protocol/6/doItAllV4MigratedToV6.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "data": {
       "_internalAppBuildDate": "Wed, 06 Jul 2022 19:10:55 GMT",
       "defaultValues": {

--- a/protocol-designer/fixtures/protocol/6/example_1_1_0MigratedFromV1_0_0.json
+++ b/protocol-designer/fixtures/protocol/6/example_1_1_0MigratedFromV1_0_0.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "data": {
       "_internalAppBuildDate": "Wed, 06 Jul 2022 19:10:55 GMT",
       "defaultValues": {

--- a/protocol-designer/fixtures/protocol/6/mix_6_0_0.json
+++ b/protocol-designer/fixtures/protocol/6/mix_6_0_0.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.1",
+    "version": "6.1.0",
     "data": {
       "_internalAppBuildDate": "Wed, 06 Jul 2022 19:10:55 GMT",
       "defaultValues": {

--- a/protocol-designer/fixtures/protocol/6/preFlexGrandfatheredProtocolMigratedFromV1_0_0.json
+++ b/protocol-designer/fixtures/protocol/6/preFlexGrandfatheredProtocolMigratedFromV1_0_0.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "data": {
       "_internalAppBuildDate": "Wed, 06 Jul 2022 18:45:38 GMT",
       "defaultValues": {

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '6.0.1'
+const OT_PD_VERSION = '6.1.0'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.tsx')


### PR DESCRIPTION
# Overview
Bump PD version to 6.1.0 for the TC GEN2 release

# Changelog

- change `webpack.config`
- adjust fixtures 

# Review requests

- in PD, the software version should say `6.1.0`

# Risk assessment

low