### PR TITLE
refactor(api): Add pause and delay handling to ProtocolEngine PAPI core

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -247,10 +247,12 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def pause(self, msg: Optional[str]) -> None:
         """Pause the protocol."""
-        raise NotImplementedError("ProtocolCore.pause not implemented")
+        self._engine_client.wait_for_resume(message=msg)
 
     def resume(self) -> None:
         """Resume the protocol."""
+        # TODO(mm, 2022-11-08): This method is not usable in practice. Consider removing
+        # it from both cores. https://github.com/Opentrons/opentrons/issues/8209
         raise NotImplementedError("ProtocolCore.resume not implemented")
 
     def comment(self, msg: str) -> None:
@@ -259,7 +261,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def delay(self, seconds: float, msg: Optional[str]) -> None:
         """Wait for a period of time before proceeding."""
-        raise NotImplementedError("ProtocolCore.delay not implemented")
+        self._engine_client.wait_for_duration(seconds=seconds, message=msg)
 
     def home(self) -> None:
         """Move all axes to their home positions."""

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -274,6 +274,16 @@ class SyncClient:
         result = self._transport.execute_command(request=request)
         return cast(commands.TouchTipResult, result)
 
+    def wait_for_duration(
+        self, seconds: float, message: Optional[str]
+    ) -> commands.WaitForDurationResult:
+        """Execute a ``waitForDuration`` command and return the result."""
+        request = commands.WaitForDurationCreate(
+            params=commands.WaitForDurationParams(seconds=seconds, message=message)
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.WaitForDurationResult, result)
+
     def wait_for_resume(self, message: Optional[str]) -> commands.WaitForResumeResult:
         """Execute a `WaitForResume` command and return the result."""
         request = commands.WaitForResumeCreate(

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -438,6 +438,7 @@ def test_pause(
     subject: ProtocolCore,
     message: Optional[str],
 ) -> None:
+    """It should issue a waitForResume command."""
     subject.pause(msg=message)
     decoy.verify(mock_engine_client.wait_for_resume(message=message))
 
@@ -451,5 +452,6 @@ def test_delay(
     seconds: float,
     message: Optional[str],
 ) -> None:
+    """It should issue a waitForDuration command."""
     subject.delay(seconds=seconds, msg=message)
     decoy.verify(mock_engine_client.wait_for_duration(seconds=seconds, message=message))

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -1,5 +1,5 @@
 """Test for the ProtocolEngine-based protocol API core."""
-from typing import Type
+from typing import Optional, Type
 
 import pytest
 from decoy import Decoy
@@ -429,3 +429,27 @@ def test_load_module_no_location(
     """Should raise an InvalidModuleLocationError exception."""
     with pytest.raises(InvalidModuleLocationError):
         subject.load_module(model=requested_model, deck_slot=None, configuration="")
+
+
+@pytest.mark.parametrize("message", [None, "Hello, world!", ""])
+def test_pause(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+    message: Optional[str],
+) -> None:
+    subject.pause(msg=message)
+    decoy.verify(mock_engine_client.wait_for_resume(message=message))
+
+
+@pytest.mark.parametrize("seconds", [0.0, -1.23, 1.23])
+@pytest.mark.parametrize("message", [None, "Hello, world!", ""])
+def test_delay(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+    seconds: float,
+    message: Optional[str],
+) -> None:
+    subject.delay(seconds=seconds, msg=message)
+    decoy.verify(mock_engine_client.wait_for_duration(seconds=seconds, message=message))

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -8,6 +8,8 @@ the subject's methods in a synchronous context in a child thread to ensure:
 - In the main thread, the Protocol Engine does its work in the main event
     loop, without blocking.
 """
+from typing import Optional
+
 import pytest
 from decoy import Decoy
 
@@ -358,6 +360,28 @@ def test_touch_tip(
         well_name="A2",
         well_location=WellLocation(),
     )
+
+    assert result == response
+
+
+@pytest.mark.parametrize("seconds", [-1.23, 0.0, 1.23])
+@pytest.mark.parametrize("message", [None, "Hello, world!", ""])
+def test_wait_for_duration(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+    seconds: float,
+    message: Optional[str],
+) -> None:
+    """It should execute a wait for resume command."""
+    request = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=seconds, message=message)
+    )
+    response = commands.WaitForDurationResult()
+
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+
+    result = subject.wait_for_duration(seconds=seconds, message=message)
 
     assert result == response
 


### PR DESCRIPTION
Closes RCORE-349

# Changelog

* Implement `protocol.pause()` in terms of Protocol Engine's `waitForResume` command.
* Implement `protocol.delay()` in terms of Protocol Engine's `waitForDuration` command.

# Review requests

This is pretty trivial pass-through code, so I expect a quick glance through the code to be sufficient.

# Risk assessment

Low.
