### PR TITLE
refactor(docs): updating older sections of Hardware Modules page

### DIFF
--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -223,7 +223,7 @@ To check whether a custom labware definition specifies engage height for the Mag
 Engaging and Disengaging
 ========================
 
-Raising and lowering the module's magnets are done with the  :py:meth:`~.MagneticModuleContext.engage` and :py:meth:`.MagneticModuleContext.disengage` functions, respectively.
+Raising and lowering the module's magnets are done with the  :py:meth:`~.MagneticModuleContext.engage` and :py:meth:`~.MagneticModuleContext.disengage` functions, respectively.
 
 If your loaded labware is fully compatible with the Magnetic Module, you can call ``engage()`` with no argument:
 
@@ -235,21 +235,19 @@ If your loaded labware is fully compatible with the Magnetic Module, you can cal
 
 This will move the magnets upward to the default height for the labware, which should be close to the bottom of the labware's wells. If your loaded labware doesn't specify a default height, this will raise an ``ExceptionInProtocolError``.
 
-For certain applications, you may want to move the magnets to a different height. [TK note about GEN1 half-millimeters vs. GEN2 true millimeters]. You can specify one (and only one) of three parameters to alter the height:
+For certain applications, you may want to move the magnets to a different height. The recommended way is to use the ``height_from_base`` parameter, which represents the distance above the base of the labware (its lowest point, where it rests on the module). Setting ``height_from_base=0`` should move the tops of the magnets level with the base of the labware. Alternatively, you can use the ``offset`` parameter, which represent the distance above *or below* the labware's default position (close to the bottom of its wells). Like using ``engage()`` with no argument, this will raise an error if there is no default height for the loaded labware.
 
-- ``height_from_base`` is the distance above the base of the labware (its lowest point, where it rests on the module). This is the recommended way to adjust the magnets' height. Setting a value of ``0`` should move the tops of the magnets level with the base of the labware. However, there is up to 1 mm of manufacturing variance across Magnetic Module units, so observe the exact position and adjust as necessary before running your protocol.
-- ``height`` is the distance above the magnets' home position, which is 2.5 mm below the labware base position.
-- ``offset`` is the distance from the labware's default position (close to the bottom of its wells). Like using ``engage()`` with no argument, this will raise an error if there is no default height for the loaded labware.
+.. note::
+    There is up to 1 mm of manufacturing variance across Magnetic Module units, so observe the exact position and adjust as necessary before running your protocol.
 
-Here are some examples of where the magnets will move when using the different parameters, in combination with the loaded NEST PCR plate, which specifies a default height of 20 mm:
+Here are some examples of where the magnets will move when using the different parameters in combination with the loaded NEST PCR plate, which specifies a default height of 20 mm:
 
   .. code-block:: python
 
       mag_mod.engage(height_from_base=13.5)  # 13.5 mm
-      mag_mod.engage(height=18.5)            # 16.0 mm
-      mag_mod.engage(offset=-2)              # 18.0 mm
+      mag_mod.engage(offset=-2)              # 15.5 mm
 
-Note that both ``height`` and ``offset`` take into account the fact that the magnets' home position is measured as −2.5 mm.
+Note that ``offset`` takes into account the fact that the magnets' home position is measured as −2.5 mm for GEN2 modules.
 
   .. versionadded:: 2.0
   .. versionchanged:: 2.2
@@ -272,14 +270,9 @@ If at any point you need to check whether the magnets are engaged or not, use th
 Changes with the GEN2 Magnetic Module
 =====================================
 
-The GEN2 Magnetic Module uses smaller magnets than the GEN1 version.
-This mitigates an issue where beads would be attracted even when the magnets were retracted.
+The GEN2 Magnetic Module uses smaller magnets than the GEN1 version to mitigate an issue with the magnets attracting beads even from their retracted position.
 
-This means it will take longer for the GEN2 module to attract beads. If you need additional strength for your application, use the available `Adapter Magnets <https://support.opentrons.com/s/article/Adapter-magnets>`_.
-
-Recommended Magnetic Module GEN2 bead attraction time:
-    - Total liquid volume <= 50 uL: 5 minutes
-    - Total liquid volume > 50 uL: 7 minutes
+This means it takes longer for the GEN2 module to attract beads. The recommended attraction time is 5 minutes for liquid volumes up to 50 µL and 7 minutes for volumes greater than 50 µL. If your application needs additional magnetic strength to attract beads within  these timeframes, use the available `Adapter Magnets <https://support.opentrons.com/s/article/Adapter-magnets>`_.
 
 
 .. _thermocycler-module:

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -84,7 +84,7 @@ Like specifying labware that will be placed directly on the deck of the OT-2, yo
     def run(protocol: protocol_api.ProtocolContext):
         temp_mod = protocol.load_module("temperature module gen2", 1)
         temp_labware = temp_mod.load_labware(
-            load_name="opentrons_24_aluminumblock_generic_2ml_screwcap",
+            "opentrons_24_aluminumblock_generic_2ml_screwcap",
             label="Temperature-Controlled Tubes",
         )
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -136,6 +136,8 @@ The examples in this section will use a Temperature Module loaded in slot 3:
         temp_mod = protocol.load_module('temperature module gen2', '3')
         plate = temp_mod.load_labware('corning_96_wellplate_360ul_flat')
 
