### PR TITLE
refactor(api): mark `separate_calibration` properties as deprecated

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -10,7 +10,7 @@ The API is versioned with a major and minor version, expressed like this: ``majo
 Major and Minor Version
 -----------------------
 
-The major version of the API is increased whenever there are signficant structural or behavioral changes to protocols. For instance, major version 2 of the API was introduced because protocols must now have a ``run`` function that takes a ``protocol`` argument rather than importing the ``robot``, ``instruments``, and ``labware`` modules. A similar level of structural change would require a major version 3. Another major version bump would be if all of the default units switched to nanoliters instead of microliters (we won't do this, it's just an example). This major behavioral change would also require a major version 3.
+The major version of the API is increased whenever there are significant structural or behavioral changes to protocols. For instance, major version 2 of the API was introduced because protocols must now have a ``run`` function that takes a ``protocol`` argument rather than importing the ``robot``, ``instruments``, and ``labware`` modules. A similar level of structural change would require a major version 3. Another major version bump would be if all of the default units switched to nanoliters instead of microliters (we won't do this, it's just an example). This major behavioral change would also require a major version 3.
 
 The minor version of the API is increased whenever we add new functionality that might change the way a protocol is written, or when we want to make a behavior change to an aspect of the API but not the whole thing. For instance, if we added support for a new module, added an option for specifying volume units in the ``aspirate`` and ``dispense`` functions, or added a way to queue up actions from multiple different modules and execute them at the same time, we would increase the minor version of the API. Another minor version bump would be if we added automatic liquid level tracking, and the position at which the OT-2 aspirated from wells was now dynamic - some people might not want that change appearing suddenly in their well-tested protocol, so we would increase the minor version.
 
@@ -268,3 +268,5 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
+- Several internal properties of :py:class:`.Labware` and :py:class:`.ModuleContext` will be deprecated and/or removed:
+    - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -45,10 +45,6 @@ class LabwareCore(AbstractLabware[WellCore]):
         )
 
     @property
-    def separate_calibration(self) -> bool:
-        raise NotImplementedError("LabwareCore.separate_calibration not implemented")
-
-    @property
     def load_name(self) -> str:
         """The API load name of the labware definition."""
         return self._definition.parameters.loadName

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -170,14 +170,10 @@ class LabwareImplementation(AbstractLabware[WellImplementation]):
         return self._geometry.z_dimension + self._calibrated_offset.z
 
     @property
-    def separate_calibration(self) -> bool:
-        return False
-
-    @property
     def load_name(self) -> str:
         return self._parameters["loadName"]
 
-    # TODO(mc, 2022-09-26): codify "from labware's base" in defintion schema
+    # TODO(mc, 2022-09-26): codify "from labware's base" in definition schema
     # https://opentrons.atlassian.net/browse/RSS-110
     def get_default_magnet_engage_height(
         self, preserve_half_mm: bool = False

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -291,6 +291,10 @@ class Labware:
 
     @property
     def separate_calibration(self) -> bool:
+        _log.warning(
+            "Labware.separate_calibrations is a deprecated internal property."
+            " It no longer has meaning, but will always return `False`"
+        )
         return False
 
     @property  # type: ignore

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -7,6 +7,7 @@ objects on the deck (as opposed to calling commands on them, which is handled
 by :py:mod:`.module_contexts`)
 """
 from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Optional
 
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
     from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
 
 
-log = logging.getLogger(__name__)
+_log = logging.getLogger(__name__)
 
 
 class NoSuchModuleError(ValueError):
@@ -62,7 +63,10 @@ class ModuleGeometry:
 
     @property
     def separate_calibration(self) -> bool:
-        # If a module is the parent of a labware it affects calibration
+        _log.warning(
+            "ModuleGeometry.separate_calibrations is a deprecated internal property."
+            " It has no longer has meaning, but will always return `True`"
+        )
         return True
 
     def __init__(
@@ -453,7 +457,7 @@ def create_geometry(
     )
     if not parent.labware.is_slot:
         par = ""
-        log.warning(
+        _log.warning(
             f"module location parent labware was {parent.labware} which is"
             "not a slot name; slot transforms will not be loaded"
         )


### PR DESCRIPTION
## Overview

Tiny PR to knock out a `NotImplementedError` in the PAPI engine core by way of removal.

Closes RCORE-416

## Changelog

- Log a warning if you try to use `Labware.separate_calibration` or `ModuleGeometry.separate_calibration`

## Review requests

Standard code review

## Risk assessment

Very low