### PR TITLE
fix(app): JSON protocol thermocycler profile steps readability

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/StepText.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/StepText.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Flex, ALIGN_CENTER, SPACING, TYPOGRAPHY } from '@opentrons/components'
+import {
+  Flex,
+  ALIGN_CENTER,
+  SPACING,
+  TYPOGRAPHY,
+  DIRECTION_COLUMN,
+} from '@opentrons/components'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { StyledText } from '../../../atoms/text'
 import { getLabwareLocation } from '../ProtocolRun/utils/getLabwareLocation'
@@ -186,17 +192,19 @@ export function StepText(props: Props): JSX.Element | null {
           t('tc_run_profile_steps', { celsius: celsius, seconds: holdSeconds })
       )
       messageNode = (
-        <Flex>
-          <StyledText>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <StyledText marginBottom={SPACING.spacing2}>
             {t('tc_starting_profile', {
               repetitions: Object.keys(steps).length,
             })}
           </StyledText>
-          <ul>
-            {steps.map((step: string, index: number) => (
-              <li key={index}> {step}</li>
-            ))}
-          </ul>
+          <Flex marginLeft={SPACING.spacing4}>
+            <ul>
+              {steps.map((step: string, index: number) => (
+                <li key={index}> {step}</li>
+              ))}
+            </ul>
+          </Flex>
         </Flex>
       )
       break


### PR DESCRIPTION
closes RQA-404

# Overview

thermocycler profile steps from PD were not formatted in a readable manner. NOw it looks like this:

<img width="908" alt="Screen Shot 2022-11-17 at 9 10 01 AM" src="https://user-images.githubusercontent.com/66035149/202470518-9e175aee-f3e3-41a3-9c85-8446a8c9c9f5.png">


# Changelog

- change `StepText` to format the thermocycler profile command message better

# Review requests

- test with Josh's protocol attached to the ticket. should be formatted as the screenshot shows in this PR

# Risk assessment

low