### PR TITLE
feat(app-shell): include opentrons_hardware package in app python env

### DIFF
--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -90,6 +90,7 @@ module.exports = function beforeBuild(context) {
         'install',
         `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
+        path.join(__dirname, '../../hardware')
         path.join(__dirname, '../../api'),
         'pandas==1.4.3',
       ])

--- a/app-shell/scripts/before-build.js
+++ b/app-shell/scripts/before-build.js
@@ -90,7 +90,7 @@ module.exports = function beforeBuild(context) {
         'install',
         `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
-        path.join(__dirname, '../../hardware')
+        path.join(__dirname, '../../hardware'),
         path.join(__dirname, '../../api'),
         'pandas==1.4.3',
       ])


### PR DESCRIPTION
Closes RLAB-209

# Overview

Including `opentrons_hardware` is necessary for the app to be able to analyze OT3 protocols locally.

# Review requests

Check that the built app is able to analyze OT3 protocols.

**Update:** Tested the CI built macOS app and it was able to analyze an OT3 gripper protocol correctly.

# Risk assessment

No impact on existing infrastructure other than increase in app size.