+In order to prevent physical obstruction of other slots, it's best to load the Temperature Module in a slot on the horizontal edges of the deck (1, 4, 7, or 10 on the left or 3, 6, or 9 on the right), with the USB cable and power cord pointing away from the deck.
+
 .. versionadded:: 2.0
 
 Temperature Control

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -185,30 +185,43 @@ All methods of :py:class:`.TemperatureModuleContext` work with both the GEN1 and
 Using a Magnetic Module
 ***********************
 
-The Magnetic Module controls a set of permanent magnets which can move vertically. When the magnets are raised or engaged, they induce a magnetic field in the labware on the module. When they are lowered or disengaged, they do not.
+The Magnetic Module controls a set of permanent magnets which can move vertically to induce a magnetic field in the labware loaded on the module.
 
-The Magnetic Module is represented by a :py:class:`.MagneticModuleContext` object.
+The Magnetic Module is represented by a :py:class:`.MagneticModuleContext` object, which has methods for engaging (raising) and disengaging (lowering) its magnets.
 
-For the purposes of this section, assume we have the following already:
+The examples in this section will use a Magnetic Module loaded in slot 6:
 
 .. code-block:: python
     :substitutions:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.3'}
 
     def run(protocol: protocol_api.ProtocolContext):
-        mag_mod = protocol.load_module('magnetic module', '1')
+        mag_mod = protocol.load_module('magnetic module gen2', '1')
         plate = mag_mod.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
-        # The code from the rest of the examples in this section goes here
 
 .. versionadded:: 2.0
 
+Loading Labware
+===============
+
+Like with all modules, use the Magnetic Module’s :py:meth:`~.MagneticModuleContext.load_labware` method to specify what you will place on the module. The Magnetic Module supports 96-well PCR plates and deep well plates. For the best compatibility, use a labware definition that specifies how far the magnets should move when engaging with the labware. The following plates in the Opentrons Labware Library include this measurement:
+
+- ``biorad_96_wellplate_200ul_pcr``
+- ``nest_96_wellplate_100ul_pcr_full_skirt``
+- ``nest_96_wellplate_2ml_deep``
+- ``thermoscientificnunc_96_wellplate_1300ul``
+- ``thermoscientificnunc_96_wellplate_2000ul``
+- ``usascientific_96_wellplate_2.4ml_deep``
+
+To check whether a custom labware definition specifies engage height for the Magnetic Module, open its JSON file and look for the key ``magneticModuleEngageHeight`` in the ``parameters`` object. If it's present and has a numerical value, the labware is ready for use with the Magnetic Module.
+
 .. _magnetic-module-engage:
 
-Engage
-======
+Engaging and Disengaging
+========================
 
 The :py:meth:`.MagneticModuleContext.engage` function raises the magnets to induce a magnetic field in the labware on top of the Magnetic Module. The height of the magnets can be specified in several different ways, based on internally stored default heights for labware:
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -31,16 +31,14 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.  It will return an
          # Load a Temperature Module GEN1 in deck slot 3.
          temperature_module = protocol.load_module('temperature module', 3)
 
-.. note::
-
-    When you load a module in a protocol, you inform the OT-2 that you want the specified module to be present. Even if you do not use the module anywhere else in your protocol, the Opentrons App and the OT-2 will not let your protocol proceed until all modules loaded with ``load_module`` are attached to the OT-2.
+When you load a module in a protocol, you inform the OT-2 that you want the specified module to be present. Even if you don't use the module anywhere else in your protocol, the Opentrons App and the OT-2 won't let your protocol proceed until all modules loaded with ``load_module`` are attached to the OT-2.
 
 .. versionadded:: 2.0
 
 Available Modules
 -----------------
 
-The first parameter to :py:meth:`.ProtocolContext.load_module`, the module's *load name*, specifies the kind of module to load. The table below lists the load names for each kind of module.
+The first parameter of :py:meth:`.ProtocolContext.load_module`, the module's *load name*, specifies the kind of module to load. The table below lists the load names for each kind of module.
 
 Some modules were added to the Protocol API later than others, and some modules have multiple hardware generations (GEN2 modules have a "GEN2" label on the device). Make sure your protocol's metadata specifies a :ref:`Protocol API version <v2-versioning>` high enough to support all the modules you want to use.
 
