### PR TITLE
refactor(api): ensure engine-core last location is set for all commands

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -96,6 +96,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             flow_rate=flow_rate,
         )
 
+        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
+
     def dispense(
         self,
         location: Location,
@@ -133,6 +135,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             flow_rate=flow_rate,
         )
 
+        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
+
     def blow_out(
         self, location: Location, well_core: Optional[WellCore], move_to_well: bool
     ) -> None:
@@ -164,6 +168,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             #   this also needs to be refactored along with other flow rate related issues
             flow_rate=self.get_absolute_blow_out_flow_rate(1.0),
         )
+
+        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
 
     def touch_tip(
         self,
@@ -213,6 +219,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             well_location=well_location,
         )
 
+        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
+
     def drop_tip(
         self, location: Optional[Location], well_core: WellCore, home_after: bool
     ) -> None:
@@ -244,6 +252,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             well_name=well_name,
             well_location=well_location,
         )
+
+        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
 
     def home(self) -> None:
         raise NotImplementedError("InstrumentCore.home not implemented")

--- a/api/src/opentrons/protocol_runner/task_queue.py
+++ b/api/src/opentrons/protocol_runner/task_queue.py
@@ -71,7 +71,7 @@ class TaskQueue:
             if self._run_func is not None:
                 await self._run_func()
         except Exception as e:
-            log.info("Exception raised during protocol run", exc_info=e)
+            log.exception("Exception raised by protocol")
             error = e
 
         await self._cleanup_func(error=error)

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -95,10 +95,8 @@ def validate_tiprack(
         valid_vols = VALID_PIP_TIPRACK_VOL[instrument_name.split("_")[0]]
         if tiprack_vol not in valid_vols:
             log.warning(
-                f"The pipette {instrument_name} and its tip rack "
-                f"{tip_rack.load_name} in slot {tip_rack.parent} appear to "
-                "be mismatched. Please check your protocol before running "
-                "on the robot."
+                f"The pipette {instrument_name} and its tip rack {tip_rack.load_name}"
+                " appear to be mismatched. Please check your protocol."
             )
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -123,7 +123,10 @@ def test_get_hardware_state(
 
 
 def test_move_to_well(
-    decoy: Decoy, mock_engine_client: EngineClient, subject: InstrumentCore
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentCore,
 ) -> None:
     """It should move the pipette to a location."""
     location = Location(point=Point(1, 2, 3), labware=None)
@@ -159,12 +162,15 @@ def test_move_to_well(
                 origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
             ),
         ),
-        times=1,
+        mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )
 
 
 def test_move_to_coordinates(
-    decoy: Decoy, mock_engine_client: EngineClient, subject: InstrumentCore
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentCore,
 ) -> None:
     """It should move the pipette to a location."""
     location = Location(point=Point(1, 2, 3), labware=None)
@@ -184,12 +190,15 @@ def test_move_to_coordinates(
             minimum_z_height=42.0,
             force_direct=True,
         ),
-        times=1,
+        mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )
 
 
 def test_pick_up_tip(
-    decoy: Decoy, mock_engine_client: EngineClient, subject: InstrumentCore
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentCore,
 ) -> None:
     """It should pick up a tip from a well."""
     location = Location(point=Point(1, 2, 3), labware=None)
@@ -224,7 +233,7 @@ def test_pick_up_tip(
                 origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
             ),
         ),
-        times=1,
+        mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )
 
 
@@ -256,6 +265,7 @@ def test_drop_tip_no_location(
 def test_aspirate_from_well(
     decoy: Decoy,
     mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
     subject: InstrumentCore,
 ) -> None:
     """It should aspirate from a well."""
@@ -286,13 +296,14 @@ def test_aspirate_from_well(
             volume=12.34,
             flow_rate=7.8,
         ),
-        times=1,
+        mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )
 
 
 def test_blow_out_to_well(
     decoy: Decoy,
     mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
     subject: InstrumentCore,
 ) -> None:
     """It should aspirate from a well."""
@@ -320,13 +331,14 @@ def test_blow_out_to_well(
             ),
             flow_rate=1.23,
         ),
-        times=1,
+        mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )
 
 
 def test_dispense_to_well(
     decoy: Decoy,
     mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
     subject: InstrumentCore,
 ) -> None:
     """It should dispense to a well."""
@@ -357,5 +369,5 @@ def test_dispense_to_well(
             volume=12.34,
             flow_rate=6.0,
         ),
-        times=1,
+        mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )


### PR DESCRIPTION
## Overview

In our current implementation of the PAI engine core, we are maintaining a location cache similar to the legacy core to work around restrictions with `Location` that are preventing us from using engine state, instead.

This PR fixes up this temporary band-aid to make sure all liquid and tip handling commands update the cache.

## Changelog

- Add `set_last_location` calls to all engine-core liquid handling methods

## Review requests

- Code + tests make sense

## Risk assessment

Low, copying existing implementation in legacy core
