### PR TITLE
feat(engine): remove pipetting restrictions around H/S on OT3

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
@@ -19,52 +19,6 @@ from ...hardware_control.modules import HeaterShaker as HardwareHeaterShaker
 from ...drivers.types import HeaterShakerLabwareLatchStatus
 
 
-def raise_if_movement_restricted(
-    hs_movement_restrictors: List[HeaterShakerMovementRestrictors],
-    destination_slot: int,
-    is_multi_channel: bool,
-    destination_is_tip_rack: bool,
-) -> None:
-    """Flag restricted movement around/to a Heater-Shaker."""
-    for hs_movement_restrictor in hs_movement_restrictors:
-        dest_east_west = destination_slot in get_east_west_slots(
-            hs_movement_restrictor.deck_slot
-        )
-        dest_north_south = destination_slot in get_north_south_slots(
-            hs_movement_restrictor.deck_slot
-        )
-        dest_heater_shaker = destination_slot == hs_movement_restrictor.deck_slot
-
-        # If Heater-Shaker is running, can't move to or around it
-        if (
-            any([dest_east_west, dest_north_south, dest_heater_shaker])
-            and hs_movement_restrictor.plate_shaking
-        ):
-            raise PipetteMovementRestrictedByHeaterShakerError(
-                "Cannot move pipette to Heater-Shaker or adjacent slot while module is shaking"
-            )
-
-        # If Heater-Shaker's latch is open, can't move to it or east and west of it
-        elif (
-            dest_east_west or dest_heater_shaker
-        ) and not hs_movement_restrictor.latch_closed:
-            raise PipetteMovementRestrictedByHeaterShakerError(
-                "Cannot move pipette to Heater-Shaker or adjacent slot to the left or right while labware latch is open"
-            )
-
-        elif is_multi_channel:
-            # Can't go to east/west slot under any circumstances if pipette is multi-channel
-            if dest_east_west:
-                raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move 8-Channel pipette to slot adjacent to the left or right of Heater-Shaker"
-                )
-            # Can only go north/south if the labware is a tip rack
-            elif dest_north_south and not destination_is_tip_rack:
-                raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move 8-Channel pipette to non-tip-rack labware directly in front of or behind a Heater-Shaker"
-                )
-
-
 class HeaterShakerMovementFlagger:
     """A helper for flagging unsafe movements to a Heater-Shaker."""
 
@@ -175,6 +129,52 @@ class HeaterShakerMovementFlagger:
             ):
                 return module
         return None
+
+    def raise_if_movement_restricted(
+        self,
+        hs_movement_restrictors: List[HeaterShakerMovementRestrictors],
+        destination_slot: int,
+        is_multi_channel: bool,
+        destination_is_tip_rack: bool,
+    ) -> None:
+        """Flag restricted movement around/to a Heater-Shaker."""
+        for hs_movement_restrictor in hs_movement_restrictors:
+            dest_east_west = destination_slot in get_east_west_slots(
+                hs_movement_restrictor.deck_slot
+            )
+            dest_north_south = destination_slot in get_north_south_slots(
+                hs_movement_restrictor.deck_slot
+            )
+            dest_heater_shaker = destination_slot == hs_movement_restrictor.deck_slot
+
+            # If Heater-Shaker is running, can't move to or around it
+            if (
+                any([dest_east_west, dest_north_south, dest_heater_shaker])
+                and hs_movement_restrictor.plate_shaking
+            ):
+                raise PipetteMovementRestrictedByHeaterShakerError(
+                    "Cannot move pipette to Heater-Shaker or adjacent slot while module is shaking"
+                )
+
+            # If Heater-Shaker's latch is open, can't move to it or east and west of it
+            elif (
+                dest_east_west or dest_heater_shaker
+            ) and not hs_movement_restrictor.latch_closed:
+                raise PipetteMovementRestrictedByHeaterShakerError(
+                    "Cannot move pipette to Heater-Shaker or adjacent slot to the left or right while labware latch is open"
+                )
+
+            elif is_multi_channel:
+                # Can't go to east/west slot under any circumstances if pipette is multi-channel
+                if dest_east_west:
+                    raise PipetteMovementRestrictedByHeaterShakerError(
+                        "Cannot move 8-Channel pipette to slot adjacent to the left or right of Heater-Shaker"
+                    )
+                # Can only go north/south if the labware is a tip rack
+                elif dest_north_south and not destination_is_tip_rack:
+                    raise PipetteMovementRestrictedByHeaterShakerError(
+                        "Cannot move 8-Channel pipette to non-tip-rack labware directly in front of or behind a Heater-Shaker"
+                    )
 
     class _HardwareHeaterShakerMissingError(Exception):
         pass

--- a/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
@@ -161,11 +161,16 @@ class HeaterShakerMovementFlagger:
                 dest_east_west or dest_heater_shaker
             ) and not hs_movement_restrictor.latch_closed:
                 raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move pipette to Heater-Shaker or adjacent slot to the left or right while labware latch is open"
+                    "Cannot move pipette to Heater-Shaker or adjacent slot to the left "
+                    "or right while labware latch is open."
                 )
 
