### PR TITLE
refactor(api): Support changing `pipette.default_speed` in ProtocolEngine-backed Python protocols

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -62,7 +62,9 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         return speed
 
     def set_default_speed(self, speed: float) -> None:
-        self._engine_client.set_pipette_movement_speed(pipette_id=self._pipette_id, speed=speed)
+        self._engine_client.set_pipette_movement_speed(
+            pipette_id=self._pipette_id, speed=speed
+        )
 
     def aspirate(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -31,6 +31,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         engine_client: EngineClient,
         sync_hardware_api: SyncHardwareAPI,
         protocol_core: ProtocolCore,
+        default_movement_speed: float,
     ) -> None:
         self._pipette_id = pipette_id
         self._engine_client = engine_client
@@ -46,16 +47,22 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         self._flow_rates = FlowRates(self)
         self._flow_rates.set_defaults(MAX_SUPPORTED_VERSION)
 
+        self.set_default_speed(speed=default_movement_speed)
+
     @property
     def pipette_id(self) -> str:
         """The instrument's unique ProtocolEngine ID."""
         return self._pipette_id
 
     def get_default_speed(self) -> float:
-        raise NotImplementedError("InstrumentCore.get_default_speed not implemented")
+        speed = self._engine_client.state.pipettes.get_motion_speed(
+            pipette_id=self._pipette_id
+        )
+        assert speed is not None, "Pipette loading should have set a default speed."
+        return speed
 
     def set_default_speed(self, speed: float) -> None:
