### PR TITLE
chore(build): Add workflow to start ot-3 builds

### DIFF
--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -40,9 +40,12 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains('ot3-build', toJSON(github.event.pull_request.labels))
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons'
     name: "Start an OT-3 build for a requested PR"
     steps:
+      - name: 'whatever'
+        runs: |
+          cat not-exists
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   handle-push:
-    if: github.event_name == "push"
+    if: github.event_name == 'push'
     name: "Start an OT-3 build for a branch push"
     steps:
       - name: 'start build'
@@ -38,7 +38,7 @@ jobs:
 
 
   handle-pr:
-    if: github.event_name == "pull_request" && github.event.pull_request.head.repo.full_name == "Opentrons/opentrons" && contains('ot3-build', toJSON(github.event.pull_request.labels))
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains('ot3-build', toJSON(github.event.pull_request.labels))
     name: "Start an OT-3 build for a requested PR"
     steps:
       - name: 'start build'

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -52,7 +52,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: side-by-side-monorepo
+          ref: heads/side-by-side-monorepo
           inputs: |
             {
               "oe-core-ref": "-",

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -52,7 +52,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: heads/side-by-side-monorepo
+          ref: side-by-side-monorepo
           inputs: |
             {
               "oe-core-ref": "-",

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   handle-push:
+    runs-on: 'ubuntu-latest'
     if: github.event_name == 'push'
     name: "Start an OT-3 build for a branch push"
     steps:
@@ -38,6 +39,7 @@ jobs:
 
 
   handle-pr:
+    runs-on: 'ubuntu-latest'
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains('ot3-build', toJSON(github.event.pull_request.labels))
     name: "Start an OT-3 build for a requested PR"
     steps:

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -47,19 +47,3 @@ jobs:
         run: |
            echo "${{ github.event.pull_request.head.repo.full_name }}"
            echo "${{ toJSON(github.event.pull_request.labels }}"
-      - name: 'start build'
-        uses: octokit/request-action@v2.x
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
-          owner: opentrons
-          repo: oe-core
-          workflow-id: build-ot3-actions.yml
-          ref: side-by-side-monorepo
-          inputs: |
-            {
-              "oe-core-ref": "-",
-              "monorepo-ref": "${{github.head_ref}}",
-              "infra-stage": "stage-prod"
-            }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   handle-push:
-    if: ${{ github.event_name == "push" }}
+    if: github.event_name == "push"
     name: "Start an OT-3 build for a branch push"
     steps:
       - name: 'start build'

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -44,7 +44,7 @@ jobs:
     name: "Start an OT-3 build for a requested PR"
     steps:
       - name: 'whatever'
-        runs: |
+        run: |
           cat not-exists
       - name: 'start build'
         uses: octokit/request-action@v2.x

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -1,0 +1,59 @@
+name: 'Start OT-3 build'
+on:
+  push:
+    branches:
+      - edge
+      - chore_bump-*
+      - chore_release-*
+      - release*
+    tags:
+      - v*
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+
+jobs:
+  handle-push:
+    if: ${{ github.event_name == "push" }}
+    name: "Start an OT-3 build for a branch push"
+    steps:
+      - name: 'start build'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: side-by-side-monorepo
+          inputs: |
+            {
+              "oe-core-ref": "-",
+              "monorepo-ref": "${{github.ref}}",
+              "infra-stage": "stage-prod"
+            }
+
+
+  handle-pr:
+    if: github.event_name == "pull_request" && github.event.pull_request.head.repo.full_name == "Opentrons/opentrons" && contains('ot3-build', toJSON(github.event.pull_request.labels))
+    name: "Start an OT-3 build for a requested PR"
+    steps:
+      - name: 'start build'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: side-by-side-monorepo
+          inputs: |
+            {
+              "oe-core-ref": "-",
+              "monorepo-ref": "${{github.head_ref}}",
+              "infra-stage": "stage-prod"
+            }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -29,7 +29,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: side-by-side-monorepo
+          ref: main
           inputs: |
             {
               "oe-core-ref": "-",
@@ -52,7 +52,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: side-by-side-monorepo
+          ref: main
           inputs: |
             {
               "oe-core-ref": "-",

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -46,4 +46,4 @@ jobs:
       - name: 'echo stuff'
         run: |
            echo "${{ github.event.pull_request.head.repo.full_name }}"
-           echo "${{ toJSON(github.event.pull_request.labels }}"
+           echo "${{ toJSON(github.event.pull_request.labels) }}"

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -40,9 +40,13 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains('ot3-build', toJSON(github.event.pull_request.labels))
+    if: github.event_name == 'pull_request'
     name: "Start an OT-3 build for a requested PR"
     steps:
+      - name: 'echo stuff'
+        run: |
+           echo "${{ github.event.pull_request.head.repo.full_name }}"
+           echo "${{ toJSON(github.event.pull_request.labels }}"
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -40,10 +40,22 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains('ot3-build', toJSON(github.event.pull_request.labels))
     name: "Start an OT-3 build for a requested PR"
     steps:
-      - name: 'echo stuff'
-        run: |
-           echo "${{ github.event.pull_request.head.repo.full_name }}"
-           echo "${{ toJSON(github.event.pull_request.labels) }}"
+      - name: 'start build'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: side-by-side-monorepo
+          inputs: |
+            {
+              "oe-core-ref": "-",
+              "monorepo-ref": "${{github.head_ref}}",
+              "infra-stage": "stage-prod"
+            }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -40,12 +40,9 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
     name: "Start an OT-3 build for a requested PR"
     steps:
-      - name: 'whatever'
-        run: |
-          cat not-exists
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -33,7 +33,7 @@ jobs:
           inputs: |
             {
               "oe-core-ref": "-",
-              "monorepo-ref": "${{github.ref}}",
+              "monorepo-ref": "${{ github.ref }}",
               "infra-stage": "stage-prod"
             }
 
@@ -56,6 +56,6 @@ jobs:
           inputs: |
             {
               "oe-core-ref": "-",
-              "monorepo-ref": "${{github.head_ref}}",
+              "monorepo-ref": "${{ github.head_ref }}",
               "infra-stage": "stage-prod"
             }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
@@ -46,7 +46,7 @@ jobs:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons


### PR DESCRIPTION
This workflow will start OT-3 system builds if
- This is a push to edge, release, or a release-related branch
- This is a pull request and it has the label ot3-build

Before merging, this should be changed to a `pull_request_target` trigger.

Also can't merge this until https://github.com/Opentrons/oe-core/pull/34 is merged.