### PR TITLE
refactor(api): allow an engine tip rack's tips to be reset

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -112,7 +112,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         raise NotImplementedError("LabwareCore.set_tip_length not implemented")
 
     def reset_tips(self) -> None:
-        raise NotImplementedError("LabwareCore.reset_tips not implemented")
+        self._engine_client.reset_tips(labware_id=self.labware_id)
 
     def get_next_tip(
         self, num_tips: int, starting_tip: Optional[WellCore]

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -683,9 +683,8 @@ class Labware(DeckItem):
 
     @requires_version(2, 0)
     def reset(self) -> None:
-        """Reset all tips in a tiprack"""
-        if self._is_tiprack:
-            self._implementation.reset_tips()
+        """Reset all tips in a tiprack."""
+        self._implementation.reset_tips()
 
     def _well_from_impl(self, well: WellCore) -> Well:
         return Well(

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -22,6 +22,7 @@ from .actions import (
     AddModuleAction,
     FinishErrorDetails,
     DoorChangeAction,
+    ResetTipsAction,
 )
 
 __all__ = [
@@ -44,6 +45,7 @@ __all__ = [
     "AddLiquidAction",
     "AddModuleAction",
     "DoorChangeAction",
+    "ResetTipsAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -152,6 +152,13 @@ class AddModuleAction:
     module_live_data: LiveData
 
 
+@dataclass(frozen=True)
+class ResetTipsAction:
+    """Reset the tip tracking state of a given tip rack."""
+
+    labware_id: str
+
+
 Action = Union[
     PlayAction,
     PauseAction,
@@ -166,4 +173,5 @@ Action = Union[
     AddLabwareDefinitionAction,
     AddModuleAction,
     AddLiquidAction,
+    ResetTipsAction,
 ]

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -41,6 +41,13 @@ class SyncClient:
             definition=definition,
         )
 
+    def reset_tips(self, labware_id: str) -> None:
+        """Reset a labware's tip tracking state.."""
+        self._transport.call_method(
+            "reset_tips",
+            labware_id=labware_id,
+        )
+
     def load_labware(
         self,
         location: LabwareLocation,

--- a/api/src/opentrons/protocol_engine/clients/transports.py
+++ b/api/src/opentrons/protocol_engine/clients/transports.py
@@ -50,6 +50,15 @@ class AbstractSyncTransport(ABC):
     @overload
     def call_method(
         self,
+        method_name: Literal["reset_tips"],
+        *,
+        labware_id: str,
+    ) -> None:
+        ...
+
+    @overload
+    def call_method(
+        self,
         method_name: str,
         **kwargs: Any,
     ) -> Any:

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -31,6 +31,7 @@ from .actions import (
     AddLiquidAction,
     AddModuleAction,
     HardwareStoppedAction,
+    ResetTipsAction,
 )
 
 
@@ -289,6 +290,10 @@ class ProtocolEngine:
     def add_liquid(self, liquid: Liquid) -> None:
         """Add a liquid to the state for subsequent liquid loads."""
         self._action_dispatcher.dispatch(AddLiquidAction(liquid=liquid))
+
+    def reset_tips(self, labware_id: str) -> None:
+        """Reset the tip state of a given labware."""
+        self._action_dispatcher.dispatch(ResetTipsAction(labware_id=labware_id))
 
     async def use_attached_modules(
         self,

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Dict, Set, Optional
 
 from .abstract_store import HasState, HandlesActions
-from ..actions import Action, UpdateCommandAction
+from ..actions import Action, UpdateCommandAction, ResetTipsAction
 from ..commands import LoadLabwareResult, PickUpTipResult
 
 
@@ -64,6 +64,14 @@ class TipStore(HasState[TipState], HandlesActions):
             self._state.tips_by_labware_id[labware_id][
                 well_name
             ] = TipRackWellState.USED
+
+        elif isinstance(action, ResetTipsAction):
+            labware_id = action.labware_id
+
+            for well_name in self._state.tips_by_labware_id[labware_id].keys():
+                self._state.tips_by_labware_id[labware_id][
+                    well_name
+                ] = TipRackWellState.CLEAN
 
 
 class TipView(HasState[TipState]):

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -184,3 +184,11 @@ def test_get_next_tip(
     assert result.get_name() == "A2"
     assert result is subject.get_wells()[2]
     assert result is subject.get_wells_by_name()["A2"]
+
+
+def test_reset_tips(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
+) -> None:
+    """It should reset the tip state of a labware."""
+    subject.reset_tips()
+    decoy.verify(mock_engine_client.reset_tips(labware_id="cool-labware"), times=1)

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -62,3 +62,11 @@ def test_wells(decoy: Decoy, mock_labware_core: LabwareCore, subject: Labware) -
     assert result[0].well_name == "Z42"
     assert isinstance(result[1], Well)
     assert result[1].well_name == "X1"
+
+
+def test_reset_tips(
+    decoy: Decoy, mock_labware_core: LabwareCore, subject: Labware
+) -> None:
+    """It should reset and tip state."""
+    subject.reset()
+    decoy.verify(mock_labware_core.reset_tips(), times=1)

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -62,6 +62,21 @@ def test_add_labware_definition(
     assert result == expected_labware_uri
 
 
+def test_reset_tips(
+    decoy: Decoy, transport: AbstractSyncTransport, subject: SyncClient
+) -> None:
+    """It should reset the tip tracking state of a labware."""
+    subject.reset_tips(labware_id="cool-labware")
+
+    decoy.verify(
+        transport.call_method(
+            "reset_tips",
+            labware_id="cool-labware",
+        ),
+        times=1,
+    )
+
+
 def test_load_labware(
     decoy: Decoy,
     transport: AbstractSyncTransport,

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -158,3 +158,22 @@ def test_get_next_tip_with_column_and_starting_tip(
     )
 
     assert result == "A2"
+
+
+def test_reset_tips(
+    subject: TipStore,
+    load_labware_command: commands.LoadLabware,
+    pick_up_tip_command: commands.PickUpTip,
+) -> None:
+    """It should be able to reset tip tracking state."""
+    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+    subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        use_column=False,
+        starting_tip_name=None,
+    )
+
+    assert result == "A1"

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -45,6 +45,7 @@ from opentrons.protocol_engine.actions import (
     FinishErrorDetails,
     QueueCommandAction,
     HardwareStoppedAction,
+    ResetTipsAction,
 )
 
 
@@ -694,4 +695,16 @@ async def test_use_attached_temp_and_mag_modules(
                 module_live_data={"status": "other-status", "data": {}},
             ),
         ),
+    )
+
+
+def test_reset_tips(
+    decoy: Decoy, action_dispatcher: ActionDispatcher, subject: ProtocolEngine
+) -> None:
+    """It should reset tip state by dispatching an action."""
+    subject.reset_tips(labware_id="cool-labware")
+
+    decoy.verify(
+        action_dispatcher.dispatch(ResetTipsAction(labware_id="cool-labware")),
+        times=1,
     )


### PR DESCRIPTION
## Overview

This PR adds the ability for a tip rack in the `ProtocolEngine` to have its tip state reset, and wires that action to the PAPIv2 engine core.

## Changelog

- Add `ResetTipsAction` to `ProtocolEngine`
- Write `ResetTipsAction` to PAPI

## Review requests

Test protocol picks up from well `A1`, drops it in the trash, resets the tip state, and then picks up well `A1` again

```python
from opentrons import protocol_api, types

requirements = {
    "apiLevel": "2.13",
}


def run(ctx: protocol_api.ProtocolContext) -> None:
    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
    right = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tr])

    right.pick_up_tip()
    right.drop_tip()

    right.reset_tipracks()

    right.pick_up_tip()
    right.drop_tip()
```

## Risk assessment

Very low, very self-contained change set.