### PR TITLE
refactor(app, shared-data): calibration/moveToLocation to calibration/moveToMaintenancePosition

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -29,7 +29,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const pipetteId = attachedPipette[mount]?.id
   //  hard coding calibration slot number for now in case it changes
   //  in the future
-  const calSlotNum = '5'
+  const calSlotNum = '2'
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
     chainRunCommands(
@@ -46,7 +46,6 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: mount,
-            location: 'attachOrDetach',
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -26,7 +26,6 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     setShowErrorMessage,
   } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  const motorAxis = mount === 'left' ? 'leftZ' : 'rightZ'
   const pipetteId = attachedPipette[mount]?.id
   //  hard coding calibration slot number for now in case it changes
   //  in the future
@@ -43,16 +42,10 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
           },
         },
         {
-          commandType: 'home' as const,
-          params: {
-            axes: [motorAxis],
-          },
-        },
-        {
           // @ts-expect-error calibration type not yet supported
-          commandType: 'calibration/moveToLocation' as const,
+          commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
-            pipetteId: pipetteId,
+            mount: mount,
             location: 'attachOrDetach',
           },
         },

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -74,10 +74,6 @@ export const BeforeBeginning = (
     chainRunCommands(
       [
         {
-          commandType: 'home' as const,
-          params: {},
-        },
-        {
           commandType: 'loadPipette' as const,
           params: {
             // @ts-expect-error pipetteName is required but missing in schema v6 type
@@ -88,9 +84,9 @@ export const BeforeBeginning = (
         },
         {
           // @ts-expect-error calibration type not yet supported
-          commandType: 'calibration/moveToLocation' as const,
+          commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
-            pipetteId: pipetteId,
+            mount: mount,
             location: 'attachOrDetach',
           },
         },
@@ -109,10 +105,13 @@ export const BeforeBeginning = (
     chainRunCommands(
       [
         {
-          commandType: 'home' as const,
-          params: {},
+          // @ts-expect-error calibration type not yet supported
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: {
+            mount: mount,
+            location: 'attachOrDetach',
+          },
         },
-        //  TODO(jr 11/17/22): move to location needs to be added
       ],
       false
     )

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -87,7 +87,6 @@ export const BeforeBeginning = (
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: mount,
-            location: 'attachOrDetach',
           },
         },
       ],
@@ -109,7 +108,6 @@ export const BeforeBeginning = (
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: mount,
-            location: 'attachOrDetach',
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -57,12 +57,8 @@ describe('AttachProbe', () => {
           params: { mount: 'left' },
         },
         {
-          commandType: 'home',
-          params: { axes: ['leftZ'] },
-        },
-        {
-          commandType: 'calibration/moveToLocation',
-          params: { pipetteId: 'abc', location: 'attachOrDetach' },
+          commandType: 'calibration/moveToMaintenancePosition',
+          params: { mount: 'left', location: 'attachOrDetach' },
         },
       ],
       false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -58,7 +58,7 @@ describe('AttachProbe', () => {
         },
         {
           commandType: 'calibration/moveToMaintenancePosition',
-          params: { mount: 'left', location: 'attachOrDetach' },
+          params: { mount: 'left' },
         },
       ],
       false
@@ -80,7 +80,7 @@ describe('AttachProbe', () => {
     const { getByText, getByAltText } = render(props)
     getByText('Stand Back, Pipette is Calibrating')
     getByText(
-      'The calibration probe will touch the sides of the calibration divot in slot 5 to determine its exact position'
+      'The calibration probe will touch the sides of the calibration divot in slot 2 to determine its exact position'
     )
     getByAltText('Pipette is calibrating')
   })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -85,7 +85,7 @@ describe('BeforeBeginning', () => {
           },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT, location: 'attachOrDetach' },
+            params: { mount: LEFT },
           },
         ],
         false
@@ -151,7 +151,7 @@ describe('BeforeBeginning', () => {
         [
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT, location: 'attachOrDetach' },
+            params: { mount: LEFT },
           },
         ],
         false
@@ -191,7 +191,7 @@ describe('BeforeBeginning', () => {
           },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT, location: 'attachOrDetach' },
+            params: { mount: LEFT },
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -76,10 +76,6 @@ describe('BeforeBeginning', () => {
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
           {
-            commandType: 'home',
-            params: {},
-          },
-          {
             commandType: 'loadPipette',
             params: {
               mount: LEFT,
@@ -88,8 +84,8 @@ describe('BeforeBeginning', () => {
             },
           },
           {
-            commandType: 'calibration/moveToLocation',
-            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT, location: 'attachOrDetach' },
           },
         ],
         false
@@ -154,8 +150,8 @@ describe('BeforeBeginning', () => {
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
           {
-            commandType: 'home',
-            params: {},
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT, location: 'attachOrDetach' },
           },
         ],
         false
@@ -186,10 +182,6 @@ describe('BeforeBeginning', () => {
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
           {
-            commandType: 'home',
-            params: {},
-          },
-          {
             commandType: 'loadPipette',
             params: {
               mount: LEFT,
@@ -198,8 +190,8 @@ describe('BeforeBeginning', () => {
             },
           },
           {
-            commandType: 'calibration/moveToLocation',
-            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT, location: 'attachOrDetach' },
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -149,10 +149,6 @@ describe('PipetteWizardFlows', () => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
           {
-            commandType: 'home',
-            params: {},
-          },
-          {
             commandType: 'loadPipette',
             params: {
               mount: LEFT,
@@ -161,8 +157,8 @@ describe('PipetteWizardFlows', () => {
             },
           },
           {
-            commandType: 'calibration/moveToLocation',
-            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT, location: 'attachOrDetach' },
           },
         ],
         false
@@ -182,15 +178,11 @@ describe('PipetteWizardFlows', () => {
         [
           {
             commandType: 'calibration/calibratePipette',
-            params: { mount: 'left' },
+            params: { mount: LEFT },
           },
           {
-            commandType: 'home',
-            params: { axes: ['leftZ'] },
-          },
-          {
-            commandType: 'calibration/moveToLocation',
-            params: { pipetteId: 'abc', location: 'attachOrDetach' },
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT, location: 'attachOrDetach' },
           },
         ],
         false
@@ -301,8 +293,8 @@ describe('PipetteWizardFlows', () => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
           {
-            commandType: 'home',
-            params: {},
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT, location: 'attachOrDetach' },
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -158,7 +158,7 @@ describe('PipetteWizardFlows', () => {
           },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT, location: 'attachOrDetach' },
+            params: { mount: LEFT },
           },
         ],
         false
@@ -182,7 +182,7 @@ describe('PipetteWizardFlows', () => {
           },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT, location: 'attachOrDetach' },
+            params: { mount: LEFT },
           },
         ],
         false
@@ -294,7 +294,7 @@ describe('PipetteWizardFlows', () => {
         [
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT, location: 'attachOrDetach' },
+            params: { mount: LEFT },
           },
         ],
         false

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -561,14 +561,10 @@
                 "enum": ["calibration/moveToMaintenancePosition"]
               },
               "params": {
-                "required": ["mount", "location"],
+                "required": ["mount"],
                 "mount": {
                   "enum": ["left", "right"],
                   "description": "Instrument mount to calibrate."
-                },
-                "location": {
-                  "description": "Location to move to before starting calibration.",
-                  "enum": ["attachOrDetach", "probePosition"]
                 }
               }
             }

--- a/shared-data/protocol/schemas/7-draft.json
+++ b/shared-data/protocol/schemas/7-draft.json
@@ -557,10 +557,15 @@
             "required": ["commandType", "params"],
             "properties": {
               "key": { "type": "string" },
-              "commandType": { "enum": ["calibration/moveToLocation"] },
+              "commandType": {
+                "enum": ["calibration/moveToMaintenancePosition"]
+              },
               "params": {
-                "required": ["pipetteId", "location"],
-                "pipetteId": { "type": "string" },
+                "required": ["mount", "location"],
+                "mount": {
+                  "enum": ["left", "right"],
+                  "description": "Instrument mount to calibrate."
+                },
                 "location": {
                   "description": "Location to move to before starting calibration.",
                   "enum": ["attachOrDetach", "probePosition"]

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -31,12 +31,6 @@ export type CalibrationCreateCommand =
   | CalibratePipetteCreateCommand
   | MoveToMaintenancePositionCreateCommand
 
-export const ATTACH_OR_DETACH = 'attachOrDetach'
-export const PROBE_POSITION = 'probePosition'
-export type CalibrationPosition =
-  | typeof ATTACH_OR_DETACH
-  | typeof PROBE_POSITION
-
 interface CalibratePipetteParams {
   mount: PipetteMount
 }
@@ -47,5 +41,4 @@ interface CalibratePipetteResult {
 
 interface MoveToMaintenancePositionParams {
   mount: PipetteMount
-  location: CalibrationPosition
 }

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -6,9 +6,10 @@ export interface CalibratePipetteCreateCommand extends CommonCommandCreateInfo {
   params: CalibratePipetteParams
 }
 
-export interface MoveToLocationCreateCommand extends CommonCommandCreateInfo {
-  commandType: 'calibration/moveToLocation'
-  params: MoveToLocationParams
+export interface MoveToMaintenancePositionCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'calibration/moveToMaintenancePosition'
+  params: MoveToMaintenancePositionParams
 }
 
 export interface CalibratePipetteRunTimeCommand
@@ -17,18 +18,18 @@ export interface CalibratePipetteRunTimeCommand
   result: CalibratePipetteResult
 }
 
-export interface MoveToLocationRunTimeCommand
-  extends MoveToLocationCreateCommand {
-  result: MoveToLocationResult
+export interface MoveToMaintenancePositionRunTimeCommand
+  extends MoveToMaintenancePositionCreateCommand {
+  result: {}
 }
 
 export type CalibrationRunTimeCommand =
   | CalibratePipetteRunTimeCommand
-  | MoveToLocationRunTimeCommand
+  | MoveToMaintenancePositionRunTimeCommand
 
 export type CalibrationCreateCommand =
   | CalibratePipetteCreateCommand
-  | MoveToLocationCreateCommand
+  | MoveToMaintenancePositionCreateCommand
 
 export const ATTACH_OR_DETACH = 'attachOrDetach'
 export const PROBE_POSITION = 'probePosition'
@@ -44,15 +45,7 @@ interface CalibratePipetteResult {
   pipetteOffset: LabwareOffset
 }
 
-interface MoveToLocationParams {
-  pipetteId: string
+interface MoveToMaintenancePositionParams {
+  mount: PipetteMount
   location: CalibrationPosition
-}
-
-interface MoveToLocationResult {
-  deckPoint: {
-    x: number
-    y: number
-    z: number
-  }
 }


### PR DESCRIPTION
fix RLIQ-265

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Refactor calibration/moveToLocation to calibration/moveToMaintenancePosition to adhere with https://github.com/Opentrons/opentrons/pull/11788

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

1. Rename calibration/moveToLocation to calibration/moveToMaintenancePosition
2. Change param from `pipetteId` to `mount`
3. Remove position from result
4. Update usage in calibration and attach/detach pipette flows, including removing home commands before calibration commands as they are no longer needed

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Verify that these changes match the python changes and that the calibration flows look good

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low