### PR TITLE
fix(protocol-designer): aspirate after dispense in transfer now count…

### DIFF
--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -1607,6 +1607,7 @@ describe('advanced options', () => {
         // use the dispense > air gap here before moving to trash
         {
           commandType: 'aspirate',
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2271,6 +2272,7 @@ describe('advanced options', () => {
         // dispense > air gap on the way to trash
         {
           commandType: 'aspirate',
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2956,6 +2958,7 @@ describe('advanced options', () => {
         // dispense > air gap
         {
           commandType: 'aspirate',
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3354,6 +3357,7 @@ describe('advanced options', () => {
         // dispense > air gap
         {
           commandType: 'aspirate',
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3680,6 +3684,7 @@ describe('advanced options', () => {
         // dispense > air gap
         {
           commandType: 'aspirate',
+          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -367,6 +367,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                     well: dispenseAirGapWell,
                     flowRate: aspirateFlowRateUlSec,
                     offsetFromBottomMm: airGapOffsetDestWell,
+                    isAirGap: true,
                   }),
                   ...(aspirateDelay != null
                     ? [


### PR DESCRIPTION
…s as air gap

closes RAUT-281

# Overview

Most instances of aspirates that were actually air gaps were converted except for adding an air gap after dispense in the transfer. This PR fixes that. 

# Changelog

- add air gap meta key to `Transfer` and fix the test

# Review requests

- go to https://opentrons.atlassian.net/browse/RESC-72 and test the `Two_target_PCR_CIDT…` protocol that is attached. If you look at the final volumes in the PCR plate wells, they should say `25uL` instead of `20uL`.
- in PD, add a `transfer` step, click on advanced settings,  add an air gap to the destination well. The final state liquid volume should not subtract that air gap volume.

# Risk assessment

low