### PR TITLE
fix(app): pick up tip from last tip rack in LPC if heater shaker is loaded into 1 or 3

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -41,20 +41,29 @@ export const getCheckSteps = (args: LPCArgs): LabwarePositionCheckStep[] => {
 
   const lastTiprackCheckStep =
     checkTipRacksSectionSteps[checkTipRacksSectionSteps.length - 1]
+  // TODO(BC, 2022-11-30): once robot model is available from analysis output, this should only
+  // be a conflict with heater shaker positioning on OT2's so something like `isOT2Protocol &&`
+  // should be prepended to this boolean
+  const cannotAccessDefaultPickUpTipLocation = args.modules.some(m =>
+    ['1', '3'].includes(m.location.slotName)
+  )
   const pickUpTipSectionStep: PickUpTipStep = {
     section: SECTIONS.PICK_UP_TIP,
     labwareId: lastTiprackCheckStep.labwareId,
     pipetteId: lastTiprackCheckStep.pipetteId,
-    location: PICK_UP_TIP_LOCATION,
+    location: cannotAccessDefaultPickUpTipLocation
+      ? lastTiprackCheckStep.location
+      : PICK_UP_TIP_LOCATION,
   }
-
   const checkLabwareSectionSteps = getCheckLabwareSectionSteps(args)
 
   const returnTipSectionStep: ReturnTipStep = {
     section: SECTIONS.RETURN_TIP,
     labwareId: lastTiprackCheckStep.labwareId,
     pipetteId: lastTiprackCheckStep.pipetteId,
-    location: PICK_UP_TIP_LOCATION,
+    location: cannotAccessDefaultPickUpTipLocation
+      ? lastTiprackCheckStep.location
+      : PICK_UP_TIP_LOCATION,
   }
 
   return [


### PR DESCRIPTION
Closes RAUT-289

# Overview

For LPC support of OT2 protocols that involve a heater shaker module in either slot 1 or slot 3, provide a fallback pickup tip location as the last checked tip rack.

# Changelog

- within LPC, if the protocol has a heater shaker loaded in slot 1 or slot 3 we will provide a fallback pick up tip location as the most last checked tip rack/location combo.

# Review requests

- run LPC for protocol with HS in 1 or 3, tip pick up should not be from slot 2.

# Risk assessment

low