### PR TITLE
fix(hardware-testing): Store git hash of ot3-firmware repo, not opentrons monorepo

### DIFF
--- a/hardware-testing/build_fw.sh
+++ b/hardware-testing/build_fw.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-GIT_HASH=$(git rev-parse --short=8 HEAD)
 TEMP_DIR_NAME="./ot3-firmware"
 TAR_NAME="$TEMP_DIR_NAME"
 
@@ -19,6 +18,7 @@ FW_PATH_GRIPPER="$REPO_DIR/build-cross/gripper/firmware/gripper-rev1.hex"
 
 # build all the firmware
 cd "$REPO_DIR" || cd "$THIS_DIR" || exit
+GIT_HASH=$(git rev-parse --short=8 HEAD)
 cmake --preset=cross .
 cmake --build --preset=gantry-x --target=gantry-x-rev1-flash || true
 cmake --build --preset=gantry-y --target=gantry-y-rev1-flash || true


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Previously we were accidentally storing the git has of the monorepo, when instead we want to ot3-firmware repo's git hash.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
