### PR TITLE
feat(app): write test of setupLabwareList

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -1,0 +1,267 @@
+import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
+import { StaticRouter } from 'react-router-dom'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../../i18n'
+import {
+  mockHeaterShaker,
+  mockMagneticModule,
+  mockTemperatureModule,
+  mockThermocycler,
+} from '../../../../../redux/modules/__fixtures__'
+import { mockLabwareDef } from '../../../../LabwarePositionCheck/__fixtures__/mockLabwareDef'
+import { SecureLabwareModal } from '../../../../ProtocolSetup/RunSetupCard/LabwareSetup/SecureLabwareModal'
+import { LabwareListItem } from '../LabwareListItem'
+import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
+import type { AttachedModule } from '../../../../../redux/modules/types'
+import type { ModuleRenderInfoForProtocol } from '../../../hooks'
+
+jest.mock(
+  '../../../../ProtocolSetup/RunSetupCard/LabwareSetup/SecureLabwareModal'
+)
+jest.mock('@opentrons/react-api-client')
+
+const mockSecureLabwareModal = SecureLabwareModal as jest.MockedFunction<
+  typeof SecureLabwareModal
+>
+const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
+  typeof useCreateLiveCommandMutation
+>
+
+const mockThermocyclerModuleDefinition = {
+  moduleId: 'someThermocyclerModule',
+  model: 'thermocyclerModuleV1' as ModuleModel,
+  type: 'thermocyclerModuleType' as ModuleType,
+  labwareOffset: { x: 5, y: 5, z: 5 },
+  cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
+  dimensions: {
+    xDimension: 100,
+    yDimension: 100,
+    footprintXDimension: 50,
+    footprintYDimension: 50,
+    labwareInterfaceXDimension: 80,
+    labwareInterfaceYDimension: 120,
+  },
+  twoDimensionalRendering: { children: [] },
+}
+
+const MODULE_ID = 'moduleId'
+
+const render = (props: React.ComponentProps<typeof LabwareListItem>) => {
+  return renderWithProviders(
+    <StaticRouter>
+      <LabwareListItem {...props} />
+    </StaticRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('LabwareListItem', () => {
+  let mockCreateLiveCommand = jest.fn()
+  beforeEach(() => {
+    mockCreateLiveCommand = jest.fn()
+    mockCreateLiveCommand.mockResolvedValue(null)
+    mockSecureLabwareModal.mockReturnValue(<div>mock secure labware modal</div>)
+    mockUseLiveCommandMutation.mockReturnValue({
+      createLiveCommand: mockCreateLiveCommand,
+    } as any)
+  })
+
+  it('renders the correct info for a thermocycler, clicking on secure labware instructions opens the modal', () => {
+    const { getByText } = render({
+      nickName: 'nickName',
+      definition: mockLabwareDef,
+      initialLocation: { moduleId: MODULE_ID },
+      moduleModel: 'thermocyclerModuleV1' as ModuleModel,
+      moduleLocation: { slotName: '7' },
+      extraAttentionModules: ['thermocyclerModuleType'],
+      attachedModuleInfo: {
+        [MODULE_ID]: ({
+          moduleId: 'thermocyclerModuleId',
+
+          attachedModuleMatch: (mockThermocycler as any) as AttachedModule,
+          x: 1,
+          y: 1,
+          z: 1,
+          nestedLabwareDef: mockLabwareDef,
+          nestedLabwareId: '1',
+          nestedLabwareDisplayName: 'nested labware display name',
+          protocolLoadOrder: 0,
+          slotName: '7',
+          moduleDef: mockThermocyclerModuleDefinition as any,
+        } as any) as ModuleRenderInfoForProtocol,
+      },
+    })
+    getByText('Mock Labware Definition')
+    getByText('Slot 7+10, Thermocycler Module GEN1')
+    const button = getByText('Secure labware instructions')
+    fireEvent.click(button)
+    getByText('mock secure labware modal')
+    getByText('nickName')
+  })
+
+  it('renders the correct info for a labware on top of a magnetic module', () => {
+    const { getByText } = render({
+      nickName: 'nickName',
+      definition: mockLabwareDef,
+      initialLocation: { moduleId: MODULE_ID },
+      moduleModel: 'magneticModuleV1' as ModuleModel,
+      moduleLocation: { slotName: '7' },
+      extraAttentionModules: ['magneticModuleType'],
+      attachedModuleInfo: {
+        [MODULE_ID]: ({
+          moduleId: 'magneticModuleId',
+
+          attachedModuleMatch: (mockMagneticModule as any) as AttachedModule,
+          x: 1,
+          y: 1,
+          z: 1,
+          nestedLabwareDef: mockLabwareDef,
+          nestedLabwareId: '1',
+          nestedLabwareDisplayName: 'nested labware display name',
+          protocolLoadOrder: 0,
+          slotName: '7',
+          moduleDef: {
+            moduleId: 'someMagneticModule',
+            model: 'magneticModuleV2' as ModuleModel,
+            type: 'magneticModuleType' as ModuleType,
+            labwareOffset: { x: 5, y: 5, z: 5 },
+            cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
+            dimensions: {
+              xDimension: 100,
+              yDimension: 100,
+              footprintXDimension: 50,
+              footprintYDimension: 50,
+              labwareInterfaceXDimension: 80,
+              labwareInterfaceYDimension: 120,
+            },
+            twoDimensionalRendering: { children: [] },
+          } as any,
+        } as any) as ModuleRenderInfoForProtocol,
+      },
+    })
+    getByText('Mock Labware Definition')
+    getByText('Slot 7, Magnetic Module GEN1')
+    const button = getByText('Secure labware instructions')
+    fireEvent.click(button)
+    getByText('mock secure labware modal')
+    getByText('nickName')
+  })
+
+  it('renders the correct info for a labware on top of a temperature module ', () => {
+    const { getByText } = render({
+      nickName: 'nickName',
+      definition: mockLabwareDef,
+      initialLocation: { moduleId: MODULE_ID },
+      moduleModel: 'temperatureModuleV1' as ModuleModel,
+      moduleLocation: { slotName: '7' },
+      extraAttentionModules: [],
+      attachedModuleInfo: {
+        [MODULE_ID]: ({
+          moduleId: 'temperatureModuleId',
+          attachedModuleMatch: (mockTemperatureModule as any) as AttachedModule,
+          x: 1,
+          y: 1,
+          z: 1,
+          nestedLabwareDef: mockLabwareDef,
+          nestedLabwareId: '1',
+          nestedLabwareDisplayName: 'nested labware display name',
+          protocolLoadOrder: 0,
+          slotName: '7',
+          moduleDef: {
+            moduleId: 'someTemperatureModule',
+            model: 'temperatureModuleV2' as ModuleModel,
+            type: 'temperatureModuleType' as ModuleType,
+            labwareOffset: { x: 5, y: 5, z: 5 },
+            cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
+            dimensions: {
+              xDimension: 100,
+              yDimension: 100,
+              footprintXDimension: 50,
+              footprintYDimension: 50,
+              labwareInterfaceXDimension: 80,
+              labwareInterfaceYDimension: 120,
+            },
+            twoDimensionalRendering: { children: [] },
+          } as any,
+        } as any) as ModuleRenderInfoForProtocol,
+      },
+    })
+    getByText('Mock Labware Definition')
+    getByText('Slot 7, Temperature Module GEN1')
+    getByText('nickName')
+  })
+
+  it('renders the correct info for a labware on top of a heater shaker', () => {
+    const { getByText, getByLabelText } = render({
+      nickName: 'nickName',
+      definition: mockLabwareDef,
+      initialLocation: { moduleId: MODULE_ID },
+      moduleModel: 'heaterShakerModuleV1' as ModuleModel,
+      moduleLocation: { slotName: '7' },
+      extraAttentionModules: ['heaterShakerModuleType'],
+      attachedModuleInfo: {
+        [MODULE_ID]: ({
+          moduleId: 'heaterShakerModuleId',
+          attachedModuleMatch: (mockHeaterShaker as any) as AttachedModule,
+          x: 1,
+          y: 1,
+          z: 1,
+          nestedLabwareDef: mockLabwareDef,
+          nestedLabwareId: '1',
+          nestedLabwareDisplayName: 'nested labware display name',
+          protocolLoadOrder: 0,
+          slotName: '7',
+          moduleDef: {
+            moduleId: 'someheaterShakerModule',
+            model: 'heaterShakerModuleV1' as ModuleModel,
+            type: 'heaterShakerModuleType' as ModuleType,
+            labwareOffset: { x: 5, y: 5, z: 5 },
+            cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
+            dimensions: {
+              xDimension: 100,
+              yDimension: 100,
+              footprintXDimension: 50,
+              footprintYDimension: 50,
+              labwareInterfaceXDimension: 80,
+              labwareInterfaceYDimension: 120,
+            },
+            twoDimensionalRendering: { children: [] },
+          } as any,
+        } as any) as ModuleRenderInfoForProtocol,
+      },
+    })
+    getByText('Mock Labware Definition')
+    getByText('Slot 7, Heater-Shaker Module GEN1')
+    getByText('nickName')
+    getByText('To add labware, use the toggle to control the latch')
+    getByText('Labware Latch')
+    getByText('Secure')
+    const button = getByLabelText('heater_shaker_7_latch_toggle')
+    fireEvent.click(button)
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        params: {
+          moduleId: mockHeaterShaker.id,
+        },
+      },
+    })
+  })
+
+  it('renders the correct info for an off deck labware', () => {
+    const { getByText } = render({
+      nickName: null,
+      definition: mockLabwareDef,
+      initialLocation: 'offDeck',
+      moduleModel: null,
+      moduleLocation: null,
+      extraAttentionModules: [],
+      attachedModuleInfo: {},
+    })
+    getByText('Mock Labware Definition')
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -29,11 +29,9 @@ const mockUseLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFu
   typeof useCreateLiveCommandMutation
 >
 
-const mockThermocyclerModuleDefinition = {
-  moduleId: 'someThermocyclerModule',
-  model: 'thermocyclerModuleV1' as ModuleModel,
-  type: 'thermocyclerModuleType' as ModuleType,
-  labwareOffset: { x: 5, y: 5, z: 5 },
+const mockNestedLabwareDisplayName = 'nested labware display name'
+const mockLocationInfo = {
+  labwareOffset: { x: 1, y: 1, z: 1 },
   cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
   dimensions: {
     xDimension: 100,
@@ -45,8 +43,25 @@ const mockThermocyclerModuleDefinition = {
   },
   twoDimensionalRendering: { children: [] },
 }
-
-const MODULE_ID = 'moduleId'
+const mockAttachedModuleInfo = {
+  x: 1,
+  y: 1,
+  z: 1,
+  nestedLabwareDef: mockLabwareDef,
+  nestedLabwareId: '1',
+  nestedLabwareDisplayName: mockNestedLabwareDisplayName,
+  protocolLoadOrder: 0,
+  slotName: '7',
+}
+const mockModuleSlot = { slotName: '7' }
+const mockThermocyclerModuleDefinition = {
+  moduleId: 'someThermocyclerModule',
+  model: 'thermocyclerModuleV1' as ModuleModel,
+  type: 'thermocyclerModuleType' as ModuleType,
+  ...mockLocationInfo,
+}
+const mockModuleId = 'moduleId'
+const mockNickName = 'nickName'
 
 const render = (props: React.ComponentProps<typeof LabwareListItem>) => {
   return renderWithProviders(
@@ -60,9 +75,8 @@ const render = (props: React.ComponentProps<typeof LabwareListItem>) => {
 }
 
 describe('LabwareListItem', () => {
-  let mockCreateLiveCommand = jest.fn()
+  const mockCreateLiveCommand = jest.fn()
   beforeEach(() => {
-    mockCreateLiveCommand = jest.fn()
     mockCreateLiveCommand.mockResolvedValue(null)
     mockSecureLabwareModal.mockReturnValue(<div>mock secure labware modal</div>)
     mockUseLiveCommandMutation.mockReturnValue({
@@ -72,26 +86,18 @@ describe('LabwareListItem', () => {
 
   it('renders the correct info for a thermocycler, clicking on secure labware instructions opens the modal', () => {
     const { getByText } = render({
-      nickName: 'nickName',
+      nickName: mockNickName,
       definition: mockLabwareDef,
-      initialLocation: { moduleId: MODULE_ID },
+      initialLocation: { moduleId: mockModuleId },
       moduleModel: 'thermocyclerModuleV1' as ModuleModel,
-      moduleLocation: { slotName: '7' },
+      moduleLocation: mockModuleSlot,
       extraAttentionModules: ['thermocyclerModuleType'],
       attachedModuleInfo: {
-        [MODULE_ID]: ({
+        [mockModuleId]: ({
           moduleId: 'thermocyclerModuleId',
-
           attachedModuleMatch: (mockThermocycler as any) as AttachedModule,
-          x: 1,
-          y: 1,
-          z: 1,
-          nestedLabwareDef: mockLabwareDef,
-          nestedLabwareId: '1',
-          nestedLabwareDisplayName: 'nested labware display name',
-          protocolLoadOrder: 0,
-          slotName: '7',
           moduleDef: mockThermocyclerModuleDefinition as any,
+          ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
     })
@@ -105,41 +111,24 @@ describe('LabwareListItem', () => {
 
   it('renders the correct info for a labware on top of a magnetic module', () => {
     const { getByText } = render({
-      nickName: 'nickName',
+      nickName: mockNickName,
       definition: mockLabwareDef,
-      initialLocation: { moduleId: MODULE_ID },
+      initialLocation: { moduleId: mockModuleId },
       moduleModel: 'magneticModuleV1' as ModuleModel,
-      moduleLocation: { slotName: '7' },
+      moduleLocation: mockModuleSlot,
       extraAttentionModules: ['magneticModuleType'],
       attachedModuleInfo: {
-        [MODULE_ID]: ({
+        [mockModuleId]: ({
           moduleId: 'magneticModuleId',
 
           attachedModuleMatch: (mockMagneticModule as any) as AttachedModule,
-          x: 1,
-          y: 1,
-          z: 1,
-          nestedLabwareDef: mockLabwareDef,
-          nestedLabwareId: '1',
-          nestedLabwareDisplayName: 'nested labware display name',
-          protocolLoadOrder: 0,
-          slotName: '7',
           moduleDef: {
             moduleId: 'someMagneticModule',
             model: 'magneticModuleV2' as ModuleModel,
             type: 'magneticModuleType' as ModuleType,
-            labwareOffset: { x: 5, y: 5, z: 5 },
-            cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
-            dimensions: {
-              xDimension: 100,
-              yDimension: 100,
-              footprintXDimension: 50,
-              footprintYDimension: 50,
-              labwareInterfaceXDimension: 80,
-              labwareInterfaceYDimension: 120,
-            },
-            twoDimensionalRendering: { children: [] },
+            ...mockLocationInfo,
           } as any,
+          ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
     })
@@ -153,40 +142,23 @@ describe('LabwareListItem', () => {
 
   it('renders the correct info for a labware on top of a temperature module ', () => {
     const { getByText } = render({
-      nickName: 'nickName',
+      nickName: mockNickName,
       definition: mockLabwareDef,
-      initialLocation: { moduleId: MODULE_ID },
+      initialLocation: { moduleId: mockModuleId },
       moduleModel: 'temperatureModuleV1' as ModuleModel,
-      moduleLocation: { slotName: '7' },
+      moduleLocation: mockModuleSlot,
       extraAttentionModules: [],
       attachedModuleInfo: {
-        [MODULE_ID]: ({
+        [mockModuleId]: ({
           moduleId: 'temperatureModuleId',
           attachedModuleMatch: (mockTemperatureModule as any) as AttachedModule,
-          x: 1,
-          y: 1,
-          z: 1,
-          nestedLabwareDef: mockLabwareDef,
-          nestedLabwareId: '1',
-          nestedLabwareDisplayName: 'nested labware display name',
-          protocolLoadOrder: 0,
-          slotName: '7',
           moduleDef: {
             moduleId: 'someTemperatureModule',
             model: 'temperatureModuleV2' as ModuleModel,
             type: 'temperatureModuleType' as ModuleType,
-            labwareOffset: { x: 5, y: 5, z: 5 },
-            cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
-            dimensions: {
-              xDimension: 100,
-              yDimension: 100,
-              footprintXDimension: 50,
-              footprintYDimension: 50,
-              labwareInterfaceXDimension: 80,
-              labwareInterfaceYDimension: 120,
-            },
-            twoDimensionalRendering: { children: [] },
+            ...mockLocationInfo,
           } as any,
+          ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
     })
@@ -197,40 +169,23 @@ describe('LabwareListItem', () => {
 
   it('renders the correct info for a labware on top of a heater shaker', () => {
     const { getByText, getByLabelText } = render({
-      nickName: 'nickName',
+      nickName: mockNickName,
       definition: mockLabwareDef,
-      initialLocation: { moduleId: MODULE_ID },
+      initialLocation: { moduleId: mockModuleId },
       moduleModel: 'heaterShakerModuleV1' as ModuleModel,
-      moduleLocation: { slotName: '7' },
+      moduleLocation: mockModuleSlot,
       extraAttentionModules: ['heaterShakerModuleType'],
       attachedModuleInfo: {
-        [MODULE_ID]: ({
+        [mockModuleId]: ({
           moduleId: 'heaterShakerModuleId',
           attachedModuleMatch: (mockHeaterShaker as any) as AttachedModule,
-          x: 1,
-          y: 1,
-          z: 1,
-          nestedLabwareDef: mockLabwareDef,
-          nestedLabwareId: '1',
-          nestedLabwareDisplayName: 'nested labware display name',
-          protocolLoadOrder: 0,
-          slotName: '7',
           moduleDef: {
             moduleId: 'someheaterShakerModule',
             model: 'heaterShakerModuleV1' as ModuleModel,
             type: 'heaterShakerModuleType' as ModuleType,
-            labwareOffset: { x: 5, y: 5, z: 5 },
-            cornerOffsetFromSlot: { x: 1, y: 1, z: 1 },
-            dimensions: {
-              xDimension: 100,
-              yDimension: 100,
-              footprintXDimension: 50,
-              footprintYDimension: 50,
-              labwareInterfaceXDimension: 80,
-              labwareInterfaceYDimension: 120,
-            },
-            twoDimensionalRendering: { children: [] },
+            ...mockLocationInfo,
           } as any,
+          ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
     })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { StaticRouter } from 'react-router-dom'
+import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../../i18n'
+import { mockLabwareDef } from '../../../../LabwarePositionCheck/__fixtures__/mockLabwareDef'
+import { LabwareListItem } from '../LabwareListItem'
+import { OffDeckLabwareList } from '../OffDeckLabwareList'
+
+jest.mock('../LabwareListItem')
+
+const mockLabwareListItem = LabwareListItem as jest.MockedFunction<
+  typeof LabwareListItem
+>
+
+const render = (props: React.ComponentProps<typeof OffDeckLabwareList>) => {
+  return renderWithProviders(
+    <StaticRouter>
+      <OffDeckLabwareList {...props} />
+    </StaticRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('OffDeckLabwareList', () => {
+  beforeEach(() => {
+    mockLabwareListItem.mockReturnValue(<div>mock labware list item</div>)
+  })
+  it('renders null if labware items is null', () => {
+    const { container } = render({
+      labwareItems: [],
+    })
+    expect(container.firstChild).toBeNull()
+  })
+  it('renders additional offdeck labware info if there is an offdeck labware', () => {
+    const { getByText } = render({
+      labwareItems: [
+        {
+          nickName: 'nickName',
+          definition: mockLabwareDef,
+          initialLocation: 'offDeck',
+          moduleModel: null,
+          moduleLocation: null,
+        },
+      ],
+    })
+    getByText('Additional Off-Deck Labware')
+    getByText('mock labware list item')
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { StaticRouter } from 'react-router-dom'
-import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../../i18n'
 import { mockLabwareDef } from '../../../../LabwarePositionCheck/__fixtures__/mockLabwareDef'

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareList.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { StaticRouter } from 'react-router-dom'
+import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../../../i18n'
+import { SetupLabwareList } from '../SetupLabwareList'
+import { LabwareListItem } from '../LabwareListItem'
+import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
+
+jest.mock('../LabwareListItem')
+
+const protocolWithTC = (_uncastedProtocolWithTC as unknown) as ProtocolAnalysisFile
+
+const mockLabwareListItem = LabwareListItem as jest.MockedFunction<
+  typeof LabwareListItem
+>
+
+const render = () => {
+  return renderWithProviders(
+    <StaticRouter>
+      <SetupLabwareList
+        commands={protocolWithTC.commands}
+        extraAttentionModules={[]}
+        attachedModuleInfo={
+          {
+            x: 1,
+            y: 2,
+            z: 3,
+            attachedModuleMatch: null,
+            moduleId: 'moduleId',
+          } as any
+        }
+      />
+    </StaticRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('SetupLabwareList', () => {
+  beforeEach(() => {
+    mockLabwareListItem.mockReturnValue(<div>mock labware list item</div>)
+  })
+
+  it('renders the correct headers and labware list items', () => {
+    const { getAllByText, getByText } = render()
+    getAllByText('mock labware list item')
+    getByText('Labware Name')
+    getByText('Initial Location')
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareList.test.tsx
@@ -3,9 +3,13 @@ import { StaticRouter } from 'react-router-dom'
 import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../../i18n'
+import { mockDefinition } from '../../../../../redux/custom-labware/__fixtures__'
 import { SetupLabwareList } from '../SetupLabwareList'
 import { LabwareListItem } from '../LabwareListItem'
-import type { ProtocolAnalysisFile } from '@opentrons/shared-data'
+import type {
+  ProtocolAnalysisFile,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
 
 jest.mock('../LabwareListItem')
 
@@ -15,22 +19,10 @@ const mockLabwareListItem = LabwareListItem as jest.MockedFunction<
   typeof LabwareListItem
 >
 
-const render = () => {
+const render = (props: React.ComponentProps<typeof SetupLabwareList>) => {
   return renderWithProviders(
     <StaticRouter>
-      <SetupLabwareList
-        commands={protocolWithTC.commands}
-        extraAttentionModules={[]}
-        attachedModuleInfo={
-          {
-            x: 1,
-            y: 2,
-            z: 3,
-            attachedModuleMatch: null,
-            moduleId: 'moduleId',
-          } as any
-        }
-      />
+      <SetupLabwareList {...props} />
     </StaticRouter>,
     {
       i18nInstance: i18n,
@@ -38,15 +30,182 @@ const render = () => {
   )[0]
 }
 
+const mockOffDeckCommands = ([
+  {
+    id: '0abc1',
+    commandType: 'loadPipette',
+    params: {
+      pipetteId: 'pipetteId',
+      mount: 'left',
+    },
+  },
+  {
+    id: '0abc2',
+    commandType: 'loadLabware',
+    params: {
+      labwareId: 'fixedTrash',
+      location: {
+        slotName: '12',
+      },
+    },
+    result: {
+      labwareId: 'fixedTrash',
+      definition: {
+        ordering: [['A1']],
+        metadata: {
+          displayCategory: 'trash',
+          displayName: 'Opentrons Fixed Trash',
+        },
+      },
+    },
+  },
+  {
+    id: '0abc3',
+    commandType: 'loadLabware',
+    params: {
+      labwareId: 'tiprackId',
+      location: {
+        slotName: '1',
+      },
+    },
+    result: {
+      labwareId: 'labwareId',
+      definition: mockDefinition,
+    },
+  },
+  {
+    id: '0abc4',
+    commandType: 'loadLabware',
+    params: {
+      labwareId: 'sourcePlateId',
+      location: {
+        slotName: '2',
+      },
+    },
+    result: {
+      labwareId: 'labwareId',
+      definition: mockDefinition,
+    },
+  },
+  {
+    id: '0abc4',
+    commandType: 'loadLabware',
+    params: {
+      labwareId: 'destPlateId',
+      location: {
+        slotName: '3',
+      },
+    },
+    result: {
+      labwareId: 'labwareId',
+      definition: mockDefinition,
+    },
+  },
+  {
+    id: '0',
+    commandType: 'pickUpTip',
+    params: {
+      pipetteId: 'pipetteId',
+      labwareId: 'tiprackId',
+      wellName: 'B1',
+    },
+  },
+  {
+    id: '1',
+    commandType: 'aspirate',
+    params: {
+      pipetteId: 'pipetteId',
+      labwareId: 'sourcePlateId',
+      wellName: 'A1',
+      volume: 5,
+      flowRate: 3,
+      wellLocation: {
+        origin: 'bottom',
+        offset: { x: 0, y: 0, z: 2 },
+      },
+    },
+  },
+  {
+    id: '2',
+    commandType: 'dispense',
+    params: {
+      pipetteId: 'pipetteId',
+      labwareId: 'destPlateId',
+      wellName: 'B1',
+      volume: 4.5,
+      flowRate: 2.5,
+      wellLocation: {
+        origin: 'bottom',
+        offset: { x: 0, y: 0, z: 1 },
+      },
+    },
+  },
+  {
+    id: '3',
+    commandType: 'dropTip',
+    params: {
+      pipetteId: 'pipetteId',
+      labwareId: 'fixedTrash',
+      wellName: 'A1',
+    },
+  },
+  {
+    id: '4',
+    commandType: 'loadLabware',
+    params: {
+      labwareId: 'fixedTrash',
+      location: 'offDeck',
+    },
+    result: {
+      labwareId: 'labwareId',
+      definition: mockDefinition,
+    },
+  },
+] as any) as RunTimeCommand[]
+
 describe('SetupLabwareList', () => {
   beforeEach(() => {
     mockLabwareListItem.mockReturnValue(<div>mock labware list item</div>)
   })
-
   it('renders the correct headers and labware list items', () => {
-    const { getAllByText, getByText } = render()
+    const { getAllByText, getByText } = render({
+      commands: protocolWithTC.commands,
+      extraAttentionModules: [],
+      attachedModuleInfo: {
+        x: 1,
+        y: 2,
+        z: 3,
+        attachedModuleMatch: null,
+        moduleId: 'moduleId',
+      } as any,
+    })
+
     getAllByText('mock labware list item')
     getByText('Labware Name')
     getByText('Initial Location')
+  })
+  it('renders null for the offdeck labware list when there are none', () => {
+    const { queryByText } = render({
+      commands: protocolWithTC.commands,
+      extraAttentionModules: [],
+      attachedModuleInfo: {
+        x: 1,
+        y: 2,
+        z: 3,
+        attachedModuleMatch: null,
+        moduleId: 'moduleId',
+      } as any,
+    })
+    expect(queryByText('Additional Off-Deck Labware')).not.toBeInTheDocument()
+  })
+
+  it('renders offdeck labware list when there are additional offdeck labwares', () => {
+    const { getAllByText, getByText } = render({
+      commands: mockOffDeckCommands,
+      extraAttentionModules: [],
+      attachedModuleInfo: {} as any,
+    })
+    getByText('Additional Off-Deck Labware')
+    getAllByText('mock labware list item')
   })
 })


### PR DESCRIPTION
closes RAUT-287

# Overview

Previously, `SetupLabwareList`, `LabwareListItem` and `OffDeckLabwareList` didn't have a test. This PR creates them.

# Changelog

- write tests for `SetupLabwareList` and `LabwareListItem` and `OffDeckLabwareList`

# Review requests

- make sure the tests cover most things. I have a test case in `LabwareListItem` to cover:
1. what it would look like for each module
2. an off deck labware

# Risk assessment

low