### PR TITLE
feat(app, app-shell): enable ot3 updates via file upload

### DIFF
--- a/app-shell/src/buildroot/index.ts
+++ b/app-shell/src/buildroot/index.ts
@@ -71,11 +71,7 @@ export function registerBuildrootUpdate(dispatch: Dispatch): Dispatch {
       }
 
       case 'buildroot:UPLOAD_FILE': {
-        const { host, path, systemFile } = action.payload as {
-          host: RobotHost
-          path: string
-          systemFile: string | null
-        }
+        const { host, path, systemFile } = action.payload
         const file = systemFile !== null ? systemFile : updateSet?.system
 
         if (file == null) {

--- a/app-shell/src/buildroot/update.ts
+++ b/app-shell/src/buildroot/update.ts
@@ -20,7 +20,7 @@ const PREMIGRATION_SERVER_WHL = path.join(
   PREMIGRATION_WHL_DIR,
   'otupdate-3.10.3-py2.py3-none-any.whl'
 )
-const SYSTEM_FILENAME = 'ot2-system.zip'
+const SYSTEM_FILENAME = 'system-update.zip'
 
 export function startPremigration(robot: RobotHost): Promise<unknown> {
   const apiUrl = `http://${robot.ip}:${robot.port}/server/update`

--- a/app-shell/src/buildroot/update.ts
+++ b/app-shell/src/buildroot/update.ts
@@ -5,6 +5,10 @@ import path from 'path'
 
 import { fetch, postFile } from '../http'
 import type { RobotHost } from '@opentrons/app/src/redux/robot-api/types'
+import type {
+  RobotModel,
+  ViewableRobot,
+} from '@opentrons/app/src/redux/discovery/types'
 
 const PREMIGRATION_WHL_DIR = path.join(
   // NOTE: __dirname refers to output directory
@@ -20,7 +24,16 @@ const PREMIGRATION_SERVER_WHL = path.join(
   PREMIGRATION_WHL_DIR,
   'otupdate-3.10.3-py2.py3-none-any.whl'
 )
+
+const OT2_FILENAME = 'ot2-system.zip'
 const SYSTEM_FILENAME = 'system-update.zip'
+
+const getSystemFileName = (robotModel: RobotModel): string => {
+  if (robotModel === 'OT-2 Standard') {
+    return OT2_FILENAME
+  }
+  return SYSTEM_FILENAME
+}
 
 export function startPremigration(robot: RobotHost): Promise<unknown> {
   const apiUrl = `http://${robot.ip}:${robot.port}/server/update`
@@ -33,11 +46,11 @@ export function startPremigration(robot: RobotHost): Promise<unknown> {
 }
 
 export function uploadSystemFile(
-  robot: RobotHost,
+  robot: ViewableRobot,
   urlPath: string,
   file: string
 ): Promise<unknown> {
   const url = `http://${robot.ip}:${robot.port}${urlPath}`
 
-  return postFile(url, SYSTEM_FILENAME, file)
+  return postFile(url, getSystemFileName(robot.robotModel), file)
 }

--- a/app/src/redux/buildroot/actions.ts
+++ b/app/src/redux/buildroot/actions.ts
@@ -1,6 +1,7 @@
 import * as Constants from './constants'
 
 import type { RobotHost } from '../robot-api/types'
+import type { ViewableRobot } from '../discovery/types'
 import type {
   BuildrootAction,
   UpdateSessionStep,
@@ -77,7 +78,7 @@ export function readUserBuildrootFile(systemFile: string): BuildrootAction {
 }
 
 export function uploadBuildrootFile(
-  host: RobotHost,
+  host: ViewableRobot,
   path: string,
   systemFile: string | null
 ): BuildrootAction {

--- a/app/src/redux/buildroot/epic.ts
+++ b/app/src/redux/buildroot/epic.ts
@@ -12,11 +12,7 @@ import {
 } from 'rxjs/operators'
 
 // imported directly to avoid circular dependencies between discovery and shell
-import {
-  getAllRobots,
-  getRobotApiVersion,
-  getRobotModelByName,
-} from '../discovery'
+import { getAllRobots, getRobotApiVersion } from '../discovery'
 import {
   startDiscovery,
   finishDiscovery,
@@ -138,7 +134,9 @@ export const startUpdateEpic: Epic = (action$, state$) =>
       // otherwise robot is ready for migration or update, so get token
       // capabilities response has the correct request path to use
       const sessionPath =
-        capabilities.buildrootUpdate || capabilities.buildrootMigration || capabilities.systemUpdate
+        capabilities.buildrootUpdate ||
+        capabilities.buildrootMigration ||
+        capabilities.systemUpdate
 
       if (sessionPath == null) {
         return unexpectedBuildrootError(

--- a/app/src/redux/buildroot/epic.ts
+++ b/app/src/redux/buildroot/epic.ts
@@ -12,7 +12,11 @@ import {
 } from 'rxjs/operators'
 
 // imported directly to avoid circular dependencies between discovery and shell
-import { getAllRobots, getRobotApiVersion } from '../discovery'
+import {
+  getAllRobots,
+  getRobotApiVersion,
+  getRobotModelByName,
+} from '../discovery'
 import {
   startDiscovery,
   finishDiscovery,
@@ -281,7 +285,6 @@ export const uploadFileEpic: Epic = (_, state$) => {
       const systemFile = session?.userFileInfo?.systemFile || null
 
       return uploadBuildrootFile(
-        // @ts-expect-error TODO: host is actually of type Robot|ReachableRobot but this action expects a RobotHost
         host,
         `${pathPrefix}/${token}/file`,
         systemFile

--- a/app/src/redux/buildroot/epic.ts
+++ b/app/src/redux/buildroot/epic.ts
@@ -134,7 +134,7 @@ export const startUpdateEpic: Epic = (action$, state$) =>
       // otherwise robot is ready for migration or update, so get token
       // capabilities response has the correct request path to use
       const sessionPath =
-        capabilities.buildrootUpdate || capabilities.buildrootMigration
+        capabilities.buildrootUpdate || capabilities.buildrootMigration || capabilities.systemUpdate
 
       if (sessionPath == null) {
         return unexpectedBuildrootError(

--- a/app/src/redux/buildroot/types.ts
+++ b/app/src/redux/buildroot/types.ts
@@ -1,3 +1,4 @@
+import type { ViewableRobot } from '../discovery/types'
 import type { RobotHost } from '../robot-api/types'
 
 export type BuildrootUpdateType = 'upgrade' | 'downgrade' | 'reinstall'
@@ -114,7 +115,7 @@ export type BuildrootAction =
     }
   | {
       type: 'buildroot:UPLOAD_FILE'
-      payload: { host: RobotHost; path: string; systemFile: string | null }
+      payload: { host: ViewableRobot; path: string; systemFile: string | null }
       meta: { shell: true }
     }
   | { type: 'buildroot:FILE_UPLOAD_DONE'; payload: string }

--- a/app/src/redux/robot-api/__fixtures__/index.ts
+++ b/app/src/redux/robot-api/__fixtures__/index.ts
@@ -39,7 +39,7 @@ export interface ResponseFixtures<SuccessBody, FailureBody> {
   }
 }
 
-export const mockRobot: RobotHost = {
+export const mockRobot: any = {
   name: 'robot',
   ip: '127.0.0.1',
   port: 31950,

--- a/app/src/redux/robot-api/__utils__/epic-test-mocks.ts
+++ b/app/src/redux/robot-api/__utils__/epic-test-mocks.ts
@@ -52,7 +52,6 @@ export const setupEpicTestMocks = <A = TriggerAction, R = RobotApiResponse>(
     ...triggerAction,
     meta: { ...(triggerAction.meta || {}), ...mockRequestMeta },
   }
-  // @ts-expect-error(sa, 2021-05-17): mockRobot does not have all properties in the return value of getRobotByName
   mockGetRobotByName.mockImplementation((state: State, robotName: string) => {
     expect(state).toBe(mockState)
     expect(robotName).toBe(mockRobot.name)

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -25,6 +25,7 @@ export type Capability =
   | 'balenaUpdate'
   | 'buildrootMigration'
   | 'buildrootUpdate'
+  | 'systemUpdate'
   | 'restart'
 
 export type CapabilityMap = {


### PR DESCRIPTION
# Overview


This PR enables OT-3 system updates from the opentrons app

Closes RCORE-389

# Changelog

- Enable ot3 updates via file upload


# Review requests
- Do an OT-2 system update via file upload
- Do an OT-3 system update via file upload

# Risk assessment

Low/med
