### PR TITLE
fix(app): remove cruft from robot card banner and prevent crash on load labware fail

### DIFF
--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
 
+import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
   Btn,
@@ -21,7 +22,6 @@ import { StyledText } from '../../atoms/text'
 import { Tooltip } from '../../atoms/Tooltip'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
-import { useProtocolDetailsForRun } from './hooks'
 
 import type { StyleProps } from '@opentrons/components'
 import type { DiscoveredRobot } from '../../redux/discovery/types'
@@ -43,7 +43,14 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
 
   const currentRunId = useCurrentRunId()
   const currentRunStatus = useCurrentRunStatus()
-  const { displayName } = useProtocolDetailsForRun(currentRunId)
+  const { data: runRecord } = useRunQuery(currentRunId, { staleTime: Infinity })
+  const protocolId = runRecord?.data?.protocolId ?? null
+  const { data: protocolRecord } = useProtocolQuery(protocolId, {
+    staleTime: Infinity,
+  })
+  const displayName =
+    protocolRecord?.data.metadata.protocolName ??
+    protocolRecord?.data.files[0].name
 
   const runningProtocolBanner: JSX.Element | null =
     currentRunId != null && currentRunStatus != null && displayName != null ? (

--- a/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
@@ -4,17 +4,15 @@ import { when, resetAllWhenMocks } from 'jest-when'
 
 import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import { renderWithProviders } from '@opentrons/components'
-import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
+import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 
 import { i18n } from '../../../i18n'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../../organisms/RunTimeControl/hooks'
-import { useProtocolDetailsForRun } from '../hooks'
 
 import { RobotStatusHeader } from '../RobotStatusHeader'
 
-import type { LegacySchemaAdapterOutput } from '@opentrons/shared-data'
-
+jest.mock('@opentrons/react-api-client')
 jest.mock('../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../organisms/RunTimeControl/hooks')
 jest.mock('../hooks')
@@ -25,18 +23,10 @@ const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
 const mockUseCurrentRunStatus = useCurrentRunStatus as jest.MockedFunction<
   typeof useCurrentRunStatus
 >
-const mockUseProtocolDetailsForRun = useProtocolDetailsForRun as jest.MockedFunction<
-  typeof useProtocolDetailsForRun
+const mockUseProtocolQuery = useProtocolQuery as jest.MockedFunction<
+  typeof useProtocolQuery
 >
-
-const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as LegacySchemaAdapterOutput
-
-const PROTOCOL_DETAILS = {
-  displayName: 'Testosaur',
-  protocolData: simpleV6Protocol,
-  protocolKey: 'fakeProtocolKey',
-  robotType: 'OT-2 Standard' as const,
-}
+const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
 
 const render = (props: React.ComponentProps<typeof RobotStatusHeader>) => {
   return renderWithProviders(
@@ -59,14 +49,28 @@ describe('RobotStatusHeader', () => {
     }
     when(mockUseCurrentRunId).calledWith().mockReturnValue(null)
     when(mockUseCurrentRunStatus).calledWith().mockReturnValue(null)
-    when(mockUseProtocolDetailsForRun)
-      .calledWith(null)
+    when(mockUseRunQuery)
+      .calledWith(null, { staleTime: Infinity })
+      .mockReturnValue({} as any)
+    when(mockUseRunQuery)
+      .calledWith('fakeRunId', { staleTime: Infinity })
       .mockReturnValue({
-        displayName: null,
-        protocolData: {} as LegacySchemaAdapterOutput,
-        protocolKey: null,
-        robotType: 'OT-2 Standard',
-      })
+        data: {
+          data: { protocolId: 'fakeProtocolId' },
+        },
+      } as any)
+    when(mockUseProtocolQuery)
+      .calledWith(null, { staleTime: Infinity })
+      .mockReturnValue({} as any)
+    when(mockUseProtocolQuery)
+      .calledWith('fakeProtocolId', { staleTime: Infinity })
+      .mockReturnValue({
+        data: {
+          data: {
+            metadata: { protocolName: 'fake protocol name' },
+          },
+        },
+      } as any)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -89,26 +93,23 @@ describe('RobotStatusHeader', () => {
   it('does not render a running protocol banner when a protocol is not running', () => {
     const [{ queryByText }] = render(props)
 
-    expect(queryByText('Testosaur;')).toBeFalsy()
+    expect(queryByText('fake protocol name;')).toBeFalsy()
     expect(queryByText('Go to Run')).toBeFalsy()
   })
 
   it('renders a running protocol banner when a protocol is running', () => {
-    when(mockUseCurrentRunId).calledWith().mockReturnValue('1')
+    when(mockUseCurrentRunId).calledWith().mockReturnValue('fakeRunId')
     when(mockUseCurrentRunStatus)
       .calledWith()
       .mockReturnValue(RUN_STATUS_RUNNING)
-    when(mockUseProtocolDetailsForRun)
-      .calledWith('1')
-      .mockReturnValue(PROTOCOL_DETAILS)
 
     const [{ getByRole, getByText }] = render(props)
 
-    getByText('Testosaur; Running')
+    getByText('fake protocol name; Running')
 
     const runLink = getByRole('link', { name: 'Go to Run' })
     expect(runLink.getAttribute('href')).toEqual(
-      '/devices/otie/protocol-runs/1/run-log'
+      '/devices/otie/protocol-runs/fakeRunId/run-log'
     )
   })
 })

--- a/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
+++ b/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
@@ -7,8 +7,17 @@ export function getLoadedLabwareDefinitionsByUri(
   return commands.reduce((acc, command) => {
     if (command.commandType === 'loadLabware') {
       const labwareDef: LabwareDefinition2 = command.result?.definition
-      const definitionUri = getLabwareDefURI(labwareDef)
-      return { ...acc, [definitionUri]: labwareDef }
+      if (labwareDef == null) {
+        console.error(
+          `could not find a labware definition in the results of load labware command: ${JSON.stringify(
+            command
+          )}`
+        )
+        return acc
+      } else {
+        const definitionUri = getLabwareDefURI(labwareDef)
+        return { ...acc, [definitionUri]: labwareDef }
+      }
     } else {
       return acc
     }


### PR DESCRIPTION
# Overview

The robot card on the device list contains a status banner and link to the running protocol if present. This doesn't need any information other than the run id and protocol display name. Remove its dependency on the schema adapter.  Also allow getLabwareDefsByURI to fail gracefully if ever encountering failed labware loads


# Review requests

- Upload a protocol with an impossible opentrons labware loadname. This analysis failure should not cause whitescreens anywhere in the devices route tree. 

# Risk assessment
low
