### PR TITLE
refactor(api): implement new Deck dependencies

### DIFF
--- a/api/src/opentrons/protocol_api/core/core_map.py
+++ b/api/src/opentrons/protocol_api/core/core_map.py
@@ -1,13 +1,14 @@
 """Map equipment cores to public PAPI objects."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Dict, Union
+from typing import overload
 
 from .common import ModuleCore, LabwareCore
 
 if TYPE_CHECKING:
     from ..labware import Labware
-    from ..module_contexts import ModuleContext
+    from ..protocol_context import ModuleTypes
 
 
 class LoadedCoreMap:
@@ -20,8 +21,41 @@ class LoadedCoreMap:
     This linkage creates a circular dependency, but keeps it contained to this instance.
     """
 
+    def __init__(self) -> None:
+        self._contexts_by_core: Dict[
+            Union[LabwareCore, ModuleCore],
+            Union[Labware, ModuleTypes],
+        ] = {}
+
+    @overload
+    def add(self, core: LabwareCore, context: Labware) -> None:
+        ...
+
+    @overload
+    def add(self, core: ModuleCore, context: ModuleTypes) -> None:
+        ...
+
+    def add(
+        self,
+        core: Union[LabwareCore, ModuleCore],
+        context: Union[Labware, ModuleTypes],
+    ) -> None:
+        self._contexts_by_core[core] = context
+
+    @overload
+    def get(self, core: LabwareCore) -> Labware:
+        ...
+
+    @overload
+    def get(self, core: ModuleCore) -> ModuleTypes:
+        ...
+
+    @overload
+    def get(self, core: None) -> None:
+        ...
+
     def get(
-        self, equipment_core: Union[LabwareCore, ModuleCore, None]
-    ) -> Union[Labware, ModuleContext[Any]]:
+        self, core: Union[LabwareCore, ModuleCore, None]
+    ) -> Union[Labware, ModuleTypes, None]:
         """Given a core, get the public PAPI object it represents."""
-        raise NotImplementedError("LoadedCoreMap.get not implemented")
+        return self._contexts_by_core[core] if core is not None else None

--- a/api/src/opentrons/protocol_api/core/core_map.py
+++ b/api/src/opentrons/protocol_api/core/core_map.py
@@ -40,6 +40,7 @@ class LoadedCoreMap:
         core: Union[LabwareCore, ModuleCore],
         context: Union[Labware, ModuleTypes],
     ) -> None:
+        """Add a core and its associated public PAPI object."""
         self._contexts_by_core[core] = context
 
     @overload

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -158,7 +158,7 @@ class LabwareCore(AbstractLabware[WellCore]):
         )
 
     def get_deck_slot(self) -> Optional[DeckSlotName]:
-        """Get the deck slot the labware is in, if in a deck slot."""
+        """Get the deck slot the labware is in, if on deck."""
         try:
             return self._engine_client.state.geometry.get_ancestor_slot_name(
                 self.labware_id

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -6,11 +6,12 @@ from opentrons_shared_data.labware.dev_types import (
     LabwareDefinition as LabwareDefinitionDict,
 )
 
+from opentrons.protocol_engine.errors import LabwareNotOnDeckError, ModuleNotOnDeckError
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 from opentrons.protocols.api_support.util import APIVersionError
-from opentrons.types import Point
+from opentrons.types import DeckSlotName, Point
 
 from ..labware import AbstractLabware, LabwareLoadParams
 from .well import WellCore
@@ -155,3 +156,12 @@ class LabwareCore(AbstractLabware[WellCore]):
             labware_id=self._labware_id,
             engine_client=self._engine_client,
         )
+
+    def get_deck_slot(self) -> Optional[DeckSlotName]:
+        """Get the deck slot the labware is in, if in a deck slot."""
+        try:
+            return self._engine_client.state.geometry.get_ancestor_slot_name(
+                self.labware_id
+            )
+        except (LabwareNotOnDeckError, ModuleNotOnDeckError):
+            return None

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -331,7 +331,11 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         self, slot_name: DeckSlotName
     ) -> Union[LabwareCore, ModuleCore, None]:
         """Get the contents of a given slot, if any."""
-        loaded_item = self._engine_client.state.geometry.get_slot_item(slot_name)
+        loaded_item = self._engine_client.state.geometry.get_slot_item(
+            slot_name=slot_name,
+            allowed_labware_ids=set(self._labware_cores_by_id.keys()),
+            allowed_module_ids=set(self._module_cores_by_id.keys()),
+        )
 
         if isinstance(loaded_item, LoadedLabware):
             return self._labware_cores_by_id[loaded_item.id]

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,5 +1,5 @@
 """ProtocolEngine-based Protocol API core implementation."""
-from typing import Dict, Optional, Type, Union
+from typing import Dict, List, Optional, Type, Union
 from typing_extensions import Literal
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
@@ -23,6 +23,8 @@ from opentrons.protocol_engine import (
     ModuleLocation,
     ModuleModel as EngineModuleModel,
     LabwareMovementStrategy,
+    LoadedLabware,
+    LoadedModule,
 )
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
@@ -61,17 +63,29 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         self._engine_client = engine_client
         self._api_version = api_version
         self._sync_hardware = sync_hardware
-        self._fixed_trash_core = LabwareCore(
-            labware_id=engine_client.state.labware.get_fixed_trash_id(),
-            engine_client=engine_client,
-        )
         self._last_location: Optional[Location] = None
         self._last_mount: Optional[Mount] = None
+        self._labware_cores_by_id: Dict[str, LabwareCore] = {}
+        self._module_cores_by_id: Dict[str, ModuleCore] = {}
+        self._load_fixed_trash()
 
     @property
     def api_version(self) -> APIVersion:
         """Get the api version protocol target."""
         return self._api_version
+
+    @property
+    def fixed_trash(self) -> LabwareCore:
+        """Get the fixed trash labware."""
+        trash_id = self._engine_client.state.labware.get_fixed_trash_id()
+        return self._labware_cores_by_id[trash_id]
+
+    def _load_fixed_trash(self) -> None:
+        trash_id = self._engine_client.state.labware.get_fixed_trash_id()
+        self._labware_cores_by_id[trash_id] = LabwareCore(
+            labware_id=trash_id,
+            engine_client=self._engine_client,
+        )
 
     def get_bundled_data(self) -> Dict[str, bytes]:
         """Get a map of file names to byte contents.
@@ -138,10 +152,14 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
             version=version or 1,
             display_name=label,
         )
-        return LabwareCore(
+        labware_core = LabwareCore(
             labware_id=load_result.labwareId,
             engine_client=self._engine_client,
         )
+
+        self._labware_cores_by_id[labware_core.labware_id] = labware_core
+
+        return labware_core
 
     def move_labware(
         self,
@@ -215,12 +233,16 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         elif module_type == ModuleType.HEATER_SHAKER:
             module_core_cls = HeaterShakerModuleCore
 
-        return module_core_cls(
+        module_core = module_core_cls(
             module_id=result.moduleId,
             engine_client=self._engine_client,
             api_version=self.api_version,
             sync_module_hardware=SynchronousAdapter(selected_hardware),
         )
+
+        self._module_cores_by_id[module_core.module_id] = module_core
+
+        return module_core
 
     # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
     # https://opentrons.atlassian.net/browse/RLIQ-255
@@ -248,10 +270,6 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
             default_movement_speed=400,
         )
 
-    def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCore]]:
-        """Get all loaded instruments by mount."""
-        raise NotImplementedError("ProtocolCore.get_loaded_instruments not implemented")
-
     def pause(self, msg: Optional[str]) -> None:
         """Pause the protocol."""
         self._engine_client.wait_for_resume(message=msg)
@@ -273,10 +291,6 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
     def home(self) -> None:
         """Move all axes to their home positions."""
         self._engine_client.home(axes=None)
-
-    def get_fixed_trash(self) -> LabwareCore:
-        """Get the fixed trash labware."""
-        return self._fixed_trash_core
 
     def set_rail_lights(self, on: bool) -> None:
         """Set the device's rail lights."""
@@ -311,18 +325,34 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def get_deck_definition(self) -> DeckDefinitionV3:
         """Get the geometry definition of the robot's deck."""
-        raise NotImplementedError("ProtocolCore.get_deck_definition not implemented")
+        return self._engine_client.state.labware.get_deck_definition()
 
     def get_slot_item(
         self, slot_name: DeckSlotName
     ) -> Union[LabwareCore, ModuleCore, None]:
         """Get the contents of a given slot, if any."""
