### PR TITLE
feature(hardware): refactor hardware controller to watch for valid responses and error messages

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -62,7 +62,7 @@ _Head_SubNodes: List[NodeId] = [NodeId.head_l, NodeId.head_r]
 
 
 class AcknowledgeListener:
-    """Helper clas for CanMessenger to listen for Acks back from commands."""
+    """Helper class for CanMessenger to listen for Acks back from commands."""
 
     def __init__(
         self,

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -38,6 +38,8 @@ from opentrons_hardware.firmware_bindings.messages.payloads import ErrorMessageP
 
 from opentrons_hardware.firmware_bindings.utils import BinarySerializableException
 
+from .errors import AsyncHardwareError
+
 log = logging.getLogger(__name__)
 
 
@@ -319,7 +321,11 @@ class CanMessenger:
             log.error(
                 f"error {str(err_msg)} recieved is asyncronous, raising exception"
             )
-            raise RuntimeError("Async firmware error", str(err_msg))
+            raise AsyncHardwareError(
+                "Async firmware error: " + str(err_msg),
+                ErrorCode(error_payload.error_code.value),
+                ErrorSeverity(error_payload.severity.value),
+            )
 
 
 class WaitableCallback:

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -308,11 +308,11 @@ class CanMessenger:
             error_name = str(ErrorCode(error_payload.error_code.value).name)
         else:
             error_name = "UNKNOWN ERROR"
-        if error_payload.severity == ErrorSeverity.WARNING:
+        if error_payload.severity == ErrorSeverity.warning:
             log.warning(f"recived a firmware warning {error_name}")
-        elif error_payload.severity == ErrorSeverity.RECOVERABLE:
+        elif error_payload.severity == ErrorSeverity.recoverable:
             log.error(f"recived a firmware recoverable error {error_name}")
-        elif error_payload.severity == ErrorSeverity.UNRECOVERABLE:
+        elif error_payload.severity == ErrorSeverity.unrecoverable:
             log.critical(f"recived a firmware critical error {error_name}")
 
         if error_payload.message_index == 0:

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -305,17 +305,7 @@ class CanMessenger:
     def _handle_error(self, build: BinarySerializable) -> None:
         err_msg = ErrorMessage(payload=build)  # type: ignore[arg-type]
         error_payload: ErrorMessagePayload = err_msg.payload
-        error_name = ""
-        if error_payload.error_code.value in [err.value for err in ErrorCode]:
-            error_name = str(ErrorCode(error_payload.error_code.value).name)
-        else:
-            error_name = "UNKNOWN ERROR"
-        if error_payload.severity == ErrorSeverity.warning:
-            log.warning(f"recived a firmware warning {error_name}")
-        elif error_payload.severity == ErrorSeverity.recoverable:
-            log.error(f"recived a firmware recoverable error {error_name}")
-        elif error_payload.severity == ErrorSeverity.unrecoverable:
-            log.critical(f"recived a firmware critical error {error_name}")
+        err_msg.log_error(log)
 
         if error_payload.message_index == 0:
             log.error(

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import asyncio
 from inspect import Traceback
-from typing import Optional, Callable, Tuple, Dict, Union, List
+from typing import Optional, Callable, Tuple, Dict, Union, List, cast
 
 import logging
 
@@ -150,9 +150,10 @@ class AcknowledgeListener:
             self._can_messenger.remove_listener(self)
 
         while not self._ack_queue.empty():
-            ack = self._ack_queue.get_nowait()
-            if isinstance(ack, ErrorMessage):
-                return ack.payload.error_code.value
+            arb_id, message = self._ack_queue.get_nowait()
+            if arb_id.parts.message_id == MessageId.error_message:
+                err_msg = cast(ErrorMessage, message)
+                return ErrorCode(err_msg.payload.error_code.value)
         return ErrorCode.ok
 
 

--- a/hardware/opentrons_hardware/drivers/can_bus/errors.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/errors.py
@@ -1,5 +1,7 @@
 """Can bus errors."""
 
+from opentrons_hardware.firmware_bindings.constants import ErrorCode, ErrorSeverity
+
 
 class CanError(Exception):
     """Can bus error."""
@@ -13,3 +15,15 @@ class ErrorFrameCanError(CanError):
     """An error frame was received on the can bus."""
 
     pass
+
+
+class AsyncHardwareError(RuntimeError):
+    """An error generated from firmware that was not caused by a command sent from hardware controller."""
+
+    def __init__(
+        self, description: str, error_code: ErrorCode, error_severity: ErrorSeverity
+    ) -> None:
+        """Build an async error."""
+        self.description = description
+        self.error_code = error_code
+        self.error_severity = error_severity

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -148,9 +148,9 @@ class MessageId(int, Enum):
 class ErrorSeverity(int, Enum):
     """Error Severity levels."""
 
-    WARNING = 0x1
-    RECOVERABLE = 0x2
-    UNRECOVERABLE = 0x3
+    warning = 0x1
+    recoverable = 0x2
+    unrecoverable = 0x3
 
 
 @unique
@@ -163,6 +163,9 @@ class ErrorCode(int, Enum):
     invalid_byte_count = 0x03
     invalid_input = 0x04
     hardware = 0x05
+    timeout = 0x06
+    estop_detected = 0x07
+    collision_detected = 0x08
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -1,7 +1,7 @@
 """Definition of CAN messages."""
 from dataclasses import dataclass
 from typing import Type, Any
-
+import threading
 from typing_extensions import Literal
 
 from ..constants import MessageId
@@ -18,10 +18,16 @@ class SingletonMessageIndexGenerator(object):
             cls.instance = super(SingletonMessageIndexGenerator, cls).__new__(cls)
         return cls.instance
 
+    def __init__(self) -> None:
+        """Initalize the lock."""
+        self._lock = threading.Lock()
+
     def get_next_index(self) -> int:
         """Return the next index."""
         # increment before returning so we never return 0 as a value
+        self._lock.acquire(timeout=1)
         self.__current_index += 1
+        self._lock.release()
         return self.__current_index
 
     __current_index = 0

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -9,6 +9,7 @@ from ..constants import MessageId
 
 MessageDefinition = Union[
     defs.Acknowledgement,
+    defs.ErrorMessage,
     defs.HeartbeatRequest,
     defs.HeartbeatResponse,
     defs.DeviceInfoRequest,

--- a/hardware/opentrons_hardware/hardware_control/current_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/current_settings.py
@@ -1,17 +1,20 @@
 """Utilities for updating the current settings on the OT3."""
 from typing import Tuple
-
+import logging
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     WriteMotorCurrentRequest,
 )
+from opentrons_hardware.firmware_bindings.constants import ErrorCode
 from opentrons_hardware.firmware_bindings.utils import UInt32Field
 from .types import NodeMap
 
 
 CompleteCurrentSettings = NodeMap[Tuple[float, float]]
 PartialCurrentSettings = NodeMap[float]
+
+log = logging.getLogger(__name__)
 
 
 async def set_currents(
@@ -20,7 +23,7 @@ async def set_currents(
 ) -> None:
     """Set hold current and run current for each node."""
     for node, currents in current_settings.items():
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=node,
             message=WriteMotorCurrentRequest(
                 payload=payloads.MotorCurrentPayload(
@@ -28,7 +31,12 @@ async def set_currents(
                     run_current=UInt32Field(int(currents[1] * (2**16))),
                 )
             ),
+            expected_nodes=[node],
         )
+        if error != ErrorCode.ok:
+            log.error(
+                f"recieved error {str(error)} trying to set currents for {str(node)}"
+            )
 
 
 async def set_run_current(
@@ -36,7 +44,7 @@ async def set_run_current(
 ) -> None:
     """Set only the run current for each node."""
     for node, current in current_settings.items():
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=node,
             message=WriteMotorCurrentRequest(
                 payload=payloads.MotorCurrentPayload(
@@ -44,7 +52,12 @@ async def set_run_current(
                     run_current=UInt32Field(int(current * (2**16))),
                 )
             ),
+            expected_nodes=[node],
         )
+        if error != ErrorCode.ok:
+            log.error(
+                f"recieved error {str(error)} trying to set run current for {str(node)}"
+            )
 
 
 async def set_hold_current(
@@ -52,7 +65,7 @@ async def set_hold_current(
 ) -> None:
     """Set only the hold current for each node."""
     for node, current in current_settings.items():
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=node,
             message=WriteMotorCurrentRequest(
                 payload=payloads.MotorCurrentPayload(
@@ -60,4 +73,9 @@ async def set_hold_current(
                     run_current=UInt32Field(0),
                 )
             ),
+            expected_nodes=[node],
         )
+        if error != ErrorCode.ok:
+            log.error(
+                f"recieved error {str(error)} trying to set run current for {str(node)}"
+            )

--- a/hardware/opentrons_hardware/hardware_control/current_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/current_settings.py
@@ -35,7 +35,7 @@ async def set_currents(
         )
         if error != ErrorCode.ok:
             log.error(
-                f"recieved error {str(error)} trying to set currents for {str(node)}"
+                f"received error {str(error)} trying to set currents for {str(node)}"
             )
 
 

--- a/hardware/opentrons_hardware/hardware_control/limit_switches.py
+++ b/hardware/opentrons_hardware/hardware_control/limit_switches.py
@@ -34,7 +34,10 @@ def _create_listener(
                 f"0x{arbitration_id.parts.originating_node_id:x}"
             )
             return
-        if message.message_id != MessageId.limit_sw_response:
+        if message.message_id == MessageId.error_message:
+            log.error(f"recieved an error {str(message)}")
+            return
+        elif message.message_id != MessageId.limit_sw_response:
             log.warning(f"unexpected message id: 0x{message.message_id:x}")
             return
         responses[originator] = cast(

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -300,7 +300,6 @@ class MoveScheduler:
         self._durations: List[float] = []
         self._stop_condition: List[MoveStopCondition] = []
         self._start_at_index = start_at_index
-        self._recieved_error = None
 
         for move_group in move_groups:
             move_set = set()
@@ -350,11 +349,11 @@ class MoveScheduler:
 
     def _handle_error(self, message: ErrorMessage) -> None:
         self._recieved_error = message
-        if message.payload.severity.value == ErrorSeverity.WARNING:
+        if message.payload.severity.value == ErrorSeverity.warning:
             log.warning(f"Recieved {ErrorCode(message.payload.error_code.value).name}")
-        if message.payload.severity.value == ErrorSeverity.RECOVERABLE:
+        if message.payload.severity.value == ErrorSeverity.recoverable:
             log.error(f"Recieved {ErrorCode(message.payload.error_code.value).name}")
-        if message.payload.severity.value == ErrorSeverity.UNRECOVERABLE:
+        if message.payload.severity.value == ErrorSeverity.unrecoverable:
             log.critical(f"Recieved {ErrorCode(message.payload.error_code.value).name}")
         raise RuntimeError("Firmware Error Revieved", message)
 

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -348,13 +348,6 @@ class MoveScheduler:
         log.debug("recieved ack")
 
     def _handle_error(self, message: ErrorMessage) -> None:
-        self._recieved_error = message
-        if message.payload.severity.value == ErrorSeverity.warning:
-            log.warning(f"Recieved {ErrorCode(message.payload.error_code.value).name}")
-        if message.payload.severity.value == ErrorSeverity.recoverable:
-            log.error(f"Recieved {ErrorCode(message.payload.error_code.value).name}")
-        if message.payload.severity.value == ErrorSeverity.unrecoverable:
-            log.critical(f"Recieved {ErrorCode(message.payload.error_code.value).name}")
         raise RuntimeError("Firmware Error Revieved", message)
 
     def _handle_move_completed(self, message: MoveCompleted) -> None:

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -8,7 +8,6 @@ import numpy as np
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
-    ErrorSeverity,
     ErrorCode,
 )
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -74,7 +74,7 @@ async def capacitive_probe(
     async with sensor_scheduler.bind_sync(
         sensor_info,
         messenger,
-        log=log_sensor_values,
+        do_log=log_sensor_values,
     ):
         position = await runner.run(can_messenger=messenger)
         return position[mover]

--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -41,6 +41,8 @@ async def _await_one_result(callback: WaitableCallback) -> ToolDetectionResult:
     async for response, _ in callback:
         if isinstance(response, message_definitions.PushToolsDetectedNotification):
             return _handle_detection_result(response)
+        if isinstance(response, message_definitions.ErrorMessage):
+            log.error(f"Recieved error message {str(response)}")
     raise RuntimeError("Messenger closed before a tool was found")
 
 
@@ -109,6 +111,8 @@ class OneshotToolDetector:
                     )
                     seen.add(node)
                     break
+                elif isinstance(response, message_definitions.ErrorMessage):
+                    log.error(f"Recieved error message {str(response)}")
 
     @staticmethod
     async def _handle_gripper_info(

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -85,8 +85,12 @@ async def task(
     """
     writer = Writer(write_to)
     label_style = "\033[0;37;40m"
-    header_style = "\033[0;36;40m"
-    data_style = "\033[1;36;40m"
+
+    info_header_style = "\033[0;36;40m"
+    info_data_style = "\033[1;36;40m"
+
+    err_header_style = "\033[0;31;40m"
+    err_data_style = "\033[1;31;40m"
 
     with WaitableCallback(messenger) as cb:
         async for message, arbitration_id in cb:
@@ -97,6 +101,14 @@ async def task(
                 arb_id_str = f"{msg_name} ({from_node}->{to_node})"
             except ValueError:
                 arb_id_str = f"0x{arbitration_id.id:x}"
+
+            if arbitration_id.parts.message_id == MessageId.error_message:
+                header_style = err_header_style
+                data_style = err_data_style
+            else:
+                header_style = info_header_style
+                data_style = info_data_style
+
             writer.write(
                 [
                     StyledOutput(style=header_style, content=str(datetime.now())),

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 
-from typing import Optional, TypeVar, Callable, AsyncIterator, cast, List
+from typing import Optional, Type, TypeVar, Callable, AsyncIterator, List, cast
 
 from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
@@ -11,6 +11,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     SensorId,
     SensorType,
     MessageId,
+    ErrorCode,
 )
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 
@@ -30,6 +31,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ReadFromSensorResponse,
     PeripheralStatusResponse,
     BindSensorOutputRequest,
+    ErrorMessage,
 )
 from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.payloads import (
@@ -135,7 +137,7 @@ class SensorScheduler:
     ) -> None:
         """Send write message."""
         sensor_info = sensor.sensor
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=sensor_info.node_id,
             message=WriteToSensorRequest(
                 payload=WriteToSensorRequestPayload(
@@ -146,7 +148,12 @@ class SensorScheduler:
                     reg_address=UInt8Field(0x0),
                 )
             ),
+            expected_nodes=[sensor_info.node_id],
         )
+        if error != ErrorCode.ok:
+            log.error(
+                f"recieved error {str(error)} trying to write sensor info to {str(sensor_info.node_id)}"
+            )
 
     async def send_read(
         self,
@@ -330,6 +337,8 @@ class SensorScheduler:
                 f"{SensorType(message.payload.sensor.value).name}: "
                 f"{SensorDataType.build(message.payload.sensor_data, message.payload.sensor).to_float()}"
             )
+        if isinstance(message, ErrorMessage):
+            log.error(f"recieved error message {str(message)}")
 
     @asynccontextmanager
     async def bind_sync(
@@ -337,13 +346,13 @@ class SensorScheduler:
         target_sensor: SensorInformation,
         can_messenger: CanMessenger,
         timeout: float = 0.5,
-        log: bool = False,
+        do_log: bool = False,
     ) -> AsyncIterator[None]:
         """While acquired, bind the specified sensor to control sync."""
         flags = [SensorOutputBinding.sync]
         if log:
             flags.append(SensorOutputBinding.report)
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=target_sensor.node_id,
             message=BindSensorOutputRequest(
                 payload=BindSensorOutputRequestPayload(
@@ -352,17 +361,21 @@ class SensorScheduler:
                     binding=SensorOutputBindingField.from_flags(flags),
                 )
             ),
+            expected_nodes=[target_sensor.node_id],
         )
+        if error != ErrorCode.ok:
+            log.error(
+                f"recieved error {str(error)} trying to bind sensor output on {str(target_sensor.node_id)}"
+            )
+
         try:
-            if log:
-                can_messenger.add_listener(
-                    self._log_sensor_output,
-                )
+            if do_log:
+                can_messenger.add_listener(self._log_sensor_output)
             yield
         finally:
-            if log:
+            if do_log:
                 can_messenger.remove_listener(self._log_sensor_output)
-            await can_messenger.send(
+            error = await can_messenger.ensure_send(
                 node_id=target_sensor.node_id,
                 message=BindSensorOutputRequest(
                     payload=BindSensorOutputRequestPayload(
@@ -373,7 +386,12 @@ class SensorScheduler:
                         ),
                     )
                 ),
+                expected_nodes=[target_sensor.node_id],
             )
+            if error != ErrorCode.ok:
+                log.error(
+                    f"recieved error {str(error)} trying to write unbind sensor output on {str(target_sensor.node_id)}"
+                )
 
     @asynccontextmanager
     async def capture_output(
@@ -387,10 +405,13 @@ class SensorScheduler:
         def _logging_listener(
             message: MessageDefinition, arb_id: ArbitrationId
         ) -> None:
-            payload = cast(ReadFromSensorResponse, message).payload
-            response_queue.put_nowait(
-                SensorDataType.build(payload.sensor_data, payload.sensor).to_float()
-            )
+            if isinstance(message, ReadFromSensorResponse):
+                payload = message.payload
+                response_queue.put_nowait(
+                    SensorDataType.build(payload.sensor_data, payload.sensor).to_float()
+                )
+            if isinstance(message, ErrorMessage):
+                log.error(f"Recieved error message {str(message)}")
 
         def _filter(arbitration_id: ArbitrationId) -> bool:
             return (
@@ -399,10 +420,11 @@ class SensorScheduler:
             ) and (
                 MessageId(arbitration_id.parts.message_id)
                 == MessageId.read_sensor_response
+                or MessageId(arbitration_id.parts.message_id) == MessageId.error_message
             )
 
         can_messenger.add_listener(_logging_listener, _filter)
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=target_sensor.node_id,
             message=BindSensorOutputRequest(
                 payload=BindSensorOutputRequestPayload(
@@ -411,12 +433,18 @@ class SensorScheduler:
                     binding=SensorOutputBindingField(SensorOutputBinding.report.value),
                 )
             ),
+            expected_nodes=[target_sensor.node_id],
         )
+        if error != ErrorCode.ok:
+            log.error(
+                f"recieved error {str(error)} trying to bind sensor output on {str(target_sensor.node_id)}"
+            )
+
         try:
             yield response_queue
         finally:
             can_messenger.remove_listener(_logging_listener)
-            await can_messenger.send(
+            error = await can_messenger.ensure_send(
                 node_id=target_sensor.node_id,
                 message=BindSensorOutputRequest(
                     payload=BindSensorOutputRequestPayload(
@@ -427,4 +455,9 @@ class SensorScheduler:
                         ),
                     )
                 ),
+                expected_nodes=[target_sensor.node_id],
             )
+            if error != ErrorCode.ok:
+                log.error(
+                    f"recieved error {str(error)} trying to write unbind sensor output on {str(target_sensor.node_id)}"
+                )

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 
-from typing import Optional, Type, TypeVar, Callable, AsyncIterator, List, cast
+from typing import Optional, TypeVar, Callable, AsyncIterator, List
 
 from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
@@ -350,7 +350,7 @@ class SensorScheduler:
     ) -> AsyncIterator[None]:
         """While acquired, bind the specified sensor to control sync."""
         flags = [SensorOutputBinding.sync]
-        if log:
+        if do_log:
             flags.append(SensorOutputBinding.report)
         error = await can_messenger.ensure_send(
             node_id=target_sensor.node_id,

--- a/hardware/tests/conftest.py
+++ b/hardware/tests/conftest.py
@@ -93,6 +93,7 @@ class CanLoopback:
         self._mock_notifier = mock_notifier
         self._responders: List[CanLoopback.LoopbackResponder] = []
         self._mock_messenger.send.side_effect = self._listener
+        self._mock_messenger.ensure_send.side_effect = self._ensure_listener
 
     def _listener(self, node_id: NodeId, message: MessageDefinition) -> None:
         for responder in self._responders:
@@ -108,6 +109,15 @@ class CanLoopback:
                         )
                     ),
                 )
+
+    def _ensure_listener(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+        timeout: float = 3,
+        expected_nodes: List[NodeId] = [],
+    ) -> None:
+        self._listener(node_id, message)
 
     def add_responder(self, responder: "CanLoopback.LoopbackResponder") -> None:
         """Add a responder."""

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -147,7 +147,7 @@ async def test_ensure_send(
             data=message.payload.message_index.value.to_bytes(4, "big"),
         )
     )
-    print(message.payload.message_index.value.to_bytes(4, "big"))
+
     """It should create a can message and use the driver to send the message and raise no exception."""
     error, ignore = await asyncio.gather(
         subject.ensure_send(node_id, message, expected_nodes=[node_id]),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_current_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_current_settings.py
@@ -78,7 +78,7 @@ async def test_complete_current_settings(
     """It should send correct hold and run current to the correct nodes."""
     await set_currents(mock_can_messenger, current_settings)
     for node_id, currents in current_settings_in_uint32.items():
-        mock_can_messenger.send.assert_any_call(
+        mock_can_messenger.ensure_send.assert_any_call(
             node_id=node_id,
             message=md.WriteMotorCurrentRequest(
                 payload=MotorCurrentPayload(
@@ -86,6 +86,7 @@ async def test_complete_current_settings(
                     run_current=currents[1],
                 )
             ),
+            expected_nodes=[node_id],
         )
 
 
@@ -97,7 +98,7 @@ async def test_send_hold_current_only(
     """It should send correct hold current only to the correct nodes."""
     await set_hold_current(mock_can_messenger, partial_current_settings)
     for node_id, current in partial_current_settings_in_uint32.items():
-        mock_can_messenger.send.assert_any_call(
+        mock_can_messenger.ensure_send.assert_any_call(
             node_id=node_id,
             message=md.WriteMotorCurrentRequest(
                 payload=MotorCurrentPayload(
@@ -105,6 +106,7 @@ async def test_send_hold_current_only(
                     run_current=UInt32Field(0),
                 )
             ),
+            expected_nodes=[node_id],
         )
 
 
@@ -116,7 +118,7 @@ async def test_send_run_current_only(
     """It should send correct run current only to the correct nodes."""
     await set_run_current(mock_can_messenger, partial_current_settings)
     for node_id, current in partial_current_settings_in_uint32.items():
-        mock_can_messenger.send.assert_any_call(
+        mock_can_messenger.ensure_send.assert_any_call(
             node_id=node_id,
             message=md.WriteMotorCurrentRequest(
                 payload=MotorCurrentPayload(
@@ -124,4 +126,5 @@ async def test_send_run_current_only(
                     run_current=current,
                 )
             ),
+            expected_nodes=[node_id],
         )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motor_engage_disengage.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motor_engage_disengage.py
@@ -23,9 +23,10 @@ async def test_set_enable_current(mock_can_messenger: AsyncMock) -> None:
     nodes_to_enable = {NodeId.gantry_x, NodeId.gantry_y}
     await set_enable_motor(mock_can_messenger, nodes_to_enable)
     for node_id in nodes_to_enable:
-        mock_can_messenger.send.assert_any_call(
+        mock_can_messenger.ensure_send.assert_any_call(
             node_id=node_id,
             message=md.EnableMotorRequest(),
+            expected_nodes=[node_id],
         )
 
 
@@ -34,7 +35,8 @@ async def test_set_disable_current(mock_can_messenger: AsyncMock) -> None:
     nodes_to_enable = {NodeId.gantry_x, NodeId.gantry_y}
     await set_disable_motor(mock_can_messenger, nodes_to_enable)
     for node_id in nodes_to_enable:
-        mock_can_messenger.send.assert_any_call(
+        mock_can_messenger.ensure_send.assert_any_call(
             node_id=node_id,
             message=md.DisableMotorRequest(),
+            expected_nodes=[node_id],
         )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -15,6 +15,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     MoveCompleted,
 )
 from opentrons_hardware.firmware_bindings.messages.payloads import (
+    EmptyPayload,
     AddLinearMoveRequestPayload,
     MoveCompletedPayload,
     ExecuteMoveGroupRequestPayload,
@@ -409,6 +410,12 @@ class MockSendMoveCompleter:
         if isinstance(message, md.ExecuteMoveGroupRequest):
             # Iterate through each move in each sequence and send a move
             # completed for it.
+            payload = EmptyPayload()
+            payload.message_index = message.payload.message_index
+            arbitration_id = ArbitrationId(
+                parts=ArbitrationIdParts(originating_node_id=node_id)
+            )
+            self._listener(md.Acknowledgement(payload=payload), arbitration_id)
             for seq_id, moves in enumerate(
                 self._move_groups[message.payload.group_id.value - self._start_at_index]
             ):
@@ -426,6 +433,16 @@ class MockSendMoveCompleter:
                         parts=ArbitrationIdParts(originating_node_id=node)
                     )
                     self._listener(md.MoveCompleted(payload=payload), arbitration_id)
+
+    async def mock_ensure_send(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+        timeout: float = 3,
+        expected_nodes: List[NodeId] = [],
+    ) -> None:
+        """Mock ensure_send function."""
+        await self.mock_send(node_id, message)
 
 
 class MockGripperSendMoveCompleter:
@@ -456,6 +473,12 @@ class MockGripperSendMoveCompleter:
         if isinstance(message, md.ExecuteMoveGroupRequest):
             # Iterate through each move in each sequence and send a move
             # completed for it.
+            payload = EmptyPayload()
+            payload.message_index = message.payload.message_index
+            arbitration_id = ArbitrationId(
+                parts=ArbitrationIdParts(originating_node_id=node_id)
+            )
+            self._listener(md.Acknowledgement(payload=payload), arbitration_id)
             for seq_id, moves in enumerate(
                 self._move_groups[message.payload.group_id.value - self._start_at_index]
             ):
@@ -474,6 +497,16 @@ class MockGripperSendMoveCompleter:
                     )
                     self._listener(md.MoveCompleted(payload=payload), arbitration_id)
 
+    async def mock_ensure_send(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+        timeout: float = 3,
+        expected_nodes: List[NodeId] = [],
+    ) -> None:
+        """Mock ensure_send function."""
+        await self.mock_send(node_id, message)
+
 
 async def test_single_move(
     mock_can_messenger: AsyncMock, move_group_single: MoveGroups
@@ -481,10 +514,13 @@ async def test_single_move(
     """It should send a start group command."""
     subject = MoveScheduler(move_groups=move_group_single)
     mock_sender = MockSendMoveCompleter(move_group_single, subject)
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
     mock_can_messenger.send.side_effect = mock_sender.mock_send
     position = await subject.run(can_messenger=mock_can_messenger)
-
-    mock_can_messenger.send.assert_has_calls(
+    expected_nodes = []
+    for mgs in move_group_single[0]:
+        expected_nodes.extend([k for k in mgs.keys()])
+    mock_can_messenger.ensure_send.assert_has_calls(
         calls=[
             call(
                 node_id=NodeId.broadcast,
@@ -495,6 +531,7 @@ async def test_single_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=expected_nodes,
             )
         ]
     )
@@ -508,10 +545,21 @@ async def test_multi_group_move(
     """It should start next group once the prior has completed."""
     subject = MoveScheduler(move_groups=move_group_multiple)
     mock_sender = MockSendMoveCompleter(move_group_multiple, subject)
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
     mock_can_messenger.send.side_effect = mock_sender.mock_send
     position = await subject.run(can_messenger=mock_can_messenger)
+    expected_nodes_list: List[List[NodeId]] = []
 
-    mock_can_messenger.send.assert_has_calls(
+    # we have to do this weird list->set->list conversion to get the same
+    # order as the one move_group_runner uses since sets hash things
+    # in a way that doesn't preserve order
+    for movegroup in move_group_multiple:
+        expected_nodes = set()
+        for seq_id, mgs in enumerate(movegroup):
+            expected_nodes.update(set((k.value, seq_id) for k in mgs.keys()))
+        expected_nodes_list.append([NodeId(n) for n, s in expected_nodes])
+
+    mock_can_messenger.ensure_send.assert_has_calls(
         calls=[
             call(
                 node_id=NodeId.broadcast,
@@ -522,6 +570,7 @@ async def test_multi_group_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=expected_nodes_list[0],
             ),
             call(
                 node_id=NodeId.broadcast,
@@ -532,6 +581,7 @@ async def test_multi_group_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=expected_nodes_list[1],
             ),
             call(
                 node_id=NodeId.broadcast,
@@ -542,6 +592,7 @@ async def test_multi_group_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=expected_nodes_list[2],
             ),
         ]
     )
@@ -560,9 +611,10 @@ async def test_multi_gripper_group_move(
     subject = MoveScheduler(move_groups=move_group_gripper_multiple)
     mock_sender = MockGripperSendMoveCompleter(move_group_gripper_multiple, subject)
     mock_can_messenger.send.side_effect = mock_sender.mock_send
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
     position = await subject.run(can_messenger=mock_can_messenger)
 
-    mock_can_messenger.send.assert_has_calls(
+    mock_can_messenger.ensure_send.assert_has_calls(
         calls=[
             call(
                 node_id=NodeId.broadcast,
@@ -573,6 +625,7 @@ async def test_multi_gripper_group_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=[NodeId.gripper_g],
             ),
             call(
                 node_id=NodeId.broadcast,
@@ -583,6 +636,7 @@ async def test_multi_gripper_group_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=[NodeId.gripper_g],
             ),
             call(
                 node_id=NodeId.broadcast,
@@ -593,6 +647,7 @@ async def test_multi_gripper_group_move(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=[NodeId.gripper_g],
             ),
         ]
     )
@@ -726,6 +781,12 @@ class MockSendMoveCompleterWithUnknown(MockSendMoveCompleter):
     async def mock_send(self, node_id: NodeId, message: MessageDefinition) -> None:
         """Overrides the send method of the messenger."""
         if isinstance(message, md.ExecuteMoveGroupRequest):
+            payload = EmptyPayload()
+            payload.message_index = message.payload.message_index
+            arbitration_id = ArbitrationId(
+                parts=ArbitrationIdParts(originating_node_id=node_id)
+            )
+            self._listener(md.Acknowledgement(payload=payload), arbitration_id)
             groups = super().groups
             bad_id = len(groups)
             payload = MoveCompletedPayload(
@@ -751,6 +812,7 @@ async def test_handles_unknown_group_ids(
     subject = MoveScheduler(move_group_single)
     mock_sender = MockSendMoveCompleterWithUnknown(move_group_single, subject)
     mock_can_messenger.send.side_effect = mock_sender.mock_send
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
     # this should not throw
     await subject.run(can_messenger=mock_can_messenger)
 
@@ -762,9 +824,13 @@ async def test_groups_from_nonzero_index(
     subject = MoveScheduler(move_group_single, 1)
     mock_sender = MockSendMoveCompleter(move_group_single, subject, 1)
     mock_can_messenger.send.side_effect = mock_sender.mock_send
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
+    expected_nodes = []
+    for mgs in move_group_single[0]:
+        expected_nodes.extend([k for k in mgs.keys()])
     # this should not throw
     await subject.run(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_has_calls(
+    mock_can_messenger.ensure_send.assert_has_calls(
         calls=[
             call(
                 node_id=NodeId.broadcast,
@@ -775,6 +841,7 @@ async def test_groups_from_nonzero_index(
                         start_trigger=UInt8Field(0),
                     )
                 ),
+                expected_nodes=expected_nodes,
             )
         ]
     )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -8,9 +8,11 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ExecuteMoveGroupRequest,
     MoveCompleted,
     ReadFromSensorResponse,
+    Acknowledgement,
 )
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.payloads import (
+    EmptyPayload,
     MoveCompletedPayload,
     ReadFromSensorResponsePayload,
 )
@@ -114,7 +116,14 @@ async def test_capacitive_probe(
     ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
         message.payload.serialize()
         if isinstance(message, ExecuteMoveGroupRequest):
+            ack_payload = EmptyPayload()
+            ack_payload.message_index = message.payload.message_index
             return [
+                (
+                    NodeId.host,
+                    Acknowledgement(payload=ack_payload),
+                    motor_node,
+                ),
                 (
                     NodeId.host,
                     MoveCompleted(
@@ -128,7 +137,7 @@ async def test_capacitive_probe(
                         )
                     ),
                     motor_node,
-                )
+                ),
             ]
         else:
             return []
@@ -151,7 +160,7 @@ async def test_capacitive_probe(
         ANY,  # this is a mock of a function on a class not a method so this is self
         sensor_info,
         ANY,
-        log=ANY,
+        do_log=ANY,
     )
 
 
@@ -182,6 +191,8 @@ async def test_capacitive_sweep(
     ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
         message.payload.serialize()
         if isinstance(message, ExecuteMoveGroupRequest):
+            ack_payload = EmptyPayload()
+            ack_payload.message_index = message.payload.message_index
             sensor_values: List[Tuple[NodeId, MessageDefinition, NodeId]] = [
                 (
                     NodeId.host,
@@ -212,7 +223,16 @@ async def test_capacitive_sweep(
                     motor_node,
                 ),
             ]
-            return sensor_values + move_ack
+            execute_ack: List[Tuple[NodeId, MessageDefinition, NodeId]] = [
+                (
+                    NodeId.host,
+                    Acknowledgement(
+                        payload=ack_payload,
+                    ),
+                    motor_node,
+                ),
+            ]
+            return execute_ack + sensor_values + move_ack
         else:
             return []
 

--- a/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
@@ -63,8 +63,10 @@ async def test_capture_output(
         ),
         mock_messenger,
     ) as output_queue:
-        mock_messenger.send.assert_called_with(
-            node_id=NodeId.pipette_left, message=stim_message
+        mock_messenger.ensure_send.assert_called_with(
+            node_id=NodeId.pipette_left,
+            message=stim_message,
+            expected_nodes=[NodeId.pipette_left],
         )
         for i in range(10):
             can_message_notifier.notify(
@@ -84,8 +86,10 @@ async def test_capture_output(
                     )
                 ),
             )
-    mock_messenger.send.assert_called_with(
-        node_id=NodeId.pipette_left, message=reset_message
+    mock_messenger.ensure_send.assert_called_with(
+        node_id=NodeId.pipette_left,
+        message=reset_message,
+        expected_nodes=[NodeId.pipette_left],
     )
 
     def _drain() -> Iterator[float]:

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -251,8 +251,10 @@ async def test_write(
     )
     messenger = mock.AsyncMock(spec=CanMessenger)
     await sensor_driver.write(messenger, sensor_type, data)
-    messenger.send.assert_called_once_with(
-        node_id=sensor_type.sensor.node_id, message=message
+    messenger.ensure_send.assert_called_once_with(
+        node_id=sensor_type.sensor.node_id,
+        message=message,
+        expected_nodes=[sensor_type.sensor.node_id],
     )
 
 


### PR DESCRIPTION
[RET-1250](https://opentrons.atlassian.net/browse/RET-1250)
[RET-1251](https://opentrons.atlassian.net/browse/RET-1251)
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will let the hardware controller listen for and handle error messages in addition to regular acks
This also implements timeouts for messages that previously didn't respond. now there is a timeout if they don't respond with an Acknowledgment for those messages

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
