### PR TITLE
 feat(app): wire up attach and detach pipette flow and adjust modals

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -37,5 +37,8 @@
   "move_gantry_to_front": "Move gantry to front",
   "pipette_attached": "{{pipetteName}} Successfully Attached",
   "pipette_failed_to_attach": "Pipette failed to attach",
-  "cal_pipette": "Calibrate pipette"
+  "cal_pipette": "Calibrate pipette",
+  "get_started_detach": "To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right",
+  "pipette_failed_to_detach": "Pipette failed to detach",
+  "pipette_detached": "Pipette Successfully Detached"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -36,5 +36,6 @@
   "remove_labware": "<block>To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.</block>",
   "move_gantry_to_front": "Move gantry to front",
   "pipette_attached": "{{pipetteName}} Successfully Attached",
-  "pipette_failed_to_attach": "Pipette failed to attach"
+  "pipette_failed_to_attach": "Pipette failed to attach",
+  "cal_pipette": "Calibrate pipette"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -35,5 +35,6 @@
   "detach_pipette": "Detach a pipette",
   "remove_labware": "<block>To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.</block>",
   "move_gantry_to_front": "Move gantry to front",
-  "pipette_attached": "{{pipetteName}} Successfully Attached"
+  "pipette_attached": "{{pipetteName}} Successfully Attached",
+  "pipette_failed_to_attach": "Pipette failed to attach"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -22,8 +22,8 @@
   "attach_this_pipette": "Attach this pipette",
   "single_or_8_channel": "{{single}} or {{eight}} pipette",
   "ninety_six_channel": "{{ninetySix}} pipette",
-  "mount_pipette": "Mount Pipette",
-  "hold_onto_pipette": "<block>Hold onto the pipette so it does not fall. Attach the pipette to the robot by alinging the pins and ensuring a secure connection with the pins.</block><block>If you are stuck on this screen after you have connected a pipette, there is more than likely a problem with the pipette.</block>",
+  "connect_and_screw_in_pipette": "Connect and screw in pipette",
+  "hold_onto_pipette": "<block>Hold onto the pipette so it does not fall. Attach the pipette to the robot by alinging the pins and ensuring a secure connection with the pins.</block><block>Hold the pipette in place and use the hex screwdriver to tighten the pipette screws. Then test that the pipette is securely attached by gently pulling it side to side.</block>",
   "continue": "Continue",
   "detach_and_reattach": "Detach and reattach pipette",
   "grab_screwdriver": "While continuing to hold in place, grab your 2.5mm driver and tighten screws as shown in the animation. Test the pipette attachment by giving it a wiggle before pressing continue",
@@ -34,5 +34,6 @@
   "attach_pipette": "Attach a pipette",
   "detach_pipette": "Detach a pipette",
   "remove_labware": "<block>To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.</block>",
-  "move_gantry_to_front": "Move gantry to front"
+  "move_gantry_to_front": "Move gantry to front",
+  "pipette_attached": "{{pipetteName}} Successfully Attached"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -32,5 +32,7 @@
   "loose_detach": "Loosen Screws and Detach",
   "hold_and_loosen": "Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette",
   "attach_pipette": "Attach a pipette",
-  "detach_pipette": "Detach a pipette"
+  "detach_pipette": "Detach a pipette",
+  "remove_labware": "<block>To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.</block>",
+  "move_gantry_to_front": "Move gantry to front"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -38,7 +38,7 @@
   "pipette_attached": "{{pipetteName}} Successfully Attached",
   "pipette_failed_to_attach": "Pipette failed to attach",
   "cal_pipette": "Calibrate pipette",
-  "get_started_detach": "To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right",
+  "get_started_detach": "<block>To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right</block>",
   "pipette_failed_to_detach": "Pipette failed to detach",
   "pipette_detached": "Pipette Successfully Detached"
 }

