### PR TITLE
refactor(api): Add a `robot_type` parameter to ProtocolEngine Config

### DIFF
--- a/api/src/opentrons/protocol_engine/state/config.py
+++ b/api/src/opentrons/protocol_engine/state/config.py
@@ -1,12 +1,16 @@
 """Top-level ProtocolEngine configuration options."""
 from dataclasses import dataclass
 
+from opentrons_shared_data.robot.dev_types import RobotType
+
 
 @dataclass(frozen=True)
 class Config:
     """ProtocolEngine configuration options.
 
     Params:
+        robot_type: What kind of robot the engine is controlling,
+            or pretending to control.
         ignore_pause: The engine should no-op instead of waiting
             for pauses and delays to complete.
         use_virtual_modules: The engine should no-op instead of calling
@@ -17,6 +21,7 @@ class Config:
             front door is opened.
     """
 
+    robot_type: RobotType
     ignore_pause: bool = False
     use_virtual_modules: bool = False
     use_virtual_gripper: bool = False

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -7,6 +7,8 @@ from opentrons.protocol_engine import (
     create_protocol_engine,
 )
 
+from opentrons_shared_data.robot.dev_types import RobotType
+
 from .legacy_wrappers import LegacySimulatingContextCreator
 from .protocol_runner import ProtocolRunner
 
@@ -41,8 +43,10 @@ async def create_simulating_runner() -> ProtocolRunner:
         simulating_hardware_api: HardwareControlAPI = (
             await OT3API.build_hardware_simulator()
         )
+        robot_type: RobotType = "OT-3 Standard"
     else:
         simulating_hardware_api = await HardwareAPI.build_hardware_simulator()
+        robot_type = "OT-2 Standard"
 
     # TODO(mc, 2021-08-25): move initial home to protocol engine
     await simulating_hardware_api.home()