@@ -199,7 +197,7 @@ The examples in this section will use a Magnetic Module loaded in slot 6:
     metadata = {'apiLevel': '2.3'}
 
     def run(protocol: protocol_api.ProtocolContext):
-        mag_mod = protocol.load_module('magnetic module gen2', '1')
+        mag_mod = protocol.load_module('magnetic module gen2', '6')
         plate = mag_mod.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
 
 .. versionadded:: 2.0
@@ -216,7 +214,7 @@ Like with all modules, use the Magnetic Module’s :py:meth:`~.MagneticModuleCon
 - ``thermoscientificnunc_96_wellplate_2000ul``
 - ``usascientific_96_wellplate_2.4ml_deep``
 
-To check whether a custom labware definition specifies engage height for the Magnetic Module, open its JSON file and look for the key ``magneticModuleEngageHeight`` in the ``parameters`` object. If it's present and has a numerical value, the labware is ready for use with the Magnetic Module.
+To check whether a custom labware definition specifies this measurement, open its JSON file and look for the key ``magneticModuleEngageHeight`` in the ``parameters`` object. If it's present and has a numerical value, the labware is ready for use with the Magnetic Module.
 
 .. _magnetic-module-engage:
 
@@ -235,7 +233,7 @@ If your loaded labware is fully compatible with the Magnetic Module, you can cal
 
 This will move the magnets upward to the default height for the labware, which should be close to the bottom of the labware's wells. If your loaded labware doesn't specify a default height, this will raise an ``ExceptionInProtocolError``.
 
-For certain applications, you may want to move the magnets to a different height. The recommended way is to use the ``height_from_base`` parameter, which represents the distance above the base of the labware (its lowest point, where it rests on the module). Setting ``height_from_base=0`` should move the tops of the magnets level with the base of the labware. Alternatively, you can use the ``offset`` parameter, which represent the distance above *or below* the labware's default position (close to the bottom of its wells). Like using ``engage()`` with no argument, this will raise an error if there is no default height for the loaded labware.
+For certain applications, you may want to move the magnets to a different height. The recommended way is to use the ``height_from_base`` parameter, which represents the distance above the base of the labware (its lowest point, where it rests on the module). Setting ``height_from_base=0`` should move the tops of the magnets level with the base of the labware. Alternatively, you can use the ``offset`` parameter, which represents the distance above *or below* the labware's default position (close to the bottom of its wells). Like using ``engage()`` with no argument, this will raise an error if there is no default height for the loaded labware.
 
 .. note::
     There is up to 1 mm of manufacturing variance across Magnetic Module units, so observe the exact position and adjust as necessary before running your protocol.
@@ -253,7 +251,7 @@ Note that ``offset`` takes into account the fact that the magnets' home position
   .. versionchanged:: 2.2
      Added the ``height_from_base`` parameter.
 
-When you need to retract the magnets back to their home position, call :py:meth:`.MagneticModuleContext.disengage`. 
+When you need to retract the magnets back to their home position, call :py:meth:`~.MagneticModuleContext.disengage`. 
 
   .. code-block:: python
 
@@ -261,7 +259,7 @@ When you need to retract the magnets back to their home position, call :py:meth:
 
 .. versionadded:: 2.0
 
-If at any point you need to check whether the magnets are engaged or not, use the :py:obj:`.MagneticModuleContext.status` property. This will return either the string ``engaged`` or ``disengaged``, not the exact height of the magnets.
+If at any point you need to check whether the magnets are engaged or not, use the :py:obj:`~.MagneticModuleContext.status` property. This will return either the string ``engaged`` or ``disengaged``, not the exact height of the magnets.
 
 .. note:: 
 
@@ -270,9 +268,7 @@ If at any point you need to check whether the magnets are engaged or not, use th
 Changes with the GEN2 Magnetic Module
 =====================================
 
-The GEN2 Magnetic Module uses smaller magnets than the GEN1 version to mitigate an issue with the magnets attracting beads even from their retracted position.
-
-This means it takes longer for the GEN2 module to attract beads. The recommended attraction time is 5 minutes for liquid volumes up to 50 µL and 7 minutes for volumes greater than 50 µL. If your application needs additional magnetic strength to attract beads within  these timeframes, use the available `Adapter Magnets <https://support.opentrons.com/s/article/Adapter-magnets>`_.
+The GEN2 Magnetic Module uses smaller magnets than the GEN1 version to mitigate an issue with the magnets attracting beads even from their retracted position. This means it takes longer for the GEN2 module to attract beads. The recommended attraction time is 5 minutes for liquid volumes up to 50 µL and 7 minutes for volumes greater than 50 µL. If your application needs additional magnetic strength to attract beads within  these timeframes, use the available `Adapter Magnets <https://support.opentrons.com/s/article/Adapter-magnets>`_.
 
 
 .. _thermocycler-module:
