### PR TITLE
feature(hardware-controller): add the basic framework for error handling

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -11,7 +11,11 @@ from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationIdParts,
 )
 from opentrons_hardware.firmware_bindings.message import CanMessage
-from opentrons_hardware.firmware_bindings.constants import NodeId, MessageId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    MessageId,
+    FunctionCode,
+)
 
 from opentrons_hardware.firmware_bindings.messages.messages import (
     MessageDefinition,
@@ -54,11 +58,17 @@ class CanMessenger:
     async def send(self, node_id: NodeId, message: MessageDefinition) -> None:
         """Send a message."""
         # TODO (amit, 2021-11-05): Use function code when it is better defined.
+        func = (
+            FunctionCode.error
+            if message.message_id == MessageId.error_message
+            else FunctionCode.network_management
+        )
+
         arbitration_id = ArbitrationId(
             parts=ArbitrationIdParts(
                 message_id=message.message_id,
                 node_id=node_id,
-                function_code=0,
+                function_code=func,
                 originating_node_id=NodeId.host,
             )
         )

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -57,7 +57,6 @@ class CanMessenger:
 
     async def send(self, node_id: NodeId, message: MessageDefinition) -> None:
         """Send a message."""
-        # TODO (amit, 2021-11-05): Use function code when it is better defined.
         func = (
             FunctionCode.error
             if message.message_id == MessageId.error_message

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -103,6 +103,8 @@ class MessageId(int, Enum):
     gripper_home_request = 0x43
     add_brushed_linear_move_request = 0x44
 
+    acknowledgement = 0x50
+
     read_presence_sensing_voltage_request = 0x600
     read_presence_sensing_voltage_response = 0x601
 

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -63,6 +63,8 @@ class MessageId(int, Enum):
 
     stop_request = 0x00
 
+    error_message = 0x02
+
     get_status_request = 0x01
     get_status_response = 0x05
 
@@ -140,6 +142,15 @@ class MessageId(int, Enum):
     bind_sensor_output_response = 0x8B
     peripheral_status_request = 0x8C
     peripheral_status_response = 0x8D
+
+
+@unique
+class ErrorSeverity(int, Enum):
+    """Error Severity levels."""
+
+    WARNING = 0x1
+    RECOVERABLE = 0x2
+    UNRECOVERABLE = 0x3
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -73,7 +73,8 @@ class ToolField(utils.UInt8Field):
 class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
     """The data field of FirmwareUpdateData."""
 
-    NUM_BYTES = 56
+    # this needs to be a multiple of 8
+    NUM_BYTES = 48
     FORMAT = f"{NUM_BYTES}s"
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -16,6 +16,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     SensorThresholdMode,
     PipetteTipActionType,
     MotorPositionFlags,
+    ErrorSeverity,
 )
 
 
@@ -76,6 +77,18 @@ class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
     # this needs to be a multiple of 8
     NUM_BYTES = 48
     FORMAT = f"{NUM_BYTES}s"
+
+
+class ErrorSeverityField(utils.UInt16Field):
+    """A field for error severity."""
+
+    def __repr__(self) -> str:
+        """Print error severity."""
+        try:
+            severity = ErrorSeverity(self.value).name
+        except ValueError:
+            severity = str(self.value)
+        return f"{self.__class__.__name__}(value={severity})"
 
 
 class ErrorCodeField(utils.UInt16Field):

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -59,6 +59,13 @@ class Acknowledgement(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
+class ErrorMessage(BaseMessage):  # noqa: D101
+    payload: payloads.ErrorMessagePayload
+    payload_type: Type[payloads.ErrorMessagePayload] = payloads.ErrorMessagePayload
+    message_id: Literal[MessageId.error_message] = MessageId.error_message
+
+
+@dataclass
 class HeartbeatRequest(EmptyPayloadMessage):  # noqa: D101
     message_id: Literal[MessageId.heartbeat_request] = MessageId.heartbeat_request
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -10,7 +10,7 @@ from .. import utils
 
 
 class SingletonMessageIndexGenerator(object):
-    """Singlton class that generates uinque index values."""
+    """Singleton class that generates uinque index values."""
 
     def __new__(cls) -> Any:
         """Either generate or return the singleton instance."""

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -1,19 +1,61 @@
 """Definition of CAN messages."""
 from dataclasses import dataclass
-from typing import Type
+from typing import Type, Any
 
 from typing_extensions import Literal
 
 from ..constants import MessageId
 from . import payloads
+from .. import utils
+
+
+class SingletonMessageIndexGenerator(object):
+    """Singlton class that generates uinque index values."""
+
+    def __new__(cls) -> Any:
+        """Either generate or return the singleton instance."""
+        if not hasattr(cls, "instance"):
+            cls.instance = super(SingletonMessageIndexGenerator, cls).__new__(cls)
+        return cls.instance
+
+    def get_next_index(self) -> int:
+        """Return the next index."""
+        # increment before returning so we never return 0 as a value
+        self.__current_index += 1
+        return self.__current_index
+
+    __current_index = 0
 
 
 @dataclass
-class EmptyPayloadMessage:
+class BaseMessage(object):
+    """Base class of a message."""
+
+    def __post_init__(self) -> None:
+        """Update the message index from the singleton."""
+        try:
+            index_generator = SingletonMessageIndexGenerator()
+            if self.payload.message_index.value is None:  # type: ignore[attr-defined]
+                self.payload.message_index = utils.UInt32Field(  # type: ignore[attr-defined]
+                    index_generator.get_next_index()
+                )
+        except AttributeError:
+            # we are probably constructing this instance from binary and it doesn't
+            # have a payload yet
+            pass
+
+
+@dataclass
+class EmptyPayloadMessage(BaseMessage):
     """Base class of a message that has an empty payload."""
 
     payload: payloads.EmptyPayload = payloads.EmptyPayload()
     payload_type: Type[payloads.EmptyPayload] = payloads.EmptyPayload
+
+
+@dataclass
+class Acknowledgement(EmptyPayloadMessage):  # noqa: D101
+    message_id: MessageId = MessageId.acknowledgement
 
 
 @dataclass
@@ -32,7 +74,7 @@ class DeviceInfoRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class DeviceInfoResponse:  # noqa: D101
+class DeviceInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.DeviceInfoResponsePayload
     payload_type: Type[
         payloads.DeviceInfoResponsePayload
@@ -46,7 +88,7 @@ class TaskInfoRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class TaskInfoResponse:  # noqa: D101
+class TaskInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.TaskInfoResponsePayload
     payload_type: Type[
         payloads.TaskInfoResponsePayload
@@ -77,7 +119,7 @@ class DisableMotorRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class GetStatusResponse:  # noqa: D101
+class GetStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetStatusResponsePayload
     payload_type: Type[
         payloads.GetStatusResponsePayload
@@ -86,35 +128,35 @@ class GetStatusResponse:  # noqa: D101
 
 
 @dataclass
-class MoveRequest:  # noqa: D101
+class MoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveRequestPayload
     payload_type: Type[payloads.MoveRequestPayload] = payloads.MoveRequestPayload
     message_id: Literal[MessageId.move_request] = MessageId.move_request
 
 
 @dataclass
-class WriteToEEPromRequest:  # noqa: D101
+class WriteToEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.write_eeprom] = MessageId.write_eeprom
 
 
 @dataclass
-class ReadFromEEPromRequest:  # noqa: D101
+class ReadFromEEPromRequest(BaseMessage):  # noqa: D101
     payload: payloads.EEPromReadPayload
     payload_type: Type[payloads.EEPromReadPayload] = payloads.EEPromReadPayload
     message_id: Literal[MessageId.read_eeprom_request] = MessageId.read_eeprom_request
 
 
 @dataclass
-class ReadFromEEPromResponse:  # noqa: D101
+class ReadFromEEPromResponse(BaseMessage):  # noqa: D101
     payload: payloads.EEPromDataPayload
     payload_type: Type[payloads.EEPromDataPayload] = payloads.EEPromDataPayload
     message_id: Literal[MessageId.read_eeprom_response] = MessageId.read_eeprom_response
 
 
 @dataclass
-class AddLinearMoveRequest:  # noqa: D101
+class AddLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.AddLinearMoveRequestPayload
     payload_type: Type[
         payloads.AddLinearMoveRequestPayload
@@ -123,7 +165,7 @@ class AddLinearMoveRequest:  # noqa: D101
 
 
 @dataclass
-class GetMoveGroupRequest:  # noqa: D101
+class GetMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveGroupRequestPayload
     payload_type: Type[
         payloads.MoveGroupRequestPayload
@@ -134,7 +176,7 @@ class GetMoveGroupRequest:  # noqa: D101
 
 
 @dataclass
-class GetMoveGroupResponse:  # noqa: D101
+class GetMoveGroupResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetMoveGroupResponsePayload
     payload_type: Type[
         payloads.GetMoveGroupResponsePayload
@@ -145,7 +187,7 @@ class GetMoveGroupResponse:  # noqa: D101
 
 
 @dataclass
-class ExecuteMoveGroupRequest:  # noqa: D101
+class ExecuteMoveGroupRequest(BaseMessage):  # noqa: D101
     payload: payloads.ExecuteMoveGroupRequestPayload
     payload_type: Type[
         payloads.ExecuteMoveGroupRequestPayload
@@ -163,7 +205,7 @@ class ClearAllMoveGroupsRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class MoveCompleted:  # noqa: D101
+class MoveCompleted(BaseMessage):  # noqa: D101
     payload: payloads.MoveCompletedPayload
     payload_type: Type[payloads.MoveCompletedPayload] = payloads.MoveCompletedPayload
     message_id: Literal[MessageId.move_completed] = MessageId.move_completed
@@ -177,7 +219,7 @@ class MotorPositionRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class MotorPositionResponse:  # noqa: D101
+class MotorPositionResponse(BaseMessage):  # noqa: D101
     payload: payloads.MotorPositionResponse
     payload_type: Type[payloads.MotorPositionResponse] = payloads.MotorPositionResponse
     message_id: Literal[
@@ -186,7 +228,7 @@ class MotorPositionResponse:  # noqa: D101
 
 
 @dataclass
-class SetMotionConstraints:  # noqa: D101
+class SetMotionConstraints(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
         payloads.MotionConstraintsPayload
@@ -204,7 +246,7 @@ class GetMotionConstraintsRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class GetMotionConstraintsResponse:  # noqa: D101
+class GetMotionConstraintsResponse(BaseMessage):  # noqa: D101
     payload: payloads.MotionConstraintsPayload
     payload_type: Type[
         payloads.MotionConstraintsPayload
@@ -215,7 +257,7 @@ class GetMotionConstraintsResponse:  # noqa: D101
 
 
 @dataclass
-class WriteMotorDriverRegister:  # noqa: D101
+class WriteMotorDriverRegister(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterDataPayload
     payload_type: Type[
         payloads.MotorDriverRegisterPayload
@@ -226,7 +268,7 @@ class WriteMotorDriverRegister:  # noqa: D101
 
 
 @dataclass
-class ReadMotorDriverRequest:  # noqa: D101
+class ReadMotorDriverRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorDriverRegisterPayload
     payload_type: Type[
         payloads.MotorDriverRegisterPayload
@@ -237,7 +279,7 @@ class ReadMotorDriverRequest:  # noqa: D101
 
 
 @dataclass
-class ReadMotorDriverResponse:  # noqa: D101
+class ReadMotorDriverResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadMotorDriverRegisterResponsePayload
     payload_type: Type[
         payloads.ReadMotorDriverRegisterResponsePayload
@@ -248,7 +290,7 @@ class ReadMotorDriverResponse:  # noqa: D101
 
 
 @dataclass
-class WriteMotorCurrentRequest:  # noqa: D101
+class WriteMotorCurrentRequest(BaseMessage):  # noqa: D101
     payload: payloads.MotorCurrentPayload
     payload_type: Type[payloads.MotorCurrentPayload] = payloads.MotorCurrentPayload
     message_id: Literal[
@@ -264,7 +306,7 @@ class ReadPresenceSensingVoltageRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class ReadPresenceSensingVoltageResponse:  # noqa: D101
+class ReadPresenceSensingVoltageResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadPresenceSensingVoltageResponsePayload
     payload_type: Type[
         payloads.ReadPresenceSensingVoltageResponsePayload
@@ -275,7 +317,7 @@ class ReadPresenceSensingVoltageResponse:  # noqa: D101
 
 
 @dataclass
-class PushToolsDetectedNotification:  # noqa: D101
+class PushToolsDetectedNotification(BaseMessage):  # noqa: D101
     payload: payloads.ToolsDetectedNotificationPayload
     payload_type: Type[
         payloads.ToolsDetectedNotificationPayload
@@ -298,14 +340,14 @@ class FirmwareUpdateInitiate(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateData:  # noqa: D101
+class FirmwareUpdateData(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateData
     payload_type: Type[payloads.FirmwareUpdateData] = payloads.FirmwareUpdateData
     message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
 
 
 @dataclass
-class FirmwareUpdateDataAcknowledge:  # noqa: D101
+class FirmwareUpdateDataAcknowledge(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateDataAcknowledge
@@ -314,7 +356,7 @@ class FirmwareUpdateDataAcknowledge:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateComplete:  # noqa: D101
+class FirmwareUpdateComplete(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
     payload_type: Type[
         payloads.FirmwareUpdateComplete
@@ -323,7 +365,7 @@ class FirmwareUpdateComplete:  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
+class FirmwareUpdateCompleteAcknowledge(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateAcknowledge
@@ -341,7 +383,7 @@ class FirmwareUpdateStatusRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateStatusResponse:  # noqa: D101
+class FirmwareUpdateStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateStatus
     payload_type: Type[payloads.FirmwareUpdateStatus] = payloads.FirmwareUpdateStatus
     message_id: Literal[
@@ -355,7 +397,7 @@ class FirmwareUpdateEraseAppRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class FirmwareUpdateEraseAppResponse:  # noqa: D101
+class FirmwareUpdateEraseAppResponse(BaseMessage):  # noqa: D101
     payload: payloads.FirmwareUpdateAcknowledge
     payload_type: Type[
         payloads.FirmwareUpdateAcknowledge
@@ -366,7 +408,7 @@ class FirmwareUpdateEraseAppResponse:  # noqa: D101
 
 
 @dataclass
-class HomeRequest:  # noqa: D101
+class HomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.HomeRequestPayload
     payload_type: Type[payloads.HomeRequestPayload] = payloads.HomeRequestPayload
     message_id: Literal[MessageId.home_request] = MessageId.home_request
@@ -383,7 +425,7 @@ class ReadLimitSwitchRequest(EmptyPayloadMessage):  # noqa: D101
 
 
 @dataclass
-class ReadLimitSwitchResponse:  # noqa: D101
+class ReadLimitSwitchResponse(BaseMessage):  # noqa: D101
     payload: payloads.GetLimitSwitchResponse
     payload_type: Type[
         payloads.GetLimitSwitchResponse
@@ -392,7 +434,7 @@ class ReadLimitSwitchResponse:  # noqa: D101
 
 
 @dataclass
-class ReadFromSensorRequest:  # noqa: D101
+class ReadFromSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorRequestPayload
     payload_type: Type[
         payloads.ReadFromSensorRequestPayload
@@ -401,7 +443,7 @@ class ReadFromSensorRequest:  # noqa: D101
 
 
 @dataclass
-class WriteToSensorRequest:  # noqa: D101
+class WriteToSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.WriteToSensorRequestPayload
     payload_type: Type[
         payloads.WriteToSensorRequestPayload
@@ -410,7 +452,7 @@ class WriteToSensorRequest:  # noqa: D101
 
 
 @dataclass
-class BaselineSensorRequest:  # noqa: D101
+class BaselineSensorRequest(BaseMessage):  # noqa: D101
     payload: payloads.BaselineSensorRequestPayload
     payload_type: Type[
         payloads.BaselineSensorRequestPayload
@@ -421,7 +463,7 @@ class BaselineSensorRequest:  # noqa: D101
 
 
 @dataclass
-class ReadFromSensorResponse:  # noqa: D101
+class ReadFromSensorResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
     payload_type: Type[
         payloads.ReadFromSensorResponsePayload
@@ -430,7 +472,7 @@ class ReadFromSensorResponse:  # noqa: D101
 
 
 @dataclass
-class SetSensorThresholdRequest:  # noqa: D101
+class SetSensorThresholdRequest(BaseMessage):  # noqa: D101
     payload: payloads.SetSensorThresholdRequestPayload
     payload_type: Type[
         payloads.SetSensorThresholdRequestPayload
@@ -441,7 +483,7 @@ class SetSensorThresholdRequest:  # noqa: D101
 
 
 @dataclass
-class SensorThresholdResponse:  # noqa: D101
+class SensorThresholdResponse(BaseMessage):  # noqa: D101
     payload: payloads.SensorThresholdResponsePayload
     payload_type: Type[
         payloads.SensorThresholdResponsePayload
@@ -452,7 +494,7 @@ class SensorThresholdResponse:  # noqa: D101
 
 
 @dataclass
-class SensorDiagnosticRequest:  # noqa: D101
+class SensorDiagnosticRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticRequestPayload
     payload_type: Type[
         payloads.SensorDiagnosticRequestPayload
@@ -463,7 +505,7 @@ class SensorDiagnosticRequest:  # noqa: D101
 
 
 @dataclass
-class SensorDiagnosticResponse:  # noqa: D101
+class SensorDiagnosticResponse(BaseMessage):  # noqa: D101
     payload: payloads.SensorDiagnosticResponsePayload
     payload_type: Type[
         payloads.SensorDiagnosticResponsePayload
@@ -474,7 +516,7 @@ class SensorDiagnosticResponse:  # noqa: D101
 
 
 @dataclass
-class PipetteInfoResponse:  # noqa: D101
+class PipetteInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.PipetteInfoResponsePayload
     payload_type: Type[
         payloads.PipetteInfoResponsePayload
@@ -485,7 +527,7 @@ class PipetteInfoResponse:  # noqa: D101
 
 
 @dataclass
-class SetBrushedMotorVrefRequest:  # noqa: D101
+class SetBrushedMotorVrefRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorVrefPayload
     payload_type: Type[
         payloads.BrushedMotorVrefPayload
@@ -496,7 +538,7 @@ class SetBrushedMotorVrefRequest:  # noqa: D101
 
 
 @dataclass
-class SetBrushedMotorPwmRequest:  # noqa: D101
+class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
     payload: payloads.BrushedMotorPwmPayload
     payload_type: Type[
         payloads.BrushedMotorPwmPayload
@@ -507,7 +549,7 @@ class SetBrushedMotorPwmRequest:  # noqa: D101
 
 
 @dataclass
-class GripperGripRequest:  # noqa: D101
+class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
         payloads.GripperMoveRequestPayload
@@ -516,7 +558,7 @@ class GripperGripRequest:  # noqa: D101
 
 
 @dataclass
-class GripperHomeRequest:  # noqa: D101
+class GripperHomeRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
         payloads.GripperMoveRequestPayload
@@ -525,7 +567,7 @@ class GripperHomeRequest:  # noqa: D101
 
 
 @dataclass
-class AddBrushedLinearMoveRequest:  # noqa: D101
+class AddBrushedLinearMoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[
         payloads.GripperMoveRequestPayload
@@ -536,7 +578,7 @@ class AddBrushedLinearMoveRequest:  # noqa: D101
 
 
 @dataclass
-class BindSensorOutputRequest:  # noqa: D101
+class BindSensorOutputRequest(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputRequestPayload
     payload_type: Type[
         payloads.BindSensorOutputRequestPayload
@@ -547,7 +589,7 @@ class BindSensorOutputRequest:  # noqa: D101
 
 
 @dataclass
-class BindSensorOutputResponse:  # noqa: D101
+class BindSensorOutputResponse(BaseMessage):  # noqa: D101
     payload: payloads.BindSensorOutputResponsePayload
     payload_type: Type[
         payloads.BindSensorOutputResponsePayload
@@ -558,7 +600,7 @@ class BindSensorOutputResponse:  # noqa: D101
 
 
 @dataclass
-class GripperInfoResponse:  # noqa: D101
+class GripperInfoResponse(BaseMessage):  # noqa: D101
     payload: payloads.GripperInfoResponsePayload
     payload_type: Type[
         payloads.GripperInfoResponsePayload
@@ -569,7 +611,7 @@ class GripperInfoResponse:  # noqa: D101
 
 
 @dataclass
-class TipActionRequest:  # noqa: D101
+class TipActionRequest(BaseMessage):  # noqa: D101
     payload: payloads.TipActionRequestPayload
     payload_type: Type[
         payloads.TipActionRequestPayload
@@ -580,7 +622,7 @@ class TipActionRequest:  # noqa: D101
 
 
 @dataclass
-class TipActionResponse:  # noqa: D101
+class TipActionResponse(BaseMessage):  # noqa: D101
     payload: payloads.TipActionResponsePayload
     payload_type: Type[
         payloads.TipActionResponsePayload
@@ -591,7 +633,7 @@ class TipActionResponse:  # noqa: D101
 
 
 @dataclass
-class PeripheralStatusRequest:  # noqa: D101
+class PeripheralStatusRequest(BaseMessage):  # noqa: D101
     payload: payloads.SensorPayload
     payload_type: Type[payloads.SensorPayload] = payloads.SensorPayload
     message_id: Literal[
@@ -600,7 +642,7 @@ class PeripheralStatusRequest:  # noqa: D101
 
 
 @dataclass
-class PeripheralStatusResponse:  # noqa: D101
+class PeripheralStatusResponse(BaseMessage):  # noqa: D101
     payload: payloads.PeripheralStatusResponsePayload
     payload_type: Type[
         payloads.PeripheralStatusResponsePayload
@@ -611,7 +653,7 @@ class PeripheralStatusResponse:  # noqa: D101
 
 
 @dataclass
-class SetSerialNumber:  # noqa: D101
+class SetSerialNumber(BaseMessage):  # noqa: D101
     payload: payloads.SerialNumberPayload
     payload_type: Type[payloads.SerialNumberPayload] = payloads.SerialNumberPayload
     message_id: Literal[MessageId.set_serial_number] = MessageId.set_serial_number

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -8,6 +8,7 @@ from . import message_definitions as defs
 from ..constants import MessageId
 
 MessageDefinition = Union[
+    defs.Acknowledgement,
     defs.HeartbeatRequest,
     defs.HeartbeatResponse,
     defs.DeviceInfoRequest,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -11,6 +11,7 @@ from .fields import (
     TaskNameDataField,
     ToolField,
     FirmwareUpdateDataField,
+    ErrorSeverityField,
     ErrorCodeField,
     SensorTypeField,
     SensorIdField,
@@ -49,6 +50,14 @@ class EmptyPayload(utils.BinarySerializable):
     message_index: utils.UInt32Field = field(
         init=False, default=utils.UInt32Field(None)  # type: ignore[arg-type]
     )
+
+
+@dataclass(eq=False)
+class ErrorMessagePayload(EmptyPayload):
+    """Message sent from firmware in the event of an error."""
+
+    severity: ErrorSeverityField
+    error_code: ErrorCodeField
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -2,7 +2,8 @@
 # TODO (amit, 2022-01-26): Figure out why using annotations import ruins
 #  dataclass fields interpretation.
 #  from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from . import message_definitions
 
 from .fields import (
     FirmwareShortSHADataField,
@@ -25,15 +26,33 @@ from .fields import (
 from .. import utils
 
 
-@dataclass
+@dataclass(eq=False)
 class EmptyPayload(utils.BinarySerializable):
     """An empty payload."""
 
-    pass
+    def __eq__(self, other: object) -> bool:
+        """Override __eq__ to ignore message_index."""
+        other_dict = vars(other)
+        self_dict = vars(self)
+        for key in self_dict:
+            if key != "message_index":
+                if not (key in other_dict and self_dict[key] == other_dict[key]):
+                    return False
+        return True
+
+    # oh boy would it be great to have python 3.10 so we could use the kw_only thing here
+    # we can't have it as a normal arg becuase we'd have to initalize it everywhere we make a message
+    # and we can't just have it set as a default becuase we get a TypeError for initizling the non-default
+    # args of subclasses after this default arg.
+    # to work around this in binary_serializable.build() and can_comm.prompt_payload
+    # we ignore the message_index when constructing args and then set the value manually after
+    message_index: utils.UInt32Field = field(
+        init=False, default=utils.UInt32Field(None)  # type: ignore[arg-type]
+    )
 
 
-@dataclass
-class DeviceInfoResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class DeviceInfoResponsePayload(EmptyPayload):
     """Device info response."""
 
     version: utils.UInt32Field
@@ -41,8 +60,8 @@ class DeviceInfoResponsePayload(utils.BinarySerializable):
     shortsha: FirmwareShortSHADataField
 
 
-@dataclass
-class TaskInfoResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class TaskInfoResponsePayload(EmptyPayload):
     """Task info response payload."""
 
     name: TaskNameDataField
@@ -52,58 +71,58 @@ class TaskInfoResponsePayload(utils.BinarySerializable):
     priority: utils.UInt16Field
 
 
-@dataclass
-class GetStatusResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class GetStatusResponsePayload(EmptyPayload):
     """Get status response."""
 
     status: utils.UInt8Field
     data: utils.UInt32Field
 
 
-@dataclass
-class MoveRequestPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class MoveRequestPayload(EmptyPayload):
     """Move request."""
 
     steps: utils.UInt32Field
 
 
-@dataclass
-class GetSpeedResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class GetSpeedResponsePayload(EmptyPayload):
     """Get speed response."""
 
     mm_sec: utils.UInt32Field
 
 
-@dataclass
-class EEPromReadPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class EEPromReadPayload(EmptyPayload):
     """Eeprom read request payload ."""
 
     address: utils.UInt16Field
     data_length: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class EEPromDataPayload(EEPromReadPayload):
     """Eeprom payload with data."""
 
     data: EepromDataField
 
 
-@dataclass
-class MoveGroupRequestPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class MoveGroupRequestPayload(EmptyPayload):
     """A payload with a group id."""
 
     group_id: utils.UInt8Field
 
 
-@dataclass
-class MoveGroupResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class MoveGroupResponsePayload(EmptyPayload):
     """A response payload with a group id."""
 
     group_id: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
     """Base of add to move group request to a message group."""
 
@@ -111,7 +130,7 @@ class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
     duration: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
     """Add a linear move request to a message group."""
 
@@ -120,14 +139,14 @@ class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
     request_stop_condition: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class HomeRequestPayload(AddToMoveGroupRequestPayload):
     """Request to home."""
 
     velocity: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class GetMoveGroupResponsePayload(MoveGroupResponsePayload):
     """Response to request to get a move group."""
 
@@ -135,7 +154,7 @@ class GetMoveGroupResponsePayload(MoveGroupResponsePayload):
     total_duration: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ExecuteMoveGroupRequestPayload(MoveGroupRequestPayload):
     """Start executing a move group."""
 
@@ -143,7 +162,7 @@ class ExecuteMoveGroupRequestPayload(MoveGroupRequestPayload):
     cancel_trigger: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MoveCompletedPayload(MoveGroupResponsePayload):
     """Notification of a completed move group."""
 
@@ -154,8 +173,8 @@ class MoveCompletedPayload(MoveGroupResponsePayload):
     ack_id: utils.UInt8Field
 
 
-@dataclass
-class MotorPositionResponse(utils.BinarySerializable):
+@dataclass(eq=False)
+class MotorPositionResponse(EmptyPayload):
     """Read Encoder Position."""
 
     current_position: utils.UInt32Field
@@ -163,8 +182,8 @@ class MotorPositionResponse(utils.BinarySerializable):
     position_flags: MotorPositionFlagsField
 
 
-@dataclass
-class MotionConstraintsPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class MotionConstraintsPayload(EmptyPayload):
     """The min and max velocity and acceleration of a motion system."""
 
     min_velocity: utils.Int32Field
@@ -173,30 +192,30 @@ class MotionConstraintsPayload(utils.BinarySerializable):
     max_acceleration: utils.Int32Field
 
 
-@dataclass
-class MotorDriverRegisterPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class MotorDriverRegisterPayload(EmptyPayload):
     """Read motor driver register request payload."""
 
     reg_addr: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class MotorDriverRegisterDataPayload(MotorDriverRegisterPayload):
     """Write motor driver register request payload."""
 
     data: utils.UInt32Field
 
 
-@dataclass
-class ReadMotorDriverRegisterResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class ReadMotorDriverRegisterResponsePayload(EmptyPayload):
     """Read motor driver register response payload."""
 
     reg_addr: utils.UInt8Field
     data: utils.UInt32Field
 
 
-@dataclass
-class MotorCurrentPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class MotorCurrentPayload(EmptyPayload):
     """Read motor current register payload."""
 
     # All values in milliAmps
@@ -204,8 +223,8 @@ class MotorCurrentPayload(utils.BinarySerializable):
     run_current: utils.UInt32Field
 
 
-@dataclass
-class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class ReadPresenceSensingVoltageResponsePayload(EmptyPayload):
     """Read head presence sensing voltage response payload."""
 
     # All values in millivolts
@@ -214,8 +233,8 @@ class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
     gripper: utils.UInt16Field
 
 
-@dataclass
-class ToolsDetectedNotificationPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class ToolsDetectedNotificationPayload(EmptyPayload):
     """Tool detection notification."""
 
     # Tools are mapped to an enum
@@ -224,14 +243,14 @@ class ToolsDetectedNotificationPayload(utils.BinarySerializable):
     gripper: ToolField
 
 
-@dataclass
-class FirmwareUpdateWithAddress(utils.BinarySerializable):
+@dataclass(eq=False)
+class FirmwareUpdateWithAddress(EmptyPayload):
     """A FW update payload with an address."""
 
     address: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateData(FirmwareUpdateWithAddress):
     """A FW update data payload."""
 
@@ -243,15 +262,28 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
     def __post_init__(self) -> None:
         """Post init processing."""
         data_length = len(self.data.value)
+        address = self.address.value
+        if address % 8 != 0:
+            raise ValueError(
+                f"Data address needs to be doubleword aligned."
+                f" {address} mod 8 equals {address % 8} and should be 0"
+            )
         if data_length > FirmwareUpdateDataField.NUM_BYTES:
             raise ValueError(
                 f"Data cannot be more than"
-                f" {FirmwareUpdateDataField.NUM_BYTES} bytes."
+                f" {FirmwareUpdateDataField.NUM_BYTES} bytes got {data_length}."
             )
 
     @classmethod
-    def create(cls, address: int, data: bytes) -> "FirmwareUpdateData":
+    def create(
+        cls, address: int, data: bytes, message_index: int = None  # type: ignore[assignment]
+    ) -> "FirmwareUpdateData":
         """Create a firmware update data payload."""
+        # this is a special case, we normally instansiate message_index
+        # when building a message, not a payload, but we need to compute
+        # the checksum so we do it here. you should not normally supply
+        # message index to this function, but i've added it for the unit
+        # tests so the object can have a predictable checksum
         checksum = 0
         obj = FirmwareUpdateData(
             address=utils.UInt32Field(address),
@@ -260,63 +292,68 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
             data=FirmwareUpdateDataField(data),
             checksum=utils.UInt16Field(checksum),
         )
+        if message_index is None:
+            index_generator = message_definitions.SingletonMessageIndexGenerator()
+            obj.message_index = utils.UInt32Field(index_generator.get_next_index())
+        else:
+            obj.message_index = utils.UInt32Field(message_index)
         checksum = (1 + ~sum(obj.serialize())) & 0xFFFF
         obj.checksum.value = checksum
         return obj
 
 
-@dataclass
+@dataclass(eq=False)
 class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
     """A FW update data acknowledge payload."""
 
     error_code: ErrorCodeField
 
 
-@dataclass
-class FirmwareUpdateComplete(utils.BinarySerializable):
+@dataclass(eq=False)
+class FirmwareUpdateComplete(EmptyPayload):
     """All data messages have been transmitted."""
 
     num_messages: utils.UInt32Field
     crc32: utils.UInt32Field
 
 
-@dataclass
-class FirmwareUpdateAcknowledge(utils.BinarySerializable):
+@dataclass(eq=False)
+class FirmwareUpdateAcknowledge(EmptyPayload):
     """A response to a firmware update message with an error code."""
 
     error_code: ErrorCodeField
 
 
-@dataclass
-class FirmwareUpdateStatus(utils.BinarySerializable):
+@dataclass(eq=False)
+class FirmwareUpdateStatus(EmptyPayload):
     """A response to the FirmwareUpdateStatusRequest message."""
 
     flags: utils.UInt32Field
 
 
-@dataclass
-class GetLimitSwitchResponse(utils.BinarySerializable):
+@dataclass(eq=False)
+class GetLimitSwitchResponse(EmptyPayload):
     """A response to the Limit Switch Status request payload."""
 
     switch_status: utils.UInt8Field
 
 
-@dataclass
-class SensorPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class SensorPayload(EmptyPayload):
     """Take a single reading from a sensor request payload."""
 
     sensor: SensorTypeField
     sensor_id: SensorIdField
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromSensorRequestPayload(SensorPayload):
     """Take a single reading from a sensor request payload."""
 
     offset_reading: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class WriteToSensorRequestPayload(SensorPayload):
     """Write a piece of data to a sensor request payload."""
 
@@ -324,21 +361,21 @@ class WriteToSensorRequestPayload(SensorPayload):
     reg_address: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class BaselineSensorRequestPayload(SensorPayload):
     """Take a specified amount of readings from a sensor request payload."""
 
     sample_rate: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class ReadFromSensorResponsePayload(SensorPayload):
     """A response for either a single reading or an averaged reading of a sensor."""
 
     sensor_data: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class SetSensorThresholdRequestPayload(SensorPayload):
     """A request to set the threshold value of a sensor."""
 
@@ -346,7 +383,7 @@ class SetSensorThresholdRequestPayload(SensorPayload):
     mode: SensorThresholdModeField
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorThresholdResponsePayload(SensorPayload):
     """A response that sends back the current threshold value of the sensor."""
 
@@ -354,14 +391,14 @@ class SensorThresholdResponsePayload(SensorPayload):
     mode: SensorThresholdModeField
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorDiagnosticRequestPayload(SensorPayload):
     """A response that sends back the current threshold value of the sensor."""
 
     reg_address: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class SensorDiagnosticResponsePayload(SensorPayload):
     """A response that sends back the current threshold value of the sensor."""
 
@@ -369,22 +406,22 @@ class SensorDiagnosticResponsePayload(SensorPayload):
     data: utils.UInt32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class BindSensorOutputRequestPayload(SensorPayload):
     """A request to link a GPIO pin output to a sensor threshold."""
 
     binding: SensorOutputBindingField
 
 
-@dataclass
+@dataclass(eq=False)
 class BindSensorOutputResponsePayload(SensorPayload):
     """A response that sends back the current binding for a sensor."""
 
     binding: SensorOutputBindingField
 
 
-@dataclass
-class PipetteInfoResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class PipetteInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached pipette."""
 
     name: PipetteNameField
@@ -392,29 +429,29 @@ class PipetteInfoResponsePayload(utils.BinarySerializable):
     serial: SerialDataCodeField
 
 
-@dataclass
-class BrushedMotorVrefPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class BrushedMotorVrefPayload(EmptyPayload):
     """A request to set the reference voltage of a brushed motor."""
 
     v_ref: utils.UInt32Field
 
 
-@dataclass
-class BrushedMotorPwmPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class BrushedMotorPwmPayload(EmptyPayload):
     """A request to set the pwm of a brushed motor."""
 
     duty_cycle: utils.UInt32Field
 
 
-@dataclass
-class GripperInfoResponsePayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class GripperInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached gripper."""
 
     model: utils.UInt16Field
     serial: SerialDataCodeField
 
 
-@dataclass
+@dataclass(eq=False)
 class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     """A request to move gripper."""
 
@@ -422,7 +459,7 @@ class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     encoder_position_um: utils.Int32Field
 
 
-@dataclass
+@dataclass(eq=False)
 class TipActionRequestPayload(AddToMoveGroupRequestPayload):
     """A request to perform a tip action."""
 
@@ -431,7 +468,7 @@ class TipActionRequestPayload(AddToMoveGroupRequestPayload):
     request_stop_condition: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class TipActionResponsePayload(MoveCompletedPayload):
     """A response that sends back whether tip action was successful."""
 
@@ -439,15 +476,15 @@ class TipActionResponsePayload(MoveCompletedPayload):
     success: utils.UInt8Field
 
 
-@dataclass
+@dataclass(eq=False)
 class PeripheralStatusResponsePayload(SensorPayload):
     """A response that sends back the initialization status of a peripheral device."""
 
     status: utils.UInt8Field
 
 
-@dataclass
-class SerialNumberPayload(utils.BinarySerializable):
+@dataclass(eq=False)
+class SerialNumberPayload(EmptyPayload):
     """A payload with a serial number."""
 
     serial: SerialField

--- a/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
+++ b/hardware/opentrons_hardware/firmware_bindings/utils/binary_serializable.py
@@ -186,9 +186,26 @@ class BinarySerializable:
             size = cls.get_size()
             # ignore bytes beyond the size of message.
             b = struct.unpack(format_string, data[:size])
-            args = {v.name: v.type.build(b[i]) for i, v in enumerate(fields(cls))}
+            # we have to do message index special until we update to python 3.10 since we can't make it a kw_only arg
+            # 3.10 has an updated dataclass field option that will make this go away, see payloads.py
+            args = {
+                v.name: v.type.build(b[i])
+                for i, v in enumerate(fields(cls))
+                if not (v.name == "message_index")
+            }
+            message_index = next(
+                (
+                    v.type.build(b[i])
+                    for i, v in enumerate(fields(cls))
+                    if v.name == "message_index"
+                ),
+                None,
+            )
             # Mypy is not liking constructing the derived types.
-            return cls(**args)  # type: ignore[call-arg]
+            ret_instance = cls(**args)  # type: ignore[call-arg]
+            if message_index is not None:
+                ret_instance.message_index = message_index  # type: ignore[attr-defined]
+            return ret_instance
         except struct.error as e:
             raise InvalidFieldException(str(e))
 

--- a/hardware/opentrons_hardware/hardware_control/limit_switches.py
+++ b/hardware/opentrons_hardware/hardware_control/limit_switches.py
@@ -1,7 +1,7 @@
 """Utilities for reading the current status of the OT3 limit switches."""
 import asyncio
 import logging
-from typing import Dict, Set, Callable
+from typing import Dict, Set, Callable, cast
 
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings import ArbitrationId
@@ -9,6 +9,7 @@ from opentrons_hardware.firmware_bindings.constants import MessageId
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ReadLimitSwitchRequest,
+    ReadLimitSwitchResponse,
 )
 from opentrons_hardware.firmware_bindings.constants import NodeId
 
@@ -36,7 +37,9 @@ def _create_listener(
         if message.message_id != MessageId.limit_sw_response:
             log.warning(f"unexpected message id: 0x{message.message_id:x}")
             return
-        responses[originator] = message.payload.switch_status.value
+        responses[originator] = cast(
+            ReadLimitSwitchResponse, message
+        ).payload.switch_status.value
         if len(responses) == len(nodes):
             event.set()
 

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -144,13 +144,26 @@ def prompt_payload(
     """
     payload_fields = dataclasses.fields(payload_type)
     i = {}
+    message_index = None
     for f in payload_fields:
         try:
-            i[f.name] = f.type.from_string(get_user_input(f"enter {f.name}: ").strip())
+            # we have to hack around message_index for now until we update to 3.10
+            # then message index can work like everything else. see payloads.py
+            if not (f.name == "message_index"):
+                i[f.name] = f.type.from_string(
+                    get_user_input(f"enter {f.name}: ").strip()
+                )
+            else:
+                message_index = f.type.from_string(
+                    get_user_input(f"enter {f.name}: ").strip()
+                )
         except ValueError as e:
             raise InvalidInput(str(e))
     # Mypy is not liking constructing the derived types.
-    return payload_type(**i)  # type: ignore[call-arg]
+    ret_instance = payload_type(**i)  # type: ignore[call-arg]
+    if message_index is not None:
+        ret_instance.message_index = message_index  # type: ignore[attr-defined]
+    return ret_instance
 
 
 def prompt_message(

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -1,6 +1,7 @@
 """A script for monitoring CAN bus."""
 import asyncio
 import dataclasses
+from dataclasses import fields
 import logging
 import argparse
 import atexit
@@ -102,7 +103,12 @@ async def task(
                     StyledOutput(style=data_style, content=arb_id_str + "\n"),
                 ]
             )
-            for name, value in dataclasses.asdict(message.payload).items():
+            for name, value in (
+                dict(
+                    (field.name, getattr(message.payload, field.name))
+                    for field in fields(message.payload)
+                )
+            ).items():
                 writer.write(
                     [
                         StyledOutput(style=label_style, content=f"\t{name}:"),

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -125,7 +125,7 @@ async def test_listen_messages(
                     originating_node_id=NodeId.gantry_x,
                 )
             ),
-            data=b"\1",
+            data=b"\x00\x00\x00\x01\1",
         )
     )
 

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_message_index.py
@@ -1,0 +1,16 @@
+"""Tests for can message_index generator."""
+from opentrons_hardware.firmware_bindings import utils
+
+from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
+
+
+def test_unqiue_index() -> None:
+    """Create several messages and make sure they have generate a new index."""
+    last_index = utils.UInt32Field(0)
+    for i in range(1, 20):
+        # we have to define a payload here because python reuses
+        # old memory locations for the HeartbeatRequest from other tests that
+        # already have a message index
+        message = message_definitions.HeartbeatRequest(payload=payloads.EmptyPayload())
+        assert message.payload.message_index != last_index
+        last_index = message.payload.message_index

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -8,7 +8,7 @@ from opentrons_hardware.firmware_bindings import utils
 @pytest.mark.parametrize(
     argnames=["address", "data", "expected_checksum"],
     argvalues=[
-        [0xF0F0F0F0, bytes(range(56)), 0xF604],
+        [0xF0F0F0F0, bytes(range(48)), 0xF7A8],
         [0x0, b"", 0x0],
         [0x0, b"\x00", 0xFFFF],
         [0x12345678, b"\x05\x06\x07", 0xFED7],
@@ -18,7 +18,7 @@ def test_create_firmware_updata_data(
     address: int, data: bytes, expected_checksum: int
 ) -> None:
     """It should create a complete firmware update data payload."""
-    obj = payloads.FirmwareUpdateData.create(address, data)
+    obj = payloads.FirmwareUpdateData.create(address, data, 0)
     assert obj == payloads.FirmwareUpdateData(
         address=utils.UInt32Field(address),
         num_bytes=utils.UInt8Field(len(data)),

--- a/hardware/tests/test_scripts/test_can_comm.py
+++ b/hardware/tests/test_scripts/test_can_comm.py
@@ -40,6 +40,7 @@ def test_prompt_message_without_payload(
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
+        "1",
     ]
     r = can_comm.prompt_message(mock_get_input, mock_output)
     assert r == CanMessage(
@@ -48,7 +49,7 @@ def test_prompt_message_without_payload(
                 message_id=message_id, node_id=node_id, originating_node_id=NodeId.host
             )
         ),
-        data=b"",
+        data=b"\x00\x00\x00\x01",
     )
 
 
@@ -61,6 +62,7 @@ def test_prompt_message_with_payload(
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
+        "1",
         str(0xFF00FF00),
         str(0xAA00BB00),
     ]
@@ -71,7 +73,7 @@ def test_prompt_message_with_payload(
                 message_id=message_id, node_id=node_id, originating_node_id=NodeId.host
             )
         ),
-        data=b"\xff\x00\xff\x00\xAA\00\xBB\x00",
+        data=b"\x00\x00\x00\x01\xff\x00\xff\x00\xAA\00\xBB\x00",
     )
 
 
@@ -119,6 +121,7 @@ def test_prompt_message_bad_input(
     mock_get_input.side_effect = [
         str(list(MessageId).index(message_id)),
         str(list(NodeId).index(node_id)),
+        "1",
         "-123",
         # out of range for Uint32
         str(0x1FF00FF00),


### PR DESCRIPTION
[RET-1244](https://opentrons.atlassian.net/browse/RET-1244)
[RET-1245](https://opentrons.atlassian.net/browse/RET-1245)
[RET-1246](https://opentrons.atlassian.net/browse/RET-1246)
[RET-1247](https://opentrons.atlassian.net/browse/RET-1247)

Add a message index to all of the can messages and generate unique Index for each packet
create an error message definition


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
