### PR TITLE
docs(api): final changes for Thermocycler GEN2 docs

### DIFF
--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -47,30 +47,30 @@ Some modules were added to the Protocol API later than others, and some modules 
 .. table::
    :widths: 4 5 2
    
-   +--------------------+-------------------------------+---------------------+
-   | Module             | Load Name                     | Minimum API Version |
-   +====================+===============================+=====================+
-   | Temperature Module | ``temperature module``        | 2.0                 |
-   | GEN1               | or ``tempdeck``               |                     |
-   +--------------------+-------------------------------+---------------------+
-   | Temperature Module | ``temperature module gen2``   | 2.3                 |
-   | GEN2               |                               |                     |
-   +--------------------+-------------------------------+---------------------+
-   | Magnetic Module    | ``magnetic module``           | 2.0                 |
-   | GEN1               | or ``magdeck``                |                     |
-   +--------------------+-------------------------------+---------------------+
-   | Magnetic Module    | ``magnetic module gen2``      | 2.3                 |
-   | GEN2               |                               |                     |
-   +--------------------+-------------------------------+---------------------+
-   | Thermocycler       | ``thermocycler module``       | 2.0                 |
-   | Module GEN1        | or ``thermocycler``           |                     |
-   +--------------------+-------------------------------+---------------------+
-   | Thermocycler       | ``thermocycler module gen2``  | 2.14                |
-   | Module GEN2        | or ``thermocyclerModuleV2``   |                     |
-   +--------------------+-------------------------------+---------------------+
-   | Heater-Shaker      | ``heaterShakerModuleV1``      | 2.13                |
-   | Module             |                               |                     |
-   +--------------------+-------------------------------+---------------------+
+   +--------------------+-------------------------------+---------------------------+
+   | Module             | Load Name                     | Introduced in API Version |
+   +====================+===============================+===========================+
+   | Temperature Module | ``temperature module``        | 2.0                       |
+   | GEN1               | or ``tempdeck``               |                           |
+   +--------------------+-------------------------------+---------------------------+
+   | Temperature Module | ``temperature module gen2``   | 2.3                       |
+   | GEN2               |                               |                           |
+   +--------------------+-------------------------------+---------------------------+
+   | Magnetic Module    | ``magnetic module``           | 2.0                       |
+   | GEN1               | or ``magdeck``                |                           |
+   +--------------------+-------------------------------+---------------------------+
+   | Magnetic Module    | ``magnetic module gen2``      | 2.3                       |
+   | GEN2               |                               |                           |
+   +--------------------+-------------------------------+---------------------------+
+   | Thermocycler       | ``thermocycler module``       | 2.0                       |
+   | Module GEN1        | or ``thermocycler``           |                           |
+   +--------------------+-------------------------------+---------------------------+
+   | Thermocycler       | ``thermocycler module gen2``  | 2.13                      |
+   | Module GEN2        | or ``thermocyclerModuleV2``   |                           |
+   +--------------------+-------------------------------+---------------------------+
+   | Heater-Shaker      | ``heaterShakerModuleV1``      | 2.13                      |
+   | Module             |                               |                           |
+   +--------------------+-------------------------------+---------------------------+
 
 Loading Labware onto Your Module
 ================================
@@ -347,7 +347,7 @@ The examples in this section will use a Thermocycler loaded as follows:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.14'}
+    metadata = {'apiLevel': '2.13'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tc_mod = protocol.load_module('thermocyclerModuleV2')
@@ -360,8 +360,6 @@ The ``location`` parameter of :py:meth:`.load_module` isn't required for the The
     If you want to specify a slot for the Thermocycler (for parallelism with other ``load_module()`` calls in your protocol), you can do so: the only accepted value is ``7``.
 
 .. versionadded:: 2.0
-.. versionchanged:: 2.14
-   Added support for Thermocycler Module GEN2.
 
 
 Lid Control
@@ -375,7 +373,7 @@ You can also control the temperature of the lid. Acceptable target temperatures 
 
 .. code-block:: python
 
-    tc_mod.set_lid_temperature(50)
+    tc_mod.set_lid_temperature(temperature=50)
 
 The protocol will only proceed once the lid temperature reaches 50 °C. This is the case whether the previous temperature was lower than 50 °C (in which case the lid will actively heat) or higher than 50 °C (in which case the lid will passively cool).
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -266,5 +266,5 @@ Version 2.14
 Upcoming, not yet released.
 
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
-- :py:meth:`.ModuleContext.load_labware_object` has been deprecated.
-- :py:meth:`.MagneticModuleContext.calibrate` has been deprecated.
+- :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
+- :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

A handful of tweaks to the Thermocycler GEN2 docs, mostly to reflect that it will work with Python API version 2.13.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- changed heading in module compatibility table
- removed references to 2.14 on modules page
- added argument name in code snippet
- 2.14 info on versioning page in future tense

# Review requests

<!--
Describe any requests for your reviewers here.
-->

[Sandbox link](http://sandbox.docs.opentrons.com/docs-tcgen2-touchups/v2/)

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

None, just docs