### PR TITLE
fix(app): handle the input via OT_APP_DISCOVERY__CANDIDATES 

### DIFF
--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -266,6 +266,7 @@ Email of app user to populate "Email" in support conversations.
 - Default: `[]`
 
 `Array<string>` of extra IP address(es)/hosts for the discovery client to track. For example, to get the discovery client to find an instance of the API server running on your own computer.
+Currently this config only allows one hostname/IP address as the value.
 
 ##### labware.directory
 

--- a/app/src/organisms/AppSettings/ManualIpHostnameList.tsx
+++ b/app/src/organisms/AppSettings/ManualIpHostnameList.tsx
@@ -20,11 +20,7 @@ export function ManualIpHostnameList({
 }: IpHostnameListProps): JSX.Element {
   const candidates = useSelector((state: State) => {
     const results = getConfig(state)?.discovery.candidates
-    return typeof results === 'string'
-      ? [results]
-      : results != null
-      ? results
-      : []
+    return typeof results === 'string' ? [].concat(results) : results
   })
 
   const robots = useSelector((state: State) => getViewableRobots(state))
@@ -32,7 +28,7 @@ export function ManualIpHostnameList({
 
   return (
     <>
-      {candidates.length > 0
+      {candidates != null && candidates.length > 0
         ? candidates
             .map<[string, boolean]>(candidate => {
               const discovered = robots.some(robot => robot.ip === candidate)

--- a/app/src/organisms/AppSettings/ManualIpHostnameList.tsx
+++ b/app/src/organisms/AppSettings/ManualIpHostnameList.tsx
@@ -18,35 +18,43 @@ export function ManualIpHostnameList({
   setMostRecentAddition,
   setMostRecentDiscovered,
 }: IpHostnameListProps): JSX.Element {
-  const candidates = useSelector(
-    (state: State) => getConfig(state)?.discovery.candidates ?? []
-  )
+  const candidates = useSelector((state: State) => {
+    const results = getConfig(state)?.discovery.candidates
+    return typeof results === 'string'
+      ? [results]
+      : results != null
+      ? results
+      : []
+  })
+
   const robots = useSelector((state: State) => getViewableRobots(state))
   const dispatch = useDispatch<Dispatch>()
 
   return (
     <>
-      {candidates
-        .map<[string, boolean]>(candidate => {
-          const discovered = robots.some(robot => robot.ip === candidate)
-          return [candidate, discovered]
-        })
-        .sort(([_candidateA, aDiscovered], [_candidateB, bDiscovered]) =>
-          bDiscovered && !aDiscovered ? -1 : 1
-        )
-        .map(([candidate, discovered], index) => (
-          <React.Fragment key={index}>
-            <ManualIpHostnameItem
-              candidate={candidate}
-              removeIp={() => dispatch(removeManualIp(candidate))}
-              discovered={discovered}
-              mostRecentAddition={mostRecentAddition}
-              setMostRecentAddition={setMostRecentAddition}
-              setMostRecentDiscovered={setMostRecentDiscovered}
-              isLast={index === candidates.length - 1}
-            />
-          </React.Fragment>
-        ))}
+      {candidates.length > 0
+        ? candidates
+            .map<[string, boolean]>(candidate => {
+              const discovered = robots.some(robot => robot.ip === candidate)
+              return [candidate, discovered]
+            })
+            .sort(([_candidateA, aDiscovered], [_candidateB, bDiscovered]) =>
+              bDiscovered && !aDiscovered ? -1 : 1
+            )
+            .map(([candidate, discovered], index) => (
+              <React.Fragment key={index}>
+                <ManualIpHostnameItem
+                  candidate={candidate}
+                  removeIp={() => dispatch(removeManualIp(candidate))}
+                  discovered={discovered}
+                  mostRecentAddition={mostRecentAddition}
+                  setMostRecentAddition={setMostRecentAddition}
+                  setMostRecentDiscovered={setMostRecentDiscovered}
+                  isLast={index === candidates.length - 1}
+                />
+              </React.Fragment>
+            ))
+        : null}
     </>
   )
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The currently Connect to a robot via IP address only can handle `string[]` so if a user sets the value via OT_APP_DISCOVERY__CANDIDATES and clicks `Setup connection` in App Settings page, the app shows white-screen.
This PR converts candidates into `string[]` if its type is `string`.
Close RQA-415
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add code to handle OT_APP_DISCOVERY__CANDIDATES (string)
- add a condition to avoid unexpected error
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- [ ] When run the desktop app pass `localhost` via `OT_APP_DISCOVERY__CANDIDATES`, Connect to a robot via IP address slideout shows localhost without showing white screen
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
