### PR TITLE
refactor(api): engine-core labware setters implementation/setter deprecation

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -38,7 +38,10 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     @property
     def highest_z(self) -> float:
-        raise NotImplementedError("LabwareCore.highest_z not implemented")
+        """The z-coordinate of the tallest single point anywhere on the labware."""
+        return self._engine_client.state.geometry.get_labware_highest_z(
+            self._labware_id
+        )
 
     @property
     def separate_calibration(self) -> bool:
@@ -46,10 +49,11 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     @property
     def load_name(self) -> str:
+        """The API load name of the labware definition."""
         return self._definition.parameters.loadName
 
     def get_uri(self) -> str:
-        """Get the URI string string of the labware's definition.
+        """Get the URI string of the labware's definition.
 
         The URI is unique for a given namespace, load name, and definition version.
         """
@@ -71,7 +75,8 @@ class LabwareCore(AbstractLabware[WellCore]):
         return self._user_display_name
 
     def get_name(self) -> str:
-        raise NotImplementedError("LabwareCore.get_name not implemented")
+        """Get the load name or the label of the labware specified by a user."""
+        return self._user_display_name or self.load_name
 
     def set_name(self, new_name: str) -> None:
         raise NotImplementedError("LabwareCore.set_name not implemented")
@@ -87,17 +92,17 @@ class LabwareCore(AbstractLabware[WellCore]):
         )
 
     def get_quirks(self) -> List[str]:
-        raise NotImplementedError("LabwareCore.get_quirks not implemented")
+        return self._definition.parameters.quirks or []
 
     def set_calibration(self, delta: Point) -> None:
         # TODO(jbl 2022-09-01): implement set calibration through the engine
         pass
 
     def get_calibrated_offset(self) -> Point:
-        raise NotImplementedError("LabwareCore.get_calibrated_offset not implemented")
+        return self._engine_client.state.geometry.get_labware_position(self._labware_id)
 
     def is_tip_rack(self) -> bool:
-        "Whether the labware is a tip rack."
+        """Whether the labware is a tip rack."""
         return self._definition.parameters.isTiprack
 
     def is_fixed_trash(self) -> bool:
@@ -107,7 +112,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         )
 
     def get_tip_length(self) -> float:
-        raise NotImplementedError("LabwareCore.get_tip_length not implemented")
+        return self._engine_client.state.labware.get_tip_length(self._labware_id)
 
     def set_tip_length(self, length: float) -> None:
         raise NotImplementedError("LabwareCore.set_tip_length not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -9,6 +9,7 @@ from opentrons_shared_data.labware.dev_types import (
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import Point
 
 from ..labware import AbstractLabware, LabwareLoadParams
@@ -79,7 +80,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         return self._user_display_name or self.load_name
 
     def set_name(self, new_name: str) -> None:
-        raise NotImplementedError("LabwareCore.set_name not implemented")
+        raise APIVersionError("LabwareCore.set_name has been deprecated")
 
     def get_definition(self) -> LabwareDefinitionDict:
         """Get the labware's definition as a plain dictionary."""
@@ -115,7 +116,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         return self._engine_client.state.labware.get_tip_length(self._labware_id)
 
     def set_tip_length(self, length: float) -> None:
