### PR TITLE
fix(app): remove labware location dependency from run log command text

### DIFF
--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -7,7 +7,6 @@ import {
   parseInitialLoadedLabwareEntity,
   parseInitialLoadedLabwareBySlot,
   parseInitialLoadedLabwareByModuleId,
-  parseInitialLoadedLabwareDefinitionsById,
   parseInitialLoadedModulesBySlot,
   parseLiquidsInLoadOrder,
   parseLabwareInfoByLiquidId,
@@ -236,27 +235,6 @@ describe('parseInitialLoadedLabwareById', () => {
     expect(parseInitialLoadedLabwareEntity(mockRunTimeCommands)).toEqual(
       expected
     )
-  })
-})
-describe('parseInitialLoadedLabwareDefinitionsById', () => {
-  it('returns labware definitions loaded by id', () => {
-    const expected = {
-      'opentrons/opentrons_96_tiprack_300ul/1': mockRunTimeCommands.find(
-        c =>
-          c.commandType === 'loadLabware' && c.result.labwareId === 'labware-1'
-      )?.result.definition,
-      'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': mockRunTimeCommands.find(
-        c =>
-          c.commandType === 'loadLabware' && c.result.labwareId === 'labware-2'
-      )?.result.definition,
-      'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1': mockRunTimeCommands.find(
-        c =>
-          c.commandType === 'loadLabware' && c.result.labwareId === 'labware-3'
-      )?.result.definition,
-    }
-    expect(
-      parseInitialLoadedLabwareDefinitionsById(mockRunTimeCommands)
-    ).toEqual(expected)
   })
 })
 describe('parseInitialLoadedModulesBySlot', () => {

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -2,11 +2,7 @@
 import reduce from 'lodash/reduce'
 
 import { COLORS } from '@opentrons/components/src/ui-style-constants'
-import type {
-  ModuleModel,
-  PipetteName,
-  Liquid,
-} from '@opentrons/shared-data'
+import type { ModuleModel, PipetteName, Liquid } from '@opentrons/shared-data'
 import type { RunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
 import type {
   LoadLabwareRunTimeCommand,

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -191,40 +191,6 @@ export function parseInitialLoadedLabwareEntity(
   })
 }
 
-export interface LoadedLabwareDefinitionsById {
-  [definitionUri: string]: LabwareDefinition2
-}
-export function parseInitialLoadedLabwareDefinitionsById(
-  commands: RunTimeCommand[]
-): LoadedLabwareDefinitionsById {
-  const labware = parseInitialLoadedLabwareEntity(commands)
-  const loadLabwareCommandsReversed = commands
-    .filter(
-      (command): command is LoadLabwareRunTimeCommand =>
-        command.commandType === 'loadLabware'
-    )
-    .reverse()
-  return reduce<LoadLabwareRunTimeCommand, LoadedLabwareDefinitionsById>(
-    loadLabwareCommandsReversed,
-    (acc, command) => {
-      const quirks = command.result.definition.parameters.quirks ?? []
-      if (quirks.includes('fixedTrash')) {
-        return { ...acc }
-      }
-      const labwareDef: LabwareDefinition2 = command.result?.definition
-      const labwareId = command.result?.labwareId ?? ''
-      const definitionUri =
-        labware.find(item => item.id === labwareId)?.definitionUri ?? ''
-
-      return {
-        ...acc,
-        [definitionUri]: labwareDef,
-      }
-    },
-    {}
-  )
-}
-
 interface LoadedModulesBySlot {
   [slotName: string]: LoadModuleRunTimeCommand
 }

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -3,7 +3,6 @@ import reduce from 'lodash/reduce'
 
 import { COLORS } from '@opentrons/components/src/ui-style-constants'
 import type {
-  LabwareDefinition2,
   ModuleModel,
   PipetteName,
   Liquid,

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,4 +1,8 @@
-import type { ModuleModel } from '@opentrons/shared-data'
+import type {
+  LoadedLabware,
+  LoadedPipette,
+  ModuleModel,
+} from '@opentrons/shared-data'
 import type { ResourceLink } from '../types'
 import type { RunCommandSummary } from './commands/types'
 export * from './commands/types'
@@ -35,8 +39,8 @@ export interface RunData {
   status: RunStatus
   actions: RunAction[]
   errors: Error[]
-  pipettes: unknown[]
-  labware: unknown[]
+  pipettes: LoadedPipette[]
+  labware: LoadedLabware[]
   protocolId?: string
   labwareOffsets?: LabwareOffset[]
 }

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
@@ -6,7 +6,7 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import { useAllHistoricOffsets } from '../useAllHistoricOffsets'
 import { getLabwareLocationCombos } from '../getLabwareLocationCombos'
-import { getDefsByURI } from '../getDefsByURI'
+import { getLoadedLabwareDefinitionsByUri } from '../../../../resources/protocols/utils'
 
 import { useOffsetCandidatesForAnalysis } from '../useOffsetCandidatesForAnalysis'
 import { storedProtocolData as storedProtocolDataFixture } from '../../../../redux/protocol-storage/__fixtures__'
@@ -16,7 +16,7 @@ import type { OffsetCandidate } from '../useOffsetCandidatesForAnalysis'
 
 jest.mock('../useAllHistoricOffsets')
 jest.mock('../getLabwareLocationCombos')
-jest.mock('../getDefsByURI')
+jest.mock('../../../../resources/protocols/utils')
 
 const mockLabwareDef = fixture_tiprack_300_ul as LabwareDefinition2
 const mockUseAllHistoricOffsets = useAllHistoricOffsets as jest.MockedFunction<
@@ -25,8 +25,8 @@ const mockUseAllHistoricOffsets = useAllHistoricOffsets as jest.MockedFunction<
 const mockGetLabwareLocationCombos = getLabwareLocationCombos as jest.MockedFunction<
   typeof getLabwareLocationCombos
 >
-const mockGetDefsByURI = getDefsByURI as jest.MockedFunction<
-  typeof getDefsByURI
+const mockgetLoadedLabwareDefinitionsByUri = getLoadedLabwareDefinitionsByUri as jest.MockedFunction<
+  typeof getLoadedLabwareDefinitionsByUri
 >
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',
@@ -94,7 +94,7 @@ describe('useOffsetCandidatesForAnalysis', () => {
           definitionUri: 'thirdFakeDefURI',
         },
       ])
-    when(mockGetDefsByURI).calledWith(expect.any(Array)).mockReturnValue({
+    when(mockgetLoadedLabwareDefinitionsByUri).calledWith(expect.any(Array)).mockReturnValue({
       firstFakeDefURI: mockLabwareDef,
       secondFakeDefURI: mockLabwareDef,
       thirdFakeDefURI: mockLabwareDef,

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
@@ -25,7 +25,7 @@ const mockUseAllHistoricOffsets = useAllHistoricOffsets as jest.MockedFunction<
 const mockGetLabwareLocationCombos = getLabwareLocationCombos as jest.MockedFunction<
   typeof getLabwareLocationCombos
 >
-const mockgetLoadedLabwareDefinitionsByUri = getLoadedLabwareDefinitionsByUri as jest.MockedFunction<
+const mockGetLoadedLabwareDefinitionsByUri = getLoadedLabwareDefinitionsByUri as jest.MockedFunction<
   typeof getLoadedLabwareDefinitionsByUri
 >
 const mockFirstCandidate: OffsetCandidate = {
@@ -94,11 +94,13 @@ describe('useOffsetCandidatesForAnalysis', () => {
           definitionUri: 'thirdFakeDefURI',
         },
       ])
-    when(mockgetLoadedLabwareDefinitionsByUri).calledWith(expect.any(Array)).mockReturnValue({
-      firstFakeDefURI: mockLabwareDef,
-      secondFakeDefURI: mockLabwareDef,
-      thirdFakeDefURI: mockLabwareDef,
-    })
+    when(mockGetLoadedLabwareDefinitionsByUri)
+      .calledWith(expect.any(Array))
+      .mockReturnValue({
+        firstFakeDefURI: mockLabwareDef,
+        secondFakeDefURI: mockLabwareDef,
+        thirdFakeDefURI: mockLabwareDef,
+      })
   })
 
   afterEach(() => {

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis.ts
@@ -1,8 +1,8 @@
 import isEqual from 'lodash/isEqual'
 import { getLabwareDisplayName, IDENTITY_VECTOR } from '@opentrons/shared-data'
+import { getLoadedLabwareDefinitionsByUri } from '../../../resources/protocols/utils'
 import { useAllHistoricOffsets } from './useAllHistoricOffsets'
 import { getLabwareLocationCombos } from './getLabwareLocationCombos'
-import { getDefsByURI } from './getDefsByURI'
 
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { LabwareOffset } from '@opentrons/api-client'
@@ -24,7 +24,7 @@ export function useOffsetCandidatesForAnalysis(
     labware,
     modules
   )
-  const defsByUri = getDefsByURI(commands)
+  const defsByUri = getLoadedLabwareDefinitionsByUri(commands)
 
   return labwareLocationCombos.reduce<OffsetCandidate[]>(
     (acc, { location, definitionUri }) => {

--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -225,6 +225,8 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
   }
 
   React.useEffect(() => {
+    console.log('RC', runCommands)
+    console.log('AC', runCommands)
     // if the run's current command key doesn't exist in the analysis commands
     if (
       runCommands.length > 0 &&

--- a/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLog.tsx
@@ -225,8 +225,6 @@ export function RunLog({ robotName, runId }: RunLogProps): JSX.Element | null {
   }
 
   React.useEffect(() => {
-    console.log('RC', runCommands)
-    console.log('AC', runCommands)
     // if the run's current command key doesn't exist in the analysis commands
     if (
       runCommands.length > 0 &&

--- a/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
@@ -58,7 +58,7 @@ export const RunLogProtocolSetupInfo = ({
     )
   } else if (setupCommand.commandType === 'loadModule') {
     // TODO(bh, 2022-03-30): parse based on module model or type, not module id
-    const moduleId = setupCommand.params.moduleId
+    const moduleId = setupCommand.result.moduleId
     const moduleModel = protocolData.modules[moduleId]
     const moduleSlotNumber = moduleId.includes('thermocycler') ? 4 : 1
     setupCommandText = (
@@ -84,7 +84,7 @@ export const RunLogProtocolSetupInfo = ({
           (command): command is LoadModuleRunTimeCommand =>
             command.commandType === 'loadModule'
         )
-        .find(command => command.params.moduleId === moduleId)
+        .find(command => command.result.moduleId === moduleId)
       const moduleSlotNumber = moduleRunTimeCommand?.params.location.slotName
       slotNumber = moduleSlotNumber
       moduleName = getModuleDisplayName(moduleModel.model)

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
@@ -21,7 +21,7 @@ import {
 import { getIsLabwareOffsetCodeSnippetsOn } from '../../../../redux/config'
 import { ModalHeader, ModalShell } from '../../../../molecules/Modal'
 import { OffsetVector } from '../../../../molecules/OffsetVector'
-import { getDefsByURI } from '../../../ApplyHistoricOffsets/hooks/getDefsByURI'
+import { getLoadedLabwareDefinitionsByUri } from '../../../../resources/protocols/utils'
 
 import type { LabwareOffset } from '@opentrons/api-client'
 import { PrimaryButton } from '../../../../atoms/buttons'
@@ -59,7 +59,7 @@ export function CurrentOffsetsModal(
 ): JSX.Element {
   const { currentOffsets, commands, onCloseClick } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
-  const defsByURI = getDefsByURI(commands)
+  const defsByURI = getLoadedLabwareDefinitionsByUri(commands)
   const [showCodeSnippet, setShowCodeSnippet] = React.useState<boolean>(false)
   const isLabwareOffsetCodeSnippetsOn = useSelector(
     getIsLabwareOffsetCodeSnippetsOn

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -15,6 +15,7 @@ import type { RunCommandSummary } from '@opentrons/api-client'
 import { getLoadedLabwareDefinitionsByUri } from '../../../resources/protocols/utils'
 
 const TRASH_ID = 'fixedTrash'
+const TEMPORARY_LOCATION_STUB = 'a slot'
 
 interface Props {
   analysisCommand: RunTimeCommand | null
@@ -74,7 +75,7 @@ export function StepText(props: Props): JSX.Element | null {
           labwareId === TRASH_ID
             ? 'Opentrons Fixed Trash'
             : getLabwareDisplayName(defsByURI[definitionUri]),
-        labware_location: 'a slot',
+        labware_location: TEMPORARY_LOCATION_STUB,
       })
       break
     }
@@ -85,7 +86,7 @@ export function StepText(props: Props): JSX.Element | null {
         labware: getLabwareDisplayName(
           labwareRenderInfoById[labwareId].labwareDef
         ),
-        labware_location: 'a slot',
+        labware_location: TEMPORARY_LOCATION_STUB,
       })
       break
     }
@@ -229,11 +230,19 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'aspirate': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
+      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const definitionUri =
+        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+
+      const labwareDisplayName =
+        labwareId === TRASH_ID
+          ? 'Opentrons Fixed Trash'
+          : getLabwareDisplayName(defsByURI[definitionUri])
 
       messageNode = t('aspirate', {
         well_name: wellName,
-        labware: 'a labware',
-        labware_location: 'a slot',
+        labware: labwareDisplayName,
+        labware_location: TEMPORARY_LOCATION_STUB,
         volume: volume,
         flow_rate: flowRate,
       })
@@ -241,10 +250,18 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dispense': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
+      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const definitionUri =
+        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+      const labwareDisplayName =
+        labwareId === TRASH_ID
+          ? 'Opentrons Fixed Trash'
+          : getLabwareDisplayName(defsByURI[definitionUri])
+
       messageNode = t('dispense', {
         well_name: wellName,
-        labware: 'a labware',
-        labware_location: 'a slot',
+        labware: labwareDisplayName,
+        labware_location: TEMPORARY_LOCATION_STUB,
         volume: volume,
         flow_rate: flowRate,
       })
@@ -253,10 +270,18 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'blowout': {
       const { wellName, labwareId, flowRate } = displayCommand.params
+      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const definitionUri =
+        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+      const labwareDisplayName =
+        labwareId === TRASH_ID
+          ? 'Opentrons Fixed Trash'
+          : getLabwareDisplayName(defsByURI[definitionUri])
+
       messageNode = t('blowout', {
         well_name: wellName,
-        labware: 'a labware',
-        labware_location: 'a slot',
+        labware: labwareDisplayName,
+        labware_location: TEMPORARY_LOCATION_STUB,
         flow_rate: flowRate,
       })
       break
@@ -274,11 +299,18 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'moveToWell': {
       const { wellName, labwareId } = displayCommand.params
+      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const definitionUri =
+        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+      const labwareDisplayName =
+        labwareId === TRASH_ID
+          ? 'Opentrons Fixed Trash'
+          : getLabwareDisplayName(defsByURI[definitionUri])
 
       messageNode = t('move_to_well', {
         well_name: wellName,
-        labware: 'a labware',
-        labware_location: 'a slot',
+        labware: labwareDisplayName,
+        labware_location: TEMPORARY_LOCATION_STUB,
       })
       break
     }

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -87,11 +87,15 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'pickUpTip': {
       const { wellName, labwareId } = displayCommand.params
+      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
+      const definitionUri =
+        labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       messageNode = t('pickup_tip', {
         well_name: wellName,
-        labware: getLabwareDisplayName(
-          labwareRenderInfoById[labwareId].labwareDef
-        ),
+        labware:
+          labwareId === TRASH_ID
+            ? 'Opentrons Fixed Trash'
+            : getLabwareDisplayName(defsByURI[definitionUri]),
         labware_location: TEMPORARY_LOCATION_STUB,
       })
       break

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Flex, ALIGN_CENTER, SPACING, TYPOGRAPHY } from '@opentrons/components'
-import { getLabwareDisplayName } from '@opentrons/shared-data'
+import { LoadedLabware } from '@opentrons/shared-data'
+import { useRunQuery } from '@opentrons/react-api-client'
 import { StyledText } from '../../../atoms/text'
 
-import {
-  useLabwareRenderInfoForRunById,
-  useProtocolDetailsForRun,
-} from '../hooks'
+import { useProtocolDetailsForRun } from '../hooks'
 import { RunLogProtocolSetupInfo } from './RunLogProtocolSetupInfo'
 
 import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { RunCommandSummary } from '@opentrons/api-client'
-import { getLoadedLabwareDefinitionsByUri } from '../../../resources/protocols/utils'
-import { useRunQuery } from '@opentrons/react-api-client'
 
-const TRASH_ID = 'fixedTrash'
 const TEMPORARY_LOCATION_STUB = 'a slot'
 
 interface Props {
@@ -29,14 +24,12 @@ export function StepText(props: Props): JSX.Element | null {
   const { t } = useTranslation('commands_run_log')
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const { protocolData } = useProtocolDetailsForRun(runId)
-  const labwareRenderInfoById = useLabwareRenderInfoForRunById(runId)
 
   let messageNode = null
 
-  const allCommands =
-    runCommand !== null ? runRecord.commands : protocolData?.commands
-  const labwareEntities =
-    runCommand !== null ? runRecord.labware : protocolData?.labware
+  const labwareEntities: LoadedLabware[] =
+    (runCommand !== null ? runRecord?.data?.labware : protocolData?.labware) ??
+    []
   const displayCommand = runCommand !== null ? runCommand : analysisCommand
 
   if (displayCommand === null) {
@@ -72,30 +65,22 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dropTip': {
       const { wellName, labwareId } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
         labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       messageNode = t('drop_tip', {
         well_name: wellName,
-        labware:
-          labwareId === TRASH_ID
-            ? 'Opentrons Fixed Trash'
-            : getLabwareDisplayName(defsByURI[definitionUri]),
+        labware: definitionUri,
         labware_location: TEMPORARY_LOCATION_STUB,
       })
       break
     }
     case 'pickUpTip': {
       const { wellName, labwareId } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
         labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       messageNode = t('pickup_tip', {
         well_name: wellName,
-        labware:
-          labwareId === TRASH_ID
-            ? 'Opentrons Fixed Trash'
-            : getLabwareDisplayName(defsByURI[definitionUri]),
+        labware: definitionUri,
         labware_location: TEMPORARY_LOCATION_STUB,
       })
       break
@@ -240,18 +225,11 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'aspirate': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
         labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
-
-      const labwareDisplayName =
-        labwareId === TRASH_ID
-          ? 'Opentrons Fixed Trash'
-          : getLabwareDisplayName(defsByURI[definitionUri])
-
       messageNode = t('aspirate', {
         well_name: wellName,
-        labware: labwareDisplayName,
+        labware: definitionUri,
         labware_location: TEMPORARY_LOCATION_STUB,
         volume: volume,
         flow_rate: flowRate,
@@ -260,17 +238,12 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dispense': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
         labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
-      const labwareDisplayName =
-        labwareId === TRASH_ID
-          ? 'Opentrons Fixed Trash'
-          : getLabwareDisplayName(defsByURI[definitionUri])
 
       messageNode = t('dispense', {
         well_name: wellName,
-        labware: labwareDisplayName,
+        labware: definitionUri,
         labware_location: TEMPORARY_LOCATION_STUB,
         volume: volume,
         flow_rate: flowRate,
@@ -280,17 +253,12 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'blowout': {
       const { wellName, labwareId, flowRate } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
         labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
-      const labwareDisplayName =
-        labwareId === TRASH_ID
-          ? 'Opentrons Fixed Trash'
-          : getLabwareDisplayName(defsByURI[definitionUri])
 
       messageNode = t('blowout', {
         well_name: wellName,
-        labware: labwareDisplayName,
+        labware: definitionUri,
         labware_location: TEMPORARY_LOCATION_STUB,
         flow_rate: flowRate,
       })
@@ -309,17 +277,12 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'moveToWell': {
       const { wellName, labwareId } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
         labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
-      const labwareDisplayName =
-        labwareId === TRASH_ID
-          ? 'Opentrons Fixed Trash'
-          : getLabwareDisplayName(defsByURI[definitionUri])
 
       messageNode = t('move_to_well', {
         well_name: wellName,
-        labware: labwareDisplayName,
+        labware: definitionUri,
         labware_location: TEMPORARY_LOCATION_STUB,
       })
       break

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -13,6 +13,7 @@ import { RunLogProtocolSetupInfo } from './RunLogProtocolSetupInfo'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { RunCommandSummary } from '@opentrons/api-client'
 import { getLoadedLabwareDefinitionsByUri } from '../../../resources/protocols/utils'
+import { useRunQuery } from '@opentrons/react-api-client'
 
 const TRASH_ID = 'fixedTrash'
 const TEMPORARY_LOCATION_STUB = 'a slot'
@@ -26,11 +27,16 @@ interface Props {
 export function StepText(props: Props): JSX.Element | null {
   const { analysisCommand, robotName, runCommand, runId } = props
   const { t } = useTranslation('commands_run_log')
+  const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const { protocolData } = useProtocolDetailsForRun(runId)
   const labwareRenderInfoById = useLabwareRenderInfoForRunById(runId)
 
   let messageNode = null
 
+  const allCommands =
+    runCommand !== null ? runRecord.commands : protocolData?.commands
+  const labwareEntities =
+    runCommand !== null ? runRecord.labware : protocolData?.labware
   const displayCommand = runCommand !== null ? runCommand : analysisCommand
 
   if (displayCommand === null) {
@@ -66,9 +72,9 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dropTip': {
       const { wellName, labwareId } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
-        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+        labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       messageNode = t('drop_tip', {
         well_name: wellName,
         labware:
@@ -230,9 +236,9 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'aspirate': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
-        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+        labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
 
       const labwareDisplayName =
         labwareId === TRASH_ID
@@ -250,9 +256,9 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dispense': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
-        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+        labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       const labwareDisplayName =
         labwareId === TRASH_ID
           ? 'Opentrons Fixed Trash'
@@ -270,9 +276,9 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'blowout': {
       const { wellName, labwareId, flowRate } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
-        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+        labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       const labwareDisplayName =
         labwareId === TRASH_ID
           ? 'Opentrons Fixed Trash'
@@ -299,9 +305,9 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'moveToWell': {
       const { wellName, labwareId } = displayCommand.params
-      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
+      const defsByURI = getLoadedLabwareDefinitionsByUri(allCommands)
       const definitionUri =
-        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
+        labwareEntities.find(l => l.id === labwareId)?.definitionUri ?? ''
       const labwareDisplayName =
         labwareId === TRASH_ID
           ? 'Opentrons Fixed Trash'

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -67,8 +67,7 @@ export function StepText(props: Props): JSX.Element | null {
       const { wellName, labwareId } = displayCommand.params
       const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
       const definitionUri =
-        protocolData.labware.find(l => l.id === labwareId)
-          ?.definitionUri ?? ''
+        protocolData.labware.find(l => l.id === labwareId)?.definitionUri ?? ''
       messageNode = t('drop_tip', {
         well_name: wellName,
         labware:
@@ -230,7 +229,7 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'aspirate': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      
+
       messageNode = t('aspirate', {
         well_name: wellName,
         labware: 'a labware',

--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { Flex, ALIGN_CENTER, SPACING, TYPOGRAPHY } from '@opentrons/components'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { StyledText } from '../../../atoms/text'
-import { getLabwareLocation } from '../ProtocolRun/utils/getLabwareLocation'
-import { getSlotLabwareName } from './utils/getSlotLabwareName'
 
 import {
   useLabwareRenderInfoForRunById,
@@ -14,6 +12,7 @@ import { RunLogProtocolSetupInfo } from './RunLogProtocolSetupInfo'
 
 import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { RunCommandSummary } from '@opentrons/api-client'
+import { getLoadedLabwareDefinitionsByUri } from '../../../resources/protocols/utils'
 
 const TRASH_ID = 'fixedTrash'
 
@@ -66,25 +65,17 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dropTip': {
       const { wellName, labwareId } = displayCommand.params
-      const labwareLocation = getLabwareLocation(
-        labwareId,
-        protocolData.commands
-      )
-      if (labwareLocation === 'offDeck' || !('slotName' in labwareLocation)) {
-        throw new Error('expected tip rack to be in a slot')
-      }
+      const defsByURI = getLoadedLabwareDefinitionsByUri(protocolData.commands)
       const definitionUri =
-        protocolData.labware.find(labware => labware.id === labwareId)
+        protocolData.labware.find(l => l.id === labwareId)
           ?.definitionUri ?? ''
       messageNode = t('drop_tip', {
         well_name: wellName,
         labware:
           labwareId === TRASH_ID
             ? 'Opentrons Fixed Trash'
-            : getLabwareDisplayName(
-                protocolData.labwareDefinitions[definitionUri]
-              ),
-        labware_location: labwareLocation.slotName,
+            : getLabwareDisplayName(defsByURI[definitionUri]),
+        labware_location: 'a slot',
       })
       break
     }
@@ -95,6 +86,7 @@ export function StepText(props: Props): JSX.Element | null {
         labware: getLabwareDisplayName(
           labwareRenderInfoById[labwareId].labwareDef
         ),
+        labware_location: 'a slot',
       })
       break
     }
@@ -238,14 +230,11 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'aspirate': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      const { slotName, labwareName } = getSlotLabwareName(
-        labwareId,
-        protocolData.commands
-      )
+      
       messageNode = t('aspirate', {
         well_name: wellName,
-        labware: labwareName,
-        labware_location: slotName,
+        labware: 'a labware',
+        labware_location: 'a slot',
         volume: volume,
         flow_rate: flowRate,
       })
@@ -253,14 +242,10 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'dispense': {
       const { wellName, labwareId, volume, flowRate } = displayCommand.params
-      const { slotName, labwareName } = getSlotLabwareName(
-        labwareId,
-        protocolData.commands
-      )
       messageNode = t('dispense', {
         well_name: wellName,
-        labware: labwareName,
-        labware_location: slotName,
+        labware: 'a labware',
+        labware_location: 'a slot',
         volume: volume,
         flow_rate: flowRate,
       })
@@ -269,14 +254,10 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'blowout': {
       const { wellName, labwareId, flowRate } = displayCommand.params
-      const { slotName, labwareName } = getSlotLabwareName(
-        labwareId,
-        protocolData.commands
-      )
       messageNode = t('blowout', {
         well_name: wellName,
-        labware: labwareName,
-        labware_location: slotName,
+        labware: 'a labware',
+        labware_location: 'a slot',
         flow_rate: flowRate,
       })
       break
@@ -294,15 +275,11 @@ export function StepText(props: Props): JSX.Element | null {
     }
     case 'moveToWell': {
       const { wellName, labwareId } = displayCommand.params
-      const { slotName, labwareName } = getSlotLabwareName(
-        labwareId,
-        protocolData.commands
-      )
 
       messageNode = t('move_to_well', {
         well_name: wellName,
-        labware: labwareName,
-        labware_location: slotName,
+        labware: 'a labware',
+        labware_location: 'a slot',
       })
       break
     }

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/RunLogProtocolSetupInfo.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/RunLogProtocolSetupInfo.test.tsx
@@ -201,12 +201,21 @@ describe('RunLogProtocolSetupInfo', () => {
       runId: RUN_ID,
       setupCommand: COMMAND_TYPE_LOAD_LABWARE_WITH_MODULE,
     }
-    when(mockUseProtocolDetailsForRun).calledWith(RUN_ID).mockReturnValue({
-      protocolData: simpleV6Protocol,
-      displayName: 'mock display name',
-      protocolKey: 'fakeProtocolKey',
-      robotType: 'OT-2 Standard',
-    })
+    when(mockUseProtocolDetailsForRun)
+      .calledWith(RUN_ID)
+      .mockReturnValue({
+        protocolData: {
+          ...simpleV6Protocol,
+          commands: simpleV6Protocol.commands.map(c =>
+            c.commandType === 'loadModule'
+              ? { ...c, result: { moduleId: c.params.moduleId } }
+              : c
+          ),
+        },
+        displayName: 'mock display name',
+        protocolKey: 'fakeProtocolKey',
+        robotType: 'OT-2 Standard',
+      })
     const { getByText } = render(props)
     getByText(
       'Load ANSI 96 Standard Microplate v1 in Magnetic Module GEN2 in Slot 3'

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/StepText.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/StepText.test.tsx
@@ -1,22 +1,19 @@
 import * as React from 'react'
 import { resetAllWhenMocks } from 'jest-when'
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import { useRunQuery } from '@opentrons/react-api-client'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 
 import { RunCommandSummary } from '@opentrons/api-client'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
-import {
-  useLabwareRenderInfoForRunById,
-  useProtocolDetailsForRun,
-} from '../../hooks'
+import { useProtocolDetailsForRun } from '../../hooks'
 import { RunLogProtocolSetupInfo } from '../RunLogProtocolSetupInfo'
 import { StepText } from '../StepText'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { RunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command'
 
-jest.mock('../../ProtocolRun/utils/getLabwareLocation')
+jest.mock('@opentrons/react-api-client')
 jest.mock('../../hooks')
 jest.mock('./../RunLogProtocolSetupInfo')
 
@@ -24,9 +21,7 @@ const mockLabwareDef = fixture_tiprack_300_ul as LabwareDefinition2
 const mockUseProtocolDetailsForRun = useProtocolDetailsForRun as jest.MockedFunction<
   typeof useProtocolDetailsForRun
 >
-const mockUseLabwareRenderInfoForRunById = useLabwareRenderInfoForRunById as jest.MockedFunction<
-  typeof useLabwareRenderInfoForRunById
->
+const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
 const mockRunLogProtocolSetupInfo = RunLogProtocolSetupInfo as jest.MockedFunction<
   typeof RunLogProtocolSetupInfo
 >
@@ -78,15 +73,19 @@ describe('StepText', () => {
             result: { labwareId: 'labwareId', definition: mockLabwareDef },
           },
         ],
-        labware: [
-          { id: 'labwareId', definitionUri: getLabwareDefURI(mockLabwareDef) },
-        ],
+        labware: [{ id: 'labwareId', definitionUri: 'fake_def_uri' }],
       },
     } as any)
-    mockUseLabwareRenderInfoForRunById.mockReturnValue({} as any)
     mockRunLogProtocolSetupInfo.mockReturnValue(
       <div>Mock Protocol Setup Step</div>
     )
+    mockUseRunQuery.mockReturnValue({
+      data: {
+        data: {
+          labware: [{ id: 'labwareId', definitionUri: 'fake_def_uri' }],
+        },
+      },
+    } as any)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -165,11 +164,6 @@ describe('StepText', () => {
   it('renders correct command text for pick up tip', () => {
     const labwareId = 'labwareId'
     const wellName = 'wellName'
-    mockUseLabwareRenderInfoForRunById.mockReturnValue({
-      labwareId: {
-        labwareDef: mockLabwareDef,
-      },
-    } as any)
     const { getByText } = render({
       robotName: ROBOT_NAME,
       runId: RUN_ID,
@@ -183,7 +177,7 @@ describe('StepText', () => {
         },
       },
     })
-    getByText('Picking up tip from wellName of 300ul Tiprack FIXTURE')
+    getByText('Picking up tip from wellName of fake_def_uri')
   })
 
   it('renders correct command text for for legacy command with non-string text', () => {
@@ -611,11 +605,6 @@ describe('StepText', () => {
   })
 
   it('renders correct command text for aspirate', () => {
-    mockUseLabwareRenderInfoForRunById.mockReturnValue({
-      labwareId: {
-        labwareDef: mockLabwareDef,
-      },
-    } as any)
     const { getByText } = render({
       robotName: ROBOT_NAME,
       runId: RUN_ID,
@@ -632,15 +621,10 @@ describe('StepText', () => {
       },
     })
     getByText(
-      'Aspirating 100 uL from wellName of 300ul Tiprack FIXTURE in a slot at 130 uL/sec'
+      'Aspirating 100 uL from wellName of fake_def_uri in a slot at 130 uL/sec'
     )
   })
   it('renders correct command text for dispense', () => {
-    mockUseLabwareRenderInfoForRunById.mockReturnValue({
-      labwareId: {
-        labwareDef: 'fake_def',
-      },
-    } as any)
     const { getByText } = render({
       robotName: ROBOT_NAME,
       runId: RUN_ID,
@@ -657,15 +641,10 @@ describe('StepText', () => {
       },
     })
     getByText(
-      'Dispensing 100 uL into wellName of 300ul Tiprack FIXTURE in a slot at 130 uL/sec'
+      'Dispensing 100 uL into wellName of fake_def_uri in a slot at 130 uL/sec'
     )
   })
   it('renders correct command text for blowout', () => {
-    mockUseLabwareRenderInfoForRunById.mockReturnValue({
-      labwareId: {
-        labwareDef: 'fake_def',
-      },
-    } as any)
     const { getByText } = render({
       robotName: ROBOT_NAME,
       runId: RUN_ID,
@@ -680,9 +659,7 @@ describe('StepText', () => {
         },
       },
     })
-    getByText(
-      'Blowing out at wellName of 300ul Tiprack FIXTURE in a slot at 130 uL/sec'
-    )
+    getByText('Blowing out at wellName of fake_def_uri in a slot at 130 uL/sec')
   })
   it('renders correct command text for touchTip', () => {
     const { getByText } = render({
@@ -710,11 +687,6 @@ describe('StepText', () => {
     getByText('Moving to slot 5')
   })
   it('renders correct command text for moveToWell', () => {
-    mockUseLabwareRenderInfoForRunById.mockReturnValue({
-      labwareId: {
-        labwareDef: 'fake_def',
-      },
-    } as any)
     const { getByText } = render({
       robotName: ROBOT_NAME,
       runId: RUN_ID,
@@ -728,7 +700,7 @@ describe('StepText', () => {
         },
       },
     })
-    getByText('Moving to wellName of 300ul Tiprack FIXTURE in a slot')
+    getByText('Moving to wellName of fake_def_uri in a slot')
   })
   it('renders correct command text for moveRelative', () => {
     const { getByText } = render({

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -14,7 +14,7 @@ export const LABWARE_ENTITY: LoadedLabwareEntity = {
   definitionUri: 'fakeLabwareDefinitionUri',
   displayName: 'a fake labware',
 }
-export const LABWARE_DEFINITIONS: {[defUri: string]: LabwareDefinition2}= {
+export const LABWARE_DEFINITIONS: { [defUri: string]: LabwareDefinition2 } = {
   fakeLabwareDefinitionId: {} as LabwareDefinition2,
 }
 export const MODULE_MODELS_BY_ID: ModuleModelsById = {

--- a/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/storedProtocolAnalysis.ts
@@ -2,7 +2,6 @@ import { storedProtocolData } from '../../../../redux/protocol-storage/__fixture
 
 import type {
   LoadedLabwareEntity,
-  LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
 } from '@opentrons/api-client'
@@ -15,7 +14,7 @@ export const LABWARE_ENTITY: LoadedLabwareEntity = {
   definitionUri: 'fakeLabwareDefinitionUri',
   displayName: 'a fake labware',
 }
-export const LABWARE_DEFINITIONS: LoadedLabwareDefinitionsById = {
+export const LABWARE_DEFINITIONS: {[defUri: string]: LabwareDefinition2}= {
   fakeLabwareDefinitionId: {} as LabwareDefinition2,
 }
 export const MODULE_MODELS_BY_ID: ModuleModelsById = {

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -8,7 +8,6 @@ import { renderHook } from '@testing-library/react-hooks'
 import {
   parseAllRequiredModuleModelsById,
   parseInitialLoadedLabwareEntity,
-  parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
@@ -45,9 +44,6 @@ const mockParseAllRequiredModuleModelsById = parseAllRequiredModuleModelsById as
 >
 const mockParseInitialLoadedLabwareEntity = parseInitialLoadedLabwareEntity as jest.MockedFunction<
   typeof parseInitialLoadedLabwareEntity
->
-const mockParseInitialLoadedLabwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById as jest.MockedFunction<
-  typeof parseInitialLoadedLabwareDefinitionsById
 >
 const mockParsePipetteEntity = parsePipetteEntity as jest.MockedFunction<
   typeof parsePipetteEntity
@@ -92,9 +88,6 @@ describe('useStoredProtocolAnalysis hook', () => {
       MODULE_MODELS_BY_ID
     )
     when(mockParseInitialLoadedLabwareEntity).mockReturnValue([LABWARE_ENTITY])
-    when(mockParseInitialLoadedLabwareDefinitionsById).mockReturnValue(
-      LABWARE_DEFINITIONS
-    )
     when(mockParsePipetteEntity).mockReturnValue([PIPETTE_NAME_BY_ID])
   })
   afterEach(() => {

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -27,7 +27,9 @@ import {
 } from '../__fixtures__/storedProtocolAnalysis'
 
 import type { Protocol, Run } from '@opentrons/api-client'
+import { getLoadedLabwareDefinitionsByUri } from '@opentrons/shared-data'
 
+jest.mock('@opentrons/shared-data')
 jest.mock('@opentrons/api-client')
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../../redux/protocol-storage/selectors')
@@ -47,6 +49,9 @@ const mockParseInitialLoadedLabwareEntity = parseInitialLoadedLabwareEntity as j
 >
 const mockParsePipetteEntity = parsePipetteEntity as jest.MockedFunction<
   typeof parsePipetteEntity
+>
+const mockGetLoadedLabwareDefinitionsByUri = getLoadedLabwareDefinitionsByUri as jest.MockedFunction<
+  typeof getLoadedLabwareDefinitionsByUri
 >
 const store: Store<any> = createStore(jest.fn(), {})
 
@@ -84,6 +89,11 @@ describe('useStoredProtocolAnalysis hook', () => {
     when(mockGetStoredProtocol)
       .calledWith(undefined as any)
       .mockReturnValue(null)
+    when(mockGetLoadedLabwareDefinitionsByUri)
+      .calledWith(
+        modifiedStoredProtocolData?.mostRecentAnalysis?.commands ?? []
+      )
+      .mockReturnValue(LABWARE_DEFINITIONS)
     when(mockParseAllRequiredModuleModelsById).mockReturnValue(
       MODULE_MODELS_BY_ID
     )

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -4,7 +4,10 @@ import {
   parseInitialLoadedLabwareEntity,
   parsePipetteEntity,
 } from '@opentrons/api-client'
-import { schemaV6Adapter, getLoadedLabwareDefinitionsByUri  } from '@opentrons/shared-data'
+import {
+  schemaV6Adapter,
+  getLoadedLabwareDefinitionsByUri,
+} from '@opentrons/shared-data'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 
 import { getStoredProtocol } from '../../../redux/protocol-storage'
@@ -14,7 +17,10 @@ import type {
   ModuleModelsById,
   PipetteNamesById,
 } from '@opentrons/api-client'
-import type { ProtocolAnalysisOutput, LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  ProtocolAnalysisOutput,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 import type { State } from '../../../redux/types'
 
 // TODO(bc, 2022-09-26): StoredProtocolAnalysis can be wholesale replaced by ProtocolAnalysisOutput,
@@ -24,7 +30,7 @@ export interface StoredProtocolAnalysis
   pipettes: PipetteNamesById[]
   modules: ModuleModelsById
   labware: LoadedLabwareEntity[]
-  labwareDefinitions: {[defUri: string]: LabwareDefinition2} 
+  labwareDefinitions: { [defUri: string]: LabwareDefinition2 }
 }
 
 export const parseProtocolAnalysisOutput = (

--- a/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
+++ b/app/src/organisms/Devices/hooks/useStoredProtocolAnalysis.ts
@@ -2,21 +2,19 @@ import { useSelector } from 'react-redux'
 import {
   parseAllRequiredModuleModelsById,
   parseInitialLoadedLabwareEntity,
-  parseInitialLoadedLabwareDefinitionsById,
   parsePipetteEntity,
 } from '@opentrons/api-client'
-import { schemaV6Adapter } from '@opentrons/shared-data'
+import { schemaV6Adapter, getLoadedLabwareDefinitionsByUri  } from '@opentrons/shared-data'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 
 import { getStoredProtocol } from '../../../redux/protocol-storage'
 
 import type {
   LoadedLabwareEntity,
-  LoadedLabwareDefinitionsById,
   ModuleModelsById,
   PipetteNamesById,
 } from '@opentrons/api-client'
-import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
+import type { ProtocolAnalysisOutput, LabwareDefinition2 } from '@opentrons/shared-data'
 import type { State } from '../../../redux/types'
 
 // TODO(bc, 2022-09-26): StoredProtocolAnalysis can be wholesale replaced by ProtocolAnalysisOutput,
@@ -26,7 +24,7 @@ export interface StoredProtocolAnalysis
   pipettes: PipetteNamesById[]
   modules: ModuleModelsById
   labware: LoadedLabwareEntity[]
-  labwareDefinitions: LoadedLabwareDefinitionsById
+  labwareDefinitions: {[defUri: string]: LabwareDefinition2} 
 }
 
 export const parseProtocolAnalysisOutput = (
@@ -41,7 +39,7 @@ export const parseProtocolAnalysisOutput = (
   const labwareById = parseInitialLoadedLabwareEntity(
     storedProtocolAnalysis?.commands ?? []
   )
-  const labwareDefinitionsById = parseInitialLoadedLabwareDefinitionsById(
+  const labwareDefinitionsByUri = getLoadedLabwareDefinitionsByUri(
     storedProtocolAnalysis?.commands ?? []
   )
   return storedProtocolAnalysis != null
@@ -50,7 +48,7 @@ export const parseProtocolAnalysisOutput = (
         pipettes: pipettesNamesById,
         modules: moduleModelsById,
         labware: labwareById,
-        labwareDefinitions: labwareDefinitionsById,
+        labwareDefinitions: labwareDefinitionsByUri,
       }
     : null
 }

--- a/app/src/resources/protocols/utils.ts
+++ b/app/src/resources/protocols/utils.ts
@@ -1,0 +1,16 @@
+import { getLabwareDefURI } from '@opentrons/shared-data'
+import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+
+export function getLoadedLabwareDefinitionsByUri(
+  commands: RunTimeCommand[]
+): { [defURI: string]: LabwareDefinition2 } {
+  return commands.reduce((acc, command) => {
+    if (command.commandType === 'loadLabware') {
+      const labwareDef: LabwareDefinition2 = command.result?.definition
+      const definitionUri = getLabwareDefURI(labwareDef)
+      return { ...acc, [definitionUri]: labwareDef }
+    } else {
+      return acc
+    }
+  }, {})
+}

--- a/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
+++ b/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
@@ -1,7 +1,7 @@
-import { getLabwareDefURI } from '@opentrons/shared-data'
-import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+import { getLabwareDefURI } from '.'
+import type { RunTimeCommand, LabwareDefinition2 } from '..'
 
-export function getDefsByURI(
+export function getLoadedLabwareDefinitionsByUri(
   commands: RunTimeCommand[]
 ): { [defURI: string]: LabwareDefinition2 } {
   return commands.reduce((acc, command) => {

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -24,6 +24,7 @@ export * from './wellSets'
 export * from './getModuleVizDims'
 export * from './getVectorDifference'
 export * from './getVectorSum'
+export * from './getLoadedLabwareDefinitionsByUri'
 
 export const getLabwareDefIsStandard = (def: LabwareDefinition2): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -13,6 +13,7 @@ import type {
   LabwareDefinition2,
   ModuleModel,
 } from '../types'
+import { getLoadedLabwareDefinitionsByUri } from './getLoadedLabwareDefinitionsByUri'
 // This adapter exists to resolve the interface mismatch between the PE analysis response
 // and the protocol schema v6 interface. Much of this logic should be deleted once we resolve
 // these discrepencies on the server side
@@ -56,25 +57,7 @@ export const schemaV6Adapter = (
       }
     })
 
-    const labwareDefinitions: {
-      [definitionUri: string]: LabwareDefinition2
-    } = protocolAnalysis.commands
-      .filter(
-        (command: RunTimeCommand): command is LoadLabwareRunTimeCommand =>
-          command.commandType === 'loadLabware'
-      )
-      .reduce((acc, command: LoadLabwareRunTimeCommand) => {
-        const labwareDef: LabwareDefinition2 = command.result?.definition
-        const labwareId = command.result?.labwareId ?? ''
-        const definitionUri =
-          protocolAnalysis.labware.find(labware => labware.id === labwareId)
-            ?.definitionUri ?? ''
-
-        return {
-          ...acc,
-          [definitionUri]: labwareDef,
-        }
-      }, {})
+    const labwareDefinitions = getLoadedLabwareDefinitionsByUri(protocolAnalysis.commands)
 
     const modules: {
       [moduleId: string]: { model: ModuleModel }

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -57,7 +57,9 @@ export const schemaV6Adapter = (
       }
     })
 
-    const labwareDefinitions = getLoadedLabwareDefinitionsByUri(protocolAnalysis.commands)
+    const labwareDefinitions = getLoadedLabwareDefinitionsByUri(
+      protocolAnalysis.commands
+    )
 
     const modules: {
       [moduleId: string]: { model: ModuleModel }

--- a/shared-data/js/helpers/schemaV6Adapter.ts
+++ b/shared-data/js/helpers/schemaV6Adapter.ts
@@ -10,7 +10,6 @@ import type {
 import type {
   PendingProtocolAnalysis,
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
   ModuleModel,
 } from '../types'
 import { getLoadedLabwareDefinitionsByUri } from './getLoadedLabwareDefinitionsByUri'


### PR DESCRIPTION
# Overview

Until there is a longer term solution for inspecting the location of a labware that is resolved from a given command in the protocol engine's timeline, the run log will not present what is likely to be a wrong location based on the  top level labware entitity key

# Review requests

- smoke test the run log for a current run
- smoke test the run log for a historic run

# Risk assessment
low (this is stubbing code to avoid short term risk)