-            elif is_multi_channel:
-                # Can't go to east/west slot under any circumstances if pipette is multi-channel
+            elif (
+                is_multi_channel
+                and self._state_store.config.robot_type == "OT-2 Standard"
+            ):
+                # Can't go to east/west slot under any circumstances on OT-2
+                # if pipette is multi-channel
                 if dest_east_west:
                     raise PipetteMovementRestrictedByHeaterShakerError(
                         "Cannot move 8-Channel pipette to slot adjacent to the left or right of Heater-Shaker"

--- a/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
@@ -157,13 +157,19 @@ class HeaterShakerMovementFlagger:
                 )
 
             # If Heater-Shaker's latch is open, can't move to it or east and west of it
-            elif (
-                dest_east_west or dest_heater_shaker
-            ) and not hs_movement_restrictor.latch_closed:
-                raise PipetteMovementRestrictedByHeaterShakerError(
-                    "Cannot move pipette to Heater-Shaker or adjacent slot to the left "
-                    "or right while labware latch is open."
-                )
+            elif not hs_movement_restrictor.latch_closed:
+                if dest_heater_shaker:
+                    raise PipetteMovementRestrictedByHeaterShakerError(
+                        "Cannot move pipette to Heater-Shaker while labware latch is open."
+                    )
+                if (
+                    dest_east_west
+                    and self._state_store.config.robot_type == "OT-2 Standard"
+                ):
+                    raise PipetteMovementRestrictedByHeaterShakerError(
+                        "Cannot move pipette to left or right of Heater-Shaker "
+                        "while labware latch is open."
+                    )
 
             elif (
                 is_multi_channel

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -17,7 +17,7 @@ from ..state import StateStore, CurrentWell
 from ..errors import MustHomeError
 from ..resources import ModelUtils
 from .thermocycler_movement_flagger import ThermocyclerMovementFlagger
-from . import heater_shaker_movement_flagger
+from .heater_shaker_movement_flagger import HeaterShakerMovementFlagger
 
 
 MOTOR_AXIS_TO_HARDWARE_AXIS: Dict[MotorAxis, HardwareAxis] = {
@@ -58,6 +58,7 @@ class MovementHandler:
         hardware_api: HardwareControlAPI,
         model_utils: Optional[ModelUtils] = None,
         thermocycler_movement_flagger: Optional[ThermocyclerMovementFlagger] = None,
+        heater_shaker_movement_flagger: Optional[HeaterShakerMovementFlagger] = None,
     ) -> None:
         """Initialize a MovementHandler instance."""
         self._state_store = state_store
@@ -66,6 +67,12 @@ class MovementHandler:
         self._tc_movement_flagger = (
             thermocycler_movement_flagger
             or ThermocyclerMovementFlagger(
+                state_store=self._state_store, hardware_api=self._hardware_api
+            )
+        )
+        self._hs_movement_flagger = (
+            heater_shaker_movement_flagger
+            or HeaterShakerMovementFlagger(
                 state_store=self._state_store, hardware_api=self._hardware_api
             )
         )
@@ -99,7 +106,7 @@ class MovementHandler:
             attached_pipettes=self._hardware_api.attached_instruments,
         )
 
