### PR TITLE
fix(app): temporarily remove setup info commands until commands include resolved entities

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
@@ -28,7 +28,14 @@ export const RunLogProtocolSetupInfo = ({
   const { t } = useTranslation('run_details')
   const { protocolData } = useProtocolDetailsForRun(runId)
   const protocolPipetteData = useRunPipetteInfoByMount(robotName, runId)
-
+  /**
+   * TODO(BC, 2022-11-11): we do not currently have the information that we need from the run commands
+   * in order to predictably create interpolated strings that describe equipment locations
+   * until there is a more reliable way to retrieve timeline specific loaded entity details
+   * we will render nothing in this component.
+   */
+  return null
+  /* eslint-disable */
   if (protocolData == null) return null
   if (setupCommand === undefined) return null
   if (

--- a/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
@@ -20,6 +20,7 @@ interface RunLogProtocolSetupInfoProps {
   runId: string
   setupCommand?: RunTimeCommand | RunCommandSummary
 }
+// test
 
 export const RunLogProtocolSetupInfo = ({
   robotName,

--- a/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
@@ -20,7 +20,6 @@ interface RunLogProtocolSetupInfoProps {
   runId: string
   setupCommand?: RunTimeCommand | RunCommandSummary
 }
-// test
 
 export const RunLogProtocolSetupInfo = ({
   robotName,

--- a/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunLogProtocolSetupInfo.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/RunLogProtocolSetupInfo.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/RunLogProtocolSetupInfo.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { when } from 'jest-when'
-
+/* eslint-disable */
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
@@ -189,93 +189,93 @@ describe('RunLogProtocolSetupInfo', () => {
       } as any)
     mockUseRunPipetteInfoByMount.mockReturnValue(mockPipetteInfoByMount)
   })
+  // TODO(bh, 2022-11-11): temporarily ignore tests while RunLogProtocolSetupInfo always renders null
+  // it('should render correct command when commandType is loadLabware', () => {
+  //   const { getByText } = render(props)
+  //   getByText('Load ANSI 96 Standard Microplate v1 in Slot 3')
+  // })
 
-  it('should render correct command when commandType is loadLabware', () => {
-    const { getByText } = render(props)
-    getByText('Load ANSI 96 Standard Microplate v1 in Slot 3')
-  })
-
-  it('should render correct command when commandType is loadLabware on top of a module', () => {
-    props = {
-      robotName: ROBOT_NAME,
-      runId: RUN_ID,
-      setupCommand: COMMAND_TYPE_LOAD_LABWARE_WITH_MODULE,
-    }
-    when(mockUseProtocolDetailsForRun)
-      .calledWith(RUN_ID)
-      .mockReturnValue({
-        protocolData: {
-          ...simpleV6Protocol,
-          commands: simpleV6Protocol.commands.map(c =>
-            c.commandType === 'loadModule'
-              ? { ...c, result: { moduleId: c.params.moduleId } }
-              : c
-          ),
-        },
-        displayName: 'mock display name',
-        protocolKey: 'fakeProtocolKey',
-        robotType: 'OT-2 Standard',
-      })
-    const { getByText } = render(props)
-    getByText(
-      'Load ANSI 96 Standard Microplate v1 in Magnetic Module GEN2 in Slot 3'
-    )
-  })
-  it('should render correct command when commandType is loadPipette', () => {
-    props = {
-      robotName: ROBOT_NAME,
-      runId: RUN_ID,
-      setupCommand: COMMAND_TYPE_LOAD_PIPETTE,
-    }
-    const { getByText } = render(props)
-    getByText(nestedTextMatcher('Load P10 Single-Channel in Left Mount'))
-  })
-  it('should render correct command when commandType is loadModule', () => {
-    props = {
-      robotName: ROBOT_NAME,
-      runId: RUN_ID,
-      setupCommand: COMMAND_TYPE_LOAD_MODULE,
-    }
-    const { getByText } = render(props)
-    getByText('Load Temperature Module GEN2 in Slot 3')
-  })
-  it('should render correct command when commandType is loadModule and a TC is used', () => {
-    props = {
-      robotName: ROBOT_NAME,
-      runId: RUN_ID,
-      setupCommand: COMMAND_TYPE_LOAD_MODULE_TC,
-    }
-    when(mockUseProtocolDetailsForRun)
-      .calledWith(RUN_ID)
-      .mockReturnValue({
-        protocolData: {
-          labware: {
-            [mockLabwarePositionCheckStepTipRack.labwareId]: {
-              slot: '3',
-              displayName: 'someDislpayName',
-              definitionId: LABWARE_DEF_ID,
-            },
-          },
-          labwareDefinitions: {
-            [LABWARE_DEF_ID]: LABWARE_DEF,
-          },
-          modules: {
-            [TC_ID]: {
-              slot: '3',
-              model: 'thermocyclerModuleV1',
-            },
-          },
-          pipettes: {
-            [PRIMARY_PIPETTE_ID]: {
-              name: PRIMARY_PIPETTE_NAME,
-              mount: 'left',
-            },
-          },
-        },
-      } as any)
-    const { getByText } = render(props)
-    getByText('Load Thermocycler Module GEN1')
-  })
+  // it('should render correct command when commandType is loadLabware on top of a module', () => {
+  //   props = {
+  //     robotName: ROBOT_NAME,
+  //     runId: RUN_ID,
+  //     setupCommand: COMMAND_TYPE_LOAD_LABWARE_WITH_MODULE,
+  //   }
+  //   when(mockUseProtocolDetailsForRun)
+  //     .calledWith(RUN_ID)
+  //     .mockReturnValue({
+  //       protocolData: {
+  //         ...simpleV6Protocol,
+  //         commands: simpleV6Protocol.commands.map(c =>
+  //           c.commandType === 'loadModule'
+  //             ? { ...c, result: { moduleId: c.params.moduleId } }
+  //             : c
+  //         ),
+  //       },
+  //       displayName: 'mock display name',
+  //       protocolKey: 'fakeProtocolKey',
+  //       robotType: 'OT-2 Standard',
+  //     })
+  //   const { getByText } = render(props)
+  //   getByText(
+  //     'Load ANSI 96 Standard Microplate v1 in Magnetic Module GEN2 in Slot 3'
+  //   )
+  // })
+  // it('should render correct command when commandType is loadPipette', () => {
+  //   props = {
+  //     robotName: ROBOT_NAME,
+  //     runId: RUN_ID,
+  //     setupCommand: COMMAND_TYPE_LOAD_PIPETTE,
+  //   }
+  //   const { getByText } = render(props)
+  //   getByText(nestedTextMatcher('Load P10 Single-Channel in Left Mount'))
+  // })
+  // it('should render correct command when commandType is loadModule', () => {
+  //   props = {
+  //     robotName: ROBOT_NAME,
+  //     runId: RUN_ID,
+  //     setupCommand: COMMAND_TYPE_LOAD_MODULE,
+  //   }
+  //   const { getByText } = render(props)
+  //   getByText('Load Temperature Module GEN2 in Slot 3')
+  // })
+  // it('should render correct command when commandType is loadModule and a TC is used', () => {
+  //   props = {
+  //     robotName: ROBOT_NAME,
+  //     runId: RUN_ID,
+  //     setupCommand: COMMAND_TYPE_LOAD_MODULE_TC,
+  //   }
+  //   when(mockUseProtocolDetailsForRun)
+  //     .calledWith(RUN_ID)
+  //     .mockReturnValue({
+  //       protocolData: {
+  //         labware: {
+  //           [mockLabwarePositionCheckStepTipRack.labwareId]: {
+  //             slot: '3',
+  //             displayName: 'someDislpayName',
+  //             definitionId: LABWARE_DEF_ID,
+  //           },
+  //         },
+  //         labwareDefinitions: {
+  //           [LABWARE_DEF_ID]: LABWARE_DEF,
+  //         },
+  //         modules: {
+  //           [TC_ID]: {
+  //             slot: '3',
+  //             model: 'thermocyclerModuleV1',
+  //           },
+  //         },
+  //         pipettes: {
+  //           [PRIMARY_PIPETTE_ID]: {
+  //             name: PRIMARY_PIPETTE_NAME,
+  //             mount: 'left',
+  //           },
+  //         },
+  //       },
+  //     } as any)
+  //   const { getByText } = render(props)
+  //   getByText('Load Thermocycler Module GEN1')
+  // })
   it('renders null if protocol data is null', () => {
     mockUseProtocolDetailsForRun.mockReturnValue({ protocolData: null } as any)
     const { container } = render(props)


### PR DESCRIPTION
# Overview

In order to prevent unnecessary failures in short term testing, we are removing the setup info commands section of the run log, to be reworked following backend changes to include more information about loaded entities in the command timeline of a run

# Changelog

 - Temporarily removes setup info commands

# Review requests

# Risk assessment

low