### PR TITLE
fix(engine): ensure command execution can be cancelled on Python >=3.8

### DIFF
--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -1,9 +1,11 @@
 """Smoke tests for the CommandExecutor class."""
-import pytest
+import asyncio
 from datetime import datetime
+from typing import Any, Optional, Type, cast
+
+import pytest
 from decoy import Decoy, matchers
 from pydantic import BaseModel
-from typing import Any, Optional, Type, cast
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -246,6 +248,10 @@ async def test_execute(
         (
             RuntimeError("oh no"),
             matchers.ErrorMatching(errors.UnexpectedProtocolError, match="oh no"),
+        ),
+        (
+            asyncio.CancelledError(),
+            matchers.ErrorMatching(errors.RunStoppedError),
         ),
     ],
 )


### PR DESCRIPTION
## Overview

This PR fixes RSS-139. On OT-3s + emulators with the ProtocolEngine PAPI core enabled, runs would not properly transition out of the `stop-requested` state into the `stopped` state, leaving the server in an effectively non-interactable state.

The cause was that in Python 3.8, `asyncio.CancelledError` became a `BaseException` rather than an `Exception`. Logic in the engine's `CommandExecutor` to update a command's status upon completion was only looking for an `Exception`, which meant a `CancelledError` on Python >= 3.8 would sail right on by, leaving the engine in a state where it though the command was still running, preventing the run from terminating.

## Changelog

- Look for `(Exception, asyncio.CancelledError)` instead of `Exception`

## Review requests

This PR is focused on fixing the immediate bug. We believe adding a new `stopped` status to commands is a better long term move, and that work is being tracked in RCORE-390

## Risk assessment

Very low.  Added an extra unit test to be sure of the fix, which CI will run in both Python 3.7 _and_ Python 3.10