@@ -282,7 +278,7 @@ Using a Thermocycler Module
 ***************************
 
 
-The Thermocycler Module provides on-deck, fully automated thermocycling and can heat and cool very quickly during operation. The module's block can heat and cool between 4 °C and 99 °C, and the module's lid can heat up to 110 °C.
+The Thermocycler Module provides on-deck, fully automated thermocycling and can heat and cool very quickly during operation. The module's block can heat and cool between 4 and 99 °C, and the module's lid can heat up to 110 °C.
 
 The Thermocycler is represented in code by a :py:class:`.ThermocyclerContext` object, which has methods for controlling the lid, controlling the block, and setting *profiles* — timed heating and cooling routines that can be automatically repeated. 
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -72,49 +72,44 @@ Some modules were added to the Protocol API later than others, and some modules 
    | Module             |                               |                           |
    +--------------------+-------------------------------+---------------------------+
 
-Loading Labware onto Your Module
-================================
+Loading Labware onto a Module
+=============================
 
-Like specifying labware that will be present on the deck of the OT-2, you must specify labware that will be present on the module you have just loaded.
-You do this using ``module.load_labware()``. For instance, to load a Temperature Module and specify an `aluminum block for 2 mL tubes <https://labware.opentrons.com/opentrons_24_aluminumblock_generic_2ml_screwcap?category=aluminumBlock>`_, you would do:
+Like specifying labware that will be placed directly on the deck of the OT-2, you must specify labware that will be present on the module you have just loaded, using ``load_labware()``. For instance, to load an `aluminum block for 2 mL tubes <https://labware.opentrons.com/opentrons_24_aluminumblock_generic_2ml_screwcap?category=aluminumBlock>`_ on top of a Temperature Module:
 
 .. code-block:: python
-    :substitutions:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.3'}
 
     def run(protocol: protocol_api.ProtocolContext):
-         module = protocol.load_module('Temperature Module', slot)
-         my_labware = module.load_labware('opentrons_24_aluminumblock_generic_2ml_screwcap',
-                                          label='Temperature-Controlled Tubes')
-
-See :py:meth:`.MagneticModuleContext.load_labware`, :py:meth:`.TemperatureModuleContext.load_labware`, :py:meth:`.ThermocyclerContext.load_labware`, or :py:meth:`.HeaterShakerContext.load_labware` for more details.
-
-Notice that when you load labware on a module, you don't specify the labware's deck slot.  The labware is loaded on the module, on whichever deck slot the module occupies.
-
+         temp_mod = protocol.load_module('temperature module gen2', 1)
+         temp_labware = temp_mod.load_labware(
+            load_name='opentrons_24_aluminumblock_generic_2ml_screwcap',
+            label='Temperature-Controlled Tubes')
 
 .. versionadded:: 2.0
+
+Notice that when you load labware on a module, you don't need to specify the labware's deck slot.  The labware is loaded on the module, on whichever deck slot the module occupies.
+
+Any :ref:`v2-custom-labware` added to your Opentrons App is also accessible when loading labware onto a module. You can find and copy its load name by going to its card on the Labware page.
+
+.. versionadded:: 2.1
+
 
 Module and Labware Compatibility
 --------------------------------
 
-It's up to you to make sure that the labware and module you chose make sense together.
-The Protocol API won't stop you from making nonsensical combinations, like a tube rack on a Thermocycler.
+It's up to you to make sure that the labware and modules you load make sense together. The Protocol API won't raise a warning or error if you load a nonsensical combination, like a tube rack on a Thermocycler.
 
-See: `What labware can I use with my modules? <https://support.opentrons.com/en/articles/3540964-what-labware-can-i-use-with-my-modules>`__
+For further information on what combinations are possible, see the support article `What labware can I use with my modules? <https://support.opentrons.com/en/articles/3540964-what-labware-can-i-use-with-my-modules>`_
 
-Loading Custom Labware Into Your Module
----------------------------------------
 
-Any custom labware added to your Opentrons App (see :ref:`v2-custom-labware`) is accessible when loading labware onto a module.
+Additional Labware Parameters
+-----------------------------
 
