### PR TITLE
fix(engine): home gripper z when not using virtual gripper

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
+++ b/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
@@ -55,7 +55,7 @@ class HardwareStopper:
             try:
                 ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
                 if (
-                    self._state_store.config.use_virtual_gripper
+                    not self._state_store.config.use_virtual_gripper
                     and ot3api.has_gripper()
                 ):
                     await ot3api.home_z(mount=OT3Mount.GRIPPER)

--- a/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
@@ -183,6 +183,7 @@ async def test_hardware_stopping_sequence_with_gripper(
     decoy.when(state_store.pipettes.get_attached_tip_labware_by_id()).then_return(
         {"pipette-id": "tiprack-id"}
     )
+    decoy.when(state_store.config.use_virtual_gripper).then_return(False)
     decoy.when(ot3_hardware_api.has_gripper()).then_return(True)
     await subject.do_stop_and_recover(drop_tips_and_home=True)
 


### PR DESCRIPTION
# Overview

In the hassle of testing and speedy fix merging, #11800 got merged with a typo that could potentially reintroduce freezing during cancellation, or in the least, cause gripper to not retract correctly if protocol is cancelled when gripper is lowered. This fixes that issue.

# Changelog

- home gripper z when *not* using virtual pipettes, updated tests

# Review requests

This was tested on the robot yesterday so code review should be enough.

# Risk assessment

Low.
