### PR TITLE
feat(app): wire up attach/detach flow modals to PipetteWizardFlows

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -30,5 +30,7 @@
   "name_and_volume_detected": "{{name}} Pipette Detected",
   "error_encountered": "Error encountered",
   "loose_detach": "Loosen Screws and Detach",
-  "hold_and_loosen": "Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette"
+  "hold_and_loosen": "Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette",
+  "attach_pipette": "Attach a pipette",
+  "detach_pipette": "Detach a pipette"
 }

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -89,15 +89,13 @@ export const PipetteOverflowMenu = (
                   : calibratePipetteText
               )}
             </MenuItem>
-            {!isOT3PipetteAttached && (
-              <MenuItem
-                key={`${pipetteDisplayName}_${mount}_detach`}
-                onClick={() => handleChangePipette()}
-                data-testid={`pipetteOverflowMenu_detach_pipette_btn_${pipetteDisplayName}_${mount}`}
-              >
-                {t('detach_pipette')}
-              </MenuItem>
-            )}
+            <MenuItem
+              key={`${pipetteDisplayName}_${mount}_detach`}
+              onClick={() => handleChangePipette()}
+              data-testid={`pipetteOverflowMenu_detach_pipette_btn_${pipetteDisplayName}_${mount}`}
+            >
+              {t('detach_pipette')}
+            </MenuItem>
             <MenuItem
               key={`${pipetteDisplayName}_${mount}_about_pipette`}
               onClick={() => handleAboutSlideout()}

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -123,13 +123,14 @@ describe('PipetteOverflowMenu', () => {
     const calibrate = getByRole('button', {
       name: 'Calibrate pipette',
     })
-    const detach = queryByRole('button', { name: 'Detach pipette' })
+    const detach = getByRole('button', { name: 'Detach pipette' })
     const settings = queryByRole('button', { name: 'Pipette Settings' })
     const about = getByRole('button', { name: 'About pipette' })
 
     fireEvent.click(calibrate)
     expect(props.handleCalibrate).toHaveBeenCalled()
-    expect(detach).toBeNull()
+    fireEvent.click(detach)
+    expect(props.handleChangePipette).toHaveBeenCalled()
     expect(settings).toBeNull()
     fireEvent.click(about)
     expect(props.handleAboutSlideout).toHaveBeenCalled()

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -50,12 +50,18 @@ import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 import type { AttachedPipette, Mount } from '../../../redux/pipettes/types'
 import {
   isOT3Pipette,
+  NINETY_SIX_CHANNEL,
   PipetteModelSpecs,
   PipetteMount,
   PipetteName,
+  SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 import type { Dispatch, State } from '../../../redux/types'
-import type { PipetteWizardFlow } from '../../PipetteWizardFlows/types'
+import type {
+  PipetteWizardFlow,
+  SelectablePipettes,
+} from '../../PipetteWizardFlows/types'
+import { ChoosePipette } from '../../PipetteWizardFlows/ChoosePipette'
 
 interface PipetteCardProps {
   pipetteInfo: PipetteModelSpecs | null
@@ -91,6 +97,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     pipetteWizardFlow,
     setPipetteWizardFlow,
   ] = React.useState<PipetteWizardFlow | null>(null)
+  const [showAttachPipette, setShowAttachPipette] = React.useState(false)
   const [showAboutSlideout, setShowAboutSlideout] = React.useState(false)
   const [showCalBlockModal, setShowCalBlockModal] = React.useState(false)
   const configHasCalibrationBlock = useSelector(getHasCalibrationBlock)
@@ -152,7 +159,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     if (isOT3PipetteAttached && isOt3) {
       setPipetteWizardFlow(FLOWS.DETACH)
     } else if (!isOT3PipetteAttached && isOt3) {
-      setPipetteWizardFlow(FLOWS.ATTACH)
+      setShowAttachPipette(true)
     } else {
       setChangePipette(true)
     }
@@ -169,6 +176,14 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     setShowSlideout(true)
   }
 
+  const handleAttachPipette = (selectedPipette: SelectablePipettes): void => {
+    if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+      setShowAttachPipette(false)
+      setPipetteWizardFlow(FLOWS.ATTACH)
+    } else if (selectedPipette === NINETY_SIX_CHANNEL) {
+      console.log('we still have to wire up the 96 channel attach flow!')
+    }
+  }
   return (
     <Flex
       backgroundColor={COLORS.fundamentalsBackground}
@@ -176,6 +191,12 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       width="100%"
       data-testid={`PipetteCard_${pipetteDisplayName}`}
     >
+      {showAttachPipette ? (
+        <ChoosePipette
+          proceed={handleAttachPipette}
+          exit={() => setShowAttachPipette(false)}
+        />
+      ) : null}
       {pipetteWizardFlow != null ? (
         <PipetteWizardFlows
           flowType={pipetteWizardFlow}

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -38,7 +38,7 @@ export const BeforeBeginning = (
   }, [])
 
   const pipetteId = attachedPipette[mount]?.id
-  if (pipetteId == null) return null
+  if (pipetteId == null && flowType === FLOWS.CALIBRATE) return null
   const handleOnClick = (): void => {
     chainRunCommands(
       [

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -18,11 +18,20 @@ import {
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
+import { Portal } from '../../App/portal'
+import { ModalShell } from '../../molecules/Modal'
+import { WizardHeader } from '../../molecules/WizardHeader'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import singleChannelAndEightChannel from '../../assets/images/change-pip/single-channel-and-eight-channel.png'
+import { ExitModal } from './ExitModal'
+import { FLOWS } from './constants'
 
-import type { PipetteWizardStepProps, SelectablePipettes } from './types'
+import type { SelectablePipettes } from './types'
 
+interface ChoosePipetteProps {
+  proceed: (selectedPipette: SelectablePipettes) => void
+  exit: () => void
+}
 const unselectedOptionStyles = css`
   background-color: ${COLORS.white};
   border: 1px solid ${COLORS.medGreyEnabled};
@@ -47,15 +56,15 @@ const selectedOptionStyles = css`
   }
 `
 
-export const ChoosePipette = (props: PipetteWizardStepProps): JSX.Element => {
-  const { proceed } = props
+export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
+  const { proceed, exit } = props
   const { t } = useTranslation('pipette_wizard_flows')
   const [
     selectedPipette,
     setSelectedPipette,
   ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
+  const [setShowExit, showExit] = React.useState<boolean>(false)
   const proceedButtonText: string = t('attach_this_pipette')
-
   const nintySixChannelWrapper =
     selectedPipette === NINETY_SIX_CHANNEL
       ? selectedOptionStyles
@@ -72,58 +81,93 @@ export const ChoosePipette = (props: PipetteWizardStepProps): JSX.Element => {
   })
 
   return (
-    <GenericWizardTile
-      header={t('choose_pipette')}
-      rightHandBody={
-        <Flex
-          onClick={() => setSelectedPipette(NINETY_SIX_CHANNEL)}
-          css={nintySixChannelWrapper}
-          height="14.5625rem"
-          width="14.5625rem"
-          alignSelf={ALIGN_FLEX_END}
-          flexDirection={DIRECTION_COLUMN}
-          justifyContent={JUSTIFY_CENTER}
-          data-testid="ChoosePipette_NinetySix"
-        >
-          <Flex justifyContent={JUSTIFY_CENTER}>
-            <img
-              //  TODO(jr, 11/2/22): change this image to the correct 96 channel pipette image
-              src={singleChannelAndEightChannel}
-              width="138.78px"
-              height="160px"
-              alt={ninetySix}
-            />
-          </Flex>
-          <StyledText css={TYPOGRAPHY.h3SemiBold} textAlign={TEXT_ALIGN_CENTER}>
-            {ninetySix}
-          </StyledText>
-        </Flex>
-      }
-      bodyText={
-        <Flex
-          onClick={() => setSelectedPipette(SINGLE_MOUNT_PIPETTES)}
-          css={singleMountWrapper}
-          height="14.5625rem"
-          width="14.5625rem"
-          flexDirection={DIRECTION_COLUMN}
-          justifyContent={JUSTIFY_CENTER}
-          data-testid="ChoosePipette_SingleAndEight"
-        >
-          <Flex justifyContent={JUSTIFY_CENTER}>
-            <img
-              src={singleChannelAndEightChannel}
-              width="138.78px"
-              height="160px"
-              alt={singleMount}
-            />
-          </Flex>
-          <StyledText css={TYPOGRAPHY.h3SemiBold} textAlign={TEXT_ALIGN_CENTER}>
-            {singleMount}
-          </StyledText>
-        </Flex>
-      }
-      proceedButtonText={proceedButtonText}
-      proceed={proceed}
-    />
+    <Portal level="top">
+      <ModalShell
+        width="47rem"
+        height="30rem"
+        header={
+          <WizardHeader
+            title={t('attach_pipette')}
+            currentStep={0}
+            totalSteps={3}
+            onExit={setShowExit ? exit : () => showExit(true)}
+          />
+        }
+      >
+        {setShowExit ? (
+          <ExitModal
+            goBack={() => showExit(false)}
+            proceed={exit}
+            flowType={FLOWS.ATTACH}
+          />
+        ) : (
+          <GenericWizardTile
+            header={t('choose_pipette')}
+            rightHandBody={
+              <Flex
+                onClick={() => setSelectedPipette(NINETY_SIX_CHANNEL)}
+                css={nintySixChannelWrapper}
+                height="14.5625rem"
+                width="14.5625rem"
+                alignSelf={ALIGN_FLEX_END}
+                flexDirection={DIRECTION_COLUMN}
+                justifyContent={JUSTIFY_CENTER}
+                data-testid="ChoosePipette_NinetySix"
+              >
+                <Flex justifyContent={JUSTIFY_CENTER}>
+                  <img
+                    //  TODO(jr, 11/2/22): change this image to the correct 96 channel pipette image
+                    src={singleChannelAndEightChannel}
+                    width="138.78px"
+                    height="160px"
+                    alt={ninetySix}
+                  />
+                </Flex>
+                <StyledText
+                  css={TYPOGRAPHY.h3SemiBold}
+                  textAlign={TEXT_ALIGN_CENTER}
+                >
+                  {ninetySix}
+                </StyledText>
+              </Flex>
+            }
+            bodyText={
+              <Flex
+                onClick={() => setSelectedPipette(SINGLE_MOUNT_PIPETTES)}
+                css={singleMountWrapper}
+                height="14.5625rem"
+                width="14.5625rem"
+                flexDirection={DIRECTION_COLUMN}
+                justifyContent={JUSTIFY_CENTER}
+                data-testid="ChoosePipette_SingleAndEight"
+              >
+                <Flex justifyContent={JUSTIFY_CENTER}>
+                  <img
+                    src={singleChannelAndEightChannel}
+                    width="138.78px"
+                    height="160px"
+                    alt={singleMount}
+                  />
+                </Flex>
+                <StyledText
+                  css={TYPOGRAPHY.h3SemiBold}
+                  textAlign={TEXT_ALIGN_CENTER}
+                >
+                  {singleMount}
+                </StyledText>
+              </Flex>
+            }
+            proceedButtonText={proceedButtonText}
+            proceed={() =>
+              proceed(
+                selectedPipette === SINGLE_MOUNT_PIPETTES
+                  ? SINGLE_MOUNT_PIPETTES
+                  : NINETY_SIX_CHANNEL
+              )
+            }
+          />
+        )}
+      </ModalShell>
+    </Portal>
   )
 }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
@@ -1,44 +1,25 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { COLORS, renderWithProviders } from '@opentrons/components'
-import { LEFT } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
-import {
-  mockAttachedPipette,
-  mockGen3P1000PipetteSpecs,
-} from '../../../redux/pipettes/__fixtures__'
-import { FLOWS } from '../constants'
 import { ChoosePipette } from '../ChoosePipette'
-import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
-import type { AttachedPipette } from '../../../redux/pipettes/types'
 
 const render = (props: React.ComponentProps<typeof ChoosePipette>) => {
   return renderWithProviders(<ChoosePipette {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
-const mockPipette: AttachedPipette = {
-  ...mockAttachedPipette,
-  modelSpecs: mockGen3P1000PipetteSpecs,
-}
 describe('ChoosePipette', () => {
   let props: React.ComponentProps<typeof ChoosePipette>
   beforeEach(() => {
     props = {
-      mount: LEFT,
-      goBack: jest.fn(),
       proceed: jest.fn(),
-      flowType: FLOWS.ATTACH,
-      chainRunCommands: jest.fn(),
-      isRobotMoving: false,
-      runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
-      errorMessage: null,
-      setShowErrorMessage: jest.fn(),
+      exit: jest.fn(),
     }
   })
   it('returns the correct information, buttons work as expected', () => {
     const { getByText, getByAltText, getByRole, getByTestId } = render(props)
+    getByText('Attach a pipette')
     getByText('Choose a pipette to attach')
     getByText('Single or 8-Channel pipette')
     getByText('96-Channel pipette')
@@ -70,5 +51,29 @@ describe('ChoosePipette', () => {
     const proceedBtn = getByRole('button', { name: 'Attach this pipette' })
     fireEvent.click(proceedBtn)
     expect(props.proceed).toHaveBeenCalled()
+  })
+  it('renders exit button and clicking on it renders the exit modal, clicking on back button works', () => {
+    const { getByText, getByLabelText } = render(props)
+    const exit = getByLabelText('Exit')
+    fireEvent.click(exit)
+    getByText('Attaching Pipette progress will be lost')
+    getByText(
+      'Are you sure you want to exit before completing Attaching Pipette?'
+    )
+    const goBack = getByText('Go back')
+    fireEvent.click(goBack)
+    getByText('Choose a pipette to attach')
+  })
+  it('renders exit button and clicking on it renders the exit modal, clicking on exit button works', () => {
+    const { getByText, getByRole, getByLabelText } = render(props)
+    const exit = getByLabelText('Exit')
+    fireEvent.click(exit)
+    getByText('Attaching Pipette progress will be lost')
+    getByText(
+      'Are you sure you want to exit before completing Attaching Pipette?'
+    )
+    const exitButton = getByRole('button', { name: 'exit' })
+    fireEvent.click(exitButton)
+    expect(props.exit).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -210,4 +210,57 @@ describe('PipetteWizardFlows', () => {
     //   expect(props.closeFlow).toHaveBeenCalled()
     // })
   })
+  it('renders the correct information, calling the correct commands for the detach flow', () => {
+    props = {
+      ...props,
+      flowType: FLOWS.DETACH,
+    }
+    mockGetPipetteWizardSteps.mockReturnValue([
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.DETACH_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+    ])
+    const { getByText } = render(props)
+    getByText('Detach a pipette')
+    //  TODO(jr 11/11/22): finish the rest of the test
+  })
+
+  it('renders the correct information, calling the correct commands for the attach flow', () => {
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+    }
+    mockGetPipetteWizardSteps.mockReturnValue([
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+    ])
+    const { getByText } = render(props)
+    getByText('Attach a pipette')
+    //  TODO(jr 11/11/22): finish the rest of the test
+  })
 })

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -20,6 +20,8 @@ import { AttachProbe } from './AttachProbe'
 import { DetachProbe } from './DetachProbe'
 import { Results } from './Results'
 import { ExitModal } from './ExitModal'
+import { MountPipette } from './MountPipette'
+import { DetachPipette } from './DetachPipette'
 
 import type { PipetteMount } from '@opentrons/shared-data'
 import type { State } from '../../redux/types'
@@ -138,7 +140,6 @@ export const PipetteWizardFlows = (
   let onExit
   if (currentStep == null) return null
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
-
   if (isExiting === true) {
     modalContent = <InProgressModal description={t('stand_back')} />
   }
@@ -183,10 +184,18 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {
     onExit = confirmExit
-    modalContent = showConfirmExit ? exitModal : <div>MountPipette</div>
+    modalContent = showConfirmExit ? (
+      exitModal
+    ) : (
+      <MountPipette {...currentStep} {...calibrateBaseProps} />
+    )
   } else if (currentStep.section === SECTIONS.DETACH_PIPETTE) {
     onExit = confirmExit
-    modalContent = showConfirmExit ? exitModal : <div>DetachPipette</div>
+    modalContent = showConfirmExit ? (
+      exitModal
+    ) : (
+      <DetachPipette {...currentStep} {...calibrateBaseProps} />
+    )
   }
 
   let wizardTitle: string = 'unknown page'

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -154,7 +154,7 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.ATTACH_PROBE) {
     onExit = confirmExit
-    modalContent = modalContent = showConfirmExit ? (
+    modalContent = showConfirmExit ? (
       exitModal
     ) : (
       <AttachProbe
@@ -165,7 +165,7 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.DETACH_PROBE) {
     onExit = confirmExit
-    modalContent = modalContent = showConfirmExit ? (
+    modalContent = showConfirmExit ? (
       exitModal
     ) : (
       <DetachProbe
@@ -176,11 +176,17 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.RESULTS) {
     onExit = confirmExit
-    modalContent = modalContent = showConfirmExit ? (
+    modalContent = showConfirmExit ? (
       exitModal
     ) : (
       <Results {...currentStep} {...calibrateBaseProps} proceed={closeFlow} />
     )
+  } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {
+    onExit = confirmExit
+    modalContent = showConfirmExit ? exitModal : <div>MountPipette</div>
+  } else if (currentStep.section === SECTIONS.DETACH_PIPETTE) {
+    onExit = confirmExit
+    modalContent = showConfirmExit ? exitModal : <div>DetachPipette</div>
   }
 
   let wizardTitle: string = 'unknown page'
@@ -189,7 +195,16 @@ export const PipetteWizardFlows = (
       wizardTitle = t('calibrate_pipette')
       break
     }
+    case FLOWS.ATTACH: {
+      wizardTitle = t('attach_pipette')
+      break
+    }
+    case FLOWS.DETACH: {
+      wizardTitle = t('detach_pipette')
+      break
+    }
   }
+
   let exitWizardButton = onExit
   if (isRobotMoving) {
     exitWizardButton = undefined


### PR DESCRIPTION
 closes RLIQ-244

# Overview

Adds the attach/detach modals to the gen3 pipette flow parent component and add logic to Pipette card

# Changelog

- `PipetteCard` and `PipetteOverflowMenu` has logic to access the attach and detach pipette flow for the ot3
- `PipetteWizardFlows` has logic that goes through both the attach/detach pipette flow modals
- `ChangePipette` logic is tweaked to go to either the single mount pipettes or 96 channel pipette on the proceed button click and has its own modal shell/wizard header. CLicking on exit on the wizard header renders the exit modal

# Review requests

- on an Ot-3, detaching a pipette flow should work all the way through from the UI prospective
- attach a pipette and selecting a 96 channel pipette will leave something in the log saying that the flow isn't there yet
- attach a pipette and selecting on single mount pipettes will render the before beginnning modal

# Risk assessment

low