### PR TITLE
fix(build): fix hardware-testing-protocols typo

### DIFF
--- a/.github/workflows/hardware-testing-protocols.yaml
+++ b/.github/workflows/hardware-testing-protocols.yaml
@@ -39,7 +39,8 @@ jobs:
     steps:
       - name: Checkout opentrons repo
         uses: 'actions/checkout@v3'
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: 'actions/setup-node@v3'


### PR DESCRIPTION
A previous change missed a with: clause in a workflow yaml
