### PR TITLE
fix(api): Allow cancelling a protocol with gripper attached

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -865,8 +865,13 @@ class OT3API(
             and mount_in_use != OT3Mount.GRIPPER
             and self._gripper_handler.gripper.state != GripperJawState.GRIPPING
         ):
-            # allows for safer gantry movement at minimum force
-            await self.grip(force_newtons=IDLE_STATE_GRIP_FORCE)
+            if self._gripper_handler.gripper.state == GripperJawState.UNHOMED:
+                self._log.warning(
+                    "Gripper jaw is not homed. " "Can't be moved to idle position"
+                )
+            else:
+                # allows for safer gantry movement at minimum force
+                await self.grip(force_newtons=IDLE_STATE_GRIP_FORCE)
 
     @ExecutionManagerProvider.wait_for_running
     async def _move(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -867,7 +867,7 @@ class OT3API(
         ):
             if self._gripper_handler.gripper.state == GripperJawState.UNHOMED:
                 self._log.warning(
-                    "Gripper jaw is not homed. " "Can't be moved to idle position"
+                    "Gripper jaw is not homed. Can't be moved to idle position"
                 )
             else:
                 # allows for safer gantry movement at minimum force

--- a/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
+++ b/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
@@ -54,7 +54,10 @@ class HardwareStopper:
             # TODO: Update this once gripper MotorAxis is available in engine.
             try:
                 ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
-                if ot3api.has_gripper():
+                if (
+                    self._state_store.config.use_virtual_gripper
+                    and ot3api.has_gripper()
+                ):
                     await ot3api.home_z(mount=OT3Mount.GRIPPER)
             except HardwareNotSupportedError:
                 pass

--- a/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
+++ b/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
@@ -3,12 +3,15 @@ import logging
 from typing import Optional
 
 from opentrons.hardware_control import HardwareControlAPI
+from ..resources.ot3_validation import ensure_ot3_hardware
 from ..state import StateStore
 from ..types import MotorAxis, WellLocation
-from ..errors import PipetteNotAttachedError
+from ..errors import PipetteNotAttachedError, HardwareNotSupportedError
 
 from .movement import MovementHandler
 from .pipetting import PipettingHandler
+
+from ...hardware_control.types import OT3Mount
 
 
 log = logging.getLogger(__name__)
@@ -48,6 +51,13 @@ class HardwareStopper:
 
         if attached_tip_racks:
             await self._hardware_api.stop(home_after=False)
+            # TODO: Update this once gripper MotorAxis is available in engine.
+            try:
+                ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
+                if ot3api.has_gripper():
+                    await ot3api.home_z(mount=OT3Mount.GRIPPER)
+            except HardwareNotSupportedError:
+                pass
             await self._movement_handler.home(
                 axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
             )


### PR DESCRIPTION
# Overview

Allow cancelling a protocol when gripper attached.

# Changelog

- When moving gripper to idle position no-op if gripper is un-homed.
- When stopping a protocol make sure to home_z the gripper if it is attached.
- Added test to hardware_stopper gripper sequence.


# Review requests

Test on an OT-3