-        raise NotImplementedError("InstrumentCore.set_default_speed not implemented")
+        self._engine_client.set_pipette_motion_speed(pipette_id=self._pipette_id, speed=speed)
 
     def aspirate(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -55,14 +55,14 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         return self._pipette_id
 
     def get_default_speed(self) -> float:
-        speed = self._engine_client.state.pipettes.get_motion_speed(
+        speed = self._engine_client.state.pipettes.get_movement_speed(
             pipette_id=self._pipette_id
         )
         assert speed is not None, "Pipette loading should have set a default speed."
         return speed
 
     def set_default_speed(self, speed: float) -> None:
-        self._engine_client.set_pipette_motion_speed(pipette_id=self._pipette_id, speed=speed)
+        self._engine_client.set_pipette_movement_speed(pipette_id=self._pipette_id, speed=speed)
 
     def aspirate(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -242,6 +242,8 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
             engine_client=self._engine_client,
             sync_hardware_api=self._sync_hardware,
             protocol_core=self,
+            # TODO(mm, 2022-11-10): Deduplicate "400" with legacy core.
+            default_movement_speed=400,
         )
 
     def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -290,7 +290,7 @@ class ProtocolContextImplementation(
             protocol_interface=self,
             mount=mount,
             instrument_name=instrument_name.value,
-            default_speed=400.0,
+            default_speed=400.0,  # TODO(mm, 2022-11-10): Deduplicate with engine core.
         )
         self._instruments[mount] = new_instr
         logger.info("Instrument {} loaded".format(new_instr))

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -23,6 +23,7 @@ from .actions import (
     FinishErrorDetails,
     DoorChangeAction,
     ResetTipsAction,
+    SetPipetteMotionSpeedAction,
 )
 
 __all__ = [
@@ -46,6 +47,7 @@ __all__ = [
     "AddModuleAction",
     "DoorChangeAction",
     "ResetTipsAction",
+    "SetPipetteMotionSpeedAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -23,7 +23,7 @@ from .actions import (
     FinishErrorDetails,
     DoorChangeAction,
     ResetTipsAction,
-    SetPipetteMotionSpeedAction,
+    SetPipetteMovementSpeedAction,
 )
 
 __all__ = [
@@ -47,7 +47,7 @@ __all__ = [
     "AddModuleAction",
     "DoorChangeAction",
     "ResetTipsAction",
-    "SetPipetteMotionSpeedAction",
+    "SetPipetteMovementSpeedAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -160,7 +160,7 @@ class ResetTipsAction:
 
 
 @dataclass(frozen=True)
-class SetPipetteMotionSpeedAction:
+class SetPipetteMovementSpeedAction:
     """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
 
     None will use the hardware API's default.
@@ -185,5 +185,5 @@ Action = Union[
     AddModuleAction,
     AddLiquidAction,
     ResetTipsAction,
-    SetPipetteMotionSpeedAction,
+    SetPipetteMovementSpeedAction,
 ]

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -159,6 +159,17 @@ class ResetTipsAction:
     labware_id: str
 
 
+@dataclass(frozen=True)
+class SetPipetteMotionSpeedAction:
+    """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
+
+    None will use the hardware API's default.
+    """
+
+    pipette_id: str
+    speed: Optional[float]
+
+
 Action = Union[
     PlayAction,
     PauseAction,
@@ -174,4 +185,5 @@ Action = Union[
     AddModuleAction,
     AddLiquidAction,
     ResetTipsAction,
+    SetPipetteMotionSpeedAction,
 ]

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -48,8 +48,8 @@ class SyncClient:
             labware_id=labware_id,
         )
 
-    def set_pipette_movement_speed(self,
-        pipette_id: str, speed: Optional[float]
+    def set_pipette_movement_speed(
+        self, pipette_id: str, speed: Optional[float]
     ) -> None:
         """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
 

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -48,7 +48,7 @@ class SyncClient:
             labware_id=labware_id,
         )
 
-    def set_pipette_motion_speed(self,
+    def set_pipette_movement_speed(self,
         pipette_id: str, speed: Optional[float]
     ) -> None:
         """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
@@ -56,7 +56,7 @@ class SyncClient:
         None will use the hardware API's default.
         """
         self._transport.call_method(
-            "set_pipette_motion_speed",
+            "set_pipette_movement_speed",
             pipette_id=pipette_id,
             speed=speed,
         )

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -48,6 +48,19 @@ class SyncClient:
             labware_id=labware_id,
         )
 
+    def set_pipette_motion_speed(self,
+        pipette_id: str, speed: Optional[float]
+    ) -> None:
+        """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
+
+        None will use the hardware API's default.
+        """
+        self._transport.call_method(
+            "set_pipette_motion_speed",
+            pipette_id=pipette_id,
+            speed=speed,
+        )
+
     def load_labware(
         self,
         location: LabwareLocation,

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -130,7 +130,7 @@ class MovementHandler:
             current_well=current_well,
         )
 
-        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+        speed = self._state_store.pipettes.get_movement_speed(pipette_id=pipette_id)
 
         # move through the waypoints
         for waypoint in waypoints:
@@ -159,7 +159,7 @@ class MovementHandler:
             z=distance if axis == MovementAxis.Z else 0,
         )
 
-        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+        speed = self._state_store.pipettes.get_movement_speed(pipette_id=pipette_id)
 
         try:
             await self._hardware_api.move_rel(
@@ -268,7 +268,7 @@ class MovementHandler:
             additional_min_travel_z=additional_min_travel_z,
         )
 
-        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+        speed = self._state_store.pipettes.get_movement_speed(pipette_id=pipette_id)
 
         # move through the waypoints
         for waypoint in waypoints:

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -130,12 +130,15 @@ class MovementHandler:
             current_well=current_well,
         )
 
+        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+
         # move through the waypoints
         for waypoint in waypoints:
             await self._hardware_api.move_to(
                 mount=hw_mount,
                 abs_position=waypoint.position,
                 critical_point=waypoint.critical_point,
+                speed=speed,
             )
 
     async def move_relative(
@@ -156,11 +159,14 @@ class MovementHandler:
             z=distance if axis == MovementAxis.Z else 0,
         )
 
+        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+
         try:
             await self._hardware_api.move_rel(
                 mount=hw_mount,
                 delta=delta,
                 fail_on_not_homed=True,
+                speed=speed,
             )
             point = await self._hardware_api.gantry_position(
                 mount=hw_mount,
@@ -262,10 +268,13 @@ class MovementHandler:
             additional_min_travel_z=additional_min_travel_z,
         )
 
+        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+
         # move through the waypoints
         for waypoint in waypoints:
             await self._hardware_api.move_to(
                 mount=hw_mount,
                 abs_position=waypoint.position,
                 critical_point=waypoint.critical_point,
+                speed=speed,
             )

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -269,6 +269,8 @@ class PipettingHandler:
             well_location=well_location,
         )
 
+        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+
         # this will handle raising if the thermocycler lid is in a bad state
         # so we don't need to put that logic elsewhere
         await self._movement_handler.move_to_well(
@@ -283,6 +285,7 @@ class PipettingHandler:
                 mount=pipette_location.mount.to_hw_mount(),
                 critical_point=pipette_location.critical_point,
                 abs_position=position,
+                speed=speed,
             )
 
     @contextmanager

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -269,7 +269,7 @@ class PipettingHandler:
             well_location=well_location,
         )
 
