### PR TITLE
refactor(api): replace `moveToLocation` pipette ID param with `mount`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/__init__.py
@@ -8,12 +8,12 @@ from .calibrate_pipette import (
     CalibratePipette,
 )
 
-from .move_to_location import (
-    MoveToLocationParams,
-    MoveToLocationResult,
-    MoveToLocationCreate,
-    MoveToLocationCommandType,
-    MoveToLocation,
+from .move_to_maintenance_position import (
+    MoveToMaintenancePositionParams,
+    MoveToMaintenancePositionResult,
+    MoveToMaintenancePositionCreate,
+    MoveToMaintenancePositionCommandType,
+    MoveToMaintenancePosition,
 )
 
 __all__ = [
@@ -24,9 +24,9 @@ __all__ = [
     "CalibratePipetteResult",
     "CalibratePipetteCommandType",
     # calibration/moveToLocation
-    "MoveToLocation",
-    "MoveToLocationCreate",
-    "MoveToLocationParams",
-    "MoveToLocationResult",
-    "MoveToLocationCommandType",
+    "MoveToMaintenancePosition",
+    "MoveToMaintenancePositionCreate",
+    "MoveToMaintenancePositionParams",
+    "MoveToMaintenancePositionResult",
+    "MoveToMaintenancePositionCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/calibration/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "CalibratePipetteParams",
     "CalibratePipetteResult",
     "CalibratePipetteCommandType",
-    # calibration/moveToLocation
+    # calibration/moveToMaintenancePosition
     "MoveToMaintenancePosition",
     "MoveToMaintenancePositionCreate",
     "MoveToMaintenancePositionParams",

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -55,7 +55,7 @@ class MoveToLocationImplementation(
 
     async def execute(self, params: MoveToLocationParams) -> MoveToLocationResult:
         """Move the requested pipette to a given deck slot."""
-        hardware_mount = MountType.to_hw_mount(params.mount)
+        hardware_mount = params.mount.to_hw_mount()
 
         result = self._state_view.labware.get_calibration_coordinates(
             location=params.location

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -57,6 +57,8 @@ class MoveToLocationImplementation(
         """Move the requested pipette to a given deck slot."""
         hardware_mount = params.mount.to_hw_mount()
 
+        await self._hardware_api.home_z(hardware_mount)
+
         result = self._state_view.labware.get_calibration_coordinates(
             location=params.location
         )

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -83,17 +83,14 @@ class MoveToLocationImplementation(
         #     additional_min_travel_z=None,
         # )
 
-        (
-            coordinates,
-            critical_point,
-        ) = self._state_view.labware.get_calibration_coordinates(
+        result = self._state_view.labware.get_calibration_coordinates(
             location=params.location
         )
 
         await self._hardware_api.move_to(
             mount=hardware_mount,
-            abs_position=coordinates,
-            critical_point=critical_point,
+            abs_position=result.coordinates,
+            critical_point=result.critical_point,
         )
 
         return MoveToLocationResult()

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Type, Optional
 from typing_extensions import Literal
-from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from opentrons.protocol_engine.types import DeckPoint
-from opentrons.types import DeckSlotName, MountType
+from opentrons.protocol_engine.types import DeckPoint, CalibrationPosition
+from opentrons.types import MountType
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -21,13 +20,6 @@ if TYPE_CHECKING:
 
 
 MoveToLocationCommandType = Literal["calibration/moveToLocation"]
-
-
-class CalibrationPosition(str, Enum):
-    """Deck slot to move to."""
-
-    PROBE_POSITION = "probePosition"
-    ATTACH_OR_DETACH = "attachOrDetach"
 
 
 class MoveToLocationParams(BaseModel):

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -56,32 +56,6 @@ class MoveToLocationImplementation(
     async def execute(self, params: MoveToLocationParams) -> MoveToLocationResult:
         """Move the requested pipette to a given deck slot."""
         hardware_mount = MountType.to_hw_mount(params.mount)
-        # if params.location == CalibrationPosition.PROBE_POSITION:
-        #     offset = DeckPoint(x=10, y=0, z=3)
-        #     deck_center = self._state_view.labware.get_slot_center_position(
-        #         DeckSlotName.SLOT_5
-        #     )
-        #     z_position = offset.z
-        # else:
-        #     # get current z coordinate and pass it into movement destination
-        #     offset = DeckPoint(x=0, y=0, z=0)
-        #     deck_center = self._state_view.labware.get_slot_center_position(
-        #         DeckSlotName.SLOT_2
-        #     )
-        #     current_position = await self._movement.save_mount_position(
-        #         mount=pipette_mount, position_id=None
-        #     )
-        #     z_position = current_position.position.z
-        # destination = DeckPoint(
-        #     x=deck_center.x + offset.x, y=deck_center.y + offset.y, z=z_position
-        # )
-        #
-        # await self._movement.move_mount_to_coordinates(
-        #     mount=params.mount,
-        #     deck_coordinates=destination,
-        #     direct=True,
-        #     additional_min_travel_z=None,
-        # )
 
         result = self._state_view.labware.get_calibration_coordinates(
             location=params.location

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -31,7 +31,7 @@ class MoveToLocationParams(BaseModel):
     )
     mount: MountType = Field(
         ...,
-        description="Gantry mount to move.",
+        description="Gantry mount to move to location.",
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -36,7 +36,7 @@ class MoveToLocationParams(BaseModel):
 
 
 class MoveToLocationResult(BaseModel):
-    """Result data from the execution of a CalibrationSetUpPosition command."""
+    """Result data from the execution of a MoveToLocation command."""
 
 
 class MoveToLocationImplementation(

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_location.py
@@ -7,9 +7,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from opentrons.protocol_engine.commands.pipetting_common import PipetteIdMixin
 from opentrons.protocol_engine.types import DeckPoint
-from opentrons.types import DeckSlotName
+from opentrons.types import DeckSlotName, MountType
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -17,7 +16,7 @@ from opentrons.protocol_engine.commands.command import (
 )
 
 if TYPE_CHECKING:
-    from opentrons.protocol_engine.execution import MovementHandler
+    from opentrons.hardware_control import HardwareControlAPI
     from opentrons.protocol_engine.state.state import StateView
 
 
@@ -31,12 +30,16 @@ class CalibrationPosition(str, Enum):
     ATTACH_OR_DETACH = "attachOrDetach"
 
 
-class MoveToLocationParams(PipetteIdMixin):
+class MoveToLocationParams(BaseModel):
     """Calibration set up position command parameters."""
 
     location: CalibrationPosition = Field(
         ...,
         description="Slot location to move to before starting calibration.",
+    )
+    mount: MountType = Field(
+        ...,
+        description="Gantry mount to move.",
     )
 
 
@@ -55,42 +58,55 @@ class MoveToLocationImplementation(
     """Calibration set up position command implementation."""
 
     def __init__(
-        self, movement: MovementHandler, state_view: StateView, **kwargs: object
+        self,
+        hardware_api: HardwareControlAPI,
+        state_view: StateView,
+        **kwargs: object,
     ) -> None:
-        self._movement = movement
         self._state_view = state_view
+        self._hardware_api = hardware_api
 
     async def execute(self, params: MoveToLocationParams) -> MoveToLocationResult:
         """Move the requested pipette to a given deck slot."""
-        if params.location == CalibrationPosition.PROBE_POSITION:
-            offset = DeckPoint(x=10, y=0, z=3)
-            deck_center = self._state_view.labware.get_slot_center_position(
-                DeckSlotName.SLOT_5
-            )
-            z_position = offset.z
-        else:
-            # get current z coordinate and pass it into movement destination
-            offset = DeckPoint(x=0, y=0, z=0)
-            deck_center = self._state_view.labware.get_slot_center_position(
-                DeckSlotName.SLOT_2
-            )
-            current_position = await self._movement.save_position(
-                pipette_id=params.pipetteId, position_id=None
-            )
-            z_position = current_position.position.z
-        destination = DeckPoint(
-            x=deck_center.x + offset.x, y=deck_center.y + offset.y, z=z_position
+        pipette_mount = MountType(params.mount)
+        # if params.location == CalibrationPosition.PROBE_POSITION:
+        #     offset = DeckPoint(x=10, y=0, z=3)
+        #     deck_center = self._state_view.labware.get_slot_center_position(
+        #         DeckSlotName.SLOT_5
+        #     )
+        #     z_position = offset.z
+        # else:
+        #     # get current z coordinate and pass it into movement destination
+        #     offset = DeckPoint(x=0, y=0, z=0)
+        #     deck_center = self._state_view.labware.get_slot_center_position(
+        #         DeckSlotName.SLOT_2
+        #     )
+        #     current_position = await self._movement.save_mount_position(
+        #         mount=pipette_mount, position_id=None
+        #     )
+        #     z_position = current_position.position.z
+        # destination = DeckPoint(
+        #     x=deck_center.x + offset.x, y=deck_center.y + offset.y, z=z_position
+        # )
+        #
+        # await self._movement.move_mount_to_coordinates(
+        #     mount=params.mount,
+        #     deck_coordinates=destination,
+        #     direct=True,
+        #     additional_min_travel_z=None,
+        # )
+
+        (
+            coordinates,
+            critical_point,
+        ) = self._state_view.labware.get_calibration_coordinates(
+            location=params.location
         )
 
-        await self._movement.move_to_coordinates(
-            pipette_id=params.pipetteId,
-            deck_coordinates=destination,
-            direct=True,
-            additional_min_travel_z=None,
-        )
+        await self._hardware_api.move_to(mount=pipette_mount)
 
-        new_position = await self._movement.save_position(
-            pipette_id=params.pipetteId, position_id=None
+        new_position = await self._hardware_api.gantry_position(
+            mount=pipette_mount, critical_point=critical_point
         )
 
         return MoveToLocationResult(position=new_position.position)

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -15,7 +15,7 @@ from opentrons.protocol_engine.commands.command import (
 
 if TYPE_CHECKING:
     from opentrons.hardware_control import HardwareControlAPI
-    from ..state import StateView
+    from ...state import StateView
 
 
 MoveToMaintenancePositionCommandType = Literal["calibration/moveToMaintenancePosition"]

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -56,7 +56,7 @@ class MoveToMaintenancePositionImplementation(
         """Move the requested mount to a maintenance deck slot."""
         hardware_mount = params.mount.to_hw_mount()
 
-        await self._hardware_api.home_z(hardware_mount)
+        await self._hardware_api.home()
 
         mount_current_position = await self._hardware_api.gantry_position(
             hardware_mount

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -31,7 +31,7 @@ class MoveToMaintenancePositionParams(BaseModel):
 
 
 class MoveToMaintenancePositionResult(BaseModel):
-    """Result data from the execution of a MoveToLocation command."""
+    """Result data from the execution of a MoveToMaintenancePosition command."""
 
 
 class MoveToMaintenancePositionImplementation(

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -53,7 +53,7 @@ class MoveToMaintenancePositionImplementation(
     async def execute(
         self, params: MoveToMaintenancePositionParams
     ) -> MoveToMaintenancePositionResult:
-        """Move the requested pipette to a given deck slot."""
+        """Move the requested mount to a maintenance deck slot."""
         hardware_mount = params.mount.to_hw_mount()
 
         await self._hardware_api.home_z(hardware_mount)

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -15,7 +15,7 @@ from opentrons.protocol_engine.commands.command import (
 
 if TYPE_CHECKING:
     from opentrons.hardware_control import HardwareControlAPI
-    from opentrons.protocol_engine.state.state import StateView
+    from ..state import StateView
 
 
 MoveToMaintenancePositionCommandType = Literal["calibration/moveToMaintenancePosition"]

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -62,14 +62,13 @@ class MoveToMaintenancePositionImplementation(
             hardware_mount
         )
 
-        result = self._state_view.labware.get_calibration_coordinates(
+        calibration_coordinates = self._state_view.labware.get_calibration_coordinates(
             current_z_position=mount_current_position.z
         )
 
         await self._hardware_api.move_to(
             mount=hardware_mount,
-            abs_position=result.coordinates,
-            critical_point=result.critical_point,
+            abs_position=calibration_coordinates,
         )
 
         return MoveToMaintenancePositionResult()

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -1,4 +1,4 @@
-"""Calibration Move To Location command payload, result, and implementation models."""
+"""Calibration Move To Maintenance Location command payload, result, and implementation models."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Type, Optional

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -221,7 +221,7 @@ Command = Union[
     thermocycler.CloseLid,
     thermocycler.RunProfile,
     calibration.CalibratePipette,
-    calibration.MoveToLocation,
+    calibration.MoveToMaintenancePosition,
 ]
 
 CommandParams = Union[
@@ -269,7 +269,7 @@ CommandParams = Union[
     thermocycler.RunProfileParams,
     thermocycler.RunProfileStepParams,
     calibration.CalibratePipetteParams,
-    calibration.MoveToLocationParams,
+    calibration.MoveToMaintenancePositionParams,
 ]
 
 CommandType = Union[
@@ -316,7 +316,7 @@ CommandType = Union[
     thermocycler.CloseLidCommandType,
     thermocycler.RunProfileCommandType,
     calibration.CalibratePipetteCommandType,
-    calibration.MoveToLocationCommandType,
+    calibration.MoveToMaintenancePositionCommandType,
 ]
 
 CommandCreate = Union[
@@ -363,7 +363,7 @@ CommandCreate = Union[
     thermocycler.CloseLidCreate,
     thermocycler.RunProfileCreate,
     calibration.CalibratePipetteCreate,
-    calibration.MoveToLocationCreate,
+    calibration.MoveToMaintenancePositionCreate,
 ]
 
 CommandResult = Union[
@@ -410,5 +410,5 @@ CommandResult = Union[
     thermocycler.CloseLidResult,
     thermocycler.RunProfileResult,
     calibration.CalibratePipetteResult,
-    calibration.MoveToLocationResult,
+    calibration.MoveToMaintenancePositionResult,
 ]

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -10,7 +10,6 @@ from opentrons_shared_data.pipette.dev_types import LabwareUri
 from opentrons.types import DeckSlotName, Point
 from opentrons.protocols.models import LabwareDefinition, WellDefinition
 from opentrons.calibration_storage.helpers import uri_from_details
-from opentrons.hardware_control.types import CriticalPoint
 
 from .. import errors
 from ..resources import DeckFixedLabware
@@ -492,7 +491,7 @@ class LabwareView(HasState[LabwareState]):
                 y=target_center.y,
                 z=current_z_position,
             ),
-            critical_point=CriticalPoint.MOUNT,
+            critical_point=None,
         )
 
         return result

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -27,7 +27,6 @@ from ..types import (
     LabwareLocation,
     LoadedLabware,
     ModuleLocation,
-    CalibrationCoordinates,
 )
 from ..actions import (
     Action,
@@ -478,23 +477,17 @@ class LabwareView(HasState[LabwareState]):
                     f"Labware {labware.loadName} is already present at {location}."
                 )
 
-    def get_calibration_coordinates(
-        self, current_z_position: float
-    ) -> CalibrationCoordinates:
+    def get_calibration_coordinates(self, current_z_position: float) -> Point:
         """Get calibration critical point and target position."""
         target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
         # TODO (tz, 11-30-22): These coordinates wont work for OT-2. We will need to apply offsets after
         # https://opentrons.atlassian.net/browse/RCORE-382
-        result = CalibrationCoordinates(
-            coordinates=Point(
-                x=target_center.x,
-                y=target_center.y,
-                z=current_z_position,
-            ),
-            critical_point=None,
-        )
 
-        return result
+        return Point(
+            x=target_center.x,
+            y=target_center.y,
+            z=current_z_position,
+        )
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:
         """Check whether the labware uri needs to be calculated in half a millimeter."""

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -500,7 +500,7 @@ class LabwareView(HasState[LabwareState]):
                 critical_point=None,
             )
         else:
-            target_center = self.get_slot_center_position(DeckSlotName.SLOT_2)
+            target_center = self.get_slot_center_position(_PIPETTE_ATTACH_SLOT)
             result = CalibrationCoordinates(
                 coordinates=target_center, critical_point=CriticalPoint.MOUNT
             )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -51,6 +51,7 @@ _MAGDECK_HALF_MM_LABWARE = {
 
 _INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_2
 
+
 @dataclass
 class LabwareState:
     """State of all loaded labware resources."""

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -490,12 +490,12 @@ class LabwareView(HasState[LabwareState]):
     ) -> CalibrationCoordinates:
         """Get calibration critical point and target position."""
         if location == CalibrationPosition.PROBE_POSITION:
-            target_center = self.get_slot_center_position(DeckSlotName.SLOT_5)
+            target_center = self.get_slot_center_position(_PIPETTE_PROBE_ATTACH_SLOT)
             result = CalibrationCoordinates(
                 coordinates=Point(
-                    x=target_center.x + _PROBE_DECK_SLOT_OFFSET.x,
-                    y=target_center.y + _PROBE_DECK_SLOT_OFFSET.y,
-                    z=_PROBE_DECK_SLOT_OFFSET.z,
+                    x=target_center.x + _PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT,
+                    y=target_center.y,
+                    z=target_center.z + _PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT,
                 ),
                 critical_point=None,
             )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -29,7 +29,6 @@ from ..types import (
     LabwareLocation,
     LoadedLabware,
     ModuleLocation,
-    CalibrationPosition,
     CalibrationCoordinates,
 )
 from ..actions import (
@@ -488,34 +487,23 @@ class LabwareView(HasState[LabwareState]):
                 )
 
     def get_calibration_coordinates(
-        self, location: CalibrationPosition
+        self, current_z_position: float
     ) -> CalibrationCoordinates:
         """Get calibration critical point and target position."""
-        if location == CalibrationPosition.INSTRUMENT_PROBE_ATTACH:
-            target_center = self.get_slot_center_position(_INSTRUMENT_PROBE_ATTACH_SLOT)
-            result = CalibrationCoordinates(
-                coordinates=Point(
-                    x=target_center.x + _PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT,
-                    y=target_center.y,
-                    z=target_center.z + _PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT,
-                ),
-                critical_point=None,
-            )
-        else:
-            target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
-            z_offset = (
-                _OT_3_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
-                if should_use_ot3
-                else _OT_2_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
-            )
-            result = CalibrationCoordinates(
-                coordinates=Point(
-                    x=target_center.x,
-                    y=target_center.y,
-                    z=target_center.z + z_offset,
-                ),
-                critical_point=CriticalPoint.MOUNT,
-            )
+        target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
+        z_offset = (
+            _OT_3_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
+            if should_use_ot3
+            else _OT_2_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
+        )
+        result = CalibrationCoordinates(
+            coordinates=Point(
+                x=target_center.x,
+                y=target_center.y,
+                z=current_z_position + z_offset,
+            ),
+            critical_point=CriticalPoint.MOUNT,
+        )
 
         return result
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Any, Mapping, Union, Tuple
+from typing import Dict, List, Optional, Sequence, Any, Mapping, Union
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3, SlotDefV3
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -10,7 +10,6 @@ from opentrons_shared_data.pipette.dev_types import LabwareUri
 from opentrons.types import DeckSlotName, Point
 from opentrons.protocols.models import LabwareDefinition, WellDefinition
 from opentrons.calibration_storage.helpers import uri_from_details
-from opentrons.hardware_control.types import CriticalPoint
 
 from .. import errors
 from ..resources import DeckFixedLabware
@@ -29,6 +28,7 @@ from ..types import (
     LoadedLabware,
     ModuleLocation,
     CalibrationPosition,
+    CalibrationCoordinates
 )
 from ..actions import (
     Action,
@@ -479,7 +479,7 @@ class LabwareView(HasState[LabwareState]):
 
     def get_calibration_coordinates(
         self, location: CalibrationPosition
-    ) -> Tuple[Point, Optional[CriticalPoint]]:
+    ) -> CalibrationCoordinates:
         """Get calibration critical point and target position."""
         pass
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -51,7 +51,6 @@ _MAGDECK_HALF_MM_LABWARE = {
 
 _INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_2
 
-
 @dataclass
 class LabwareState:
     """State of all loaded labware resources."""

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -475,6 +475,9 @@ class LabwareView(HasState[LabwareState]):
                     f"Labware {labware.loadName} is already present at {location}."
                 )
 
+    def get_calibration_coordinates(self):
+        pass
+
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:
         """Check whether the labware uri needs to be calculated in half a millimeter."""
         uri = self.get_uri_from_definition(self.get_definition(labware_id))

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -30,7 +30,6 @@ from ..types import (
     ModuleLocation,
     CalibrationPosition,
     CalibrationCoordinates,
-    DeckPoint,
 )
 from ..actions import (
     Action,
@@ -51,11 +50,11 @@ _MAGDECK_HALF_MM_LABWARE = {
     "opentrons/usascientific_96_wellplate_2.4ml_deep/1",
 }
 
-_PIPETTE_PROBE_ATTACH_SLOT = DeckSlotName.SLOT_5
+_INSTRUMENT_PROBE_ATTACH_SLOT = DeckSlotName.SLOT_5
 _PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT = 10.0
 _PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT = 3.0
 
-_PIPETTE_ATTACH_SLOT = DeckSlotName.SLOT_2
+_INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_2
 
 
 @dataclass
@@ -489,10 +488,10 @@ class LabwareView(HasState[LabwareState]):
         self, location: CalibrationPosition
     ) -> CalibrationCoordinates:
         """Get calibration critical point and target position."""
-        if location == CalibrationPosition.PIPETTE_PROBE_ATTACH:
-            target_center = self.get_slot_center_position(_PIPETTE_PROBE_ATTACH_SLOT)
+        if location == CalibrationPosition.INSTRUMENT_PROBE_ATTACH:
+            target_center = self.get_slot_center_position(_INSTRUMENT_PROBE_ATTACH_SLOT)
             result = CalibrationCoordinates(
-                coordinates=DeckPoint(
+                coordinates=Point(
                     x=target_center.x + _PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT,
                     y=target_center.y,
                     z=target_center.z + _PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT,
@@ -500,7 +499,7 @@ class LabwareView(HasState[LabwareState]):
                 critical_point=None,
             )
         else:
-            target_center = self.get_slot_center_position(_PIPETTE_ATTACH_SLOT)
+            target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
             result = CalibrationCoordinates(
                 coordinates=target_center, critical_point=CriticalPoint.MOUNT
             )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -30,7 +30,7 @@ from ..types import (
     ModuleLocation,
     CalibrationPosition,
     CalibrationCoordinates,
-    DeckSlotOffsetVector,
+    DeckPoint,
 )
 from ..actions import (
     Action,
@@ -489,10 +489,10 @@ class LabwareView(HasState[LabwareState]):
         self, location: CalibrationPosition
     ) -> CalibrationCoordinates:
         """Get calibration critical point and target position."""
-        if location == CalibrationPosition.PROBE_POSITION:
+        if location == CalibrationPosition.PIPETTE_PROBE_ATTACH:
             target_center = self.get_slot_center_position(_PIPETTE_PROBE_ATTACH_SLOT)
             result = CalibrationCoordinates(
-                coordinates=Point(
+                coordinates=DeckPoint(
                     x=target_center.x + _PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT,
                     y=target_center.y,
                     z=target_center.z + _PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -51,7 +51,11 @@ _MAGDECK_HALF_MM_LABWARE = {
     "opentrons/usascientific_96_wellplate_2.4ml_deep/1",
 }
 
-_PROBE_DECK_SLOT_OFFSET = DeckSlotOffsetVector(x=10, y=0, z=3)
+_PIPETTE_PROBE_ATTACH_SLOT = DeckSlotName.SLOT_5
+_PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT = 10.0
+_PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT = 3.0
+
+_PIPETTE_ATTACH_SLOT = DeckSlotName.SLOT_2
 
 
 @dataclass

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Any, Mapping, Union
+from typing import Dict, List, Optional, Sequence, Any, Mapping, Union, Tuple
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3, SlotDefV3
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -10,6 +10,7 @@ from opentrons_shared_data.pipette.dev_types import LabwareUri
 from opentrons.types import DeckSlotName, Point
 from opentrons.protocols.models import LabwareDefinition, WellDefinition
 from opentrons.calibration_storage.helpers import uri_from_details
+from opentrons.hardware_control.types import CriticalPoint
 
 from .. import errors
 from ..resources import DeckFixedLabware
@@ -27,6 +28,7 @@ from ..types import (
     LabwareLocation,
     LoadedLabware,
     ModuleLocation,
+    CalibrationPosition,
 )
 from ..actions import (
     Action,
@@ -475,7 +477,10 @@ class LabwareView(HasState[LabwareState]):
                     f"Labware {labware.loadName} is already present at {location}."
                 )
 
-    def get_calibration_coordinates(self):
+    def get_calibration_coordinates(
+        self, location: CalibrationPosition
+    ) -> Tuple[Point, Optional[CriticalPoint]]:
+        """Get calibration critical point and target position."""
         pass
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -11,7 +11,6 @@ from opentrons.types import DeckSlotName, Point
 from opentrons.protocols.models import LabwareDefinition, WellDefinition
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons import should_use_ot3
 
 from .. import errors
 from ..resources import DeckFixedLabware
@@ -49,12 +48,6 @@ _MAGDECK_HALF_MM_LABWARE = {
     "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
     "opentrons/usascientific_96_wellplate_2.4ml_deep/1",
 }
-
-_INSTRUMENT_PROBE_ATTACH_SLOT = DeckSlotName.SLOT_5
-_PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT = 10.0
-_PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT = 3.0
-_OT_2_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT = 30.0
-_OT_3_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT = 250.0
 
 _INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_2
 
@@ -491,16 +484,13 @@ class LabwareView(HasState[LabwareState]):
     ) -> CalibrationCoordinates:
         """Get calibration critical point and target position."""
         target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
-        z_offset = (
-            _OT_3_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
-            if should_use_ot3
-            else _OT_2_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
-        )
+        # TODO (tz, 11-30-22): These coordinates wont work for OT-2. We will need to apply offsets after
+        # https://opentrons.atlassian.net/browse/RCORE-382
         result = CalibrationCoordinates(
             coordinates=Point(
                 x=target_center.x,
                 y=target_center.y,
-                z=current_z_position + z_offset,
+                z=current_z_position,
             ),
             critical_point=CriticalPoint.MOUNT,
         )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -11,6 +11,7 @@ from opentrons.types import DeckSlotName, Point
 from opentrons.protocols.models import LabwareDefinition, WellDefinition
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.hardware_control.types import CriticalPoint
+from opentrons import should_use_ot3
 
 from .. import errors
 from ..resources import DeckFixedLabware
@@ -53,6 +54,8 @@ _MAGDECK_HALF_MM_LABWARE = {
 _INSTRUMENT_PROBE_ATTACH_SLOT = DeckSlotName.SLOT_5
 _PIPETTE_PROBE_ATTACH_X_OFFSET_FROM_SLOT = 10.0
 _PIPETTE_PROBE_ATTACH_Z_OFFSET_FROM_SLOT = 3.0
+_OT_2_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT = 30.0
+_OT_3_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT = 250.0
 
 _INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_2
 
@@ -500,8 +503,18 @@ class LabwareView(HasState[LabwareState]):
             )
         else:
             target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
+            z_offset = (
+                _OT_3_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
+                if should_use_ot3
+                else _OT_2_PIPETTE_ATTACH_Z_OFFSET_FROM_SLOT
+            )
             result = CalibrationCoordinates(
-                coordinates=target_center, critical_point=CriticalPoint.MOUNT
+                coordinates=Point(
+                    x=target_center.x,
+                    y=target_center.y,
+                    z=target_center.z + z_offset,
+                ),
+                critical_point=CriticalPoint.MOUNT,
             )
 
         return result

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -9,7 +9,7 @@ from typing import Optional, Union, List, Dict, Any, NamedTuple
 from typing_extensions import Literal, TypeGuard
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import MountType, DeckSlotName
+from opentrons.types import MountType, DeckSlotName, Point
 from opentrons.hardware_control.modules import ModuleType as ModuleType
 from opentrons.hardware_control.types import CriticalPoint
 
@@ -404,12 +404,12 @@ class HeaterShakerMovementRestrictors:
 class CalibrationPosition(str, Enum):
     """Deck slot to move to."""
 
-    PIPETTE_PROBE_ATTACH = "pipetteProbeAttach"
-    ATTACH_OR_DETACH = "attachOrDetach"
+    INSTRUMENT_PROBE_ATTACH = "instrumentProbeAttach"
+    INSTRUMENT_ATTACH = "instrumentAttach"
 
 
 class CalibrationCoordinates(NamedTuple):
     """Calibration coordinates and critical point."""
 
-    coordinates: DeckPoint
+    coordinates: Point
     critical_point: Optional[CriticalPoint]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -230,6 +230,14 @@ class InstrumentOffsetVector(BaseModel):
     z: float
 
 
+class DeckSlotOffsetVector(BaseModel):
+    """Deck slot Offset from home position to robot deck."""
+
+    x: float
+    y: float
+    z: float
+
+
 class ModuleDefinition(BaseModel):
     """Module definition class."""
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -401,13 +401,6 @@ class HeaterShakerMovementRestrictors:
     deck_slot: int
 
 
-class CalibrationPosition(str, Enum):
-    """Deck slot to move to."""
-
-    INSTRUMENT_PROBE_ATTACH = "instrumentProbeAttach"
-    INSTRUMENT_ATTACH = "instrumentAttach"
-
-
 class CalibrationCoordinates(NamedTuple):
     """Calibration coordinates and critical point."""
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -398,3 +398,10 @@ class HeaterShakerMovementRestrictors:
     plate_shaking: bool
     latch_closed: bool
     deck_slot: int
+
+
+class CalibrationPosition(str, Enum):
+    """Deck slot to move to."""
+
+    PROBE_POSITION = "probePosition"
+    ATTACH_OR_DETACH = "attachOrDetach"

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -230,14 +230,6 @@ class InstrumentOffsetVector(BaseModel):
     z: float
 
 
-class DeckSlotOffsetVector(BaseModel):
-    """Deck slot Offset from home position to robot deck."""
-
-    x: float
-    y: float
-    z: float
-
-
 class ModuleDefinition(BaseModel):
     """Module definition class."""
 
@@ -412,7 +404,7 @@ class HeaterShakerMovementRestrictors:
 class CalibrationPosition(str, Enum):
     """Deck slot to move to."""
 
-    PROBE_POSITION = "probePosition"
+    PIPETTE_PROBE_ATTACH = "pipetteProbeAttach"
     ATTACH_OR_DETACH = "attachOrDetach"
 
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -9,8 +9,9 @@ from typing import Optional, Union, List, Dict, Any, NamedTuple
 from typing_extensions import Literal, TypeGuard
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import MountType, DeckSlotName
+from opentrons.types import MountType, DeckSlotName, Point
 from opentrons.hardware_control.modules import ModuleType as ModuleType
+from opentrons.hardware_control.types import CriticalPoint
 
 
 from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
@@ -405,3 +406,10 @@ class CalibrationPosition(str, Enum):
 
     PROBE_POSITION = "probePosition"
     ATTACH_OR_DETACH = "attachOrDetach"
+
+
+class CalibrationCoordinates(NamedTuple):
+    """Calibration coordinates and critical point."""
+
+    coordinates: Point
+    critical_point: Optional[CriticalPoint]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -9,10 +9,8 @@ from typing import Optional, Union, List, Dict, Any, NamedTuple
 from typing_extensions import Literal, TypeGuard
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import MountType, DeckSlotName, Point
+from opentrons.types import MountType, DeckSlotName
 from opentrons.hardware_control.modules import ModuleType as ModuleType
-from opentrons.hardware_control.types import CriticalPoint
-
 
 from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
     # convenience re-export of LabwareUri type
@@ -399,10 +397,3 @@ class HeaterShakerMovementRestrictors:
     plate_shaking: bool
     latch_closed: bool
     deck_slot: int
-
-
-class CalibrationCoordinates(NamedTuple):
-    """Calibration coordinates and critical point."""
-
-    coordinates: Point
-    critical_point: Optional[CriticalPoint]

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -9,7 +9,7 @@ from typing import Optional, Union, List, Dict, Any, NamedTuple
 from typing_extensions import Literal, TypeGuard
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import MountType, DeckSlotName, Point
+from opentrons.types import MountType, DeckSlotName
 from opentrons.hardware_control.modules import ModuleType as ModuleType
 from opentrons.hardware_control.types import CriticalPoint
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -419,5 +419,5 @@ class CalibrationPosition(str, Enum):
 class CalibrationCoordinates(NamedTuple):
     """Calibration coordinates and critical point."""
 
-    coordinates: Point
+    coordinates: DeckPoint
     critical_point: Optional[CriticalPoint]

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -2,45 +2,41 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_engine.commands.calibration.move_to_location import (
-    MoveToLocationParams,
-    MoveToLocationImplementation,
-    MoveToLocationResult,
+from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position import (
+    MoveToMaintenancePositionParams,
+    MoveToMaintenancePositionImplementation,
+    MoveToMaintenancePositionResult,
 )
+from opentrons.protocol_engine.types import CalibrationCoordinates
+
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import Point, MountType, Mount
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons.protocol_engine.types import CalibrationPosition, CalibrationCoordinates
 
 
 @pytest.fixture
 def subject(
     state_view: StateView, hardware_api: HardwareControlAPI
-) -> MoveToLocationImplementation:
+) -> MoveToMaintenancePositionImplementation:
     """Get command subject to test."""
-    return MoveToLocationImplementation(
+    return MoveToMaintenancePositionImplementation(
         state_view=state_view, hardware_api=hardware_api
     )
 
 
 async def test_calibration_move_to_location_implementation(
     decoy: Decoy,
-    subject: MoveToLocationImplementation,
+    subject: MoveToMaintenancePositionImplementation,
     state_view: StateView,
     hardware_api: HardwareControlAPI,
 ) -> None:
     """Command should get a Point value for a given deck slot center and \
         call Movement.move_to_coordinates with the correct input."""
-    params = MoveToLocationParams(
-        mount=MountType.LEFT,
-        location=CalibrationPosition.INSTRUMENT_ATTACH,
-    )
+    params = MoveToMaintenancePositionParams(mount=MountType.LEFT)
 
     decoy.when(
-        state_view.labware.get_calibration_coordinates(
-            location=CalibrationPosition.INSTRUMENT_ATTACH
-        )
+        state_view.labware.get_calibration_coordinates(current_z_position=3.0)
     ).then_return(
         CalibrationCoordinates(
             coordinates=Point(x=1, y=2, z=3), critical_point=CriticalPoint.MOUNT
@@ -48,7 +44,7 @@ async def test_calibration_move_to_location_implementation(
     )
 
     result = await subject.execute(params=params)
-    assert result == MoveToLocationResult()
+    assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
         await hardware_api.home_z(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -56,12 +56,7 @@ async def test_calibration_move_to_location_implementation(
         await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=1, y=2, z=3),
-<<<<<<< HEAD
-            critical_point=critical_point_result,
-        ),
-        times=1
-=======
             critical_point=CriticalPoint.MOUNT,
-        )
->>>>>>> 11691c028 (pr fixes)
+        ),
+        times=1,
     )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -7,7 +7,7 @@ from typing import Optional
 from opentrons.protocol_engine.commands.calibration.move_to_location import (
     MoveToLocationParams,
     MoveToLocationImplementation,
-    MoveToLocationResult
+    MoveToLocationResult,
 )
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.state import StateView
@@ -43,7 +43,6 @@ async def test_calibration_set_up_position_implementation(
 ) -> None:
     """Command should get a Point value for a given deck slot center and \
         call Movement.move_to_coordinates with the correct input."""
-
     params = MoveToLocationParams(
         mount=MountType.LEFT,
         location=slot_name,
@@ -51,7 +50,11 @@ async def test_calibration_set_up_position_implementation(
 
     decoy.when(
         state_view.labware.get_calibration_coordinates(location=slot_name)
-    ).then_return(CalibrationCoordinates(coordinates=Point(x=1, y=2, z=3), critical_point=critical_point_result))
+    ).then_return(
+        CalibrationCoordinates(
+            coordinates=Point(x=1, y=2, z=3), critical_point=critical_point_result
+        )
+    )
 
     result = await subject.execute(params=params)
     assert result == MoveToLocationResult()

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -35,7 +35,7 @@ def subject(
 )
 async def test_calibration_set_up_position_implementation(
     decoy: Decoy,
-    slot_name: CalibrationPosition,
+    input_position: CalibrationPosition,
     critical_point_result: Optional[CriticalPoint],
     subject: MoveToLocationImplementation,
     state_view: StateView,

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -45,7 +45,7 @@ async def test_calibration_set_up_position_implementation(
         call Movement.move_to_coordinates with the correct input."""
     params = MoveToLocationParams(
         mount=MountType.LEFT,
-        location=slot_name,
+        location=input_position,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -33,7 +33,7 @@ def subject(
         (CalibrationPosition.ATTACH_OR_DETACH, CriticalPoint.MOUNT),
     ],
 )
-async def test_calibration_set_up_position_implementation(
+async def test_calibration_move_to_location_implementation(
     decoy: Decoy,
     input_position: CalibrationPosition,
     critical_point_result: Optional[CriticalPoint],

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -2,8 +2,6 @@
 import pytest
 from decoy import Decoy
 
-from typing import Optional
-
 from opentrons.protocol_engine.commands.calibration.move_to_location import (
     MoveToLocationParams,
     MoveToLocationImplementation,
@@ -36,12 +34,12 @@ async def test_calibration_move_to_location_implementation(
         call Movement.move_to_coordinates with the correct input."""
     params = MoveToLocationParams(
         mount=MountType.LEFT,
-        location=CalibrationPosition.ATTACH_OR_DETACH,
+        location=CalibrationPosition.INSTRUMENT_ATTACH,
     )
 
     decoy.when(
         state_view.labware.get_calibration_coordinates(
-            location=CalibrationPosition.ATTACH_OR_DETACH
+            location=CalibrationPosition.INSTRUMENT_ATTACH
         )
     ).then_return(
         CalibrationCoordinates(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -27,7 +27,7 @@ def subject(
 
 
 @pytest.mark.parametrize(
-    argnames=["slot_name", "critical_point_result"],
+    argnames=["input_position", "critical_point_result"],
     argvalues=[
         (CalibrationPosition.PROBE_POSITION, None),
         (CalibrationPosition.ATTACH_OR_DETACH, CriticalPoint.MOUNT),

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -26,17 +26,8 @@ def subject(
     )
 
 
-@pytest.mark.parametrize(
-    argnames=["input_position", "critical_point_result"],
-    argvalues=[
-        (CalibrationPosition.PROBE_POSITION, None),
-        (CalibrationPosition.ATTACH_OR_DETACH, CriticalPoint.MOUNT),
-    ],
-)
 async def test_calibration_move_to_location_implementation(
     decoy: Decoy,
-    input_position: CalibrationPosition,
-    critical_point_result: Optional[CriticalPoint],
     subject: MoveToLocationImplementation,
     state_view: StateView,
     hardware_api: HardwareControlAPI,
@@ -45,14 +36,16 @@ async def test_calibration_move_to_location_implementation(
         call Movement.move_to_coordinates with the correct input."""
     params = MoveToLocationParams(
         mount=MountType.LEFT,
-        location=input_position,
+        location=CalibrationPosition.ATTACH_OR_DETACH,
     )
 
     decoy.when(
-        state_view.labware.get_calibration_coordinates(location=input_position)
+        state_view.labware.get_calibration_coordinates(
+            location=CalibrationPosition.ATTACH_OR_DETACH
+        )
     ).then_return(
         CalibrationCoordinates(
-            coordinates=Point(x=1, y=2, z=3), critical_point=critical_point_result
+            coordinates=Point(x=1, y=2, z=3), critical_point=CriticalPoint.MOUNT
         )
     )
 
@@ -63,7 +56,12 @@ async def test_calibration_move_to_location_implementation(
         await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=1, y=2, z=3),
+<<<<<<< HEAD
             critical_point=critical_point_result,
         ),
         times=1
+=======
+            critical_point=CriticalPoint.MOUNT,
+        )
+>>>>>>> 11691c028 (pr fixes)
     )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -64,5 +64,6 @@ async def test_calibration_move_to_location_implementation(
             mount=Mount.LEFT,
             abs_position=Point(x=1, y=2, z=3),
             critical_point=critical_point_result,
-        )
+        ),
+        times=1
     )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -51,6 +51,13 @@ async def test_calibration_move_to_location_implementation(
     assert result == MoveToLocationResult()
 
     decoy.verify(
+        await hardware_api.home_z(
+            mount=Mount.LEFT,
+        ),
+        times=1,
+    )
+
+    decoy.verify(
         await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=1, y=2, z=3),

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_location.py
@@ -49,7 +49,7 @@ async def test_calibration_set_up_position_implementation(
     )
 
     decoy.when(
-        state_view.labware.get_calibration_coordinates(location=slot_name)
+        state_view.labware.get_calibration_coordinates(location=input_position)
     ).then_return(
         CalibrationCoordinates(
             coordinates=Point(x=1, y=2, z=3), critical_point=critical_point_result

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
@@ -36,6 +36,12 @@ async def test_calibration_move_to_location_implementation(
     params = MoveToMaintenancePositionParams(mount=MountType.LEFT)
 
     decoy.when(
+        await hardware_api.gantry_position(mount=Mount.LEFT)
+    ).then_return(
+        Point(x=1, y=2, z=3)
+    )
+
+    decoy.when(
         state_view.labware.get_calibration_coordinates(current_z_position=3.0)
     ).then_return(
         CalibrationCoordinates(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
@@ -50,9 +50,7 @@ async def test_calibration_move_to_location_implementation(
     assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
-        await hardware_api.home_z(
-            mount=Mount.LEFT,
-        ),
+        await hardware_api.home(),
         times=1,
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
@@ -11,7 +11,6 @@ from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import Point, MountType, Mount
-from opentrons.hardware_control.types import CriticalPoint
 
 
 @pytest.fixture
@@ -50,8 +49,6 @@ async def test_calibration_move_to_location_implementation(
     )
 
     decoy.verify(
-        await hardware_api.move_to(
-            mount=Mount.LEFT,
-            abs_position=Point(x=1, y=2, z=3)        ),
+        await hardware_api.move_to(mount=Mount.LEFT, abs_position=Point(x=1, y=2, z=3)),
         times=1,
     )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
@@ -35,9 +35,7 @@ async def test_calibration_move_to_location_implementation(
         call Movement.move_to_coordinates with the correct input."""
     params = MoveToMaintenancePositionParams(mount=MountType.LEFT)
 
-    decoy.when(
-        await hardware_api.gantry_position(mount=Mount.LEFT)
-    ).then_return(
+    decoy.when(await hardware_api.gantry_position(mount=Mount.LEFT)).then_return(
         Point(x=1, y=2, z=3)
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
@@ -31,8 +31,7 @@ async def test_calibration_move_to_location_implementation(
     state_view: StateView,
     hardware_api: HardwareControlAPI,
 ) -> None:
-    """Command should get a Point value for a given deck slot center and \
-        call Movement.move_to_coordinates with the correct input."""
+    """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(mount=MountType.LEFT)
 
     decoy.when(await hardware_api.gantry_position(mount=Mount.LEFT)).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibration_move_to_maintenance_position.py
@@ -7,7 +7,6 @@ from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position
     MoveToMaintenancePositionImplementation,
     MoveToMaintenancePositionResult,
 )
-from opentrons.protocol_engine.types import CalibrationCoordinates
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.state import StateView
@@ -40,11 +39,7 @@ async def test_calibration_move_to_location_implementation(
 
     decoy.when(
         state_view.labware.get_calibration_coordinates(current_z_position=3.0)
-    ).then_return(
-        CalibrationCoordinates(
-            coordinates=Point(x=1, y=2, z=3), critical_point=CriticalPoint.MOUNT
-        )
-    )
+    ).then_return(Point(x=1, y=2, z=3))
 
     result = await subject.execute(params=params)
     assert result == MoveToMaintenancePositionResult()
@@ -57,8 +52,6 @@ async def test_calibration_move_to_location_implementation(
     decoy.verify(
         await hardware_api.move_to(
             mount=Mount.LEFT,
-            abs_position=Point(x=1, y=2, z=3),
-            critical_point=CriticalPoint.MOUNT,
-        ),
+            abs_position=Point(x=1, y=2, z=3)        ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -762,7 +762,9 @@ def test_get_calibration_coordinates(
             ]
         }
     }
+
     subject = get_labware_view(deck_definition=cast(DeckDefinitionV3, slot_definitions))
+    
 
     result = subject.get_calibration_coordinates(location=input_location)
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -718,7 +718,11 @@ def test_raise_if_labware_in_location(
 @pytest.mark.parametrize(
     "input_location, critical_point_result, coordinates_result",
     [
-        (CalibrationPosition.PROBE_POSITION, None, Point(x=206.5, y=133.5, z=3.0)),
+        (
+            CalibrationPosition.PIPETTE_PROBE_ATTACH,
+            None,
+            Point(x=206.5, y=133.5, z=3.0),
+        ),
         (
             CalibrationPosition.ATTACH_OR_DETACH,
             CriticalPoint.MOUNT,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -19,6 +19,7 @@ from opentrons.protocol_engine.types import (
     LoadedLabware,
     ModuleModel,
     ModuleLocation,
+    CalibrationPosition,
 )
 
 from opentrons.protocol_engine.state.labware import LabwareState, LabwareView
@@ -717,5 +718,6 @@ def test_get_calibration_coordinates() -> None:
     """Should return critical point and coordinates."""
     subject = get_labware_view()
 
-    coordinates, critical_point = subject.get_calibration_coordinates()
-
+    coordinates, critical_point = subject.get_calibration_coordinates(
+        location=CalibrationPosition.PROBE_POSITION
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -8,7 +8,6 @@ from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.pipette.dev_types import LabwareUri
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName, Point
-from opentrons.hardware_control.types import CriticalPoint
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
@@ -737,6 +736,4 @@ def test_get_calibration_coordinates() -> None:
 
     result = subject.get_calibration_coordinates(current_z_position=3.0)
 
-    assert result.critical_point == None
-
-    assert result.coordinates == Point(x=4, y=5, z=3)
+    assert result == Point(x=4, y=5, z=3)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -711,3 +711,11 @@ def test_raise_if_labware_in_location(
     )
     with expected_raise:
         subject.raise_if_labware_in_location(location=location)
+
+
+def test_get_calibration_coordinates() -> None:
+    """Should return critical point and coordinates."""
+    subject = get_labware_view()
+
+    coordinates, critical_point = subject.get_calibration_coordinates()
+

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -728,17 +728,7 @@ def test_get_calibration_coordinates() -> None:
                         "zDimension": 0,
                     },
                     "displayName": "Slot 2",
-                },
-                # {
-                #     "id": "5",
-                #     "position": [5, 5, 0.0],
-                #     "boundingBox": {
-                #         "xDimension": 10.0,
-                #         "yDimension": 15.0,
-                #         "zDimension": 0,
-                #     },
-                #     "displayName": "Slot 5",
-                # },
+                }
             ]
         }
     }
@@ -749,4 +739,4 @@ def test_get_calibration_coordinates() -> None:
 
     assert result.critical_point == CriticalPoint.MOUNT
 
-    assert result.coordinates == Point(x=2, y=5, z=0)
+    assert result.coordinates == Point(x=4, y=5, z=3)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -20,7 +20,6 @@ from opentrons.protocol_engine.types import (
     LoadedLabware,
     ModuleModel,
     ModuleLocation,
-    CalibrationPosition,
 )
 
 from opentrons.protocol_engine.state.labware import LabwareState, LabwareView
@@ -715,26 +714,7 @@ def test_raise_if_labware_in_location(
         subject.raise_if_labware_in_location(location=location)
 
 
-@pytest.mark.parametrize(
-    "input_location, critical_point_result, coordinates_result",
-    [
-        (
-            CalibrationPosition.INSTRUMENT_PROBE_ATTACH,
-            None,
-            Point(x=20.0, y=12.5, z=3.0),
-        ),
-        (
-            CalibrationPosition.INSTRUMENT_ATTACH,
-            CriticalPoint.MOUNT,
-            Point(x=4.0, y=5.0, z=250.0),
-        ),
-    ],
-)
-def test_get_calibration_coordinates(
-    input_location: CalibrationPosition,
-    critical_point_result: Optional[CriticalPoint],
-    coordinates_result: Point,
-) -> None:
+def test_get_calibration_coordinates() -> None:
     """Should return critical point and coordinates."""
     slot_definitions = {
         "locations": {
@@ -749,25 +729,24 @@ def test_get_calibration_coordinates(
                     },
                     "displayName": "Slot 2",
                 },
-                {
-                    "id": "5",
-                    "position": [5, 5, 0.0],
-                    "boundingBox": {
-                        "xDimension": 10.0,
-                        "yDimension": 15.0,
-                        "zDimension": 0,
-                    },
-                    "displayName": "Slot 5",
-                },
+                # {
+                #     "id": "5",
+                #     "position": [5, 5, 0.0],
+                #     "boundingBox": {
+                #         "xDimension": 10.0,
+                #         "yDimension": 15.0,
+                #         "zDimension": 0,
+                #     },
+                #     "displayName": "Slot 5",
+                # },
             ]
         }
     }
 
     subject = get_labware_view(deck_definition=cast(DeckDefinitionV3, slot_definitions))
-    
 
-    result = subject.get_calibration_coordinates(location=input_location)
+    result = subject.get_calibration_coordinates(current_z_position=3.0)
 
-    assert result.critical_point == critical_point_result
+    assert result.critical_point == CriticalPoint.MOUNT
 
-    assert result.coordinates == coordinates_result
+    assert result.coordinates == Point(x=2, y=5, z=0)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -726,7 +726,7 @@ def test_raise_if_labware_in_location(
         (
             CalibrationPosition.INSTRUMENT_ATTACH,
             CriticalPoint.MOUNT,
-            Point(x=4.0, y=5.0, z=0.0),
+            Point(x=4.0, y=5.0, z=250.0),
         ),
     ],
 )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -719,12 +719,12 @@ def test_raise_if_labware_in_location(
     "input_location, critical_point_result, coordinates_result",
     [
         (
-            CalibrationPosition.PIPETTE_PROBE_ATTACH,
+            CalibrationPosition.INSTRUMENT_PROBE_ATTACH,
             None,
             Point(x=20.0, y=12.5, z=3.0),
         ),
         (
-            CalibrationPosition.ATTACH_OR_DETACH,
+            CalibrationPosition.INSTRUMENT_ATTACH,
             CriticalPoint.MOUNT,
             Point(x=4.0, y=5.0, z=0.0),
         ),

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -721,12 +721,12 @@ def test_raise_if_labware_in_location(
         (
             CalibrationPosition.PIPETTE_PROBE_ATTACH,
             None,
-            Point(x=206.5, y=133.5, z=3.0),
+            Point(x=20.0, y=12.5, z=3.0),
         ),
         (
             CalibrationPosition.ATTACH_OR_DETACH,
             CriticalPoint.MOUNT,
-            Point(x=196.5, y=43.0, z=0.0),
+            Point(x=4.0, y=5.0, z=0.0),
         ),
     ],
 )
@@ -734,10 +734,35 @@ def test_get_calibration_coordinates(
     input_location: CalibrationPosition,
     critical_point_result: Optional[CriticalPoint],
     coordinates_result: Point,
-    standard_deck_def: DeckDefinitionV3,
 ) -> None:
     """Should return critical point and coordinates."""
-    subject = get_labware_view(deck_definition=standard_deck_def)
+    slot_definitions = {
+        "locations": {
+            "orderedSlots": [
+                {
+                    "id": "2",
+                    "position": [2, 2, 0.0],
+                    "boundingBox": {
+                        "xDimension": 4.0,
+                        "yDimension": 6.0,
+                        "zDimension": 0,
+                    },
+                    "displayName": "Slot 2",
+                },
+                {
+                    "id": "5",
+                    "position": [5, 5, 0.0],
+                    "boundingBox": {
+                        "xDimension": 10.0,
+                        "yDimension": 15.0,
+                        "zDimension": 0,
+                    },
+                    "displayName": "Slot 5",
+                },
+            ]
+        }
+    }
+    subject = get_labware_view(deck_definition=cast(DeckDefinitionV3, slot_definitions))
 
     result = subject.get_calibration_coordinates(location=input_location)
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -737,6 +737,6 @@ def test_get_calibration_coordinates() -> None:
 
     result = subject.get_calibration_coordinates(current_z_position=3.0)
 
-    assert result.critical_point == CriticalPoint.MOUNT
+    assert result.critical_point == None
 
     assert result.coordinates == Point(x=4, y=5, z=3)


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RLIQ-268.
Change command name from `calibration/moveToLocation` to `calibration/moveToMaintenancePosition`. accepts `mount` instead of `pipetteId`.

# Changelog

- Changed MoveToLocation prefix classes to MoveToMaintenancePosition prefix.
- Refactored `MoveToMaintenancePositionParams` to accept `mount` instead of `pipetteId`.
- Refactored `MoveToMaintenancePositionParams` and removed `location` property. instead we are now moving to slot 2 for both probe attaching and pipette/gripper attachment. 
- Refactored `MoveToMaintenancePositionResult` to not return current position in the result.
- Refactored `MoveToMaintenancePositionImplementation` to act as a collaborator and moved logic into `LabwareView`.
- Added a hardware `home()` call at the beginning of `MoveToMaintenancePositionImplementation` instead of relaying on the app to create a `home` command before calling `calibration/moveToMaintenancePosition`.
- get `hardware_api.gantry_position` for the z height.
- Added new method to `LabwareView` to get calibration coordinates and critical point.


# Review requests

changes make sense? 

# Risk assessment

Low. Should react the same as the only implementation. will test on an OT-2 and OT-3.
