### PR TITLE
refactor(api): implement new Deck collaborations

### DIFF
--- a/api/src/opentrons/motion_planning/adjacent_slots_getters.py
+++ b/api/src/opentrons/motion_planning/adjacent_slots_getters.py
@@ -3,7 +3,7 @@
 from typing import Optional, List
 
 
-def _get_north_slot(slot: int) -> Optional[int]:
+def get_north_slot(slot: int) -> Optional[int]:
     """Get slot north of the given slot."""
     if slot in [10, 11, 12]:
         return None
@@ -19,7 +19,7 @@ def get_south_slot(slot: int) -> Optional[int]:
         return slot - 3
 
 
-def _get_east_slot(slot: int) -> Optional[int]:
+def get_east_slot(slot: int) -> Optional[int]:
     """Get slot east of the given slot."""
     if slot in [3, 6, 9, 12]:
         return None
@@ -27,7 +27,7 @@ def _get_east_slot(slot: int) -> Optional[int]:
         return slot + 1
 
 
-def _get_west_slot(slot: int) -> Optional[int]:
+def get_west_slot(slot: int) -> Optional[int]:
     """Get slot west of the given slot."""
     if slot in [1, 4, 7, 10]:
         return None
@@ -37,14 +37,14 @@ def _get_west_slot(slot: int) -> Optional[int]:
 
 def get_east_west_slots(slot: int) -> List[int]:
     """Get slots east & west of the given slot."""
-    east = _get_east_slot(slot)
-    west = _get_west_slot(slot)
+    east = get_east_slot(slot)
+    west = get_west_slot(slot)
     return [maybe_slot for maybe_slot in [east, west] if maybe_slot is not None]
 
 
 def get_north_south_slots(slot: int) -> List[int]:
     """Get slots north & south of the given slot."""
-    north = _get_north_slot(slot)
+    north = get_north_slot(slot)
     south = get_south_slot(slot)
     return [maybe_slot for maybe_slot in [north, south] if maybe_slot is not None]
 

--- a/api/src/opentrons/protocol_api/core/core_map.py
+++ b/api/src/opentrons/protocol_api/core/core_map.py
@@ -1,0 +1,27 @@
+"""Map equipment cores to public PAPI objects."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Union
+
+from .common import ModuleCore, LabwareCore
+
+if TYPE_CHECKING:
+    from ..labware import Labware
+    from ..module_contexts import ModuleContext
+
+
+class LoadedCoreMap:
+    """A map of equipment (labware, modules) cores to public PAPI instances.
+
+    This object keeps track of every core instance that has been created
+    so that later, those cores can be used to look up the public PAPI objects
+    they represent.
+
+    This linkage creates a circular dependency, but keeps it contained to this instance.
+    """
+
+    def get(
+        self, equipment_core: Union[LabwareCore, ModuleCore, None]
+    ) -> Union[Labware, ModuleContext[Any]]:
+        """Given a core, get the public PAPI object it represents."""
+        raise NotImplementedError("LoadedCoreMap.get not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -2,11 +2,12 @@
 from typing import Dict, Optional, Type, Union
 from typing_extensions import Literal
 
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
-from opentrons.types import Mount, MountType, Location, DeckSlotName
+from opentrons.types import DeckSlotName, Location, Mount, MountType, Point
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import (
@@ -307,3 +308,21 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         """Set the last accessed location."""
         self._last_location = location
         self._last_mount = mount
+
+    def get_deck_definition(self) -> DeckDefinitionV3:
+        """Get the geometry definition of the robot's deck."""
+        raise NotImplementedError("ProtocolCore.get_deck_definition not implemented")
+
+    def get_slot_item(
+        self, slot_name: DeckSlotName
+    ) -> Union[LabwareCore, ModuleCore, None]:
+        """Get the contents of a given slot, if any."""
+        raise NotImplementedError("ProtocolCore.get_slot_item not implemented")
+
+    def get_slot_center(self, slot_name: DeckSlotName) -> Point:
+        """Get the absolute coordinate of a slot's center."""
+        raise NotImplementedError("ProtocolCore.get_slot_center not implemented.")
+
+    def get_highest_z(self) -> float:
+        """Get the highest Z point of all deck items."""
+        raise NotImplementedError("ProtocolCore.get_highest_z not implemented")

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from typing import Dict, Generic, Optional, Union
 
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons.types import Mount, Location, DeckSlotName
+
+from opentrons.types import DeckSlotName, Location, Mount, Point
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules.types import ModuleModel
 from opentrons.protocols.api_support.util import AxisMaxSpeeds
