### PR TITLE
refactor(api): make WellBottomClearance property of InstrumentContext

### DIFF
--- a/api/src/opentrons/protocol_api/config.py
+++ b/api/src/opentrons/protocol_api/config.py
@@ -1,0 +1,23 @@
+"""Contains configuration related classes for Protocol API."""
+
+
+class Clearances:
+    def __init__(self, default_aspirate: float, default_dispense: float) -> None:
+        self._aspirate = default_aspirate
+        self._dispense = default_dispense
+
+    @property
+    def aspirate(self) -> float:
+        return self._aspirate
+
+    @aspirate.setter
+    def aspirate(self, new_val: float) -> None:
+        self._aspirate = float(new_val)
+
+    @property
+    def dispense(self) -> float:
+        return self._dispense
+
+    @dispense.setter
+    def dispense(self, new_val: float) -> None:
+        self._dispense = float(new_val)

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -6,7 +6,7 @@ from typing import Optional, TYPE_CHECKING
 from opentrons.types import Location, Mount
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
+from opentrons.protocols.api_support.util import PlungerSpeeds, FlowRates
 from opentrons.protocol_engine import DeckPoint, WellLocation
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
@@ -40,10 +40,6 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         self._sync_hardware_api = sync_hardware_api
         self._protocol_core = protocol_core
 
-        # TODO(jbl 2022-11-09) clearances should be move out of the core
-        self._well_bottom_clearances = Clearances(
-            default_aspirate=1.0, default_dispense=1.0
-        )
         # TODO(jbl 2022-11-03) flow_rates should not live in the cores, and should be moved to the protocol context
         #   along with other rate related refactors (for the hardware API)
         self._flow_rates = FlowRates(self)
@@ -376,9 +372,6 @@ class InstrumentCore(AbstractInstrument[WellCore]):
 
     def get_return_height(self) -> float:
         raise NotImplementedError("InstrumentCore.get_return_height not implemented")
-
-    def get_well_bottom_clearance(self) -> Clearances:
-        return self._well_bottom_clearances
 
     def get_speed(self) -> PlungerSpeeds:
         raise NotImplementedError("InstrumentCore.get_speed not implemented")

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -7,7 +7,7 @@ from typing import Any, Generic, Optional, TypeVar
 
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
+from opentrons.protocols.api_support.util import PlungerSpeeds, FlowRates
 
 from .well import WellCoreType
 
@@ -188,10 +188,6 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
 
     @abstractmethod
     def get_return_height(self) -> float:
