### PR TITLE
feat(app): add error handling screen and home robot on exit

### DIFF
--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -16,6 +16,7 @@ export interface RunCommandSummary {
   result?: RunTimeCommand['result']
   startedAt?: string
   completedAt?: string
+  error?: RunCommandError
 }
 
 export interface CommandDetail {
@@ -45,4 +46,11 @@ export interface CommandsData {
 export interface CreateCommandParams {
   waitUntilComplete?: boolean
   timeout?: number
+}
+
+export interface RunCommandError {
+  id: string
+  errorType: string
+  createdAt: string
+  detail: string
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -27,5 +27,6 @@
   "continue": "Continue",
   "detach_and_reattach": "Detach and reattach pipette",
   "grab_screwdriver": "While continuing to hold in place, grab your 2.5mm driver and tighten screws as shown in the animation. Test the pipette attachment by giving it a wiggle before pressing continue",
-  "name_and_volume_detected": "{{name}} Pipette Detected"
+  "name_and_volume_detected": "{{name}} Pipette Detected",
+  "error_encountered": "Error encountered"
 }

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -12,10 +12,10 @@ import { StyledText } from '../../atoms/text'
 
 interface Props {
   iconColor: string
-  children: React.ReactNode
   header: string
-  subHeader?: string
   isSuccess: boolean
+  children?: React.ReactNode
+  subHeader?: string
 }
 
 export function SimpleWizardBody(props: Props): JSX.Element {
@@ -61,7 +61,7 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         paddingBottom={SPACING.spacing6}
         justifyContent={JUSTIFY_FLEX_END}
       >
-        {children}
+        {children ?? null}
       </Flex>
     </Flex>
   )

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -61,7 +61,7 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         paddingBottom={SPACING.spacing6}
         justifyContent={JUSTIFY_FLEX_END}
       >
-        {children ?? null}
+        {children}
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -45,29 +45,32 @@ export const BeforeBeginning = (
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
     setIsBetweenCommands(true)
-    chainRunCommands([
-      {
-        commandType: 'home' as const,
-        params: {},
-      },
-      {
-        commandType: 'loadPipette' as const,
-        params: {
-          // @ts-expect-error pipetteName is required but missing in schema v6 type
-          pipetteName: attachedPipette[mount]?.name,
-          pipetteId: pipetteId,
-          mount: mount,
+    chainRunCommands(
+      [
+        // {
+        //   commandType: 'home' as const,
+        //   params: {},
+        // },
+        {
+          commandType: 'loadPipette' as const,
+          params: {
+            // @ts-expect-error pipetteName is required but missing in schema v6 type
+            pipetteName: attachedPipette[mount]?.name,
+            pipetteId: pipetteId,
+            mount: mount,
+          },
         },
-      },
-      {
-        // @ts-expect-error calibration type not yet supported
-        commandType: 'calibration/moveToLocation' as const,
-        params: {
-          pipetteId: pipetteId,
-          location: 'attachOrDetach',
+        {
+          // @ts-expect-error calibration type not yet supported
+          commandType: 'calibration/moveToLocation' as const,
+          params: {
+            pipetteId: pipetteId,
+            location: 'attachOrDetach',
+          },
         },
-      },
-    ])
+      ],
+      false
+    )
       .then(() => {
         setIsBetweenCommands(false)
         proceed()

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { UseMutateFunction } from 'react-query'
+import { COLORS } from '@opentrons/components'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { WizardRequiredEquipmentList } from '../../molecules/WizardRequiredEquipmentList'
@@ -30,6 +32,9 @@ export const BeforeBeginning = (
     setIsBetweenCommands,
   } = props
   const { t } = useTranslation('pipette_wizard_flows')
+  const [errorMessage, setShowErrorMessage] = React.useState<null | string>(
+    null
+  )
   //  TODO(jr, 10/26/22): when we wire up other flows, const will turn into let
   //  for proceedButtonText and rightHandBody
   React.useEffect(() => {
@@ -69,7 +74,7 @@ export const BeforeBeginning = (
       })
       .catch(error => {
         console.log(error)
-        // let's early return an error modal here
+        setShowErrorMessage(error.message)
       })
   }
 
@@ -86,8 +91,17 @@ export const BeforeBeginning = (
     }
     //  TODO(jr, 10/26/22): wire up the other flows
   }
-  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
-  return (
+  if (isRobotMoving && errorMessage == null)
+    return <InProgressModal description={t('stand_back')} />
+
+  return errorMessage != null ? (
+    <SimpleWizardBody
+      isSuccess={false}
+      iconColor={COLORS.errorEnabled}
+      header={t('error_encountered')}
+      subHeader={errorMessage}
+    />
+  ) : (
     <GenericWizardTile
       header={t('before_you_begin')}
       //  TODO(jr, 11/3/22): wire up this URL and unhide the link!

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -62,10 +62,15 @@ export const BeforeBeginning = (
           location: 'attachOrDetach',
         },
       },
-    ]).then(() => {
-      setIsBetweenCommands(false)
-      proceed()
-    })
+    ])
+      .then(() => {
+        setIsBetweenCommands(false)
+        proceed()
+      })
+      .catch(error => {
+        console.log(error)
+        // let's early return an error modal here
+      })
   }
 
   const proceedButtonText: string = t('get_started')

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -33,8 +33,6 @@ export const BeforeBeginning = (
     setShowErrorMessage,
   } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  //  TODO(jr, 10/26/22): when we wire up other flows, const will turn into let
-  //  for proceedButtonText and rightHandBody
   React.useEffect(() => {
     createRun({})
   }, [])
@@ -44,10 +42,10 @@ export const BeforeBeginning = (
   const handleOnClick = (): void => {
     chainRunCommands(
       [
-        // {
-        //   commandType: 'home' as const,
-        //   params: {},
-        // },
+        {
+          commandType: 'home' as const,
+          params: {},
+        },
         {
           commandType: 'loadPipette' as const,
           params: {
@@ -75,7 +73,8 @@ export const BeforeBeginning = (
         setShowErrorMessage(error.message)
       })
   }
-
+  //  TODO(jr, 10/26/22): when we wire up other flows, const will turn into let
+  //  for proceedButtonText and rightHandBody
   const proceedButtonText: string = t('get_started')
   const rightHandBody = (
     <WizardRequiredEquipmentList

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -29,12 +29,10 @@ export const BeforeBeginning = (
     isCreateLoading,
     mount,
     isRobotMoving,
-    setIsBetweenCommands,
+    errorMessage,
+    setShowErrorMessage,
   } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  const [errorMessage, setShowErrorMessage] = React.useState<null | string>(
-    null
-  )
   //  TODO(jr, 10/26/22): when we wire up other flows, const will turn into let
   //  for proceedButtonText and rightHandBody
   React.useEffect(() => {
@@ -44,7 +42,6 @@ export const BeforeBeginning = (
   const pipetteId = attachedPipette[mount]?.id
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
-    setIsBetweenCommands(true)
     chainRunCommands(
       [
         // {
@@ -72,11 +69,9 @@ export const BeforeBeginning = (
       false
     )
       .then(() => {
-        setIsBetweenCommands(false)
         proceed()
       })
       .catch(error => {
-        console.log(error)
         setShowErrorMessage(error.message)
       })
   }
@@ -94,8 +89,7 @@ export const BeforeBeginning = (
     }
     //  TODO(jr, 10/26/22): wire up the other flows
   }
-  if (isRobotMoving && errorMessage == null)
-    return <InProgressModal description={t('stand_back')} />
+  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
 
   return errorMessage != null ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -34,7 +34,8 @@ describe('AttachProbe', () => {
       runId: RUN_ID_1,
       attachedPipette: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
-      setIsBetweenCommands: jest.fn(),
+      errorMessage: null,
+      setShowErrorMessage: jest.fn(),
       isRobotMoving: false,
       isExiting: false,
     }
@@ -48,23 +49,24 @@ describe('AttachProbe', () => {
     getByAltText('Attach probe')
     const proceedBtn = getByRole('button', { name: 'Initiate calibration' })
     fireEvent.click(proceedBtn)
-    expect(props.setIsBetweenCommands).toHaveBeenCalled()
-    expect(props.chainRunCommands).toHaveBeenCalledWith([
-      {
-        commandType: 'calibration/calibratePipette',
-        params: { mount: 'left' },
-      },
-      {
-        commandType: 'home',
-        params: { axes: ['leftZ'] },
-      },
-      {
-        commandType: 'calibration/moveToLocation',
-        params: { pipetteId: 'abc', location: 'attachOrDetach' },
-      },
-    ])
+    expect(props.chainRunCommands).toHaveBeenCalledWith(
+      [
+        {
+          commandType: 'calibration/calibratePipette',
+          params: { mount: 'left' },
+        },
+        {
+          commandType: 'home',
+          params: { axes: ['leftZ'] },
+        },
+        {
+          commandType: 'calibration/moveToLocation',
+          params: { pipetteId: 'abc', location: 'attachOrDetach' },
+        },
+      ],
+      false
+    )
     await waitFor(() => {
-      expect(props.setIsBetweenCommands).toHaveBeenCalled()
       expect(props.proceed).toHaveBeenCalled()
     })
 
@@ -84,5 +86,15 @@ describe('AttachProbe', () => {
       'The calibration probe will touch the sides of the calibration divot in slot 5 to determine its exact position'
     )
     getByAltText('Pipette is calibrating')
+  })
+
+  it('renders the error modal screen when errorMessage is true', () => {
+    props = {
+      ...props,
+      errorMessage: 'error shmerror',
+    }
+    const { getByText } = render(props)
+    getByText('Error encountered')
+    getByText('error shmerror')
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -49,7 +49,8 @@ describe('BeforeBeginning', () => {
       attachedPipette: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
       createRun: jest.fn(),
-      setIsBetweenCommands: jest.fn(),
+      errorMessage: null,
+      setShowErrorMessage: jest.fn(),
       isCreateLoading: false,
       isRobotMoving: false,
     }
@@ -70,27 +71,28 @@ describe('BeforeBeginning', () => {
     getByAltText('Calibration Probe')
     const proceedBtn = getByRole('button', { name: 'Get started' })
     fireEvent.click(proceedBtn)
-    expect(props.setIsBetweenCommands).toHaveBeenCalled()
-    expect(props.chainRunCommands).toHaveBeenCalledWith([
-      {
-        commandType: 'home',
-        params: {},
-      },
-      {
-        commandType: 'loadPipette',
-        params: {
-          mount: LEFT,
-          pipetteId: 'abc',
-          pipetteName: 'p1000_single_gen3',
+    expect(props.chainRunCommands).toHaveBeenCalledWith(
+      [
+        {
+          commandType: 'home',
+          params: {},
         },
-      },
-      {
-        commandType: 'calibration/moveToLocation',
-        params: { pipetteId: 'abc', location: 'attachOrDetach' },
-      },
-    ])
+        {
+          commandType: 'loadPipette',
+          params: {
+            mount: LEFT,
+            pipetteId: 'abc',
+            pipetteName: 'p1000_single_gen3',
+          },
+        },
+        {
+          commandType: 'calibration/moveToLocation',
+          params: { pipetteId: 'abc', location: 'attachOrDetach' },
+        },
+      ],
+      false
+    )
     await waitFor(() => {
-      expect(props.setIsBetweenCommands).toHaveBeenCalled()
       expect(props.proceed).toHaveBeenCalled()
     })
   })
@@ -111,5 +113,15 @@ describe('BeforeBeginning', () => {
     const { getByRole } = render(props)
     const proceedBtn = getByRole('button', { name: 'Get started' })
     expect(proceedBtn).toBeDisabled()
+  })
+
+  it('renders the error modal screen when errorMessage is true', () => {
+    props = {
+      ...props,
+      errorMessage: 'error shmerror',
+    }
+    const { getByText } = render(props)
+    getByText('Error encountered')
+    getByText('error shmerror')
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
@@ -33,7 +33,8 @@ describe('ChoosePipette', () => {
       isRobotMoving: false,
       runId: RUN_ID_1,
       attachedPipette: { left: mockPipette, right: null },
-      setIsBetweenCommands: jest.fn(),
+      errorMessage: null,
+      setShowErrorMessage: jest.fn(),
     }
   })
   it('returns the correct information, buttons work as expected', () => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
@@ -39,7 +39,8 @@ describe('DetachProbe', () => {
       attachedPipette: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
       handleCleanUp: jest.fn(),
-      setIsBetweenCommands: jest.fn(),
+      errorMessage: null,
+      setShowErrorMessage: jest.fn(),
       isRobotMoving: false,
     }
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
@@ -33,7 +33,8 @@ describe('MountPipette', () => {
       runId: RUN_ID_1,
       attachedPipette: { left: mockPipette, right: null },
       flowType: FLOWS.ATTACH,
-      setIsBetweenCommands: jest.fn(),
+      errorMessage: null,
+      setShowErrorMessage: jest.fn(),
       isRobotMoving: false,
     }
   })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -129,24 +129,27 @@ describe('PipetteWizardFlows', () => {
     const getStarted = getByRole('button', { name: 'Get started' })
     fireEvent.click(getStarted)
     await waitFor(() => {
-      expect(mockChainRunCommands).toHaveBeenCalledWith([
-        {
-          commandType: 'home',
-          params: {},
-        },
-        {
-          commandType: 'loadPipette',
-          params: {
-            mount: LEFT,
-            pipetteId: 'abc',
-            pipetteName: 'p1000_single_gen3',
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: {},
           },
-        },
-        {
-          commandType: 'calibration/moveToLocation',
-          params: { pipetteId: 'abc', location: 'attachOrDetach' },
-        },
-      ])
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
+          {
+            commandType: 'calibration/moveToLocation',
+            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+          },
+        ],
+        false
+      )
       expect(mockCreateRun).toHaveBeenCalled()
     })
     // second page
@@ -158,20 +161,23 @@ describe('PipetteWizardFlows', () => {
     const initiate = getByRole('button', { name: 'Initiate calibration' })
     fireEvent.click(initiate)
     await waitFor(() => {
-      expect(mockChainRunCommands).toHaveBeenCalledWith([
-        {
-          commandType: 'calibration/calibratePipette',
-          params: { mount: 'left' },
-        },
-        {
-          commandType: 'home',
-          params: { axes: ['leftZ'] },
-        },
-        {
-          commandType: 'calibration/moveToLocation',
-          params: { pipetteId: 'abc', location: 'attachOrDetach' },
-        },
-      ])
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'calibration/calibratePipette',
+            params: { mount: 'left' },
+          },
+          {
+            commandType: 'home',
+            params: { axes: ['leftZ'] },
+          },
+          {
+            commandType: 'calibration/moveToLocation',
+            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+          },
+        ],
+        false
+      )
     })
     //  third page
     getByText('Step 2 / 3')
@@ -182,12 +188,15 @@ describe('PipetteWizardFlows', () => {
     const complete = getByRole('button', { name: 'Complete calibration' })
     fireEvent.click(complete)
     await waitFor(() => {
-      expect(mockChainRunCommands).toHaveBeenCalledWith([
-        {
-          commandType: 'home',
-          params: {},
-        },
-      ])
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: {},
+          },
+        ],
+        false
+      )
       //  TODO(jr, 11/2/22): wire this up when stop run logic is figured out
       // expect(mockStopRun).toHaveBeenCalled()
     })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -32,7 +32,8 @@ describe('Results', () => {
       isRobotMoving: false,
       runId: RUN_ID_1,
       attachedPipette: { left: mockPipette, right: null },
-      setIsBetweenCommands: jest.fn(),
+      errorMessage: null,
+      setShowErrorMessage: jest.fn(),
       flowType: FLOWS.CALIBRATE,
     }
   })

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '@opentrons/react-api-client'
 import { ModalShell } from '../../molecules/Modal'
 import { Portal } from '../../App/portal'
+import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { WizardHeader } from '../../molecules/WizardHeader'
 import { useChainRunCommands } from '../../resources/runs/hooks'
 import { getPipetteWizardSteps } from './getPipetteWizardSteps'
@@ -75,20 +76,13 @@ export const PipetteWizardFlows = (
     },
   })
 
-  const [isBetweenCommands, setIsBetweenCommands] = React.useState<boolean>(
-    false
+  const [errorMessage, setShowErrorMessage] = React.useState<null | string>(
+    null
   )
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
 
   const proceed = (): void => {
-    if (
-      !(
-        isCommandMutationLoading ||
-        isStopLoading ||
-        isBetweenCommands ||
-        isExiting
-      )
-    ) {
+    if (!(isCommandMutationLoading || isStopLoading || isExiting)) {
       setCurrentStepIndex(
         currentStepIndex !== pipetteWizardSteps.length - 1
           ? currentStepIndex + 1
@@ -98,12 +92,15 @@ export const PipetteWizardFlows = (
   }
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
-    chainRunCommands([
-      {
-        commandType: 'home' as const,
-        params: {},
-      },
-    ]).then(() => {
+    chainRunCommands(
+      [
+        {
+          commandType: 'home' as const,
+          params: {},
+        },
+      ],
+      false
+    ).then(() => {
       setIsExiting(false)
       if (runId !== '') stopRun(runId)
     })
@@ -117,18 +114,13 @@ export const PipetteWizardFlows = (
   const [isRobotMoving, setIsRobotMoving] = React.useState<boolean>(false)
 
   React.useEffect(() => {
-    if (
-      isCommandMutationLoading ||
-      isStopLoading ||
-      isBetweenCommands ||
-      isExiting
-    ) {
+    if (isCommandMutationLoading || isStopLoading || isExiting) {
       const timer = setTimeout(() => setIsRobotMoving(true), 700)
       return () => clearTimeout(timer)
     } else {
       setIsRobotMoving(false)
     }
-  }, [isCommandMutationLoading, isStopLoading, isBetweenCommands, isExiting])
+  }, [isCommandMutationLoading, isStopLoading, isExiting])
 
   const calibrateBaseProps = {
     chainRunCommands,
@@ -137,8 +129,8 @@ export const PipetteWizardFlows = (
     runId,
     goBack,
     attachedPipette,
-    setIsBetweenCommands,
-    isBetweenCommands,
+    setShowErrorMessage,
+    errorMessage,
   }
   const exitModal = (
     <ExitModal goBack={cancelExit} proceed={confirmExit} flowType={flowType} />
@@ -147,6 +139,9 @@ export const PipetteWizardFlows = (
   if (currentStep == null) return null
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
 
+  if (isExiting === true) {
+    modalContent = <InProgressModal description={t('stand_back')} />
+  }
   if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {
     onExit = handleCleanUpAndClose
     modalContent = (
@@ -198,7 +193,8 @@ export const PipetteWizardFlows = (
   let exitWizardButton = onExit
   if (isRobotMoving) {
     exitWizardButton = undefined
-  } else if (showConfirmExit) exitWizardButton = handleCleanUpAndClose
+  } else if (showConfirmExit || errorMessage != null)
+    exitWizardButton = handleCleanUpAndClose
 
   return (
     <Portal level="top">

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -64,11 +64,15 @@ export interface PipetteWizardStepProps {
   mount: PipetteMount
   proceed: () => void
   goBack: () => void
-  chainRunCommands: (commands: CreateCommand[]) => Promise<unknown>
+  chainRunCommands: (
+    commands: CreateCommand[],
+    continuePastCommandFailure: boolean
+  ) => Promise<unknown>
   isRobotMoving: boolean
   runId: string
   attachedPipette: AttachedPipettesByMount
-  setIsBetweenCommands: React.Dispatch<React.SetStateAction<boolean>>
+  setShowErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
+  errorMessage: string | null
 }
 
 export type SelectablePipettes = '96-Channel' | 'Single-Channel_and_8-Channel'

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -29,13 +29,19 @@ export function useCreateRunCommandMutation(
 export function useChainRunCommands(
   runId: string
 ): {
-  chainRunCommands: (commands: CreateCommand[]) => Promise<unknown>
+  chainRunCommands: (
+    commands: CreateCommand[],
+    continuePastCommandFailure: boolean
+  ) => Promise<unknown>
   isCommandMutationLoading: boolean
 } {
   const { createRunCommand, isLoading } = useCreateRunCommandMutation(runId)
   return {
-    chainRunCommands: (commands: CreateCommand[]) =>
-      chainRunCommands(commands, createRunCommand),
+    chainRunCommands: (
+      commands: CreateCommand[],
+      continuePastCommandFailure: boolean
+    ) =>
+      chainRunCommands(commands, createRunCommand, continuePastCommandFailure),
     isCommandMutationLoading: isLoading,
   }
 }

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -13,9 +13,10 @@ export const chainRunCommands = (
     waitUntilComplete: true,
   })
     .then(response => {
+      console.log(response)
       if (!continuePastCommandFailure && response.data.status === 'failed') {
         return Promise.reject(
-          new Error(response.data.error.detail ?? 'command failed')
+          new Error(response.data.error?.detail ?? 'command failed')
         )
       }
       if (commands.slice(1).length < 1) {

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -13,7 +13,6 @@ export const chainRunCommands = (
     waitUntilComplete: true,
   })
     .then(response => {
-      console.log(response)
       if (!continuePastCommandFailure && response.data.status === 'failed') {
         return Promise.reject(
           new Error(response.data.error?.detail ?? 'command failed')

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -12,6 +12,8 @@ export const chainRunCommands = (
     waitUntilComplete: true,
   })
     .then(response => {
+      console.log(response)
+      // we may want to exit early here and reject the promise if the command status is failed
       if (commands.slice(1).length < 1) {
         return Promise.resolve(response)
       } else {


### PR DESCRIPTION
closes RLIQ-226

# Overview

Both `BeforeBeginning` and `AttachProbe` display an error screen if an error occurs.

co-authored by @smb2268 

# Changelog

- create `RunCommandError` type
- make `children` optional in `SimpleWizardBody`
- Add the `.catch` to the promises in `BeforeBeginning` and `AttachProbe` so the error message can be displayed in the error modal
- modify `useChainRunCommands` hook to take in `continuePastCommandFailure` boolean for error handling
- extend `PipetteWizardFlow` props to include `errorMessage` and `setShowErrorMessage`

# Review requests

- in the ot-3  emulator, go through pipette calibration and you should see the error screen occur. Clicking on the exit button in the wizard header should home the robot and close the modal.

# Risk assessment

low