@@ -143,3 +145,21 @@ class AbstractProtocol(
         mount: Optional[Mount] = None,
     ) -> None:
         ...
+
+    @abstractmethod
+    def get_deck_definition(self) -> DeckDefinitionV3:
+        """Get the geometry definition of the robot's deck."""
+
+    @abstractmethod
+    def get_slot_item(
+        self, slot_name: DeckSlotName
+    ) -> Union[LabwareCoreType, ModuleCoreType, None]:
+        """Get the contents of a given slot, if any."""
+
+    @abstractmethod
+    def get_slot_center(self, slot_name: DeckSlotName) -> Point:
+        """Get the absolute coordinate of a slot's center."""
+
+    @abstractmethod
+    def get_highest_z(self) -> float:
+        """Get the highest Z point of all deck items."""

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -1,10 +1,11 @@
 import logging
 from typing import Dict, List, Optional, Set, Union
 
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
-from opentrons.types import Mount, Location, DeckSlotName
+from opentrons.types import DeckSlotName, Location, Mount, Point
 from opentrons.equipment_broker import EquipmentBroker
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.modules import AbstractModule, ModuleModel, ModuleType
@@ -381,3 +382,23 @@ class ProtocolContextImplementation(
     def get_module_cores(self) -> List[legacy_module_core.LegacyModuleCore]:
         """Get loaded module cores."""
         return self._module_cores
+
+    def get_deck_definition(self) -> DeckDefinitionV3:
+        """Get the geometry definition of the robot's deck."""
+        raise NotImplementedError(
+            "LegacyProtocolCore.get_deck_definition not implemented"
+        )
+
+    def get_slot_item(
+        self, slot_name: DeckSlotName
+    ) -> Union[LabwareImplementation, legacy_module_core.LegacyModuleCore, None]:
+        """Get the contents of a given slot, if any."""
+        raise NotImplementedError("LegacyProtocolCore.get_slot_item not implemented")
+
+    def get_slot_center(self, slot_name: DeckSlotName) -> Point:
+        """Get the absolute coordinate of a slot's center."""
+        raise NotImplementedError("LegacyProtocolCore.get_slot_center not implemented.")
+
+    def get_highest_z(self) -> float:
+        """Get the highest Z point of all deck items."""
+        raise NotImplementedError("LegacyProtocolCore.get_highest_z not implemented")

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -198,6 +198,9 @@ class DeckSlotName(str, enum.Enum):
         str_val = str(value)
         return cls(str_val)
 
+    def as_int(self) -> int:
+        return int(self.value)
+
     def __str__(self) -> str:
         """Stringify to a simple integer string."""
         return str(self.value)

--- a/api/tests/opentrons/motion_planning/test_adjacent_slots_getters.py
+++ b/api/tests/opentrons/motion_planning/test_adjacent_slots_getters.py
@@ -1,8 +1,12 @@
 """Tests for adjacent_slots_getters."""
 import pytest
-from typing import List
+from typing import List, Optional
 
 from opentrons.motion_planning.adjacent_slots_getters import (
+    get_east_slot,
+    get_south_slot,
+    get_west_slot,
+    get_north_slot,
     get_east_west_slots,
     get_north_south_slots,
     get_adjacent_slots,
@@ -10,47 +14,61 @@ from opentrons.motion_planning.adjacent_slots_getters import (
 
 
 @pytest.mark.parametrize(
-    argnames=["slot", "expected_east_west"],
+    argnames=["slot", "expected_east", "expected_west", "expected_both"],
     argvalues=[
-        [1, [2]],
-        [2, [1, 3]],
-        [3, [2]],
-        [4, [5]],
-        [5, [4, 6]],
-        [6, [5]],
-        [7, [8]],
-        [8, [7, 9]],
-        [9, [8]],
-        [10, [11]],
-        [11, [10, 12]],
-        [12, [11]],
+        [1, 2, None, [2]],
+        [2, 3, 1, [3, 1]],
+        [3, None, 2, [2]],
+        [4, 5, None, [5]],
+        [5, 6, 4, [6, 4]],
+        [6, None, 5, [5]],
+        [7, 8, None, [8]],
+        [8, 9, 7, [9, 7]],
+        [9, None, 8, [8]],
+        [10, 11, None, [11]],
+        [11, 12, 10, [12, 10]],
+        [12, None, 11, [11]],
     ],
 )
-def test_get_east_west_slots(slot: int, expected_east_west: List[int]) -> None:
+def test_get_east_west_slots(
+    slot: int,
+    expected_west: Optional[int],
+    expected_east: Optional[int],
+    expected_both: List[int],
+) -> None:
     """It should return a list of slots on the east & west."""
-    assert sorted(get_east_west_slots(slot)) == sorted(expected_east_west)
+    assert get_east_slot(slot) == expected_east
+    assert get_west_slot(slot) == expected_west
+    assert get_east_west_slots(slot) == expected_both
 
 
 @pytest.mark.parametrize(
-    argnames=["slot", "expected_north_south"],
+    argnames=["slot", "expected_north", "expected_south", "expected_both"],
     argvalues=[
-        [1, [4]],
-        [2, [5]],
-        [3, [6]],
-        [4, [7, 1]],
-        [5, [2, 8]],
-        [6, [9, 3]],
-        [7, [10, 4]],
-        [8, [11, 5]],
-        [9, [12, 6]],
-        [10, [7]],
-        [11, [8]],
-        [12, [9]],
+        [1, 4, None, [4]],
+        [2, 5, None, [5]],
+        [3, 6, None, [6]],
+        [4, 7, 1, [7, 1]],
+        [5, 8, 2, [8, 2]],
+        [6, 9, 3, [9, 3]],
+        [7, 10, 4, [10, 4]],
+        [8, 11, 5, [11, 5]],
+        [9, 12, 6, [12, 6]],
+        [10, None, 7, [7]],
+        [11, None, 8, [8]],
+        [12, None, 9, [9]],
     ],
 )
-def test_get_north_south_slots(slot: int, expected_north_south: List[int]) -> None:
+def test_get_north_south_slots(
+    slot: int,
+    expected_north: Optional[int],
+    expected_south: Optional[int],
+    expected_both: List[int],
+) -> None:
     """It should return a list of slots in the north & south."""
-    assert sorted(get_north_south_slots(slot)) == sorted(expected_north_south)
+    assert get_north_slot(slot) == expected_north
+    assert get_south_slot(slot) == expected_south
+    assert get_north_south_slots(slot) == expected_both
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -1,0 +1,269 @@
+"""Tests for opentrons.protocol_api.Deck."""
+import inspect
+from typing import cast
+
+import pytest
+from decoy import Decoy
+
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
+
+from opentrons.motion_planning import adjacent_slots_getters as mock_adjacent_slots
+from opentrons.protocol_api.core.common import ProtocolCore, LabwareCore
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
+from opentrons.protocol_api import Deck, Labware, validation as mock_validation
+from opentrons.protocol_api.deck import CalibrationPosition
+from opentrons.types import DeckSlotName, Point
+
+
+@pytest.fixture
+def deck_definition() -> DeckDefinitionV3:
+    """Get a deck definition value object."""
+    return cast(
+        DeckDefinitionV3, {"locations": {"orderedSlots": [], "calibrationPoints": []}}
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_validation_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock out opentrons.protocol_api.validation functions."""
+    for name, func in inspect.getmembers(mock_validation, inspect.isfunction):
+        monkeypatch.setattr(mock_validation, name, decoy.mock(func=func))
+
+
+@pytest.fixture(autouse=True)
+def _mock_adjacent_slots_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock out opentrons.motion_planning.adjacent_slots_getters functions."""
+    for name, func in inspect.getmembers(mock_adjacent_slots, inspect.isfunction):
+        monkeypatch.setattr(mock_adjacent_slots, name, decoy.mock(func=func))
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock ProtocolCore."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
+
+
+@pytest.fixture
+def subject(
+    decoy: Decoy,
+    deck_definition: DeckDefinitionV3,
+    mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+) -> Deck:
+    """Get a Deck test subject with its dependencies mocked out."""
+    decoy.when(mock_protocol_core.get_deck_definition()).then_return(deck_definition)
+
+    return Deck(
+        protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
+    )
+
+
+def test_get_empty_slot(
+    decoy: Decoy, mock_protocol_core: ProtocolCore, subject: Deck
+) -> None:
+    """It should return None for slots if empty."""
+    decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_2)
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_2)).then_return(None)
+
+    assert subject[42] is None
+
+
+def test_get_slot_invalid_key(
+    decoy: Decoy, mock_protocol_core: ProtocolCore, subject: Deck
+) -> None:
+    """It should map a ValueError from validation to a KeyError."""
+    decoy.when(mock_validation.ensure_deck_slot(1)).then_raise(TypeError("uh oh"))
+    decoy.when(mock_validation.ensure_deck_slot(2)).then_raise(ValueError("oh no"))
+
+    with pytest.raises(KeyError, match="uh oh"):
+        subject[1]
+
+    with pytest.raises(KeyError, match="oh no"):
+        subject[2]
+
+
+def test_get_slot_item(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    subject: Deck,
+) -> None:
+    """It should map a ValueError from validation to a KeyError."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+    mock_labware = decoy.mock(cls=Labware)
+
+    decoy.when(mock_validation.ensure_deck_slot(42)).then_return(DeckSlotName.SLOT_2)
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_2)).then_return(
+        mock_labware_core
+    )
+    decoy.when(mock_core_map.get(mock_labware_core)).then_return(mock_labware)
+
+    assert subject[42] is mock_labware
+
+
+@pytest.mark.parametrize(
+    "deck_definition",
+    [
+        {
+            "locations": {
+                "orderedSlots": [
+                    {"id": "1"},
+                    {"id": "2"},
+                    {"id": "3"},
+                ],
+                "calibrationPoints": [],
+            }
+        },
+    ],
+)
+def test_slot_keys_iter(subject: Deck) -> None:
+    """It should provide an iterable interface to deck slots."""
+    result = list(subject)
+
+    assert len(subject) == 3
+    assert result == ["1", "2", "3"]
+
+
+@pytest.mark.parametrize(
+    "deck_definition",
+    [
+        {
+            "locations": {
+                "orderedSlots": [
+                    {"id": "1"},
+                    {"id": "2"},
+                    {"id": "3"},
+                ],
+                "calibrationPoints": [],
+            }
+        },
+    ],
+)
+def test_get_slots(decoy: Decoy, subject: Deck) -> None:
+    """It should provide slot definitions."""
+    decoy.when(mock_validation.ensure_deck_slot(222)).then_return(DeckSlotName.SLOT_2)
+
+    assert subject.slots == [
+        {"id": "1"},
+        {"id": "2"},
+        {"id": "3"},
+    ]
+
+    assert subject.get_slot_definition(222) == {"id": "2"}
+
+
+@pytest.mark.parametrize(
+    "deck_definition",
+    [
+        {
+            "locations": {
+                "orderedSlots": [
+                    {"id": "3", "position": [1.0, 2.0, 3.0]},
+                ],
+                "calibrationPoints": [],
+            }
+        },
+    ],
+)
+def test_get_position_for(decoy: Decoy, subject: Deck) -> None:
+    """It should return a `Location` for a deck slot."""
+    decoy.when(mock_validation.ensure_deck_slot(333)).then_return(DeckSlotName.SLOT_3)
+
+    result = subject.position_for(333)
+    assert result.point == Point(x=1.0, y=2.0, z=3.0)
+    assert result.labware.is_slot is True
+    assert str(result.labware) == "3"
+
+
+def test_highest_z(
+    decoy: Decoy, mock_protocol_core: ProtocolCore, subject: Deck
+) -> None:
+    """It should return the highest Z point of all deck items."""
+    decoy.when(mock_protocol_core.get_highest_z()).then_return(42.0)
+
+    assert subject.highest_z == 42.0
+
+
+def test_right_of_and_left_of(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    subject: Deck,
+) -> None:
+    """It should return items left and right of a slot."""
+    left_labware_core = decoy.mock(cls=LabwareCore)
+    right_labware_core = decoy.mock(cls=LabwareCore)
+    left_labware = decoy.mock(cls=Labware)
+    right_labware = decoy.mock(cls=Labware)
+
+    decoy.when(mock_adjacent_slots.get_east_slot(4)).then_return(111)
+    decoy.when(mock_adjacent_slots.get_west_slot(4)).then_return(999)
+    decoy.when(mock_validation.ensure_deck_slot(444)).then_return(DeckSlotName.SLOT_4)
+    decoy.when(mock_validation.ensure_deck_slot(111)).then_return(DeckSlotName.SLOT_1)
+    decoy.when(mock_validation.ensure_deck_slot(999)).then_return(DeckSlotName.SLOT_9)
+
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_1)).then_return(
+        right_labware_core
+    )
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_9)).then_return(
+        left_labware_core
+    )
+
+    decoy.when(mock_core_map.get(right_labware_core)).then_return(right_labware)
+    decoy.when(mock_core_map.get(left_labware_core)).then_return(left_labware)
+
+    assert subject.right_of(444) is right_labware
+    assert subject.left_of(444) is left_labware
+
+
+@pytest.mark.parametrize(
+    "deck_definition",
+    [
+        {
+            "locations": {
+                "orderedSlots": [],
+                "calibrationPoints": [
+                    {
+                        "id": "123",
+                        "position": [1.0, 2.0, 3.0],
+                        "displayName": "Point 123",
+                    },
+                    {
+                        "id": "456",
+                        "position": [4.0, 5.0, 6.0],
+                        "displayName": "Point 456",
+                    },
+                ],
+            }
+        },
+    ],
+)
+def test_get_calibration_positions(subject: Deck) -> None:
+    """It should return calibration positions from the definition."""
+    assert subject.calibration_positions == [
+        CalibrationPosition(
+            id="123", position=(1.0, 2.0, 3.0), displayName="Point 123"
+        ),
+        CalibrationPosition(
+            id="456", position=(4.0, 5.0, 6.0), displayName="Point 456"
+        ),
+    ]
+
+
+def test_get_slot_center(
+    decoy: Decoy, mock_protocol_core: ProtocolCore, subject: Deck
+) -> None:
+    """It should get the geometric center of a slot."""
+    decoy.when(mock_validation.ensure_deck_slot(222)).then_return(DeckSlotName.SLOT_2)
+    decoy.when(mock_protocol_core.get_slot_center(DeckSlotName.SLOT_2)).then_return(
+        Point(1, 2, 3)
+    )
+
+    assert subject.get_slot_center(222) == Point(1, 2, 3)

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -17,11 +17,12 @@ from opentrons.protocol_api import (
     ProtocolContext,
     InstrumentContext,
     ModuleContext,
+    TemperatureModuleContext,
     Labware,
     Deck,
     validation as mock_validation,
 )
-from opentrons.protocol_api.module_contexts import TemperatureModuleContext
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.common import (
     InstrumentCore,
@@ -52,11 +53,27 @@ def mock_core(decoy: Decoy) -> ProtocolCore:
 
 
 @pytest.fixture
-def subject(mock_core: ProtocolCore) -> ProtocolContext:
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
+
+
+@pytest.fixture
+def mock_deck(decoy: Decoy) -> Deck:
+    """Get a mock Deck."""
+    return decoy.mock(cls=Deck)
+
+
+@pytest.fixture
+def subject(
+    mock_core: ProtocolCore, mock_core_map: LoadedCoreMap, mock_deck: Deck
+) -> ProtocolContext:
     """Get a ProtocolContext test subject with its dependencies mocked out."""
     return ProtocolContext(
         api_version=MAX_SUPPORTED_VERSION,
         implementation=mock_core,
+        core_map=mock_core_map,
+        deck=mock_deck,
     )
 
 

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -917,9 +917,6 @@ def test_pipette_speed(ctx, monkeypatch):
 
 
 def test_loaded_labwares(ctx):
-    print(ctx.loaded_labwares)
-    print(ctx.loaded_labwares[12] is ctx.fixed_trash)
-
     assert ctx.loaded_labwares == {12: ctx.fixed_trash}
     lw1 = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
     lw2 = ctx.load_labware("opentrons_96_tiprack_300ul", 8)

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -917,6 +917,9 @@ def test_pipette_speed(ctx, monkeypatch):
 
 
 def test_loaded_labwares(ctx):
+    print(ctx.loaded_labwares)
+    print(ctx.loaded_labwares[12] is ctx.fixed_trash)
+
     assert ctx.loaded_labwares == {12: ctx.fixed_trash}
     lw1 = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
     lw2 = ctx.load_labware("opentrons_96_tiprack_300ul", 8)


### PR DESCRIPTION
## Overview

This PR fleshes out the implementation of the new `Deck` class in order to flesh out the API changes needed for its dependencies. It leaves those dependencies unimplemented in favor of a future PR to be merged alongside this one.

## Review requests

Code review only. If merged on its own, this PR will completely break engine-based PAPI, because we'll hit a `NotImplementedError` in the `ProtocolContext` constructor.

Another PR that builds on top of this one will be up shortly which will be suitable for smoke testing.

## Risk assessment

Low, changes guarded by FF
