### PR TITLE
feat(app): wire up 96-channel attach flow when gantry has other pipette

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -41,7 +41,6 @@
   "get_started_detach": "<block>To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right</block>",
   "pipette_failed_to_detach": "Pipette failed to detach",
   "pipette_detached": "Pipette Successfully Detached",
-  "get_started_flow": "<block>To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right</block>",
   "unscrew_carriage": "Unscrew Z Axis Carriage",
   "unscrew_at_top": "<block>Reach the top of of the gantry carriage and unscrew the captive screw connecting right pippete mount to the the z axis.</block><block>The detached right mount should freely move up and down the z axis.</block>",
   "connect_mounting_plate": "Connect and Attach Mounting Plate",

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -16,7 +16,7 @@ interface AttachProbeProps extends PipetteWizardStepProps {
 export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const {
     proceed,
-    attachedPipette,
+    attachedPipettes,
     chainRunCommands,
     mount,
     isRobotMoving,
@@ -26,7 +26,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     setShowErrorMessage,
   } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  const pipetteId = attachedPipette[mount]?.id
+  const pipetteId = attachedPipettes[mount]?.id
   //  hard coding calibration slot number for now in case it changes
   //  in the future
   const calSlotNum = '2'

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -2,9 +2,7 @@ import * as React from 'react'
 import { UseMutateFunction } from 'react-query'
 import { COLORS } from '@opentrons/components'
 import {
-  LEFT,
   NINETY_SIX_CHANNEL,
-  RIGHT,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 import { Trans, useTranslation } from 'react-i18next'
@@ -52,28 +50,13 @@ export const BeforeBeginning = (
   React.useEffect(() => {
     createRun({})
   }, [])
-  let pipetteId = attachedPipette[mount]?.id
+  const pipetteId = attachedPipette[mount]?.id
 
   const isGantryEmpty = getIsGantryEmpty(attachedPipette)
   const isGantryEmptyFor96ChannelAttachment =
     isGantryEmpty &&
     selectedPipette === NINETY_SIX_CHANNEL &&
     flowType === FLOWS.ATTACH
-
-  let mountInfo: string = mount
-  if (
-    flowType === FLOWS.ATTACH &&
-    !isGantryEmpty &&
-    selectedPipette === NINETY_SIX_CHANNEL
-  ) {
-    if (attachedPipette[LEFT] == null) {
-      mountInfo = RIGHT
-      pipetteId = attachedPipette[RIGHT]?.id
-    } else if (attachedPipette[RIGHT] == null) {
-      mountInfo = LEFT
-      pipetteId = attachedPipette[LEFT]?.id
-    }
-  }
 
   if (
     pipetteId == null &&
@@ -126,16 +109,16 @@ export const BeforeBeginning = (
           commandType: 'loadPipette' as const,
           params: {
             // @ts-expect-error pipetteName is required but missing in schema v6 type
-            pipetteName: attachedPipette[mountInfo]?.name,
+            pipetteName: attachedPipette[mount]?.name,
             pipetteId: pipetteId,
-            mount: mountInfo,
+            mount: mount,
           },
         },
         {
           // @ts-expect-error calibration type not yet supported
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
-            mount: mountInfo,
+            mount: mount,
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -37,7 +37,7 @@ export const BeforeBeginning = (
     proceed,
     flowType,
     createRun,
-    attachedPipette,
+    attachedPipettes,
     chainRunCommands,
     isCreateLoading,
     mount,
@@ -50,9 +50,9 @@ export const BeforeBeginning = (
   React.useEffect(() => {
     createRun({})
   }, [])
-  const pipetteId = attachedPipette[mount]?.id
+  const pipetteId = attachedPipettes[mount]?.id
 
-  const isGantryEmpty = getIsGantryEmpty(attachedPipette)
+  const isGantryEmpty = getIsGantryEmpty(attachedPipettes)
   const isGantryEmptyFor96ChannelAttachment =
     isGantryEmpty &&
     selectedPipette === NINETY_SIX_CHANNEL &&
@@ -109,7 +109,7 @@ export const BeforeBeginning = (
           commandType: 'loadPipette' as const,
           params: {
             // @ts-expect-error pipetteName is required but missing in schema v6 type
-            pipetteName: attachedPipette[mount]?.name,
+            pipetteName: attachedPipettes[mount]?.name,
             pipetteId: pipetteId,
             mount: mount,
           },

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -22,14 +22,13 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     goBack,
     proceed,
     robotName,
-    attachedPipette,
+    attachedPipettes,
     mount,
     isPending,
     setPending,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
-  // swap this out with util
-  const is96ChannelPipette = attachedPipette[mount]?.name === 'p1000_96'
+  const is96ChannelPipette = attachedPipettes[mount]?.name === 'p1000_96'
 
   let bodyText: React.ReactNode = <div></div>
   if (isPending) {

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -1,8 +1,4 @@
 import * as React from 'react'
-import {
-  NINETY_SIX_CHANNEL,
-  SINGLE_MOUNT_PIPETTES,
-} from '@opentrons/shared-data'
 import capitalize from 'lodash/capitalize'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
@@ -12,8 +8,6 @@ import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal
 import detachPipette from '../../assets/images/change-pip/single-channel-detach-pipette.png'
 import detach96Pipette from '../../assets/images/change-pip/detach-96-pipette.png'
 import { CheckPipetteButton } from './CheckPipetteButton'
-import { getIsGantryEmpty } from './utils'
-import { FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
 
 interface DetachPipetteProps extends PipetteWizardStepProps {
@@ -28,19 +22,14 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     goBack,
     proceed,
     robotName,
-    selectedPipette,
     attachedPipette,
-    flowType,
+    mount,
     isPending,
     setPending,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
-  const isSingleMountPipette = selectedPipette === SINGLE_MOUNT_PIPETTES
-  const isGantryEmpty = getIsGantryEmpty(attachedPipette)
-  const isPipetteAttachedFor96ChannelAttachement =
-    !isGantryEmpty &&
-    selectedPipette === NINETY_SIX_CHANNEL &&
-    flowType === FLOWS.ATTACH
+  // swap this out with util
+  const is96ChannelPipette = attachedPipette[mount]?.name === 'p1000_96'
 
   let bodyText: React.ReactNode = <div></div>
   if (isPending) {
@@ -58,7 +47,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
         />
       </>
     )
-  } else if (isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement) {
+  } else if (!is96ChannelPipette) {
     bodyText = <StyledText as="p">{t('hold_and_loosen')}</StyledText>
   } else {
     bodyText = (
@@ -83,11 +72,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
             backgroundSize={BACKGROUND_SIZE}
           />
         ) : (
-          t(
-            isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement
-              ? 'loose_detach'
-              : 'unscrew_remove_96_channel'
-          )
+          t(!is96ChannelPipette ? 'loose_detach' : 'unscrew_remove_96_channel')
         )
       }
       //  TODO(Jr, 11/8/22): replace image with correct one!
@@ -100,14 +85,10 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           />
         ) : (
           <img
-            src={
-              isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement
-                ? detachPipette
-                : detach96Pipette
-            }
+            src={!is96ChannelPipette ? detachPipette : detach96Pipette}
             width="100%"
             alt={
-              isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement
+              !is96ChannelPipette
                 ? 'Detach pipette'
                 : 'Unscrew 96 channel pipette'
             }

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import { SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
+import {
+  NINETY_SIX_CHANNEL,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
 import capitalize from 'lodash/capitalize'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
@@ -9,6 +12,8 @@ import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal
 import detachPipette from '../../assets/images/change-pip/single-channel-detach-pipette.png'
 import detach96Pipette from '../../assets/images/change-pip/detach-96-pipette.png'
 import { CheckPipetteButton } from './CheckPipetteButton'
+import { getIsGantryEmpty } from './utils'
+import { FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
 
 interface DetachPipetteProps extends PipetteWizardStepProps {
@@ -24,11 +29,19 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     proceed,
     robotName,
     selectedPipette,
+    attachedPipette,
+    flowType,
     isPending,
     setPending,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
   const isSingleMountPipette = selectedPipette === SINGLE_MOUNT_PIPETTES
+  const isGantryEmpty = getIsGantryEmpty(attachedPipette)
+  const isPipetteAttachedFor96ChannelAttachement =
+    !isGantryEmpty &&
+    selectedPipette === NINETY_SIX_CHANNEL &&
+    flowType === FLOWS.ATTACH
+
   let bodyText: React.ReactNode = <div></div>
   if (isPending) {
     bodyText = (
@@ -45,7 +58,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
         />
       </>
     )
-  } else if (isSingleMountPipette) {
+  } else if (isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement) {
     bodyText = <StyledText as="p">{t('hold_and_loosen')}</StyledText>
   } else {
     bodyText = (
@@ -70,7 +83,11 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
             backgroundSize={BACKGROUND_SIZE}
           />
         ) : (
-          t(isSingleMountPipette ? 'loose_detach' : 'unscrew_remove_96_channel')
+          t(
+            isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement
+              ? 'loose_detach'
+              : 'unscrew_remove_96_channel'
+          )
         )
       }
       //  TODO(Jr, 11/8/22): replace image with correct one!
@@ -83,10 +100,14 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           />
         ) : (
           <img
-            src={isSingleMountPipette ? detachPipette : detach96Pipette}
+            src={
+              isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement
+                ? detachPipette
+                : detach96Pipette
+            }
             width="100%"
             alt={
-              isSingleMountPipette
+              isSingleMountPipette || isPipetteAttachedFor96ChannelAttachement
                 ? 'Detach pipette'
                 : 'Unscrew 96 channel pipette'
             }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -17,7 +17,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
   const {
     proceed,
     flowType,
-    attachedPipette,
+    attachedPipettes,
     mount,
     handleCleanUpAndClose,
     selectedPipette,
@@ -37,8 +37,8 @@ export const Results = (props: ResultsProps): JSX.Element => {
     }
     case FLOWS.ATTACH: {
       // attachment flow success
-      if (attachedPipette[mount] != null) {
-        const pipetteName = attachedPipette[mount]?.modelSpecs.displayName
+      if (attachedPipettes[mount] != null) {
+        const pipetteName = attachedPipettes[mount]?.modelSpecs.displayName
         header = t('pipette_attached', { pipetteName: pipetteName })
         if (selectedPipette === NINETY_SIX_CHANNEL) {
           buttonText = t('shared:exit')
@@ -54,7 +54,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       break
     }
     case FLOWS.DETACH: {
-      if (attachedPipette[mount] != null) {
+      if (attachedPipettes[mount] != null) {
         header = t('pipette_failed_to_detach')
         iconColor = COLORS.errorEnabled
         isSuccess = false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -33,7 +33,7 @@ describe('AttachProbe', () => {
         .fn()
         .mockImplementationOnce(() => Promise.resolve()),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
       errorMessage: null,
       setShowErrorMessage: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -58,7 +58,7 @@ describe('BeforeBeginning', () => {
         .fn()
         .mockImplementationOnce(() => Promise.resolve()),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
       createRun: jest.fn(),
       errorMessage: null,
@@ -139,7 +139,7 @@ describe('BeforeBeginning', () => {
     it('renders the modal with all correct text. clicking on proceed button sends commands', async () => {
       props = {
         ...props,
-        attachedPipette: { left: null, right: null },
+        attachedPipettes: { left: null, right: null },
         flowType: FLOWS.ATTACH,
       }
       const { getByText, getByAltText, getByRole } = render(props)
@@ -177,7 +177,7 @@ describe('BeforeBeginning', () => {
     it('renders the modal with all correct text. clicking on proceed button sends commands for detach flow', async () => {
       props = {
         ...props,
-        attachedPipette: { left: mockPipette, right: null },
+        attachedPipettes: { left: mockPipette, right: null },
         flowType: FLOWS.DETACH,
       }
       const { getByText, getByAltText, getByRole } = render(props)
@@ -218,7 +218,7 @@ describe('BeforeBeginning', () => {
       mockGetIsGantryEmpty.mockReturnValue(true)
       props = {
         ...props,
-        attachedPipette: { left: null, right: null },
+        attachedPipettes: { left: null, right: null },
         flowType: FLOWS.ATTACH,
         selectedPipette: NINETY_SIX_CHANNEL,
       }
@@ -262,7 +262,7 @@ describe('BeforeBeginning', () => {
       props = {
         ...props,
         mount: RIGHT,
-        attachedPipette: { left: null, right: mockPipette },
+        attachedPipettes: { left: null, right: mockPipette },
         flowType: FLOWS.ATTACH,
         selectedPipette: NINETY_SIX_CHANNEL,
       }
@@ -313,7 +313,7 @@ describe('BeforeBeginning', () => {
       mockGetIsGantryEmpty.mockReturnValue(false)
       props = {
         ...props,
-        attachedPipette: { left: mockPipette, right: null },
+        attachedPipettes: { left: mockPipette, right: null },
         flowType: FLOWS.ATTACH,
         selectedPipette: NINETY_SIX_CHANNEL,
       }
@@ -365,7 +365,7 @@ describe('BeforeBeginning', () => {
     it('renders the modal with all correct text. clicking on proceed button sends commands for detach flow', async () => {
       props = {
         ...props,
-        attachedPipette: { left: mockPipette, right: null },
+        attachedPipettes: { left: mockPipette, right: null },
         flowType: FLOWS.DETACH,
         selectedPipette: NINETY_SIX_CHANNEL,
       }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -4,6 +4,7 @@ import { renderWithProviders } from '@opentrons/components'
 import {
   LEFT,
   NINETY_SIX_CHANNEL,
+  RIGHT,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
@@ -16,13 +17,18 @@ import { InProgressModal } from '../../../molecules/InProgressModal/InProgressMo
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { BeforeBeginning } from '../BeforeBeginning'
 import { FLOWS } from '../constants'
+import { getIsGantryEmpty } from '../utils'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
 //  TODO(jr, 11/3/22): uncomment out the get help link when we have
 //  the correct URL to link it to
 // jest.mock('../../CalibrationPanels')
 jest.mock('../../../molecules/InProgressModal/InProgressModal')
+jest.mock('../utils')
 
+const mockGetIsGantryEmpty = getIsGantryEmpty as jest.MockedFunction<
+  typeof getIsGantryEmpty
+>
 const mockInProgressModal = InProgressModal as jest.MockedFunction<
   typeof InProgressModal
 >
@@ -62,6 +68,7 @@ describe('BeforeBeginning', () => {
     }
     // mockNeedHelpLink.mockReturnValue(<div>mock need help link</div>)
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
+    mockGetIsGantryEmpty.mockReturnValue(false)
   })
   describe('calibrate flow single mount', () => {
     it('returns the correct information for calibrate flow', async () => {
@@ -207,7 +214,8 @@ describe('BeforeBeginning', () => {
     })
   })
   describe('attach flow 96 channel', () => {
-    it('renders the modal with all the correct text, clicking on proceed button sends commands for attach flow', async () => {
+    it('renders the modal with all the correct text, clicking on proceed button sends commands for attach flow with an empty gantry', async () => {
+      mockGetIsGantryEmpty.mockReturnValue(true)
       props = {
         ...props,
         attachedPipette: { left: null, right: null },
@@ -238,6 +246,108 @@ describe('BeforeBeginning', () => {
       fireEvent.click(proceedBtn)
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
+    it('renders the 96 channel flow when there is a pipette on the gantry on the right mount', async () => {
+      mockGetIsGantryEmpty.mockReturnValue(false)
+      props = {
+        ...props,
+        attachedPipette: { left: null, right: mockPipette },
+        flowType: FLOWS.ATTACH,
+        selectedPipette: NINETY_SIX_CHANNEL,
+      }
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.'
+      )
+      getByText(
+        'The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.'
+      )
+      getByText(
+        'The 96-channel pipette is <weight> so be cautious during uninstall. Having a helper near by can be really useful for this process'
+      )
+      getByAltText('2.5 mm Hex Screwdriver')
+      getByAltText('Calibration Probe')
+      getByAltText('96 Channel Pipette')
+      getByAltText('96 Channel Mounting Plate')
+      getByText(
+        'Provided with robot. Using another size can strip the instruments’s screws.'
+      )
+      const proceedBtn = getByRole('button', {
+        name: 'Move gantry to front',
+      })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: RIGHT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: RIGHT },
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
+    it('renders the 96 channel flow when there is a pipette on the gantry on the left mount', async () => {
+      mockGetIsGantryEmpty.mockReturnValue(false)
+      props = {
+        ...props,
+        attachedPipette: { left: mockPipette, right: null },
+        flowType: FLOWS.ATTACH,
+        selectedPipette: NINETY_SIX_CHANNEL,
+      }
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.'
+      )
+      getByText(
+        'The calibration probe is included with the robot and should be stored on the right-hand side of the door opening.'
+      )
+      getByText(
+        'The 96-channel pipette is <weight> so be cautious during uninstall. Having a helper near by can be really useful for this process'
+      )
+      getByAltText('2.5 mm Hex Screwdriver')
+      getByAltText('Calibration Probe')
+      getByAltText('96 Channel Pipette')
+      getByAltText('96 Channel Mounting Plate')
+      getByText(
+        'Provided with robot. Using another size can strip the instruments’s screws.'
+      )
+      const proceedBtn = getByRole('button', {
+        name: 'Move gantry to front',
+      })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -261,6 +261,7 @@ describe('BeforeBeginning', () => {
       mockGetIsGantryEmpty.mockReturnValue(false)
       props = {
         ...props,
+        mount: RIGHT,
         attachedPipette: { left: null, right: mockPipette },
         flowType: FLOWS.ATTACH,
         selectedPipette: NINETY_SIX_CHANNEL,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -36,7 +36,7 @@ describe('Carriage', () => {
       proceed: jest.fn(),
       chainRunCommands: jest.fn(),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.ATTACH,
       errorMessage: null,
       setShowErrorMessage: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -16,16 +16,21 @@ import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { FLOWS } from '../constants'
 import { DetachPipette } from '../DetachPipette'
 import { CheckPipetteButton } from '../CheckPipetteButton'
+import { getIsGantryEmpty } from '../utils'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
 jest.mock('../CheckPipetteButton')
 jest.mock('../../../molecules/InProgressModal/InProgressModal')
+jest.mock('../utils')
 
 const mockInProgressModal = InProgressModal as jest.MockedFunction<
   typeof InProgressModal
 >
 const mockCheckPipetteButton = CheckPipetteButton as jest.MockedFunction<
   typeof CheckPipetteButton
+>
+const mockGetIsGantryEmpty = getIsGantryEmpty as jest.MockedFunction<
+  typeof getIsGantryEmpty
 >
 const render = (props: React.ComponentProps<typeof DetachPipette>) => {
   return renderWithProviders(<DetachPipette {...props} />, {
@@ -57,6 +62,7 @@ describe('DetachPipette', () => {
     }
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
     mockCheckPipetteButton.mockReturnValue(<div>mock check pipette button</div>)
+    mockGetIsGantryEmpty.mockReturnValue(true)
   })
   it('returns the correct information, buttons work as expected for single mount pipettes', () => {
     const { getByText, getByAltText, getByLabelText } = render(props)
@@ -81,6 +87,7 @@ describe('DetachPipette', () => {
   it('returns the correct information, buttons work as expected for 96 channel pipettes', () => {
     props = {
       ...props,
+      flowType: FLOWS.ATTACH,
       selectedPipette: NINETY_SIX_CHANNEL,
     }
     const { getByText, getByAltText, getByLabelText } = render(props)
@@ -107,5 +114,22 @@ describe('DetachPipette', () => {
     getAllByTestId('Skeleton')
     const backBtn = getByLabelText('back')
     expect(backBtn).toBeDisabled()
+  })
+  it('returns the correct information, buttons work as expected for 96 channel pipette flow when single mount is attached', () => {
+    mockGetIsGantryEmpty.mockReturnValue(false)
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      selectedPipette: NINETY_SIX_CHANNEL,
+    }
+    const { getByText, getByAltText, getByLabelText } = render(props)
+    getByText('Loosen Screws and Detach')
+    getByText(
+      'Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette'
+    )
+    getByAltText('Detach pipette')
+    getByText('mock check pipette button')
+    getByLabelText('back').click()
+    expect(props.goBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -47,7 +47,7 @@ describe('DetachPipette', () => {
       proceed: jest.fn(),
       chainRunCommands: jest.fn(),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
       errorMessage: null,
       setShowErrorMessage: jest.fn(),
@@ -83,7 +83,7 @@ describe('DetachPipette', () => {
       ...props,
       flowType: FLOWS.ATTACH,
       selectedPipette: NINETY_SIX_CHANNEL,
-      attachedPipette: {
+      attachedPipettes: {
         left: {
           id: 'abc',
           name: 'p1000_96',

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -16,21 +16,16 @@ import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { FLOWS } from '../constants'
 import { DetachPipette } from '../DetachPipette'
 import { CheckPipetteButton } from '../CheckPipetteButton'
-import { getIsGantryEmpty } from '../utils'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
 jest.mock('../CheckPipetteButton')
 jest.mock('../../../molecules/InProgressModal/InProgressModal')
-jest.mock('../utils')
 
 const mockInProgressModal = InProgressModal as jest.MockedFunction<
   typeof InProgressModal
 >
 const mockCheckPipetteButton = CheckPipetteButton as jest.MockedFunction<
   typeof CheckPipetteButton
->
-const mockGetIsGantryEmpty = getIsGantryEmpty as jest.MockedFunction<
-  typeof getIsGantryEmpty
 >
 const render = (props: React.ComponentProps<typeof DetachPipette>) => {
   return renderWithProviders(<DetachPipette {...props} />, {
@@ -62,7 +57,6 @@ describe('DetachPipette', () => {
     }
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
     mockCheckPipetteButton.mockReturnValue(<div>mock check pipette button</div>)
-    mockGetIsGantryEmpty.mockReturnValue(true)
   })
   it('returns the correct information, buttons work as expected for single mount pipettes', () => {
     const { getByText, getByAltText, getByLabelText } = render(props)
@@ -89,6 +83,18 @@ describe('DetachPipette', () => {
       ...props,
       flowType: FLOWS.ATTACH,
       selectedPipette: NINETY_SIX_CHANNEL,
+      attachedPipette: {
+        left: {
+          id: 'abc',
+          name: 'p1000_96',
+          model: 'p1000_96_v1.0',
+          tip_length: 42,
+          mount_axis: 'c',
+          plunger_axis: 'd',
+          modelSpecs: mockGen3P1000PipetteSpecs,
+        },
+        right: null,
+      },
     }
     const { getByText, getByAltText, getByLabelText } = render(props)
     getByText('Unscrew and Remove 96 Channel Pipette')
@@ -116,7 +122,6 @@ describe('DetachPipette', () => {
     expect(backBtn).toBeDisabled()
   })
   it('returns the correct information, buttons work as expected for 96 channel pipette flow when single mount is attached', () => {
-    mockGetIsGantryEmpty.mockReturnValue(false)
     props = {
       ...props,
       flowType: FLOWS.ATTACH,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
@@ -38,7 +38,7 @@ describe('DetachProbe', () => {
       proceed: jest.fn(),
       chainRunCommands: jest.fn(),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.CALIBRATE,
       handleCleanUp: jest.fn(),
       errorMessage: null,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
@@ -42,7 +42,7 @@ describe('MountPipette', () => {
       proceed: jest.fn(),
       chainRunCommands: jest.fn(),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.ATTACH,
       errorMessage: null,
       setShowErrorMessage: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -36,7 +36,7 @@ describe('MountingPlate', () => {
       proceed: jest.fn(),
       chainRunCommands: jest.fn(),
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       flowType: FLOWS.ATTACH,
       errorMessage: null,
       setShowErrorMessage: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -315,6 +315,7 @@ describe('PipetteWizardFlows', () => {
     })
   })
   it('renders the correct information, calling the correct commands for the attach flow 96 channel', async () => {
+    mockGetAttachedPipettes.mockReturnValue({ left: null, right: null })
     props = {
       ...props,
       flowType: FLOWS.ATTACH,
@@ -370,6 +371,7 @@ describe('PipetteWizardFlows', () => {
     // TODO wait until commands are wired up to write out more of this test!
   })
   it('renders the correct information, calling the correct commands for the detach flow 96 channel', async () => {
+    mockGetAttachedPipettes.mockReturnValue({ left: mockPipette, right: null })
     props = {
       ...props,
       flowType: FLOWS.DETACH,
@@ -435,5 +437,67 @@ describe('PipetteWizardFlows', () => {
     await waitFor(() => {
       expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
     })
+  })
+  it('renders the correct information, calling the correct commands for the attach flow 96 channel with gantry not empty', async () => {
+    mockGetAttachedPipettes.mockReturnValue({ left: null, right: mockPipette })
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      selectedPipette: NINETY_SIX_CHANNEL,
+    }
+    mockGetPipetteWizardSteps.mockReturnValue([
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+      {
+        section: SECTIONS.CARRIAGE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNTING_PLATE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+    ])
+    const { getByText, getByRole } = render(props)
+    getByText('Attach 96-Channel Pipette')
+    getByText('Before you begin')
+    // page 1
+    const getStarted = getByRole('button', { name: 'Move gantry to front' })
+    fireEvent.click(getStarted)
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+      expect(mockCreateRun).toHaveBeenCalled()
+    })
+    // page 2
+    getByText('Loosen Screws and Detach')
+    getByText('Continue')
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -371,7 +371,18 @@ describe('PipetteWizardFlows', () => {
     // TODO wait until commands are wired up to write out more of this test!
   })
   it('renders the correct information, calling the correct commands for the detach flow 96 channel', async () => {
-    mockGetAttachedPipettes.mockReturnValue({ left: mockPipette, right: null })
+    mockGetAttachedPipettes.mockReturnValue({
+      left: {
+        id: 'abc',
+        name: 'p1000_96',
+        model: 'p1000_96_v1.0',
+        tip_length: 42,
+        mount_axis: 'c',
+        plunger_axis: 'd',
+        modelSpecs: mockGen3P1000PipetteSpecs,
+      },
+      right: null,
+    })
     props = {
       ...props,
       flowType: FLOWS.DETACH,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -38,7 +38,7 @@ describe('Results', () => {
       chainRunCommands: jest.fn(),
       isRobotMoving: false,
       runId: RUN_ID_1,
-      attachedPipette: { left: mockPipette, right: null },
+      attachedPipettes: { left: mockPipette, right: null },
       errorMessage: null,
       setShowErrorMessage: jest.fn(),
       flowType: FLOWS.CALIBRATE,
@@ -76,7 +76,7 @@ describe('Results', () => {
   it('renders the correct information when pipette wizard is a fail for attach flow', () => {
     props = {
       ...props,
-      attachedPipette: { left: null, right: null },
+      attachedPipettes: { left: null, right: null },
       flowType: FLOWS.ATTACH,
     }
     const { getByText, getByRole, getByLabelText } = render(props)
@@ -91,7 +91,7 @@ describe('Results', () => {
   it('renders the correct information when pipette wizard is a success for detach flow', () => {
     props = {
       ...props,
-      attachedPipette: { left: null, right: null },
+      attachedPipettes: { left: null, right: null },
       currentStepIndex: 6,
       flowType: FLOWS.DETACH,
     }
@@ -137,7 +137,7 @@ describe('Results', () => {
     props = {
       ...props,
       flowType: FLOWS.DETACH,
-      attachedPipette: { left: null, right: null },
+      attachedPipettes: { left: null, right: null },
       selectedPipette: NINETY_SIX_CHANNEL,
     }
     const { getByText, getByRole, getByLabelText } = render(props)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -14,15 +14,9 @@ import { i18n } from '../../../i18n'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { Results } from '../Results'
 import { FLOWS } from '../constants'
-import { getIsGantryEmpty } from '../utils'
 
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
-jest.mock('../utils')
-
-const mockGetIsGantryEmpty = getIsGantryEmpty as jest.MockedFunction<
-  typeof getIsGantryEmpty
->
 const render = (props: React.ComponentProps<typeof Results>) => {
   return renderWithProviders(<Results {...props} />, {
     i18nInstance: i18n,
@@ -50,8 +44,8 @@ describe('Results', () => {
       flowType: FLOWS.CALIBRATE,
       handleCleanUpAndClose: jest.fn(),
       currentStepIndex: 2,
+      totalStepCount: 6,
     }
-    mockGetIsGantryEmpty.mockReturnValue(true)
   })
   it('renders the correct information when pipette cal is a success for calibrate flow', () => {
     const { getByText, getByRole, getByLabelText } = render(props)
@@ -92,12 +86,13 @@ describe('Results', () => {
     )
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard is a success for detach flow', () => {
     props = {
       ...props,
       attachedPipette: { left: null, right: null },
+      currentStepIndex: 6,
       flowType: FLOWS.DETACH,
     }
     const { getByText, getByRole, getByLabelText } = render(props)
@@ -124,10 +119,9 @@ describe('Results', () => {
     expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard is a fail for 96 channel attach flow and gantry not empty', () => {
-    mockGetIsGantryEmpty.mockReturnValue(false)
     props = {
       ...props,
-      flowType: FLOWS.ATTACH,
+      flowType: FLOWS.DETACH,
       selectedPipette: NINETY_SIX_CHANNEL,
     }
     const { getByText, getByRole, getByLabelText } = render(props)
@@ -140,10 +134,10 @@ describe('Results', () => {
     expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard is a success for 96 channel attach flow and gantry not empty', () => {
-    mockGetIsGantryEmpty.mockReturnValue(true)
     props = {
       ...props,
-      flowType: FLOWS.ATTACH,
+      flowType: FLOWS.DETACH,
+      attachedPipette: { left: null, right: null },
       selectedPipette: NINETY_SIX_CHANNEL,
     }
     const { getByText, getByRole, getByLabelText } = render(props)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -33,7 +33,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, SINGLE_MOUNT_PIPETTES)
+      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
   it('returns the correct array of info for attach pipette flow single channel', () => {
@@ -71,7 +71,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, SINGLE_MOUNT_PIPETTES)
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -95,7 +95,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, SINGLE_MOUNT_PIPETTES)
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 
@@ -129,7 +129,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL)
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -163,15 +163,53 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL)
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
+  it('returns the correct array when 96-channel is going to be attached and there is a pipette already on the mount', () => {
+    const mockAttachPipetteFlowSteps = [
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+      {
+        section: SECTIONS.CARRIAGE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNTING_PLATE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+    ] as PipetteWizardStep[]
 
+    expect(
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false)
+    ).toStrictEqual(mockAttachPipetteFlowSteps)
+  })
   //  TODO(jr, 12/5/22): fix this test when the calibrate steps are added
   it('returns the corect array of info for calibrate pipette 96 channel', () => {
     const mockDetachPipetteFlowSteps = [] as PipetteWizardStep[]
     expect(
-      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, NINETY_SIX_CHANNEL)
+      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, NINETY_SIX_CHANNEL, false)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -3,10 +3,31 @@ import {
   SINGLE_MOUNT_PIPETTES,
   NINETY_SIX_CHANNEL,
 } from '@opentrons/shared-data'
+import {
+  mockAttachedPipette,
+  mockGen3P1000PipetteSpecs,
+} from '../../../redux/pipettes/__fixtures__'
 import { FLOWS, SECTIONS } from '../constants'
 import { getPipetteWizardSteps } from '../getPipetteWizardSteps'
+import type {
+  AttachedPipette,
+  AttachedPipettesByMount,
+} from '../../../redux/pipettes/types'
 import type { PipetteWizardStep } from '../types'
 
+const mockPipette: AttachedPipette = {
+  ...mockAttachedPipette,
+  modelSpecs: mockGen3P1000PipetteSpecs,
+}
+
+const mockAttachedPipettesEmpty: AttachedPipettesByMount = {
+  left: null,
+  right: null,
+}
+const mockAttachedPipettesNotEmpty: AttachedPipettesByMount = {
+  left: mockPipette,
+  right: null,
+}
 describe('getPipetteWizardSteps', () => {
   it('returns the correct array of info when the flow is calibrate single channel', () => {
     const mockCalibrateFlowSteps = [
@@ -33,7 +54,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, SINGLE_MOUNT_PIPETTES, false)
+      getPipetteWizardSteps(
+        FLOWS.CALIBRATE,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        mockAttachedPipettesNotEmpty
+      )
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
   it('returns the correct array of info for attach pipette flow single channel', () => {
@@ -71,7 +98,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
+      getPipetteWizardSteps(
+        FLOWS.ATTACH,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        mockAttachedPipettesEmpty
+      )
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -95,7 +128,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
+      getPipetteWizardSteps(
+        FLOWS.DETACH,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        mockAttachedPipettesNotEmpty
+      )
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 
@@ -129,7 +168,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true)
+      getPipetteWizardSteps(
+        FLOWS.ATTACH,
+        LEFT,
+        NINETY_SIX_CHANNEL,
+        true,
+        mockAttachedPipettesEmpty
+      )
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -163,7 +208,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true)
+      getPipetteWizardSteps(
+        FLOWS.DETACH,
+        LEFT,
+        NINETY_SIX_CHANNEL,
+        true,
+        mockAttachedPipettesNotEmpty
+      )
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
   it('returns the correct array when 96-channel is going to be attached and there is a pipette already on the mount', () => {
@@ -176,9 +227,9 @@ describe('getPipetteWizardSteps', () => {
       {
         section: SECTIONS.DETACH_PIPETTE,
         mount: LEFT,
-        flowType: FLOWS.ATTACH,
+        flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -202,14 +253,26 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false)
+      getPipetteWizardSteps(
+        FLOWS.ATTACH,
+        LEFT,
+        NINETY_SIX_CHANNEL,
+        false,
+        mockAttachedPipettesNotEmpty
+      )
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
   //  TODO(jr, 12/5/22): fix this test when the calibrate steps are added
   it('returns the corect array of info for calibrate pipette 96 channel', () => {
     const mockDetachPipetteFlowSteps = [] as PipetteWizardStep[]
     expect(
-      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, NINETY_SIX_CHANNEL, false)
+      getPipetteWizardSteps(
+        FLOWS.CALIBRATE,
+        LEFT,
+        NINETY_SIX_CHANNEL,
+        false,
+        mockAttachedPipettesNotEmpty
+      )
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/utils.test.ts
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/utils.test.ts
@@ -1,0 +1,25 @@
+import {
+  mockAttachedPipette,
+  mockGen3P1000PipetteSpecs,
+} from '../../../redux/pipettes/__fixtures__'
+import { getIsGantryEmpty } from '../utils'
+import type { AttachedPipette } from '../../../redux/pipettes/types'
+
+const mockPipette: AttachedPipette = {
+  ...mockAttachedPipette,
+  modelSpecs: mockGen3P1000PipetteSpecs,
+}
+
+describe('getIsGantryEmpty', () => {
+  it('should return true when no pipettes attached', () => {
+    expect(getIsGantryEmpty({ left: null, right: null })).toEqual(true)
+  })
+  it('should return false when 1 pipette is attached', () => {
+    expect(getIsGantryEmpty({ left: mockPipette, right: null })).toEqual(false)
+  })
+  it('should return false when 2 pipettes are attached', () => {
+    expect(getIsGantryEmpty({ left: mockPipette, right: mockPipette })).toEqual(
+      false
+    )
+  })
+})

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -13,7 +13,8 @@ import type { PipetteMount } from '@opentrons/shared-data'
 export const getPipetteWizardSteps = (
   flowType: PipetteWizardFlow,
   mount: PipetteMount,
-  selectedPipette: SelectablePipettes
+  selectedPipette: SelectablePipettes,
+  isGantryEmpty: boolean
 ): PipetteWizardStep[] => {
   if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
     switch (flowType) {
@@ -66,25 +67,62 @@ export const getPipetteWizardSteps = (
         return []
       }
       case FLOWS.ATTACH: {
-        return [
-          {
-            section: SECTIONS.BEFORE_BEGINNING,
-            mount: mount,
-            flowType: flowType,
-          },
-          {
-            section: SECTIONS.CARRIAGE,
-            mount: mount,
-            flowType: flowType,
-          },
-          {
-            section: SECTIONS.MOUNTING_PLATE,
-            mount: mount,
-            flowType: flowType,
-          },
-          { section: SECTIONS.MOUNT_PIPETTE, mount: mount, flowType: flowType },
-          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
-        ]
+        //  for attaching 96 channel but a pipette is attached
+        if (!isGantryEmpty) {
+          return [
+            {
+              section: SECTIONS.BEFORE_BEGINNING,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.DETACH_PIPETTE,
+              mount: mount,
+              flowType: flowType,
+            },
+            { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+            {
+              section: SECTIONS.CARRIAGE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.MOUNTING_PLATE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.MOUNT_PIPETTE,
+              mount: mount,
+              flowType: flowType,
+            },
+            { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+          ]
+        } else {
+          return [
+            {
+              section: SECTIONS.BEFORE_BEGINNING,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.CARRIAGE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.MOUNTING_PLATE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.MOUNT_PIPETTE,
+              mount: mount,
+              flowType: flowType,
+            },
+            { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+          ]
+        }
       }
       case FLOWS.DETACH: {
         return [

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -2,6 +2,8 @@ import { FLOWS, SECTIONS } from './constants'
 import {
   SINGLE_MOUNT_PIPETTES,
   NINETY_SIX_CHANNEL,
+  LEFT,
+  RIGHT,
 } from '@opentrons/shared-data'
 import type {
   PipetteWizardStep,
@@ -9,12 +11,14 @@ import type {
   SelectablePipettes,
 } from './types'
 import type { PipetteMount } from '@opentrons/shared-data'
+import { AttachedPipettesByMount } from '@opentrons/api-client'
 
 export const getPipetteWizardSteps = (
   flowType: PipetteWizardFlow,
   mount: PipetteMount,
   selectedPipette: SelectablePipettes,
-  isGantryEmpty: boolean
+  isGantryEmpty: boolean,
+  attachedPipettes: AttachedPipettesByMount
 ): PipetteWizardStep[] => {
   if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
     switch (flowType) {
@@ -67,36 +71,47 @@ export const getPipetteWizardSteps = (
         return []
       }
       case FLOWS.ATTACH: {
+        let detachMount = mount
+        if (attachedPipettes[LEFT] == null) {
+          detachMount = RIGHT
+        } else if (attachedPipettes[RIGHT] == null) {
+          detachMount = LEFT
+        }
+
         //  for attaching 96 channel but a pipette is attached
         if (!isGantryEmpty) {
           return [
             {
               section: SECTIONS.BEFORE_BEGINNING,
-              mount: mount,
+              mount: detachMount,
               flowType: flowType,
             },
             {
               section: SECTIONS.DETACH_PIPETTE,
-              mount: mount,
-              flowType: flowType,
+              mount: detachMount,
+              flowType: FLOWS.DETACH,
             },
-            { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+            {
+              section: SECTIONS.RESULTS,
+              mount: detachMount,
+              flowType: FLOWS.DETACH,
+            },
             {
               section: SECTIONS.CARRIAGE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.MOUNTING_PLATE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.MOUNT_PIPETTE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
-            { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+            { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
           ]
         } else {
           return [

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -148,7 +148,7 @@ export const PipetteWizardFlows = (
     proceed,
     runId,
     goBack,
-    attachedPipette: attachedPipettes,
+    attachedPipettes,
     setShowErrorMessage,
     errorMessage,
     robotName,

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -47,16 +47,17 @@ export const PipetteWizardFlows = (
 ): JSX.Element | null => {
   const { flowType, mount, closeFlow, robotName, selectedPipette } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  const attachedPipette = useSelector((state: State) =>
+  const attachedPipettes = useSelector((state: State) =>
     getAttachedPipettes(state, robotName)
   )
   const isGantryEmpty =
-    attachedPipette[LEFT] == null && attachedPipette[RIGHT] == null
+    attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null
   const pipetteWizardSteps = getPipetteWizardSteps(
     flowType,
     mount,
     selectedPipette,
-    isGantryEmpty
+    isGantryEmpty,
+    attachedPipettes
   )
   const host = useHost()
   const [runId, setRunId] = React.useState<string>('')
@@ -147,7 +148,7 @@ export const PipetteWizardFlows = (
     proceed,
     runId,
     goBack,
-    attachedPipette,
+    attachedPipette: attachedPipettes,
     setShowErrorMessage,
     errorMessage,
     robotName,
@@ -196,13 +197,8 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.RESULTS) {
     const handleProceed = (): void => {
-      if (
-        currentStepIndex === 2 &&
-        //  only proceeds if we know that the pipette was successfully attached
-        attachedPipette[mount] != null
-      ) {
+      if (currentStepIndex < totalStepCount) {
         proceed()
-        //  if you completed detaching the pipette, robot will home and delete run
       } else {
         closeFlow()
       }
@@ -218,6 +214,7 @@ export const PipetteWizardFlows = (
         proceed={handleProceed}
         handleCleanUpAndClose={handleCleanUpAndClose}
         currentStepIndex={currentStepIndex}
+        totalStepCount={totalStepCount}
       />
     )
   } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -3,8 +3,10 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useConditionalConfirm } from '@opentrons/components'
 import {
+  LEFT,
   NINETY_SIX_CHANNEL,
   SINGLE_MOUNT_PIPETTES,
+  RIGHT,
 } from '@opentrons/shared-data'
 import {
   useHost,
@@ -48,10 +50,13 @@ export const PipetteWizardFlows = (
   const attachedPipette = useSelector((state: State) =>
     getAttachedPipettes(state, robotName)
   )
+  const isGantryEmpty =
+    attachedPipette[LEFT] == null && attachedPipette[RIGHT] == null
   const pipetteWizardSteps = getPipetteWizardSteps(
     flowType,
     mount,
-    selectedPipette
+    selectedPipette,
+    isGantryEmpty
   )
   const host = useHost()
   const [runId, setRunId] = React.useState<string>('')
@@ -212,6 +217,7 @@ export const PipetteWizardFlows = (
         {...calibrateBaseProps}
         proceed={handleProceed}
         handleCleanUpAndClose={handleCleanUpAndClose}
+        currentStepIndex={currentStepIndex}
       />
     )
   } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -80,7 +80,7 @@ export interface PipetteWizardStepProps {
   ) => Promise<unknown>
   isRobotMoving: boolean
   runId: string
-  attachedPipette: AttachedPipettesByMount
+  attachedPipettes: AttachedPipettesByMount
   setShowErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
   errorMessage: string | null
   robotName: string

--- a/app/src/organisms/PipetteWizardFlows/utils.ts
+++ b/app/src/organisms/PipetteWizardFlows/utils.ts
@@ -1,0 +1,8 @@
+import { LEFT, RIGHT } from '@opentrons/shared-data'
+import type { AttachedPipettesByMount } from '@opentrons/api-client'
+
+export function getIsGantryEmpty(
+  attachedPipette: AttachedPipettesByMount
+): boolean {
+  return attachedPipette[LEFT] == null && attachedPipette[RIGHT] == null
+}


### PR DESCRIPTION
closes RLIQ-275

# Overview

Wires up the sections for the 96-channel attach flow when there is a pipette attached beforehand so you have to remove that pipette. Also fixes the logic in the modals to accommodate this.

I stubbed in some info but this is more or less how it should look (the last results page should say the 96 channel was attached but there is a p50 on the left mount stubbed in for now):


https://user-images.githubusercontent.com/66035149/207672184-63600d3e-39f5-43dc-a2cb-94a2dde9dc5f.mov

# Changelog

- add the sections to `getPipetteWizardFlow` and wire up in `PipetteWizardFlow`
- add the logic to `BeforeBeginning`, `DetachPipette`, and `Results`
- create new util `getIsGantryEmpty` to get if there are any pipettes attached/is the gantry empty

# Review requests

- test on an ot-3 with a pipette attached on the other mount. it should prompt you to detach it before attaching the 96 channel
- check logic to make sure everything makes sense - i tried to have a thorough test coverage for this so I think no other flows were affected by this added logic

# Risk assessment

low