### PR TITLE
refactor(api): add support for Well.has_tip to the engine core

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -268,5 +268,6 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
-- Several internal properties of :py:class:`.Labware` and :py:class:`.ModuleContext` will be deprecated and/or removed:
-    - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists
+- Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
+    - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
+    - The ``Well.has_tip`` setter, which will cease to function in a future upgrade to the Python protocol execution system. The corresponding `Well.has_tip` getter will not be deprecated..

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -3,6 +3,7 @@ from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Point
 
@@ -42,11 +43,15 @@ class WellCore(AbstractWellCore):
 
     def has_tip(self) -> bool:
         """Whether the well contains a tip."""
-        raise NotImplementedError("WellCore.has_tip not implemented")
+        return self._engine_client.state.tips.has_clean_tip(
+            self._labware_id, self._name
+        )
 
     def set_has_tip(self, value: bool) -> None:
         """Set the well as containing or not containing a tip."""
-        raise NotImplementedError("WellCore.set_has_tip not implemented")
+        raise APIVersionError(
+            "Manually setting the tip state of a well in a tip rack has been deprecated."
+        )
 
     def get_display_name(self) -> str:
         """Get the well's full display name."""

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -100,10 +100,12 @@ class Well:
 
     @has_tip.setter
     def has_tip(self, value: bool) -> None:
-        _log.warning(
-            "Setting the `Well.has_tip` property manually has been deprecated,"
-            " and will raise an error in a future version of the Python Protocol API."
-        )
+        if self._api_version > APIVersion(3, 13):
+            _log.warning(
+                "Setting the `Well.has_tip` property manually has been deprecated"
+                " and will raise an error in a future version of the Python Protocol API."
+            )
+
         self._impl.set_has_tip(value)
 
     @property

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -95,10 +95,15 @@ class Well:
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def has_tip(self) -> bool:
+        """If parent labware is a tip rack, whether this well contains a tip."""
         return self._impl.has_tip()
 
     @has_tip.setter
     def has_tip(self, value: bool) -> None:
+        _log.warning(
+            "Setting the `Well.has_tip` property manually has been deprecated,"
+            " and will raise an error in a future version of the Python Protocol API."
+        )
         self._impl.set_has_tip(value)
 
     @property

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -100,11 +100,10 @@ class Well:
 
     @has_tip.setter
     def has_tip(self, value: bool) -> None:
-        if self._api_version > APIVersion(3, 13):
-            _log.warning(
-                "Setting the `Well.has_tip` property manually has been deprecated"
-                " and will raise an error in a future version of the Python Protocol API."
-            )
+        _log.warning(
+            "Setting the `Well.has_tip` property manually has been deprecated"
+            " and will raise an error in a future version of the Python Protocol API."
+        )
 
         self._impl.set_has_tip(value)
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -8,6 +8,7 @@ from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import Point
 
 from opentrons.protocol_api.core.engine import WellCore
@@ -130,3 +131,22 @@ def test_get_center(
     ).then_return(Point(1, 2, 3))
 
     assert subject.get_center() == Point(1, 2, 3)
+
+
+def test_has_tip(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
+) -> None:
+    """It should get whether a clean tip is present."""
+    decoy.when(
+        mock_engine_client.state.tips.has_clean_tip(
+            labware_id="labware-id", well_name="well-name"
+        )
+    ).then_return(True)
+
+    assert subject.has_tip() is True
+
+
+def test_set_has_tip(subject: WellCore) -> None:
+    """Trying to set the has tip state should raise an error."""
+    with pytest.raises(APIVersionError):
+        subject.set_has_tip(True)

--- a/api/tests/opentrons/protocol_api/test_well.py
+++ b/api/tests/opentrons/protocol_api/test_well.py
@@ -102,3 +102,12 @@ def test_well_center(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> N
     assert isinstance(result, Location)
     assert result.point == Point(1, 2, 3)
     assert result.labware.as_well() is subject
+
+
+def test_has_tip(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
+    """It should get tip state from the core."""
+    decoy.when(mock_well_core.has_tip()).then_return(True)
+    assert subject.has_tip is True
+
+    decoy.when(mock_well_core.has_tip()).then_return(False)
+    assert subject.has_tip is False


### PR DESCRIPTION
## Overview

This PR implements RCORE-418. See ticket for details and acceptance criteria.

## Changelog

- Implement `WellCore.has_tip()` using a ProtocolEngine state selector
- Implement `WellCore.set_has_tip()` by raising an `APIVersionError`
- Add warning log to note that `has_tip` setter has been deprecated and will raise an error in the future.
- Update API docs to note that the `has_tip` setter is deprecated and will raise an error in the future.

## Review requests

Pretty straightforward! Made some tweaks to tip state, let me know if you think I should add or change any more tests.

## Risk assessment

Low
