### PR TITLE
refactor(engine): work around lack of instrument caching in hardware simulator

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -171,6 +171,19 @@ class EquipmentHandler:
             )
         }
 
+        # TODO(mc, 2022-12-09): putting the other pipette in the cache request
+        # is only to support protocol analysis, since the hardware simulator
+        # does not cache requested virtual instruments. Remove per
+        # https://opentrons.atlassian.net/browse/RLIQ-258
+        other_mount = mount.other_mount()
+        other_pipette = self._state_store.pipettes.get_by_mount(other_mount)
+        if other_pipette is not None:
+            cache_request[other_mount.to_hw_mount()] = (
+                other_pipette.pipetteName.value
+                if isinstance(other_pipette.pipetteName, PipetteNameType)
+                else other_pipette.pipetteName
+            )
+
         # TODO(mc, 2020-10-18): calling `cache_instruments` mirrors the
         # behavior of protocol_context.load_instrument, and is used here as a
         # pipette existence check

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -585,60 +585,6 @@ async def test_load_pipette_uses_provided_id(
     )
 
 
-async def test_load_pipette_checks_existence_with_already_loaded(
-    decoy: Decoy,
-    model_utils: ModelUtils,
-    state_store: StateStore,
-    hardware_api: HardwareControlAPI,
-    action_dispatcher: ActionDispatcher,
-    subject: EquipmentHandler,
-) -> None:
-    """Loading a pipette should cache with pipettes already attached."""
-    decoy.when(model_utils.generate_id()).then_return("unique-id")
-
-    decoy.when(state_store.pipettes.get_by_mount(MountType.RIGHT)).then_return(
-        LoadedPipette(
-            id="pipette-id",
-            mount=MountType.RIGHT,
-            pipetteName=PipetteNameType.P300_MULTI_GEN2,
-        )
-    )
-
-    decoy.when(hardware_api.get_attached_instrument(mount=HwMount.LEFT)).then_return(
-        cast(
-            PipetteDict,
-            {
-                "model": "pipette-model",
-                "min_volume": 1.23,
-                "max_volume": 4.56,
-                "channels": 7,
-            },
-        )
-    )
-
-    result = await subject.load_pipette(
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-        pipette_id=None,
-    )
-
-    assert result == LoadedPipetteData(pipette_id="unique-id")
-
-    decoy.verify(
-        await hardware_api.cache_instruments(
-            {HwMount.LEFT: PipetteNameType.P300_SINGLE.value}
-        ),
-        action_dispatcher.dispatch(
-            AddPipetteConfigAction(
-                pipette_id="unique-id",
-                static_config=StaticPipetteConfig(
-                    model="pipette-model", min_volume=1.23, max_volume=4.56, channels=7
-                ),
-            )
-        ),
-    )
-
-
 async def test_load_pipette_raises_if_pipette_not_attached(
     decoy: Decoy,
     model_utils: ModelUtils,


### PR DESCRIPTION
## Overview

In #11802 we removed what looked to be an unnecessary part of a Hardware API call we make during the `loadPipette` call. It turns out, it was only unnecessary for the actual Hardware API. The removal broke our interaction with the Hardware API simulator, which we still rely on for protocol analysis, 

Namely, when one calls `hwapi.cache_instruments(requirements_dict)`, the regular HW API performs differently than the HW API simulators:

- Actual: All pipettes are refreshed by querying hardware, spec'd requirements are checked against requirements dict, if present
- Simulator: Simulator assumes that the pipettes in `requirements_dict` are the **only** pipettes attached

This manifested in protocol analyses on the engine thinking that only one pipette was attached at a time, because a subsequent call to `cache_instruments` would only include the pipette spec'd in the command, leading to any previously loaded pipette being erased from the Hardware API's memory.

## Changelog

Given a choice between fixing the simulators or working around the issue in the Protocol Engine (which is what we were doing before), we elected to go with the latter because:

- Messing with the simulators felt risky
- We intend to move protocol analysis off the hardware simulator per RLIQ-258

## Review requests

Simple verification protocol. Run as follows:

```
cd opentrons/api
pipenv shell
export OT_API_FF_enableProtocolEnginePAPICore=1
export OT_API_FF_enableOT3HardwareController=1
python -m opentrons.cli analyze --json-output=/dev/null -- /path/to/pipette_testing.ot3.py
```

Protocol

```python
# /path/to/pipette_testing.ot3.py

from opentrons import protocol_api, types

requirements = {
    "apiLevel": "2.13",
    "robotType": "OT-3"
}

def run(ctx: protocol_api.ProtocolContext) -> None:
    p1000 = ctx.load_instrument("p1000_multi_gen3", types.Mount.LEFT, [])
    p50 = ctx.load_instrument("p50_single_gen3", types.Mount.RIGHT, [])

    print("P1000 multi HW state", p1000.hw_pipette)
    print("P50 single HW state", p50.hw_pipette)
```

Bad output (`edge`)

```shell
P1000 multi HW state {}
P50 single HW state {'name': 'p50_single_gen3', 'min_volume': 1, 'max_volume': 50, 'channels': 1, 'aspirate_flow_rate': 7.85, 'dispense_flow_rate': 7.85, 'pipette_id': None, 'current_volume': 0.0, 'display_name': 'P50 Single-Channel GEN3', 'tip_length': 0.0, 'model': 'p50_single_v3.0', 'blow_out_flow_rate': 7.85, 'working_volume': 50, 'tip_overlap': {'default': 10.5, 'opentrons/opentrons_96_tiprack_50ul/1': 10.5}, 'available_volume': 50.0, 'return_tip_height': 0.83, 'default_aspirate_flow_rates': {'2.0': 7.85}, 'default_blow_out_flow_rates': {'2.0': 7.85}, 'default_dispense_flow_rates': {'2.0': 7.85}, 'back_compat_names': [], 'has_tip': False, 'aspirate_speed': 10.539742, 'dispense_speed': 10.539742, 'blow_out_speed': 10.539742, 'ready_to_aspirate': False, 'default_blow_out_speeds': {'2.0': 10.539742}, 'default_dispense_speeds': {'2.0': 10.539742}, 'default_aspirate_speeds': {'2.0': 10.539742}}
```

Good output (`RLIQ-258_fix-simulator-pipette-cache`)

```shell
P1000 multi HW state {'name': 'p1000_multi_gen3', 'min_volume': 1, 'max_volume': 1000, 'channels': 8, 'aspirate_flow_rate': 159.04, 'dispense_flow_rate': 159.04, 'pipette_id': None, 'current_volume': 0.0, 'display_name': 'P1000 8-Channel GEN3', 'tip_length': 0.0, 'model': 'p1000_multi_v3.0', 'blow_out_flow_rate': 78.52, 'working_volume': 1000, 'tip_overlap': {'default': 10.5, 'opentrons/opentrons_ot3_96_tiprack_1000ul/1': 10.5, 'opentrons/opentrons_ot3_96_tiprack_200ul/1': 10.5}, 'available_volume': 1000.0, 'return_tip_height': 0.83, 'default_aspirate_flow_rates': {'2.0': 159.04, '2.6': 159.04}, 'default_blow_out_flow_rates': {'2.0': 78.52}, 'default_dispense_flow_rates': {'2.0': 159.04}, 'back_compat_names': [], 'has_tip': False, 'aspirate_speed': 10.287718, 'dispense_speed': 10.287718, 'blow_out_speed': 5.079173, 'ready_to_aspirate': False, 'default_blow_out_speeds': {'2.0': 10.287718, '2.6': 10.287718}, 'default_dispense_speeds': {'2.0': 10.287718}, 'default_aspirate_speeds': {'2.0': 10.287718, '2.6': 10.287718}}
P50 single HW state {'name': 'p50_single_gen3', 'min_volume': 1, 'max_volume': 50, 'channels': 1, 'aspirate_flow_rate': 7.85, 'dispense_flow_rate': 7.85, 'pipette_id': None, 'current_volume': 0.0, 'display_name': 'P50 Single-Channel GEN3', 'tip_length': 0.0, 'model': 'p50_single_v3.0', 'blow_out_flow_rate': 7.85, 'working_volume': 50, 'tip_overlap': {'default': 10.5, 'opentrons/opentrons_96_tiprack_50ul/1': 10.5}, 'available_volume': 50.0, 'return_tip_height': 0.83, 'default_aspirate_flow_rates': {'2.0': 7.85}, 'default_blow_out_flow_rates': {'2.0': 7.85}, 'default_dispense_flow_rates': {'2.0': 7.85}, 'back_compat_names': [], 'has_tip': False, 'aspirate_speed': 10.539742, 'dispense_speed': 10.539742, 'blow_out_speed': 10.539742, 'ready_to_aspirate': False, 'default_blow_out_speeds': {'2.0': 10.539742}, 'default_dispense_speeds': {'2.0': 10.539742}, 'default_aspirate_speeds': {'2.0': 10.539742}}
```

## Risk assessment

Low