-        speed = self._state_store.pipettes.get_motion_speed(pipette_id=pipette_id)
+        speed = self._state_store.pipettes.get_movement_speed(pipette_id=pipette_id)
 
         # this will handle raising if the thermocycler lid is in a bad state
         # so we don't need to put that logic elsewhere

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -32,7 +32,7 @@ from .actions import (
     AddModuleAction,
     HardwareStoppedAction,
     ResetTipsAction,
-    SetPipetteMotionSpeedAction,
+    SetPipetteMovementSpeedAction,
 )
 
 
@@ -299,14 +299,14 @@ class ProtocolEngine:
     # TODO(mm, 2022-11-10): This is a method on ProtocolEngine instead of a command
     # as a quick hack to support Python protocols. We should consider making this a
     # command, or adding speed parameters to existing commands.
-    def set_pipette_motion_speed(
+    def set_pipette_movement_speed(
         self, pipette_id: str, speed: Optional[float]
     ) -> None:
         """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
 
         None will use the hardware API's default.
         """
-        self._action_dispatcher.dispatch(SetPipetteMotionSpeedAction(pipette_id=pipette_id, speed=speed))
+        self._action_dispatcher.dispatch(SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=speed))
 
     async def use_attached_modules(
         self,

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -306,7 +306,9 @@ class ProtocolEngine:
 
         None will use the hardware API's default.
         """
-        self._action_dispatcher.dispatch(SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=speed))
+        self._action_dispatcher.dispatch(
+            SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=speed)
+        )
 
     async def use_attached_modules(
         self,

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -32,6 +32,7 @@ from .actions import (
     AddModuleAction,
     HardwareStoppedAction,
     ResetTipsAction,
+    SetPipetteMotionSpeedAction,
 )
 
 
@@ -294,6 +295,18 @@ class ProtocolEngine:
     def reset_tips(self, labware_id: str) -> None:
         """Reset the tip state of a given labware."""
         self._action_dispatcher.dispatch(ResetTipsAction(labware_id=labware_id))
+
+    # TODO(mm, 2022-11-10): This is a method on ProtocolEngine instead of a command
+    # as a quick hack to support Python protocols. We should consider making this a
+    # command, or adding speed parameters to existing commands.
+    def set_pipette_motion_speed(
+        self, pipette_id: str, speed: Optional[float]
+    ) -> None:
+        """Set the speed of a pipette's X/Y/Z movements. Does not affect plunger speed.
+
+        None will use the hardware API's default.
+        """
+        self._action_dispatcher.dispatch(SetPipetteMotionSpeedAction(pipette_id=pipette_id, speed=speed))
 
     async def use_attached_modules(
         self,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -26,7 +26,7 @@ from ..commands import (
     thermocycler,
     heater_shaker,
 )
-from ..actions import Action, SetPipetteMotionSpeedAction, UpdateCommandAction
+from ..actions import Action, SetPipetteMovementSpeedAction, UpdateCommandAction
 from .abstract_store import HasState, HandlesActions
 
 
@@ -55,7 +55,7 @@ class PipetteState:
     aspirated_volume_by_id: Dict[str, float]
     current_well: Optional[CurrentWell]
     attached_tip_labware_by_id: Dict[str, str]
-    motion_speed_by_id: Dict[str, Optional[float]]
+    movement_speed_by_id: Dict[str, Optional[float]]
 
 
 
@@ -71,15 +71,15 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             aspirated_volume_by_id={},
             current_well=None,
             attached_tip_labware_by_id={},
-            motion_speed_by_id={},
+            movement_speed_by_id={},
         )
 
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""
         if isinstance(action, UpdateCommandAction):
             self._handle_command(action.command)
-        elif isinstance(action, SetPipetteMotionSpeedAction):
-            self._state.motion_speed_by_id[action.pipette_id] = action.speed
+        elif isinstance(action, SetPipetteMovementSpeedAction):
+            self._state.movement_speed_by_id[action.pipette_id] = action.speed
 
     def _handle_command(self, command: Command) -> None:
         self._update_current_well(command)
@@ -93,7 +93,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 mount=command.params.mount,
             )
             self._state.aspirated_volume_by_id[pipette_id] = 0
-            self._state.motion_speed_by_id[pipette_id] = None
+            self._state.movement_speed_by_id[pipette_id] = None
 
         elif isinstance(command.result, AspirateResult):
             pipette_id = command.params.pipetteId
@@ -274,5 +274,5 @@ class PipetteView(HasState[PipetteState]):
         """Get the tiprack ids of attached tip by pipette ids."""
         return self._state.attached_tip_labware_by_id
 
-    def get_motion_speed(self, pipette_id: str) -> Optional[float]:
-        return self._state.motion_speed_by_id[pipette_id]
+    def get_movement_speed(self, pipette_id: str) -> Optional[float]:
+        return self._state.movement_speed_by_id[pipette_id]

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -58,7 +58,6 @@ class PipetteState:
     movement_speed_by_id: Dict[str, Optional[float]]
 
 
-
 class PipetteStore(HasState[PipetteState], HandlesActions):
     """Pipette state container."""
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -274,4 +274,5 @@ class PipetteView(HasState[PipetteState]):
         return self._state.attached_tip_labware_by_id
 
     def get_movement_speed(self, pipette_id: str) -> Optional[float]:
+        """Return the given pipette's current movement speed."""
         return self._state.movement_speed_by_id[pipette_id]

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -26,7 +26,7 @@ from ..commands import (
     thermocycler,
     heater_shaker,
 )
-from ..actions import Action, UpdateCommandAction
+from ..actions import Action, SetPipetteMotionSpeedAction, UpdateCommandAction
 from .abstract_store import HasState, HandlesActions
 
 
@@ -55,6 +55,8 @@ class PipetteState:
     aspirated_volume_by_id: Dict[str, float]
     current_well: Optional[CurrentWell]
     attached_tip_labware_by_id: Dict[str, str]
+    motion_speed_by_id: Dict[str, Optional[float]]
+
 
 
 class PipetteStore(HasState[PipetteState], HandlesActions):
@@ -69,12 +71,15 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             aspirated_volume_by_id={},
             current_well=None,
             attached_tip_labware_by_id={},
+            motion_speed_by_id={},
         )
 
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""
         if isinstance(action, UpdateCommandAction):
             self._handle_command(action.command)
