### PR TITLE
fix(docs): replaced broken support link

### DIFF
--- a/api/docs/ot1/api.html
+++ b/api/docs/ot1/api.html
@@ -479,7 +479,7 @@ window.intercomSettings = {
                             <a
                               target="_blank"
                               rel="noopener noreferrer"
-                              href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                              href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                               data-gtm-category="d-header"
                               data-gtm-label="labware-library"
                               data-gtm-action="click"
@@ -956,7 +956,7 @@ window.intercomSettings = {
                             <a
                               target="_blank"
                               rel="noopener noreferrer"
-                              href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                              href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                               data-gtm-category="d-header"
                               data-gtm-label="labware-library"
                               data-gtm-action="click"

--- a/api/docs/ot1/calibration.html
+++ b/api/docs/ot1/calibration.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/containers.html
+++ b/api/docs/ot1/containers.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/examples.html
+++ b/api/docs/ot1/examples.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/firmware.html
+++ b/api/docs/ot1/firmware.html
@@ -515,7 +515,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1049,7 +1049,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/genindex.html
+++ b/api/docs/ot1/genindex.html
@@ -514,7 +514,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1048,7 +1048,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/index.html
+++ b/api/docs/ot1/index.html
@@ -515,7 +515,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1049,7 +1049,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/modules.html
+++ b/api/docs/ot1/modules.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/pipettes.html
+++ b/api/docs/ot1/pipettes.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/py-modindex.html
+++ b/api/docs/ot1/py-modindex.html
@@ -515,7 +515,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1049,7 +1049,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/robot.html
+++ b/api/docs/ot1/robot.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/search.html
+++ b/api/docs/ot1/search.html
@@ -523,7 +523,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1057,7 +1057,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/transfer.html
+++ b/api/docs/ot1/transfer.html
@@ -517,7 +517,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1051,7 +1051,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/ot1/writing.html
+++ b/api/docs/ot1/writing.html
@@ -516,7 +516,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"
@@ -1050,7 +1050,7 @@
                         <a
                           target="_blank"
                           rel="noopener noreferrer"
-                          href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                          href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                           data-gtm-category="d-header"
                           data-gtm-label="labware-library"
                           data-gtm-action="click"

--- a/api/docs/templates/hardware/layout.html
+++ b/api/docs/templates/hardware/layout.html
@@ -459,7 +459,7 @@ in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                      href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                       data-gtm-category="d-header"
                       data-gtm-label="labware-library"
                       data-gtm-action="click"
@@ -988,7 +988,7 @@ in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                      href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                       data-gtm-category="d-header"
                       data-gtm-label="labware-library"
                       data-gtm-action="click"

--- a/api/docs/templates/v1/layout.html
+++ b/api/docs/templates/v1/layout.html
@@ -459,7 +459,7 @@ in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                      href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                       data-gtm-category="d-header"
                       data-gtm-label="labware-library"
                       data-gtm-action="click"
@@ -988,7 +988,7 @@ in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                      href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                       data-gtm-category="d-header"
                       data-gtm-label="labware-library"
                       data-gtm-action="click"

--- a/api/docs/templates/v2/layout.html
+++ b/api/docs/templates/v2/layout.html
@@ -459,7 +459,7 @@ in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                      href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                       data-gtm-category="d-header"
                       data-gtm-label="labware-library"
                       data-gtm-action="click"
@@ -988,7 +988,7 @@ in sidebar #} {%- block relbar1 %}{% endblock %} {%- block relbar2 %}{% endblock
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href="https://support.opentrons.com/en/articles/4168651-opentrons-standard-labware"
+                      href="https://support.opentrons.com/s/article/What-labware-can-I-use-with-the-OT-2"
                       data-gtm-category="d-header"
                       data-gtm-label="labware-library"
                       data-gtm-action="click"


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

A link in the docs subdomain top nav was not properly redirecting to the intended support article.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Search and replace for link, affecting:
- [v2 docs](http://sandbox.docs.opentrons.com/docs-fix-broken-labware-link/v2/) template
- [v1 docs](http://sandbox.docs.opentrons.com/docs-fix-broken-labware-link/v1/) template
- individual [OT-One docs](http://sandbox.docs.opentrons.com/docs-fix-broken-labware-link/ot1/index.html) pages (they don't use a template)

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Click the link 🔗 

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

None, docs nav only.