### PR TITLE
fix(api): separate calibrate pipette from mount

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -385,7 +385,7 @@ async def find_slot_center_noncontact(
     return x_center, y_center
 
 
-async def calibrate_mount(
+async def _calibrate_mount(
     hcapi: OT3API,
     mount: OT3Mount,
     method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
@@ -467,7 +467,7 @@ async def calibrate_gripper(hcapi: OT3API, probe: GripperProbe) -> Point:
     hcapi.add_gripper_probe(probe)
     try:
         await hcapi.grip(GRIPPER_GRIP_FORCE)
-        offset = await calibrate_mount(hcapi, OT3Mount.GRIPPER)
+        offset = await _calibrate_mount(hcapi, OT3Mount.GRIPPER)
         return offset
     finally:
         hcapi.remove_gripper_probe()
@@ -481,7 +481,7 @@ async def calibrate_pipette(
 ) -> Point:
     try:
         await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
-        offset = await calibrate_mount(hcapi, mount, method)
+        offset = await _calibrate_mount(hcapi, mount, method)
         # save instrument offset for pipette
         await hcapi.save_instrument_offset(mount, offset)
         return offset

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -5,7 +5,7 @@ and expose it to a python commandline.
 """
 
 import os
-from functools import partial, wraps
+from functools import wraps
 import asyncio
 
 has_robot_server = True

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -96,7 +96,7 @@ def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
             "GripperProbe": GripperProbe,
             "find_edge": wrap_async_util_fn(find_edge, api),
             "find_deck_position": wrap_async_util_fn(find_deck_position, api),
-            "calibrate_pipette": partial(calibrate_pipette, api),
+            "calibrate_pipette": wrap_async_util_fn(calibrate_pipette, api),
             "calibrate_gripper": wrap_async_util_fn(calibrate_gripper, api),
             "gripper_pin_offsets_mean": gripper_pin_offsets_mean,
             "CalibrationMethod": CalibrationMethod,

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -24,7 +24,7 @@ else:
 
 from code import interact  # noqa: E402
 from subprocess import run  # noqa: E402
-from typing import Union, Type, Any, cast  # noqa: E402
+from typing import Union, Type, Any  # noqa: E402
 import logging  # noqa: E402
 
 from opentrons.types import Mount, Point  # noqa: E402
@@ -36,7 +36,7 @@ from opentrons.hardware_control.types import (  # noqa: E402
     GripperProbe,
 )
 from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
-    calibrate_mount,
+    calibrate_pipette,
     calibrate_gripper,
     find_edge,
     find_deck_position,
@@ -51,18 +51,6 @@ if ff.enable_ot3_hardware_controller():
     from opentrons.hardware_control.ot3api import OT3API
 
     HCApi: Union[Type[OT3API], Type["API"]] = OT3API
-
-    def calibrate_pipette(
-        api: ThreadManager[OT3API], mount: OT3Mount, tip_length: float
-    ) -> Point:
-        api.sync.add_tip(mount, tip_length)
-        try:
-            result = asyncio.get_event_loop().run_until_complete(
-                calibrate_mount(cast(OT3API, api), mount)
-            )
-        finally:
-            api.sync.remove_tip(mount)
-        return result
 
     def wrap_async_util_fn(fn: Any, *bind_args: Any, **bind_kwargs: Any) -> Any:
         @wraps(fn)
@@ -106,7 +94,6 @@ def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
             "OT3Axis": OT3Axis,
             "OT3Mount": OT3Mount,
             "GripperProbe": GripperProbe,
-            "calibrate_mount": wrap_async_util_fn(calibrate_mount, api),
             "find_edge": wrap_async_util_fn(find_edge, api),
             "find_deck_position": wrap_async_util_fn(find_deck_position, api),
             "calibrate_pipette": partial(calibrate_pipette, api),

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
@@ -55,8 +55,9 @@ class CalibratePipetteImplementation(
             self._hardware_api,
         )
         ot3_mount = OT3Mount.from_mount(params.mount)
+        assert ot3_mount is not OT3Mount.GRIPPER
 
-        pipette_offset = await calibration.calibrate_mount(
+        pipette_offset = await calibration.calibrate_pipette(
             hcapi=ot3_api, mount=ot3_mount
         )
 

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -18,7 +18,7 @@ from opentrons.hardware_control.ot3_calibration import (
     find_deck_position,
     find_slot_center_binary,
     find_slot_center_noncontact,
-    calibrate_mount,
+    calibrate_pipette,
     CalibrationMethod,
     _edges_from_data,
     InaccurateNonContactSweepError,
@@ -90,6 +90,7 @@ plus_x_point = (0, 10, 0)
 plus_y_point = (10, 0, 0)
 minus_x_point = (0, -10, 0)
 minus_y_point = (-10, 0, 0)
+nominal_centr = (0, 0, 0)
 
 
 @pytest.fixture
@@ -106,6 +107,7 @@ async def override_cal_config(ot3_hardware: ThreadManager[OT3API]) -> Iterator[N
             plus_y_pos=plus_y_point,
             minus_x_pos=minus_x_point,
             minus_y_pos=minus_y_point,
+            nominal_center=nominal_centr,
         )
     )
     try:
@@ -210,7 +212,10 @@ async def test_find_deck_checks_z_only(
     assert isclose(second_move_point.y, config_point.y)
 
 
-async def test_method_enum(ot3_hardware: ThreadManager[OT3API]) -> None:
+async def test_method_enum(
+    ot3_hardware: ThreadManager[OT3API],
+    override_cal_config: None,
+) -> None:
     with patch(
         "opentrons.hardware_control.ot3_calibration.find_slot_center_binary",
         AsyncMock(spec=find_slot_center_binary),
@@ -228,7 +233,7 @@ async def test_method_enum(ot3_hardware: ThreadManager[OT3API]) -> None:
         find_deck.return_value = 10
         binary.return_value = (1.0, 2.0)
         noncontact.return_value = (3.0, 4.0)
-        binval = await calibrate_mount(
+        binval = await calibrate_pipette(
             ot3_hardware, OT3Mount.RIGHT, CalibrationMethod.BINARY_SEARCH
         )
         reset_instrument_offset.assert_called_once()
@@ -244,7 +249,7 @@ async def test_method_enum(ot3_hardware: ThreadManager[OT3API]) -> None:
         noncontact.reset_mock()
         save_instrument_offset.reset_mock()
 
-        ncval = await calibrate_mount(
+        ncval = await calibrate_pipette(
             ot3_hardware, OT3Mount.LEFT, CalibrationMethod.NONCONTACT_PASS
         )
         reset_instrument_offset.assert_called_once()
@@ -264,14 +269,19 @@ async def test_calibrate_mount_errors(
         ot3_hardware.managed_obj, "save_instrument_offset", AsyncMock()
     ) as save_instrument_offset:
         mock_data_analysis.return_value = (-1000, 1000)
-        await calibrate_mount(
-            ot3_hardware, OT3Mount.RIGHT, CalibrationMethod.NONCONTACT_PASS
-        )
+
+        # calibrate pipette should re-raise exception
+        with pytest.raises(InaccurateNonContactSweepError):
+            await calibrate_pipette(
+                ot3_hardware, OT3Mount.RIGHT, CalibrationMethod.NONCONTACT_PASS
+            )
+
         reset_calls = [
             mock_call(OT3Mount.RIGHT),
             mock_call(OT3Mount.RIGHT, to_default=False),
         ]
         reset_instrument_offset.assert_has_calls(reset_calls)
+        # instrument offset should not be saved
         save_instrument_offset.assert_not_called()
 
         reset_instrument_offset.reset_mock()

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
@@ -43,7 +43,7 @@ async def test_calibrate_pipette_implementation(
     )
 
     decoy.when(
-        await calibration.calibrate_mount(hcapi=ot3_hardware_api, mount=OT3Mount.LEFT)
+        await calibration.calibrate_pipette(hcapi=ot3_hardware_api, mount=OT3Mount.LEFT)
     ).then_return(Point(x=3, y=4, z=6))
 
     result = await subject.execute(params)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

Since the calibration process for the pipettes and the gripper are rather different, it makes sense for us to call `calibrate_pipette` and `calibrate_gripper` separately so we can easily define the set up and clean up actions for individual instrument type.

# Changelog

#### 1. `calibrate_pipette()`
* For pipettes only
* Adds a tip (the calibration probe) before calling `calibrate_mount`
* Saves pipette offset to the file system and reload pipette offset if calibration succeeded without raising any errors
* Cleans up after calibration by removing the attached tip


#### 2. `calibrate_gripper()`
* Gripper only
* Adds a probe (front or rear probe) before calling `calibrate_mount`
* Calibrate the offset of the specified calibration probes on the gripper
* Does not save offset to the file system because we will need both the front probe offset and the rear probe offset in order to get the accurate gripper offset
* After calling `calibrate_gripper` twice, one on each probe, you can then use `gripper_pin_offsets_mean()` to get the actual gripper offset and save that value
* Cleans up after calibration by removing the attached probe


 3. Fix the problem where the try... except... else... finally... block in `calibrate_mount` was swallowing exceptions `InaccurateNonContactSweepError`, `EarlyCapacitiveSenseTrigger` because we were calling `return` in the finally clause (see [clean-up-actions](https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions))
 4. `center` value returned by `calibrate_mount` was not actually the offset, but in fact, the calibrated center of the edge sensing slot, therefore we have been passing the wrong value to protocol engine
 