+        elif isinstance(action, SetPipetteMotionSpeedAction):
+            self._state.motion_speed_by_id[action.pipette_id] = action.speed
 
     def _handle_command(self, command: Command) -> None:
         self._update_current_well(command)
@@ -88,6 +93,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 mount=command.params.mount,
             )
             self._state.aspirated_volume_by_id[pipette_id] = 0
+            self._state.motion_speed_by_id[pipette_id] = None
 
         elif isinstance(command.result, AspirateResult):
             pipette_id = command.params.pipetteId
@@ -267,3 +273,6 @@ class PipetteView(HasState[PipetteState]):
     def get_attached_tip_labware_by_id(self) -> Dict[str, str]:
         """Get the tiprack ids of attached tip by pipette ids."""
         return self._state.attached_tip_labware_by_id
+
+    def get_motion_speed(self, pipette_id: str) -> Optional[float]:
+        return self._state.motion_speed_by_id[pipette_id]

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -68,6 +68,8 @@ def subject(
         engine_client=mock_engine_client,
         sync_hardware_api=mock_sync_hardware,
         protocol_core=mock_protocol_core,
+        # When this baby hits 88 mph, you're going to see some serious shit.
+        default_movement_speed=39339.5,
     )
 
 
@@ -371,3 +373,44 @@ def test_dispense_to_well(
         ),
         mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
     )
