### PR TITLE
refactor(api): engine based is_simulating

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -105,7 +105,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def is_simulating(self) -> bool:
         """Get whether the protocol is being analyzed or actually run."""
-        return self._sync_hardware.is_simulator  # type: ignore[no-any-return]
+        return self._engine_client.state.config.ignore_pause
 
     def add_labware_definition(
         self,

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -493,3 +493,13 @@ def test_home(
     """It should home all axes."""
     subject.home()
     decoy.verify(mock_engine_client.home(axes=None), times=1)
+
+
+def test_is_simulating(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+) -> None:
+    """It should return if simulating."""
+    decoy.when(mock_engine_client.state.config.ignore_pause).then_return(True)
+    assert subject.is_simulating()


### PR DESCRIPTION
# Overview

Closes RCORE-412.

Refactors the PAPIv2 protocol engine implementation of `is_simulating` to use the engine client instead of the hardware API, by checking the engine config `ignore_pause` field.

# Changelog

- engine core `is_simulating` checks engine config instead of hardware API

# Review requests

Basic smoke testing of simulating/analyzing runs.

# Risk assessment

Low, very small change to engine core.