-        heater_shaker_movement_flagger.raise_if_movement_restricted(
+        self._hs_movement_flagger.raise_if_movement_restricted(
             hs_movement_restrictors=hs_movement_restrictors,
             destination_slot=dest_slot_int,
             is_multi_channel=hw_pipette.config["channels"] > 1,

--- a/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
@@ -22,7 +22,6 @@ from opentrons.protocol_engine.errors import (
     WrongModuleTypeError,
 )
 from opentrons.protocol_engine.execution.heater_shaker_movement_flagger import (
-    raise_if_movement_restricted,
     HeaterShakerMovementFlagger,
 )
 from opentrons.protocol_engine.state import StateStore
@@ -94,6 +93,7 @@ def subject(
     ],
 )
 async def test_raises_when_moving_to_restricted_slots_while_shaking(
+    subject: HeaterShakerMovementFlagger,
     destination_slot: int,
     expected_raise: ContextManager[Any],
 ) -> None:
@@ -105,7 +105,7 @@ async def test_raises_when_moving_to_restricted_slots_while_shaking(
     ]
 
     with expected_raise:
-        raise_if_movement_restricted(
+        subject.raise_if_movement_restricted(
             hs_movement_restrictors=heater_shaker_data,
             destination_slot=destination_slot,
             is_multi_channel=False,
@@ -134,6 +134,7 @@ async def test_raises_when_moving_to_restricted_slots_while_shaking(
     ],
 )
 async def test_raises_when_moving_to_restricted_slots_while_latch_open(
+    subject: HeaterShakerMovementFlagger,
     destination_slot: int,
     expected_raise: ContextManager[Any],
 ) -> None:
@@ -145,7 +146,7 @@ async def test_raises_when_moving_to_restricted_slots_while_latch_open(
     ]
 
     with expected_raise:
-        raise_if_movement_restricted(
+        subject.raise_if_movement_restricted(
             hs_movement_restrictors=heater_shaker_data,
             destination_slot=destination_slot,
             is_multi_channel=False,
@@ -193,6 +194,7 @@ async def test_raises_when_moving_to_restricted_slots_while_latch_open(
     ],
 )
 async def test_raises_on_restricted_movement_with_multi_channel(
+    subject: HeaterShakerMovementFlagger,
     destination_slot: int,
     is_tiprack: bool,
     expected_raise: ContextManager[Any],
@@ -205,7 +207,7 @@ async def test_raises_on_restricted_movement_with_multi_channel(
     ]
 
     with expected_raise:
-        raise_if_movement_restricted(
+        subject.raise_if_movement_restricted(
             hs_movement_restrictors=heater_shaker_data,
             destination_slot=destination_slot,
             is_multi_channel=True,
@@ -225,6 +227,7 @@ async def test_raises_on_restricted_movement_with_multi_channel(
     ],
 )
 async def test_does_not_raise_when_idle_and_latch_closed(
+    subject: HeaterShakerMovementFlagger,
     destination_slot: int,
 ) -> None:
     """It should not raise if single channel pipette moves anywhere near heater-shaker when idle and latch closed."""
@@ -235,7 +238,7 @@ async def test_does_not_raise_when_idle_and_latch_closed(
     ]
 
     with does_not_raise():
-        raise_if_movement_restricted(
+        subject.raise_if_movement_restricted(
             hs_movement_restrictors=heater_shaker_data,
             destination_slot=destination_slot,
             is_multi_channel=False,

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -29,7 +29,6 @@ from opentrons.protocol_engine.state import (
     CurrentWell,
     HardwarePipette,
 )
-from opentrons.protocol_engine.execution import heater_shaker_movement_flagger
 from opentrons.protocol_engine.execution.movement import (
     MovementHandler,
     MoveRelativeData,
@@ -38,21 +37,10 @@ from opentrons.protocol_engine.execution.movement import (
 from opentrons.protocol_engine.execution.thermocycler_movement_flagger import (
     ThermocyclerMovementFlagger,
 )
-
+from opentrons.protocol_engine.execution.heater_shaker_movement_flagger import (
+    HeaterShakerMovementFlagger,
+)
 from .mock_defs import MockPipettes
-
-
-@pytest.fixture(autouse=True)
-def mock_raise_heater_shaker_movement_restriction(
-    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Mock out raise heater-shaker movement restriction."""
-    mock_raise = decoy.mock(
-        func=heater_shaker_movement_flagger.raise_if_movement_restricted
-    )
-    monkeypatch.setattr(
-        heater_shaker_movement_flagger, "raise_if_movement_restricted", mock_raise
-    )
 
 
 @pytest.fixture
@@ -82,16 +70,24 @@ def thermocycler_movement_flagger(decoy: Decoy) -> ThermocyclerMovementFlagger:
 
 
 @pytest.fixture
+def heater_shaker_movement_flagger(decoy: Decoy) -> HeaterShakerMovementFlagger:
+    """Get a mock in the shape of a HeaterShakerMovementFlagger."""
+    return decoy.mock(cls=HeaterShakerMovementFlagger)
+
+
+@pytest.fixture
 def subject(
     state_store: StateStore,
     hardware_api: HardwareAPI,
     thermocycler_movement_flagger: ThermocyclerMovementFlagger,
+    heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
 ) -> MovementHandler:
     """Create a PipettingHandler with its dependencies mocked out."""
     return MovementHandler(
         state_store=state_store,
         hardware_api=hardware_api,
         thermocycler_movement_flagger=thermocycler_movement_flagger,
+        heater_shaker_movement_flagger=heater_shaker_movement_flagger,
     )
 
 
@@ -100,6 +96,7 @@ async def test_move_to_well(
     state_store: StateStore,
     hardware_api: HardwareAPI,
     thermocycler_movement_flagger: ThermocyclerMovementFlagger,
+    heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
     mock_hw_pipettes: MockPipettes,
     subject: MovementHandler,
 ) -> None:
@@ -216,6 +213,7 @@ async def test_move_to_well_from_starting_location(
     state_store: StateStore,
     hardware_api: HardwareAPI,
     thermocycler_movement_flagger: ThermocyclerMovementFlagger,
+    heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
     mock_hw_pipettes: MockPipettes,
     subject: MovementHandler,
 ) -> None:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
RCORE-446

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Removes some pipetting restrictions around H/S on OT3 so that now we'll be able to:
- pipette to any slot around h/s with a multi-channel without any restrictions
- pipette to any slot around h/s when the h/s labware latch is open.

These restrictions will still apply:
- no pipetting to labware *on* the h/s when labware latch is open
- no pipetting to any slots around the h/s when h/s is shaking

# Changelog

- moved `raise_if_movement_restricted()` into the `HeaterShakerMovementFlagger` class
- added gating for raising pipetting errors based on robot type

# Review requests

- It's a pretty simple change. Main thing to verify would be that the h/s latches don't get in the way of pipetting to left/right of h/s with any pipettes on the OT3.
- The usual- code makes sense and tests are updated correctly

# Risk assessment

Low. Only affects OT3 in a small and contained way
