### PR TITLE
feat(engine, hardware control): add basic gripper collision avoidance measures

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -834,12 +834,9 @@ class OT3API(
         """
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
-        if mount != OT3Mount.GRIPPER:
+        if self._gripper_handler.gripper and mount != OT3Mount.GRIPPER:
             # TODO: check if we can avoid gripping during every retract
-            if (
-                self._gripper_handler.gripper
-                and self._gripper_handler.gripper.state == GripperJawState.UNHOMED
-            ):
+            if self._gripper_handler.gripper.state == GripperJawState.UNHOMED:
                 await self.home_gripper_jaw()
             await self.grip(force_newtons=20)  # allows for safer gantry movement
         self._last_moved_mount = mount

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -836,6 +836,8 @@ class OT3API(
             await self.retract(self._last_moved_mount, 10)
         if mount != OT3Mount.GRIPPER:
             # TODO: check if we can avoid gripping during every retract
+            if self._gripper_handler.gripper.state == GripperJawState.UNHOMED:
+                await self.home_gripper_jaw()
             await self.grip(force_newtons=20)  # allows for safer gantry movement
         self._last_moved_mount = mount
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -19,6 +19,11 @@ from typing import (
 )
 
 from opentrons_shared_data.pipette import name_config
+from opentrons_shared_data.pipette.dev_types import (
+    PipetteName,
+)
+from opentrons_shared_data.gripper.constants import IDLE_STATE_GRIP_FORCE
+
 from opentrons import types as top_types
 from opentrons.config import robot_configs
 from opentrons.config.types import (
@@ -97,10 +102,6 @@ from .motion_utilities import (
     deck_from_machine,
     machine_from_deck,
     machine_vector_from_deck_vector,
-)
-
-from opentrons_shared_data.pipette.dev_types import (
-    PipetteName,
 )
 
 from .dev_types import (
@@ -839,7 +840,8 @@ class OT3API(
             and mount != OT3Mount.GRIPPER
             and self._gripper_handler.gripper.state != GripperJawState.GRIPPING
         ):
-            await self.grip(force_newtons=20)  # allows for safer gantry movement
+            # allows for safer gantry movement at minimum force
+            await self.grip(force_newtons=IDLE_STATE_GRIP_FORCE)
         self._last_moved_mount = mount
 
     @ExecutionManagerProvider.wait_for_running

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -836,7 +836,7 @@ class OT3API(
             await self.retract(self._last_moved_mount, 10)
         if mount != OT3Mount.GRIPPER:
             # TODO: check if we can avoid gripping during every retract
-            await self.grip(force_newtons=20)   # allows for safer gantry movement
+            await self.grip(force_newtons=20)  # allows for safer gantry movement
         self._last_moved_mount = mount
 
     @ExecutionManagerProvider.wait_for_running

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -834,12 +834,12 @@ class OT3API(
         """
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
-        if self._gripper_handler.gripper and mount != OT3Mount.GRIPPER:
-            gripper_state = self._gripper_handler.gripper.state
-            if gripper_state == GripperJawState.UNHOMED:
-                await self.home_gripper_jaw()
-            if gripper_state != GripperJawState.GRIPPING:
-                await self.grip(force_newtons=20)  # allows for safer gantry movement
+        if (
+            self._gripper_handler.gripper
+            and mount != OT3Mount.GRIPPER
+            and self._gripper_handler.gripper.state != GripperJawState.GRIPPING
+        ):
+            await self.grip(force_newtons=20)  # allows for safer gantry movement
         self._last_moved_mount = mount
 
     @ExecutionManagerProvider.wait_for_running

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -834,6 +834,9 @@ class OT3API(
         """
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
+        if mount != OT3Mount.GRIPPER:
+            # TODO: check if we can avoid gripping during every retract
+            await self.grip(force_newtons=20)   # allows for safer gantry movement
         self._last_moved_mount = mount
 
     @ExecutionManagerProvider.wait_for_running

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -835,10 +835,11 @@ class OT3API(
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
         if self._gripper_handler.gripper and mount != OT3Mount.GRIPPER:
-            # TODO: check if we can avoid gripping during every retract
-            if self._gripper_handler.gripper.state == GripperJawState.UNHOMED:
+            gripper_state = self._gripper_handler.gripper.state
+            if gripper_state == GripperJawState.UNHOMED:
                 await self.home_gripper_jaw()
-            await self.grip(force_newtons=20)  # allows for safer gantry movement
+            if gripper_state != GripperJawState.GRIPPING:
+                await self.grip(force_newtons=20)  # allows for safer gantry movement
         self._last_moved_mount = mount
 
     @ExecutionManagerProvider.wait_for_running

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -776,6 +776,7 @@ class OT3API(
             checked_max = None
 
         await self._cache_and_maybe_retract_mount(realmount)
+        await self._move_gripper_to_idle_position(realmount)
         await self._move(target_position, speed=speed, max_speeds=checked_max)
 
     async def move_rel(
@@ -818,6 +819,7 @@ class OT3API(
         else:
             checked_max = None
         await self._cache_and_maybe_retract_mount(realmount)
+        await self._move_gripper_to_idle_position(realmount)
         await self._move(
             target_position,
             speed=speed,
@@ -835,14 +837,23 @@ class OT3API(
         """
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
+        self._last_moved_mount = mount
+
+    async def _move_gripper_to_idle_position(self, mount_in_use: OT3Mount) -> None:
+        """Move gripper to its idle, gripped position.
+
+        If the gripper is not currently in use, puts its jaws in a low-current,
+        gripped position. Experimental behavior in order to prevent gripper jaws
+        from colliding into thermocycler lid & lid latch clips.
+        """
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-214
         if (
             self._gripper_handler.gripper
-            and mount != OT3Mount.GRIPPER
+            and mount_in_use != OT3Mount.GRIPPER
             and self._gripper_handler.gripper.state != GripperJawState.GRIPPING
         ):
             # allows for safer gantry movement at minimum force
             await self.grip(force_newtons=IDLE_STATE_GRIP_FORCE)
-        self._last_moved_mount = mount
 
     @ExecutionManagerProvider.wait_for_running
     async def _move(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -836,7 +836,10 @@ class OT3API(
             await self.retract(self._last_moved_mount, 10)
         if mount != OT3Mount.GRIPPER:
             # TODO: check if we can avoid gripping during every retract
-            if self._gripper_handler.gripper.state == GripperJawState.UNHOMED:
+            if (
+                self._gripper_handler.gripper
+                and self._gripper_handler.gripper.state == GripperJawState.UNHOMED
+            ):
                 await self.home_gripper_jaw()
             await self.grip(force_newtons=20)  # allows for safer gantry movement
         self._last_moved_mount = mount

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -87,7 +87,6 @@ class LabwareMovementHandler:
 
         # Retract all mounts
         await ot3api.home(axes=[OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.Z_G])
-        # TODO: reset well location cache upon completion of command execution
         await ot3api.home_gripper_jaw()
 
         gripper_homed_position = await ot3api.gantry_position(mount=gripper_mount)
@@ -111,8 +110,8 @@ class LabwareMovementHandler:
             else None
         )
 
-        # TODO: This is a bandaid for saving the gripper after a collision.
-        #       Remove once collisions & recovery are fixed.
+        # TODO: homing is temporary fix to save a gripper after collision.
+        #       Remove this call to home when RLAB-211 is addressed
         await ot3api.home(axes=[OT3Axis.Z_G])
 
         waypoints_to_new_location = self._get_gripper_movement_waypoints(
@@ -127,6 +126,10 @@ class LabwareMovementHandler:
             await ot3api.move_to(mount=gripper_mount, abs_position=waypoint)
 
         await ot3api.ungrip()
+        # TODO: homing is temporary fix to save a gripper after collision.
+        #       Remove this call to home and uncomment `move_to` when
+        #       RLAB-211 is addressed
+        await ot3api.home(axes=[OT3Axis.Z_G])
         # await ot3api.move_to(
         #     mount=OT3Mount.GRIPPER,
         #     abs_position=Point(
@@ -135,9 +138,6 @@ class LabwareMovementHandler:
         #         gripper_homed_position.z,
         #     ),
         # )
-        # TODO: This is a bandaid for saving the gripper after a collision.
-        #       Remove once collisions & recovery are fixed.
-        await ot3api.home(axes=[OT3Axis.Z_G])
 
         # Keep the gripper in gripped position so it avoids colliding with
         # things like the thermocycler latches

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -106,8 +106,8 @@ class LabwareMovementHandler:
             if waypoint == waypoints_to_labware[-1]:
                 # TODO: We do this to have the gripper move to location with
                 #  closed grip and open right before picking up the labware to
-                #  avoid collisions as much as possible. Re-evaluate whether we need it
-                #  once collision avoidance is in place.
+                #  avoid collisions as much as possible.
+                #  See https://opentrons.atlassian.net/browse/RLAB-214
                 await ot3api.home_gripper_jaw()
             await ot3api.move_to(mount=gripper_mount, abs_position=waypoint)
 
@@ -119,8 +119,7 @@ class LabwareMovementHandler:
             else None
         )
 
-        # TODO: homing is temporary fix to save a gripper after collision.
-        #       Remove this call to home when RLAB-211 is addressed
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-215
         await ot3api.home(axes=[OT3Axis.Z_G])
 
         waypoints_to_new_location = self._get_gripper_movement_waypoints(
@@ -135,9 +134,7 @@ class LabwareMovementHandler:
             await ot3api.move_to(mount=gripper_mount, abs_position=waypoint)
 
         await ot3api.ungrip()
-        # TODO: homing is temporary fix to save a gripper after collision.
-        #       Replace the call to home with a gripper retract using `move_to` when
-        #       RLAB-211 is addressed
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-215
         await ot3api.home(axes=[OT3Axis.Z_G])
 
         # Keep the gripper in gripped position so it avoids colliding with

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -168,13 +168,13 @@ async def test_move_labware_with_gripper(
     gripper = OT3Mount.GRIPPER
     decoy.verify(
         await ot3_hardware_api.home(axes=[OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.Z_G]),
-        await ot3_hardware_api.home_gripper_jaw(),
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[0]
         ),
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[1]
         ),
+        await ot3_hardware_api.home_gripper_jaw(),
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[2]
         ),

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -182,10 +182,9 @@ async def test_move_labware_with_gripper(
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[2]
         ),
-        await ot3_hardware_api.grip(
-            force_newtons=LABWARE_GRIP_FORCE
-        ),  # TODO: replace this once we have this spec in hardware control
-        # TODO: homing is temporary fix for evt. Remove when RLAB-211 is addressed
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-214
+        await ot3_hardware_api.grip(force_newtons=LABWARE_GRIP_FORCE),
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-215
         await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[3]
@@ -197,15 +196,10 @@ async def test_move_labware_with_gripper(
             mount=gripper, abs_position=expected_waypoints[5]
         ),
         await ot3_hardware_api.ungrip(),
-        # TODO: homing is temporary fix for EVT. Remove verification for home and
-        #  uncomment `move_to` verification when RLAB-211 is addressed
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-215
         await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
-        # await ot3_hardware_api.move_to(
-        #     mount=gripper, abs_position=expected_waypoints[6]
-        # ),
-        await ot3_hardware_api.grip(
-            force_newtons=IDLE_STATE_GRIP_FORCE
-        ),  # TODO: replace this once we have this spec in hardware control
+        # TODO: see https://opentrons.atlassian.net/browse/RLAB-214
+        await ot3_hardware_api.grip(force_newtons=IDLE_STATE_GRIP_FORCE),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -181,7 +181,7 @@ async def test_move_labware_with_gripper(
         await ot3_hardware_api.grip(
             force_newtons=20
         ),  # TODO: replace this once we have this spec in hardware control
-        # TODO: homing is temporary fix for evt. Remove when appropriate fix is in place
+        # TODO: homing is temporary fix for evt. Remove when RLAB-211 is addressed
         await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[3]
@@ -193,11 +193,12 @@ async def test_move_labware_with_gripper(
             mount=gripper, abs_position=expected_waypoints[5]
         ),
         await ot3_hardware_api.ungrip(),
+        # TODO: homing is temporary fix for EVT. Remove verification for home and
+        #  uncomment `move_to` verification when RLAB-211 is addressed
+        await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
         # await ot3_hardware_api.move_to(
         #     mount=gripper, abs_position=expected_waypoints[6]
         # ),
-        # TODO: homing is temporary fix for evt. Remove when appropriate fix is in place
-        await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
         await ot3_hardware_api.grip(
             force_newtons=20
         ),  # TODO: replace this once we have this spec in hardware control

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -181,6 +181,8 @@ async def test_move_labware_with_gripper(
         await ot3_hardware_api.grip(
             force_newtons=20
         ),  # TODO: replace this once we have this spec in hardware control
+        # TODO: homing is temporary fix for evt. Remove when appropriate fix is in place
+        await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[3]
         ),
@@ -191,9 +193,14 @@ async def test_move_labware_with_gripper(
             mount=gripper, abs_position=expected_waypoints[5]
         ),
         await ot3_hardware_api.ungrip(),
-        await ot3_hardware_api.move_to(
-            mount=gripper, abs_position=expected_waypoints[6]
-        ),
+        # await ot3_hardware_api.move_to(
+        #     mount=gripper, abs_position=expected_waypoints[6]
+        # ),
+        # TODO: homing is temporary fix for evt. Remove when appropriate fix is in place
+        await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
+        await ot3_hardware_api.grip(
+            force_newtons=20
+        ),  # TODO: replace this once we have this spec in hardware control
     )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -7,6 +7,10 @@ import pytest
 from decoy import Decoy, matchers
 from typing import TYPE_CHECKING, Union
 
+from opentrons_shared_data.gripper.constants import (
+    LABWARE_GRIP_FORCE,
+    IDLE_STATE_GRIP_FORCE,
+)
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.types import DeckSlotName, Point
@@ -179,7 +183,7 @@ async def test_move_labware_with_gripper(
             mount=gripper, abs_position=expected_waypoints[2]
         ),
         await ot3_hardware_api.grip(
-            force_newtons=20
+            force_newtons=LABWARE_GRIP_FORCE
         ),  # TODO: replace this once we have this spec in hardware control
         # TODO: homing is temporary fix for evt. Remove when RLAB-211 is addressed
         await ot3_hardware_api.home(axes=[OT3Axis.Z_G]),
@@ -200,7 +204,7 @@ async def test_move_labware_with_gripper(
         #     mount=gripper, abs_position=expected_waypoints[6]
         # ),
         await ot3_hardware_api.grip(
-            force_newtons=20
+            force_newtons=IDLE_STATE_GRIP_FORCE
         ),  # TODO: replace this once we have this spec in hardware control
     )
 

--- a/shared-data/python/opentrons_shared_data/gripper/constants.py
+++ b/shared-data/python/opentrons_shared_data/gripper/constants.py
@@ -1,0 +1,4 @@
+"""Gripper constants and default values."""
+
+LABWARE_GRIP_FORCE: float = 20  # Newtons
+IDLE_STATE_GRIP_FORCE: float = 5   # Newtons

--- a/shared-data/python/opentrons_shared_data/gripper/constants.py
+++ b/shared-data/python/opentrons_shared_data/gripper/constants.py
@@ -1,4 +1,4 @@
 """Gripper constants and default values."""
 
 LABWARE_GRIP_FORCE: float = 20  # Newtons
-IDLE_STATE_GRIP_FORCE: float = 5   # Newtons
+IDLE_STATE_GRIP_FORCE: float = 10  # Newtons


### PR DESCRIPTION
Closes RLAB-210

# Overview

Adds measures to make the gripper avoid collision with thermocycler latch clips and improves recovery from collision

# Changelog

- makes the gripper jaw move to the grip position before every pipette movement. This makes sure that the gripper would not be in the way during LPC
- makes the gripper jaw move to the grip position after every labware movement. This might not be necessary if the above gripping-before-every-pipette-movement covers all ground.
- makes the gripper home-Z instead of performing a `move_to` to the z-home position during labware movement. (Mitigation for RLAB-211) 

# Review requests

- Make sure this doesn't break any existing behavior, especially the gripping during mount retraction before every move
- Test on a robot

# Risk assessment

Medium because it plays with the pipette retraction code. But as long as the change doesn't do anything radical, the existing retraction behavior should remain the same.
