### PR TITLE
feat(api, robot-server): Allow load liquids via json protocols

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -184,11 +184,6 @@ settings = [
             " Do not enable."
         ),
     ),
-    SettingDefinition(
-        _id="enableLoadLiquid",
-        title="Enable load liquid command and liquids translation",
-        description="Allow load liquid command and liquids translation.",
-    ),
 ]
 
 if ARCHITECTURE == SystemArchitecture.BUILDROOT:
@@ -495,6 +490,16 @@ def _migrate17to18(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate18to19(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 19 of the feature flags file.
+
+    - Removes deprecated enableLoadLiquid option
+    """
+    removals = ["enableLoadLiquid"]
+    newmap = {k: v for k, v in previous.items() if k not in removals}
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -514,6 +519,7 @@ _MIGRATIONS = [
     _migrate15to16,
     _migrate16to17,
     _migrate17to18,
+    _migrate18to19,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -35,9 +35,3 @@ def enable_protocol_engine_papi_core() -> bool:
     """Whether to use the ProtocolEngine core to execute Protocol API v2 protocols."""
 
     return advs.get_setting_with_env_overload("enableProtocolEnginePAPICore")
-
-
-def enable_load_liquid() -> bool:
-    """Whether to enable loadLiquid command."""
-
-    return advs.get_setting_with_env_overload("enableLoadLiquid")

--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -6,8 +6,6 @@ from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
-from opentrons.config import feature_flags
-
 if TYPE_CHECKING:
     from ..state import StateView
 
@@ -45,12 +43,11 @@ class LoadLiquidImplementation(AbstractCommandImpl[LoadLiquidParams, LoadLiquidR
 
     async def execute(self, params: LoadLiquidParams) -> LoadLiquidResult:
         """Load data necessary for a liquid."""
-        if feature_flags.enable_load_liquid():
-            self._state_view.liquid.validate_liquid_id(params.liquidId)
+        self._state_view.liquid.validate_liquid_id(params.liquidId)
 
-            self._state_view.labware.validate_liquid_allowed_in_labware(
-                labware_id=params.labwareId, wells=params.volumeByWell
-            )
+        self._state_view.labware.validate_liquid_allowed_in_labware(
+            labware_id=params.labwareId, wells=params.volumeByWell
+        )
 
         return LoadLiquidResult()
 

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -157,10 +157,9 @@ class ProtocolRunner:
         protocol = self._json_file_reader.read(protocol_source)
         commands = self._json_translator.translate_commands(protocol)
 
-        if feature_flags.enable_load_liquid():
-            liquids = self._json_translator.translate_liquids(protocol)
-            for liquid in liquids:
-                self._protocol_engine.add_liquid(liquid=liquid)
+        liquids = self._json_translator.translate_liquids(protocol)
+        for liquid in liquids:
+            self._protocol_engine.add_liquid(liquid=liquid)
 
         for command in commands:
             self._protocol_engine.add_command(request=command)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 18
+    return 19
 
 
 @pytest.fixture
@@ -22,7 +22,6 @@ def default_file_settings() -> Dict[str, Any]:
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
         "enableProtocolEnginePAPICore": None,
-        "enableLoadLiquid": None,
     }
 
 
@@ -342,5 +341,4 @@ def test_ensures_config() -> None:
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
         "enableProtocolEnginePAPICore": None,
-        "enableLoadLiquid": None,
     }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -117,14 +117,6 @@ async def enable_ot3_hardware_controller(
     decoy.when(config.feature_flags.enable_ot3_hardware_controller()).then_return(True)
 
 
-@pytest.fixture
-async def enable_load_liquid() -> AsyncGenerator[None, None]:
-    """Fixture enabling load-liquid support."""
-    await config.advanced_settings.set_adv_setting("enableLoadLiquid", True)
-    yield
-    await config.advanced_settings.set_adv_setting("enableLoadLiquid", False)
-
-
 @pytest.fixture()
 def protocol_file() -> str:
     return "testosaur_v2.py"

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -26,7 +26,6 @@ async def test_load_liquid_implementation(
     decoy: Decoy,
     subject: LoadLiquidImplementation,
     mock_state_view: StateView,
-    enable_load_liquid: None,
 ) -> None:
     """Test LoadLiquid command execution."""
     data = LoadLiquidParams(
@@ -44,27 +43,4 @@ async def test_load_liquid_implementation(
         mock_state_view.labware.validate_liquid_allowed_in_labware(
             "labware-id", {"A1": 30.0, "B2": 100.0}
         )
-    )
-
-
-async def test_load_liquid_implementation_ff_off(
-    decoy: Decoy, subject: LoadLiquidImplementation, mock_state_view: StateView
-) -> None:
-    """Test LoadLiquid command execution."""
-    data = LoadLiquidParams(
-        labwareId="labware-id",
-        liquidId="liquid-id",
-        volumeByWell={"A1": 30, "B2": 100},
-    )
-    result = await subject.execute(data)
-
-    assert result == LoadLiquidResult()
-
-    decoy.verify(mock_state_view.liquid.validate_liquid_id("liquid-id"), times=0)
-
-    decoy.verify(
-        mock_state_view.labware.validate_liquid_allowed_in_labware(
-            "labware-id", {"A1": 30.0, "B2": 100.0}
-        ),
-        times=0,
     )

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -100,9 +100,7 @@ async def test_runner_with_python(
     assert expected_command in commands_result
 
 
-async def test_runner_with_json(
-    json_protocol_file: Path, enable_load_liquid: None
-) -> None:
+async def test_runner_with_json(json_protocol_file: Path) -> None:
     """It should run a JSON protocol on the ProtocolRunner."""
     protocol_reader = ProtocolReader()
     protocol_source = await protocol_reader.read_saved(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -292,7 +292,6 @@ def test_load_json_liquids_ff_on(
     protocol_engine: ProtocolEngine,
     task_queue: TaskQueue,
     subject: ProtocolRunner,
-    enable_load_liquid: None,
 ) -> None:
     """It should load a JSON protocol file."""
     json_protocol_source = ProtocolSource(

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -260,18 +260,6 @@ def set_disable_fast_analysis(
 
 
 @pytest.fixture
-def set_enable_load_liquid(request_session: requests.Session) -> Iterator[None]:
-    """For integration tests that need to set then clear the
-    enableLoadLiquid feature flag"""
-    url = "http://localhost:31950/settings"
-    data = {"id": "enableLoadLiquid", "value": True}
-    request_session.post(url, json=data)
-    yield None
-    data["value"] = None
-    request_session.post(url, json=data)
-
-
-@pytest.fixture
 def get_labware_fixture() -> Callable[[str], LabwareDefinition]:
     def _get_labware_fixture(fixture_name: str) -> LabwareDefinition:
         with open(

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -537,7 +537,11 @@ stages:
                 startedAt: !anystr
                 completedAt: !anystr
             errors: []
-            liquids: []
+            liquids:
+              - id: waterId
+                displayName: Water
+                description: Liquid H2O
+                displayColor: '#7332a8'
 
 ---
 test_name: Upload and analyze a JSONv6 protocol, with liquids
@@ -545,7 +549,6 @@ test_name: Upload and analyze a JSONv6 protocol, with liquids
 marks:
   - usefixtures:
       - run_server
-      - set_enable_load_liquid
 
 stages:
   - name: Upload simple v6 protocol

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -3,7 +3,6 @@ test_name: Upload and run a JSONv6 protocol.
 marks:
   - usefixtures:
       - run_server
-      - set_enable_load_liquid
 stages:
   - name: Upload simple JSONv6 protocol
     request:

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -3,7 +3,6 @@ test_name: Upload and run a JSON v6 protocol that should fail.
 marks:
   - usefixtures:
       - run_server
-      - set_enable_load_liquid
 stages:
   - name: Upload a protocol
     request:

--- a/robot-server/tests/integration/http_api/runs/test_pause_then_cancel.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_then_cancel.tavern.yaml
@@ -3,7 +3,6 @@ test_name: Test a JSONv6 run can be paused and then cancelled.
 marks:
   - usefixtures:
       - run_server
-      - set_enable_load_liquid
 stages:
   - name: Upload a JSONv6 protocol
     request:

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -60,12 +60,6 @@ stages:
             description: !re_search 'Opentrons-internal setting to test new execution logic'
             restart_required: false
             value: !anything
-          - id: enableLoadLiquid
-            old_id: Null
-            title: Enable load liquid command and liquids translation
-            description: !re_search 'Allow load liquid command and liquids translation.'
-            restart_required: false
-            value: !anything
         links: !anydict
 
 ---


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-425.
Remove `enableLoadLiquid` api ff

# Changelog

- Added a migration step to remove `enableLoadLiquid` ff and removed it from `advanced_setting.py`.
- removed `enableLoadLiquid` ff from `feature_flags.py`
- Removed fixture that enables ff.

# Review requests

Did I miss anything? 

# Risk assessment

Low. Liquids are now exposed in the results form analysis and runs. Should not break anything. 