### PR TITLE
refactor(app): update custom keyboard

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/CustomKeyboard.tsx
+++ b/app/src/atoms/SoftwareKeyboard/CustomKeyboard.tsx
@@ -11,13 +11,13 @@ const customLayout = {
     'q w e r t y u i o p',
     'a s d f g h j k l',
     '{shift} z x c v b n m {backspace}',
-    '{numbers} {space} {ent}',
+    '{numbers}',
   ],
   shift: [
     'Q W E R T Y U I O P',
     'A S D F G H J K L',
     '{shift} Z X C V B N M {backspace}',
-    '{numbers} {space} {ent}',
+    '{numbers}',
   ],
   numbers: ['1 2 3', '4 5 6', '7 8 9', '{abc} 0 {backspace}'],
 }

--- a/app/src/atoms/SoftwareKeyboard/CustomKeyboard.tsx
+++ b/app/src/atoms/SoftwareKeyboard/CustomKeyboard.tsx
@@ -24,7 +24,6 @@ const customLayout = {
 
 const customDisplay = {
   '{numbers}': '123',
-  '{ent}': '< enter',
   '{escape}': 'esc ⎋',
   '{tab}': 'tab ⇥',
   '{backspace}': '⌫',

--- a/app/src/atoms/SoftwareKeyboard/__tests__/CustomKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/__tests__/CustomKeyboard.test.tsx
@@ -57,8 +57,6 @@ describe('CustomKeyboard', () => {
 
     // fourth row
     getByRole('button', { name: '123' }) // numbers
-    getByRole('button', { name: '' }) // space keyboard
-    getByRole('button', { name: '< enter' })
   })
   it('should render the custom keyboards upper case, when clicking shift key', () => {
     const { getByRole } = render(props)
@@ -98,8 +96,6 @@ describe('CustomKeyboard', () => {
     getByRole('button', { name: 'M' })
     // fourth row
     getByRole('button', { name: '123' }) // numbers
-    getByRole('button', { name: '' }) // space keyboard
-    getByRole('button', { name: '< enter' })
   })
 
   it('should render the custom keyboards numbers, when clicking number key', () => {


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Remove `enter key` and `space key` from the softwarekeyboard. 
The reason: We don't allow users to use space for a robot name and the ODD UI will have a button to submit a robot name instead `enter key`.

RCORE-374
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- remove enter key and space key code from a component
- remove enter key and space key code from a test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] the component, custom keyboard doesn't show `enter` and `space` keys.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
