### PR TITLE
test(engine): add missing module_view test

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -525,7 +525,6 @@ class ModuleView(HasState[ModuleState]):
         """Get the specified module's dimensions."""
         return self.get_definition(module_id).dimensions
 
-    # TODO(mc, 2022-01-19): this method is missing unit test coverage
     def get_module_offset(self, module_id: str) -> LabwareOffsetVector:
         """Get the module's offset vector computed with slot transform."""
         definition = self.get_definition(module_id)

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -13,7 +13,8 @@ from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleDefinition,
     ModuleModel,
-    ModuleLocation, LabwareOffsetVector,
+    ModuleLocation,
+    LabwareOffsetVector,
 )
 from opentrons.protocol_engine.state.modules import (
     ModuleView,
@@ -226,30 +227,72 @@ def test_get_properties_by_id(
 @pytest.mark.parametrize(
     argnames=["module_def", "slot", "expected_offset"],
     argvalues=[
-        (lazy_fixture("tempdeck_v1_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-0.15, y=-0.15, z=80.09)),
-        (lazy_fixture("tempdeck_v2_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-1.45, y=-0.15, z=80.09)),
-        (lazy_fixture("tempdeck_v2_def"), DeckSlotName.SLOT_3, LabwareOffsetVector(x=1.15, y=-0.15, z=80.09)),
-        (lazy_fixture("magdeck_v1_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=0.125, y=-0.125, z=82.25)),
-        (lazy_fixture("magdeck_v2_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-1.175, y=-0.125, z=82.25)),
-        (lazy_fixture("magdeck_v2_def"), DeckSlotName.SLOT_3, LabwareOffsetVector(x=1.425, y=-0.125, z=82.25)),
-        (lazy_fixture("thermocycler_v1_def"), DeckSlotName.SLOT_7, LabwareOffsetVector(x=0, y=82.56, z=97.8)),
-        (lazy_fixture("thermocycler_v2_def"), DeckSlotName.SLOT_7, LabwareOffsetVector(x=0, y=68.06, z=98.26)),
-        (lazy_fixture("heater_shaker_v1_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-0.125, y=1.125, z=68.275)),
-        (lazy_fixture("heater_shaker_v1_def"), DeckSlotName.SLOT_3, LabwareOffsetVector(x=0.125, y=-1.125, z=68.275)),
-    ]
+        (
+            lazy_fixture("tempdeck_v1_def"),
+            DeckSlotName.SLOT_1,
+            LabwareOffsetVector(x=-0.15, y=-0.15, z=80.09),
+        ),
+        (
+            lazy_fixture("tempdeck_v2_def"),
+            DeckSlotName.SLOT_1,
+            LabwareOffsetVector(x=-1.45, y=-0.15, z=80.09),
+        ),
+        (
+            lazy_fixture("tempdeck_v2_def"),
+            DeckSlotName.SLOT_3,
+            LabwareOffsetVector(x=1.15, y=-0.15, z=80.09),
+        ),
+        (
+            lazy_fixture("magdeck_v1_def"),
+            DeckSlotName.SLOT_1,
+            LabwareOffsetVector(x=0.125, y=-0.125, z=82.25),
+        ),
+        (
+            lazy_fixture("magdeck_v2_def"),
+            DeckSlotName.SLOT_1,
+            LabwareOffsetVector(x=-1.175, y=-0.125, z=82.25),
+        ),
+        (
+            lazy_fixture("magdeck_v2_def"),
+            DeckSlotName.SLOT_3,
+            LabwareOffsetVector(x=1.425, y=-0.125, z=82.25),
+        ),
+        (
+            lazy_fixture("thermocycler_v1_def"),
+            DeckSlotName.SLOT_7,
+            LabwareOffsetVector(x=0, y=82.56, z=97.8),
+        ),
+        (
+            lazy_fixture("thermocycler_v2_def"),
+            DeckSlotName.SLOT_7,
+            LabwareOffsetVector(x=0, y=68.06, z=98.26),
+        ),
+        (
+            lazy_fixture("heater_shaker_v1_def"),
+            DeckSlotName.SLOT_1,
+            LabwareOffsetVector(x=-0.125, y=1.125, z=68.275),
+        ),
+        (
+            lazy_fixture("heater_shaker_v1_def"),
+            DeckSlotName.SLOT_3,
+            LabwareOffsetVector(x=0.125, y=-1.125, z=68.275),
+        ),
+    ],
 )
 def test_get_module_offset(
-        module_def: ModuleDefinition,
-        slot: DeckSlotName,
-        expected_offset: LabwareOffsetVector,
+    module_def: ModuleDefinition,
+    slot: DeckSlotName,
+    expected_offset: LabwareOffsetVector,
 ) -> None:
     """It should return the correct labware offset for module in specified slot."""
     subject = make_module_view(
         slot_by_module_id={"module-id": slot},
-        hardware_by_module_id={"module-id": HardwareModule(
-            serial_number="module-serial",
-            definition=module_def,
-        )}
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="module-serial",
+                definition=module_def,
+            )
+        },
     )
     assert subject.get_module_offset("module-id") == expected_offset
 

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -13,7 +13,7 @@ from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleDefinition,
     ModuleModel,
-    ModuleLocation,
+    ModuleLocation, LabwareOffsetVector,
 )
 from opentrons.protocol_engine.state.modules import (
     ModuleView,
@@ -179,6 +179,79 @@ def test_get_all_modules(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
         ),
     ]
+
+
+def test_get_properties_by_id(
+    tempdeck_v1_def: ModuleDefinition,
+    tempdeck_v2_def: ModuleDefinition,
+) -> None:
+    """It should return a loaded module's properties by ID."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_1,
+            "module-2": DeckSlotName.SLOT_2,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=tempdeck_v1_def,
+            ),
+            "module-2": HardwareModule(
+                serial_number="serial-2",
+                definition=tempdeck_v2_def,
+            ),
+        },
+    )
+
+    assert subject.get_definition("module-1") == tempdeck_v1_def
+    assert subject.get_dimensions("module-1") == tempdeck_v1_def.dimensions
+    assert subject.get_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
+    assert subject.get_serial_number("module-1") == "serial-1"
+    assert subject.get_location("module-1") == DeckSlotLocation(
+        slotName=DeckSlotName.SLOT_1
+    )
+
+    assert subject.get_definition("module-2") == tempdeck_v2_def
+    assert subject.get_dimensions("module-2") == tempdeck_v2_def.dimensions
+    assert subject.get_model("module-2") == ModuleModel.TEMPERATURE_MODULE_V2
+    assert subject.get_serial_number("module-2") == "serial-2"
+    assert subject.get_location("module-2") == DeckSlotLocation(
+        slotName=DeckSlotName.SLOT_2
+    )
+
+    with pytest.raises(errors.ModuleNotLoadedError):
+        subject.get_definition("Not a module ID oh no")
+
+
+@pytest.mark.parametrize(
+    argnames=["module_def", "slot", "expected_offset"],
+    argvalues=[
+        (lazy_fixture("tempdeck_v1_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-0.15, y=-0.15, z=80.09)),
+        (lazy_fixture("tempdeck_v2_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-1.45, y=-0.15, z=80.09)),
+        (lazy_fixture("tempdeck_v2_def"), DeckSlotName.SLOT_3, LabwareOffsetVector(x=1.15, y=-0.15, z=80.09)),
+        (lazy_fixture("magdeck_v1_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=0.125, y=-0.125, z=82.25)),
+        (lazy_fixture("magdeck_v2_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-1.175, y=-0.125, z=82.25)),
+        (lazy_fixture("magdeck_v2_def"), DeckSlotName.SLOT_3, LabwareOffsetVector(x=1.425, y=-0.125, z=82.25)),
+        (lazy_fixture("thermocycler_v1_def"), DeckSlotName.SLOT_7, LabwareOffsetVector(x=0, y=82.56, z=97.8)),
+        (lazy_fixture("thermocycler_v2_def"), DeckSlotName.SLOT_7, LabwareOffsetVector(x=0, y=68.06, z=98.26)),
+        (lazy_fixture("heater_shaker_v1_def"), DeckSlotName.SLOT_1, LabwareOffsetVector(x=-0.125, y=1.125, z=68.275)),
+        (lazy_fixture("heater_shaker_v1_def"), DeckSlotName.SLOT_3, LabwareOffsetVector(x=0.125, y=-1.125, z=68.275)),
+    ]
+)
+def test_get_module_offset(
+        module_def: ModuleDefinition,
+        slot: DeckSlotName,
+        expected_offset: LabwareOffsetVector,
+) -> None:
+    """It should return the correct labware offset for module in specified slot."""
+    subject = make_module_view(
+        slot_by_module_id={"module-id": slot},
+        hardware_by_module_id={"module-id": HardwareModule(
+            serial_number="module-serial",
+            definition=module_def,
+        )}
+    )
+    assert subject.get_module_offset("module-id") == expected_offset
 
 
 def test_get_magnetic_module_substate(
@@ -354,48 +427,6 @@ def test_get_temperature_module_substate(
 
     with pytest.raises(errors.ModuleNotLoadedError):
         subject.get_temperature_module_substate(module_id="nonexistent-module-id")
-
-
-def test_get_properties_by_id(
-    tempdeck_v1_def: ModuleDefinition,
-    tempdeck_v2_def: ModuleDefinition,
-) -> None:
-    """It should return a loaded module's properties by ID."""
-    subject = make_module_view(
-        slot_by_module_id={
-            "module-1": DeckSlotName.SLOT_1,
-            "module-2": DeckSlotName.SLOT_2,
-        },
-        hardware_by_module_id={
-            "module-1": HardwareModule(
-                serial_number="serial-1",
-                definition=tempdeck_v1_def,
-            ),
-            "module-2": HardwareModule(
-                serial_number="serial-2",
-                definition=tempdeck_v2_def,
-            ),
-        },
-    )
-
-    assert subject.get_definition("module-1") == tempdeck_v1_def
-    assert subject.get_dimensions("module-1") == tempdeck_v1_def.dimensions
-    assert subject.get_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
-    assert subject.get_serial_number("module-1") == "serial-1"
-    assert subject.get_location("module-1") == DeckSlotLocation(
-        slotName=DeckSlotName.SLOT_1
-    )
-
-    assert subject.get_definition("module-2") == tempdeck_v2_def
-    assert subject.get_dimensions("module-2") == tempdeck_v2_def.dimensions
-    assert subject.get_model("module-2") == ModuleModel.TEMPERATURE_MODULE_V2
-    assert subject.get_serial_number("module-2") == "serial-2"
-    assert subject.get_location("module-2") == DeckSlotLocation(
-        slotName=DeckSlotName.SLOT_2
-    )
-
-    with pytest.raises(errors.ModuleNotLoadedError):
-        subject.get_definition("Not a module ID oh no")
 
 
 def test_get_plate_target_temperature(heater_shaker_v1_def: ModuleDefinition) -> None:


### PR DESCRIPTION
# Overview

Adds missing test for `module_vie.get_module_offset()`. 
Since we're updating transforms and calculation of module offsets for OT3, I'm adding the missing tests separately so that they can be used to verify that the offsets remain same even with the updated transforms.

# Changelog

- added `test_get_module_offset` for verifying offsets of all modules

# Review requests

- anything else needs to be added to the test?

# Risk assessment

None.