### PR TITLE
fix(ot3): 96 channel diagnostics must home pick up motors first

### DIFF
--- a/hardware/opentrons_hardware/scripts/high_throughput_diagnostics.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_diagnostics.py
@@ -165,6 +165,7 @@ async def run_gear_motors(args: argparse.Namespace) -> None:
     try:
         # Home the gear motors and Z before performing the test
         await home_z.run(can_messenger=messenger)
+        await drop_tip_runner.run(can_messenger=messenger)
         await asyncio.sleep(0.1)
         # # Move to the tiprack
         for i in range(reps):


### PR DESCRIPTION
## Overview
We need to home the pick up motors first before moving those motors down.