-.. versionadded:: 2.1
-
-.. note::
-
-    In API version 2.0, ``module.load_labware()`` only took a ``load_name`` argument. In API version 2.1 (introduced in Robot Software version 3.15.2) or higher you can now specify a label, version, and namespace (though most of the time you won't have to).
+In addition to the mandatory ``load_name`` argument, you can also specify additional parameters. If you specify a ``label``, this name will appear in the Opentrons App and the run log instead of the load name. For labware that has multiple definitions, you can specify ``version`` and ``namespace`` (though most of the time you won't have to). See :py:meth:`.MagneticModuleContext.load_labware`, :py:meth:`.TemperatureModuleContext.load_labware`, :py:meth:`.ThermocyclerContext.load_labware`, or :py:meth:`.HeaterShakerContext.load_labware` for more details.
 
 
 .. _temperature-module:

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -31,7 +31,7 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.  It will return an
          # Load a Temperature Module GEN1 in deck slot 3.
          temperature_module = protocol.load_module('temperature module', 3)
 
-When you load a module in a protocol, you inform the OT-2 that you want the specified module to be present. Even if you don't use the module anywhere else in your protocol, the Opentrons App and the OT-2 won't let your protocol proceed until all modules loaded with ``load_module`` are attached to the OT-2.
+When you load a module in a protocol, you inform the OT-2 that you want the specified module to be present. Even if you don't use the module anywhere else in your protocol, the Opentrons App and the OT-2 won't let you start the protocol run until all loaded modules are connected to the OT-2 and powered on.
 
 .. versionadded:: 2.0
 
@@ -102,7 +102,7 @@ Module and Labware Compatibility
 
 It's up to you to make sure that the labware and modules you load make sense together. The Protocol API won't raise a warning or error if you load a nonsensical combination, like a tube rack on a Thermocycler.
 
-For further information on what combinations are possible, see the support article `What labware can I use with my modules? <https://support.opentrons.com/en/articles/3540964-what-labware-can-i-use-with-my-modules>`_
+For further information on what combinations are possible, see the support article `What labware can I use with my modules? <https://support.opentrons.com/s/article/What-labware-can-I-use-with-my-modules>`_
 
 
 Additional Labware Parameters
@@ -214,7 +214,7 @@ Like with all modules, use the Magnetic Module’s :py:meth:`~.MagneticModuleCon
 - ``thermoscientificnunc_96_wellplate_2000ul``
 - ``usascientific_96_wellplate_2.4ml_deep``
 
-To check whether a custom labware definition specifies this measurement, open its JSON file and look for the key ``magneticModuleEngageHeight`` in the ``parameters`` object. If it's present and has a numerical value, the labware is ready for use with the Magnetic Module.
+To check whether a custom labware definition specifies this measurement, load the labware and query its :py:attr:`~.Labware.magdeck_engage_height` property. If has a numerical value, the labware is ready for use with the Magnetic Module.
 
 .. _magnetic-module-engage:
 

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -31,7 +31,7 @@ Modules
 -------
 .. autoclass:: opentrons.protocol_api.TemperatureModuleContext
    :members:
-   :exclude-members: start_set_temperature, broker, geometry
+   :exclude-members: start_set_temperature, await_temperature, broker, geometry
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.MagneticModuleContext

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -328,45 +328,31 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         offset: Optional[float] = None,
         height_from_base: Optional[float] = None,
     ) -> None:
-        """Raise the Magnetic Module's magnets.
+        """Raise the Magnetic Module's magnets.  You can specify how high the magnets 
+        should move:
 
-        You can specify how high the magnets should go in several different ways:
-
-           - If you specify ``height_from_base``, it's measured relative to the bottom
-             of the labware.
+           - No parameter: Move to the default height for the loaded labware. If 
+             the loaded labware has no default, or if no labware is loaded, this will
+             raise an error.
+             
+           - ``height_from_base``: Move this many millimeters above the bottom
+             of the labware. Acceptable values are between ``0`` and ``25``.
 
              This is the recommended way to adjust the magnets' height.
+             
+           - ``offset``: Move this many millimeters above (positive value) or below
+             (negative value) the default height for the loaded labware. The sum of
+             the default height and ``offset`` must be between 0 and 25.
 
-           - If you specify ``height``, it's measured relative to the magnets'
-             home position.
+           - ``height``: Intended to move this many millimeters above the magnets'
+             home position. However, depending on the generation of module and the loaded
+             labware, this may produce unpredictable results. You should normally use 
+             ``height_from_base`` instead.
+             
+             This parameter may be deprecated in a future release of the Python API.
 
-             You should normally use ``height_from_base`` instead.
-
-           - If you specify nothing,
-             the magnets will rise to a reasonable default height
-             based on what labware you've loaded on this Magnetic Module.
-
-             Only certain labware have a defined engage height.
-             If you've loaded a labware that doesn't,
-             or if you haven't loaded any labware, then you'll need to specify
-             a height yourself with ``height`` or ``height_from_base``.
-             Otherwise, an exception will be raised.
-
-           - If you specify ``offset``,
-             it's measured relative to the default height, as described above.
-             A positive number moves the magnets higher and
-             a negative number moves the magnets lower.
-
-        The units of ``height_from_base``, ``height``, and ``offset``
-        depend on which generation of Magnetic Module you're using:
-
-           - For GEN1 Magnetic Modules, they're in *half-millimeters*,
-             for historical reasons. This will not be the case in future
-             releases of the Python Protocol API.
-           - For GEN2 Magnetic Modules, they're in true millimeters.
-
-        You may not specify more than one of
-        ``height_from_base``, ``height``, and ``offset``.
+        You should not specify more than one of these parameters. However, if you do,
+        their order of precedence is ``height``, then ``height_from_base``, then ``offset``.
 
         .. versionadded:: 2.2
             The *height_from_base* parameter.

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -328,30 +328,30 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         offset: Optional[float] = None,
         height_from_base: Optional[float] = None,
     ) -> None:
-        """Raise the Magnetic Module's magnets.  You can specify how high the magnets 
+        """Raise the Magnetic Module's magnets.  You can specify how high the magnets
         should move:
 
-           - No parameter: Move to the default height for the loaded labware. If 
+           - No parameter: Move to the default height for the loaded labware. If
              the loaded labware has no default, or if no labware is loaded, this will
              raise an error.
-             
+
            - ``height_from_base``: Move this many millimeters above the bottom
              of the labware. Acceptable values are between ``0`` and ``25``.
 
              This is the recommended way to adjust the magnets' height.
-             
+
            - ``offset``: Move this many millimeters above (positive value) or below
              (negative value) the default height for the loaded labware. The sum of
              the default height and ``offset`` must be between 0 and 25.
 
            - ``height``: Intended to move this many millimeters above the magnets'
              home position. However, depending on the generation of module and the loaded
-             labware, this may produce unpredictable results. You should normally use 
+             labware, this may produce unpredictable results. You should normally use
              ``height_from_base`` instead.
-             
+
              This parameter may be deprecated in a future release of the Python API.
 
-        You should not specify more than one of these parameters. However, if you do,
+        You shouldn't specify more than one of these parameters. However, if you do,
         their order of precedence is ``height``, then ``height_from_base``, then ``offset``.
 
         .. versionadded:: 2.2
@@ -383,7 +383,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     @property  # type: ignore
     @requires_version(2, 0)
     def status(self) -> str:
-        """The status of the module: either ``engaged`` or ``disengaged``"""
+        """The status of the module, either ``engaged`` or ``disengaged``."""
         return self._core.get_status().value
 
 
@@ -545,7 +545,7 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             and is actively maintaining that temperature.
         - ``cooling``: The block is cooling to a target temperature.
         - ``heating``: The block is heating to a target temperature.
-        - ``idle``: The block has not heated or cooled since the beginning of the protocol.
+        - ``idle``: The block is not currently heating or cooling.
         - ``error``: The temperature status can't be determined.
         """
         return self._core.get_block_temperature_status().value
@@ -659,13 +659,13 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     @property  # type: ignore[misc]
     @requires_version(2, 13)
     def current_speed(self) -> int:
-        """The current speed in RPM of the Heater-Shaker's plate."""
+        """The current speed of the Heater-Shaker's plate in rpm."""
         return self._core.get_current_speed()
 
     @property  # type: ignore[misc]
     @requires_version(2, 13)
     def target_speed(self) -> Optional[int]:
-        """Target speed in RPM of the Heater-Shaker's plate."""
+        """Target speed of the Heater-Shaker's plate in rpm."""
         return self._core.get_target_speed()
 
     @property  # type: ignore[misc]
@@ -734,7 +734,8 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
 
         Sets the Heater-Shaker's target temperature and returns immediately without
         waiting for the target to be reached. Does not delay the protocol until
-        target temperature has reached. Use `wait_for_target_temperature` to delay
+        target temperature has reached.
+        Use :py:meth:`~.HeaterShakerContext.wait_for_temperature` to delay
         protocol execution.
 
         :param celsius: A value between 27 and 95, representing the target temperature in °C.
@@ -748,14 +749,16 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     @publish(command=cmds.heater_shaker_wait_for_temperature)
     def wait_for_temperature(self) -> None:
         """Delays protocol execution until the Heater-Shaker has reached its target
-        temperature. Returns an error if no target temperature was previously set.
+        temperature.
+
+        Raises an error if no target temperature was previously set.
         """
         self._core.wait_for_target_temperature()
 
     @requires_version(2, 13)
     @publish(command=cmds.heater_shaker_set_and_wait_for_shake_speed)
     def set_and_wait_for_shake_speed(self, rpm: int) -> None:
-        """Set a shake speed in RPM and block execution of further commands until the module reaches the target.
+        """Set a shake speed in rpm and block execution of further commands until the module reaches the target.
 
         Reaching a target shake speed typically only takes a few seconds.
 
@@ -802,7 +805,7 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     def deactivate_shaker(self) -> None:
         """Stops shaking.
 
-        Decelerating to 0 RPM typically only takes a few seconds.
+        Decelerating to 0 rpm typically only takes a few seconds.
         """
         self._core.deactivate_shaker()
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -285,11 +285,11 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     def status(self) -> str:
         """One of four possible temperature statuses:
 
-        - ``holding at target``: The module has reached its target temperature
-            and is actively maintaining that temperature.
-        - ``cooling``: The module is cooling to a target temperature.
-        - ``heating``: The module is heating to a target temperature.
-        - ``idle``: The module has been deactivated.
+        - ``holding at target`` – The module has reached its target temperature
+          and is actively maintaining that temperature.
+        - ``cooling`` – The module is cooling to a target temperature.
+        - ``heating`` – The module is heating to a target temperature.
+        - ``idle`` – The module has been deactivated.
         """
         return self._core.get_status().value
 
@@ -335,16 +335,16 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
              the loaded labware has no default, or if no labware is loaded, this will
              raise an error.
 
-           - ``height_from_base``: Move this many millimeters above the bottom
+           - ``height_from_base`` – Move this many millimeters above the bottom
              of the labware. Acceptable values are between ``0`` and ``25``.
 
              This is the recommended way to adjust the magnets' height.
 
-           - ``offset``: Move this many millimeters above (positive value) or below
+           - ``offset`` – Move this many millimeters above (positive value) or below
              (negative value) the default height for the loaded labware. The sum of
              the default height and ``offset`` must be between 0 and 25.
 
-           - ``height``: Intended to move this many millimeters above the magnets'
+           - ``height`` – Intended to move this many millimeters above the magnets'
              home position. However, depending on the generation of module and the loaded
              labware, this may produce unpredictable results. You should normally use
              ``height_from_base`` instead.
@@ -528,10 +528,10 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def lid_position(self) -> Optional[str]:
         """One of these possible lid statuses:
 
-        - ``closed``: The lid is closed.
-        - ``in_between``: The lid is neither open nor closed.
-        - ``open``: The lid is open.
-        - ``unknown``: The lid position can't be determined.
+        - ``closed`` – The lid is closed.
+        - ``in_between`` – The lid is neither open nor closed.
+        - ``open`` – The lid is open.
+        - ``unknown`` – The lid position can't be determined.
         """
         status = self._core.get_lid_position()
         return status.value if status is not None else None
@@ -541,12 +541,12 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def block_temperature_status(self) -> str:
         """One of five possible temperature statuses:
 
-        - ``holding at target``: The block has reached its target temperature
-            and is actively maintaining that temperature.
-        - ``cooling``: The block is cooling to a target temperature.
-        - ``heating``: The block is heating to a target temperature.
-        - ``idle``: The block is not currently heating or cooling.
-        - ``error``: The temperature status can't be determined.
+        - ``holding at target`` – The block has reached its target temperature
+          and is actively maintaining that temperature.
+        - ``cooling`` – The block is cooling to a target temperature.
+        - ``heating`` – The block is heating to a target temperature.
+        - ``idle`` – The block is not currently heating or cooling.
+        - ``error`` – The temperature status can't be determined.
         """
         return self._core.get_block_temperature_status().value
 
@@ -555,13 +555,13 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def lid_temperature_status(self) -> Optional[str]:
         """One of five possible temperature statuses:
 
-        - ``holding at target``: The lid has reached its target temperature
-            and is actively maintaining that temperature.
-        - ``cooling``: The lid has previously heated and is now passively cooling.
+        - ``holding at target`` – The lid has reached its target temperature
+          and is actively maintaining that temperature.
+        - ``cooling`` – The lid has previously heated and is now passively cooling.
             `The Thermocycler lid does not have active cooling.`
-        - ``heating``: The lid is heating to a target temperature.
-        - ``idle``: The lid has not heated since the beginning of the protocol.
-        - ``error``: The temperature status can't be determined.
+        - ``heating`` – The lid is heating to a target temperature.
+        - ``idle`` – The lid has not heated since the beginning of the protocol.
+        - ``error`` – The temperature status can't be determined.
         """
         status = self._core.get_lid_temperature_status()
         return status.value if status is not None else None
@@ -673,13 +673,13 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     def temperature_status(self) -> str:
         """One of five possible temperature statuses:
 
-        - ``holding at target``: The module has reached its target temperature
-            and is actively maintaining that temperature.
-        - ``cooling``: The module has previously heated and is now passively cooling.
-            `The Heater-Shaker does not have active cooling.`
-        - ``heating``: The module is heating to a target temperature.
-        - ``idle``: The module has not heated since the beginning of the protocol.
-        - ``error``: The temperature status can't be determined.
+        - ``holding at target`` – The module has reached its target temperature
+          and is actively maintaining that temperature.
+        - ``cooling`` – The module has previously heated and is now passively cooling.
+          `The Heater-Shaker does not have active cooling.`
+        - ``heating`` – The module is heating to a target temperature.
+        - ``idle`` – The module has not heated since the beginning of the protocol.
+        - ``error`` – The temperature status can't be determined.
         """
         return self._core.get_temperature_status().value
 
@@ -688,13 +688,13 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     def speed_status(self) -> str:
         """One of five possible shaking statuses:
 
-        - ``holding at target``: The module has reached its target shake speed
-            and is actively maintaining that speed.
-        - ``speeding up``: The module is increasing its shake speed towards a target.
-        - ``slowing down``: The module was previously shaking at a faster speed
-            and is currently reducing its speed to a lower target or to deactivate.
-        - ``idle``: The module is not shaking.
-        - ``error``: The shaking status can't be determined.
+        - ``holding at target`` – The module has reached its target shake speed
+          and is actively maintaining that speed.
+        - ``speeding up`` – The module is increasing its shake speed towards a target.
+        - ``slowing down`` – The module was previously shaking at a faster speed
+          and is currently reducing its speed to a lower target or to deactivate.
+        - ``idle`` – The module is not shaking.
+        - ``error`` – The shaking status can't be determined.
         """
         return self._core.get_speed_status().value
 
@@ -703,14 +703,14 @@ class HeaterShakerContext(ModuleContext[HeaterShakerGeometry]):
     def labware_latch_status(self) -> str:
         """One of six possible latch statuses:
 
-        - ``opening``: The latch is currently opening (in motion).
-        - ``idle_open``: The latch is open and not moving.
-        - ``closing``: The latch is currently closing (in motion).
-        - ``idle_closed``: The latch is closed and not moving.
-        - ``idle_unknown``: The default status upon reset, regardless of physical latch position.
-            Use :py:meth:`~HeaterShakerContext.close_labware_latch` before other commands
-            requiring confirmation that the latch is closed.
-        - ``unknown``: The latch status can't be determined.
+        - ``opening`` – The latch is currently opening (in motion).
+        - ``idle_open`` – The latch is open and not moving.
+        - ``closing`` – The latch is currently closing (in motion).
+        - ``idle_closed`` – The latch is closed and not moving.
+        - ``idle_unknown`` – The default status upon reset, regardless of physical latch position.
+          Use :py:meth:`~HeaterShakerContext.close_labware_latch` before other commands
+          requiring confirmation that the latch is closed.
+        - ``unknown`` – The latch status can't be determined.
         """
         return self._core.get_labware_latch_status().value
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -360,7 +360,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         The units of ``height_from_base``, ``height``, and ``offset``
         depend on which generation of Magnetic Module you're using:
 
-           - For GEN1 Magnetic Modules, they're in *half-millimeters,*
+           - For GEN1 Magnetic Modules, they're in *half-millimeters*,
              for historical reasons. This will not be the case in future
              releases of the Python Protocol API.
            - For GEN2 Magnetic Modules, they're in true millimeters.


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This PR aims to bring the older sections of the Hardware Modules page in line with more recent sections (i.e. Heater-Shaker and Thermocycler). It also touches up a few typos and style issues in those newer sections.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Hardware Modules article
   - significant edits to Temperature Module section
   - significant edits to Magnetic Module section, including removing any recommendation of using the `height` parameter of `engage()`
- API Reference
   - hid `TemperatureModuleContext.await_temperature`
   - moved example protocol and note from `TemperatureModuleContext` into article
   - removed mention of half-millimeters from `MagneticModuleContext.engage()` and cautioned against using the `height` parameter, which is the only place they could still be used
   - added some default values and acceptable value ranges
   - use en dashes instead of colons in lists so hard-wrapped source produces soft-wrapped output
   - general prose edits

# Review requests

<!--
Describe any requests for your reviewers here.
-->

- [ ] Please make sure all new prose guidance is accurate and pointing users to the simplest and best supported paths. 
- [x] Some code snippets have changed, and their validity and effects (when noted in comments) should be double checked.
- [ ] General prose mechanics and readability both in the [article](http://sandbox.docs.opentrons.com/docs-modules-updates/v2/new_modules.html) and the [reference](http://sandbox.docs.opentrons.com/docs-modules-updates/v2/new_protocol_api.html#modules). <-- sandbox links

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Docs only.