+
+
+def test_initialization_sets_default_movement_speed(
+    decoy: Decoy,
+    subject: InstrumentCore,
+    mock_engine_client: EngineClient,
+) -> None:
+    """It should set a default movement speed as soon as it's initialized."""
+    decoy.verify(
+        mock_engine_client.set_pipette_movement_speed(
+            pipette_id="abc123", speed=39339.5
+        )
+    )
+
+
+def test_set_default_speed(
+    decoy: Decoy,
+    subject: InstrumentCore,
+    mock_engine_client: EngineClient,
+) -> None:
+    """It should delegate to the engine client to set the pipette's movement speed."""
+    subject.set_default_speed(speed=9000.1)
+    decoy.verify(
+        mock_engine_client.set_pipette_movement_speed(
+            pipette_id=subject.pipette_id, speed=9000.1
+        )
+    )
+
+
+def test_get_default_speed(
+    decoy: Decoy,
+    subject: InstrumentCore,
+    mock_engine_client: EngineClient,
+) -> None:
+    """It should delegate to the engine client to set the pipette's movement speed."""
+    decoy.when(
+        mock_engine_client.state.pipettes.get_movement_speed(
+            pipette_id=subject.pipette_id
+        )
+    ).then_return(9000.1)
+    assert subject.get_default_speed() == 9000.1

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -154,6 +154,10 @@ async def test_move_to_well(
     )
 
     decoy.when(
+        state_store.pipettes.get_movement_speed(pipette_id="pipette-id")
+    ).then_return(39339.5)
+
+    decoy.when(
         state_store.motion.get_movement_waypoints_to_well(
             origin=Point(1, 1, 1),
             origin_cp=CriticalPoint.FRONT_NOZZLE,
@@ -189,11 +193,13 @@ async def test_move_to_well(
             mount=Mount.LEFT,
             abs_position=Point(1, 2, 3),
             critical_point=CriticalPoint.XY_CENTER,
+            speed=39339.5,
         ),
         await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(4, 5, 6),
             critical_point=None,
+            speed=39339.5,
         ),
     )
 
@@ -275,6 +281,10 @@ async def test_move_to_well_from_starting_location(
         )
     ).then_return([Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER)])
 
+    decoy.when(
+        state_store.pipettes.get_movement_speed(pipette_id="pipette-id")
+    ).then_return(39339.5)
+
     await subject.move_to_well(
         pipette_id="pipette-id",
         labware_id="labware-id",
@@ -297,6 +307,7 @@ async def test_move_to_well_from_starting_location(
             mount=Mount.RIGHT,
             abs_position=Point(1, 2, 3),
             critical_point=CriticalPoint.XY_CENTER,
+            speed=39339.5,
         ),
     )
 
@@ -355,6 +366,10 @@ async def test_move_relative(
         )
     ).then_return(Point(x=1, y=2, z=3))
 
