### PR TITLE
fix(app): correct modal width prop and liquid whitescreen

### DIFF
--- a/app/src/atoms/Skeleton/Skeleton.stories.tsx
+++ b/app/src/atoms/Skeleton/Skeleton.stories.tsx
@@ -8,7 +8,7 @@ import {
   JUSTIFY_END,
   ALIGN_FLEX_END,
 } from '@opentrons/components'
-import { ModalShell } from '../../molecules/Modal'
+import { Modal } from '../../molecules/Modal'
 import { PrimaryButton } from '../buttons'
 import { Skeleton } from '.'
 
@@ -21,7 +21,7 @@ export default {
 
 const Template: Story<React.ComponentProps<typeof Skeleton>> = args => {
   return (
-    <ModalShell width="47rem">
+    <Modal width="47rem">
       <Flex flexDirection={DIRECTION_COLUMN} height="24.6rem">
         <Flex
           flexDirection={DIRECTION_ROW}
@@ -54,7 +54,7 @@ const Template: Story<React.ComponentProps<typeof Skeleton>> = args => {
           <PrimaryButton>{'Button text'}</PrimaryButton>
         </Flex>
       </Flex>
-    </ModalShell>
+    </Modal>
   )
 }
 

--- a/app/src/molecules/Modal/index.tsx
+++ b/app/src/molecules/Modal/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { StyleProps, SPACING, COLORS, Box } from '@opentrons/components'
+import { SPACING, COLORS, Box } from '@opentrons/components'
 import { ModalHeader } from './ModalHeader'
 import { ModalShell } from './ModalShell'
+import type { StyleProps } from '@opentrons/components'
 
 type ModalType = 'info' | 'warning' | 'error'
 export * from './ModalShell'
@@ -15,7 +16,6 @@ export interface ModalProps extends StyleProps {
   fullPage?: boolean
   childrenPadding?: string | number
   children?: React.ReactNode
-  modalWidth?: string
 }
 
 export const Modal = (props: ModalProps): JSX.Element => {
@@ -26,7 +26,7 @@ export const Modal = (props: ModalProps): JSX.Element => {
     title,
     childrenPadding = `${SPACING.spacing4} ${SPACING.spacing5} ${SPACING.spacing5}`,
     children,
-    modalWidth,
+    ...styleProps
   } = props
 
   const modalHeader = (
@@ -49,7 +49,7 @@ export const Modal = (props: ModalProps): JSX.Element => {
 
   return (
     <ModalShell
-      width={modalWidth ?? '31.25rem'}
+      width={styleProps.width ?? '31.25rem'}
       header={modalHeader}
       onOutsideClick={closeOnOutsideClick ? onClose : undefined}
       // center within viewport aside from nav

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -74,7 +74,7 @@ export function ProtocolRunSetup({
     let nextStepKeysInOrder = stepsKeysInOrder
     const showModuleSetup = protocolData != null && modules.length > 0
     const showLiquidSetup =
-      protocolData != null && protocolData.liquids.length > 0
+      protocolData != null && protocolData.liquids?.length > 0
 
     if (showModuleSetup && showLiquidSetup) {
       nextStepKeysInOrder = [

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/HowLPCWorksModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/HowLPCWorksModal.tsx
@@ -29,7 +29,7 @@ export const HowLPCWorksModal = (props: HowLPCWorksModalProps): JSX.Element => {
       <Modal
         title={t('how_offset_data_works')}
         onClose={props.onCloseClick}
-        modalWidth="31.25rem"
+        width="31.25rem"
       >
         <Flex flexDirection={DIRECTION_COLUMN}>
           <StyledText as="p" marginBottom={SPACING.spacing4}>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/SecureLabwareModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/SecureLabwareModal.tsx
@@ -37,7 +37,7 @@ export const SecureLabwareModal = (
           name: moduleName,
         })}
         onClose={props.onCloseClick}
-        modalWidth="44.75rem"
+        width="44.75rem"
       >
         <Flex flexDirection={DIRECTION_COLUMN}>
           {props.type === 'magneticModuleType' && (

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/MultipleModulesModal.tsx
@@ -32,7 +32,7 @@ export const MultipleModulesModal = (
       <Modal
         title={t('multiple_modules_modal')}
         onClose={props.onCloseClick}
-        modalWidth="44.75rem"
+        width="44.75rem"
       >
         <Flex flexDirection={DIRECTION_COLUMN}>
           <Flex flexDirection={DIRECTION_ROW}>


### PR DESCRIPTION
closes RAUT-295

# Overview

fixes 2 bugs:
1. protocols without liquids were white screening in `ProtocolRunSetup`
2. the `modalWidth` was causing a warning in console for several usages of `Modal`

# Changelog

- remove `modalWidth` and just use `width` prop - something that some of the `Modal` usages were already using. Clean up `Modal` a bit.
- add nullish coalescing to `protocolData.liquids` in `ProtocolRunSetup`

# Review requests

- with the robot server load liquid ff turned off and on, test liquid setup in the app and test with a protocol without liquids. shouldn't run into any white screens when going through protocol analysis
- check the LPC modal, multiple modules modal, and the secure module modals in labware setup, the console should not show any warnings

# Risk assessment

low