### PR TITLE
fix(hardware): don't finish current move group execution when a stale group finishes

### DIFF
--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -3,9 +3,10 @@ import pytest
 from typing import List, Any, Tuple
 from numpy import float64, float32, int32
 from mock import AsyncMock, call, MagicMock
+import asyncio
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId, ErrorCode
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     MessageListenerCallback,
 )
@@ -84,7 +85,7 @@ def move_group_single() -> MoveGroups:
                 NodeId.head: MoveGroupSingleAxisStep(
                     distance_mm=float64(246),
                     velocity_mm_sec=float64(2),
-                    duration_sec=float64(123),
+                    duration_sec=float64(1),
                 )
             }
         ]
@@ -440,9 +441,10 @@ class MockSendMoveCompleter:
         message: MessageDefinition,
         timeout: float = 3,
         expected_nodes: List[NodeId] = [],
-    ) -> None:
+    ) -> ErrorCode:
         """Mock ensure_send function."""
         await self.mock_send(node_id, message)
+        return ErrorCode.ok
 
 
 class MockGripperSendMoveCompleter:
@@ -503,9 +505,10 @@ class MockGripperSendMoveCompleter:
         message: MessageDefinition,
         timeout: float = 3,
         expected_nodes: List[NodeId] = [],
-    ) -> None:
+    ) -> ErrorCode:
         """Mock ensure_send function."""
         await self.mock_send(node_id, message)
+        return ErrorCode.ok
 
 
 async def test_single_move(
@@ -602,6 +605,88 @@ async def test_multi_group_move(
     assert position[2][1].payload.current_position_um.value == 25000
     assert position[3][1].payload.current_position_um.value == 12000
     assert position[4][1].payload.current_position_um.value == 12000
+
+
+async def test_multi_group_move_with_stale_complete(
+    mock_can_messenger: AsyncMock,
+    move_group_multiple: MoveGroups,
+    move_group_single: MoveGroups,
+) -> None:
+    """It should start next group once the prior has completed."""
+    subject = MoveScheduler(move_groups=move_group_multiple)
+    mock_sender = MockSendMoveCompleter(move_group_multiple, subject)
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
+    mock_can_messenger.send.side_effect = mock_sender.mock_send
+
+    # set up a stale move schedluer and set its listener to the subject
+    stale_subject = MoveScheduler(move_groups=move_group_single)
+    stale_mock_sender = MockSendMoveCompleter(move_group_single, subject)
+    stale_mock_can_messenger = AsyncMock()
+    stale_mock_can_messenger.ensure_send.side_effect = (
+        stale_mock_sender.mock_ensure_send
+    )
+    stale_mock_can_messenger.send.side_effect = stale_mock_sender.mock_send
+
+    position, stale = await asyncio.gather(
+        subject.run(can_messenger=mock_can_messenger),
+        stale_subject.run(can_messenger=stale_mock_can_messenger),
+    )
+    expected_nodes_list: List[List[NodeId]] = []
+
+    # we have to do this weird list->set->list conversion to get the same
+    # order as the one move_group_runner uses since sets hash things
+    # in a way that doesn't preserve order
+    for movegroup in move_group_multiple:
+        expected_nodes = set()
+        for seq_id, mgs in enumerate(movegroup):
+            expected_nodes.update(set((k.value, seq_id) for k in mgs.keys()))
+        expected_nodes_list.append([NodeId(n) for n, s in expected_nodes])
+
+    mock_can_messenger.ensure_send.assert_has_calls(
+        calls=[
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(0),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+                expected_nodes=expected_nodes_list[0],
+            ),
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(1),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+                expected_nodes=expected_nodes_list[1],
+            ),
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ExecuteMoveGroupRequest(
+                    payload=ExecuteMoveGroupRequestPayload(
+                        group_id=UInt8Field(2),
+                        cancel_trigger=UInt8Field(0),
+                        start_trigger=UInt8Field(0),
+                    )
+                ),
+                expected_nodes=expected_nodes_list[2],
+            ),
+        ]
+    )
+    assert len(position) == 5
+    assert position[0][1].payload.current_position_um.value == 229000
+    assert position[1][1].payload.current_position_um.value == 522000
+    assert position[2][1].payload.current_position_um.value == 25000
+    assert position[3][1].payload.current_position_um.value == 12000
+    assert position[4][1].payload.current_position_um.value == 12000
+
+    assert len(stale) == 0
 
 
 async def test_multi_gripper_group_move(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Closes RLAB-229

# Changelog
The Logic for finishing a move group had a catch for when we got a message for a stale move group but it was not being used to guard against killing the current group when we got that stale message.

This fixes the bug by not trying to process if a message completes a move group if that message is stale

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