--- a/app/src/molecules/GenericWizardTile/__tests__/GenericWizardTile.test.tsx
+++ b/app/src/molecules/GenericWizardTile/__tests__/GenericWizardTile.test.tsx
@@ -18,7 +18,7 @@ describe('GenericWizardTile', () => {
       rightHandBody: <div>right hand body</div>,
       bodyText: 'body',
       proceed: jest.fn(),
-      proceedButtonText: 'Continue',
+      proceedButtonText: <div>Continue</div>,
       header: 'header',
       getHelp: 'getHelpUrl',
     }

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-import capitalize from 'lodash/capitalize'
 import { useTranslation } from 'react-i18next'
 import {
   DIRECTION_COLUMN,
@@ -27,7 +26,7 @@ export interface GenericWizardTileProps {
   getHelp?: string
   back?: () => void
   proceed?: () => void
-  proceedButtonText?: string
+  proceedButtonText?: React.ReactNode
   proceedIsDisabled?: boolean
 }
 
@@ -98,7 +97,7 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
         {getHelp != null ? <NeedHelpLink href={getHelp} /> : null}
         {proceed != null ? (
           <PrimaryButton disabled={proceedIsDisabled} onClick={proceed}>
-            {capitalize(proceedButtonText)}
+            {proceedButtonText}
           </PrimaryButton>
         ) : null}
       </Flex>

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -28,6 +28,7 @@ export interface GenericWizardTileProps {
   proceed?: () => void
   proceedButtonText?: React.ReactNode
   proceedIsDisabled?: boolean
+  proceedButton?: JSX.Element
 }
 
 const GO_BACK_BUTTON_STYLE = css`
@@ -49,6 +50,7 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
     proceed,
     proceedButtonText,
     proceedIsDisabled,
+    proceedButton,
   } = props
   const { t } = useTranslation('shared')
 
@@ -95,11 +97,12 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
           </Btn>
         ) : null}
         {getHelp != null ? <NeedHelpLink href={getHelp} /> : null}
-        {proceed != null ? (
+        {proceed != null && proceedButton == null ? (
           <PrimaryButton disabled={proceedIsDisabled} onClick={proceed}>
             {proceedButtonText}
           </PrimaryButton>
         ) : null}
+        {proceed == null && proceedButton != null ? proceedButton : null}
       </Flex>
     </Flex>
   )

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -55,9 +55,16 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
   const { t } = useTranslation('shared')
 
   let buttonPositioning: string = ''
-  if ((back != null || getHelp != null) && proceed != null) {
+  if (
+    (back != null || getHelp != null) &&
+    (proceedButton != null || proceed != null)
+  ) {
     buttonPositioning = JUSTIFY_SPACE_BETWEEN
-  } else if (back == null && getHelp == null && proceed != null) {
+  } else if (
+    back == null &&
+    getHelp == null &&
+    (proceedButton != null || proceed != null)
+  ) {
     buttonPositioning = JUSTIFY_FLEX_END
   } else if ((back != null || getHelp != null) && proceed == null) {
     buttonPositioning = JUSTIFY_START

--- a/app/src/molecules/WizardRequiredEquipmentList/equipmentImages.ts
+++ b/app/src/molecules/WizardRequiredEquipmentList/equipmentImages.ts
@@ -2,4 +2,7 @@
 
 export const equipmentImages = {
   calibration_probe: require('../../assets/images/change-pip/calibration_probe.png'),
+  //  TODO(jr, 11/17/22): update screwdriver and pipette images
+  hex_screwdriver: require('../../assets/images/change-pip/calibration_probe.png'),
+  gen3_pipette: require('../../assets/images/change-pip/calibration_probe.png'),
 }

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -81,7 +81,7 @@ function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
         width="100%"
       >
         <Flex
-          height="6rem"
+          height={loadName in equipmentImages ? '3.5rem' : '6rem'}
           flex="0 1 30%"
           justifyContent={JUSTIFY_CENTER}
           alignItems={ALIGN_CENTER}

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -47,19 +47,24 @@ export const BeforeBeginning = (
 
   let equipmentList = [CALIBRATION_PROBE]
   let proceedButtonText: string = t('get_started')
-  let bodyText: string = t('remove_labware_to_get_started')
+  let bodyText: string = ''
 
   switch (flowType) {
     case FLOWS.CALIBRATE: {
-      equipmentList = [CALIBRATION_PROBE]
+      bodyText = t('remove_labware_to_get_started')
       break
     }
     case FLOWS.ATTACH: {
       equipmentList = [PIPETTE, CALIBRATION_PROBE, HEX_SCREWDRIVER]
       proceedButtonText = t('move_gantry_to_front')
       bodyText = t('remove_labware')
+      break
     }
-    //  TODO(jr, 11/17/22): wire up detach flow
+    case FLOWS.DETACH: {
+      equipmentList = [HEX_SCREWDRIVER]
+      bodyText = t('get_started_detach')
+      break
+    }
   }
   const rightHandBody = (
     <WizardRequiredEquipmentList width="100%" equipmentList={equipmentList} />

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { Flex, Icon, JUSTIFY_CENTER } from '@opentrons/components'
+import { fetchPipettes, FETCH_PIPETTES } from '../../redux/pipettes'
+import {
+  getRequestById,
+  useDispatchApiRequests,
+  PENDING,
+  SUCCESS,
+  FAILURE,
+} from '../../redux/robot-api'
+import { PrimaryButton } from '../../atoms/buttons'
+
+import type { RequestState } from '../../redux/robot-api/types'
+import type { State } from '../../redux/types'
+
+interface CheckPipetteButtonProps {
+  robotName: string
+  proceedButtonText: string
+  proceed: () => void
+}
+export const CheckPipetteButton = (
+  props: CheckPipetteButtonProps
+): JSX.Element => {
+  const { robotName, proceedButtonText, proceed } = props
+  const fetchPipettesRequestId = React.useRef<string | null>(null)
+  const [dispatch] = useDispatchApiRequests(dispatchedAction => {
+    if (
+      dispatchedAction.type === FETCH_PIPETTES &&
+      'requestId' in dispatchedAction.meta &&
+      dispatchedAction.meta.requestId
+    ) {
+      fetchPipettesRequestId.current = dispatchedAction.meta.requestId
+    }
+  })
+  const handleCheckPipette = (): void =>
+    dispatch(fetchPipettes(robotName, true))
+  const requestStatus = useSelector<State, RequestState | null>(state =>
+    fetchPipettesRequestId.current
+      ? getRequestById(state, fetchPipettesRequestId.current)
+      : null
+  )?.status
+
+  const isPending = requestStatus === PENDING
+
+  React.useEffect(() => {
+    //  if requestStatus is FAILURE then the error modal will be in the results page
+    if (requestStatus === SUCCESS || requestStatus === FAILURE) proceed()
+  }, [proceed, requestStatus])
+
+  return (
+    <PrimaryButton disabled={isPending} onClick={handleCheckPipette}>
+      {isPending ? (
+        //  TODO(jr 11/17/22): temporary spinner until we implement the simmer state
+        <Flex width="5rem" justifyContent={JUSTIFY_CENTER}>
+          <Icon name="ot-spinner" height="1rem" spin />
+        </Flex>
+      ) : (
+        proceedButtonText
+      )}
+    </PrimaryButton>
+  )
+}

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import capitalize from 'lodash/capitalize'
 import { useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -19,7 +20,7 @@ export const DetachPipette = (props: PipetteWizardStepProps): JSX.Element => {
         <img src={detachPipette} width="100%" alt="Detach pipette" />
       }
       bodyText={<StyledText as="p">{t('hold_and_loosen')}</StyledText>}
-      proceedButtonText={t('shared:continue')}
+      proceedButtonText={capitalize(t('shared:continue'))}
       proceed={proceed}
       back={goBack}
     />

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -5,10 +5,11 @@ import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import detachPipette from '../../assets/images/change-pip/single-channel-detach-pipette.png'
+import { CheckPipetteButton } from './CheckPipetteButton'
 import type { PipetteWizardStepProps } from './types'
 
 export const DetachPipette = (props: PipetteWizardStepProps): JSX.Element => {
-  const { isRobotMoving, goBack, proceed } = props
+  const { isRobotMoving, goBack, proceed, robotName } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
 
   if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
@@ -20,9 +21,14 @@ export const DetachPipette = (props: PipetteWizardStepProps): JSX.Element => {
         <img src={detachPipette} width="100%" alt="Detach pipette" />
       }
       bodyText={<StyledText as="p">{t('hold_and_loosen')}</StyledText>}
-      proceedButtonText={capitalize(t('shared:continue'))}
-      proceed={proceed}
       back={goBack}
+      proceedButton={
+        <CheckPipetteButton
+          robotName={robotName}
+          proceedButtonText={capitalize(t('shared:continue'))}
+          proceed={proceed}
+        />
+      }
     />
   )
 }

--- a/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
@@ -8,6 +8,7 @@ import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import screwPattern from '../../assets/images/change-pip/screw-pattern.png'
 import { fetchPipettes, FETCH_PIPETTES } from '../../redux/pipettes'
 import {
+  FAILURE,
   getRequestById,
   PENDING,
   SUCCESS,
@@ -40,7 +41,8 @@ export const MountPipette = (props: PipetteWizardStepProps): JSX.Element => {
   const isPending = requestStatus === PENDING
 
   React.useEffect(() => {
-    if (requestStatus === SUCCESS) proceed()
+    //  if requestStatus is FAILURE then the error modal will be in the results page
+    if (requestStatus === SUCCESS || requestStatus === FAILURE) proceed()
   }, [proceed, requestStatus])
 
   return (
@@ -68,7 +70,7 @@ export const MountPipette = (props: PipetteWizardStepProps): JSX.Element => {
       }
       proceedButtonText={
         isPending ? (
-          //  temporary spinner until we implement the simmer state
+          //  TODO(jr 11/17/22): temporary spinner until we implement the simmer state
           <Flex width="5rem" justifyContent={JUSTIFY_CENTER}>
             <Icon name="ot-spinner" height="1rem" spin />
           </Flex>

--- a/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
@@ -25,10 +25,9 @@ export const MountPipette = (props: PipetteWizardStepProps): JSX.Element => {
   const [dispatch] = useDispatchApiRequests(dispatchedAction => {
     if (
       dispatchedAction.type === FETCH_PIPETTES &&
-      // @ts-expect-error(sa, 2021-05-27): avoiding src code change, need to type narrow
+      'requestId' in dispatchedAction.meta &&
       dispatchedAction.meta.requestId
     ) {
-      // @ts-expect-error(sa, 2021-05-27): avoiding src code change, need to type narrow
       fetchPipettesRequestId.current = dispatchedAction.meta.requestId
     }
   })

--- a/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
@@ -1,48 +1,16 @@
 import * as React from 'react'
 import capitalize from 'lodash/capitalize'
 import { Trans, useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
-import { Flex, Icon, JUSTIFY_CENTER } from '@opentrons/components'
+import { Flex, JUSTIFY_CENTER } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import screwPattern from '../../assets/images/change-pip/screw-pattern.png'
-import { fetchPipettes, FETCH_PIPETTES } from '../../redux/pipettes'
-import {
-  FAILURE,
-  getRequestById,
-  PENDING,
-  SUCCESS,
-  useDispatchApiRequests,
-} from '../../redux/robot-api'
-import type { RequestState } from '../../redux/robot-api/types'
-import type { State } from '../../redux/types'
+import { CheckPipetteButton } from './CheckPipetteButton'
 import type { PipetteWizardStepProps } from './types'
 
 export const MountPipette = (props: PipetteWizardStepProps): JSX.Element => {
   const { proceed, goBack, robotName } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  const fetchPipettesRequestId = React.useRef<string | null>(null)
-  const [dispatch] = useDispatchApiRequests(dispatchedAction => {
-    if (
-      dispatchedAction.type === FETCH_PIPETTES &&
-      'requestId' in dispatchedAction.meta &&
-      dispatchedAction.meta.requestId
-    ) {
-      fetchPipettesRequestId.current = dispatchedAction.meta.requestId
-    }
-  })
-  const handleClick = (): void => dispatch(fetchPipettes(robotName, true))
-  const requestStatus = useSelector<State, RequestState | null>(state =>
-    fetchPipettesRequestId.current
-      ? getRequestById(state, fetchPipettesRequestId.current)
-      : null
-  )?.status
-  const isPending = requestStatus === PENDING
-
-  React.useEffect(() => {
-    //  if requestStatus is FAILURE then the error modal will be in the results page
-    if (requestStatus === SUCCESS || requestStatus === FAILURE) proceed()
-  }, [proceed, requestStatus])
 
   return (
     <GenericWizardTile
@@ -67,19 +35,14 @@ export const MountPipette = (props: PipetteWizardStepProps): JSX.Element => {
           }}
         />
       }
-      proceedButtonText={
-        isPending ? (
-          //  TODO(jr 11/17/22): temporary spinner until we implement the simmer state
-          <Flex width="5rem" justifyContent={JUSTIFY_CENTER}>
-            <Icon name="ot-spinner" height="1rem" spin />
-          </Flex>
-        ) : (
-          capitalize(t('continue'))
-        )
-      }
       back={goBack}
-      proceed={handleClick}
-      proceedIsDisabled={isPending}
+      proceedButton={
+        <CheckPipetteButton
+          proceed={proceed}
+          robotName={robotName}
+          proceedButtonText={capitalize(t('continue'))}
+        />
+      }
     />
   )
 }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -13,7 +13,7 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
   let header: string = 'unknown results screen'
   let iconColor: string = COLORS.successEnabled
   let isSuccess: boolean = true
-
+  let buttonText: string = t('shared:exit')
   switch (flowType) {
     case FLOWS.CALIBRATE: {
       header = t('pip_cal_success')
@@ -23,6 +23,7 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
       if (attachedPipette[mount] != null) {
         const pipetteName = attachedPipette[mount]?.modelSpecs.displayName
         header = t('pipette_attached', { pipetteName: pipetteName })
+        buttonText = t('cal_pipette')
       } else {
         header = t('pipette_failed_to_attach')
         iconColor = COLORS.errorEnabled
@@ -43,7 +44,7 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
         onClick={proceed}
         aria-label="Results_exit"
       >
-        {t('shared:exit')}
+        {buttonText}
       </PrimaryButton>
     </SimpleWizardBody>
   )

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -29,8 +29,18 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
         iconColor = COLORS.errorEnabled
         isSuccess = false
       }
+      break
     }
-    //  TODO(jr, 10/26/22): wire up the other flows
+    case FLOWS.DETACH: {
+      if (attachedPipette[mount] != null) {
+        header = t('pipette_failed_to_detach')
+        iconColor = COLORS.errorEnabled
+        isSuccess = false
+      } else {
+        header = t('pipette_detached')
+      }
+      break
+    }
   }
 
   return (

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -10,27 +10,33 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
   const { proceed, flowType, attachedPipette, mount } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
 
-  // TODO(jr 11/17/22): add error states
-  const pipetteName = attachedPipette[mount]?.modelSpecs.displayName ?? ''
-
   let header: string = 'unknown results screen'
+  let iconColor: string = COLORS.successEnabled
+  let isSuccess: boolean = true
+
   switch (flowType) {
     case FLOWS.CALIBRATE: {
       header = t('pip_cal_success')
       break
     }
     case FLOWS.ATTACH: {
-      header = t('pipette_attached', { pipetteName: pipetteName })
+      if (attachedPipette[mount] != null) {
+        const pipetteName = attachedPipette[mount]?.modelSpecs.displayName
+        header = t('pipette_attached', { pipetteName: pipetteName })
+      } else {
+        header = t('pipette_failed_to_attach')
+        iconColor = COLORS.errorEnabled
+        isSuccess = false
+      }
     }
     //  TODO(jr, 10/26/22): wire up the other flows
   }
 
   return (
     <SimpleWizardBody
-      iconColor={COLORS.successEnabled}
+      iconColor={iconColor}
       header={header}
-      //  TODO(jr, 10/26/22): wire up isSuccess when we add error states
-      isSuccess={true}
+      isSuccess={isSuccess}
     >
       <PrimaryButton
         textTransform={TEXT_TRANSFORM_CAPITALIZE}

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -7,15 +7,20 @@ import { FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
 
 export const Results = (props: PipetteWizardStepProps): JSX.Element => {
-  const { proceed, flowType } = props
+  const { proceed, flowType, attachedPipette, mount } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
 
-  //  TODO(jr, 10/26/22): change header to let when we plug in other flows
-  //  and add error states
-  const header = t('pip_cal_success')
+  // TODO(jr 11/17/22): add error states
+  const pipetteName = attachedPipette[mount]?.modelSpecs.displayName ?? ''
+
+  let header: string = 'unknown results screen'
   switch (flowType) {
     case FLOWS.CALIBRATE: {
+      header = t('pip_cal_success')
       break
+    }
+    case FLOWS.ATTACH: {
+      header = t('pipette_attached', { pipetteName: pipetteName })
     }
     //  TODO(jr, 10/26/22): wire up the other flows
   }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -6,8 +6,18 @@ import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
 
-export const Results = (props: PipetteWizardStepProps): JSX.Element => {
-  const { proceed, flowType, attachedPipette, mount } = props
+interface ResultsProps extends PipetteWizardStepProps {
+  handleCleanUpAndClose: () => void
+}
+
+export const Results = (props: ResultsProps): JSX.Element => {
+  const {
+    proceed,
+    flowType,
+    attachedPipette,
+    mount,
+    handleCleanUpAndClose,
+  } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
 
   let header: string = 'unknown results screen'
@@ -43,6 +53,14 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
     }
   }
 
+  const handleProceed = (): void => {
+    if (flowType === FLOWS.DETACH) {
+      handleCleanUpAndClose()
+    } else {
+      proceed()
+    }
+  }
+
   return (
     <SimpleWizardBody
       iconColor={iconColor}
@@ -51,7 +69,7 @@ export const Results = (props: PipetteWizardStepProps): JSX.Element => {
     >
       <PrimaryButton
         textTransform={TEXT_TRANSFORM_CAPITALIZE}
-        onClick={proceed}
+        onClick={handleProceed}
         aria-label="Results_exit"
       >
         {buttonText}

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -25,6 +25,7 @@ describe('AttachProbe', () => {
   let props: React.ComponentProps<typeof AttachProbe>
   beforeEach(() => {
     props = {
+      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -57,71 +57,111 @@ describe('BeforeBeginning', () => {
     // mockNeedHelpLink.mockReturnValue(<div>mock need help link</div>)
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
   })
-  it('returns the correct information for calibrate flow', async () => {
-    const { getByText, getByAltText, getByRole } = render(props)
-    getByText('Before you begin')
-    getByText(
-      'To get started, remove labware from the rest of the deck and clean up the work area to make attachment and calibration easier. Also gather the needed equipment shown on the right hand side'
-    )
-    getByText(
-      'The calibration probe is included with the robot and should be stored on the right hand side of the door opening.'
-    )
-    getByText('You will need:')
-    // getByText('mock need help link')
-    getByAltText('Calibration Probe')
-    const proceedBtn = getByRole('button', { name: 'Get started' })
-    fireEvent.click(proceedBtn)
-    expect(props.chainRunCommands).toHaveBeenCalledWith(
-      [
-        {
-          commandType: 'home',
-          params: {},
-        },
-        {
-          commandType: 'loadPipette',
-          params: {
-            mount: LEFT,
-            pipetteId: 'abc',
-            pipetteName: 'p1000_single_gen3',
+  describe('calibrate flow', () => {
+    it('returns the correct information for calibrate flow', async () => {
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the rest of the deck and clean up the work area to make attachment and calibration easier. Also gather the needed equipment shown on the right hand side'
+      )
+      getByText(
+        'The calibration probe is included with the robot and should be stored on the right hand side of the door opening.'
+      )
+      getByText('You will need:')
+      // getByText('mock need help link')
+      getByAltText('Calibration Probe')
+      const proceedBtn = getByRole('button', { name: 'Get started' })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: {},
           },
-        },
-        {
-          commandType: 'calibration/moveToLocation',
-          params: { pipetteId: 'abc', location: 'attachOrDetach' },
-        },
-      ],
-      false
-    )
-    await waitFor(() => {
-      expect(props.proceed).toHaveBeenCalled()
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
+          {
+            commandType: 'calibration/moveToLocation',
+            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
+    it('returns the correct information for in progress modal when robot is moving', () => {
+      props = {
+        ...props,
+        isRobotMoving: true,
+      }
+      const { getByText } = render(props)
+      getByText('mock in progress')
+    })
+
+    it('continue button is disabled when isCreateLoading is true', () => {
+      props = {
+        ...props,
+        isCreateLoading: true,
+      }
+      const { getByRole } = render(props)
+      const proceedBtn = getByRole('button', { name: 'Get started' })
+      expect(proceedBtn).toBeDisabled()
+    })
+
+    it('renders the error modal screen when errorMessage is true', () => {
+      props = {
+        ...props,
+        errorMessage: 'error shmerror',
+      }
+      const { getByText } = render(props)
+      getByText('Error encountered')
+      getByText('error shmerror')
     })
   })
-  it('returns the correct information for in progress modal when robot is moving', () => {
-    props = {
-      ...props,
-      isRobotMoving: true,
-    }
-    const { getByText } = render(props)
-    getByText('mock in progress')
-  })
-
-  it('continue button is disabled when isCreateLoading is true', () => {
-    props = {
-      ...props,
-      isCreateLoading: true,
-    }
-    const { getByRole } = render(props)
-    const proceedBtn = getByRole('button', { name: 'Get started' })
-    expect(proceedBtn).toBeDisabled()
-  })
-
-  it('renders the error modal screen when errorMessage is true', () => {
-    props = {
-      ...props,
-      errorMessage: 'error shmerror',
-    }
-    const { getByText } = render(props)
-    getByText('Error encountered')
-    getByText('error shmerror')
+  describe('attach flow', () => {
+    it('renders the modal with all correct text. clicking on proceed button sends commands', async () => {
+      props = {
+        ...props,
+        attachedPipette: { left: null, right: null },
+        flowType: FLOWS.ATTACH,
+      }
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.'
+      )
+      getByText(
+        'The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.'
+      )
+      getByAltText('GEN3 Pipette')
+      getByText('You will need:')
+      getByAltText('Calibration Probe')
+      getByAltText('2.5 mm Hex Screwdriver')
+      getByText(
+        'Provided with robot. Using another size can strip the instruments’s screws.'
+      )
+      const proceedBtn = getByRole('button', { name: 'Move gantry to front' })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: {},
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -165,4 +165,48 @@ describe('BeforeBeginning', () => {
       })
     })
   })
+  describe('detach flow', () => {
+    it('renders the modal with all correct text. clicking on proceed button sends commands for detach flow', async () => {
+      props = {
+        ...props,
+        attachedPipette: { left: mockPipette, right: null },
+        flowType: FLOWS.DETACH,
+      }
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right'
+      )
+      getByAltText('2.5 mm Hex Screwdriver')
+      getByText(
+        'Provided with robot. Using another size can strip the instruments’s screws.'
+      )
+      const proceedBtn = getByRole('button', { name: 'Get started' })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: {},
+          },
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
+          {
+            commandType: 'calibration/moveToLocation',
+            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
+  })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -39,6 +39,7 @@ describe('BeforeBeginning', () => {
   let props: React.ComponentProps<typeof BeforeBeginning>
   beforeEach(() => {
     props = {
+      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { renderWithProviders } from '@opentrons/components'
+import * as RobotApi from '../../../redux/robot-api'
+import { fetchPipettes } from '../../../redux/pipettes'
+import { CheckPipetteButton } from '../CheckPipetteButton'
+
+import { DispatchApiRequestType } from '../../../redux/robot-api'
+
+jest.mock('../../../redux/robot-api')
+jest.mock('../../../redux/pipettes')
+
+const mockFetchPipettes = fetchPipettes as jest.MockedFunction<
+  typeof fetchPipettes
+>
+const mockUseDispatchApiRequests = RobotApi.useDispatchApiRequests as jest.MockedFunction<
+  typeof RobotApi.useDispatchApiRequests
+>
+const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
+  typeof RobotApi.getRequestById
+>
+const render = (props: React.ComponentProps<typeof CheckPipetteButton>) => {
+  return renderWithProviders(<CheckPipetteButton {...props} />)[0]
+}
+
+describe('CheckPipetteButton', () => {
+  let props: React.ComponentProps<typeof CheckPipetteButton>
+  let dispatchApiRequest: DispatchApiRequestType
+  beforeEach(() => {
+    props = {
+      robotName: 'otie',
+      proceed: jest.fn(),
+      proceedButtonText: 'continue',
+    }
+    dispatchApiRequest = jest.fn()
+    mockGetRequestById.mockReturnValue(null)
+    mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, ['id']])
+  })
+  it('clicking on the button dispatches api request', () => {
+    const { getByRole } = render(props)
+    const proceedBtn = getByRole('button', { name: 'continue' })
+    fireEvent.click(proceedBtn)
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
+  })
+})

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -11,12 +11,17 @@ import { InProgressModal } from '../../../molecules/InProgressModal/InProgressMo
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { FLOWS } from '../constants'
 import { DetachPipette } from '../DetachPipette'
+import { CheckPipetteButton } from '../CheckPipetteButton'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
+jest.mock('../CheckPipetteButton')
 jest.mock('../../../molecules/InProgressModal/InProgressModal')
 
 const mockInProgressModal = InProgressModal as jest.MockedFunction<
   typeof InProgressModal
+>
+const mockCheckPipetteButton = CheckPipetteButton as jest.MockedFunction<
+  typeof CheckPipetteButton
 >
 const render = (props: React.ComponentProps<typeof DetachPipette>) => {
   return renderWithProviders(<DetachPipette {...props} />, {
@@ -44,6 +49,7 @@ describe('DetachPipette', () => {
       isRobotMoving: false,
     }
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
+    mockCheckPipetteButton.mockReturnValue(<div>mock check pipette button</div>)
   })
   it('returns the correct information, buttons work as expected', () => {
     const { getByText, getByAltText, getByRole } = render(props)
@@ -52,9 +58,7 @@ describe('DetachPipette', () => {
       'Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette'
     )
     getByAltText('Detach pipette')
-    const proceedBtn = getByRole('button', { name: 'Continue' })
-    fireEvent.click(proceedBtn)
-    expect(props.proceed).toHaveBeenCalled()
+    getByText('mock check pipette button')
     const backBtn = getByRole('button', { name: 'Go back' })
     fireEvent.click(backBtn)
     expect(props.goBack).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -31,6 +31,7 @@ describe('DetachPipette', () => {
   let props: React.ComponentProps<typeof DetachPipette>
   beforeEach(() => {
     props = {
+      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
@@ -31,6 +31,7 @@ describe('DetachProbe', () => {
   let props: React.ComponentProps<typeof DetachProbe>
   beforeEach(() => {
     props = {
+      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
@@ -1,17 +1,32 @@
 import * as React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { LEFT } from '@opentrons/shared-data'
+import * as RobotApi from '../../../redux/robot-api'
 import { i18n } from '../../../i18n'
+import { fetchPipettes } from '../../../redux/pipettes'
 import {
   mockAttachedPipette,
   mockGen3P1000PipetteSpecs,
 } from '../../../redux/pipettes/__fixtures__'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
+import { DispatchApiRequestType } from '../../../redux/robot-api'
 import { FLOWS } from '../constants'
 import { MountPipette } from '../MountPipette'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
+jest.mock('../../../redux/robot-api')
+jest.mock('../../../redux/pipettes')
+
+const mockFetchPipettes = fetchPipettes as jest.MockedFunction<
+  typeof fetchPipettes
+>
+const mockUseDispatchApiRequests = RobotApi.useDispatchApiRequests as jest.MockedFunction<
+  typeof RobotApi.useDispatchApiRequests
+>
+const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
+  typeof RobotApi.getRequestById
+>
 const render = (props: React.ComponentProps<typeof MountPipette>) => {
   return renderWithProviders(<MountPipette {...props} />, {
     i18nInstance: i18n,
@@ -23,9 +38,11 @@ const mockPipette: AttachedPipette = {
 }
 describe('MountPipette', () => {
   let props: React.ComponentProps<typeof MountPipette>
+  let dispatchApiRequest: DispatchApiRequestType
   jest.useFakeTimers()
   beforeEach(() => {
     props = {
+      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),
@@ -37,35 +54,26 @@ describe('MountPipette', () => {
       setShowErrorMessage: jest.fn(),
       isRobotMoving: false,
     }
+    dispatchApiRequest = jest.fn()
+    mockGetRequestById.mockReturnValue(null)
+    mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, ['id']])
   })
-  it('returns the correct information, buttons work as expected', async () => {
+  it('returns the correct information, buttons work as expected', () => {
     const { getByText, getByAltText, getByRole } = render(props)
-    getByText('Mount Pipette')
+    getByText('Connect and screw in pipette')
     getByText(
       'Hold onto the pipette so it does not fall. Attach the pipette to the robot by alinging the pins and ensuring a secure connection with the pins.'
     )
     getByText(
-      'If you are stuck on this screen after you have connected a pipette, there is more than likely a problem with the pipette.'
+      'Hold the pipette in place and use the hex screwdriver to tighten the pipette screws. Then test that the pipette is securely attached by gently pulling it side to side.'
     )
-    getByRole('button', { name: 'Detach and reattach pipette' })
     getByAltText('Screw pattern')
 
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
     expect(props.goBack).toHaveBeenCalled()
-
-    await waitFor(() => {
-      jest.runOnlyPendingTimers()
-    })
-
-    getByText('P1000 Single-Channel GEN3 Pipette Detected')
-    getByText(
-      'While continuing to hold in place, grab your 2.5mm driver and tighten screws as shown in the animation. Test the pipette attachment by giving it a wiggle before pressing continue'
-    )
-    getByAltText('Screw pattern pt 2')
-    getByRole('button', { name: 'Go back' })
     const proceedBtn = getByRole('button', { name: 'Continue' })
     fireEvent.click(proceedBtn)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
@@ -2,30 +2,21 @@ import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { LEFT } from '@opentrons/shared-data'
-import * as RobotApi from '../../../redux/robot-api'
 import { i18n } from '../../../i18n'
-import { fetchPipettes } from '../../../redux/pipettes'
 import {
   mockAttachedPipette,
   mockGen3P1000PipetteSpecs,
 } from '../../../redux/pipettes/__fixtures__'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
-import { DispatchApiRequestType } from '../../../redux/robot-api'
 import { FLOWS } from '../constants'
+import { CheckPipetteButton } from '../CheckPipetteButton'
 import { MountPipette } from '../MountPipette'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
-jest.mock('../../../redux/robot-api')
-jest.mock('../../../redux/pipettes')
+jest.mock('../CheckPipetteButton')
 
-const mockFetchPipettes = fetchPipettes as jest.MockedFunction<
-  typeof fetchPipettes
->
-const mockUseDispatchApiRequests = RobotApi.useDispatchApiRequests as jest.MockedFunction<
-  typeof RobotApi.useDispatchApiRequests
->
-const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
-  typeof RobotApi.getRequestById
+const mockCheckPipetteButton = CheckPipetteButton as jest.MockedFunction<
+  typeof CheckPipetteButton
 >
 const render = (props: React.ComponentProps<typeof MountPipette>) => {
   return renderWithProviders(<MountPipette {...props} />, {
@@ -38,7 +29,6 @@ const mockPipette: AttachedPipette = {
 }
 describe('MountPipette', () => {
   let props: React.ComponentProps<typeof MountPipette>
-  let dispatchApiRequest: DispatchApiRequestType
   beforeEach(() => {
     props = {
       robotName: 'otie',
@@ -53,9 +43,7 @@ describe('MountPipette', () => {
       setShowErrorMessage: jest.fn(),
       isRobotMoving: false,
     }
-    dispatchApiRequest = jest.fn()
-    mockGetRequestById.mockReturnValue(null)
-    mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, ['id']])
+    mockCheckPipetteButton.mockReturnValue(<div>mock check pipette button</div>)
   })
   it('returns the correct information, buttons work as expected', () => {
     const { getByText, getByAltText, getByRole } = render(props)
@@ -71,8 +59,6 @@ describe('MountPipette', () => {
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
     expect(props.goBack).toHaveBeenCalled()
-    const proceedBtn = getByRole('button', { name: 'Continue' })
-    fireEvent.click(proceedBtn)
-    expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
+    getByText('mock check pipette button')
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
@@ -39,7 +39,6 @@ const mockPipette: AttachedPipette = {
 describe('MountPipette', () => {
   let props: React.ComponentProps<typeof MountPipette>
   let dispatchApiRequest: DispatchApiRequestType
-  jest.useFakeTimers()
   beforeEach(() => {
     props = {
       robotName: 'otie',

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { LEFT } from '@opentrons/shared-data'
-import { renderWithProviders } from '@opentrons/components'
+import { COLORS, renderWithProviders } from '@opentrons/components'
 import {
   mockAttachedPipette,
   mockGen3P1000PipetteSpecs,
@@ -39,8 +39,11 @@ describe('Results', () => {
     }
   })
   it('renders the correct information when pipette cal is a success for calibrate flow', () => {
-    const { getByText, getByRole } = render(props)
+    const { getByText, getByRole, getByLabelText } = render(props)
     getByText('Pipette Successfully Calibrated')
+    expect(getByLabelText('ot-check')).toHaveStyle(
+      `color: ${COLORS.successEnabled}`
+    )
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()
@@ -51,8 +54,26 @@ describe('Results', () => {
       ...props,
       flowType: FLOWS.ATTACH,
     }
-    const { getByText, getByRole } = render(props)
+    const { getByText, getByRole, getByLabelText } = render(props)
     getByText('P1000 Single-Channel GEN3 Successfully Attached')
+    expect(getByLabelText('ot-check')).toHaveStyle(
+      `color: ${COLORS.successEnabled}`
+    )
+    const exit = getByRole('button', { name: 'Results_exit' })
+    fireEvent.click(exit)
+    expect(props.proceed).toHaveBeenCalled()
+  })
+  it('renders the correct information when pipette cal is a fail for attach flow', () => {
+    props = {
+      ...props,
+      attachedPipette: { left: null, right: null },
+      flowType: FLOWS.ATTACH,
+    }
+    const { getByText, getByRole, getByLabelText } = render(props)
+    getByText('Pipette failed to attach')
+    expect(getByLabelText('ot-alert')).toHaveStyle(
+      `color: ${COLORS.errorEnabled}`
+    )
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -25,6 +25,7 @@ describe('Results', () => {
   let props: React.ComponentProps<typeof Results>
   beforeEach(() => {
     props = {
+      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),
@@ -40,6 +41,18 @@ describe('Results', () => {
   it('renders the correct information when pipette cal is a success for calibrate flow', () => {
     const { getByText, getByRole } = render(props)
     getByText('Pipette Successfully Calibrated')
+    const exit = getByRole('button', { name: 'Results_exit' })
+    fireEvent.click(exit)
+    expect(props.proceed).toHaveBeenCalled()
+  })
+
+  it('renders the correct information when pipette cal is a success for attach flow', () => {
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+    }
+    const { getByText, getByRole } = render(props)
+    getByText('P1000 Single-Channel GEN3 Successfully Attached')
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -50,7 +50,7 @@ describe('Results', () => {
     expect(props.proceed).toHaveBeenCalled()
   })
 
-  it('renders the correct information when pipette cal is a success for attach flow', () => {
+  it('renders the correct information when pipette wizard is a success for attach flow', () => {
     props = {
       ...props,
       flowType: FLOWS.ATTACH,
@@ -65,7 +65,7 @@ describe('Results', () => {
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()
   })
-  it('renders the correct information when pipette cal is a fail for attach flow', () => {
+  it('renders the correct information when pipette wizard is a fail for attach flow', () => {
     props = {
       ...props,
       attachedPipette: { left: null, right: null },
@@ -73,6 +73,35 @@ describe('Results', () => {
     }
     const { getByText, getByRole, getByLabelText } = render(props)
     getByText('Pipette failed to attach')
+    expect(getByLabelText('ot-alert')).toHaveStyle(
+      `color: ${COLORS.errorEnabled}`
+    )
+    const exit = getByRole('button', { name: 'Results_exit' })
+    fireEvent.click(exit)
+    expect(props.proceed).toHaveBeenCalled()
+  })
+  it('renders the correct information when pipette wizard is a success for detach flow', () => {
+    props = {
+      ...props,
+      attachedPipette: { left: null, right: null },
+      flowType: FLOWS.DETACH,
+    }
+    const { getByText, getByRole, getByLabelText } = render(props)
+    getByText('Pipette Successfully Detached')
+    expect(getByLabelText('ot-check')).toHaveStyle(
+      `color: ${COLORS.successEnabled}`
+    )
+    const exit = getByRole('button', { name: 'Results_exit' })
+    fireEvent.click(exit)
+    expect(props.proceed).toHaveBeenCalled()
+  })
+  it('renders the correct information when pipette wizard is a fail for detach flow', () => {
+    props = {
+      ...props,
+      flowType: FLOWS.DETACH,
+    }
+    const { getByText, getByRole, getByLabelText } = render(props)
+    getByText('Pipette failed to detach')
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${COLORS.errorEnabled}`
     )

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -10,6 +10,7 @@ import { i18n } from '../../../i18n'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { Results } from '../Results'
 import { FLOWS } from '../constants'
+
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
 const render = (props: React.ComponentProps<typeof Results>) => {
@@ -59,6 +60,7 @@ describe('Results', () => {
     expect(getByLabelText('ot-check')).toHaveStyle(
       `color: ${COLORS.successEnabled}`
     )
+    getByText('Calibrate pipette')
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -37,6 +37,7 @@ describe('Results', () => {
       errorMessage: null,
       setShowErrorMessage: jest.fn(),
       flowType: FLOWS.CALIBRATE,
+      handleCleanUpAndClose: jest.fn(),
     }
   })
   it('renders the correct information when pipette cal is a success for calibrate flow', () => {
@@ -93,7 +94,7 @@ describe('Results', () => {
     )
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard is a fail for detach flow', () => {
     props = {
@@ -107,6 +108,6 @@ describe('Results', () => {
     )
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -49,6 +49,21 @@ describe('getPipetteWizardSteps', () => {
         mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
     ] as PipetteWizardStep[]
 
     expect(getPipetteWizardSteps(FLOWS.ATTACH, LEFT)).toStrictEqual(

--- a/app/src/organisms/PipetteWizardFlows/constants.ts
+++ b/app/src/organisms/PipetteWizardFlows/constants.ts
@@ -12,11 +12,21 @@ export const FLOWS = {
   DETACH: 'DETACH',
   CALIBRATE: 'CALIBRATE',
 }
-
 export const CALIBRATION_PROBE_DISPLAY_NAME = 'Calibration Probe'
-
+export const HEX_SCREWDRIVER_DISPLAY_NAME = '2.5 mm Hex Screwdriver'
+export const PIPETTE_DISPLAY_NAME = 'GEN3 Pipette'
 //  required equipment list
 export const CALIBRATION_PROBE = {
   loadName: 'calibration_probe',
   displayName: CALIBRATION_PROBE_DISPLAY_NAME,
+}
+export const HEX_SCREWDRIVER = {
+  loadName: 'hex_screwdriver',
+  displayName: HEX_SCREWDRIVER_DISPLAY_NAME,
+  subtitle:
+    'Provided with robot. Using another size can strip the instruments’s screws.',
+}
+export const PIPETTE = {
+  loadName: 'gen3_pipette',
+  displayName: PIPETTE_DISPLAY_NAME,
 }

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -28,6 +28,9 @@ export const getPipetteWizardSteps = (
         },
         { section: SECTIONS.MOUNT_PIPETTE, mount: mount, flowType: flowType },
         { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+        { section: SECTIONS.ATTACH_PROBE, mount: mount, flowType: flowType },
+        { section: SECTIONS.DETACH_PROBE, mount: mount, flowType: flowType },
+        { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
       ]
     }
     case FLOWS.DETACH: {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -133,6 +133,7 @@ export const PipetteWizardFlows = (
     attachedPipette,
     setShowErrorMessage,
     errorMessage,
+    robotName,
   }
   const exitModal = (
     <ExitModal goBack={cancelExit} proceed={confirmExit} flowType={flowType} />

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -178,7 +178,12 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.RESULTS) {
     const handleProceed = (): void => {
-      if (flowType === FLOWS.ATTACH && currentStepIndex === 2) {
+      if (
+        flowType === FLOWS.ATTACH &&
+        currentStepIndex === 2 &&
+        //  only proceeds if we know that the pipette was successfully attached
+        attachedPipette[mount] != null
+      ) {
         proceed()
       } else {
         closeFlow()

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -117,8 +117,7 @@ export const PipetteWizardFlows = (
 
   React.useEffect(() => {
     if (isCommandMutationLoading || isStopLoading || isExiting) {
-      const timer = setTimeout(() => setIsRobotMoving(true), 700)
-      return () => clearTimeout(timer)
+      setIsRobotMoving(true)
     } else {
       setIsRobotMoving(false)
     }
@@ -185,6 +184,9 @@ export const PipetteWizardFlows = (
         attachedPipette[mount] != null
       ) {
         proceed()
+        //  if you completed detaching the pipette, robot will home and delete run
+      } else if (flowType === FLOWS.DETACH) {
+        handleCleanUpAndClose()
       } else {
         closeFlow()
       }

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -177,11 +177,23 @@ export const PipetteWizardFlows = (
       />
     )
   } else if (currentStep.section === SECTIONS.RESULTS) {
+    const handleProceed = (): void => {
+      if (flowType === FLOWS.ATTACH && currentStepIndex === 2) {
+        proceed()
+      } else {
+        closeFlow()
+      }
+    }
+
     onExit = confirmExit
     modalContent = showConfirmExit ? (
       exitModal
     ) : (
-      <Results {...currentStep} {...calibrateBaseProps} proceed={closeFlow} />
+      <Results
+        {...currentStep}
+        {...calibrateBaseProps}
+        proceed={handleProceed}
+      />
     )
   } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {
     onExit = confirmExit

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -84,7 +84,7 @@ export const PipetteWizardFlows = (
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
 
   const proceed = (): void => {
-    if (!(isCommandMutationLoading || isStopLoading || isExiting)) {
+    if (!isCommandMutationLoading) {
       setCurrentStepIndex(
         currentStepIndex !== pipetteWizardSteps.length - 1
           ? currentStepIndex + 1
@@ -103,8 +103,8 @@ export const PipetteWizardFlows = (
       ],
       false
     ).then(() => {
-      setIsExiting(false)
       if (runId !== '') stopRun(runId)
+      setIsExiting(false)
     })
   }
   const {
@@ -140,7 +140,7 @@ export const PipetteWizardFlows = (
   let onExit
   if (currentStep == null) return null
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
-  if (isExiting === true) {
+  if (isExiting) {
     modalContent = <InProgressModal description={t('stand_back')} />
   }
   if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -178,15 +178,12 @@ export const PipetteWizardFlows = (
   } else if (currentStep.section === SECTIONS.RESULTS) {
     const handleProceed = (): void => {
       if (
-        flowType === FLOWS.ATTACH &&
         currentStepIndex === 2 &&
         //  only proceeds if we know that the pipette was successfully attached
         attachedPipette[mount] != null
       ) {
         proceed()
         //  if you completed detaching the pipette, robot will home and delete run
-      } else if (flowType === FLOWS.DETACH) {
-        handleCleanUpAndClose()
       } else {
         closeFlow()
       }
@@ -200,6 +197,7 @@ export const PipetteWizardFlows = (
         {...currentStep}
         {...calibrateBaseProps}
         proceed={handleProceed}
+        handleCleanUpAndClose={handleCleanUpAndClose}
       />
     )
   } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -73,6 +73,7 @@ export interface PipetteWizardStepProps {
   attachedPipette: AttachedPipettesByMount
   setShowErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
   errorMessage: string | null
+  robotName: string
 }
 
 export type SelectablePipettes = '96-Channel' | 'Single-Channel_and_8-Channel'

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { useCreateCommandMutation } from '@opentrons/react-api-client'
 import { chainRunCommands } from './utils'
 import type { CreateCommand } from '@opentrons/shared-data'
@@ -35,13 +36,19 @@ export function useChainRunCommands(
   ) => Promise<unknown>
   isCommandMutationLoading: boolean
 } {
-  const { createRunCommand, isLoading } = useCreateRunCommandMutation(runId)
+  const [isLoading, setIsLoading] = React.useState(false)
+  const { createRunCommand } = useCreateRunCommandMutation(runId)
   return {
     chainRunCommands: (
       commands: CreateCommand[],
       continuePastCommandFailure: boolean
     ) =>
-      chainRunCommands(commands, createRunCommand, continuePastCommandFailure),
+      chainRunCommands(
+        commands,
+        createRunCommand,
+        continuePastCommandFailure,
+        setIsLoading
+      ),
     isCommandMutationLoading: isLoading,
   }
 }

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -1,34 +1,41 @@
+import * as React from 'react'
 import { CreateCommand } from '@opentrons/shared-data'
 import { CreateRunCommand } from './hooks'
 
 export const chainRunCommands = (
   commands: CreateCommand[],
   createRunCommand: CreateRunCommand,
-  continuePastCommandFailure: boolean = true
+  continuePastCommandFailure: boolean = true,
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 ): Promise<unknown> => {
   if (commands.length < 1)
     return Promise.reject(new Error('no commands to execute'))
+  setIsLoading(true)
   return createRunCommand({
     command: commands[0],
     waitUntilComplete: true,
   })
     .then(response => {
       if (!continuePastCommandFailure && response.data.status === 'failed') {
+        setIsLoading(false)
         return Promise.reject(
           new Error(response.data.error?.detail ?? 'command failed')
         )
       }
       if (commands.slice(1).length < 1) {
+        setIsLoading(false)
         return Promise.resolve(response)
       } else {
         return chainRunCommands(
           commands.slice(1),
           createRunCommand,
-          continuePastCommandFailure
+          continuePastCommandFailure,
+          setIsLoading
         )
       }
     })
     .catch(error => {
+      setIsLoading(false)
       return Promise.reject(error)
     })
 }


### PR DESCRIPTION
 closes RLIQ-261 and RLIQ-266 and RLIQ-240

# Overview

From an empty pipette card on an ot-3, you can now go through the attach and calibrate flows back to back with the modals up to date with figma. 

From a pipette card with an ot-3 pipette attached, you can now go through the detach pipette flow with the modals up to date with figma.

However, images are still not final throughout the flows

# Changelog

- add equipment images for `BeforeBeginning` page
- add branching logic to `BeforeBeginning` and `Results` to accommodate the attach and detach flow
- modify `mountPipette` to be 1 modal screen and when clicking continue button, it fetches pipettes
- results pages has some error handling. If you have no pipette attached in attach pipette flow, it errors. If you have a pipette attached still when its the detach flow, it errors.
- modify the Attach flow steps in `getPipetteWizardFlows` to include the correct calibrate steps
- extend props of `PipetteWizardFlowProps` to include `robotname`
- create `CheckPipetteButton` to reuse the logic for fetching pipettes for both `DetachPipette` and `MountPipette` components

# Review requests

- with an ot-3 and empty pipette card, click on `attach pipette` button. It should bring you through the gen3 pipette attach flow followed by the calibrate flow. There should be some error handling if it doesn't detect that a pipette has been attached
- with an ot-3 and a gen3 pipette attached, click on `detach pipette` button. It should bring you through the gen3 pipette detach flow. There should be some error handling if it detects that the pipette was not detached

# Risk assessment

low