+    decoy.when(
+        state_store.pipettes.get_movement_speed(pipette_id="pipette-id")
+    ).then_return(39339.5)
+
     result = await subject.move_relative(
         pipette_id="pipette-id",
         axis=axis,
@@ -368,6 +383,7 @@ async def test_move_relative(
             mount=Mount.LEFT,
             delta=expected_delta,
             fail_on_not_homed=True,
+            speed=39339.5,
         )
     )
 
@@ -389,10 +405,15 @@ async def test_move_relative_must_home(
     )
 
     decoy.when(
+        state_store.pipettes.get_movement_speed(pipette_id="pipette-id")
+    ).then_return(39339.5)
+
+    decoy.when(
         await hardware_api.move_rel(
             mount=Mount.LEFT,
             delta=Point(x=0, y=0, z=42.0),
             fail_on_not_homed=True,
+            speed=39339.5,
         )
     ).then_raise(HardwareMustHomeError("oh no"))
 
@@ -569,6 +590,10 @@ async def test_move_to_coordinates(
         )
     ).then_return([planned_waypoint_1, planned_waypoint_2])
 
+    decoy.when(
+        state_store.pipettes.get_movement_speed(pipette_id="pipette-id")
+    ).then_return(39339.5)
+
     await subject.move_to_coordinates(
         pipette_id="pipette-id",
         deck_coordinates=destination_deck,
@@ -581,11 +606,13 @@ async def test_move_to_coordinates(
             mount=mount,
             abs_position=planned_waypoint_1.position,
             critical_point=planned_waypoint_1.critical_point,
+            speed=39339.5,
         ),
         await hardware_api.move_to(
             mount=mount,
             abs_position=planned_waypoint_2.position,
             critical_point=planned_waypoint_2.critical_point,
+            speed=39339.5,
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -584,6 +584,10 @@ async def test_touch_tip(
         )
     ).then_return([Point(x=0, y=1, z=2), Point(x=3, y=4, z=5)])
 
+    decoy.when(
+        state_store.pipettes.get_movement_speed(pipette_id="pipette-id")
+    ).then_return(39339.5)
+
     await subject.touch_tip(
         pipette_id="pipette-id",
         labware_id="labware-id",
@@ -602,10 +606,12 @@ async def test_touch_tip(
             mount=Mount.LEFT,
             critical_point=CriticalPoint.XY_CENTER,
             abs_position=Point(x=0, y=1, z=2),
+            speed=39339.5,
         ),
         await hardware_api.move_to(
             mount=Mount.LEFT,
             critical_point=CriticalPoint.XY_CENTER,
             abs_position=Point(x=3, y=4, z=5),
+            speed=39339.5,
         ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -74,7 +74,7 @@ def test_handles_load_pipette(subject: PipetteStore) -> None:
         mount=MountType.LEFT,
     )
     assert result.aspirated_volume_by_id["pipette-id"] == 0
-    assert result.movement_speed_by_id["pipette-id"] == None
+    assert result.movement_speed_by_id["pipette-id"] is None
 
 
 def test_pipette_volume_adds_aspirate(subject: PipetteStore) -> None:
@@ -531,6 +531,7 @@ def test_tip_commands_update_has_tip(subject: PipetteStore) -> None:
 
 
 def test_set_movement_speed(subject: PipetteStore) -> None:
+    """It should issue an action to set the movement speed."""
     pipette_id = "pipette-id"
     load_pipette_command = create_load_pipette_command(
         pipette_id=pipette_id,

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -14,7 +14,10 @@ from opentrons.protocol_engine.types import (
     OFF_DECK_LOCATION,
     LabwareMovementStrategy,
 )
-from opentrons.protocol_engine.actions import SetPipetteMovementSpeedAction, UpdateCommandAction
+from opentrons.protocol_engine.actions import (
+    SetPipetteMovementSpeedAction,
+    UpdateCommandAction,
+)
 from opentrons.protocol_engine.state.pipettes import (
     PipetteStore,
     PipetteState,
@@ -535,6 +538,7 @@ def test_set_movement_speed(subject: PipetteStore) -> None:
         mount=MountType.LEFT,
     )
     subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=123.456))
+    subject.handle_action(
+        SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=123.456)
+    )
     assert subject.state.movement_speed_by_id[pipette_id] == 123.456
