### PR TITLE
refactor(api): implement more core methods to unblock `transfer` et. al.

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -340,19 +340,24 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         ).pipetteName.value
 
     def get_model(self) -> str:
-        raise NotImplementedError("InstrumentCore.get_model not implemented")
+        # TODO(mc, 2022-11-11): https://opentrons.atlassian.net/browse/RCORE-382
+        return self.get_hardware_state()["model"]
 
     def get_min_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore.get_min_volume not implemented")
+        # TODO(mc, 2022-11-11): https://opentrons.atlassian.net/browse/RCORE-382
+        return self.get_hardware_state()["min_volume"]
 
     def get_max_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore.get_max_volume not implemented")
+        # TODO(mc, 2022-11-11): https://opentrons.atlassian.net/browse/RCORE-382
+        return self.get_hardware_state()["max_volume"]
 
     def get_current_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore.get_current_volume not implemented")
+        # TODO(mc, 2022-11-11): https://opentrons.atlassian.net/browse/RCORE-381
+        return self.get_hardware_state()["current_volume"]
 
     def get_available_volume(self) -> float:
-        raise NotImplementedError("InstrumentCore.get_available_volume not implemented")
+        # TODO(mc, 2022-11-11): https://opentrons.atlassian.net/browse/RCORE-381
+        return self.get_hardware_state()["available_volume"]
 
     def get_hardware_state(self) -> PipetteDict:
         """Get the current state of the pipette hardware as a dictionary."""
@@ -360,6 +365,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
 
     # TODO(mc, 2022-11-09): read pipette config into engine state at load
     def get_channels(self) -> int:
+        # TODO(mc, 2022-11-11): https://opentrons.atlassian.net/browse/RCORE-382
         return self.get_hardware_state()["channels"]
 
     def has_tip(self) -> bool:

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -39,6 +39,10 @@ class LabwareCore(AbstractLabware[WellCore]):
             for well_name in column
         }
 
+        # TODO(mc, 2022-11-11): redo this implementation
+        # https://opentrons.atlassian.net/browse/RCORE-380
+        self._well_grid = WellGrid(wells=self.get_wells())
+
     @property
     def labware_id(self) -> str:
         """The labware's unique ProtocolEngine ID."""
@@ -89,7 +93,9 @@ class LabwareCore(AbstractLabware[WellCore]):
         return cast(LabwareDefinitionDict, self._definition.dict(exclude_none=True))
 
     def get_parameters(self) -> LabwareParameters:
-        raise NotImplementedError("LabwareCore.get_parameters not implemented")
+        return cast(
+            LabwareParameters, self._definition.parameters.dict(exclude_none=True)
+        )
 
     def get_quirks(self) -> List[str]:
         raise NotImplementedError("LabwareCore.get_quirks not implemented")
@@ -140,7 +146,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         raise NotImplementedError("LabwareCore.get_tip_tracker not implemented")
 
     def get_well_grid(self) -> WellGrid:
-        raise NotImplementedError("LabwareCore.get_well_grid not implemented")
+        return self._well_grid
 
     def get_wells(self) -> List[WellCore]:
         return list(self._wells_by_name.values())

--- a/api/src/opentrons/protocol_api/core/protocol_api/well.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well.py
@@ -56,11 +56,11 @@ class WellImplementation(AbstractWellCore):
         return self._name
 
     def get_column_name(self) -> str:
-        """Get the column portion of the well name (e.g. "A")."""
+        """Get the column portion of the well name (e.g. "1")."""
         return self._column_name
 
     def get_row_name(self) -> str:
-        """Get the row portion of the well name (e.g. "1")."""
+        """Get the row portion of the well name (e.g. "A")."""
         return self._row_name
 
     def get_max_volume(self) -> float:

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -32,12 +32,12 @@ class AbstractWellCore(ABC):
 
     @abstractmethod
     def get_column_name(self) -> str:
-        """Get the column portion of the well name (e.g. "A")."""
+        """Get the column portion of the well name (e.g. "1")."""
         ...
 
     @abstractmethod
     def get_row_name(self) -> str:
-        """Get the row portion of the well name (e.g. "1")."""
+        """Get the row portion of the well name (e.g. "A")."""
         ...
 
     @abstractmethod

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -4,7 +4,10 @@ from typing import cast
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition as LabwareDefDict,
+    LabwareParameters as LabwareParamsDict,
+)
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     Parameters as LabwareDefinitionParameters,
@@ -69,14 +72,20 @@ def test_set_calibration(subject: LabwareCore) -> None:
 @pytest.mark.parametrize(
     "labware_definition",
     [
-        LabwareDefinition.construct(namespace="hello", ordering=[])  # type: ignore[call-arg]
+        LabwareDefinition.construct(  # type: ignore[call-arg]
+            namespace="hello",
+            parameters=LabwareDefinitionParameters.construct(loadName="world"),  # type: ignore[call-arg]
+            ordering=[],
+        )
     ],
 )
 def test_get_definition(subject: LabwareCore) -> None:
     """It should get the labware's definition as a dictionary."""
-    result = subject.get_definition()
-
-    assert result == cast(LabwareDefDict, {"namespace": "hello", "ordering": []})
+    assert subject.get_definition() == cast(
+        LabwareDefDict,
+        {"namespace": "hello", "parameters": {"loadName": "world"}, "ordering": []},
+    )
+    assert subject.get_parameters() == cast(LabwareParamsDict, {"loadName": "world"})
 
 
 def test_get_user_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:


### PR DESCRIPTION
## Overview

This PR is a result of working with @sanni-t on getting more test protocols working on the engine-core. It implements a few easy methods that were left unimplemented so that `InstrumentContext.transfer` (among other things) can work without erroring out.

## Changelog

- refactor(api): implement more core methods to unblock `transfer` et. al.

## Review requests

This is a pretty small diff, make sure the code makes sense. I created a few tickets to track TODOs, since some of these implementations are not good for the long term.

## Risk assessment

Low