### PR TITLE
fix(app): include offsets generated in current run when finding historic offset candidates

### DIFF
--- a/app/src/organisms/ApplyHistoricOffsets/hooks/useHistoricRunDetails.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/useHistoricRunDetails.ts
@@ -9,10 +9,8 @@ export function useHistoricRunDetails(
 
   return allHistoricRuns == null
     ? []
-    : allHistoricRuns.data
-        .filter(run => !run.current)
-        .sort(
-          (a, b) =>
-            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-        )
+    : allHistoricRuns.data.sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      )
 }


### PR DESCRIPTION
# Overview

Now that historic offsets are applied prior to run creation, and there is no need for populating a run record with identity offsets to "clear offsets". We can remove the filtering out of the current run's offsets when finding offset candidates for the next run.

# Review requests

Perform LPC on a run. With offsets applied, but before starting the run, return to the protocol page and create another run of the same protocol on the same robot. Once in the "Choose a Robot" slideout, you should be able to see the offsets that you just applied proposed as historic offset candidates in the "view offset data" modal.

# Risk assessment
low

