### PR TITLE
refactor(app): use LocalStorage to save recent used sortKey for protocols list

### DIFF
--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -43,12 +43,17 @@ const SORT_BY_BUTTON_STYLE = css`
   }
 `
 
+const LOCAL_STORAGE_KEY = 'protocolListSortKey'
+
 interface ProtocolListProps {
   storedProtocols: StoredProtocolData[]
 }
 export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
   const [showSlideout, setShowSlideout] = React.useState<boolean>(false)
-  const [sortBy, setSortBy] = React.useState<ProtocolSort>('alphabetical')
+  const [sortBy, setSortBy] = React.useState<ProtocolSort>(() => {
+    const savedSortKey = localStorage.getItem(LOCAL_STORAGE_KEY)
+    return savedSortKey != null ? JSON.parse(savedSortKey) : 'alphabetical'
+  })
   const [showSortByMenu, setShowSortByMenu] = React.useState<boolean>(false)
   const toggleSetShowSortByMenu = (): void => setShowSortByMenu(!showSortByMenu)
   const { t } = useTranslation('protocol_info')
@@ -83,6 +88,15 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
       label: t('oldest_updates'),
     },
   }
+
+  const handleSort = (sortKey: ProtocolSort): void => {
+    setSortBy(sortKey)
+    setShowSortByMenu(false)
+  }
+
+  React.useEffect(() => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(sortBy))
+  }, [sortBy])
 
   return (
     <Box padding={SPACING.spacing4}>
@@ -149,36 +163,16 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
               right="7rem"
               flexDirection={DIRECTION_COLUMN}
             >
-              <MenuItem
-                onClick={() => {
-                  setSortBy('alphabetical')
-                  setShowSortByMenu(false)
-                }}
-              >
+              <MenuItem onClick={() => handleSort('alphabetical')}>
                 {t('labware_landing:alphabetical')}
               </MenuItem>
-              <MenuItem
-                onClick={() => {
-                  setSortBy('recent')
-                  setShowSortByMenu(false)
-                }}
-              >
+              <MenuItem onClick={() => handleSort('recent')}>
                 {t('most_recent_updates')}
               </MenuItem>
-              <MenuItem
-                onClick={() => {
-                  setSortBy('reverse')
-                  setShowSortByMenu(false)
-                }}
-              >
+              <MenuItem onClick={() => handleSort('reverse')}>
                 {t('labware_landing:reverse')}
               </MenuItem>
-              <MenuItem
-                onClick={() => {
-                  setSortBy('oldest')
-                  setShowSortByMenu(false)
-                }}
-              >
+              <MenuItem onClick={() => handleSort('oldest')}>
                 {t('oldest_updates')}
               </MenuItem>
             </Flex>

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -18,7 +18,7 @@ import {
   Overlay,
 } from '@opentrons/components'
 
-import { useSortedProtocols } from './hooks'
+import { useSortedProtocols, useLocalStorage } from './hooks'
 import { StyledText } from '../../atoms/text'
 import { SecondaryButton } from '../../atoms/buttons'
 import { Slideout } from '../../atoms/Slideout'
@@ -50,10 +50,10 @@ interface ProtocolListProps {
 }
 export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
   const [showSlideout, setShowSlideout] = React.useState<boolean>(false)
-  const [sortBy, setSortBy] = React.useState<ProtocolSort>(() => {
-    const savedSortKey = localStorage.getItem(LOCAL_STORAGE_KEY)
-    return savedSortKey != null ? JSON.parse(savedSortKey) : 'alphabetical'
-  })
+  const [sortBy, setSortBy] = useLocalStorage<ProtocolSort>(
+    LOCAL_STORAGE_KEY,
+    'alphabetical'
+  )
   const [showSortByMenu, setShowSortByMenu] = React.useState<boolean>(false)
   const toggleSetShowSortByMenu = (): void => setShowSortByMenu(!showSortByMenu)
   const { t } = useTranslation('protocol_info')
@@ -93,10 +93,6 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
     setSortBy(sortKey)
     setShowSortByMenu(false)
   }
-
-  React.useEffect(() => {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(sortBy))
-  }, [sortBy])
 
   return (
     <Box padding={SPACING.spacing4}>

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -70,6 +70,11 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
     setShowSortByMenu(false)
   }
 
