### PR TITLE
refactor(shared-data): Remove OT-2 calibration points from OT-3 deck def

### DIFF
--- a/shared-data/deck/definitions/3/ot3_standard.json
+++ b/shared-data/deck/definitions/3/ot3_standard.json
@@ -201,68 +201,7 @@
         "compatibleModuleTypes": []
       }
     ],
-    "calibrationPoints": [
-      {
-        "id": "1BLC",
-        "position": [12.13, 9.0, 0.0],
-        "displayName": "Slot 1 Bottom Left Cross"
-      },
-      {
-        "id": "3BRC",
-        "position": [380.87, 9.0, 0.0],
-        "displayName": "Slot 3 Bottom Right Cross"
-      },
-      {
-        "id": "7TLC",
-        "position": [12.13, 258.0, 0.0],
-        "displayName": "Slot 7 Top Left Cross"
-      },
-      {
-        "id": "9TRC",
-        "position": [380.87, 258.0, 0.0],
-        "displayName": "Slot 9 Top Right Cross"
-      },
-      {
-        "id": "10TLC",
-        "position": [12.13, 348.5, 0.0],
-        "displayName": "Slot 10 Top Left Cross"
-      },
-      {
-        "id": "11TRC",
-        "position": [248.37, 348.5, 0.0],
-        "displayName": "Slot 11 Top Right Cross"
-      },
-      {
-        "id": "1BLD",
-        "position": [12.13, 6.0, 0.0],
-        "displayName": "Slot 1 Bottom Left Dot"
-      },
-      {
-        "id": "3BRD",
-        "position": [380.87, 6.0, 0.0],
-        "displayName": "Slot 3 Bottom Right Dot"
-      },
-      {
-        "id": "7TLD",
-        "position": [12.13, 261.0, 0.0],
-        "displayName": "Slot 7 Top Left Dot"
-      },
-      {
-        "id": "9TRD",
-        "position": [380.87, 261.0, 0.0],
-        "displayName": "Slot 9 Top Right Dot"
-      },
-      {
-        "id": "10TLD",
-        "position": [12.13, 351.5, 0.0],
-        "displayName": "Slot 10 Top Left Dot"
-      },
-      {
-        "id": "11TRD",
-        "position": [248.37, 351.5, 0.0],
-        "displayName": "Slot 11 Top Right Dot"
-      }
-    ],
+    "calibrationPoints": [],
     "fixtures": [
       {
         "id": "fixedTrash",


### PR DESCRIPTION
# Overview

The OT-3 deck definition describes a bunch of calibration points. These points don't actually physically exist on the OT-3, though. They appear to be an accidental carryover from the OT-2 deck definition.

# Changelog

Remove all calibration points from the OT-3's deck definition.

# Risk assessment

Low if all of the tests keep passing.