-

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -14,7 +14,7 @@ from opentrons.protocol_engine.types import (
     OFF_DECK_LOCATION,
     LabwareMovementStrategy,
 )
-from opentrons.protocol_engine.actions import UpdateCommandAction
+from opentrons.protocol_engine.actions import SetPipetteMovementSpeedAction, UpdateCommandAction
 from opentrons.protocol_engine.state.pipettes import (
     PipetteStore,
     PipetteState,
@@ -49,6 +49,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         aspirated_volume_by_id={},
         current_well=None,
         attached_tip_labware_by_id={},
+        movement_speed_by_id={},
     )
 
 
@@ -70,6 +71,7 @@ def test_handles_load_pipette(subject: PipetteStore) -> None:
         mount=MountType.LEFT,
     )
     assert result.aspirated_volume_by_id["pipette-id"] == 0
+    assert result.movement_speed_by_id["pipette-id"] == None
 
 
 def test_pipette_volume_adds_aspirate(subject: PipetteStore) -> None:
@@ -523,3 +525,16 @@ def test_tip_commands_update_has_tip(subject: PipetteStore) -> None:
     subject.handle_action(UpdateCommandAction(command=drop_tip_command))
 
     assert not subject.state.attached_tip_labware_by_id
+
+
+def test_set_movement_speed(subject: PipetteStore) -> None:
+    pipette_id = "pipette-id"
+    load_pipette_command = create_load_pipette_command(
+        pipette_id=pipette_id,
+        pipette_name=PipetteNameType.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
+    subject.handle_action(SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=123.456))
+    assert subject.state.movement_speed_by_id[pipette_id] == 123.456
+

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -267,6 +267,7 @@ def test_pipette_not_ready_to_aspirate() -> None:
 
 
 def test_get_movement_speed() -> None:
