### PR TITLE
fix(api): ot3controller should utilize `check_ready_for_movement`

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -151,6 +151,7 @@ class OT3Controller:
             )
         self._present_nodes: Set[NodeId] = set()
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
+        self._homed_nodes: Set[NodeId] = set()
 
     async def update_to_default_current_settings(self, gantry_load: GantryLoad) -> None:
         self._current_settings = get_current_settings(
@@ -196,7 +197,10 @@ class OT3Controller:
         """Set the module controls"""
         self._module_controls = module_controls
 
-    def is_homed(self, axes: Sequence[OT3Axis]) -> bool:
+    def has_homed(self, axes: Sequence[OT3Axis]) -> bool:
+        for a in axes:
+            if axis_to_node(a) not in self._homed_nodes:
+                return False
         return True
 
     async def update_position(self) -> OT3AxisMap[float]:
@@ -334,9 +338,10 @@ class OT3Controller:
         if OT3Axis.G in checked_axes:
             await self.gripper_home_jaw()
         for position in positions:
-            for p in position.items():
-                self._position.update({p[0]: p[1][0]})
-                self._encoder_position.update({p[0]: p[1][1]})
+            for axis, p in position.items():
+                self._position.update({axis: p[0]})
+                self._encoder_position.update({axis: p[1]})
+                self._homed_nodes.add(axis)
         return axis_convert(self._position, 0.0)
 
     def _filter_move_group(self, move_group: MoveGroup) -> MoveGroup:
@@ -395,6 +400,7 @@ class OT3Controller:
         for axis, point in positions.items():
             self._position.update({axis: point[0]})
             self._encoder_position.update({axis: point[1]})
+            self._homed_nodes.add(axis)
 
     @staticmethod
     def _synthesize_model_name(name: FirmwarePipetteName, model: str) -> "PipetteModel":

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -159,6 +159,11 @@ class OT3Controller:
         )
         await self.set_default_currents()
 
+    def clear_positions(self) -> None:
+        self._position = self._get_home_position()
+        self._encoder_position = self._get_home_position()
+        self._homed_nodes = set()
+
     @property
     def motor_run_currents(self) -> OT3AxisMap[float]:
         assert self._current_settings

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -197,7 +197,7 @@ class OT3Controller:
         """Set the module controls"""
         self._module_controls = module_controls
 
-    def has_homed(self, axes: Sequence[OT3Axis]) -> bool:
+    def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:
         for a in axes:
             if axis_to_node(a) not in self._homed_nodes:
                 return False

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -159,11 +159,6 @@ class OT3Controller:
         )
         await self.set_default_currents()
 
-    def clear_positions(self) -> None:
-        self._position = self._get_home_position()
-        self._encoder_position = self._get_home_position()
-        self._homed_nodes = set()
-
     @property
     def motor_run_currents(self) -> OT3AxisMap[float]:
         assert self._current_settings

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -152,6 +152,11 @@ class OT3Simulator:
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
         self._homed_nodes: Set[NodeId] = set()
 
+    def clear_positions(self) -> None:
+        self._position = self._get_home_position()
+        self._encoder_position = self._get_home_position()
+        self._homed_nodes = set()
+
     @property
     def board_revision(self) -> BoardRevision:
         """Get the board revision"""

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -150,6 +150,7 @@ class OT3Simulator:
         self._encoder_position = self._get_home_position()
         self._present_nodes: Set[NodeId] = set()
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
+        self._homed_nodes: Set[NodeId] = set()
 
     @property
     def board_revision(self) -> BoardRevision:
@@ -173,7 +174,10 @@ class OT3Simulator:
             self._configuration.current_settings, gantry_load
         )
 
-    def is_homed(self, axes: Sequence[OT3Axis]) -> bool:
+    def has_homed(self, axes: Sequence[OT3Axis]) -> bool:
+        for a in axes:
+            if axis_to_node(a) not in self._homed_nodes:
+                return False
         return True
 
     async def update_position(self) -> OT3AxisMap[float]:
