### PR TITLE
fix(app): only attempt to close the latch of heater shaker modules in lpc pick up tip

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -13,6 +13,7 @@ import {
   getLabwareDisplayName,
   getModuleType,
   getVectorDifference,
+  HEATERSHAKER_MODULE_TYPE,
   IDENTITY_VECTOR,
 } from '@opentrons/shared-data'
 import { getLabwareDef } from './utils/labware'
@@ -86,7 +87,7 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
   const handleConfirmPlacement = (): void => {
     const modulePrepCommands = protocolData.modules.reduce<CreateCommand[]>(
       (acc, module) => {
-        if (getModuleType(module.model)) {
+        if (getModuleType(module.model) === HEATERSHAKER_MODULE_TYPE) {
           return [
             ...acc,
             {


### PR DESCRIPTION
# Overview

Fixes a bug where close labware latch commands would be issued to all modules regardless of type within the pick up tip step of labware position check

# Review requests

Confirm that only heater shaker modules should be the target of the `heaterShaker/closeLabwareLatch` command issued within LPC's pick up tip step.

# Risk assessment
low