### PR TITLE
feat(ot3): support 96 channel serial numbers

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -195,6 +195,8 @@ class PipetteName(int, Enum):
     p1000_multi = 0x01
     p50_single = 0x02
     p50_multi = 0x03
+    p1000_96 = 0x04
+    p50_96 = 0x05
     unknown = 0xFFFF
 
 

--- a/hardware/opentrons_hardware/instruments/pipettes/serials.py
+++ b/hardware/opentrons_hardware/instruments/pipettes/serials.py
@@ -12,6 +12,8 @@ NAME_LOOKUP: Dict[str, PipetteName] = {
     "P1KM": PipetteName.p1000_multi,
     "P50S": PipetteName.p50_single,
     "P50M": PipetteName.p50_multi,
+    "P1KH": PipetteName.p1000_96,
+    "P50H": PipetteName.p50_96,
 }
 
 SERIAL_FORMAT_MSG = (


### PR DESCRIPTION
We want to start flashing serial numbers to 96 channels starting next week. Myself and hardware have
come up with the following format for now: `P1KHV<version><serial>` and `p50HV<version><serial>`.