-        raise NotImplementedError("ProtocolCore.get_slot_item not implemented")
+        loaded_item = self._engine_client.state.geometry.get_slot_item(slot_name)
+
+        if isinstance(loaded_item, LoadedLabware):
+            return self._labware_cores_by_id[loaded_item.id]
+
+        if isinstance(loaded_item, LoadedModule):
+            return self._module_cores_by_id[loaded_item.id]
+
+        return None
 
     def get_slot_center(self, slot_name: DeckSlotName) -> Point:
         """Get the absolute coordinate of a slot's center."""
-        raise NotImplementedError("ProtocolCore.get_slot_center not implemented.")
+        return self._engine_client.state.labware.get_slot_center_position(slot_name)
 
     def get_highest_z(self) -> float:
         """Get the highest Z point of all deck items."""
-        raise NotImplementedError("ProtocolCore.get_highest_z not implemented")
+        return self._engine_client.state.geometry.get_all_labware_highest_z()
+
+    def get_labware_cores(self) -> List[LabwareCore]:
+        """Get all loaded labware cores."""
+        return list(self._labware_cores_by_id.values())
+
+    def get_module_cores(self) -> List[ModuleCore]:
+        """Get all loaded module cores."""
+        return list(self._module_cores_by_id.values())

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -12,7 +12,7 @@ from opentrons_shared_data.labware.dev_types import (
 
 from opentrons.protocols.geometry.labware_geometry import AbstractLabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
-from opentrons.types import Point
+from opentrons.types import DeckSlotName, Point
 
 from .well import WellCoreType
 
@@ -148,6 +148,10 @@ class AbstractLabware(ABC, Generic[WellCoreType]):
     @abstractmethod
     def get_well_core(self, well_name: str) -> WellCoreType:
         """Get a well core interface to a given well in this labware."""
+
+    @abstractmethod
+    def get_deck_slot(self) -> Optional[DeckSlotName]:
+        """Get the deck slot the labware or its parent is in, if any."""
 
 
 LabwareCoreType = TypeVar("LabwareCoreType", bound=AbstractLabware[Any])

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod, ABC
-from typing import Dict, Generic, Optional, Union
+from typing import Dict, Generic, List, Optional, Union
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
@@ -22,6 +22,12 @@ from .module import ModuleCoreType
 class AbstractProtocol(
     ABC, Generic[InstrumentCoreType, LabwareCoreType, ModuleCoreType]
 ):
+    @property
+    @abstractmethod
+    def fixed_trash(self) -> LabwareCoreType:
+        """Get the fixed trash labware core."""
+        ...
+
     @abstractmethod
     def get_bundled_data(self) -> Dict[str, bytes]:
         """Get a mapping of name to contents"""
@@ -92,10 +98,6 @@ class AbstractProtocol(
         ...
 
     @abstractmethod
-    def get_loaded_instruments(self) -> Dict[Mount, Optional[InstrumentCoreType]]:
-        ...
-
-    @abstractmethod
     def pause(self, msg: Optional[str]) -> None:
         ...
 
@@ -113,10 +115,6 @@ class AbstractProtocol(
 
     @abstractmethod
     def home(self) -> None:
-        ...
-
-    @abstractmethod
-    def get_fixed_trash(self) -> LabwareCoreType:
         ...
 
     @abstractmethod
@@ -163,3 +161,11 @@ class AbstractProtocol(
     @abstractmethod
     def get_highest_z(self) -> float:
         """Get the highest Z point of all deck items."""
+
+    @abstractmethod
+    def get_labware_cores(self) -> List[LabwareCoreType]:
+        """Get all loaded labware cores."""
+
+    @abstractmethod
+    def get_module_cores(self) -> List[ModuleCoreType]:
+        """Get all loaded module cores."""

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -5,7 +5,7 @@ from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 
-from opentrons.types import Point, Location
+from opentrons.types import DeckSlotName, Location, Point
 from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
 from ..labware import AbstractLabware, LabwareLoadParams
@@ -199,3 +199,8 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
 
     def get_well_core(self, well_name: str) -> WellImplementation:
         return self._wells_by_name[well_name]
+
+    def get_deck_slot(self) -> Optional[DeckSlotName]:
+        """Get the deck slot the labware is in, if in a deck slot."""
+        slot = self._geometry.parent.labware.first_parent()
+        return DeckSlotName.from_primitive(slot) if slot is not None else None

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -372,17 +372,6 @@ class LegacyThermocyclerCore(
         """
         self._geometry.flag_unsafe_move(to_loc, from_loc, self.get_lid_position())
 
-    def _get_fixed_trash(self) -> Labware:
-        trash = self._protocol_core.get_fixed_trash()
-
-        if isinstance(trash, LabwareImplementation):
-            trash = Labware(
-                implementation=trash,
-                api_version=self._protocol_core.api_version,
-            )
-
-        return trash
-
     def _prepare_for_lid_move(self) -> None:
         loaded_instruments = [
             instr
@@ -401,8 +390,10 @@ class LegacyThermocyclerCore(
             hardware = protocol_core.get_hardware()
             hardware.retract(instr_core.get_mount())
             high_point = hardware.current_position(instr_core.get_mount())
-            trash_top = self._get_fixed_trash().wells()[0].top()
-            safe_point = trash_top.point._replace(
+            trash_top = protocol_core.fixed_trash.get_well_core("A1").get_top(
+                z_offset=0
+            )
+            safe_point = trash_top._replace(
                 z=high_point[Axis.by_mount(instr_core.get_mount())]
             )
             instr_core.move_to(

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, cast
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
@@ -85,6 +85,7 @@ class ProtocolContextImplementation(
         self._last_mount: Optional[Mount] = None
         self._loaded_modules: Set["AbstractModule"] = set()
         self._module_cores: List[legacy_module_core.LegacyModuleCore] = []
+        self._labware_cores: List[LabwareImplementation] = [self.fixed_trash]
 
     @property
     def api_version(self) -> APIVersion:
@@ -188,6 +189,7 @@ class ProtocolContextImplementation(
         )
         labware_core.set_calibration(labware_offset.delta)
 
+        self._labware_cores.append(labware_core)
         if isinstance(location, DeckSlotName):
             self._deck_layout[location.value] = labware_core
 
@@ -341,12 +343,17 @@ class ProtocolContextImplementation(
         """Get the deck layout."""
         return self._deck_layout
 
-    def get_fixed_trash(self) -> Union[Labware, LabwareImplementation]:  # type: ignore[override]
+    @property
+    def fixed_trash(self) -> LabwareImplementation:
         """The trash fixed to slot 12 of the robot deck."""
         trash = self._deck_layout["12"]
-        if not trash:
-            raise RuntimeError("Robot must have a trash container in 12")
-        return trash  # type: ignore[return-value]
+
+        if isinstance(trash, LabwareImplementation):
+            return trash
+        if isinstance(trash, Labware):
+            return cast(LabwareImplementation, trash._implementation)
+
+        raise RuntimeError("Robot must have a trash container in 12")
 
     def set_rail_lights(self, on: bool) -> None:
         """Set the rail light state."""
@@ -382,6 +389,10 @@ class ProtocolContextImplementation(
     def get_module_cores(self) -> List[legacy_module_core.LegacyModuleCore]:
         """Get loaded module cores."""
         return self._module_cores
+
+    def get_labware_cores(self) -> List[LabwareImplementation]:
+        """Get all loaded labware cores."""
+        return self._labware_cores
 
     def get_deck_definition(self) -> DeckDefinitionV3:
         """Get the geometry definition of the robot's deck."""

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -27,6 +27,7 @@ from .core.common import (
     ThermocyclerCore,
     HeaterShakerCore,
 )
+from .core.core_map import LoadedCoreMap
 
 from .module_validation_and_errors import (
     validate_heater_shaker_temperature,
@@ -54,12 +55,14 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         self,
         core: ModuleCore,
         protocol_core: ProtocolCore,
+        core_map: LoadedCoreMap,
         api_version: APIVersion,
         broker: Broker,
     ) -> None:
         super().__init__(broker=broker)
         self._core = core
         self._protocol_core = protocol_core
+        self._core_map = core_map
         self._api_version = api_version
         self._labware: Optional[Labware] = None
 
@@ -133,6 +136,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):
         )
 
         labware = self._core.add_labware_core(labware_core)
+        self._core_map.add(labware_core, labware)
 
         return labware
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1,21 +1,11 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Callable, Dict, List, NamedTuple, Optional, Type, Union
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
-from opentrons.types import Mount, Location, DeckLocation, DeckSlotName
+from opentrons.types import Mount, Location, DeckLocation
 from opentrons.broker import Broker
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.commands import protocol_commands as cmds, types as cmd_types
@@ -27,12 +17,10 @@ from opentrons.protocols.api_support.util import (
     requires_version,
     APIVersionError,
 )
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 from .core.common import ModuleCore, ProtocolCore
 from .core.core_map import LoadedCoreMap
-from .core.labware import AbstractLabware
 from .core.module import (
     AbstractTemperatureModuleCore,
     AbstractMagneticModuleCore,
@@ -118,15 +106,12 @@ class ProtocolContext(CommandPublisher):
         super().__init__(broker)
         self._api_version = api_version
         self._implementation = implementation
-        self._loaded_cores = core_map or LoadedCoreMap()
-        self._deck = deck or Deck(
-            protocol_core=implementation, core_map=self._loaded_cores
-        )
-
+        self._core_map = core_map or LoadedCoreMap()
+        self._deck = deck or Deck(protocol_core=implementation, core_map=self._core_map)
         self._instruments: Dict[Mount, Optional[InstrumentContext]] = {
             mount: None for mount in Mount
         }
-        self._modules: Dict[DeckSlotName, ModuleTypes] = {}
+        self._load_fixed_trash()
 
         self._commands: List[str] = []
         self._unsubscribe_commands: Optional[Callable[[], None]] = None
@@ -314,7 +299,10 @@ class ProtocolContext(CommandPublisher):
             version=version,
         )
 
-        return Labware(implementation=labware_core, api_version=self._api_version)
+        labware = Labware(implementation=labware_core, api_version=self._api_version)
+        self._core_map.add(labware_core, labware)
+
+        return labware
 
     @requires_version(2, 0)
     def load_labware_by_name(
@@ -352,22 +340,16 @@ class ProtocolContext(CommandPublisher):
         :returns: Dict mapping deck slot number to labware, sorted in order of
                   the locations.
         """
+        labware_cores = (
+            (core.get_deck_slot(), core)
+            for core in self._implementation.get_labware_cores()
+        )
 
-        def _only_labwares() -> Iterator[Tuple[int, Labware]]:
-            for slotnum, slotitem in self._deck.items():
-                slotnum = int(slotnum)
-
-                if isinstance(slotitem, AbstractLabware):
-                    yield slotnum, Labware(
-                        implementation=slotitem, api_version=self._api_version
-                    )
-                elif isinstance(slotitem, Labware):
-                    yield slotnum, slotitem
-                elif isinstance(slotitem, ModuleGeometry):
-                    if slotitem.labware:
-                        yield slotnum, slotitem.labware
-
-        return dict(_only_labwares())
+        return {
+            slot.as_int(): self._core_map.get(core)
+            for slot, core in labware_cores
+            if slot is not None
+        }
 
     # TODO: gate move_labware behind API version
     def move_labware(
@@ -473,11 +455,12 @@ class ProtocolContext(CommandPublisher):
         module_context = _create_module_context(
             module_core=module_core,
             protocol_core=self._implementation,
+            core_map=self._core_map,
             broker=self._broker,
             api_version=self._api_version,
         )
 
-        self._modules[module_core.get_deck_slot()] = module_context
+        self._core_map.add(module_core, module_context)
 
         return module_context
 
@@ -498,7 +481,8 @@ class ProtocolContext(CommandPublisher):
                                            ordered by slot number.
         """
         return {
-            int(deck_slot.value): module for deck_slot, module in self._modules.items()
+            core.get_deck_slot().as_int(): self._core_map.get(core)
+            for core in self._implementation.get_module_cores()
         }
 
     @requires_version(2, 0)
@@ -709,14 +693,14 @@ class ProtocolContext(CommandPublisher):
         It has one well and should be accessed like labware in your protocol.
         e.g. ``protocol.fixed_trash['A1']``
         """
-        trash = self._implementation.get_fixed_trash()
+        return self._core_map.get(self._implementation.fixed_trash)
 
-        # TODO AL 20201113 - remove this when DeckLayout only holds
-        #  LabwareInterface instances.
-        if not isinstance(trash, Labware):
-            return Labware(implementation=trash, api_version=self._api_version)
-
-        return trash
+    def _load_fixed_trash(self) -> None:
+        fixed_trash_core = self._implementation.fixed_trash
+        fixed_trash = Labware(
+            implementation=fixed_trash_core, api_version=self._api_version
+        )
+        self._core_map.add(fixed_trash_core, fixed_trash)
 
     @requires_version(2, 5)
     def set_rail_lights(self, on: bool) -> None:
@@ -743,6 +727,7 @@ class ProtocolContext(CommandPublisher):
 def _create_module_context(
     module_core: ModuleCore,
     protocol_core: ProtocolCore,
+    core_map: LoadedCoreMap,
     api_version: APIVersion,
     broker: Broker,
 ) -> ModuleTypes:
@@ -761,6 +746,7 @@ def _create_module_context(
     return module_cls(
         core=module_core,
         protocol_core=protocol_core,
+        core_map=core_map,
         api_version=api_version,
         broker=broker,
     )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -7,13 +7,14 @@ from opentrons.hardware_control.dev_types import PipetteDict
 
 from .. import errors
 from ..types import (
+    OFF_DECK_LOCATION,
     LoadedLabware,
+    LoadedModule,
     WellLocation,
     WellOrigin,
     WellOffset,
     DeckSlotLocation,
     ModuleLocation,
-    OFF_DECK_LOCATION,
     LabwareLocation,
     LabwareOffsetVector,
 )
@@ -389,3 +390,12 @@ class GeometryView:
             )
             return [(slot_5_center.x, slot_5_center.y)]
         return []
+
+    def get_slot_item(
+        self, slot_name: DeckSlotName
+    ) -> Union[LoadedLabware, LoadedModule, None]:
+        """Get the item present in a deck slot, if any."""
+        maybe_labware = self._labware.get_by_slot(slot_name)
+        maybe_module = self._modules.get_by_slot(slot_name)
+
+        return maybe_labware or maybe_module or None

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1,6 +1,6 @@
 """Geometry state getters."""
 from dataclasses import dataclass
-from typing import Optional, List, Tuple, Union
+from typing import Optional, List, Set, Tuple, Union
 
 from opentrons.types import Point, DeckSlotName
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -391,11 +391,23 @@ class GeometryView:
             return [(slot_5_center.x, slot_5_center.y)]
         return []
 
+    # TODO(mc, 2022-12-09): enforce data integrity (e.g. one module per slot)
+    # rather than shunting this work to callers via `allowed_ids`.
+    # This has larger implications and is tied up in splitting LPC out of the protocol run
     def get_slot_item(
-        self, slot_name: DeckSlotName
+        self,
+        slot_name: DeckSlotName,
+        allowed_labware_ids: Set[str],
+        allowed_module_ids: Set[str],
     ) -> Union[LoadedLabware, LoadedModule, None]:
         """Get the item present in a deck slot, if any."""
-        maybe_labware = self._labware.get_by_slot(slot_name)
-        maybe_module = self._modules.get_by_slot(slot_name)
+        maybe_labware = self._labware.get_by_slot(
+            slot_name=slot_name,
+            allowed_ids=allowed_labware_ids,
+        )
+        maybe_module = self._modules.get_by_slot(
+            slot_name=slot_name,
+            allowed_ids=allowed_module_ids,
+        )
 
         return maybe_labware or maybe_module or None

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -37,8 +37,6 @@ from ..actions import (
 from .abstract_store import HasState, HandlesActions
 
 
-_TRASH_LOCATION = DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH)
-
 # URIs of labware whose definitions accidentally specify an engage height
 # in units of half-millimeters instead of millimeters.
 _MAGDECK_HALF_MM_LABWARE = {
@@ -210,6 +208,19 @@ class LabwareView(HasState[LabwareState]):
         raise errors.exceptions.LabwareNotLoadedOnModuleError(
             "There is no labware loaded on this Module"
         )
+
+    def get_by_slot(self, slot_name: DeckSlotName) -> Optional[LoadedLabware]:
+        """Get the labware located in a given slot, if any."""
+        all_labware = reversed(list(self._state.labware_by_id.values()))
+
+        for labware in all_labware:
+            if (
+                isinstance(labware.location, DeckSlotLocation)
+                and labware.location.slotName == slot_name
+            ):
+                return labware
+
+        return None
 
     def get_definition(self, labware_id: str) -> LabwareDefinition:
         """Get labware definition by the labware's unique identifier."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -403,6 +403,16 @@ class ModuleView(HasState[ModuleState]):
         """Get a list of all module entries in state."""
         return [self.get(mod_id) for mod_id in self._state.slot_by_module_id.keys()]
 
+    def get_by_slot(self, slot_name: DeckSlotName) -> Optional[LoadedModule]:
+        """Get the module located in a given slot, if any."""
+        module_slots = reversed(list(self._state.slot_by_module_id.items()))
+
+        for module_id, module_slot in module_slots:
+            if module_slot == slot_name:
+                return self.get(module_id)
+
+        return None
+
     def _get_module_substate(
         self, module_id: str, expected_type: Type[ModuleSubStateT], expected_name: str
     ) -> ModuleSubStateT:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -9,10 +9,11 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
-    overload,
-    Union,
+    Set,
     Type,
     TypeVar,
+    Union,
+    overload,
 )
 from numpy import array, dot
 
@@ -403,12 +404,17 @@ class ModuleView(HasState[ModuleState]):
         """Get a list of all module entries in state."""
         return [self.get(mod_id) for mod_id in self._state.slot_by_module_id.keys()]
 
-    def get_by_slot(self, slot_name: DeckSlotName) -> Optional[LoadedModule]:
+    # TODO(mc, 2022-12-09): enforce data integrity (e.g. one module per slot)
+    # rather than shunting this work to callers via `allowed_ids`.
+    # This has larger implications and is tied up in splitting LPC out of the protocol run
+    def get_by_slot(
+        self, slot_name: DeckSlotName, allowed_ids: Set[str]
+    ) -> Optional[LoadedModule]:
         """Get the module located in a given slot, if any."""
-        module_slots = reversed(list(self._state.slot_by_module_id.items()))
+        slots_by_id = reversed(list(self._state.slot_by_module_id.items()))
 
-        for module_id, module_slot in module_slots:
-            if module_slot == slot_name:
+        for module_id, module_slot in slots_by_id:
+            if module_slot == slot_name and module_id in allowed_ids:
                 return self.get(module_id)
 
         return None

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -14,8 +14,9 @@ from opentrons_shared_data.labware.labware_definition import (
     Metadata as LabwareDefinitionMetadata,
 )
 
-from opentrons.types import Point
+from opentrons.types import DeckSlotName, Point
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_engine.errors import LabwareNotOnDeckError
 
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.engine import LabwareCore, WellCore
@@ -281,3 +282,20 @@ def test_get_quirks(subject: LabwareCore) -> None:
     result = subject.get_quirks()
 
     assert result == ["quirk"]
+
+
+def test_get_deck_slot(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
+) -> None:
+    """It should return its deck slot location, if in a slot."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_ancestor_slot_name("cool-labware")
+    ).then_return(DeckSlotName.SLOT_5)
+
+    assert subject.get_deck_slot() == DeckSlotName.SLOT_5
+
+    decoy.when(
+        mock_engine_client.state.geometry.get_ancestor_slot_name("cool-labware")
+    ).then_raise(LabwareNotOnDeckError("oh no"))
+
+    assert subject.get_deck_slot() is None

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -127,7 +127,11 @@ def test_get_slot_item_empty(
 ) -> None:
     """It should return None for an empty deck slot."""
     decoy.when(
-        mock_engine_client.state.geometry.get_slot_item(DeckSlotName.SLOT_1)
+        mock_engine_client.state.geometry.get_slot_item(
+            slot_name=DeckSlotName.SLOT_1,
+            allowed_labware_ids={"fixed-trash-123"},
+            allowed_module_ids=set(),
+        )
     ).then_return(None)
 
     assert subject.get_slot_item(DeckSlotName.SLOT_1) is None
@@ -208,7 +212,11 @@ def test_load_labware(
     assert subject.get_labware_cores() == [subject.fixed_trash, result]
 
     decoy.when(
-        mock_engine_client.state.geometry.get_slot_item(DeckSlotName.SLOT_5)
+        mock_engine_client.state.geometry.get_slot_item(
+            slot_name=DeckSlotName.SLOT_5,
+            allowed_labware_ids={"fixed-trash-123", "abc123"},
+            allowed_module_ids=set(),
+        )
     ).then_return(
         LoadedLabware.construct(id="abc123")  # type: ignore[call-arg]
     )
@@ -401,7 +409,11 @@ def test_load_module(
     assert subject.get_module_cores() == [result]
 
     decoy.when(
-        mock_engine_client.state.geometry.get_slot_item(DeckSlotName.SLOT_1)
+        mock_engine_client.state.geometry.get_slot_item(
+            slot_name=DeckSlotName.SLOT_1,
+            allowed_labware_ids={"fixed-trash-123"},
+            allowed_module_ids={"abc123"},
+        )
     ).then_return(
         LoadedModule.construct(id="abc123")  # type: ignore[call-arg]
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -4,6 +4,7 @@ from typing import Optional, Type, cast
 import pytest
 from decoy import Decoy
 
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.labware.dev_types import (
     LabwareDefinition as LabwareDefDict,
@@ -11,7 +12,7 @@ from opentrons_shared_data.labware.dev_types import (
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
-from opentrons.types import Mount, MountType, DeckSlotName
+from opentrons.types import DeckSlotName, Mount, MountType, Point
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules import AbstractModule
@@ -28,6 +29,8 @@ from opentrons.protocol_engine import (
     ModuleLocation,
     ModuleDefinition,
     LabwareMovementStrategy,
+    LoadedLabware,
+    LoadedModule,
     LoadedPipette,
     commands,
 )
@@ -107,15 +110,27 @@ def test_api_version(
     assert subject.api_version == api_version
 
 
-def test_get_fixed_trash(subject: ProtocolCore) -> None:
+def test_fixed_trash(subject: ProtocolCore) -> None:
     """It should have a single labware core for the fixed trash."""
-    result = subject.get_fixed_trash()
+    result = subject.fixed_trash
 
     assert isinstance(result, LabwareCore)
     assert result.labware_id == "fixed-trash-123"
+    assert subject.get_labware_cores() == [result]
 
     # verify it's the same core every time
-    assert subject.get_fixed_trash() is result
+    assert subject.fixed_trash is result
+
+
+def test_get_slot_item_empty(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ProtocolCore
+) -> None:
+    """It should return None for an empty deck slot."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_slot_item(DeckSlotName.SLOT_1)
+    ).then_return(None)
+
+    assert subject.get_slot_item(DeckSlotName.SLOT_1) is None
 
 
 def test_load_instrument(
@@ -190,6 +205,15 @@ def test_load_labware(
 
     assert isinstance(result, LabwareCore)
     assert result.labware_id == "abc123"
+    assert subject.get_labware_cores() == [subject.fixed_trash, result]
+
+    decoy.when(
+        mock_engine_client.state.geometry.get_slot_item(DeckSlotName.SLOT_5)
+    ).then_return(
+        LoadedLabware.construct(id="abc123")  # type: ignore[call-arg]
+    )
+
+    assert subject.get_slot_item(DeckSlotName.SLOT_5) is result
 
 
 @pytest.mark.parametrize(
@@ -374,6 +398,15 @@ def test_load_module(
 
     assert isinstance(result, expected_core_cls)
     assert result.module_id == "abc123"
+    assert subject.get_module_cores() == [result]
+
+    decoy.when(
+        mock_engine_client.state.geometry.get_slot_item(DeckSlotName.SLOT_1)
+    ).then_return(
+        LoadedModule.construct(id="abc123")  # type: ignore[call-arg]
+    )
+
+    assert subject.get_slot_item(DeckSlotName.SLOT_1) is result
 
 
 @pytest.mark.parametrize(
@@ -524,3 +557,44 @@ def test_get_rail_lights(
 
     result = subject.get_rail_lights_on()
     assert result is True
+
+
+def test_get_deck_definition(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ProtocolCore
+) -> None:
+    """It should return the loaded deck definition from engine state."""
+    deck_definition = cast(DeckDefinitionV3, {"schemaVersion": "3"})
+
+    decoy.when(mock_engine_client.state.labware.get_deck_definition()).then_return(
+        deck_definition
+    )
+
+    result = subject.get_deck_definition()
+
+    assert result == deck_definition
+
+
+def test_get_slot_center(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ProtocolCore
+) -> None:
+    """It should return a slot center from engine state."""
+    decoy.when(
+        mock_engine_client.state.labware.get_slot_center_position(DeckSlotName.SLOT_2)
+    ).then_return(Point(1, 2, 3))
+
+    result = subject.get_slot_center(DeckSlotName.SLOT_2)
+
+    assert result == Point(1, 2, 3)
+
+
+def test_get_highest_z(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: ProtocolCore
+) -> None:
+    """It should return a slot center from engine state."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_all_labware_highest_z()
+    ).then_return(9001)
+
+    result = subject.get_highest_z()
+
+    assert result == 9001

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -88,6 +88,8 @@ def mock_deck(decoy: Decoy) -> Deck:
     setattr(
         deck, "resolve_module_location", decoy.mock(name="Deck.resolve_module_location")
     )
+    deck["12"] = decoy.mock(cls=LabwareImplementation)
+
     return cast(Deck, deck)
 
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -12,7 +12,7 @@ from opentrons.hardware_control.modules.types import (
 )
 from opentrons.protocols.geometry.module_geometry import ThermocyclerGeometry
 
-from opentrons.protocol_api.labware import Labware, Well
+from opentrons.protocol_api.labware import Labware
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
 )
@@ -23,6 +23,7 @@ from opentrons.protocol_api.core.protocol_api.legacy_module_core import (
 from opentrons.protocol_api.core.protocol_api.instrument_context import (
     InstrumentContextImplementation,
 )
+from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 
 SyncThermocyclerHardware = SynchronousAdapter[Thermocycler]
 
@@ -68,9 +69,9 @@ def mock_labware(decoy: Decoy) -> Labware:
 
 
 @pytest.fixture
-def mock_well(decoy: Decoy) -> Well:
-    """Get a mock well."""
-    return decoy.mock(cls=Well)
+def mock_trash_well_core(decoy: Decoy) -> WellImplementation:
+    """Get a mock well implementation for the trash."""
+    return decoy.mock(cls=WellImplementation)
 
 
 @pytest.fixture
@@ -259,8 +260,7 @@ def test_open_lid(
     mock_protocol_core: ProtocolContextImplementation,
     mock_instrument_core: InstrumentContextImplementation,
     mock_geometry: ThermocyclerGeometry,
-    mock_labware: Labware,
-    mock_well: Well,
+    mock_trash_well_core: WellImplementation,
     subject: LegacyThermocyclerCore,
 ) -> None:
     """It should open the lid with the hardware."""
@@ -271,10 +271,11 @@ def test_open_lid(
     decoy.when(mock_sync_hardware_api.current_position(Mount.RIGHT)).then_return(
         {Axis.A: 4}
     )
-    decoy.when(subject._get_fixed_trash()).then_return(mock_labware)
-    decoy.when(mock_labware.wells()).then_return([mock_well])
-    decoy.when(mock_well.top()).then_return(
-        Location(point=Point(x=1, y=2, z=3), labware=mock_well)
+    decoy.when(mock_protocol_core.fixed_trash.get_well_core("A1")).then_return(
+        mock_trash_well_core
+    )
+    decoy.when(mock_trash_well_core.get_top(z_offset=0)).then_return(
+        Point(x=1, y=2, z=3)
     )
 
     decoy.when(mock_sync_module_hardware.open()).then_return("open")
@@ -302,8 +303,7 @@ def test_close_lid(
     mock_protocol_core: ProtocolContextImplementation,
     mock_instrument_core: InstrumentContextImplementation,
     mock_geometry: ThermocyclerGeometry,
-    mock_labware: Labware,
-    mock_well: Well,
+    mock_trash_well_core: WellImplementation,
     subject: LegacyThermocyclerCore,
 ) -> None:
     """It should close the lid with the hardware."""
@@ -314,10 +314,11 @@ def test_close_lid(
     decoy.when(mock_sync_hardware_api.current_position(Mount.LEFT)).then_return(
         {Axis.Z: 4}
     )
-    decoy.when(subject._get_fixed_trash()).then_return(mock_labware)
-    decoy.when(mock_labware.wells()).then_return([mock_well])
-    decoy.when(mock_well.top()).then_return(
-        Location(point=Point(x=1, y=2, z=3), labware=mock_well)
+    decoy.when(mock_protocol_core.fixed_trash.get_well_core("A1")).then_return(
+        mock_trash_well_core
+    )
+    decoy.when(mock_trash_well_core.get_top(z_offset=0)).then_return(
+        Point(x=1, y=2, z=3)
     )
 
     decoy.when(mock_sync_module_hardware.close()).then_return("closed")

--- a/api/tests/opentrons/protocol_api/core/test_core_map.py
+++ b/api/tests/opentrons/protocol_api/core/test_core_map.py
@@ -1,0 +1,43 @@
+"""Tests for opentrons.protocol_api.core.core_map.LoadedCoreMap."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_api import Labware, MagneticModuleContext
+from opentrons.protocol_api.core.common import LabwareCore, ModuleCore
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
+
+
+def test_get_nothing() -> None:
+    """If you ask for nothing, you get nothing."""
+    subject = LoadedCoreMap()
+    assert subject.get(None) is None
+
+
+def test_add_labware(decoy: Decoy) -> None:
+    """It should be able to add labwares to the map."""
+    labware_core = decoy.mock(cls=LabwareCore)
+    other_labware_core = decoy.mock(cls=LabwareCore)
+    labware = decoy.mock(cls=Labware)
+
+    subject = LoadedCoreMap()
+    subject.add(labware_core, labware)
+
+    assert subject.get(labware_core) is labware
+
+    with pytest.raises(KeyError):
+        subject.get(other_labware_core)
+
+
+def test_add_module(decoy: Decoy) -> None:
+    """It should be able to add modules to the map."""
+    module_core = decoy.mock(cls=ModuleCore)
+    other_module_core = decoy.mock(cls=ModuleCore)
+    module = decoy.mock(cls=MagneticModuleContext)
+
+    subject = LoadedCoreMap()
+    subject.add(module_core, module)
+
+    assert subject.get(module_core) is module
+
+    with pytest.raises(KeyError):
+        subject.get(other_module_core)

--- a/api/tests/opentrons/protocol_api/test_heater_shaker_context.py
+++ b/api/tests/opentrons/protocol_api/test_heater_shaker_context.py
@@ -8,6 +8,7 @@ from opentrons.hardware_control.modules import TemperatureStatus, SpeedStatus
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, HeaterShakerContext
 from opentrons.protocol_api.core.common import ProtocolCore, HeaterShakerCore
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
 
 @pytest.fixture
@@ -20,6 +21,12 @@ def mock_core(decoy: Decoy) -> HeaterShakerCore:
 def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
     """Get a mock protocol implementation core."""
     return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
 
 
 @pytest.fixture
@@ -39,12 +46,14 @@ def subject(
     api_version: APIVersion,
     mock_core: HeaterShakerCore,
     mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     mock_broker: Broker,
 ) -> HeaterShakerContext:
     """Get a temperature module context with its dependencies mocked out."""
     return HeaterShakerContext(
         core=mock_core,
         protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
         broker=mock_broker,
         api_version=api_version,
     )

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -7,6 +7,7 @@ from opentrons.hardware_control.modules import MagneticStatus
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MagneticModuleContext
 from opentrons.protocol_api.core.common import ProtocolCore, MagneticModuleCore
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
 
 @pytest.fixture
@@ -19,6 +20,12 @@ def mock_core(decoy: Decoy) -> MagneticModuleCore:
 def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
     """Get a mock protocol implementation core."""
     return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
 
 
 @pytest.fixture
@@ -38,12 +45,14 @@ def subject(
     api_version: APIVersion,
     mock_core: MagneticModuleCore,
     mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     mock_broker: Broker,
 ) -> MagneticModuleContext:
     """Get a magnetic module context with its dependencies mocked out."""
     return MagneticModuleContext(
         core=mock_core,
         protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
         broker=mock_broker,
         api_version=api_version,
     )

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -18,6 +18,7 @@ from opentrons.protocol_api import (
     InstrumentContext,
     ModuleContext,
     TemperatureModuleContext,
+    MagneticModuleContext,
     Labware,
     Deck,
     validation as mock_validation,
@@ -29,6 +30,7 @@ from opentrons.protocol_api.core.common import (
     LabwareCore,
     ProtocolCore,
     TemperatureModuleCore,
+    MagneticModuleCore,
 )
 
 
@@ -49,7 +51,11 @@ def _mock_instrument_support_module(
 @pytest.fixture
 def mock_core(decoy: Decoy) -> ProtocolCore:
     """Get a mock implementation core."""
-    return decoy.mock(cls=ProtocolCore)
+    mock_core = decoy.mock(cls=ProtocolCore)
+    decoy.when(mock_core.fixed_trash.get_name()).then_return("cool trash")
+    decoy.when(mock_core.fixed_trash.get_display_name()).then_return("Cool Trash")
+    decoy.when(mock_core.fixed_trash.get_well_columns()).then_return([])
+    return mock_core
 
 
 @pytest.fixture
@@ -78,17 +84,23 @@ def subject(
 
 
 def test_fixed_trash(
-    decoy: Decoy, mock_core: ProtocolCore, subject: ProtocolContext
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    subject: ProtocolContext,
 ) -> None:
     """It should get the fixed trash labware from the core."""
-    mock_labware_core = decoy.mock(cls=LabwareCore)
+    trash_captor = matchers.Captor()
 
-    decoy.when(mock_core.get_fixed_trash()).then_return(mock_labware_core)
-    decoy.when(mock_labware_core.get_name()).then_return("cool trash")
-    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+    decoy.verify(mock_core_map.add(mock_core.fixed_trash, trash_captor), times=1)
+
+    trash = trash_captor.value
+
+    decoy.when(mock_core_map.get(mock_core.fixed_trash)).then_return(trash)
 
     result = subject.fixed_trash
 
+    assert result is trash
     assert isinstance(result, Labware)
     assert result.name == "cool trash"
 
@@ -106,11 +118,8 @@ def test_load_instrument(
 ) -> None:
     """It should create a instrument using its execution core."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
-    mock_trash_core = decoy.mock(cls=LabwareCore)
     mock_tip_racks = [decoy.mock(cls=Labware), decoy.mock(cls=Labware)]
 
-    decoy.when(mock_core.get_fixed_trash()).then_return(mock_trash_core)
-    decoy.when(mock_trash_core.get_well_columns()).then_return([])
     decoy.when(mock_validation.ensure_mount("shadowfax")).then_return(Mount.LEFT)
     decoy.when(mock_validation.ensure_lowercase_name("Gandalf")).then_return("gandalf")
     decoy.when(mock_validation.ensure_pipette_name("gandalf")).then_return(
@@ -154,10 +163,7 @@ def test_load_instrument_replace(
 ) -> None:
     """It should allow/disallow pipette replacement."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
-    mock_trash_core = decoy.mock(cls=LabwareCore)
 
-    decoy.when(mock_core.get_fixed_trash()).then_return(mock_trash_core)
-    decoy.when(mock_trash_core.get_well_columns()).then_return([])
     decoy.when(mock_validation.ensure_lowercase_name("ada")).then_return("ada")
     decoy.when(mock_validation.ensure_mount(matchers.IsA(Mount))).then_return(
         Mount.RIGHT
@@ -188,6 +194,7 @@ def test_load_instrument_replace(
 def test_load_labware(
     decoy: Decoy,
     mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     subject: ProtocolContext,
 ) -> None:
     """It should create a labware using its execution core."""
@@ -209,6 +216,7 @@ def test_load_labware(
     ).then_return(mock_labware_core)
 
     decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+    decoy.when(mock_labware_core.get_display_name()).then_return("Display Name")
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
     result = subject.load_labware(
@@ -221,6 +229,8 @@ def test_load_labware(
 
     assert isinstance(result, Labware)
     assert result.name == "Full Name"
+
+    decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
 
 
 def test_load_labware_from_definition(
@@ -263,6 +273,31 @@ def test_load_labware_from_definition(
     assert result.name == "Full Name"
 
 
+def test_loaded_labware(
+    decoy: Decoy,
+    mock_core_map: LoadedCoreMap,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should return a list of all loaded modules."""
+    labware_core_4 = decoy.mock(cls=LabwareCore)
+    labware_core_6 = decoy.mock(cls=LabwareCore)
+    labware_4 = decoy.mock(cls=Labware)
+    labware_6 = decoy.mock(cls=Labware)
+
+    decoy.when(mock_core.get_labware_cores()).then_return(
+        [labware_core_4, labware_core_6]
+    )
+    decoy.when(labware_core_4.get_deck_slot()).then_return(DeckSlotName.SLOT_4)
+    decoy.when(labware_core_6.get_deck_slot()).then_return(DeckSlotName.SLOT_6)
+    decoy.when(mock_core_map.get(labware_core_4)).then_return(labware_4)
+    decoy.when(mock_core_map.get(labware_core_6)).then_return(labware_6)
+
+    result = subject.loaded_labwares
+
+    assert result == {4: labware_4, 6: labware_6}
+
+
 def test_move_labware_to_slot(
     decoy: Decoy,
     mock_core: ProtocolCore,
@@ -296,6 +331,7 @@ def test_move_labware_to_slot(
 def test_move_labware_to_module(
     decoy: Decoy,
     mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     subject: ProtocolContext,
 ) -> None:
     """It should move labware to new module location."""
@@ -312,6 +348,7 @@ def test_move_labware_to_module(
     module_location = TemperatureModuleContext(
         core=mock_module_core,
         protocol_core=mock_core,
+        core_map=mock_core_map,
         api_version=MAX_SUPPORTED_VERSION,
         broker=mock_broker,
     )
@@ -329,6 +366,7 @@ def test_move_labware_to_module(
 def test_load_module(
     decoy: Decoy,
     mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     subject: ProtocolContext,
 ) -> None:
     """It should load a module."""
@@ -358,7 +396,7 @@ def test_load_module(
     result = subject.load_module(module_name="spline reticulator", location=42)
 
     assert isinstance(result, ModuleContext)
-    assert subject.loaded_modules[3] is result
+    decoy.verify(mock_core_map.add(mock_module_core, result), times=1)
 
 
 def test_load_module_default_location(
@@ -394,7 +432,29 @@ def test_load_module_default_location(
     result = subject.load_module(module_name="spline reticulator", location=42)
 
     assert isinstance(result, ModuleContext)
-    assert subject.loaded_modules[3] is result
+
+
+def test_loaded_modules(
+    decoy: Decoy,
+    mock_core_map: LoadedCoreMap,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should return a list of all loaded modules."""
+    module_core_4 = decoy.mock(cls=TemperatureModuleCore)
+    module_core_6 = decoy.mock(cls=MagneticModuleCore)
+    module_4 = decoy.mock(cls=TemperatureModuleContext)
+    module_6 = decoy.mock(cls=MagneticModuleContext)
+
+    decoy.when(mock_core.get_module_cores()).then_return([module_core_4, module_core_6])
+    decoy.when(module_core_4.get_deck_slot()).then_return(DeckSlotName.SLOT_4)
+    decoy.when(module_core_6.get_deck_slot()).then_return(DeckSlotName.SLOT_6)
+    decoy.when(mock_core_map.get(module_core_4)).then_return(module_4)
+    decoy.when(mock_core_map.get(module_core_6)).then_return(module_6)
+
+    result = subject.loaded_modules
+
+    assert result == {4: module_4, 6: module_6}
 
 
 def test_home(

--- a/api/tests/opentrons/protocol_api/test_temperature_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_temperature_module_context.py
@@ -8,6 +8,7 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, TemperatureModuleContext
 from opentrons.protocol_api.core.common import ProtocolCore, TemperatureModuleCore
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
 
 @pytest.fixture
@@ -20,6 +21,12 @@ def mock_core(decoy: Decoy) -> TemperatureModuleCore:
 def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
     """Get a mock protocol implementation core."""
     return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
 
 
 @pytest.fixture
@@ -39,12 +46,14 @@ def subject(
     api_version: APIVersion,
     mock_core: TemperatureModuleCore,
     mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     mock_broker: Broker,
 ) -> TemperatureModuleContext:
     """Get a temperature module context with its dependencies mocked out."""
     return TemperatureModuleContext(
         core=mock_core,
         protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
         broker=mock_broker,
         api_version=api_version,
     )

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -13,6 +13,7 @@ from opentrons.protocol_api import (
     validation as mock_validation,
 )
 from opentrons.protocol_api.core.common import ProtocolCore, ThermocyclerCore
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +35,12 @@ def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
 
 
 @pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
+
+
+@pytest.fixture
 def mock_broker(decoy: Decoy) -> Broker:
     """Get a mock command message broker."""
     return decoy.mock(cls=Broker)
@@ -50,12 +57,14 @@ def subject(
     api_version: APIVersion,
     mock_core: ThermocyclerCore,
     mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     mock_broker: Broker,
 ) -> ThermocyclerContext:
     """Get a thermocycler module context with its dependencies mocked out."""
     return ThermocyclerContext(
         core=mock_core,
         protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
         broker=mock_broker,
         api_version=api_version,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -1013,17 +1013,46 @@ def test_get_slot_item(
     subject: GeometryView,
 ) -> None:
     """It should get items in certain slots."""
+    allowed_labware_ids = {"foo", "bar"}
+    allowed_module_ids = {"fizz", "buzz"}
     labware = LoadedLabware.construct(id="cool-labware")  # type: ignore[call-arg]
     module = LoadedModule.construct(id="cool-module")  # type: ignore[call-arg]
 
-    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_1)).then_return(None)
-    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_2)).then_return(labware)
-    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_3)).then_return(None)
+    decoy.when(
+        labware_view.get_by_slot(DeckSlotName.SLOT_1, allowed_labware_ids)
+    ).then_return(None)
+    decoy.when(
+        labware_view.get_by_slot(DeckSlotName.SLOT_2, allowed_labware_ids)
+    ).then_return(labware)
+    decoy.when(
+        labware_view.get_by_slot(DeckSlotName.SLOT_3, allowed_labware_ids)
+    ).then_return(None)
 
-    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_1)).then_return(None)
-    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_2)).then_return(None)
-    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_3)).then_return(module)
+    decoy.when(
+        module_view.get_by_slot(DeckSlotName.SLOT_1, allowed_module_ids)
+    ).then_return(None)
+    decoy.when(
+        module_view.get_by_slot(DeckSlotName.SLOT_2, allowed_module_ids)
+    ).then_return(None)
+    decoy.when(
+        module_view.get_by_slot(DeckSlotName.SLOT_3, allowed_module_ids)
+    ).then_return(module)
 
-    assert subject.get_slot_item(DeckSlotName.SLOT_1) is None
-    assert subject.get_slot_item(DeckSlotName.SLOT_2) == labware
-    assert subject.get_slot_item(DeckSlotName.SLOT_3) == module
+    assert (
+        subject.get_slot_item(
+            DeckSlotName.SLOT_1, allowed_labware_ids, allowed_module_ids
+        )
+        is None
+    )
+    assert (
+        subject.get_slot_item(
+            DeckSlotName.SLOT_2, allowed_labware_ids, allowed_module_ids
+        )
+        == labware
+    )
+    assert (
+        subject.get_slot_item(
+            DeckSlotName.SLOT_3, allowed_labware_ids, allowed_module_ids
+        )
+        == module
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -1004,3 +1004,26 @@ def test_get_extra_waypoints(
     extra_waypoints = subject.get_extra_waypoints("to-labware-id", location)
 
     assert extra_waypoints == expected_waypoints
+
+
+def test_get_slot_item(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    module_view: ModuleView,
+    subject: GeometryView,
+) -> None:
+    """It should get items in certain slots."""
+    labware = LoadedLabware.construct(id="cool-labware")  # type: ignore[call-arg]
+    module = LoadedModule.construct(id="cool-module")  # type: ignore[call-arg]
+
+    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_1)).then_return(None)
+    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_2)).then_return(labware)
+    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_3)).then_return(None)
+
+    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_1)).then_return(None)
+    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_2)).then_return(None)
+    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_3)).then_return(module)
+
+    assert subject.get_slot_item(DeckSlotName.SLOT_1) is None
+    assert subject.get_slot_item(DeckSlotName.SLOT_2) == labware
+    assert subject.get_slot_item(DeckSlotName.SLOT_3) == module

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -747,8 +747,13 @@ def test_get_by_slot() -> None:
     labware_2 = LoadedLabware.construct(  # type: ignore[call-arg]
         id="2", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2)
     )
