### PR TITLE
fix(hardware): use temporary gripper serial number for integration test

### DIFF
--- a/hardware/tests/firmware_integration/test_serial_number.py
+++ b/hardware/tests/firmware_integration/test_serial_number.py
@@ -7,7 +7,7 @@ from opentrons_hardware.firmware_bindings.messages.fields import SerialField
 from opentrons_hardware.instruments.pipettes.serials import (
     serial_val_from_parts,
 )
-from opentrons_hardware.instruments.gripper.serials import (
+from opentrons_hardware.instruments.gripper.serials import (  # noqa: F401
     gripper_serial_val_from_parts,
 )
 
@@ -34,17 +34,16 @@ def filter_func(arb: ArbitrationId) -> bool:
     )
 
 
-@pytest.mark.parametrize(
-    "model,datecode",
-    [
-        (31, b"2020190802A02"),
-        (500, b""),
-        (0, b"asdasdasdasdasda"),
-        (0xFFFF, b"\xff" * 16),
-    ],
-)
-
 # TODO: (2022-11-15 AA) Enable this test when the gripper EEPROM rework is complete
+# @pytest.mark.parametrize(
+#     "model,datecode",
+#     [
+#         (31, b"2020190802A02"),
+#         (500, b""),
+#         (0, b"asdasdasdasdasda"),
+#         (0xFFFF, b"\xff" * 16),
+#     ],
+# )
 # @pytest.mark.requires_emulator
 # @pytest.mark.can_filter_func.with_args(filter_func)
 # async def test_set_serial_gripper(
@@ -67,6 +66,8 @@ def filter_func(arb: ArbitrationId) -> bool:
 
 
 # TODO: (2022-11-15 AA) This tests the temporary serial number for the gripper
+@pytest.mark.requires_emulator
+@pytest.mark.can_filter_func.with_args(filter_func)
 async def test_temp_serial_gripper(
     can_messenger: CanMessenger,
     can_messenger_queue: WaitableCallback,

--- a/hardware/tests/firmware_integration/test_serial_number.py
+++ b/hardware/tests/firmware_integration/test_serial_number.py
@@ -45,29 +45,25 @@ def filter_func(arb: ArbitrationId) -> bool:
 )
 
 # TODO: (2022-11-15 AA) Enable this test when the gripper EEPROM rework is complete
-"""
-@pytest.mark.requires_emulator
-@pytest.mark.can_filter_func.with_args(filter_func)
-async def test_set_serial_gripper(
-    can_messenger: CanMessenger,
-    can_messenger_queue: WaitableCallback,
-    model: int,
-    datecode: bytes,
-) -> None:
-    """It should write a serial number and read it back."""
-    node_id = NodeId.gripper
-    gripper_serial = gripper_serial_val_from_parts(model, datecode)
-    s = SerialNumberPayload(serial=SerialField(gripper_serial))
-
-    await can_messenger.send(node_id=node_id, message=SetSerialNumber(payload=s))
-    await can_messenger.send(node_id=node_id, message=InstrumentInfoRequest())
-    response, arbitration_id = await asyncio.wait_for(can_messenger_queue.read(), 1)
-
-    assert arbitration_id.parts.originating_node_id == node_id
-    assert isinstance(response, GripperInfoResponse)
-    assert response.payload.model.value == model
-    assert response.payload.serial.value[: len(datecode)] == datecode
-"""
+# @pytest.mark.requires_emulator
+# @pytest.mark.can_filter_func.with_args(filter_func)
+# async def test_set_serial_gripper(
+#     can_messenger: CanMessenger,
+#     can_messenger_queue: WaitableCallback,
+#     model: int,
+#     datecode: bytes,
+# ) -> None:
+#     """It should write a serial number and read it back."""
+#     node_id = NodeId.gripper
+#     gripper_serial = gripper_serial_val_from_parts(model, datecode)
+#     s = SerialNumberPayload(serial=SerialField(gripper_serial))
+#     await can_messenger.send(node_id=node_id, message=SetSerialNumber(payload=s))
+#     await can_messenger.send(node_id=node_id, message=InstrumentInfoRequest())
+#     response, arbitration_id = await asyncio.wait_for(can_messenger_queue.read(), 1)
+#     assert arbitration_id.parts.originating_node_id == node_id
+#     assert isinstance(response, GripperInfoResponse)
+#     assert response.payload.model.value == model
+#     assert response.payload.serial.value[: len(datecode)] == datecode
 
 
 # TODO: (2022-11-15 AA) This tests the temporary serial number for the gripper

--- a/hardware/tests/firmware_integration/test_serial_number.py
+++ b/hardware/tests/firmware_integration/test_serial_number.py
@@ -43,6 +43,9 @@ def filter_func(arb: ArbitrationId) -> bool:
         (0xFFFF, b"\xff" * 16),
     ],
 )
+
+# TODO: (2022-11-15 AA) Enable this test when the gripper EEPROM rework is complete
+"""
 @pytest.mark.requires_emulator
 @pytest.mark.can_filter_func.with_args(filter_func)
 async def test_set_serial_gripper(
@@ -64,6 +67,26 @@ async def test_set_serial_gripper(
     assert isinstance(response, GripperInfoResponse)
     assert response.payload.model.value == model
     assert response.payload.serial.value[: len(datecode)] == datecode
+"""
+
+
+# TODO: (2022-11-15 AA) This tests the temporary serial number for the gripper
+async def test_temp_serial_gripper(
+    can_messenger: CanMessenger,
+    can_messenger_queue: WaitableCallback,
+) -> None:
+    """It should write a serial number and read it back."""
+    node_id = NodeId.gripper
+    temp_model = 1
+    temp_serial = b"20221115A01"
+
+    await can_messenger.send(node_id=node_id, message=InstrumentInfoRequest())
+    response, arbitration_id = await asyncio.wait_for(can_messenger_queue.read(), 1)
+
+    assert arbitration_id.parts.originating_node_id == node_id
+    assert isinstance(response, GripperInfoResponse)
+    assert response.payload.model.value == temp_model
+    assert response.payload.serial.value[: len(temp_serial)] == temp_serial
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Because of an electrical issue with the EVT model, we cannot set and save serial number for the gripper. So we've hard-coded the serial number for all grippers until we can set real serial number with DVT, and integration tests should reflect that. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
