### PR TITLE
fix(api): Increase XY hold-currents from 0.1 to 0.5 amps

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -181,27 +181,27 @@ DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
 
 DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     none={
-        OT3AxisKind.X: 0.1,
-        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.X: 0.5,
+        OT3AxisKind.Y: 0.5,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.3,
         OT3AxisKind.Z_G: 0.2,
     },
     high_throughput={
-        OT3AxisKind.X: 0.1,
-        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.X: 0.5,
+        OT3AxisKind.Y: 0.5,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.3,
     },
     low_throughput={
-        OT3AxisKind.X: 0.1,
-        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.X: 0.5,
+        OT3AxisKind.Y: 0.5,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.3,
     },
     two_low_throughput={
-        OT3AxisKind.X: 0.1,
-        OT3AxisKind.Y: 0.1,
+        OT3AxisKind.X: 0.5,
+        OT3AxisKind.Y: 0.5,
     },
     gripper={
         OT3AxisKind.Z: 0.1,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Gantry hold currents are too low, and it skips during pick-up-tip and some gripper actions. Increasing hold current from `0.1` to `0.5` is working much better, and the motors are not hot to the touch after a few hours of holding current.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

The biggest risk is overheating the motors and/or robot. EE team says hold-currents can be 50-70% of max current (`1.4`), which means a hold-current of `0.5` is well within the motor's spec.

The added heat from the motors may increase the robot's internal temperature, making it more difficult for T/C and TempDeck from reaching low temperatures. Finding the right compromise between holding force and increased heat will need to be determined through more extensive testing with EVT and again with DVT.