+    labware_3 = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="3", location=ModuleLocation(moduleId="cool-module")
+    )
 
-    subject = get_labware_view(labware_by_id={"1": labware_1, "2": labware_2})
+    subject = get_labware_view(
+        labware_by_id={"1": labware_1, "2": labware_2, "3": labware_3}
+    )
 
     assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1", "2"}) == labware_1
     assert subject.get_by_slot(DeckSlotName.SLOT_2, {"1", "2"}) == labware_2

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -737,3 +737,33 @@ def test_get_calibration_coordinates() -> None:
     result = subject.get_calibration_coordinates(current_z_position=3.0)
 
     assert result == Point(x=4, y=5, z=3)
+
+
+def test_get_by_slot() -> None:
+    """It should get the labware in a given slot."""
+    labware_1 = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="1", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+    labware_2 = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="2", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2)
+    )
+
+    subject = get_labware_view(labware_by_id={"1": labware_1, "2": labware_2})
+
+    assert subject.get_by_slot(DeckSlotName.SLOT_1) == labware_1
+    assert subject.get_by_slot(DeckSlotName.SLOT_2) == labware_2
+    assert subject.get_by_slot(DeckSlotName.SLOT_3) is None
+
+
+def test_get_by_slot_prefers_later() -> None:
+    """It should get the labware in a slot, preferring later items if locations match."""
+    labware_1 = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="1", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+    labware_1_again = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="2", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+
+    subject = get_labware_view(labware_by_id={"1": labware_1, "2": labware_1_again})
+
+    assert subject.get_by_slot(DeckSlotName.SLOT_1) == labware_1_again

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -750,9 +750,9 @@ def test_get_by_slot() -> None:
 
     subject = get_labware_view(labware_by_id={"1": labware_1, "2": labware_2})
 
