### PR TITLE
feat(app): map/List view design QA

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -144,5 +144,6 @@
   "secure": "Secure",
   "additional_off_deck_labware": "Additional Off-Deck Labware",
   "recommended_workflow_for_labware_positioning": "Recommended workflow that helps you verify the position of each labware on the deck. <anchor>Learn how it works</anchor>",
-  "view_current_offsets": "View current offsets"
+  "view_current_offsets": "View current offsets",
+  "view_module_setup_instructions": "View module setup instructions"
 }

--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -80,13 +80,14 @@ export function Banner(props: BannerProps): JSX.Element {
     closeButton,
     marginRight,
     marginLeft,
+    size,
     ...styleProps
   } = props
   const bannerProps = BANNER_PROPS_BY_TYPE[type]
 
   const iconProps = {
     ...(icon ?? bannerProps.icon),
-    size: SPACING.spacing4,
+    size: size ?? SPACING.spacing4,
     marginRight: marginRight ?? SPACING.spacing3,
     marginLeft: marginLeft ?? '0rem',
     color: BANNER_PROPS_BY_TYPE[type].color,
@@ -120,6 +121,7 @@ export function Banner(props: BannerProps): JSX.Element {
             <Icon
               width={SPACING.spacing5}
               height={SPACING.spacing5}
+              marginTop="0.375rem"
               name="close"
               aria-label="close_icon"
             />

--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -36,6 +36,10 @@ export interface BannerProps extends StyleProps {
   isCloseActionLoading?: boolean
   /** Override the Exit icon */
   closeButton?: React.ReactNode
+  /** Icon margin right for large banners */
+  iconMarginRight?: string
+  /** Icon margin left for large banners */
+  iconMarginLeft?: string
 }
 
 const BANNER_PROPS_BY_TYPE: Record<
@@ -78,8 +82,8 @@ export function Banner(props: BannerProps): JSX.Element {
     isCloseActionLoading,
     padding,
     closeButton,
-    marginRight,
-    marginLeft,
+    iconMarginLeft,
+    iconMarginRight,
     size,
     ...styleProps
   } = props
@@ -87,9 +91,9 @@ export function Banner(props: BannerProps): JSX.Element {
 
   const iconProps = {
     ...(icon ?? bannerProps.icon),
-    size: size ?? SPACING.spacing4,
-    marginRight: marginRight ?? SPACING.spacing3,
-    marginLeft: marginLeft ?? '0rem',
+    size: size ?? SIZE_1,
+    marginRight: iconMarginRight ?? SPACING.spacing3,
+    marginLeft: iconMarginLeft ?? '0rem',
     color: BANNER_PROPS_BY_TYPE[type].color,
   }
   return (
@@ -115,7 +119,7 @@ export function Banner(props: BannerProps): JSX.Element {
       <Flex flex="1" alignItems={ALIGN_CENTER}>
         {props.children}
       </Flex>
-      {onCloseClick && !isCloseActionLoading ? (
+      {onCloseClick && !(isCloseActionLoading ?? false) ? (
         <Btn data-testid="Banner_close-button" onClick={props.onCloseClick}>
           {closeButton ?? (
             <Icon

--- a/app/src/atoms/Banner/index.tsx
+++ b/app/src/atoms/Banner/index.tsx
@@ -78,6 +78,8 @@ export function Banner(props: BannerProps): JSX.Element {
     isCloseActionLoading,
     padding,
     closeButton,
+    marginRight,
+    marginLeft,
     ...styleProps
   } = props
   const bannerProps = BANNER_PROPS_BY_TYPE[type]
@@ -85,7 +87,8 @@ export function Banner(props: BannerProps): JSX.Element {
   const iconProps = {
     ...(icon ?? bannerProps.icon),
     size: SPACING.spacing4,
-    marginRight: SPACING.spacing3,
+    marginRight: marginRight ?? SPACING.spacing3,
+    marginLeft: marginLeft ?? '0rem',
     color: BANNER_PROPS_BY_TYPE[type].color,
   }
   return (

--- a/app/src/atoms/buttons/ToggleButton.tsx
+++ b/app/src/atoms/buttons/ToggleButton.tsx
@@ -46,7 +46,7 @@ interface ToggleButtonProps extends StyleProps {
 }
 
 export const ToggleButton = (props: ToggleButtonProps): JSX.Element => {
-  const { label, toggledOn, disabled, ...buttonProps } = props
+  const { label, toggledOn, disabled, size, ...buttonProps } = props
   const iconName = toggledOn ? 'ot-toggle-input-on' : 'ot-toggle-input-off'
 
   return (
@@ -55,7 +55,7 @@ export const ToggleButton = (props: ToggleButtonProps): JSX.Element => {
       role="switch"
       aria-label={label}
       aria-checked={toggledOn}
-      size={SIZE_2}
+      size={size ?? SIZE_2}
       css={props.toggledOn ? TOGGLE_ENABLED_STYLES : TOGGLE_DISABLED_STYLES}
       {...buttonProps}
     >

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -188,7 +188,7 @@ export function LabwareListItem(
           flexDirection={DIRECTION_COLUMN}
           justifyContent={JUSTIFY_CENTER}
           marginLeft={SPACING.spacing4}
-          marginRight={SPACING.spacing3}
+          marginRight={SPACING.spacing5}
         >
           <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
             {labwareDisplayName}
@@ -216,7 +216,7 @@ export function LabwareListItem(
               flexDirection={DIRECTION_ROW}
               alignItems={ALIGN_CENTER}
               justifyContent={JUSTIFY_SPACE_BETWEEN}
-              marginTop="3px"
+              marginTop={SPACING.spacingS}
             >
               <ToggleButton
                 label={`heater_shaker_${
@@ -229,9 +229,7 @@ export function LabwareListItem(
                 display="flex"
                 alignItems={ALIGN_CENTER}
               />
-              {isLatchClosed ? (
-                <StyledText as="p">{t('secure')}</StyledText>
-              ) : null}
+              <StyledText as="p">{t('secure')}</StyledText>
             </Flex>
           </Flex>
         ) : null}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import {
   Flex,
   SPACING,
@@ -38,12 +38,11 @@ import type {
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
 import type { ModuleTypesThatRequireExtraAttention } from '../../../ProtocolSetup/RunSetupCard/LabwareSetup/utils/getModuleTypesThatRequireExtraAttention'
 import type { ModuleRenderInfoForProtocol } from '../../hooks'
-import { LabwareSetupItem } from './types'
+import type { LabwareSetupItem } from './types'
 
 const LabwareRow = styled.div`
   display: grid;
   grid-template-columns: 6fr 5fr;
-  grip-gap: ${SPACING.spacing3};
   border-style: ${BORDERS.styleSolid};
   border-width: ${SPACING.spacingXXS};
   border-color: ${COLORS.medGreyEnabled};
@@ -114,7 +113,13 @@ export function LabwareListItem(
       case THERMOCYCLER_MODULE_TYPE:
         extraAttentionText = (
           <Btn
-            color={COLORS.darkGreyEnabled}
+            css={css`
+              color: ${COLORS.darkGreyEnabled};
+
+              &:hover {
+                color: ${COLORS.darkGreyHover};
+              }
+            `}
             onClick={() => setSecureLabwareModalType(moduleType)}
           >
             <Flex flexDirection={DIRECTION_ROW}>
@@ -137,11 +142,7 @@ export function LabwareListItem(
       case HEATERSHAKER_MODULE_TYPE:
         isHeaterShakerInProtocol = true
         extraAttentionText = (
-          <StyledText
-            as="p"
-            color={COLORS.darkGreyEnabled}
-            textDecoration={TYPOGRAPHY.textDecorationUnderline}
-          >
+          <StyledText as="p" color={COLORS.darkGreyEnabled}>
             {t('heater_shaker_labware_list_view')}
           </StyledText>
         )
@@ -215,11 +216,13 @@ export function LabwareListItem(
               flexDirection={DIRECTION_ROW}
               alignItems={ALIGN_CENTER}
               justifyContent={JUSTIFY_SPACE_BETWEEN}
+              marginTop="3px"
             >
               <ToggleButton
                 label={`heater_shaker_${
                   moduleLocation?.slotName ?? ''
                 }_latch_toggle`}
+                size="auto"
                 disabled={!isCorrectHeaterShakerAttached}
                 toggledOn={isLatchClosed}
                 onClick={toggleLatch}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -115,7 +115,6 @@ export function LabwareListItem(
         extraAttentionText = (
           <Btn
             color={COLORS.darkGreyEnabled}
-            marginTop={SPACING.spacing3}
             onClick={() => setSecureLabwareModalType(moduleType)}
           >
             <Flex flexDirection={DIRECTION_ROW}>
@@ -124,7 +123,11 @@ export function LabwareListItem(
                 size="0.75rem"
                 marginTop={SPACING.spacingXS}
               />
-              <StyledText marginLeft={SPACING.spacing2} as="p">
+              <StyledText
+                marginLeft={SPACING.spacing2}
+                as="p"
+                textDecoration={TYPOGRAPHY.textDecorationUnderline}
+              >
                 {t('secure_labware_instructions')}
               </StyledText>
             </Flex>
@@ -134,7 +137,11 @@ export function LabwareListItem(
       case HEATERSHAKER_MODULE_TYPE:
         isHeaterShakerInProtocol = true
         extraAttentionText = (
-          <StyledText as="p" color={COLORS.darkGreyEnabled}>
+          <StyledText
+            as="p"
+            color={COLORS.darkGreyEnabled}
+            textDecoration={TYPOGRAPHY.textDecorationUnderline}
+          >
             {t('heater_shaker_labware_list_view')}
           </StyledText>
         )
@@ -180,6 +187,7 @@ export function LabwareListItem(
           flexDirection={DIRECTION_COLUMN}
           justifyContent={JUSTIFY_CENTER}
           marginLeft={SPACING.spacing4}
+          marginRight={SPACING.spacing3}
         >
           <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
             {labwareDisplayName}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -117,7 +117,7 @@ export function LabwareListItem(
               color: ${COLORS.darkGreyEnabled};
 
               &:hover {
-                color: ${COLORS.darkGreyHover};
+                color: ${COLORS.darkBlackEnabled};
               }
             `}
             onClick={() => setSecureLabwareModalType(moduleType)}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -16,6 +16,7 @@ import {
   Btn,
   BORDERS,
   WELL_LABEL_OPTIONS,
+  SIZE_AUTO,
 } from '@opentrons/components'
 import {
   getLabwareDisplayName,
@@ -222,7 +223,7 @@ export function LabwareListItem(
                 label={`heater_shaker_${
                   moduleLocation?.slotName ?? ''
                 }_latch_toggle`}
-                size="auto"
+                size={SIZE_AUTO}
                 disabled={!isCorrectHeaterShakerAttached}
                 toggledOn={isLatchClosed}
                 onClick={toggleLatch}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
@@ -11,10 +11,10 @@ import { RunTimeCommand } from '@opentrons/shared-data'
 import { StyledText } from '../../../../atoms/text'
 import { getLabwareSetupItemGroups } from './utils'
 import { LabwareListItem } from './LabwareListItem'
+import { OffDeckLabwareList } from './OffDeckLabwareList'
 
 import type { ModuleTypesThatRequireExtraAttention } from '../../../ProtocolSetup/RunSetupCard/LabwareSetup/utils/getModuleTypesThatRequireExtraAttention'
 import type { ModuleRenderInfoForProtocol } from '../../hooks'
-import { OffDeckLabwareList } from './OffDeckLabwareList'
 
 const HeaderRow = styled.div`
   display: grid;

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
@@ -20,7 +20,7 @@ const HeaderRow = styled.div`
   display: grid;
   grid-template-columns: 6fr 5fr;
   grip-gap: ${SPACING.spacing3};
-  padding: ${SPACING.spacing4};
+  padding: ${SPACING.spacing3};
 `
 interface SetupLabwareListProps {
   attachedModuleInfo: { [moduleId: string]: ModuleRenderInfoForProtocol }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
@@ -35,7 +35,11 @@ export function SetupLabwareList(
   const { offDeckItems, onDeckItems } = getLabwareSetupItemGroups(commands)
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing2}>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing2}
+      marginBottom={SPACING.spacing4}
+    >
       <HeaderRow>
         <StyledText as="label" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
           {t('labware_name')}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/index.tsx
@@ -78,7 +78,6 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
         flexDirection={DIRECTION_COLUMN}
         justifyContent={JUSTIFY_CENTER}
         marginTop={SPACING.spacing6}
-        gridGap={SPACING.spacing4}
       >
         {enableLiquidSetup ? (
           <>

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import map from 'lodash/map'
+import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import {
   BORDERS,
@@ -111,6 +112,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
         justifyContent={JUSTIFY_SPACE_BETWEEN}
         marginTop={SPACING.spacing4}
         marginLeft={SPACING.spacingM}
+        marginBottom={SPACING.spacing2}
       >
         <StyledText
           css={TYPOGRAPHY.labelSemiBold}
@@ -234,7 +236,13 @@ export const ModulesListItem = ({
             {moduleModel === HEATERSHAKER_MODULE_V1 ? (
               <Btn
                 marginLeft={SPACING.spacingM}
-                color={COLORS.darkGreyEnabled}
+                css={css`
+                  color: ${COLORS.darkGreyEnabled};
+
+                  &:hover {
+                    color: ${COLORS.darkGreyHover};
+                  }
+                `}
                 marginTop={'4px'}
                 onClick={() => setShowHeaterShakerFlow(true)}
               >

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -83,12 +83,14 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
           <Banner
             marginRight={SPACING.spacing4}
             marginLeft={SPACING.spacing3}
+            size={SPACING.spacingM}
             type="informing"
             onCloseClick={() => setShowMultipleModulesModal(true)}
             closeButton={
               <StyledText
                 as="p"
                 textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                marginRight={SPACING.spacing3}
               >
                 {t('learn_more')}
               </StyledText>

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -242,7 +242,7 @@ export const ModulesListItem = ({
                   color: ${COLORS.darkGreyEnabled};
 
                   &:hover {
-                    color: ${COLORS.darkGreyHover};
+                    color: ${COLORS.darkBlackEnabled};
                   }
                 `}
                 marginTop={'4px'}

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -78,8 +78,8 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
       {hasADuplicateModule ? (
         <Box marginTop={SPACING.spacing3}>
           <Banner
-            marginRight={SPACING.spacing4}
-            marginLeft={SPACING.spacing3}
+            iconMarginRight={SPACING.spacing4}
+            iconMarginLeft={SPACING.spacing3}
             size={SPACING.spacingM}
             type="informing"
             onCloseClick={() => setShowMultipleModulesModal(true)}
@@ -121,7 +121,6 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
         >
           {t('module_name')}
         </StyledText>
-
         <StyledText
           css={TYPOGRAPHY.labelSemiBold}
           data-testid="SetupModulesList_location"
@@ -243,7 +242,7 @@ export const ModulesListItem = ({
                     color: ${COLORS.darkBlackEnabled};
                   }
                 `}
-                marginTop={'4px'}
+                marginTop={SPACING.spacing2}
                 onClick={() => setShowHeaterShakerFlow(true)}
               >
                 <Flex flexDirection={DIRECTION_ROW}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -61,9 +61,6 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
     setShowMultipleModulesModal,
   ] = React.useState<boolean>(false)
 
-  const heaterShakerModules = Object.values(
-    moduleRenderInfoForProtocolById
-  ).filter(module => module.moduleDef.model === 'heaterShakerModuleV1')
   const moduleModels = map(
     moduleRenderInfoForProtocolById,
     ({ moduleDef }) => moduleDef.model
@@ -152,7 +149,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
       >
         {map(
           moduleRenderInfoForProtocolById,
-          ({ moduleDef, attachedModuleMatch, slotName }) => {
+          ({ moduleDef, attachedModuleMatch, slotName, moduleId }) => {
             return (
               <ModulesListItem
                 key={`SetupModulesList_${moduleDef.model}_slot_${slotName}`}
@@ -160,7 +157,12 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
                 displayName={moduleDef.displayName}
                 location={slotName}
                 attachedModuleMatch={attachedModuleMatch}
-                heaterShakerModules={heaterShakerModules}
+                heaterShakerModuleFromProtocol={
+                  moduleRenderInfoForProtocolById[moduleId].moduleDef
+                    .moduleType === HEATERSHAKER_MODULE_TYPE
+                    ? moduleRenderInfoForProtocolById[moduleId]
+                    : null
+                }
               />
             )
           }
@@ -175,7 +177,7 @@ interface ModulesListItemProps {
   displayName: string
   location: string
   attachedModuleMatch: AttachedModule | null
-  heaterShakerModules: ModuleRenderInfoForProtocol[]
+  heaterShakerModuleFromProtocol: ModuleRenderInfoForProtocol | null
 }
 
 export const ModulesListItem = ({
@@ -183,7 +185,7 @@ export const ModulesListItem = ({
   displayName,
   location,
   attachedModuleMatch,
-  heaterShakerModules,
+  heaterShakerModuleFromProtocol,
 }: ModulesListItemProps): JSX.Element => {
   const { t } = useTranslation('protocol_setup')
   const moduleConnectionStatus =
@@ -194,15 +196,11 @@ export const ModulesListItem = ({
     showHeaterShakerFlow,
     setShowHeaterShakerFlow,
   ] = React.useState<Boolean>(false)
-
   const heaterShakerAttachedModule =
     attachedModuleMatch != null &&
     attachedModuleMatch.moduleType === HEATERSHAKER_MODULE_TYPE
       ? attachedModuleMatch
       : null
-  const heaterShakerModuleFromProtocol = heaterShakerModules.find(
-    module => module.attachedModuleMatch?.id === attachedModuleMatch?.id
-  )
 
   return (
     <Box
@@ -214,7 +212,7 @@ export const ModulesListItem = ({
       backgroundColor={COLORS.white}
       data-testid="ModulesListItem_Row"
     >
-      {showHeaterShakerFlow ? (
+      {showHeaterShakerFlow && heaterShakerModuleFromProtocol != null ? (
         <HeaterShakerWizard
           onCloseClick={() => setShowHeaterShakerFlow(false)}
           moduleFromProtocol={heaterShakerModuleFromProtocol}

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
@@ -259,7 +259,7 @@ describe('SetupModulesList', () => {
     const { getByText } = render(props)
     getByText('mock unmatched module Banner')
   })
-  it('should render the heater shaker banner when hs is attached', () => {
+  it('should render the heater shaker text when hs is attached', () => {
     mockUseModuleRenderInfoForProtocolById.mockReturnValue({
       [mockHeaterShaker.id]: {
         moduleId: mockHeaterShaker.id,

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
@@ -12,13 +12,13 @@ import {
   mockThermocycler,
 } from '../../../../../redux/modules/__fixtures__'
 import { MultipleModulesModal } from '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal'
-import { HeaterShakerBanner } from '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner'
 import { UnMatchedModuleWarning } from '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning'
 import {
   useModuleRenderInfoForProtocolById,
   useRunHasStarted,
   useUnmatchedModulesForProtocol,
 } from '../../../hooks'
+import { HeaterShakerWizard } from '../../../HeaterShakerWizard'
 import { SetupModulesList } from '../SetupModulesList'
 
 import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
@@ -27,9 +27,7 @@ jest.mock('../../../hooks')
 jest.mock(
   '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning'
 )
-jest.mock(
-  '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner'
-)
+jest.mock('../../../HeaterShakerWizard')
 jest.mock(
   '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal'
 )
@@ -39,8 +37,8 @@ const mockUseModuleRenderInfoForProtocolById = useModuleRenderInfoForProtocolByI
 const mockUnMatchedModuleWarning = UnMatchedModuleWarning as jest.MockedFunction<
   typeof UnMatchedModuleWarning
 >
-const mockHeaterShakerBanner = HeaterShakerBanner as jest.MockedFunction<
-  typeof HeaterShakerBanner
+const mockHeaterShakerWizard = HeaterShakerWizard as jest.MockedFunction<
+  typeof HeaterShakerWizard
 >
 const mockUseUnmatchedModulesForProtocol = useUnmatchedModulesForProtocol as jest.MockedFunction<
   typeof useUnmatchedModulesForProtocol
@@ -91,8 +89,8 @@ describe('SetupModulesList', () => {
       robotName: ROBOT_NAME,
       runId: RUN_ID,
     }
-    when(mockHeaterShakerBanner).mockReturnValue(
-      <div>mock Heater Shaker Banner</div>
+    when(mockHeaterShakerWizard).mockReturnValue(
+      <div>mockHeaterShakerWizard</div>
     )
     when(mockUnMatchedModuleWarning).mockReturnValue(
       <div>mock unmatched module Banner</div>
@@ -297,6 +295,8 @@ describe('SetupModulesList', () => {
       },
     } as any)
     const { getByText } = render(props)
-    getByText('mock Heater Shaker Banner')
+    const moduleSetup = getByText('View module setup instructions')
+    fireEvent.click(moduleSetup)
+    getByText('mockHeaterShakerWizard')
   })
 })

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/HeaterShakerSetupWizard/HeaterShakerBanner.tsx
@@ -17,6 +17,9 @@ interface HeaterShakerBannerProps {
   modules: ModuleRenderInfoForProtocol[]
 }
 
+/**
+ * @deprecated when we remove the liquid setup FF this banner will no longer be used
+ */
 export function HeaterShakerBanner(
   props: HeaterShakerBannerProps
 ): JSX.Element | null {

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
@@ -18,8 +18,8 @@ export const UnMatchedModuleWarning = (): JSX.Element | null => {
   return (
     <Box marginTop={SPACING.spacing3}>
       <Banner
-        marginRight={SPACING.spacing4}
-        marginLeft={SPACING.spacing3}
+        iconMarginRight={SPACING.spacing4}
+        iconMarginLeft={SPACING.spacing3}
         type="warning"
         size={SPACING.spacingM}
         onCloseClick={() => setShowBanner(false)}

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
@@ -21,6 +21,7 @@ export const UnMatchedModuleWarning = (): JSX.Element | null => {
         marginRight={SPACING.spacing4}
         marginLeft={SPACING.spacing3}
         type="warning"
+        size={SPACING.spacingM}
         onCloseClick={() => setShowBanner(false)}
       >
         <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning.tsx
@@ -17,7 +17,12 @@ export const UnMatchedModuleWarning = (): JSX.Element | null => {
 
   return (
     <Box marginTop={SPACING.spacing3}>
-      <Banner type="warning" onCloseClick={() => setShowBanner(false)}>
+      <Banner
+        marginRight={SPACING.spacing4}
+        marginLeft={SPACING.spacing3}
+        type="warning"
+        onCloseClick={() => setShowBanner(false)}
+      >
         <Flex flexDirection={DIRECTION_COLUMN}>
           <StyledText
             as="p"


### PR DESCRIPTION
 closes RCORE-391

# Overview

Design QA for the map/list views for labware and module setup, also some refactoring for accessing the heater-shaker setup wizard from module setup.

# Changelog

- make changes to `SetupModuleList` and `LabwareListItem`
- change `banner` a bit to modify how much padding the icon has, depending on if the prop is specified
- optional prop to change the size of the toggle button
- deprecate `HeaterShakerBanner` since when the liquid setup FF is removed, we will no longer be using that component

# Review requests

- review my logic for the Heater-Shaker setup wizard button, does it make sense in the MoaM context? Clicking on the `View module setup instructions` link should launch the H-S wizard with the known adapter and labware name required for the protocol.

- make sure it matches designs

# Risk assessment

low