### PR TITLE
refactor(api): Support protocol.comment() backed by ProtocolEngine core

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -260,7 +260,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def comment(self, msg: str) -> None:
         """Create a comment in the protocol to be shown in the log."""
-        raise NotImplementedError("ProtocolCore.comment not implemented")
+        self._engine_client.comment(message=msg)
 
     def delay(self, seconds: float, msg: Optional[str]) -> None:
         """Wait for a period of time before proceeding."""

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -5,6 +5,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
+from opentrons.commands.protocol_commands import comment as make_legacy_comment_command
 from opentrons.types import MountType
 from opentrons.hardware_control.modules.types import ThermocyclerStep
 
@@ -292,6 +293,31 @@ class SyncClient:
         )
         result = self._transport.execute_command(request=request)
         return cast(commands.WaitForResumeResult, result)
+
+    def comment(self, message: str) -> commands.CustomResult:
+        """Execute a comment command and return the result."""
+        # TODO(mm, 2022-11-09): Protocol Engine doesn't yet have a proper comment
+        # command. So, we use a legacy-style command wrapped inside a Protocol Engine
+        # CustomCommand. The Opentrons App knows how to render this in its run log
+        # because this is what we used to do for PAPIv2 commands in general.
+        #
+        # When Protocol Engine has a proper comment command, we should use it here.
+        legacy_comment_command = make_legacy_comment_command(msg=message)
+
+        class LegacyCommentCustomParams(commands.CustomParams):
+            legacyCommandType: str
+            legacyCommandText: str
+
+        request = commands.CustomCreate(
+            params=LegacyCommentCustomParams(
+                # This matches how LegacyCommandWrapper handles comments coming from
+                # protocols running under the older non-ProtocolEngine core.
+                legacyCommandType=legacy_comment_command["name"],
+                legacyCommandText=legacy_comment_command["payload"]["text"],
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.CustomResult, result)
 
     def set_rail_lights(self, on: bool) -> commands.SetRailLightsResult:
         """Execute a ``setRailLights`` command and return the result."""

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -48,6 +48,7 @@ from .aspirate import (
 from .custom import (
     Custom,
     CustomParams,
+    CustomCreate,
     CustomResult,
     CustomCommandType,
 )
@@ -228,6 +229,7 @@ __all__ = [
     "AspirateCommandType",
     # custom command models
     "Custom",
+    "CustomCreate",
     "CustomParams",
     "CustomResult",
     "CustomCommandType",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -28,6 +28,7 @@ from .aspirate import (
 from .custom import (
     Custom,
     CustomParams,
+    CustomCreate,
     CustomResult,
     CustomCommandType,
 )
@@ -320,6 +321,7 @@ CommandType = Union[
 
 CommandCreate = Union[
     AspirateCreate,
+    CustomCreate,
     DispenseCreate,
     DispenseInPlaceCreate,
     BlowOutCreate,

--- a/api/src/opentrons/protocol_engine/commands/custom.py
+++ b/api/src/opentrons/protocol_engine/commands/custom.py
@@ -14,7 +14,8 @@ from pydantic import BaseModel, Extra
 from typing import Optional, Type
 from typing_extensions import Literal
 
-from .command import BaseCommand, AbstractCommandImpl
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
 
 CustomCommandType = Literal["custom"]
 
@@ -38,13 +39,14 @@ class CustomResult(BaseModel):
 
 
 class CustomImplementation(AbstractCommandImpl[CustomParams, CustomResult]):
-    """Aspirate command implementation."""
+    """Custom command implementation."""
 
-    # TODO(mc, 2021-09-24): figure out how a plugin can specify a custom command
-    # implementation. For now, raise so we remember not to allow this to happen.
+    # TODO(mm, 2022-11-09): figure out how a plugin can specify a custom command
+    # implementation. For now, always no-op, so we can use custom commands as containers
+    # for legacy RPC (pre-ProtocolEngine) payloads.
     async def execute(self, params: CustomParams) -> CustomResult:
-        """A custom command cannot be executed directly."""
-        raise NotImplementedError("Custom commands cannot be executed directly.")
+        """A custom command does nothing when executed directly."""
+        return CustomResult.construct()
 
 
 class Custom(BaseCommand[CustomParams, CustomResult]):
@@ -55,3 +57,12 @@ class Custom(BaseCommand[CustomParams, CustomResult]):
     result: Optional[CustomResult]
 
     _ImplementationCls: Type[CustomImplementation] = CustomImplementation
+
+
+class CustomCreate(BaseCommandCreate[CustomParams]):
+    """A request to create a custom command."""
+
+    commandType: CustomCommandType = "custom"
+    params: CustomParams
+
+    _CommandCls: Type[Custom] = Custom

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -473,3 +473,13 @@ def test_delay(
     """It should issue a waitForDuration command."""
     subject.delay(seconds=seconds, msg=message)
     decoy.verify(mock_engine_client.wait_for_duration(seconds=seconds, message=message))
+
+
+def test_comment(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+) -> None:
+    """It should issue a comment command."""
+    subject.comment("Hello, world!")
+    decoy.verify(mock_engine_client.comment("Hello, world!"))

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -409,6 +409,31 @@ def test_wait_for_resume(
     assert result == response
 
 
+def test_comment(
+    decoy: Decoy, transport: AbstractSyncTransport, subject: SyncClient
+) -> None:
+    """It should execute a comment command."""
+    # TODO(mm, 2022-11-09): Use a proper Protocol Engine Comment command instead of
+    # a Custom command, once one exists.
+    class LegacyCommentCustomParams(commands.CustomParams):
+        legacyCommandType: str
+        legacyCommandText: str
+
+    request = commands.CustomCreate(
+        params=LegacyCommentCustomParams(
+            legacyCommandType="command.COMMENT",
+            legacyCommandText="Hello, world!",
+        )
+    )
+    response = commands.CustomResult()
+
+    decoy.when(transport.execute_command(request=request)).then_return(response)
+
+    result = subject.comment(message="Hello, world!")
+
+    assert result == response
+
+
 def test_set_rail_lights(
     decoy: Decoy,
     transport: AbstractSyncTransport,


### PR DESCRIPTION
# Overview

This adds support for `protocol.comment("message")` in the new Protocol-Engine–based infrastructure for running Python protocols. Closes RCORE-350.

# Changelog

* Since Protocol Engine doesn't yet have a proper `Comment` command (nor would the Opentrons App understand how to parse it), as a temporary hack, we report `protocol.comment()`s the same way we do from the non–Protocol-Engine legacy core. That is: we report it as a legacy RPC-style command, wrapped inside a Protocol Engine `Custom` command.
  * I stuffed this translation logic in `SyncClient`. That isn't really the proper place for this kind of thing, but it seemed good enough for our immediate purposes. And we know this whole `CustomCommand` approach will be temporary, anyway.
* When Protocol Engine executes a `Custom` command, make it no-op instead of raising a `NotImplementedError`. The former behavior was sufficient when we were just using the `Custom` command *models* to report legacy protocol activity, but now, because of the way the Protocol Engine core works, the command will actually need to execute for the first time.

# Testing

Try running a dev server that uses the new Protocol-Engine–based core to run Python protocols:

```shell
env OT_API_enableProtocolEnginePAPICore=1 make dev
```

Then, upload and run this protocol through the Opentrons App:

```python
metadata = {"apiLevel": "2.13"}

def run(protocol):
    protocol.comment("Hello, world!")
```

The comment should display reasonably in the Opentrons App's run log.

# Review requests

None in particular.

# Risk assessment

Low.
