### PR TITLE
feat(protocol-designer): remove liquid color enhancements FF

### DIFF
--- a/protocol-designer/src/components/ColorPicker/index.tsx
+++ b/protocol-designer/src/components/ColorPicker/index.tsx
@@ -29,7 +29,10 @@ export function ColorPicker(props: ColorPickerProps): JSX.Element {
         />
       </div>
       {showColorPicker ? (
-        <div className={styles.popover}>
+        <div
+          className={styles.popover}
+          onBlur={() => setShowColorPicker(false)}
+        >
           <div
             className={styles.cover}
             onClick={() => setShowColorPicker(false)}
@@ -39,7 +42,6 @@ export function ColorPicker(props: ColorPickerProps): JSX.Element {
             color={props.value}
             onChange={(color, event) => {
               props.onChange(color.hex)
-              setShowColorPicker(showColorPicker => !showColorPicker)
             }}
             triangle="top-right"
           />

--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { selectors } from '../../labware-ingred/selectors'
-import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { IconButton, SidePanel } from '@opentrons/components'
 import { sortWells } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
@@ -49,10 +48,6 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): JSX.Element | null => {
   const wellsWithIngred = Object.keys(labwareWellContents)
     .sort(sortWells)
     .filter(well => labwareWellContents[well][groupId])
-
-  const enableLiquidColorEnhancements = useSelector(
-    featureFlagSelectors.getEnabledLiquidColorEnhancements
-  )
   const liquidDisplayColors = useSelector(selectors.getLiquidDisplayColors)
 
   if (wellsWithIngred.length < 1) {
@@ -65,9 +60,7 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): JSX.Element | null => {
       title={ingredGroup.name || i18n.t('card.unnamedLiquid')}
       iconProps={{
         style: {
-          fill: enableLiquidColorEnhancements
-            ? liquidDisplayColors[Number(groupId)] ?? swatchColors(groupId)
-            : swatchColors(groupId),
+          fill: liquidDisplayColors[Number(groupId)] ?? swatchColors(groupId),
         },
       }}
       iconName="circle"

--- a/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
@@ -13,7 +13,6 @@ import {
   PrimaryButton,
 } from '@opentrons/components'
 import { selectors } from '../../labware-ingred/selectors'
-import { selectors as featureFlagSelectors } from '../../feature-flags'
 import styles from './LiquidEditForm.css'
 import formStyles from '../forms/forms.css'
 
@@ -51,9 +50,6 @@ export const liquidEditFormSchema: Yup.Schema<
 
 export function LiquidEditForm(props: Props): JSX.Element {
   const { deleteLiquidGroup, cancelForm, canDelete, saveForm } = props
-  const enableLiquidColorEnhancements = useSelector(
-    featureFlagSelectors.getEnabledLiquidColorEnhancements
-  )
   const selectedLiquid = useSelector(selectors.getSelectedLiquidGroupState)
   const nextGroupId = useSelector(selectors.getNextLiquidGroupId)
   const liquidId = selectedLiquid.liquidGroupId ?? nextGroupId
@@ -118,18 +114,16 @@ export function LiquidEditForm(props: Props): JSX.Element {
                     onChange={handleChange}
                   />
                 </FormGroup>
-                {enableLiquidColorEnhancements ? (
-                  <FormGroup label={i18n.t('form.liquid_edit.displayColor')}>
-                    <Field
-                      name="displayColor"
-                      component={ColorPicker}
-                      value={values.displayColor}
-                      onChange={(color: ColorResult['hex']) => {
-                        setFieldValue('displayColor', color)
-                      }}
-                    />
-                  </FormGroup>
-                ) : null}
+                <FormGroup label={i18n.t('form.liquid_edit.displayColor')}>
+                  <Field
+                    name="displayColor"
+                    component={ColorPicker}
+                    value={values.displayColor}
+                    onChange={(color: ColorResult['hex']) => {
+                      setFieldValue('displayColor', color)
+                    }}
+                  />
+                </FormGroup>
               </div>
             </section>
 

--- a/protocol-designer/src/components/LiquidsSidebar/index.tsx
+++ b/protocol-designer/src/components/LiquidsSidebar/index.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
-import { connect, useSelector } from 'react-redux'
+import { connect } from 'react-redux'
 import { i18n } from '../../localization'
 import { PrimaryButton, SidePanel } from '@opentrons/components'
 import { PDTitledList } from '../lists'
 import { swatchColors } from '../swatchColors'
 import listButtonStyles from '../listButtons.css'
 
-import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { OrderedLiquids } from '../../labware-ingred/types'
 import * as labwareIngredActions from '../../labware-ingred/actions'
@@ -28,9 +27,6 @@ type Props = SP & DP
 
 function LiquidsSidebarComponent(props: Props): JSX.Element {
   const { liquids, selectedLiquid, createNewLiquid, selectLiquid } = props
-  const enableLiquidColorEnhancements = useSelector(
-    featureFlagSelectors.getEnabledLiquidColorEnhancements
-  )
   return (
     <SidePanel title="Liquids">
       {liquids.map(({ ingredientId, name, displayColor }) => (
@@ -41,13 +37,11 @@ function LiquidsSidebarComponent(props: Props): JSX.Element {
           iconName="circle"
           iconProps={{
             style: {
-              fill: enableLiquidColorEnhancements
-                ? displayColor ?? swatchColors(ingredientId)
-                : swatchColors(ingredientId),
+              fill: displayColor ?? swatchColors(ingredientId),
             },
-            ...(enableLiquidColorEnhancements && {
+            ...{
               className: styles.liquid_icon_container,
-            }),
+            },
           }}
           title={name || `Unnamed Ingredient ${ingredientId}`} // fallback, should not happen
         />

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -19,8 +19,6 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
-  OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS:
-    process.env.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS === '1' || false,
   OT_PD_ENABLE_OT_3: process.env.OT_PD_ENABLE_OT_3 === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -15,10 +15,6 @@ export const getDisableModuleRestrictions: Selector<
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
-export const getEnabledLiquidColorEnhancements: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS ?? false
-)
 export const getEnabledOT3: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_OT_3 ?? false

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -18,12 +18,12 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_SCHEMA_V6',
   'OT_PD_ENABLE_HEATER_SHAKER',
   'OT_PD_ENABLE_THERMOCYCLER_GEN_2',
+  'OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS',
 ]
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
-  | 'OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS'
   | 'OT_PD_ENABLE_OT_3'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -16,14 +16,6 @@
     "title": "Enable schema v6 support",
     "description": "Allow users to migrate older protocols to schema v6"
   },
-  "OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS": {
-    "title": "Enable liquid color enhancements",
-    "description": "Allow users to enable liquid color picking"
-  },
-  "OT_PD_ENABLE_THERMOCYCLER_GEN_2": {
-    "title": "Enable Thermocycler GEN2 module",
-    "description": "Allow users to enable Thermocycler GEN2 module and steps in protocols"
-  },
   "OT_PD_ENABLE_OT_3": {
     "title": "Enable OT-3 support",
     "description": "Allow users to enable OT-3 support in protocol designer"


### PR DESCRIPTION
closes RQA-262

# Overview

Removes the liquid color enhancements FF

# Changelog

- deprecates the FF and removes usage of it from i18n and components
- deletes forgotten i18n key for thermocycler gen2 ff

# Review requests

- run `make -C protocol-designer dev` and build a protocol with liquids. Should be able to choose the different liquids as well as add your own hex colors. When uploading to the app and testing the liquid setup step, make sure the robot-server `loadLiquid` ff is turned on and it should work as expected

# Risk assessment

low