+  const handleSort = (sortKey: ProtocolSort): void => {
+    setSortBy(sortKey)
+    setShowSortByMenu(false)
+  }
+
   const sortByLabelType: {
     [key in ProtocolSort]: {
       label: string
@@ -87,11 +92,6 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
     oldest: {
       label: t('oldest_updates'),
     },
-  }
-
-  const handleSort = (sortKey: ProtocolSort): void => {
-    setSortBy(sortKey)
-    setShowSortByMenu(false)
   }
 
   return (

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
@@ -68,6 +68,7 @@ describe('ProtocolList', () => {
     getByText('mock empty state links')
     const cards = getAllByText('mock protocol card')
     expect(cards.length).toBe(2)
+    // expect(mockLocalStorageFunc.getItem).toHaveBeenCalled()
   })
 
   it('renders and clicks on import button and opens slideout', () => {

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
@@ -9,7 +9,7 @@ import {
   storedProtocolDataTwo,
 } from '../../../redux/protocol-storage/__fixtures__'
 import { ProtocolList } from '../ProtocolList'
-import { useSortedProtocols } from '../hooks'
+import { useSortedProtocols, useLocalStorage } from '../hooks'
 import { EmptyStateLinks } from '../EmptyStateLinks'
 import { ProtocolCard } from '../ProtocolCard'
 
@@ -28,6 +28,11 @@ const mockEmptyStateLinks = EmptyStateLinks as jest.MockedFunction<
 const mockProtocolCard = ProtocolCard as jest.MockedFunction<
   typeof ProtocolCard
 >
+const mockUseLocalStorage = useLocalStorage as jest.MockedFunction<
+  typeof useLocalStorage
+>
+
+const LOCAL_STORAGE_KEY = 'protocolListSortKey'
 
 const render = (props: React.ComponentProps<typeof ProtocolList>) => {
   return renderWithProviders(
@@ -52,6 +57,9 @@ describe('ProtocolList', () => {
     when(mockUseSortedProtocols)
       .calledWith('alphabetical', [storedProtocolData, storedProtocolDataTwo])
       .mockReturnValue([storedProtocolData, storedProtocolDataTwo])
+    when(mockUseLocalStorage)
+      .calledWith(LOCAL_STORAGE_KEY, 'alphabetical')
+      .mockReturnValue(['alphabetical', jest.fn()])
   })
 
   afterEach(() => {
@@ -96,6 +104,9 @@ describe('ProtocolList', () => {
     when(mockUseSortedProtocols)
       .calledWith('reverse', [storedProtocolData, storedProtocolDataTwo])
       .mockReturnValue([storedProtocolDataTwo, storedProtocolData])
+    when(mockUseLocalStorage)
+      .calledWith(LOCAL_STORAGE_KEY, 'alphabetical')
+      .mockReturnValue(['reverse', jest.fn()])
     const { getByRole, getByText, getByTestId } = render(props)
     fireEvent.click(getByTestId('ProtocolList_SortByMenu'))
     getByRole('button', { name: 'Alphabetical' })
@@ -110,6 +121,9 @@ describe('ProtocolList', () => {
     when(mockUseSortedProtocols)
       .calledWith('recent', [storedProtocolData, storedProtocolDataTwo])
       .mockReturnValue([storedProtocolData, storedProtocolDataTwo])
+    when(mockUseLocalStorage)
+      .calledWith(LOCAL_STORAGE_KEY, 'alphabetical')
+      .mockReturnValue(['recent', jest.fn()])
 
     const { getByRole, getByText, getByTestId } = render(props)
     fireEvent.click(getByTestId('ProtocolList_SortByMenu'))
@@ -125,6 +139,9 @@ describe('ProtocolList', () => {
     when(mockUseSortedProtocols)
       .calledWith('oldest', [storedProtocolData, storedProtocolDataTwo])
       .mockReturnValue([storedProtocolDataTwo, storedProtocolData])
+    when(mockUseLocalStorage)
+      .calledWith(LOCAL_STORAGE_KEY, 'alphabetical')
+      .mockReturnValue(['oldest', jest.fn()])
 
     const { getByRole, getByText, getByTestId } = render(props)
     fireEvent.click(getByTestId('ProtocolList_SortByMenu'))

--- a/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import { renderHook } from '@testing-library/react-hooks'
 
-import { useSortedProtocols } from '../hooks'
+import { useSortedProtocols, useLocalStorage } from '../hooks'
 import { StoredProtocolData } from '../../../redux/protocol-storage'
 
 import type { Store } from 'redux'
@@ -273,6 +273,8 @@ const mockStoredProtocolData = [
   },
 ] as StoredProtocolData[]
 
+const LOCAL_STORAGE_KEY = 'protocolListSortKey'
+
 describe('useSortedProtocols', () => {
   const store: Store<State> = createStore(jest.fn(), {})
   beforeEach(() => {
@@ -376,5 +378,16 @@ describe('useSortedProtocols', () => {
     expect(thirdProtocol.protocolKey).toBe(
       '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
     )
+  })
+})
+
+describe('useLocalStorage', () => {
+  it('should return sortKey and function', () => {
+    const mockSortKey = 'alphabetical'
+    const { result } = renderHook(() =>
+      useLocalStorage(LOCAL_STORAGE_KEY, mockSortKey)
+    )
+    expect(result.current[0]).toBe('alphabetical')
+    expect(typeof result.current[1] === 'function').toBe(true)
   })
 })

--- a/app/src/organisms/ProtocolsLanding/hooks.tsx
+++ b/app/src/organisms/ProtocolsLanding/hooks.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { StoredProtocolData } from '../../redux/protocol-storage'
 import { getProtocolDisplayName } from './utils'
 
@@ -34,4 +35,36 @@ export function useSortedProtocols(
     return 0
   })
   return protocolData
+}
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((val: T) => T)) => void] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue
+    }
+    try {
+      const item = window.localStorage.getItem(key)
+      return item != null ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.log(error)
+      return initialValue
+    }
+  })
+
+  const setValue = (value: T | ((val: T) => T)): void => {
+    try {
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
+  return [storedValue, setValue]
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
use LocalStorage to save the used sort key for the protocols list
Close RAUT-227
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add a custom hook
- add a test case for useLocalStorage
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] If there is a better way to do this, please let me know.
- [ ] Currently, put under ProtocolsLanding, but we may need to call this custom hook from a different page/screen 
Should I move this function to a different folder? If so, any suggestions?
- [ ] change the sort key from `alphabetical` to something and close the app then re-open the app and check the sort key
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
