### PR TITLE
fix(api): allow loadLiquid command to no-op when liquid FF is off

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -6,6 +6,8 @@ from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
+from opentrons.config import feature_flags
+
 if TYPE_CHECKING:
     from ..state import StateView
 
@@ -43,11 +45,12 @@ class LoadLiquidImplementation(AbstractCommandImpl[LoadLiquidParams, LoadLiquidR
 
     async def execute(self, params: LoadLiquidParams) -> LoadLiquidResult:
         """Load data necessary for a liquid."""
-        self._state_view.liquid.validate_liquid_id(params.liquidId)
+        if feature_flags.enable_load_liquid():
+            self._state_view.liquid.validate_liquid_id(params.liquidId)
 
-        self._state_view.labware.validate_liquid_allowed_in_labware(
-            labware_id=params.labwareId, wells=params.volumeByWell
-        )
+            self._state_view.labware.validate_liquid_allowed_in_labware(
+                labware_id=params.labwareId, wells=params.volumeByWell
+            )
 
         return LoadLiquidResult()
 

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -11,7 +11,6 @@ from opentrons.protocol_reader import (
     JsonProtocolConfig,
 )
 from opentrons.protocol_engine import ProtocolEngine, StateSummary, Command
-from opentrons.protocol_engine.errors.exceptions import CommandDoesNotExistError
 
 from .task_queue import TaskQueue
 from .json_file_reader import JsonFileReader
@@ -157,11 +156,6 @@ class ProtocolRunner:
     def _load_json(self, protocol_source: ProtocolSource) -> None:
         protocol = self._json_file_reader.read(protocol_source)
         commands = self._json_translator.translate_commands(protocol)
-
-        if not feature_flags.enable_load_liquid() and any(
-            c.commandType == "loadLiquid" for c in commands
-        ):
-            raise CommandDoesNotExistError("loadLiquid command is not yet supported.")
 
         if feature_flags.enable_load_liquid():
             liquids = self._json_translator.translate_liquids(protocol)

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -20,7 +20,6 @@ def _list_fixtures(version: int) -> Iterator[Path]:
 def test_analyze(
     fixture_path: Path,
     tmp_path: Path,
-    enable_load_liquid: None,
 ) -> None:
     """Should return with no errors and a non-empty output."""
     analysis_output_path = tmp_path / "analysis_output.json"

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -23,7 +23,10 @@ def subject(mock_state_view: StateView) -> LoadLiquidImplementation:
 
 
 async def test_load_liquid_implementation(
-    decoy: Decoy, subject: LoadLiquidImplementation, mock_state_view: StateView, enable_load_liquid: None
+    decoy: Decoy,
+    subject: LoadLiquidImplementation,
+    mock_state_view: StateView,
+    enable_load_liquid: None,
 ) -> None:
     """Test LoadLiquid command execution."""
     data = LoadLiquidParams(
@@ -43,6 +46,7 @@ async def test_load_liquid_implementation(
         )
     )
 
+
 async def test_load_liquid_implementation_ff_off(
     decoy: Decoy, subject: LoadLiquidImplementation, mock_state_view: StateView
 ) -> None:
@@ -61,5 +65,6 @@ async def test_load_liquid_implementation_ff_off(
     decoy.verify(
         mock_state_view.labware.validate_liquid_allowed_in_labware(
             "labware-id", {"A1": 30.0, "B2": 100.0}
-        ), times=0
+        ),
+        times=0,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -42,3 +42,24 @@ async def test_load_liquid_implementation(
             "labware-id", {"A1": 30.0, "B2": 100.0}
         )
     )
+
+async def test_load_liquid_implementation_ff_off(
+    decoy: Decoy, subject: LoadLiquidImplementation, mock_state_view: StateView
+) -> None:
+    """Test LoadLiquid command execution."""
+    data = LoadLiquidParams(
+        labwareId="labware-id",
+        liquidId="liquid-id",
+        volumeByWell={"A1": 30, "B2": 100},
+    )
+    result = await subject.execute(data)
+
+    assert result == LoadLiquidResult()
+
+    decoy.verify(mock_state_view.liquid.validate_liquid_id("liquid-id"), times=0)
+
+    decoy.verify(
+        mock_state_view.labware.validate_liquid_allowed_in_labware(
+            "labware-id", {"A1": 30.0, "B2": 100.0}
+        ), times=0
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -23,7 +23,7 @@ def subject(mock_state_view: StateView) -> LoadLiquidImplementation:
 
 
 async def test_load_liquid_implementation(
-    decoy: Decoy, subject: LoadLiquidImplementation, mock_state_view: StateView
+    decoy: Decoy, subject: LoadLiquidImplementation, mock_state_view: StateView, enable_load_liquid: None
 ) -> None:
     """Test LoadLiquid command execution."""
     data = LoadLiquidParams(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -16,7 +16,6 @@ from opentrons_shared_data.protocol.models.protocol_schema_v6 import ProtocolSch
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.protocol_api_experimental import ProtocolContext
 from opentrons.protocol_engine import ProtocolEngine, Liquid, commands as pe_commands
-from opentrons.protocol_engine.errors.exceptions import CommandDoesNotExistError
 from opentrons.protocol_reader import (
     ProtocolSource,
     JsonProtocolConfig,
@@ -292,7 +291,7 @@ def test_load_json_liquids_ff_on(
     protocol_engine: ProtocolEngine,
     task_queue: TaskQueue,
     subject: ProtocolRunner,
-    enable_load_liquid: None
+    enable_load_liquid: None,
 ) -> None:
     """It should load a JSON protocol file."""
     json_protocol_source = ProtocolSource(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -219,7 +219,7 @@ async def test_run(
     )
 
 
-def test_load_json_liquids_ff_off(
+def test_load_json(
     decoy: Decoy,
     json_file_reader: JsonFileReader,
     json_translator: JsonTranslator,

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -219,14 +219,13 @@ async def test_run(
     )
 
 
-def test_load_json(
+def test_load_json_liquids_ff_off(
     decoy: Decoy,
     json_file_reader: JsonFileReader,
     json_translator: JsonTranslator,
     protocol_engine: ProtocolEngine,
     task_queue: TaskQueue,
     subject: ProtocolRunner,
-    enable_load_liquid: None,
 ) -> None:
     """It should load a JSON protocol file."""
     json_protocol_source = ProtocolSource(
@@ -265,9 +264,6 @@ def test_load_json(
     subject.load(json_protocol_source)
 
     decoy.verify(
-        protocol_engine.add_liquid(
-            liquid=Liquid(id="water-id", displayName="water", description=" water desc")
-        ),
         protocol_engine.add_command(
             request=pe_commands.WaitForResumeCreate(
                 params=pe_commands.WaitForResumeParams(message="hello")
@@ -289,16 +285,16 @@ def test_load_json(
     )
 
 
-# TODO (tz, 10-12-22): remove this test when liquids ff is removed
-def test_load_json_raises_error_when_ff_disabled(
+def test_load_json_liquids_ff_on(
     decoy: Decoy,
     json_file_reader: JsonFileReader,
     json_translator: JsonTranslator,
     protocol_engine: ProtocolEngine,
     task_queue: TaskQueue,
     subject: ProtocolRunner,
+    enable_load_liquid: None
 ) -> None:
-    """It should raise an error when loading a JSON protocol file with loadLiquid command and liquids ff is off."""
+    """It should load a JSON protocol file."""
     json_protocol_source = ProtocolSource(
         directory=Path("/dev/null"),
         main_file=Path("/dev/null/abc.json"),
@@ -311,12 +307,6 @@ def test_load_json_raises_error_when_ff_disabled(
     json_protocol = ProtocolSchemaV6.construct()  # type: ignore[call-arg]
 
     commands: List[pe_commands.CommandCreate] = [
-        pe_commands.WaitForResumeCreate(
-            params=pe_commands.WaitForResumeParams(message="hello")
-        ),
-        pe_commands.WaitForResumeCreate(
-            params=pe_commands.WaitForResumeParams(message="goodbye")
-        ),
         pe_commands.LoadLiquidCreate(
             params=pe_commands.LoadLiquidParams(
                 liquidId="water-id", labwareId="labware-id", volumeByWell={"A1": 30}
@@ -332,8 +322,21 @@ def test_load_json_raises_error_when_ff_disabled(
     decoy.when(json_translator.translate_commands(json_protocol)).then_return(commands)
     decoy.when(json_translator.translate_liquids(json_protocol)).then_return(liquids)
 
-    with pytest.raises(CommandDoesNotExistError):
-        subject.load(json_protocol_source)
+    subject.load(json_protocol_source)
+
+    decoy.verify(
+        protocol_engine.add_liquid(
+            liquid=Liquid(id="water-id", displayName="water", description=" water desc")
+        ),
+        protocol_engine.add_command(
+            request=pe_commands.LoadLiquidCreate(
+                params=pe_commands.LoadLiquidParams(
+                    liquidId="water-id", labwareId="labware-id", volumeByWell={"A1": 30}
+                )
+            ),
+        ),
+        task_queue.set_run_func(func=protocol_engine.wait_until_complete),
+    )
 
 
 def test_load_python(

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -27,8 +27,8 @@ stages:
             - id: !anystr
               status: pending
   - name: Retry until analyses status is completed.
-    max_retries: 20
-    delay_after: 2
+    max_retries: 10
+    delay_after: 0.1
     request:
       url: '{host:s}:{port:d}/protocols'
       method: GET
@@ -553,8 +553,8 @@ stages:
             - id: !anystr
               status: pending
   - name: Retry until analyses status is completed.
-    max_retries: 20
-    delay_after: 2
+    max_retries: 10
+    delay_after: 0.1
     request:
       url: '{host:s}:{port:d}/protocols'
       method: GET

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -1,9 +1,9 @@
-test_name: Upload, analyze, delete basic_transfer_standalone protocol.
+test_name: Upload and analyze a JSONv6 protocol
 
 marks:
   - usefixtures:
       - run_server
-      - set_enable_load_liquid
+
 stages:
   - name: Upload simple v6 protocol
     request:
@@ -519,6 +519,68 @@ stages:
                     z: !anyfloat
                 startedAt: !anystr
                 completedAt: !anystr
+            errors: []
+            liquids: []
+
+---
+test_name: Upload and analyze a JSONv6 protocol, with liquids
+
+marks:
+  - usefixtures:
+      - run_server
+      - set_enable_load_liquid
+
+stages:
+  - name: Upload simple v6 protocol
+    request:
+      url: '{host:s}:{port:d}/protocols'
+      method: POST
+      files:
+        files: '../shared-data/protocol/fixtures/6/simpleV6.json'
+    response:
+      strict:
+        - json:off
+      save:
+        json:
+          protocol_id: data.id
+          analysis_id: data.analysisSummaries[0].id
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          protocolType: json
+          analysisSummaries:
+            - id: !anystr
+              status: pending
+  - name: Retry until analyses status is completed.
+    max_retries: 20
+    delay_after: 2
+    request:
+      url: '{host:s}:{port:d}/protocols'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          - id: '{protocol_id}'
+            analysisSummaries:
+              - id: '{analysis_id}'
+                status: completed
+  - name: Get protocol analysis by ID
+    request:
+      url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          - id: '{analysis_id}'
+            status: completed
+            result: ok
             errors: []
             liquids:
               - id: waterId


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Allow loadLiquid command to load when using a json protocol with liquids ff off but with no-op.

# Changelog

- Add ff check when executing a `loadLiquid` command
- Removed raised error when loading a json protocol with a `loadLiquid` command.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low. removed raised error for loadLiquid commands in json protocol. added a ff condition when executing the loadLiquid command.