-    assert subject.get_by_slot(DeckSlotName.SLOT_1) == labware_1
-    assert subject.get_by_slot(DeckSlotName.SLOT_2) == labware_2
-    assert subject.get_by_slot(DeckSlotName.SLOT_3) is None
+    assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1", "2"}) == labware_1
+    assert subject.get_by_slot(DeckSlotName.SLOT_2, {"1", "2"}) == labware_2
+    assert subject.get_by_slot(DeckSlotName.SLOT_3, {"1", "2"}) is None
 
 
 def test_get_by_slot_prefers_later() -> None:
@@ -761,9 +761,27 @@ def test_get_by_slot_prefers_later() -> None:
         id="1", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
     )
     labware_1_again = LoadedLabware.construct(  # type: ignore[call-arg]
-        id="2", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+        id="1-again", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
     )
 
-    subject = get_labware_view(labware_by_id={"1": labware_1, "2": labware_1_again})
+    subject = get_labware_view(
+        labware_by_id={"1": labware_1, "1-again": labware_1_again}
+    )
 
-    assert subject.get_by_slot(DeckSlotName.SLOT_1) == labware_1_again
+    assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1", "1-again"}) == labware_1_again
+
+
+def test_get_by_slot_filter_ids() -> None:
+    """It should filter labwares in the same slot using IDs."""
+    labware_1 = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="1", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+    labware_1_again = LoadedLabware.construct(  # type: ignore[call-arg]
+        id="1-again", location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+
+    subject = get_labware_view(
+        labware_by_id={"1": labware_1, "1-again": labware_1_again}
+    )
+
+    assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1"}) == labware_1

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1467,3 +1467,72 @@ def test_raise_if_labware_in_location(
     )
     with expected_raise:
         subject.raise_if_module_in_location(location=location)
+
+
+def test_get_by_slot() -> None:
+    """It should get the module in a given slot."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": DeckSlotName.SLOT_2,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-number-1",
+                definition=ModuleDefinition.construct(  # type: ignore[call-arg]
+                    model=ModuleModel.TEMPERATURE_MODULE_V1
+                ),
+            ),
+            "module-2": HardwareModule(
+                serial_number="serial-number-2",
+                definition=ModuleDefinition.construct(  # type: ignore[call-arg]
+                    model=ModuleModel.TEMPERATURE_MODULE_V2
+                ),
+            ),
+        },
+    )
+
+    assert subject.get_by_slot(DeckSlotName.SLOT_1) == LoadedModule(
+        id="module-1",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
+        serialNumber="serial-number-1",
+    )
+    assert subject.get_by_slot(DeckSlotName.SLOT_2) == LoadedModule(
+        id="module-2",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
+        model=ModuleModel.TEMPERATURE_MODULE_V2,
+        serialNumber="serial-number-2",
+    )
+    assert subject.get_by_slot(DeckSlotName.SLOT_3) is None
+
+
+def test_get_by_slot_prefers_later() -> None:
+    """It should get the labware in a slot, preferring later items if locations match."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-1-again": DeckSlotName.SLOT_1,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-number-1",
+                definition=ModuleDefinition.construct(  # type: ignore[call-arg]
+                    model=ModuleModel.TEMPERATURE_MODULE_V1
+                ),
+            ),
+            "module-1-again": HardwareModule(
+                serial_number="serial-number-1",
+                definition=ModuleDefinition.construct(  # type: ignore[call-arg]
+                    model=ModuleModel.TEMPERATURE_MODULE_V1
+                ),
+            ),
+        },
+    )
+
+    assert subject.get_by_slot(DeckSlotName.SLOT_1) == LoadedModule(
+        id="module-1-again",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
+        serialNumber="serial-number-1",
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -1473,17 +1473,17 @@ def test_get_by_slot() -> None:
     """It should get the module in a given slot."""
     subject = make_module_view(
         slot_by_module_id={
-            "module-1": DeckSlotName.SLOT_1,
-            "module-2": DeckSlotName.SLOT_2,
+            "1": DeckSlotName.SLOT_1,
+            "2": DeckSlotName.SLOT_2,
         },
         hardware_by_module_id={
-            "module-1": HardwareModule(
+            "1": HardwareModule(
                 serial_number="serial-number-1",
                 definition=ModuleDefinition.construct(  # type: ignore[call-arg]
                     model=ModuleModel.TEMPERATURE_MODULE_V1
                 ),
             ),
-            "module-2": HardwareModule(
+            "2": HardwareModule(
                 serial_number="serial-number-2",
                 definition=ModuleDefinition.construct(  # type: ignore[call-arg]
                     model=ModuleModel.TEMPERATURE_MODULE_V2
@@ -1492,37 +1492,37 @@ def test_get_by_slot() -> None:
         },
     )
 
-    assert subject.get_by_slot(DeckSlotName.SLOT_1) == LoadedModule(
-        id="module-1",
+    assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1", "2"}) == LoadedModule(
+        id="1",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         model=ModuleModel.TEMPERATURE_MODULE_V1,
         serialNumber="serial-number-1",
     )
-    assert subject.get_by_slot(DeckSlotName.SLOT_2) == LoadedModule(
-        id="module-2",
+    assert subject.get_by_slot(DeckSlotName.SLOT_2, {"1", "2"}) == LoadedModule(
+        id="2",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         model=ModuleModel.TEMPERATURE_MODULE_V2,
         serialNumber="serial-number-2",
     )
-    assert subject.get_by_slot(DeckSlotName.SLOT_3) is None
+    assert subject.get_by_slot(DeckSlotName.SLOT_3, {"1", "2"}) is None
 
 
 def test_get_by_slot_prefers_later() -> None:
-    """It should get the labware in a slot, preferring later items if locations match."""
+    """It should get the module in a slot, preferring later items if locations match."""
     subject = make_module_view(
         slot_by_module_id={
-            "module-1": DeckSlotName.SLOT_1,
-            "module-1-again": DeckSlotName.SLOT_1,
+            "1": DeckSlotName.SLOT_1,
+            "1-again": DeckSlotName.SLOT_1,
         },
         hardware_by_module_id={
-            "module-1": HardwareModule(
+            "1": HardwareModule(
                 serial_number="serial-number-1",
                 definition=ModuleDefinition.construct(  # type: ignore[call-arg]
                     model=ModuleModel.TEMPERATURE_MODULE_V1
                 ),
             ),
-            "module-1-again": HardwareModule(
-                serial_number="serial-number-1",
+            "1-again": HardwareModule(
+                serial_number="serial-number-1-again",
                 definition=ModuleDefinition.construct(  # type: ignore[call-arg]
                     model=ModuleModel.TEMPERATURE_MODULE_V1
                 ),
@@ -1530,8 +1530,39 @@ def test_get_by_slot_prefers_later() -> None:
         },
     )
 
-    assert subject.get_by_slot(DeckSlotName.SLOT_1) == LoadedModule(
-        id="module-1-again",
+    assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1", "1-again"}) == LoadedModule(
+        id="1-again",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
+        serialNumber="serial-number-1-again",
+    )
+
+
+def test_get_by_slot_filter_ids() -> None:
+    """It should filter modules by ID in addition to checking the slot."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "1": DeckSlotName.SLOT_1,
+            "1-again": DeckSlotName.SLOT_1,
+        },
+        hardware_by_module_id={
+            "1": HardwareModule(
+                serial_number="serial-number-1",
+                definition=ModuleDefinition.construct(  # type: ignore[call-arg]
+                    model=ModuleModel.TEMPERATURE_MODULE_V1
+                ),
+            ),
+            "1-again": HardwareModule(
+                serial_number="serial-number-1-again",
+                definition=ModuleDefinition.construct(  # type: ignore[call-arg]
+                    model=ModuleModel.TEMPERATURE_MODULE_V1
+                ),
+            ),
+        },
+    )
+
+    assert subject.get_by_slot(DeckSlotName.SLOT_1, {"1"}) == LoadedModule(
+        id="1",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         model=ModuleModel.TEMPERATURE_MODULE_V1,
         serialNumber="serial-number-1",


### PR DESCRIPTION
## Overview

This PR closes RCORE-420 by implementing the dependencies necessary for the engine-based `Deck` class to function.

## Changelog

### ProtocolCore additions

These additions used directly by the new `Deck`

- Get deck definition
- Get labware or module core in slot
- Get slot center
- Get highest Z

### LabwareCOre additions

- Get slot of self or parent

### LoadedCoreMap (new dependency)

A box that public context classes can use to map cores back to the contexts that use those cores.

- Add core <> context to map, used by:
    - `ProtocolContext.load_labware`
    - `ProtocolContext.load_module`
    - `ModuleContext.load_labware`
- Get context from core, used by:
    - `Deck.__getitem__`
    - `ProtocolContext.loaded_modules`
    - `ProtocolContext.loaded_labwares`

### General cleanup

The additions of these dependencies allowed for the following cleanups:

- `ProtocolContext.loaded_modules` and `loaded_labware` are now more simple, removing state and complexity from `ProtocolContext`
- General cleanups with the fixed trash
    - Changed from getter (`core.get_fixed_trash()`) to property (`core.fixed_trash`) to ease usage (and write cleaner tests)
    - The legacy `ProtocolCore` will now always return a `LabwareCore` and _never_ a `Labware` from its `fixed_trash` property, which papers over a bad thing the old `Deck` does
    - It also allows the legacy ThermocyclerCore's "move to safe position for lid movement" procedure to get cleaned up a little

## Review requests

- Try out protocols that use `ctx.deck`
- Test all OT-2 calibration flows that continue to depend on the old `Deck` interface
    - Deck calibration
    - Deck calibration check
    - Pipette offset calibration
    - Tip length check

## Risk assessment

Medium, due to complexity from previous refactors and the importance of `Deck` in the legacy core's geometry system

### Test results

I've done the following tests on hardware

- [x] OT-2 deck calibration
- [x] OT-2 pipette offset calibration
- [x] OT-2 tip length calibration
- [x] OT-3 protocol w/ engine core FF on 
- [x] OT-2 protocol /w engine core FF on
- [x] OT-2 protocol /w engine core FF off

## Testing protocols

### OT-3 FF on

This protocol demonstrates the primary changes that will happen with the engine core FF on: `deck[some_slot]` will directly return a `Labware` or `ModuleContext`. As a result, this protocol will **only work if the FF is on**.

```python
from opentrons import protocol_api, types

metadata = {
    "protocolName": "Deck Testing",
    "author": "Mike Cousins <mike@opentrons.com>",
}

requirements = {
    "apiLevel": "2.13",
    "robotType": "OT-3"
}

_TIP_RACK_LOCATION = "9"
_WELL_PLATE_LOCATION = "5"

def run(ctx: protocol_api.ProtocolContext) -> None:
    ctx.load_labware("opentrons_ot3_96_tiprack_50ul", _TIP_RACK_LOCATION)
    ctx.load_labware("corning_96_wellplate_360ul_flat", _WELL_PLATE_LOCATION)

    tip_rack = ctx.deck[_TIP_RACK_LOCATION]
    well_plate = ctx.deck[_WELL_PLATE_LOCATION]
    p50 = ctx.load_instrument("p50_single_gen3", types.Mount.LEFT, [tip_rack])

    p50.pick_up_tip()
    p50.aspirate(10, well_plate.wells()[0])
    p50.dispense(10, well_plate.wells()[1])
    p50.drop_tip()
```

### OT-2 / FF on

The same protocol as above for an OT-2 using the engine core

```python
from opentrons import protocol_api, types

metadata = {
    "protocolName": "Deck Testing",
    "author": "Mike Cousins <mike@opentrons.com>",
}

requirements = {
    "apiLevel": "2.13",
    "robotType": "OT-2"
}

_TIP_RACK_LOCATION = "9"
_WELL_PLATE_LOCATION = "5"

def run(ctx: protocol_api.ProtocolContext) -> None:
    ctx.load_labware("opentrons_96_tiprack_300ul", _TIP_RACK_LOCATION)
    ctx.load_labware("corning_96_wellplate_360ul_flat", _WELL_PLATE_LOCATION)

    tip_rack = ctx.deck[_TIP_RACK_LOCATION]
    well_plate = ctx.deck[_WELL_PLATE_LOCATION]
    p300 = ctx.load_instrument("p300_single_gen2", types.Mount.RIGHT, [tip_rack])

    p300.pick_up_tip()
    p300.aspirate(10, well_plate.wells()[0])
    p300.dispense(10, well_plate.wells()[1])
    p300.drop_tip()
```

### OT-2 / FF off

This protocol uses other Deck APIs to validate that with the FF off, the old Deck class remains usable.

```python
from opentrons import protocol_api, types

metadata = {
    "protocolName": "Deck Testing",
    "author": "Mike Cousins <mike@opentrons.com>",
}

requirements = {
    "apiLevel": "2.13",
    "robotType": "OT-2"
}

_TIP_RACK_LOCATION = "9"

def run(ctx: protocol_api.ProtocolContext) -> None:
    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", _TIP_RACK_LOCATION)
    p300 = ctx.load_instrument("p300_single_gen2", types.Mount.RIGHT, [tip_rack])

    p300.pick_up_tip()
    p300.move_to(ctx.deck.position_for("5"))
    p300.drop_tip()
```
