### PR TITLE
feat(protocol-designer): add Thermocycler GEN2 to announcement modal

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -129,7 +129,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
 
           cy.get('div')
             .contains(
-              'This protocol can only run on app and robot server version 6.1 or higher'
+              'This protocol can only run on app and robot server version 6.2 or higher'
             )
             .should('exist')
           cy.get('button').contains('continue', { matchCase: false }).click()
@@ -145,7 +145,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
               assert.match(
                 savedFile.designerApplication.version,
                 /^6\.1\.\d+$/,
-                'designerApplication.version is 6.1.x'
+                'designerApplication.version is 6.2.x'
               )
               ;[savedFile, expectedFile].forEach(f => {
                 // Homogenize fields we don't want to compare

--- a/protocol-designer/cypress/integration/newProtocol.spec.js
+++ b/protocol-designer/cypress/integration/newProtocol.spec.js
@@ -138,13 +138,13 @@ describe('Desktop Navigation', () => {
         cy.contains('Your protocol has no steps').should('not.exist')
       })
 
-      it('displays a warning modal saying the protocol needs to be run on robot stack version 6.1 or higher', () => {
+      it('displays a warning modal saying the protocol needs to be run on robot stack version 6.2 or higher', () => {
         cy.get('button').contains('Export').click()
         // skip the first modal we checked for (your protocol has no steps)
         cy.get('button').contains('CONTINUE WITH EXPORT').click()
         // check that the robot stack version modal starts
         cy.contains(
-          'This protocol can only run on app and robot server version 6.1 or higher'
+          'This protocol can only run on app and robot server version 6.2 or higher'
         ).should('exist')
       })
 

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -142,9 +142,9 @@ function getWarningContent({
 export const v6WarningContent: JSX.Element = (
   <div>
     <p>
-      {i18n.t(`alert.hint.export_v6_protocol_6_10.body1`)}{' '}
-      <strong>{i18n.t(`alert.hint.export_v6_protocol_6_10.body2`)}</strong>
-      {i18n.t(`alert.hint.export_v6_protocol_6_10.body3`)}
+      {i18n.t(`alert.hint.export_v6_protocol_6_20.body1`)}{' '}
+      <strong>{i18n.t(`alert.hint.export_v6_protocol_6_20.body2`)}</strong>
+      {i18n.t(`alert.hint.export_v6_protocol_6_20.body3`)}
     </p>
   </div>
 )
@@ -202,7 +202,7 @@ export function FileSidebar(props: Props): JSX.Element {
     content: React.ReactNode
   } => {
     return {
-      hintKey: 'export_v6_protocol_6_10',
+      hintKey: 'export_v6_protocol_6_20',
       content: v6WarningContent,
     }
   }

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -207,7 +207,7 @@ describe('FileSidebar', () => {
     // Before save button is clicked, enabled should be false
     expect(mockUseBlockingHint).toHaveBeenNthCalledWith(1, {
       enabled: false,
-      hintKey: 'export_v6_protocol_6_10',
+      hintKey: 'export_v6_protocol_6_20',
       content: v6WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),
@@ -219,7 +219,7 @@ describe('FileSidebar', () => {
     // After save button is clicked, enabled should be true
     expect(mockUseBlockingHint).toHaveBeenLastCalledWith({
       enabled: true,
-      hintKey: 'export_v6_protocol_6_10',
+      hintKey: 'export_v6_protocol_6_20',
       content: v6WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -143,4 +143,27 @@ export const announcements: Announcement[] = [
       </>
     ),
   },
+  {
+    announcementKey: 'thermocyclerGen2Support',
+    image: (
+      <div className={styles.modules_diagrams_row}>
+        <img
+          className={styles.modules_diagram}
+          src={require('../../../images/modules/thermocycler_gen2.png')}
+        />
+      </div>
+    ),
+    heading: "We've updated the Protocol Designer",
+    message: (
+      <>
+        <p>
+          The Opentrons Protocol Designer now supports our Thermocycler GEN2!
+        </p>
+        <p>
+          All protocols now require Opentrons App version
+          <strong> 6.2+ </strong> to run.
+        </p>
+      </>
+    ),
+  },
 ]

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -157,7 +157,8 @@ export const announcements: Announcement[] = [
     message: (
       <>
         <p>
-          The Opentrons Protocol Designer now supports our Thermocycler GEN2!
+          The Opentrons Protocol Designer now supports our Thermocycler Module
+          GEN2!
         </p>
         <p>
           All protocols now require Opentrons App version

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -49,10 +49,10 @@
       "title": "Missing labware",
       "body": "Your module has no labware on it. We recommend you add labware before proceeding."
     },
-    "export_v6_protocol_6_10": {
+    "export_v6_protocol_6_20": {
       "title": "Robot and app update may be required",
       "body1": "This protocol can only run on app and robot server version",
-      "body2": "6.1 or higher",
+      "body2": "6.2 or higher",
       "body3": ". Please ensure your OT-2 is updated to the correct version."
     },
     "change_magnet_module_model": {

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -9,11 +9,12 @@ type HintKey =  // normal hints
   | 'protocol_can_enter_batch_edit'
   // blocking hints
   | 'custom_labware_with_modules'
-  | 'export_v6_protocol_6_10'
+  | 'export_v6_protocol_6_20'
   | 'change_magnet_module_model'
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
 // 'export_v4_protocol'
 // | 'export_v4_protocol_3_18'
 // | 'export_v5_protocol_3_20'
+// | 'export_v6_protocol_6_10'
 export { actions, rootReducer, selectors }
 export type { RootState, HintKey }


### PR DESCRIPTION
closes RCORE-388

# Overview

This adds the TC GEN2 key to the announcement modal so users will be notified when they first use version 6.1.0 of PD. Also, when exporting, the modal will say App version `6.2 or higher` is required.

<img width="622" alt="Screen Shot 2022-11-14 at 5 21 34 PM" src="https://user-images.githubusercontent.com/66035149/201780346-28a95c2a-0064-44c7-b7e1-f90dacf3055a.png">

<img width="661" alt="Screen Shot 2022-11-14 at 12 11 10 PM" src="https://user-images.githubusercontent.com/66035149/201722837-5f3e2caa-c196-456e-96f9-46b565ac79a3.png">

# Changelog

- add TC GEN2 key to the Announcement array
- update alert key to 6.2 instead of 6.1, and deprecate old hint

# Review requests

-  open the branch in PD, the modal should pop up since you are opening it for the first time since the updated modal was added. Does the modal look acceptable with the correct information?
- when you export a protocol, the modal should say that 6.2 or higher of the app version is required

# Risk assessment

low