### PR TITLE
feat(hardware): add other sensors to monitor_sensors

### DIFF
--- a/hardware/opentrons_hardware/scripts/monitor_sensors.py
+++ b/hardware/opentrons_hardware/scripts/monitor_sensors.py
@@ -66,7 +66,9 @@ async def do_run(
                 d = SensorDataType.build(
                     message.payload.sensor_data, message.payload.sensor
                 )
-                print(f"{ts:.3f}: {s} {d.to_float():5.3f}")
+                rd = message.payload.sensor_data
+                print(f"{ts:.3f}: {s} {d.to_float():5.3f}, \traw data: {str(rd)}")
+                await asyncio.sleep(1.0)
     finally:
         print("cleaning up")
         await messenger.send(target_node, reset_message)

--- a/hardware/opentrons_hardware/scripts/monitor_sensors.py
+++ b/hardware/opentrons_hardware/scripts/monitor_sensors.py
@@ -68,7 +68,6 @@ async def do_run(
                 )
                 rd = message.payload.sensor_data
                 print(f"{ts:.3f}: {s} {d.to_float():5.3f}, \traw data: {str(rd)}")
-                await asyncio.sleep(1.0)
     finally:
         print("cleaning up")
         await messenger.send(target_node, reset_message)

--- a/hardware/opentrons_hardware/scripts/monitor_sensors.py
+++ b/hardware/opentrons_hardware/scripts/monitor_sensors.py
@@ -104,7 +104,7 @@ def main() -> None:
         "-s",
         "--sensor",
         type=str,
-        choices=["capacitive"],
+        choices=["capacitive", "pressure", "environment"],
         help="which sensor",
         default="capacitive",
     )


### PR DESCRIPTION
Just adds arguments for pressure and environment sensors to `monitor_sensors.py` to allow streaming sensor values to terminal- this should be all we need to send the correct `BindSensorOutput` messages