### PR TITLE
feature(hardware): broadcast a stop message when a critical error is detected

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -27,6 +27,7 @@ from opentrons_hardware.firmware_bindings.constants import (
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     Acknowledgement,
     ErrorMessage,
+    StopRequest,
 )
 
 from opentrons_hardware.firmware_bindings.messages.messages import (
@@ -307,6 +308,9 @@ class CanMessenger:
         err_msg = ErrorMessage(payload=build)  # type: ignore[arg-type]
         error_payload: ErrorMessagePayload = err_msg.payload
         err_msg.log_error(log)
+
+        if error_payload.severity == ErrorSeverity.unrecoverable:
+            self.send(NodeId.broadcast, StopRequest())
 
         if error_payload.message_index == 0:
             log.error(

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_can_messenger.py
@@ -200,7 +200,7 @@ async def test_ensure_send_error(
 ) -> None:
     """It should create a can message and use the driver to send the message."""
     error_payload = ErrorMessagePayload(
-        severity=ErrorSeverityField(3),
+        severity=ErrorSeverityField(1),
         error_code=ErrorCodeField(5),
     )
     error_payload.message_index = message.payload.message_index
@@ -348,6 +348,49 @@ async def test_ensure_send_timeout(
                 )
             ),
             data=message.payload.serialize(),
+        )
+    )
+
+
+async def test_auto_halt(
+    subject: CanMessenger, mock_driver: AsyncMock, incoming_messages: Queue[CanMessage]
+) -> None:
+    """Test to make sure can messenger broadcasts a stop when a critical error orrcurs."""
+    error_payload = ErrorMessagePayload(
+        severity=ErrorSeverityField(3),
+        error_code=ErrorCodeField(5),
+    )
+    error_payload.message_index = UInt32Field(0)
+
+    incoming_messages.put_nowait(
+        CanMessage(
+            arbitration_id=ArbitrationId(
+                parts=ArbitrationIdParts(
+                    message_id=MessageId.error_message,
+                    node_id=NodeId.host,
+                    function_code=2,
+                    originating_node_id=NodeId.gripper_g,
+                )
+            ),
+            data=error_payload.serialize(),
+        )
+    )
+    await asyncio.gather(subject.__aenter__())
+
+    while not incoming_messages.empty():
+        await asyncio.sleep(0.01)
+
+    mock_driver.send.assert_called_once_with(
+        message=CanMessage(
+            arbitration_id=ArbitrationId(
+                parts=ArbitrationIdParts(
+                    message_id=MessageId.stop_request,
+                    node_id=NodeId.broadcast,
+                    function_code=0,
+                    originating_node_id=NodeId.host,
+                )
+            ),
+            data=(1).to_bytes(4, "big"),
         )
     )
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If the can messenger receives a critical error it will now broadcast a stop message to halt all the motors
https://opentrons.atlassian.net/browse/RET-1252
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
