### PR TITLE
feat(robot-server)!: Wait forever when adding a command without an explicit timeout

### DIFF
--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -67,11 +67,14 @@ async def create_command(
             "\n\n"
             "The timer starts as soon as you enqueue the new command with this request,"
             " *not* when the new command starts running. So if there are other commands"
-            " in the queue in front of the new one, they will also count towards the"
+            " in the queue before the new one, they will also count towards the"
             " timeout."
             "\n\n"
             "If the timeout elapses before the command succeeds or fails,"
             " the command will be returned with its current status."
+            "\n\n"
+            "Compatibility note: on robot software v6.2.0 and older,"
+            " the default was 30 seconds, not infinite."
         ),
     ),
     engine: ProtocolEngine = Depends(get_default_engine),

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -61,9 +61,16 @@ async def create_command(
         default=None,
         gt=0,
         description=(
-            "If `waitUntilComplete` is true, the maximum time in milliseconds to wait,"
-            " **starting from when the command is queued**, before returning."
-            " If the timeout elapses before the command succeeds or fails,"
+            "If `waitUntilComplete` is `true`,"
+            " the maximum time in milliseconds to wait before returning."
+            " The default is infinite."
+            "\n\n"
+            "The timer starts as soon as you enqueue the new command with this request,"
+            " *not* when the new command starts running. So if there are other commands"
+            " in the queue in front of the new one, they will also count towards the"
+            " timeout."
+            "\n\n"
+            "If the timeout elapses before the command succeeds or fails,"
             " the command will be returned with its current status."
         ),
     ),

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -35,7 +35,7 @@ class CommandNotFound(ErrorDetails):
 
 @commands_router.post(
     path="/commands",
-    summary="Add a command to be executed.",
+    summary="Add a command to be executed",
     description=(
         "Run a single command on the robot. This endpoint is meant for"
         " simple, stateless control of the robot. For complex control,"

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -149,8 +149,7 @@ async def create_run_command(
         default=False,
         description=(
             "If `false`, return immediately, while the new command is still queued."
-            "\n\n"
-            "If `true`, only return once the new command succeeds or fails,"
+            " If `true`, only return once the new command succeeds or fails,"
             " or when the timeout is reached. See the `timeout` query parameter."
         ),
     ),
@@ -159,18 +158,16 @@ async def create_run_command(
         gt=0,
         description=(
             "If `waitUntilComplete` is `true`,"
-            " the maximum number of milliseconds to wait before returning."
-            " Ignored if `waitUntilComplete` is `false`."
+            " the maximum time in milliseconds to wait before returning."
+            " The default is infinite."
             "\n\n"
-            "The timer starts when the new command is enqueued,"
-            " *not* when it starts running."
-            " So if a different command runs before the new command,"
-            " it may exhaust the timeout even if the new command on its own"
-            " would have completed in time."
+            "The timer starts as soon as you enqueue the new command with this request,"
+            " *not* when the new command starts running. So if there are other commands"
+            " in the queue in front of the new one, they will also count towards the"
+            " timeout."
             "\n\n"
-            "If the timeout triggers, the command will still be returned"
-            " with a `201` HTTP status code."
-            " Inspect the returned command's `status` to detect the timeout."
+            "If the timeout elapses before the command succeeds or fails,"
+            " the command will be returned with its current status."
         ),
     ),
     protocol_engine: ProtocolEngine = Depends(get_current_run_engine_from_url),

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -163,11 +163,14 @@ async def create_run_command(
             "\n\n"
             "The timer starts as soon as you enqueue the new command with this request,"
             " *not* when the new command starts running. So if there are other commands"
-            " in the queue in front of the new one, they will also count towards the"
+            " in the queue before the new one, they will also count towards the"
             " timeout."
             "\n\n"
             "If the timeout elapses before the command succeeds or fails,"
             " the command will be returned with its current status."
+            "\n\n"
+            "Compatibility note: on robot software v6.2.0 and older,"
+            " the default was 30 seconds, not infinite."
         ),
     ),
     protocol_engine: ProtocolEngine = Depends(get_current_run_engine_from_url),


### PR DESCRIPTION
# Changelog

* For `POST /runs/{runId}/commands` and `POST /commands`, when you provide `waitUntilComplete=true` but omit an explicit `timeout`, default to an infinite timeout instead of 30 seconds. This closes RSS-138. See that ticket for the rationale.
* Unify the docstrings for those endpoints.

# Review requests

* As written, this PR makes this change without any kind of versioning, such as with the `Opentrons-Version` header. My thinking is that if it were easy to forget the `timeout` before, it would be easy to forget `Opentrons-Version` now. Do we agree that this is acceptable?
* Do the docstrings seem clear?
* Do we want to add a note in the docs like "Older versions of the robot software defaulted to 30 seconds"? This would help people who are consulting the modern docs write correct clients for older robot software versions, but it would add noise, and I don't know if it would be worthwhile.

# Testing

* `POST`ing a long command, like `home`, should not return until the command completes—even if it takes longer than 30 seconds.
* Cancelling the HTTP request should not cause any internal Protocol Engine errors because of async cancellation stuff.

# Risk assessment

Low.