### PR TITLE
fix(app-shell): dispatch DOWNLOAD_LOGS_DONE when download cancelled

### DIFF
--- a/app-shell/src/robot-logs.ts
+++ b/app-shell/src/robot-logs.ts
@@ -24,6 +24,7 @@ export function registerRobotLogs(
             return download(mainWindow, url, {
               saveAs: true,
               openFolderWhenDone: index === logUrls.length - 1,
+              onCancel: () => dispatch({ type: 'shell:DOWNLOAD_LOGS_DONE' }),
             })
           })
         }, Promise.resolve())


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

add an onCancel handler to the electron-dl download method that dispatches a DOWNLOAD_LOGS_DONE action so the app ui correctly updates button and toast state

closes RQA-420

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

- fixed a bug in advanced robot settings where canceling a download locks the button in a disabled state and the toast message remains on screen, by adding an onCancel callback to the download function in app-shell

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

N/A

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