@@ -50,6 +54,7 @@ async def create_simulating_runner() -> ProtocolRunner:
     protocol_engine = await create_protocol_engine(
         hardware_api=simulating_hardware_api,
         config=ProtocolEngineConfig(
+            robot_type=robot_type,
             ignore_pause=True,
             use_virtual_modules=True,
             use_virtual_gripper=True,

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -49,6 +49,13 @@ from opentrons.protocol_engine.execution.equipment import (
 )
 
 
+def _make_config(use_virtual_modules: bool) -> Config:
+    return Config(
+        use_virtual_modules=use_virtual_modules,
+        robot_type="OT-2 Standard",  # Arbitrary.
+    )
+
+
 @pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mocked out StateStore instance."""
@@ -693,7 +700,7 @@ async def test_load_module(
         ]
     )
 
-    decoy.when(state_store.config).then_return(Config(use_virtual_modules=False))
+    decoy.when(state_store.config).then_return(_make_config(use_virtual_modules=False))
 
     decoy.when(
         state_store.modules.select_hardware_module_to_load(
@@ -742,7 +749,7 @@ async def test_load_module_using_virtual(
         module_data_provider.get_definition(ModuleModel.TEMPERATURE_MODULE_V1)
     ).then_return(tempdeck_v1_def)
 
-    decoy.when(state_store.config).then_return(Config(use_virtual_modules=True))
+    decoy.when(state_store.config).then_return(_make_config(use_virtual_modules=True))
 
     result = await subject.load_module(
         model=ModuleModel.TEMPERATURE_MODULE_V1,
@@ -768,7 +775,7 @@ def test_get_module_hardware_api(
     module_2 = decoy.mock(cls=MagDeck)
     module_3 = decoy.mock(cls=HeaterShaker)
 
-    decoy.when(state_store.config).then_return(Config(use_virtual_modules=False))
+    decoy.when(state_store.config).then_return(_make_config(use_virtual_modules=False))
     decoy.when(state_store.modules.get_serial_number("module-id")).then_return(
         "serial-2"
     )
@@ -795,7 +802,7 @@ def test_get_module_hardware_api_virtual(
     module_2 = decoy.mock(cls=MagDeck)
     module_3 = decoy.mock(cls=HeaterShaker)
 
-    decoy.when(state_store.config).then_return(Config(use_virtual_modules=True))
+    decoy.when(state_store.config).then_return(_make_config(use_virtual_modules=True))
     decoy.when(state_store.modules.get_serial_number("module-id")).then_return(
         "serial-2"
     )
@@ -822,7 +829,7 @@ def test_get_module_hardware_api_missing(
     module_2 = decoy.mock(cls=MagDeck)
     module_3 = decoy.mock(cls=HeaterShaker)
 
-    decoy.when(state_store.config).then_return(Config(use_virtual_modules=False))
+    decoy.when(state_store.config).then_return(_make_config(use_virtual_modules=False))
     decoy.when(state_store.modules.get_serial_number("module-id")).then_return(
         "the-limit-does-not-exist"
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_run_control_handler.py
@@ -10,6 +10,13 @@ from opentrons.protocol_engine.execution.run_control import RunControlHandler
 from opentrons.protocol_engine.state import Config
 
 
+def _make_config(ignore_pause: bool) -> Config:
+    return Config(
+        ignore_pause=ignore_pause,
+        robot_type="OT-2 Standard",  # Arbitrary.
+    )
+
+
 @pytest.fixture
 def mock_state_store(decoy: Decoy) -> StateStore:
     """Get a mocked out StateStore."""
@@ -41,7 +48,7 @@ async def test_pause(
     subject: RunControlHandler,
 ) -> None:
     """It should be able to execute a pause."""
-    decoy.when(mock_state_store.config).then_return(Config(ignore_pause=False))
+    decoy.when(mock_state_store.config).then_return(_make_config(ignore_pause=False))
     await subject.wait_for_resume()
     decoy.verify(
         mock_action_dispatcher.dispatch(PauseAction(source=PauseSource.PROTOCOL)),
@@ -58,7 +65,7 @@ async def test_pause_analysis(
     subject: RunControlHandler,
 ) -> None:
     """It should no op during a protocol analysis."""
-    decoy.when(mock_state_store.config).then_return(Config(ignore_pause=True))
+    decoy.when(mock_state_store.config).then_return(_make_config(ignore_pause=True))
     await subject.wait_for_resume()
     decoy.verify(
         mock_action_dispatcher.dispatch(PauseAction(source=matchers.Anything())),
@@ -77,7 +84,7 @@ async def test_wait_for_duration(
     An implementation that is "more testabe" probably involves
     re-implementing `asyncio.sleep`, which just isn't worth it.
     """
-    decoy.when(mock_state_store.config).then_return(Config(ignore_pause=False))
+    decoy.when(mock_state_store.config).then_return(_make_config(ignore_pause=False))
     start = time_monotonic()
     await subject.wait_for_duration(seconds=0.2)
     end = time_monotonic()
@@ -98,7 +105,7 @@ async def test_wait_for_duration_ignore_pause(
     An implementation that is "more testabe" probably involves
     re-implementing `asyncio.sleep`, which just isn't worth it.
     """
-    decoy.when(mock_state_store.config).then_return(Config(ignore_pause=True))
+    decoy.when(mock_state_store.config).then_return(_make_config(ignore_pause=True))
     start = time_monotonic()
     # This wait time would be disruptively long for the test suite,
     # but it only matters when the subject has a bug and this test fails,

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -42,13 +42,21 @@ from .command_fixtures import (
 )
 
 
+def _make_config(block_on_door_open: bool = False) -> Config:
+    return Config(
+        block_on_door_open=block_on_door_open,
+        # Choice of robot_type is arbitrary.
+        robot_type="OT-2 Standard",
+    )
+
+
 @pytest.mark.parametrize(
     ("is_door_open", "config", "expected_is_door_blocking"),
     [
-        (False, Config(), False),
-        (True, Config(), False),
-        (False, Config(block_on_door_open=True), False),
-        (True, Config(block_on_door_open=True), True),
+        (False, _make_config(), False),
+        (True, _make_config(), False),
+        (False, _make_config(block_on_door_open=True), False),
+        (True, _make_config(block_on_door_open=True), True),
     ],
 )
 def test_initial_state(
@@ -213,7 +221,7 @@ def test_command_store_queues_commands(
         params=command_request.params,  # type: ignore[arg-type]
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     subject.handle_action(action)
 
     assert subject.state.commands_by_id == {
@@ -230,7 +238,7 @@ def test_command_queue_with_hash() -> None:
         params=commands.WaitForResumeParams(message="hello world"),
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     subject.handle_action(
         QueueCommandAction(
             request=create,
@@ -276,7 +284,7 @@ def test_command_queue_and_unqueue() -> None:
         command=create_running_command(command_id="command-id-2"),
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(queue_1)
     assert subject.state.queued_command_ids == OrderedSet(["command-id-1"])
@@ -320,7 +328,7 @@ def test_setup_command_queue_and_unqueue() -> None:
         command=create_running_command(command_id="command-id-2"),
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(queue_1)
     assert subject.state.queued_setup_command_ids == OrderedSet(["command-id-1"])
@@ -359,7 +367,7 @@ def test_setup_queue_action_updates_command_intent() -> None:
         intent=commands.CommandIntent.SETUP,
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(queue_cmd)
     assert subject.state.commands_by_id["command-id-1"] == CommandEntry(
@@ -382,7 +390,7 @@ def test_running_command_id() -> None:
         command=create_succeeded_command(command_id="command-id-1"),
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(queue)
     assert subject.state.running_command_id is None
@@ -403,7 +411,7 @@ def test_running_command_no_queue() -> None:
         command=create_succeeded_command(command_id="command-id-1"),
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(running_update)
     assert subject.state.all_command_ids == ["command-id-1"]
@@ -474,7 +482,7 @@ def test_command_failure_clears_queues() -> None:
         status=commands.CommandStatus.FAILED,
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(queue_1)
     subject.handle_action(queue_2)
@@ -576,7 +584,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
         intent=commands.CommandIntent.SETUP,
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(queue_action_1_non_setup)
     subject.handle_action(queue_action_2_setup)
@@ -606,7 +614,7 @@ def test_command_store_preserves_handle_order() -> None:
     command_b = create_running_command(command_id="command-id-2")
     command_c = create_succeeded_command(command_id="command-id-1")
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(UpdateCommandAction(command=command_a))
     assert subject.state.all_command_ids == ["command-id-1"]
@@ -632,7 +640,7 @@ def test_command_store_preserves_handle_order() -> None:
 @pytest.mark.parametrize("pause_source", PauseSource)
 def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
     """It should clear the running flag on pause."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     subject.handle_action(PauseAction(source=pause_source))
 
     assert subject.state == CommandState(
@@ -654,7 +662,7 @@ def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
 @pytest.mark.parametrize("pause_source", PauseSource)
 def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
     """It should set the running flag on play."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
 
     assert subject.state == CommandState(
@@ -675,7 +683,7 @@ def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
 
 def test_command_store_handles_finish_action() -> None:
     """It should change to a succeeded state with FinishAction."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(FinishAction())
@@ -698,7 +706,7 @@ def test_command_store_handles_finish_action() -> None:
 
 def test_command_store_handles_finish_action_with_stopped() -> None:
     """It should change to a stopped state if FinishAction has set_run_status=False."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(FinishAction(set_run_status=False))
@@ -708,7 +716,7 @@ def test_command_store_handles_finish_action_with_stopped() -> None:
 
 def test_command_store_handles_stop_action() -> None:
     """It should mark the engine as non-gracefully stopped on StopAction."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(StopAction())
@@ -731,7 +739,7 @@ def test_command_store_handles_stop_action() -> None:
 
 def test_command_store_cannot_restart_after_should_stop() -> None:
     """It should reject a play action after finish."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     subject.handle_action(FinishAction())
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
 
@@ -753,7 +761,7 @@ def test_command_store_cannot_restart_after_should_stop() -> None:
 
 def test_command_store_save_started_completed_run_timestamp() -> None:
     """It should save started and completed timestamps."""
-    subject = CommandStore(config=Config(), is_door_open=False)
+    subject = CommandStore(config=_make_config(), is_door_open=False)
     start_time = datetime(year=2021, month=1, day=1)
     hardware_stopped_time = datetime(year=2022, month=2, day=2)
 
@@ -766,7 +774,7 @@ def test_command_store_save_started_completed_run_timestamp() -> None:
 
 def test_timestamps_are_latched() -> None:
     """It should not change startedAt or completedAt once set."""
-    subject = CommandStore(config=Config(), is_door_open=False)
+    subject = CommandStore(config=_make_config(), is_door_open=False)
 
     play_time_1 = datetime(year=2021, month=1, day=1)
     play_time_2 = datetime(year=2022, month=2, day=2)
@@ -785,7 +793,7 @@ def test_timestamps_are_latched() -> None:
 
 def test_command_store_saves_unknown_finish_error() -> None:
     """It not store a ProtocolEngineError that comes in with the stop action."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     error_details = FinishErrorDetails(
         error=RuntimeError("oh no"),
@@ -819,7 +827,7 @@ def test_command_store_saves_unknown_finish_error() -> None:
 
 def test_command_store_ignores_stop_after_graceful_finish() -> None:
     """It should no-op on stop if already gracefully finished."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(FinishAction())
@@ -843,7 +851,7 @@ def test_command_store_ignores_stop_after_graceful_finish() -> None:
 
 def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
     """It should no-op on finish if already ungracefully stopped."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(StopAction())
@@ -882,7 +890,7 @@ def test_command_store_handles_command_failed() -> None:
         completed_at=datetime(year=2022, month=2, day=2),
     )
 
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     subject.handle_action(UpdateCommandAction(command=command))
     subject.handle_action(
         FailCommandAction(
@@ -913,7 +921,7 @@ def test_command_store_handles_command_failed() -> None:
 
 def test_handles_hardware_stopped() -> None:
     """It should mark the hardware as stopped on HardwareStoppedAction."""
-    subject = CommandStore(is_door_open=False, config=Config())
+    subject = CommandStore(is_door_open=False, config=_make_config())
     completed_at = datetime(year=2021, day=1, month=1)
     subject.handle_action(HardwareStoppedAction(completed_at=completed_at))
 
@@ -936,10 +944,10 @@ def test_handles_hardware_stopped() -> None:
 @pytest.mark.parametrize(
     ("is_door_open", "config", "expected_queue_status"),
     [
-        (False, Config(), QueueStatus.RUNNING),
-        (True, Config(), QueueStatus.RUNNING),
-        (False, Config(block_on_door_open=True), QueueStatus.RUNNING),
-        (True, Config(block_on_door_open=True), QueueStatus.PAUSED),
+        (False, _make_config(), QueueStatus.RUNNING),
+        (True, _make_config(), QueueStatus.RUNNING),
+        (False, _make_config(block_on_door_open=True), QueueStatus.RUNNING),
+        (True, _make_config(block_on_door_open=True), QueueStatus.PAUSED),
     ],
 )
 def test_command_store_handles_play_according_to_initial_door_state(
@@ -959,8 +967,8 @@ def test_command_store_handles_play_according_to_initial_door_state(
 @pytest.mark.parametrize(
     ("config", "expected_is_door_blocking"),
     [
-        (Config(block_on_door_open=True), True),
-        (Config(block_on_door_open=False), False),
+        (_make_config(block_on_door_open=True), True),
+        (_make_config(block_on_door_open=False), False),
     ],
 )
 def test_handles_door_open_and_close_event_before_play(
@@ -983,8 +991,8 @@ def test_handles_door_open_and_close_event_before_play(
 @pytest.mark.parametrize(
     ("config", "expected_queue_status", "expected_is_door_blocking"),
     [
-        (Config(block_on_door_open=True), QueueStatus.PAUSED, True),
-        (Config(block_on_door_open=False), QueueStatus.RUNNING, False),
+        (_make_config(block_on_door_open=True), QueueStatus.PAUSED, True),
+        (_make_config(block_on_door_open=False), QueueStatus.RUNNING, False),
     ],
 )
 def test_handles_door_open_and_close_event_after_play(
@@ -1007,7 +1015,9 @@ def test_handles_door_open_and_close_event_after_play(
 
 def test_command_store_handles_stop_action_with_queued_commands() -> None:
     """It should clear queued commands."""
-    subject = CommandStore(config=Config(block_on_door_open=False), is_door_open=False)
+    subject = CommandStore(
+        config=_make_config(block_on_door_open=False), is_door_open=False
+    )
 
     action = QueueCommandAction(
         request=commands.WaitForResumeCreate(

--- a/api/tests/opentrons/protocol_engine/state/test_state_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_state_store.py
@@ -20,7 +20,10 @@ def change_notifier(decoy: Decoy) -> ChangeNotifier:
 @pytest.fixture
 def engine_config() -> Config:
     """Get a ProtocolEngine config value object."""
-    return Config()
+    return Config(
+        # Choice of robot_type is arbitrary.
+        robot_type="OT-2 Standard"
+    )
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -59,7 +59,7 @@ async def test_create_engine_initializes_state_with_door_state(
         hardware_api=hardware_api,
         config=EngineConfig(
             block_on_door_open=True,
-            robot_type="OT-2 Standard",  # Choce of robot_type is arbitrary.
+            robot_type="OT-2 Standard",  # Choice of robot_type is arbitrary.
         ),
     )
     state = engine.state_view

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -22,11 +22,18 @@ async def test_create_engine_initializes_state_with_deck_geometry(
     """It should load deck geometry data into the store on create."""
     engine = await create_protocol_engine(
         hardware_api=hardware_api,
-        config=EngineConfig(),
+        config=EngineConfig(
+            # robot_type chosen to match hardware_api.
+            robot_type="OT-2 Standard"
+        ),
     )
     state = engine.state_view
 
     assert isinstance(engine, ProtocolEngine)
+
+    # TODO(mm, 2022-12-07): The expected deck definition and fixed trash
+    # labware should depend on EngineConfig, and we should parametrize this
+    # test to cover that.
     assert state.labware.get_deck_definition() == standard_deck_def
     assert state.labware.get_all() == [
         LoadedLabware(
@@ -50,7 +57,10 @@ async def test_create_engine_initializes_state_with_door_state(
     hardware_api.door_state = DoorState.OPEN
     engine = await create_protocol_engine(
         hardware_api=hardware_api,
-        config=EngineConfig(block_on_door_open=True),
+        config=EngineConfig(
+            block_on_door_open=True,
+            robot_type="OT-2 Standard",  # Choce of robot_type is arbitrary.
+        ),
     )
     state = engine.state_view
     assert state.commands.get_is_door_blocking() is True

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_python_context_creator.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_python_context_creator.py
@@ -4,6 +4,8 @@ import asyncio
 from functools import partial
 from typing import AsyncIterable
 
+from opentrons_shared_data.deck.dev_types import RobotModel
+
 from opentrons.protocol_runner.python_context_creator import PythonContextCreator
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.protocol_api_experimental import ProtocolContext, DeckSlotName
@@ -16,9 +18,14 @@ from opentrons.protocol_engine import (
 
 
 @pytest.fixture
-async def protocol_engine(hardware: HardwareAPI) -> AsyncIterable[ProtocolEngine]:
+async def protocol_engine(
+    hardware: HardwareAPI,
+    robot_model: RobotModel,
+) -> AsyncIterable[ProtocolEngine]:
     """Get a ProtocolEngine wired to a simulating HardwareAPI."""
-    engine = await create_protocol_engine(hardware_api=hardware, config=EngineConfig())
+    engine = await create_protocol_engine(
+        hardware_api=hardware, config=EngineConfig(robot_type=robot_model)
+    )
     engine.play()
     yield engine
     await engine.finish()

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -6,6 +6,8 @@ from fastapi import Depends, status
 from typing import Callable, Union
 from typing_extensions import Literal
 
+from opentrons_shared_data.robot.dev_types import RobotType
+
 from opentrons import initialize as initialize_api, should_use_ot3
 from opentrons.config import IS_ROBOT, ARCHITECTURE, SystemArchitecture
 from opentrons.util.helpers import utc_now
@@ -131,6 +133,11 @@ async def get_hardware(
         ApiError: The Hardware API is still initializing or failed to initialize.
     """
     return thread_manager.wrapped()
+
+
+async def get_robot_type() -> RobotType:
+    """Return what kind of robot this server is running on."""
+    return "OT-3 Standard" if should_use_ot3() else "OT-2 Standard"
 
 
 async def _initialize_hardware_api(app_state: AppState) -> None:

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -2,10 +2,12 @@
 from fastapi import Depends
 from sqlalchemy.engine import Engine as SQLEngine
 
+from opentrons_shared_data.robot.dev_types import RobotType
+
 from opentrons.hardware_control import HardwareControlAPI
 
 from robot_server.app_state import AppState, AppStateAccessor, get_app_state
-from robot_server.hardware import get_hardware
+from robot_server.hardware import get_hardware, get_robot_type
 from robot_server.persistence import get_sql_engine
 from robot_server.service.task_runner import get_task_runner, TaskRunner
 from robot_server.deletion_planner import RunDeletionPlanner
@@ -36,12 +38,13 @@ async def get_run_store(
 async def get_engine_store(
     app_state: AppState = Depends(get_app_state),
     hardware_api: HardwareControlAPI = Depends(get_hardware),
+    robot_type: RobotType = Depends(get_robot_type),
 ) -> EngineStore:
     """Get a singleton EngineStore to keep track of created engines / runners."""
     engine_store = _engine_store_accessor.get_from(app_state)
 
     if engine_store is None:
-        engine_store = EngineStore(hardware_api=hardware_api)
+        engine_store = EngineStore(hardware_api=hardware_api, robot_type=robot_type)
         _engine_store_accessor.set_on(app_state, engine_store)
 
     return engine_store

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -47,6 +47,7 @@ class EngineStore:
         Arguments:
             hardware_api: Hardware control API instance used for ProtocolEngine
                 construction.
+            robot_type: Passed along to `opentrons.protocol_engine.Config`.
         """
         self._hardware_api = hardware_api
         self._robot_type = robot_type


### PR DESCRIPTION
# Overview

Closes RCORE-448.

# Changelog

* Require `ProtocolEngine`s to be constructed with a new `robot_type` parameter, which is either `"OT-2 Standard"` or `"OT-3 Standard"`.
    * Following the ticket, this isn't used for anything yet. But we plan for it to take over for certain `isinstance(hw_api, OT3API)` checks inside `ProtocolEngine`.
* When constructing a `ProtocolEngine`, decide the `robotType` the same way we decide whether to use an OT-2 or OT-3 hardware controller—by looking at feature flags.
    * A future PR will need to change this to follow the protocol's declared `robotType` when the `ProtocolEngine` is being used for analysis, and not an actual run.

# Review requests

See GitHub code review comments.

# Risk assessment

Low for now, since this doesn't change any business logic; it only adds a piece of logical information that's currently unused.
