### PR TITLE
fix(app): downgrading robot software version and install btn fix

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
@@ -14,6 +14,7 @@ import {
 } from '@opentrons/components'
 import { StyledText } from '../../../../atoms/text'
 import { Portal } from '../../../../App/portal'
+import { TertiaryButton } from '../../../../atoms/buttons'
 import { getRobotApiVersion, UNREACHABLE } from '../../../../redux/discovery'
 import { getBuildrootUpdateDisplayInfo } from '../../../../redux/buildroot'
 import { UpdateRobotBanner } from '../../../UpdateRobotBanner'
@@ -89,9 +90,19 @@ export function RobotServerVersion({
         </Box>
         {autoUpdateAction !== 'reinstall' && robot != null ? null : (
           <Flex justifyContent={JUSTIFY_FLEX_END} alignItems="center">
-            <StyledText as="label" color={COLORS.darkGreyEnabled}>
+            <StyledText
+              as="label"
+              color={COLORS.darkGreyEnabled}
+              paddingRight={SPACING.spacing4}
+            >
               {t('up_to_date')}
             </StyledText>
+            <TertiaryButton
+              onClick={() => setShowVersionInfoModal(true)}
+              textTransform={TYPOGRAPHY.textTransformCapitalize}
+            >
+              {t('reinstall')}
+            </TertiaryButton>
           </Flex>
         )}
       </Flex>

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
@@ -89,7 +89,7 @@ export function RobotServerVersion({
           </StyledText>
         </Box>
         {autoUpdateAction !== 'reinstall' && robot != null ? null : (
-          <Flex justifyContent={JUSTIFY_FLEX_END} alignItems="center">
+          <Flex justifyContent={JUSTIFY_FLEX_END} alignItems={ALIGN_CENTER}>
             <StyledText
               as="label"
               color={COLORS.darkGreyEnabled}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
@@ -62,8 +62,11 @@ describe('RobotSettings RobotServerVersion', () => {
   })
 
   it('should render the message, up to date, if the robot server version is the same as the latest version', () => {
-    const [{ getByText }] = render()
+    const [{ getByText, getByRole }] = render()
     getByText('up to date')
+    const reinstall = getByRole('button', { name: 'reinstall' })
+    fireEvent.click(reinstall)
+    getByText('mock update buildroot')
   })
 
   it('should render the warning message if the robot server version needs to upgrade', () => {

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/VersionInfoModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/VersionInfoModal.tsx
@@ -75,7 +75,7 @@ export function VersionInfoModal(props: VersionInfoModalProps): JSX.Element {
     )
     primaryButton = {
       ...primaryButton,
-      onClick: goToViewUpdate,
+      onClick: robotUpdateType === 'upgrade' ? goToViewUpdate : installUpdate,
       children:
         robotUpdateType === 'upgrade' ? 'View Robot Update' : 'Downgrade Robot',
     }

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/VersionInfoModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/VersionInfoModal.test.tsx
@@ -120,9 +120,9 @@ describe('VersionInfoModal', () => {
     expect(handleClose).not.toHaveBeenCalled()
     closeButton.invoke('onClick')?.({} as React.MouseEvent)
     expect(handleClose).toHaveBeenCalled()
-    expect(mockGoToViewUpdate).not.toHaveBeenCalled()
+    expect(mockInstallUpdate).not.toHaveBeenCalled()
     primaryButton.invoke('onClick')?.({} as React.MouseEvent)
-    expect(mockGoToViewUpdate).toHaveBeenCalled()
+    expect(mockInstallUpdate).toHaveBeenCalled()
   })
 
   it('should render an AlertModal with the proper children for a reinstall', () => {


### PR DESCRIPTION
# Overview

Slight logic fix so when you are downgrading the robot, the primary button on the modal does the correct thing instead of opening the `view update` modal

Also this adds the `reinstall` button back

<img width="903" alt="Screen Shot 2022-11-09 at 4 50 29 PM" src="https://user-images.githubusercontent.com/66035149/200949269-cab9b921-5b3e-4b5a-b34a-fa1aa70f065a.png">

# Changelog

- fix logic in `VersionInfoModal`, fix test
- add `reinstall` button back to robot advanced settings, and add test case for it.

# Review requests

- i tested the downgrade on my OT-2  in `edge` and worked (this bug also exists in edge). Please double check that the logic makes sense!
- look in the robot advanced settings, the `reinstall` button should be there

# Risk assessment

low