### PR TITLE
feat(hardware): read gripper jaw motor driver config via CAN

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -104,6 +104,8 @@ class MessageId(int, Enum):
     gripper_grip_request = 0x42
     gripper_home_request = 0x43
     add_brushed_linear_move_request = 0x44
+    brushed_motor_conf_request = 0x45
+    brushed_motor_conf_response = 0x46
 
     acknowledgement = 0x50
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -578,6 +578,24 @@ class SetBrushedMotorPwmRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass
+class BrushedMotorConfRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[
+        MessageId.brushed_motor_conf_request
+    ] = MessageId.brushed_motor_conf_request
+
+
+@dataclass
+class BrushedMotorConfResponse(BaseMessage):  # noqa: D101
+    payload: payloads.BrushedMotorConfPayload
+    payload_type: Type[
+        payloads.BrushedMotorConfPayload
+    ] = payloads.BrushedMotorConfPayload
+    message_id: Literal[
+        MessageId.brushed_motor_conf_response
+    ] = MessageId.brushed_motor_conf_response
+
+
+@dataclass
 class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -79,6 +79,8 @@ MessageDefinition = Union[
     defs.PeripheralStatusResponse,
     defs.SetSerialNumber,
     defs.InstrumentInfoRequest,
+    defs.BrushedMotorConfRequest,
+    defs.BrushedMotorConfResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -453,6 +453,14 @@ class BrushedMotorPwmPayload(EmptyPayload):
 
 
 @dataclass(eq=False)
+class BrushedMotorConfPayload(EmptyPayload):
+    """A response carrying data about a brushed motor driver."""
+
+    v_ref: utils.UInt32Field
+    duty_cycle: utils.UInt32Field
+
+
+@dataclass(eq=False)
 class GripperInfoResponsePayload(EmptyPayload):
     """A response carrying data about an attached gripper."""
 

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -1,6 +1,13 @@
 """Utilities for updating the gripper settings."""
 import logging
-from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+import asyncio
+from dataclasses import dataclass
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    WaitableCallback,
+)
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+
 from opentrons_hardware.firmware_bindings.messages import payloads
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     SetBrushedMotorVrefRequest,
@@ -8,6 +15,8 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     GripperGripRequest,
     GripperHomeRequest,
     AddBrushedLinearMoveRequest,
+    BrushedMotorConfRequest,
+    BrushedMotorConfResponse,
 )
 from opentrons_hardware.firmware_bindings.utils import (
     UInt8Field,
@@ -18,6 +27,14 @@ from opentrons_hardware.firmware_bindings.constants import NodeId, ErrorCode
 from .constants import brushed_motor_interrupts_per_sec
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DriverConfig:
+    """Brushed motor driver config."""
+
+    reference_voltage: float
+    duty_cycle: int
 
 
 async def set_reference_voltage(
@@ -52,6 +69,31 @@ async def set_pwm_param(
     )
     if error != ErrorCode.ok:
         log.error(f"recieved error trying to set gripper pwm {str(error)}")
+
+
+async def get_gripper_jaw_motor_param(
+    can_messenger: CanMessenger,
+) -> DriverConfig:
+    """Get gripper brushed motor driver params: reference voltage and duty cycle."""
+
+    def _filter(arbitration_id: ArbitrationId) -> bool:
+        return NodeId(arbitration_id.parts.originating_node_id) == NodeId.gripper_g
+
+    with WaitableCallback(can_messenger, _filter) as reader:
+        await can_messenger.send(
+            node_id=NodeId.gripper_g,
+            message=BrushedMotorConfRequest(),
+        )
+        try:
+            response = await asyncio.wait_for(reader.read(), 1.0)
+            assert isinstance(response, BrushedMotorConfResponse)
+            return DriverConfig(
+                reference_voltage=float(response.payload.v_ref / (2**16)),
+                duty_cycle=int(response.payload.duty_cycle / (2**16)),
+            )
+        except asyncio.TimeoutError:
+            log.warning("Read brushed motor driver config timed out")
+            raise StopAsyncIteration
 
 
 async def grip(

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -82,10 +82,11 @@ async def get_gripper_jaw_motor_param(
     async def _wait_for_response(reader: WaitableCallback) -> DriverConfig:
         """Listener for receiving messages back."""
         async for response, _ in reader:
-            return DriverConfig(
-                reference_voltage=float(response.payload.v_ref.value / (2**16)),
-                duty_cycle=int(response.payload.duty_cycle.value / (2**16)),
-            )
+            if isinstance(response, BrushedMotorConfResponse):
+                return DriverConfig(
+                    reference_voltage=float(response.payload.v_ref.value / (2**16)),
+                    duty_cycle=int(response.payload.duty_cycle.value / (2**16)),
+                )
         raise StopAsyncIteration
 
     with WaitableCallback(can_messenger, _filter) as reader:

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -83,8 +83,8 @@ async def get_gripper_jaw_motor_param(
         """Listener for receiving messages back."""
         async for response, _ in reader:
             return DriverConfig(
-                reference_voltage=float(response.payload.v_ref / (2**16)),
-                duty_cycle=int(response.payload.duty_cycle / (2**16)),
+                reference_voltage=float(response.payload.v_ref.value / (2**16)),
+                duty_cycle=int(response.payload.duty_cycle.value / (2**16)),
             )
         raise StopAsyncIteration
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This lets us read the duty cycle and the reference voltage of the brushed motor using CAN.

Related firmware changes: https://github.com/Opentrons/ot3-firmware/pull/520
