### PR TITLE
fix(api): ensure Thermocycler status APIs return vanilla strings

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -582,19 +582,23 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @requires_version(2, 0)
     def lid_position(self) -> Optional[str]:
         """Lid open/close status string"""
-        return self._core.get_lid_position()
+        # TODO(mc, 2022-11-08): this will never be None, update typings and logic
+        position = self._core.get_lid_position()
+        return position.value if position is not None else None
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def block_temperature_status(self) -> str:
         """Block temperature status string"""
-        return self._core.get_block_temperature_status()
+        return self._core.get_block_temperature_status().value
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def lid_temperature_status(self) -> Optional[str]:
         """Lid temperature status string"""
-        return self._core.get_lid_temperature_status()
+        # TODO(mc, 2022-11-08): this will never be None, update typings and logic
+        status = self._core.get_lid_temperature_status()
+        return status.value if status is not None else None
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -57,7 +57,9 @@ def test_get_lid_position(
     """It should get the lid position status from the core."""
     decoy.when(mock_core.get_lid_position()).then_return(ThermocyclerLidStatus.OPEN)
     result = subject.lid_position
+
     assert result == "open"
+    assert isinstance(result, ThermocyclerLidStatus) is False
 
 
 def test_get_block_temperature_status(
@@ -68,7 +70,9 @@ def test_get_block_temperature_status(
         TemperatureStatus.IDLE
     )
     result = subject.block_temperature_status
+
     assert result == "idle"
+    assert isinstance(result, TemperatureStatus) is False
 
 
 def test_get_lid_temperature_status(
@@ -79,7 +83,9 @@ def test_get_lid_temperature_status(
         TemperatureStatus.IDLE
     )
     result = subject.lid_temperature_status
+
     assert result == "idle"
+    assert isinstance(result, TemperatureStatus) is False
 
 
 def test_get_block_temperature(
@@ -198,7 +204,9 @@ def test_open_lid(
             matchers.DictMatching({"$": "after"}),
         ),
     )
+
     assert result == "open"
+    assert isinstance(result, ThermocyclerLidStatus) is False
 
 
 def test_close_lid(
@@ -227,7 +235,9 @@ def test_close_lid(
             matchers.DictMatching({"$": "after"}),
         ),
     )
+
     assert result == "closed"
+    assert isinstance(result, ThermocyclerLidStatus) is False
 
 
 def test_set_block_temperature(

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -8,7 +8,10 @@ import opentrons.protocol_api as papi
 import opentrons.protocols.geometry as papi_geometry
 
 from opentrons.types import Point, Location
-from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
+from opentrons.drivers.types import (
+    HeaterShakerLabwareLatchStatus,
+    ThermocyclerLidStatus,
+)
 from opentrons.hardware_control import modules as hw_modules
 from opentrons.hardware_control.modules.magdeck import OFFSET_TO_LABWARE_BOTTOM
 from opentrons.hardware_control.modules.types import (
@@ -206,7 +209,7 @@ def test_thermocycler(ctx_with_thermocycler, mock_module_controller):
 
 def test_thermocycler_lid_status(ctx_with_thermocycler, mock_module_controller):
     mod = ctx_with_thermocycler.load_module("thermocycler")
-    m = mock.PropertyMock(return_value="open")
+    m = mock.PropertyMock(return_value=ThermocyclerLidStatus.OPEN)
     type(mock_module_controller).lid_status = m
     assert mod.lid_position == "open"
 
@@ -276,7 +279,7 @@ def test_thermocycler_flag_unsafe_move(ctx_with_thermocycler, mock_module_contro
     with_tc_labware = Location(None, tc_labware)  # type: ignore[arg-type]
     without_tc_labware = Location(None, None)  # type: ignore[arg-type]
 
-    m = mock.PropertyMock(return_value="closed")
+    m = mock.PropertyMock(return_value=ThermocyclerLidStatus.CLOSED)
     type(mock_module_controller).lid_status = m
 
     with pytest.raises(RuntimeError, match="Cannot move to labware"):


### PR DESCRIPTION
## Overview

This PR ensures that Thermocycler status APIs return vanilla strings, like the other modules.

Addresses RQA-368 in conjunction with #11692

## Changelog

- fix(api): ensure Thermocycler status APIs return vanilla strings

## Review requests

- Code and tests look good
- RQA-368 no longer manifests

## Risk assessment

Low