### PR TITLE
feat(app): launch pipette cal from robot settings

### DIFF
--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -149,7 +149,7 @@ export function OverflowMenu({
     e.preventDefault()
     if (!isRunning) {
       if (calType === 'pipetteOffset' && pipetteName != null) {
-        if (isGen3Pipette) {
+        if (Boolean(isGen3Pipette)) {
           setShowPipetteWizardFlows(true)
         } else {
           if (applicablePipetteOffsetCal != null) {
@@ -267,7 +267,7 @@ export function OverflowMenu({
                 : t('recalibrate_tip_and_pipette')}
             </MenuItem>
           )}
-          {!isGen3Pipette ? (
+          {!Boolean(isGen3Pipette) ? (
             <MenuItem onClick={e => handleDownload(calType, e)}>
               {t('download_calibration_data')}
             </MenuItem>

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -14,11 +14,12 @@ import {
   useOnClickOutside,
   useConditionalConfirm,
 } from '@opentrons/components'
+import { isOT3Pipette } from '@opentrons/shared-data'
 
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
-import { AskForCalibrationBlockModal } from '../../CalibrateTipLength/AskForCalibrationBlockModal'
 import { Portal } from '../../../App/portal'
+import { useMenuHandleClickOutside } from '../../../atoms/MenuList/hooks'
 import {
   INTENT_RECALIBRATE_PIPETTE_OFFSET,
   INTENT_TIP_LENGTH_OUTSIDE_PROTOCOL,
@@ -32,9 +33,14 @@ import {
   useRunStatuses,
   useTipLengthCalibrations,
 } from '../../../organisms/Devices/hooks'
+import { AskForCalibrationBlockModal } from '../../CalibrateTipLength/AskForCalibrationBlockModal'
+import { PipetteWizardFlows } from '../../PipetteWizardFlows'
+import { FLOWS } from '../../PipetteWizardFlows/constants'
 import { useCalibratePipetteOffset } from '../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import { DeckCalibrationConfirmModal } from '../DeckCalibrationConfirmModal'
-import { useMenuHandleClickOutside } from '../../../atoms/MenuList/hooks'
+
+import type { PipetteMount, PipetteName } from '@opentrons/shared-data'
+import type { PipetteWizardFlow } from '../../PipetteWizardFlows/types'
 
 const CAL_BLOCK_MODAL_CLOSED: 'cal_block_modal_closed' =
   'cal_block_modal_closed'
@@ -54,6 +60,7 @@ interface OverflowMenuProps {
   mount: Mount
   serialNumber: string | null
   updateRobotStatus: (isRobotBusy: boolean) => void
+  pipetteName?: string | null
 }
 
 export function OverflowMenu({
@@ -62,6 +69,7 @@ export function OverflowMenu({
   mount,
   serialNumber,
   updateRobotStatus,
+  pipetteName,
 }: OverflowMenuProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'shared'])
   const doTrackEvent = useTrackEvent()
@@ -89,7 +97,10 @@ export function OverflowMenu({
     setCalBlockModalState,
   ] = React.useState<CalBlockModalState>(CAL_BLOCK_MODAL_CLOSED)
   const { isRunRunning: isRunning } = useRunStatuses()
-
+  const [showPipetteWizardFlows, setShowPipetteWizardFlows] = React.useState(
+    false
+  )
+  const isGen3Pipette = isOT3Pipette(pipetteName as PipetteName)
   interface StartWizardOptions {
     keepTipLength: boolean
     hasBlockModalResponse?: boolean | null
@@ -137,15 +148,19 @@ export function OverflowMenu({
   ): void => {
     e.preventDefault()
     if (!isRunning) {
-      if (calType === 'pipetteOffset') {
-        if (applicablePipetteOffsetCal != null) {
-          // recalibrate pipette offset
-          startPipetteOffsetCalibration({
-            withIntent: INTENT_RECALIBRATE_PIPETTE_OFFSET,
-          })
+      if (calType === 'pipetteOffset' && pipetteName != null) {
+        if (isGen3Pipette) {
+          setShowPipetteWizardFlows(true)
         } else {
-          // calibrate pipette offset with a wizard since not calibrated yet
-          confirmStart()
+          if (applicablePipetteOffsetCal != null) {
+            // recalibrate pipette offset
+            startPipetteOffsetCalibration({
+              withIntent: INTENT_RECALIBRATE_PIPETTE_OFFSET,
+            })
+          } else {
+            // calibrate pipette offset with a wizard since not calibrated yet
+            confirmStart()
+          }
         }
       } else {
         startPipetteOffsetPossibleTLC({
@@ -219,7 +234,14 @@ export function OverflowMenu({
           />
         </Portal>
       )}
-
+      {showPipetteWizardFlows ? (
+        <PipetteWizardFlows
+          flowType={FLOWS.CALIBRATE as PipetteWizardFlow}
+          mount={mount as PipetteMount}
+          closeFlow={() => setShowPipetteWizardFlows(false)}
+          robotName={robotName}
+        />
+      ) : null}
       {showOverflowMenu ? (
         <Flex
           ref={calsOverflowWrapperRef}
@@ -245,9 +267,11 @@ export function OverflowMenu({
                 : t('recalibrate_tip_and_pipette')}
             </MenuItem>
           )}
-          <MenuItem onClick={e => handleDownload(calType, e)}>
-            {t('download_calibration_data')}
-          </MenuItem>
+          {!isGen3Pipette ? (
+            <MenuItem onClick={e => handleDownload(calType, e)}>
+              {t('download_calibration_data')}
+            </MenuItem>
+          ) : null}
           {/* TODO 5/6/2021 kj: This is scoped out from 6.0 */}
           {/* <Divider /> */}
           {/* <MenuItem onClick={() => handleDeleteCalibrationData(calType)}>

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -39,8 +39,7 @@ import { FLOWS } from '../../PipetteWizardFlows/constants'
 import { useCalibratePipetteOffset } from '../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import { DeckCalibrationConfirmModal } from '../DeckCalibrationConfirmModal'
 
-import type { PipetteMount, PipetteName } from '@opentrons/shared-data'
-import type { PipetteWizardFlow } from '../../PipetteWizardFlows/types'
+import type { PipetteName } from '@opentrons/shared-data'
 
 const CAL_BLOCK_MODAL_CLOSED: 'cal_block_modal_closed' =
   'cal_block_modal_closed'
@@ -97,9 +96,10 @@ export function OverflowMenu({
     setCalBlockModalState,
   ] = React.useState<CalBlockModalState>(CAL_BLOCK_MODAL_CLOSED)
   const { isRunRunning: isRunning } = useRunStatuses()
-  const [showPipetteWizardFlows, setShowPipetteWizardFlows] = React.useState(
-    false
-  )
+  const [
+    showPipetteWizardFlows,
+    setShowPipetteWizardFlows,
+  ] = React.useState<boolean>(false)
   const isGen3Pipette = isOT3Pipette(pipetteName as PipetteName)
   interface StartWizardOptions {
     keepTipLength: boolean
@@ -236,8 +236,8 @@ export function OverflowMenu({
       )}
       {showPipetteWizardFlows ? (
         <PipetteWizardFlows
-          flowType={FLOWS.CALIBRATE as PipetteWizardFlow}
-          mount={mount as PipetteMount}
+          flowType={FLOWS.CALIBRATE}
+          mount={mount}
           closeFlow={() => setShowPipetteWizardFlows(false)}
           robotName={robotName}
         />

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -155,6 +155,9 @@ export function PipetteOffsetCalibrationItems({
                     mount={calibration.mount}
                     serialNumber={calibration.serialNumber ?? null}
                     updateRobotStatus={updateRobotStatus}
+                    pipetteName={
+                      attachedPipettes[calibration.mount]?.name ?? null
+                    }
                   />
                 </StyledTableCell>
               </StyledTableRow>


### PR DESCRIPTION
closes RLIQ-248

# Overview

Under PIpette Offset Calibrations in the Robot Settings Calibration tab, the overflow menu when an gen3 pipette is attached will only show the `Calibrate Pipette Offset` button and clicking on it will launch the gen3 pipette cal flow.

# Changelog

- grab pipette name in `PipetteOffsetCalibrationItems`
- in `OverflowMenu`, extend the props to take in the pipette name and filter out the gen3 pipettes to launch the correct flow.
- fix test

I made `pipetteName` an optional prop since it will not be used in `TipLengthCalibrationItems` i don't think?

# Review requests

- test with an ot-3 pipette. you should be able to launch the correct flow

# Risk assessment

low