### PR TITLE
fix(app): display correct thermocycler slots per robot

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -26,7 +26,8 @@ import {
   LabwareDefinition2,
   MAGNETIC_MODULE_TYPE,
   ModuleType,
-  TC_MODULE_LOCATION,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
@@ -55,6 +56,7 @@ const LabwareRow = styled.div`
 interface LabwareListItemProps extends LabwareSetupItem {
   attachedModuleInfo: { [moduleId: string]: ModuleRenderInfoForProtocol }
   extraAttentionModules: ModuleTypesThatRequireExtraAttention[]
+  isOt3: boolean
 }
 
 export function LabwareListItem(
@@ -68,6 +70,7 @@ export function LabwareListItem(
     moduleModel,
     moduleLocation,
     extraAttentionModules,
+    isOt3,
   } = props
   const { t } = useTranslation('protocol_setup')
   const [
@@ -104,7 +107,7 @@ export function LabwareListItem(
     )
     let moduleSlotName = moduleLocation.slotName
     if (moduleType === THERMOCYCLER_MODULE_TYPE) {
-      moduleSlotName = TC_MODULE_LOCATION
+      moduleSlotName = isOt3 ? TC_MODULE_LOCATION_OT3 : TC_MODULE_LOCATION_OT2
     }
     slotInfo = t('module_slot_location', {
       slotName: moduleSlotName,

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/OffDeckLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/OffDeckLabwareList.tsx
@@ -7,11 +7,12 @@ import type { LabwareSetupItem } from './types'
 
 interface OffDeckLabwareListProps {
   labwareItems: LabwareSetupItem[]
+  isOt3: boolean
 }
 export function OffDeckLabwareList(
   props: OffDeckLabwareListProps
 ): JSX.Element | null {
-  const { labwareItems } = props
+  const { labwareItems, isOt3 } = props
   const { t } = useTranslation('protocol_setup')
   if (labwareItems.length < 1) return null
   return (
@@ -30,6 +31,7 @@ export function OffDeckLabwareList(
           attachedModuleInfo={{}}
           extraAttentionModules={[]}
           {...labwareItem}
+          isOt3={isOt3}
         />
       ))}
     </>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
@@ -26,11 +26,12 @@ interface SetupLabwareListProps {
   attachedModuleInfo: { [moduleId: string]: ModuleRenderInfoForProtocol }
   commands: RunTimeCommand[]
   extraAttentionModules: ModuleTypesThatRequireExtraAttention[]
+  isOt3: boolean
 }
 export function SetupLabwareList(
   props: SetupLabwareListProps
 ): JSX.Element | null {
-  const { attachedModuleInfo, commands, extraAttentionModules } = props
+  const { attachedModuleInfo, commands, extraAttentionModules, isOt3 } = props
   const { t } = useTranslation('protocol_setup')
   const { offDeckItems, onDeckItems } = getLabwareSetupItemGroups(commands)
 
@@ -54,9 +55,10 @@ export function SetupLabwareList(
           attachedModuleInfo={attachedModuleInfo}
           extraAttentionModules={extraAttentionModules}
           {...labwareItem}
+          isOt3={isOt3}
         />
       ))}
-      <OffDeckLabwareList labwareItems={offDeckItems} />
+      <OffDeckLabwareList labwareItems={offDeckItems} isOt3={isOt3} />
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -119,7 +119,10 @@ export function SetupLabwareMap({
             )}
           </RobotWorkSpace>
         </Box>
-        <OffDeckLabwareList labwareItems={offDeckItems} />
+        <OffDeckLabwareList
+          labwareItems={offDeckItems}
+          isOt3={robotType === 'OT-3 Standard'}
+        />
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -100,7 +100,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
-      isOt3: false
+      isOt3: false,
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7,8,10,11, Thermocycler Module GEN1')
@@ -126,7 +126,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
-      isOt3: true
+      isOt3: true,
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7+10, Thermocycler Module GEN1')
@@ -154,7 +154,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
-      isOt3: false
+      isOt3: false,
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7, Magnetic Module GEN1')
@@ -185,7 +185,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
-      isOt3: false
+      isOt3: false,
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7, Temperature Module GEN1')
@@ -213,7 +213,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
-      isOt3: false
+      isOt3: false,
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7, Heater-Shaker Module GEN1')
@@ -242,7 +242,7 @@ describe('LabwareListItem', () => {
       moduleLocation: null,
       extraAttentionModules: [],
       attachedModuleInfo: {},
-      isOt3: false
+      isOt3: false,
     })
     getByText('Mock Labware Definition')
   })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -84,7 +84,7 @@ describe('LabwareListItem', () => {
     } as any)
   })
 
-  it('renders the correct info for a thermocycler, clicking on secure labware instructions opens the modal', () => {
+  it('renders the correct info for a thermocycler (OT2), clicking on secure labware instructions opens the modal', () => {
     const { getByText } = render({
       nickName: mockNickName,
       definition: mockLabwareDef,
@@ -100,13 +100,36 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
+      isOt3: false
     })
     getByText('Mock Labware Definition')
-    getByText('Slot 7+10, Thermocycler Module GEN1')
+    getByText('Slot 7,8,10,11, Thermocycler Module GEN1')
     const button = getByText('Secure labware instructions')
     fireEvent.click(button)
     getByText('mock secure labware modal')
     getByText('nickName')
+  })
+
+  it('renders the correct info for a thermocycler (OT3)', () => {
+    const { getByText } = render({
+      nickName: mockNickName,
+      definition: mockLabwareDef,
+      initialLocation: { moduleId: mockModuleId },
+      moduleModel: 'thermocyclerModuleV1' as ModuleModel,
+      moduleLocation: mockModuleSlot,
+      extraAttentionModules: ['thermocyclerModuleType'],
+      attachedModuleInfo: {
+        [mockModuleId]: ({
+          moduleId: 'thermocyclerModuleId',
+          attachedModuleMatch: (mockThermocycler as any) as AttachedModule,
+          moduleDef: mockThermocyclerModuleDefinition as any,
+          ...mockAttachedModuleInfo,
+        } as any) as ModuleRenderInfoForProtocol,
+      },
+      isOt3: true
+    })
+    getByText('Mock Labware Definition')
+    getByText('Slot 7+10, Thermocycler Module GEN1')
   })
 
   it('renders the correct info for a labware on top of a magnetic module', () => {
@@ -131,6 +154,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
+      isOt3: false
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7, Magnetic Module GEN1')
@@ -140,7 +164,7 @@ describe('LabwareListItem', () => {
     getByText('nickName')
   })
 
-  it('renders the correct info for a labware on top of a temperature module ', () => {
+  it('renders the correct info for a labware on top of a temperature module', () => {
     const { getByText } = render({
       nickName: mockNickName,
       definition: mockLabwareDef,
@@ -161,6 +185,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
+      isOt3: false
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7, Temperature Module GEN1')
@@ -188,6 +213,7 @@ describe('LabwareListItem', () => {
           ...mockAttachedModuleInfo,
         } as any) as ModuleRenderInfoForProtocol,
       },
+      isOt3: false
     })
     getByText('Mock Labware Definition')
     getByText('Slot 7, Heater-Shaker Module GEN1')
@@ -216,6 +242,7 @@ describe('LabwareListItem', () => {
       moduleLocation: null,
       extraAttentionModules: [],
       attachedModuleInfo: {},
+      isOt3: false
     })
     getByText('Mock Labware Definition')
   })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
@@ -30,6 +30,7 @@ describe('OffDeckLabwareList', () => {
   it('renders null if labware items is null', () => {
     const { container } = render({
       labwareItems: [],
+      isOt3: false,
     })
     expect(container.firstChild).toBeNull()
   })
@@ -44,6 +45,7 @@ describe('OffDeckLabwareList', () => {
           moduleLocation: null,
         },
       ],
+      isOt3: false,
     })
     getByText('Additional Off-Deck Labware')
     getByText('mock labware list item')

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareList.test.tsx
@@ -178,6 +178,7 @@ describe('SetupLabwareList', () => {
         attachedModuleMatch: null,
         moduleId: 'moduleId',
       } as any,
+      isOt3: false,
     })
 
     getAllByText('mock labware list item')
@@ -195,6 +196,7 @@ describe('SetupLabwareList', () => {
         attachedModuleMatch: null,
         moduleId: 'moduleId',
       } as any,
+      isOt3: false,
     })
     expect(queryByText('Additional Off-Deck Labware')).not.toBeInTheDocument()
   })
@@ -204,6 +206,7 @@ describe('SetupLabwareList', () => {
       commands: mockOffDeckCommands,
       extraAttentionModules: [],
       attachedModuleInfo: {} as any,
+      isOt3: false,
     })
     getByText('Additional Off-Deck Labware')
     getAllByText('mock labware list item')

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/index.tsx
@@ -14,6 +14,7 @@ import { getModuleTypesThatRequireExtraAttention } from '../../../ProtocolSetup/
 import { ReapplyOffsetsModal } from '../../../ReapplyOffsetsModal'
 import { useCurrentRun } from '../../../ProtocolUpload/hooks'
 import {
+  useIsOT3,
   useModuleRenderInfoForProtocolById,
   useProtocolDetailsForRun,
   useStoredProtocolAnalysis,
@@ -45,6 +46,7 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
     t('list_view'),
     t('map_view')
   )
+  const isOt3 = useIsOT3(robotName)
   /**
    * This component's usage of the reapply offsets modal can be removed
    * along with the enableManualDeckStateMod feature flag.
@@ -85,6 +87,7 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
             attachedModuleInfo={moduleRenderInfoById}
             commands={protocolData?.commands ?? []}
             extraAttentionModules={moduleTypesThatRequireExtraAttention}
+            isOt3={isOt3}
           />
         ) : (
           <SetupLabwareMap

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -20,7 +20,8 @@ import {
   getModuleType,
   HEATERSHAKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_V1,
-  TC_MODULE_LOCATION,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
 } from '@opentrons/shared-data'
 import { Banner } from '../../../../atoms/Banner'
 import { StyledText } from '../../../../atoms/text'
@@ -29,6 +30,7 @@ import { UnMatchedModuleWarning } from '../../../ProtocolSetup/RunSetupCard/Modu
 import { MultipleModulesModal } from '../../../ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal'
 import {
   ModuleRenderInfoForProtocol,
+  useIsOT3,
   useModuleRenderInfoForProtocolById,
   useUnmatchedModulesForProtocol,
 } from '../../hooks'
@@ -55,6 +57,8 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
     missingModuleIds,
     remainingAttachedModules,
   } = useUnmatchedModulesForProtocol(robotName, runId)
+
+  const isOt3 = useIsOT3(robotName)
 
   const [
     showMultipleModulesModal,
@@ -162,6 +166,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
                     ? moduleRenderInfoForProtocolById[moduleId]
                     : null
                 }
+                isOt3={isOt3}
               />
             )
           }
@@ -177,6 +182,7 @@ interface ModulesListItemProps {
   location: string
   attachedModuleMatch: AttachedModule | null
   heaterShakerModuleFromProtocol: ModuleRenderInfoForProtocol | null
+  isOt3: boolean
 }
 
 export const ModulesListItem = ({
@@ -185,6 +191,7 @@ export const ModulesListItem = ({
   location,
   attachedModuleMatch,
   heaterShakerModuleFromProtocol,
+  isOt3,
 }: ModulesListItemProps): JSX.Element => {
   const { t } = useTranslation('protocol_setup')
   const moduleConnectionStatus =
@@ -267,7 +274,9 @@ export const ModulesListItem = ({
           {t('slot_location', {
             slotName:
               getModuleType(moduleModel) === 'thermocyclerModuleType'
-                ? TC_MODULE_LOCATION
+                ? isOt3
+                  ? TC_MODULE_LOCATION_OT3
+                  : TC_MODULE_LOCATION_OT2
                 : location,
           })}
         </StyledText>

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
@@ -14,6 +14,7 @@ import {
 import { MultipleModulesModal } from '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal'
 import { UnMatchedModuleWarning } from '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/UnMatchedModuleWarning'
 import {
+  useIsOT3,
   useModuleRenderInfoForProtocolById,
   useRunHasStarted,
   useUnmatchedModulesForProtocol,
@@ -31,6 +32,7 @@ jest.mock('../../../HeaterShakerWizard')
 jest.mock(
   '../../../../ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal'
 )
+const mockUseIsOt3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUseModuleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById as jest.MockedFunction<
   typeof useModuleRenderInfoForProtocolById
 >
@@ -165,7 +167,7 @@ describe('SetupModulesList', () => {
     })
   })
 
-  it('should render a thermocycler module that is connected', () => {
+  it('should render a thermocycler module that is connected, OT2', () => {
     when(mockUseUnmatchedModulesForProtocol)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({
@@ -186,6 +188,36 @@ describe('SetupModulesList', () => {
         attachedModuleMatch: mockThermocycler,
       },
     } as any)
+    mockUseIsOt3.mockReturnValue(false)
+
+    const { getByText } = render(props)
+    getByText('Thermocycler Module')
+    getByText('Slot 7,8,10,11')
+    getByText('Connected')
+  })
+
+  it('should render a thermocycler module that is connected, OT3', () => {
+    when(mockUseUnmatchedModulesForProtocol)
+      .calledWith(ROBOT_NAME, RUN_ID)
+      .mockReturnValue({
+        missingModuleIds: [],
+        remainingAttachedModules: [],
+      })
+    mockUseModuleRenderInfoForProtocolById.mockReturnValue({
+      [mockTCModule.moduleId]: {
+        moduleId: mockTCModule.moduleId,
+        x: MOCK_TC_COORDS[0],
+        y: MOCK_TC_COORDS[1],
+        z: MOCK_TC_COORDS[2],
+        moduleDef: mockTCModule as any,
+        nestedLabwareDef: null,
+        nestedLabwareId: null,
+        protocolLoadOrder: 0,
+        slotName: '7',
+        attachedModuleMatch: mockThermocycler,
+      },
+    } as any)
+    mockUseIsOt3.mockReturnValue(true)
 
     const { getByText } = render(props)
     getByText('Thermocycler Module')

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -16,8 +16,6 @@ import {
   getModuleDisplayName,
   getModuleType,
   getPipetteNameSpecs,
-  TC_MODULE_LOCATION_OT2,
-  TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -25,16 +23,17 @@ import { InstrumentContainer } from '../../atoms/InstrumentContainer'
 import { Divider } from '../../atoms/structure'
 import { StyledText } from '../../atoms/text'
 import { useFeatureFlag } from '../../redux/config'
+import { getSlotsForThermocycler } from './utils'
 
 import type { LoadModuleRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
-import type { PipetteName } from '@opentrons/shared-data'
+import type { PipetteName, RobotType } from '@opentrons/shared-data'
 
 interface RobotConfigurationDetailsProps {
   leftMountPipetteName: PipetteName | null
   rightMountPipetteName: PipetteName | null
   requiredModuleDetails: LoadModuleRunTimeCommand[] | null
   isLoading: boolean
-  robotType: 'OT-2 Standard' | 'OT-3 Standard' | null
+  robotType: RobotType | null
 }
 
 export const RobotConfigurationDetails = (
@@ -105,15 +104,6 @@ export const RobotConfigurationDetails = (
     ) : (
       emptyText
     )
-
-  const getSlotsForThermocycler = (
-    robotType: 'OT-2 Standard' | 'OT-3 Standard' | null
-  ): typeof TC_MODULE_LOCATION_OT2 | typeof TC_MODULE_LOCATION_OT3 => {
-    if (robotType === 'OT-2 Standard') return TC_MODULE_LOCATION_OT2
-    if (robotType === 'OT-3 Standard') return TC_MODULE_LOCATION_OT3
-    // the protocol was analyzed before the robotType property was added to protocol data, this means it could only be for an OT-2
-    return TC_MODULE_LOCATION_OT2
-  }
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} paddingBottom={SPACING.spacing5}>

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -16,7 +16,8 @@ import {
   getModuleDisplayName,
   getModuleType,
   getPipetteNameSpecs,
-  TC_MODULE_LOCATION,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -33,6 +34,7 @@ interface RobotConfigurationDetailsProps {
   rightMountPipetteName: PipetteName | null
   requiredModuleDetails: LoadModuleRunTimeCommand[] | null
   isLoading: boolean
+  robotType: 'OT-2 Standard' | 'OT-3 Standard' | null
 }
 
 export const RobotConfigurationDetails = (
@@ -43,6 +45,7 @@ export const RobotConfigurationDetails = (
     rightMountPipetteName,
     requiredModuleDetails,
     isLoading,
+    robotType,
   } = props
   const { t } = useTranslation(['protocol_details', 'shared'])
   const enableExtendedHardware = useFeatureFlag('enableExtendedHardware')
@@ -103,6 +106,15 @@ export const RobotConfigurationDetails = (
       emptyText
     )
 
+  const getSlotsForThermocycler = (
+    robotType: 'OT-2 Standard' | 'OT-3 Standard' | null
+  ): typeof TC_MODULE_LOCATION_OT2 | typeof TC_MODULE_LOCATION_OT3 => {
+    if (robotType === 'OT-2 Standard') return TC_MODULE_LOCATION_OT2
+    if (robotType === 'OT-3 Standard') return TC_MODULE_LOCATION_OT3
+    // the protocol was analyzed before the robotType property was added to protocol data, this means it could only be for an OT-2
+    return TC_MODULE_LOCATION_OT2
+  }
+
   return (
     <Flex flexDirection={DIRECTION_COLUMN} paddingBottom={SPACING.spacing5}>
       <RobotConfigurationDetailsItem
@@ -143,7 +155,7 @@ export const RobotConfigurationDetails = (
                     slot_number:
                       getModuleType(module.params.model) ===
                       THERMOCYCLER_MODULE_TYPE
-                        ? TC_MODULE_LOCATION
+                        ? getSlotsForThermocycler(robotType)
                         : module.params.location.slotName,
                   })}
                   item={

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -92,7 +92,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: null,
       requiredModuleDetails: null,
       isLoading: false,
-      robotType: "OT-2 Standard"
+      robotType: 'OT-2 Standard',
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -107,7 +107,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: null,
       isLoading: false,
-      robotType: "OT-2 Standard"
+      robotType: 'OT-2 Standard',
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -131,7 +131,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: mockRequiredModuleDetails,
       isLoading: false,
-      robotType: "OT-2 Standard"
+      robotType: 'OT-2 Standard',
     }
 
     const { getByText } = render(props)
@@ -145,7 +145,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: null,
       requiredModuleDetails: null,
       isLoading: true,
-      robotType: "OT-2 Standard"
+      robotType: 'OT-2 Standard',
     }
     const { getAllByText, getByText } = render(props)
     getByText('right mount')

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
+import { OT2_STANDARD_MODEL } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { useFeatureFlag } from '../../../redux/config'
 import { RobotConfigurationDetails } from '../RobotConfigurationDetails'
@@ -92,7 +93,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: null,
       requiredModuleDetails: null,
       isLoading: false,
-      robotType: 'OT-2 Standard',
+      robotType: OT2_STANDARD_MODEL,
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -107,7 +108,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: null,
       isLoading: false,
-      robotType: 'OT-2 Standard',
+      robotType: OT2_STANDARD_MODEL,
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -131,7 +132,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: mockRequiredModuleDetails,
       isLoading: false,
-      robotType: 'OT-2 Standard',
+      robotType: OT2_STANDARD_MODEL,
     }
 
     const { getByText } = render(props)
@@ -145,7 +146,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: null,
       requiredModuleDetails: null,
       isLoading: true,
-      robotType: 'OT-2 Standard',
+      robotType: OT2_STANDARD_MODEL,
     }
     const { getAllByText, getByText } = render(props)
     getByText('right mount')

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -92,6 +92,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: null,
       requiredModuleDetails: null,
       isLoading: false,
+      robotType: "OT-2 Standard"
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -106,6 +107,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: null,
       isLoading: false,
+      robotType: "OT-2 Standard"
     }
     const { getByText } = render(props)
     getByText('left mount')
@@ -129,6 +131,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: 'p10_single',
       requiredModuleDetails: mockRequiredModuleDetails,
       isLoading: false,
+      robotType: "OT-2 Standard"
     }
 
     const { getByText } = render(props)
@@ -142,6 +145,7 @@ describe('RobotConfigurationDetails', () => {
       rightMountPipetteName: null,
       requiredModuleDetails: null,
       isLoading: true,
+      robotType: "OT-2 Standard"
     }
     const { getAllByText, getByText } = render(props)
     getByText('right mount')

--- a/app/src/organisms/ProtocolDetails/__tests__/utils.test.ts
+++ b/app/src/organisms/ProtocolDetails/__tests__/utils.test.ts
@@ -1,0 +1,24 @@
+import {
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
+  OT2_STANDARD_MODEL,
+  OT3_STANDARD_MODEL,
+} from '@opentrons/shared-data'
+import { getSlotsForThermocycler } from '../utils'
+
+describe('getSlotsForThermocylcer', () => {
+  it('returns the correct thermocylcer slots given an OT3', () => {
+    const result = getSlotsForThermocycler(OT3_STANDARD_MODEL)
+    expect(result).toEqual(TC_MODULE_LOCATION_OT3)
+  })
+
+  it('returns the correct thermocylcer slots given an OT2', () => {
+    const result = getSlotsForThermocycler(OT2_STANDARD_MODEL)
+    expect(result).toEqual(TC_MODULE_LOCATION_OT2)
+  })
+
+  it('returns OT2 thermocycler location when robotType is not available', () => {
+    const result = getSlotsForThermocycler(null)
+    expect(result).toEqual(TC_MODULE_LOCATION_OT2)
+  })
+})

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -319,8 +319,7 @@ export function ProtocolDetails(
     mostRecentAnalysis?.createdAt != null
       ? format(new Date(mostRecentAnalysis.createdAt), 'MMM dd yy HH:mm')
       : t('shared:no_data')
-  const robotType =
-    (mostRecentAnalysis?.robotType as 'OT-2 Standard' | 'OT-3 Standard') ?? null
+  const robotType = mostRecentAnalysis?.robotType ?? null
 
   const contentsByTabName = {
     labware: (

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -319,6 +319,8 @@ export function ProtocolDetails(
     mostRecentAnalysis?.createdAt != null
       ? format(new Date(mostRecentAnalysis.createdAt), 'MMM dd yy HH:mm')
       : t('shared:no_data')
+  const robotType =
+    (mostRecentAnalysis?.robotType as 'OT-2 Standard' | 'OT-3 Standard') ?? null
 
   const contentsByTabName = {
     labware: (
@@ -330,6 +332,7 @@ export function ProtocolDetails(
         rightMountPipetteName={rightMountPipetteName}
         requiredModuleDetails={requiredModuleDetails}
         isLoading={analysisStatus === 'loading'}
+        robotType={robotType}
       />
     ),
     liquids: (

--- a/app/src/organisms/ProtocolDetails/utils.ts
+++ b/app/src/organisms/ProtocolDetails/utils.ts
@@ -1,0 +1,17 @@
+import {
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
+  OT2_STANDARD_MODEL,
+  OT3_STANDARD_MODEL,
+} from '@opentrons/shared-data'
+
+import type { RobotType } from '@opentrons/shared-data'
+
+export function getSlotsForThermocycler(
+  robotType: RobotType | null
+): typeof TC_MODULE_LOCATION_OT2 | typeof TC_MODULE_LOCATION_OT3 {
+  if (robotType === OT2_STANDARD_MODEL) return TC_MODULE_LOCATION_OT2
+  if (robotType === OT3_STANDARD_MODEL) return TC_MODULE_LOCATION_OT3
+  // the protocol was analyzed before the robotType property was added to protocol data, this means it could only be for an OT-2
+  return TC_MODULE_LOCATION_OT2
+}

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -139,4 +139,5 @@ export const SINGLE_MOUNT_PIPETTES: 'Single-Channel_and_8-Channel' =
   'Single-Channel_and_8-Channel'
 
 // Thermocycler module info
-export const TC_MODULE_LOCATION: '7+10' = '7+10'
+export const TC_MODULE_LOCATION_OT2: '7,8,10,11' = '7,8,10,11'
+export const TC_MODULE_LOCATION_OT3: '7+10' = '7+10'

--- a/shared-data/protocol/types/schemaV6/index.ts
+++ b/shared-data/protocol/types/schemaV6/index.ts
@@ -94,6 +94,7 @@ export interface ProtocolAnalysisOutput {
   modules: LoadedModule[]
   liquids: Liquid[]
   errors: AnalysisError[]
+  robotType?: 'OT-2 Standard' | 'OT-3 Standard'
 }
 
 interface AnalysisSourceFile {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
**In Draft status while I check test coverage and finish up adding some tests**

Several components in the app display the slots of the Thermocycler. Previously this was always '7+10' but that value only applies to OT3s. Thermocyclers with OT2s take up slots '7,8,10,11'. This PR adds some logic to conditionally display the appropriate slots for thermocyclers based on the robot the protocol is written for in the Protocol section and the current robot in the Device section

closes RAUT-282
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

- changed `TC_MODULE_LOCATION` to 2 different consts, 1 for OT2 and one for OT3
- adds optional `robotType` property to the `ProtocolAnalysisOutput` interface to line up more closely to the protocol analysis response from the `robot-server`
- Introduces logic to `LabwareListItem` and `RobotConfigurationDetails` to display correct slots

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Please ensure the changes made look like an appropriate solution for the issue

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low. These changes are fairly contained and are textual changes that shouldn't adversely affect actual functionality

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