-        ...
-
-    @abstractmethod
-    def get_well_bottom_clearance(self) -> Clearances:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/instrument_context.py
@@ -11,7 +11,6 @@ from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import (
-    Clearances,
     build_edges,
     FlowRates,
     PlungerSpeeds,
@@ -48,9 +47,6 @@ class InstrumentContextImplementation(AbstractInstrument[WellImplementation]):
         self._mount = mount
         self._instrument_name = instrument_name
         self._default_speed = default_speed
-        self._well_bottom_clearances = Clearances(
-            default_aspirate=1.0, default_dispense=1.0
-        )
         self._flow_rates = FlowRates(self)
         self._speeds = PlungerSpeeds(self)
         self._flow_rates.set_defaults(api_level=self._api_version)
@@ -407,10 +403,6 @@ class InstrumentContextImplementation(AbstractInstrument[WellImplementation]):
     def get_return_height(self) -> float:
         """The height to return a tip to its tiprack."""
         return self.get_hardware_state().get("return_tip_height", 0.5)
-
-    def get_well_bottom_clearance(self) -> Clearances:
-        """The distance above the bottom of a well to aspirate or dispense."""
-        return self._well_bottom_clearances
 
     def get_flow_rate(self) -> FlowRates:
         return self._flow_rates

--- a/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
+++ b/api/src/opentrons/protocol_api/core/simulator/instrument_context.py
@@ -11,7 +11,7 @@ from opentrons.protocols.api_support import instrument as instrument_support
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, Clearances
+from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds
 from opentrons.protocols.geometry import planning
 
 from ..instrument import AbstractInstrument
@@ -295,9 +295,6 @@ class InstrumentContextSimulation(AbstractInstrument[WellImplementation]):
 
     def get_return_height(self) -> float:
         return self._pipette_dict["return_tip_height"]
-
-    def get_well_bottom_clearance(self) -> Clearances:
-        return Clearances(default_aspirate=1, default_dispense=1)
 
     def get_speed(self) -> PlungerSpeeds:
         return self._plunger_speeds

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -18,13 +18,13 @@ from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.util import (
     FlowRates,
     PlungerSpeeds,
-    Clearances,
     clamp_value,
     requires_version,
     APIVersionError,
 )
 
 from .core.common import InstrumentCore, ProtocolCore
+from .config import Clearances
 from . import labware
 
 
@@ -77,6 +77,9 @@ class InstrumentContext(publisher.CommandPublisher):
         self._tip_racks = tip_racks
         self._last_tip_picked_up_from: Union[labware.Well, None] = None
         self._starting_tip: Union[labware.Well, None] = None
+        self._well_bottom_clearances = Clearances(
+            default_aspirate=1.0, default_dispense=1.0
+        )
 
         self.trash_container = trash
         self.requested_as = requested_as
@@ -169,7 +172,7 @@ class InstrumentContext(publisher.CommandPublisher):
         last_location = self._protocol_core.get_last_location()
 
         if isinstance(location, labware.Well):
-            move_to_location = location.bottom(z=self.well_bottom_clearance.aspirate)
+            move_to_location = location.bottom(z=self._well_bottom_clearances.aspirate)
             well = location
         elif isinstance(location, types.Location):
             move_to_location = location
@@ -278,7 +281,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 move_to_location = location.top()
             else:
                 move_to_location = location.bottom(
-                    z=self.well_bottom_clearance.dispense
+                    z=self._well_bottom_clearances.dispense
                 )
         elif isinstance(location, types.Location):
             move_to_location = location
@@ -1482,7 +1485,7 @@ class InstrumentContext(publisher.CommandPublisher):
             instr.well_bottom_clearance.aspirate = 1
 
         """
-        return self._implementation.get_well_bottom_clearance()
+        return self._well_bottom_clearances
 
     def __repr__(self) -> str:
         return "<{}: {} in {}>".format(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -35,6 +35,9 @@ AdvancedLiquidHandling = Union[
     Sequence[Sequence[labware.Well]],
 ]
 
+_DEFAULT_ASPIRATE_CLEARANCE = 1.0
+_DEFAULT_DISPENSE_CLEARANCE = 1.0
+
 _log = logging.getLogger(__name__)
 
 _PREP_AFTER_ADDED_IN = APIVersion(2, 13)
@@ -78,7 +81,8 @@ class InstrumentContext(publisher.CommandPublisher):
         self._last_tip_picked_up_from: Union[labware.Well, None] = None
         self._starting_tip: Union[labware.Well, None] = None
         self._well_bottom_clearances = Clearances(
-            default_aspirate=1.0, default_dispense=1.0
+            default_aspirate=_DEFAULT_ASPIRATE_CLEARANCE,
+            default_dispense=_DEFAULT_DISPENSE_CLEARANCE,
         )
 
         self.trash_container = trash

--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -19,7 +19,7 @@ from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
 # todo(mm, 2021-04-09): How customer-facing are these classes? Should they be
 # accessible and documented as part of this package?
-from opentrons.protocols.api_support.util import PlungerSpeeds, FlowRates, Clearances
+from opentrons.protocols.api_support.util import PlungerSpeeds, FlowRates
 
 
 # todo(mm, 2021-04-09): Can/should we remove the word "Context" from the name?
@@ -346,9 +346,4 @@ class PipetteContext:  # noqa: D101
     @property
     def return_height(self) -> float:  # noqa: D102
         # TODO: https://github.com/Opentrons/opentrons/issues/9516
-        raise NotImplementedError()
-
-    @property
-    def well_bottom_clearance(self) -> Clearances:  # noqa: D102
-        # TODO: https://github.com/Opentrons/opentrons/issues/9512
         raise NotImplementedError()

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -246,28 +246,6 @@ class PlungerSpeeds:
         )
 
 
-class Clearances:
-    def __init__(self, default_aspirate: float, default_dispense: float) -> None:
-        self._aspirate = default_aspirate
-        self._dispense = default_dispense
-
-    @property
-    def aspirate(self) -> float:
-        return self._aspirate
-
-    @aspirate.setter
-    def aspirate(self, new_val: float):
-        self._aspirate = float(new_val)
-
-    @property
-    def dispense(self) -> float:
-        return self._dispense
-
-    @dispense.setter
-    def dispense(self, new_val: float):
-        self._dispense = float(new_val)
-
-
 class AxisMaxSpeeds(UserDict):
     """Special mapping allowing internal storage by Mount enums and
     user access by string

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -9,7 +9,6 @@ from opentrons.broker import Broker
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support import instrument as mock_instrument_support
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.api_support.util import Clearances
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     InstrumentContext,
@@ -200,11 +199,7 @@ def test_aspirate(
     mock_well = decoy.mock(cls=Well)
     bottom_location = Location(point=Point(1, 2, 3), labware=mock_well)
 
-    decoy.when(mock_instrument_core.get_well_bottom_clearance()).then_return(
-        Clearances(default_aspirate=1.2, default_dispense=3.4)
-    )
-
-    decoy.when(mock_well.bottom(z=1.2)).then_return(bottom_location)
+    decoy.when(mock_well.bottom(z=1.0)).then_return(bottom_location)
     decoy.when(mock_instrument_core.get_absolute_aspirate_flow_rate(1.23)).then_return(
         5.67
     )
@@ -521,12 +516,8 @@ def test_dispense_with_well_location(
     """It should dispense to a well."""
     mock_well = decoy.mock(cls=Well)
 
-    decoy.when(mock_well.bottom(2.0)).then_return(
+    decoy.when(mock_well.bottom(1.0)).then_return(
         Location(point=Point(1, 2, 3), labware=mock_well)
-    )
-
-    decoy.when(mock_instrument_core.get_well_bottom_clearance()).then_return(
-        Clearances(default_aspirate=3.0, default_dispense=2.0)
     )
 
     decoy.when(mock_instrument_core.get_absolute_dispense_flow_rate(1.0)).then_return(


### PR DESCRIPTION
# Overview

Closes RCORE-419.

This PR refactors `Clearances`, moving the class into a new `config.py` in the `protocol_api` folder, moves the class into the public `InstrumentContext` itself, and removes all references and related methods out of the cores (abstract, legacy, engine and simulating).

# Changelog

- Moved `Clearances` into `opentrons.protocol_api.config`
- Instantiate `well_bottom_clearances` in public `InstrumentContext`
- removed all references to `Clearances` and `well_bottom_clearances` in cores

# Review requests

Simple smoke test of aspirate and dispense analyzing correctly.

# Risk assessment

Low, clearance related code has been simplified and is functionally identical.