+    """It should return the movement speed that was set for the given pipette."""
     subject = get_pipette_view(
         movement_speed_by_id={
             "pipette-with-movement-speed": 123.456,
@@ -278,5 +279,5 @@ def test_get_movement_speed() -> None:
         subject.get_movement_speed(pipette_id="pipette-with-movement-speed") == 123.456
     )
     assert (
-        subject.get_movement_speed(pipette_id="pipette-without-movement-speed") == None
+        subject.get_movement_speed(pipette_id="pipette-without-movement-speed") is None
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -21,7 +21,7 @@ def get_pipette_view(
     aspirated_volume_by_id: Optional[Dict[str, float]] = None,
     current_well: Optional[CurrentWell] = None,
     attached_tip_labware_by_id: Optional[Dict[str, str]] = None,
-    movement_speed_by_id: Optional[Dict[str, Optional[float]]] = None
+    movement_speed_by_id: Optional[Dict[str, Optional[float]]] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""
     state = PipetteState(
@@ -29,7 +29,7 @@ def get_pipette_view(
         aspirated_volume_by_id=aspirated_volume_by_id or {},
         current_well=current_well,
         attached_tip_labware_by_id=attached_tip_labware_by_id or {},
-        movement_speed_by_id=movement_speed_by_id or {}
+        movement_speed_by_id=movement_speed_by_id or {},
     )
 
     return PipetteView(state=state)
@@ -270,9 +270,13 @@ def test_get_movement_speed() -> None:
     subject = get_pipette_view(
         movement_speed_by_id={
             "pipette-with-movement-speed": 123.456,
-            "pipette-without-movement-speed": None
+            "pipette-without-movement-speed": None,
         }
     )
 
-    assert subject.get_movement_speed(pipette_id="pipette-with-movement-speed") == 123.456
-    assert subject.get_movement_speed(pipette_id="pipette-without-movement-speed") == None
+    assert (
+        subject.get_movement_speed(pipette_id="pipette-with-movement-speed") == 123.456
+    )
+    assert (
+        subject.get_movement_speed(pipette_id="pipette-without-movement-speed") == None
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -21,6 +21,7 @@ def get_pipette_view(
     aspirated_volume_by_id: Optional[Dict[str, float]] = None,
     current_well: Optional[CurrentWell] = None,
     attached_tip_labware_by_id: Optional[Dict[str, str]] = None,
+    movement_speed_by_id: Optional[Dict[str, Optional[float]]] = None
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""
     state = PipetteState(
@@ -28,6 +29,7 @@ def get_pipette_view(
         aspirated_volume_by_id=aspirated_volume_by_id or {},
         current_well=current_well,
         attached_tip_labware_by_id=attached_tip_labware_by_id or {},
+        movement_speed_by_id=movement_speed_by_id or {}
     )
 
     return PipetteView(state=state)
@@ -262,3 +264,15 @@ def test_pipette_not_ready_to_aspirate() -> None:
     )
 
     assert result is False
+
+
+def test_get_movement_speed() -> None:
+    subject = get_pipette_view(
+        movement_speed_by_id={
+            "pipette-with-movement-speed": 123.456,
+            "pipette-without-movement-speed": None
+        }
+    )
+
+    assert subject.get_movement_speed(pipette_id="pipette-with-movement-speed") == 123.456
+    assert subject.get_movement_speed(pipette_id="pipette-without-movement-speed") == None


### PR DESCRIPTION
# Overview

This is a quick and dirty PR to extend Protocol Engine to allow changing a pipette's movement speed up and down and across the deck. (Not to be confused with the pipette's plunger speed.) This is just enough to support `pipette.default_speed = ...` in Python protocols, which we need for OT-3 scientific testing.

Closes RCORE-353.

# Changelog

* Every time Protocol Engine uses `hardware_api.move_to()`, provide an explicit `speed`. This should be every `hardware_api.move_to()` in `opentrons.protocol_engine` except for the one that's controlling the gripper.
* By default, we provide `speed=None`, meaning let the hardware controller decide. This preserves existing behavior of basic runs and JSON protocol runs.
* If a Python protocol running via the in-development `engine` core does `pipette.default_speed = ...`, use that value.
    * I implemented this with a new method on the `ProtocolEngine` class instead of adding a new bona-fide command. This is certainly not the correct way to do it. I did it this way to avoid some boilerplate and to avoid having to think about public-facing JSON shapes.

# Testing

Try running this on an OT-3 (run time is approximately 6 minutes):

```python
metadata = {
    'apiLevel': '2.13'
}

def run(protocol):
    plate_1 = protocol.load_labware('nest_96_wellplate_100ul_pcr_full_skirt','1')
    plate_2 = protocol.load_labware('nest_96_wellplate_100ul_pcr_full_skirt','3')
    well_1 = plate_1["A1"]
    well_2 = plate_2["A12"]

    pipette = protocol.load_instrument(
        "p50_single_gen3",
        "left",
        tip_racks=[protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "2")]
    )

    protocol.comment("Normal speed:")
    pipette.pick_up_tip()
    pipette.aspirate(50, well_1)
    pipette.dispense(50, well_2)

    protocol.comment("Sloooooow:")
    pipette.default_speed = 10
    pipette.aspirate(50, well_1)
    pipette.dispense(50, well_2)
    pipette.return_tip()
```

# Review requests

Is there any other place where the hardware API might be using a default speed, and we might need to override it?

# Risk assessment

Low as long as we haven't productionized

In the longer term: it's very easy to forget to set the `speed` argument when calling `hardware_api.move_to()`, which would cause bugs where setting `pipette.default_speed` has no effect. We should think about how to solve this. Either centralize all our `hardware_api.move_to()` calls somewhere where that mistake would be harder to make, or change `hardware_api.move_to()` so the `speed` argument is mandatory.