@@ -214,6 +218,9 @@ class OT3Simulator:
         Returns:
             Homed position.
         """
+        homed = [axis_to_node(a) for a in axes] if axes else self._position.keys()
+        for h in homed:
+            self._homed_nodes.add(h)
         return axis_convert(self._position, 0.0)
 
     async def fast_home(
@@ -228,6 +235,9 @@ class OT3Simulator:
         Returns:
             New position.
         """
+        homed = [axis_to_node(a) for a in axes] if axes else self._position.keys()
+        for h in homed:
+            self._homed_nodes.add(h)
         return axis_convert(self._position, 0.0)
 
     async def gripper_grip_jaw(
@@ -241,6 +251,7 @@ class OT3Simulator:
     async def gripper_home_jaw(self) -> None:
         """Move gripper outward."""
         _ = create_gripper_jaw_home_group()
+        self._homed_nodes.add(NodeId.gripper_g)
 
     async def gripper_hold_jaw(
         self,

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -174,7 +174,7 @@ class OT3Simulator:
             self._configuration.current_settings, gantry_load
         )
 
-    def has_homed(self, axes: Sequence[OT3Axis]) -> bool:
+    def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:
         for a in axes:
             if axis_to_node(a) not in self._homed_nodes:
                 return False

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -218,7 +218,10 @@ class OT3Simulator:
         Returns:
             Homed position.
         """
-        homed = [axis_to_node(a) for a in axes] if axes else self._position.keys()
+        if axes:
+            homed = [axis_to_node(a) for a in axes]
+        else:
+            homed = self._position.keys()
         for h in homed:
             self._homed_nodes.add(h)
         return axis_convert(self._position, 0.0)

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -221,7 +221,7 @@ class OT3Simulator:
         if axes:
             homed = [axis_to_node(a) for a in axes]
         else:
-            homed = self._position.keys()
+            homed = list(self._position.keys())
         for h in homed:
             self._homed_nodes.add(h)
         return axis_convert(self._position, 0.0)

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -152,11 +152,6 @@ class OT3Simulator:
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
         self._homed_nodes: Set[NodeId] = set()
 
-    def clear_positions(self) -> None:
-        self._position = self._get_home_position()
-        self._encoder_position = self._get_home_position()
-        self._homed_nodes = set()
-
     @property
     def board_revision(self) -> BoardRevision:
         """Get the board revision"""

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -96,6 +96,7 @@ def axis_to_node(axis: OT3Axis) -> "NodeId":
         OT3Axis.P_R: NodeId.pipette_right,
         OT3Axis.Z_G: NodeId.gripper_z,
         OT3Axis.G: NodeId.gripper_g,
+        OT3Axis.Q: NodeId.pipette_left,
     }
     return anm[axis]
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -558,6 +558,11 @@ class OT3API(
         self._log.info("Recovering from halt")
         await self.reset()
 
+        # TODO: (2022-11-21 AA) remove this logic when encoder is added to the gripper
+        # Always refresh gripper z position as a safeguard, since we don't have an
+        # encoder position for reference
+        await self.home_z(OT3Mount.GRIPPER)
+
         if home_after:
             await self.home()
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -643,7 +643,7 @@ class OT3API(
         position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, plunger_ax]
 
         if fail_on_not_homed and (
-            not self._backend.is_homed(position_axes) or not self._current_position
+            not self._backend.has_homed(position_axes) or not self._current_position
         ):
             raise MustHomeError(
                 f"Current position of {str(mount)} pipette is unknown, please home."
@@ -692,7 +692,7 @@ class OT3API(
         position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, plunger_ax]
 
         if fail_on_not_homed and (
-            not self._backend.is_homed(position_axes)
+            not self._backend.has_homed(position_axes)
             or not self._encoder_current_position
         ):
             raise MustHomeError(
@@ -769,10 +769,12 @@ class OT3API(
     ) -> None:
         """Move the critical point of the specified mount to a location
         relative to the deck, at the specified speed."""
-        if not self._current_position:
-            await self.home()
-
         realmount = OT3Mount.from_mount(mount)
+
+        axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
+        if not self._backend.has_homed(axes_moving):
+            await self.home(axes_moving)
+
         target_position = target_position_from_absolute(
             realmount,
             abs_position,
@@ -810,18 +812,19 @@ class OT3API(
         mhe = MustHomeError(
             "Cannot make a relative move because absolute position is unknown"
         )
-        if not self._current_position:
+
+        realmount = OT3Mount.from_mount(mount)
+        axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
+        if not self._backend.has_homed([axis for axis in axes_moving]):
             if fail_on_not_homed:
                 raise mhe
             else:
-                await self.home()
+                await self.home(axes_moving)
 
-        realmount = OT3Mount.from_mount(mount)
         target_position = target_position_from_relative(
             realmount, delta, self._current_position
         )
-        axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
-        if fail_on_not_homed and not self._backend.is_homed(
+        if fail_on_not_homed and not self._backend.has_homed(
             [axis for axis in axes_moving if axis is not None]
         ):
             raise mhe

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -559,7 +559,6 @@ class OT3API(
         await self.reset()
 
         if home_after:
-            self._backend.clear_positions()
             await self.home()
 
     async def reset(self) -> None:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -643,7 +643,8 @@ class OT3API(
         position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, plunger_ax]
 
         if fail_on_not_homed and (
-            not self._backend.has_homed(position_axes) or not self._current_position
+            not self._backend.check_ready_for_movement(position_axes)
+            or not self._current_position
         ):
             raise MustHomeError(
                 f"Current position of {str(mount)} pipette is unknown, please home."
@@ -692,7 +693,7 @@ class OT3API(
         position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, plunger_ax]
 
         if fail_on_not_homed and (
-            not self._backend.has_homed(position_axes)
+            not self._backend.check_ready_for_movement(position_axes)
             or not self._encoder_current_position
         ):
             raise MustHomeError(
@@ -772,7 +773,7 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
 
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
-        if not self._backend.has_homed(axes_moving):
+        if not self._backend.check_ready_for_movement(axes_moving):
             await self.home(axes_moving)
 
         target_position = target_position_from_absolute(
@@ -815,7 +816,7 @@ class OT3API(
 
         realmount = OT3Mount.from_mount(mount)
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
-        if not self._backend.has_homed([axis for axis in axes_moving]):
+        if not self._backend.check_ready_for_movement([axis for axis in axes_moving]):
             if fail_on_not_homed:
                 raise mhe
             else:
@@ -824,7 +825,7 @@ class OT3API(
         target_position = target_position_from_relative(
             realmount, delta, self._current_position
         )
-        if fail_on_not_homed and not self._backend.has_homed(
+        if fail_on_not_homed and not self._backend.check_ready_for_movement(
             [axis for axis in axes_moving if axis is not None]
         ):
             raise mhe

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -559,6 +559,7 @@ class OT3API(
         await self.reset()
 
         if home_after:
+            self._backend.clear_positions()
             await self.home()
 
     async def reset(self) -> None:

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -28,7 +28,6 @@ from opentrons_hardware.hardware_control.motion import (
     MoveType,
     MoveStopCondition,
 )
-from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.hardware_control.tools.detector import OneshotToolDetector
 from opentrons_hardware.hardware_control.tools.types import (
     ToolSummary,

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -163,7 +163,7 @@ async def test_home_execute(
 
     # all commanded axes have been homed
     assert controller._homed_nodes == set(axis_to_node(ax) for ax in axes)
-    assert controller.has_homed(axes)
+    assert controller.check_ready_for_movement(axes)
 
 
 @pytest.mark.parametrize("axes", home_test_params)
@@ -189,7 +189,7 @@ async def test_home_prioritize_mount(
 
     # all commanded axes have been homed
     assert controller._homed_nodes == set(axis_to_node(ax) for ax in axes)
-    assert controller.has_homed(axes)
+    assert controller.check_ready_for_movement(axes)
 
 
 @pytest.mark.parametrize("axes", home_test_params)
@@ -219,7 +219,7 @@ async def test_home_build_runners(
 
     # all commanded axes have been homed
     assert controller._homed_nodes == set(axis_to_node(ax) for ax in axes)
-    assert controller.has_homed(axes)
+    assert controller.check_ready_for_movement(axes)
 
 
 @pytest.mark.parametrize("axes", home_test_params)

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1,6 +1,6 @@
 """ Tests for behaviors specific to the OT3 hardware controller.
 """
-from typing import cast, Iterator, Union, Dict, Tuple
+from typing import cast, Iterator, Union, Dict, Tuple, List
 from typing_extensions import Literal
 from math import copysign
 import pytest
@@ -52,6 +52,19 @@ def mock_move_to(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
         AsyncMock(
             spec=ot3_hardware.managed_obj.move_to,
             wraps=ot3_hardware.managed_obj.move_to,
+        ),
+    ) as mock_move:
+        yield mock_move
+
+
+@pytest.fixture
+def mock_home(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
+    with patch.object(
+        ot3_hardware.managed_obj,
+        "home",
+        AsyncMock(
+            spec=ot3_hardware.managed_obj.home,
+            wraps=ot3_hardware.managed_obj.home,
         ),
     ) as mock_move:
         yield mock_move
@@ -215,9 +228,36 @@ def mock_backend_capacitive_pass(
         yield mock_pass
 
 
-def test_home_z_only(ot3_hardware: ThreadManager[OT3API]):
-    assert ot3_hardware._current_position == {}
-    
+@pytest.mark.parametrize(
+    "mount,homed_axis",
+    [
+        (OT3Mount.RIGHT, [OT3Axis.X, OT3Axis.Y, OT3Axis.Z_R]),
+        (OT3Mount.LEFT, [OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L]),
+        (OT3Mount.GRIPPER, [OT3Axis.X, OT3Axis.Y, OT3Axis.Z_G]),
+    ],
+)
+async def test_move_to_without_homing_first(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_home: AsyncMock,
+    mount: OT3Mount,
+    homed_axis: List[OT3Axis],
+) -> None:
+    """Before a mount can be moved, XY and the corresponding Z  must be homed first"""
+    if mount == OT3Mount.GRIPPER:
+        # attach a gripper if we're testing the gripper mount
+        gripper_config = gc.load(GripperModel.V1, "test")
+        instr_data = AttachedGripper(config=gripper_config, id="test")
+        await ot3_hardware.cache_gripper(instr_data)
+
+    ot3_hardware._backend._homed_nodes = set()
+    assert not ot3_hardware._backend.has_homed(homed_axis)
+
+    await ot3_hardware.move_to(
+        mount,
+        Point(0.001, 0.001, 0.001),
+    )
+    mock_home.assert_called_once_with(homed_axis)
+    assert ot3_hardware._backend.has_homed(homed_axis)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -215,6 +215,11 @@ def mock_backend_capacitive_pass(
         yield mock_pass
 
 
+def test_home_z_only(ot3_hardware: ThreadManager[OT3API]):
+    assert ot3_hardware._current_position == {}
+    
+
+
 @pytest.mark.parametrize(
     "mount,moving",
     [

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -250,14 +250,14 @@ async def test_move_to_without_homing_first(
         await ot3_hardware.cache_gripper(instr_data)
 
     ot3_hardware._backend._homed_nodes = set()
-    assert not ot3_hardware._backend.has_homed(homed_axis)
+    assert not ot3_hardware._backend.check_ready_for_movement(homed_axis)
 
     await ot3_hardware.move_to(
         mount,
         Point(0.001, 0.001, 0.001),
     )
     mock_home.assert_called_once_with(homed_axis)
-    assert ot3_hardware._backend.has_homed(homed_axis)
+    assert ot3_hardware._backend.check_ready_for_movement(homed_axis)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
## Overview

We found a bug after booting up the first time, the OT3 would attempt to move to a location before all axes have a chance to home. This is because we call `OT3API.home_z()` during hardware controller initialization, which updates the tracked current position for all axes. Before a move, the hardware controller checks whether or not a previous current position has been recorded for all available axes, and falsely thinks everything has been homed and ready for movement. 

Rather than solely rely on the hardware controller's current position, we should just keep track of the axes that have actually been homed in a list on the backend. Before each move, we should check against that list to make sure we are are confident that a home command has been called on each moving axis.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
