### PR TITLE
fix(hardware): Remove gripper g from present_nodes in create step 

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -120,13 +120,13 @@ def create_step(
     Returns:
         A Move
     """
+    ordered_nodes = sorted(present_nodes, key=lambda node: node.value)
     # Gripper G cannont process this type of move and this will
     # result in numerous move set timeouts if the gripper is attached
     # possible TODO if requested is to also add a move group step that
     # adds a MoveGroupeSingleGripperStep
-    present_nodes = iter([n for n in present_nodes if n != NodeId.gripper_g])
+    ordered_nodes = list([n for n in present_nodes if n != NodeId.gripper_g])
 
-    ordered_nodes = sorted(present_nodes, key=lambda node: node.value)
     step: MoveGroupStep = {}
     for axis_node in ordered_nodes:
         step[axis_node] = MoveGroupSingleAxisStep(

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -120,6 +120,12 @@ def create_step(
     Returns:
         A Move
     """
+    # Gripper G cannont process this type of move and this will
+    # result in numerous move set timeouts if the gripper is attached
+    # possible TODO if requested is to also add a move group step that
+    # adds a MoveGroupeSingleGripperStep
+    present_nodes = iter([n for n in present_nodes if n != NodeId.gripper_g])
+
     ordered_nodes = sorted(present_nodes, key=lambda node: node.value)
     step: MoveGroupStep = {}
     for axis_node in ordered_nodes:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -51,3 +51,55 @@ def test_build_move() -> None:
             (NodeId.gantry_x, NodeId.gantry_y, NodeId.head_r, NodeId.head_l)
         ),
     )
+
+
+def test_build_move_with_jaw_node() -> None:
+    """It should build a move step and remove gripper g if its in present_nodes.
+
+    Nodes in present_nodes but not in the move should be added.
+    Nodes in the move but not in present_nodes should be removed.
+    """
+    expected = {
+        NodeId.gantry_x: MoveGroupSingleAxisStep(
+            distance_mm=float64(0.0),
+            velocity_mm_sec=float64(0.0),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(0),
+        ),
+        NodeId.gantry_y: MoveGroupSingleAxisStep(
+            distance_mm=float64(0.0),
+            velocity_mm_sec=float64(0.0),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(0),
+        ),
+        NodeId.head_r: MoveGroupSingleAxisStep(
+            distance_mm=float64(0.0),
+            velocity_mm_sec=float64(0.0),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(0),
+        ),
+        NodeId.head_l: MoveGroupSingleAxisStep(
+            distance_mm=float64(4),
+            velocity_mm_sec=float64(0.25),
+            duration_sec=float64(10),
+            acceleration_mm_sec_sq=float64(1000),
+        ),
+    }
+    assert expected == create_step(
+        distance={NodeId.head_l: float64(4), NodeId.pipette_right: float64(10)},
+        velocity={NodeId.head_l: float64(0.25), NodeId.pipette_right: float64(0.3)},
+        acceleration={
+            NodeId.head_l: float64(1000),
+            NodeId.pipette_right: float64(1000),
+        },
+        duration=float64(10),
+        present_nodes=set(
+            (
+                NodeId.gantry_x,
+                NodeId.gantry_y,
+                NodeId.head_r,
+                NodeId.head_l,
+                NodeId.gripper_g,
+            )
+        ),
+    )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This fixes the many "Move Set Timed Out" messages received in the log when a gripper is attached.

the move group runner keeps waiting for the gripper jaw to respond to a stepper motor move, which the gripper jaw doesn't listen to and therefore never responds to
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