-        raise NotImplementedError("LabwareCore.set_tip_length not implemented")
+        raise APIVersionError("LabwareCore.set_tip_length has been deprecated")
 
     def reset_tips(self) -> None:
         self._engine_client.reset_tips(labware_id=self.labware_id)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -324,6 +324,7 @@ class Labware(DeckItem):
         load it, or the label of the labware specified by a user."""
         return self._implementation.get_name()
 
+    # TODO(jbl, 2022-12-06): deprecate officially when there is a PAPI version for the engine core
     @name.setter
     def name(self, new_name: str) -> None:
         """Set the labware name"""
@@ -613,6 +614,7 @@ class Labware(DeckItem):
     def tip_length(self) -> float:
         return self._implementation.get_tip_length()
 
+    # TODO(jbl, 2022-12-06): deprecate officially when there is a PAPI version for the engine core
     @tip_length.setter
     def tip_length(self, length: float) -> None:
         self._implementation.set_tip_length(length)

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -123,6 +123,42 @@ def test_get_display_name(subject: LabwareCore) -> None:
     "labware_definition",
     [
         LabwareDefinition.construct(  # type: ignore[call-arg]
+            parameters=LabwareDefinitionParameters.construct(loadName="load-name"),  # type: ignore[call-arg]
+        ),
+    ],
+)
+def test_get_name_load_name(subject: LabwareCore) -> None:
+    """It should get the load name when no display name is defined."""
+    result = subject.get_name()
+
+    assert result == "load-name"
+
+
+@pytest.mark.parametrize(
+    "labware_definition",
+    [
+        LabwareDefinition.construct(  # type: ignore[call-arg]
+            parameters=LabwareDefinitionParameters.construct(loadName="load-name"),  # type: ignore[call-arg]
+        ),
+    ],
+)
+def test_get_name_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get the user display name when one is defined."""
+    decoy.when(
+        mock_engine_client.state.labware.get_display_name("cool-labware")
+    ).then_return("my cool display name")
+
+    subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
+
+    result = subject.get_name()
+
+    assert result == "my cool display name"
+
+
+@pytest.mark.parametrize(
+    "labware_definition",
+    [
+        LabwareDefinition.construct(  # type: ignore[call-arg]
             ordering=[],
             parameters=LabwareDefinitionParameters.construct(isTiprack=True),  # type: ignore[call-arg]
         )
@@ -198,3 +234,58 @@ def test_reset_tips(
     """It should reset the tip state of a labware."""
     subject.reset_tips()
     decoy.verify(mock_engine_client.reset_tips(labware_id="cool-labware"), times=1)
+
+
+def test_get_tip_length(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
+) -> None:
+    """It should get the tip length of a labware."""
+    decoy.when(
+        mock_engine_client.state.labware.get_tip_length("cool-labware")
+    ).then_return(1.23)
+
+    result = subject.get_tip_length()
+
+    assert result == 1.23
+
+
+def test_highest_z(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
+) -> None:
+    """It should return the highest z of a labware."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_labware_highest_z("cool-labware")
+    ).then_return(9000.1)
+
+    result = subject.highest_z
+
+    assert result == 9000.1
+
+
+def test_get_calibrated_offset(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
+) -> None:
+    """It should get the calibrated offset."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_labware_position("cool-labware")
+    ).then_return(Point(1, 2, 3))
+
+    result = subject.get_calibrated_offset()
+
+    assert result == Point(1, 2, 3)
+
+
+@pytest.mark.parametrize(
+    "labware_definition",
+    [
+        LabwareDefinition.construct(  # type: ignore[call-arg]
+            ordering=[],
+            parameters=LabwareDefinitionParameters.construct(quirks=["quirk"]),  # type: ignore[call-arg]
+        )
+    ],
+)
+def test_get_quirks(subject: LabwareCore) -> None:
+    """It should get a list of labware quirks."""
+    result = subject.get_quirks()
+
+    assert result == ["quirk"]

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -134,14 +134,6 @@ def test_get_name_load_name(subject: LabwareCore) -> None:
     assert result == "load-name"
 
 
-@pytest.mark.parametrize(
-    "labware_definition",
-    [
-        LabwareDefinition.construct(  # type: ignore[call-arg]
-            parameters=LabwareDefinitionParameters.construct(loadName="load-name"),  # type: ignore[call-arg]
-        ),
-    ],
-)
 def test_get_name_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:
     """It should get the user display name when one is defined."""
     decoy.when(


### PR DESCRIPTION
# Overview

Closes RCORE-414.

This PR adds engine-based implementations to the PAPIv2 labware engine core for the property `highest_z` and methods `get_name`, `get_calibrated_offset`, `get_tip_length`, and `get_quirks`.

Additionally, the set methods `set_name` and `set_tip_length` have been deprecated in the engine core, with TODO notes to officially deprecate the public implementations on official PAPI version.

# Changelog

- Engine core implementations of `highest_z`, `get_name`, `get_calibrated_offset`, `get_tip_length`, and `get_quirks`
- Deprecated engine core `set_name` and `set_tip_length`

# Review requests

Basic smoke testing of added property/methods.

# Risk assessment

Low, engine based implementations based on existing code, deprecated methods were not implemented in core.