### PR TITLE
fix(robot-server): Do not raise exception when unpickling unknown types

### DIFF
--- a/robot-server/robot_server/persistence/legacy_pickle.py
+++ b/robot-server/robot_server/persistence/legacy_pickle.py
@@ -173,7 +173,6 @@ class LegacyUnpickler(Unpickler):
                 known_type = False
 
             if not known_type:
-                raise NotImplementedError
                 _log.warning(
                     f'Unpickling unknown type "{name}" from module "{module}".'
                     f" This may cause problems with reading records created by"


### PR DESCRIPTION
# Overview

This removes a `NotImplementedError` that I accidentally left in #11569. The intent of this code was only to log a warning, not raise an exception.

This PR fixes part of RQA-368. The underlying problem of pickling an unknown type will still exist, but this PR will make it a non-fatal error.

# Review requests

Code review should be sufficient. I've tested on a dev server that:

* Before this PR, uploading https://github.com/Opentrons/test-protocols/blob/main/thermo/thermo_error.py and getting its analysis fails with a `NotImplementedError`.
* After this PR, it succeeds, and logs:

  ```
  Unpickling unknown type "ThermocyclerLidStatus" from module "opentrons.drivers.types". This may cause problems with reading records created by older versions of this robot software. This should be reported to Opentrons and investigated.
  ```

# Risk assessment

Very low.