### PR TITLE
chore(build): fix default version for robot-stack

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -78,14 +78,12 @@ def _latest_tag_for_prefix(prefix):
             + '- build before release or no tags. Using 0.0.0-dev\n')
         tags_result = prefix.encode() + b'0.0.0-dev'
     tags_matching = tags_result.strip().split(b'\n')
-
-
     return tags_matching[-1].decode()
 
 def _latest_version_for_project(project):
     prefix = project_entries[project].tag_prefix
     tag = _latest_tag_for_prefix(prefix)
-    return tag.split(prefix)[1]
+    return prefix.join(tag.split(prefix)[1:])
 
 def _ref_from_sha(sha):
     # codebuild leaves us in detached HEAD, so we need to pull some


### PR DESCRIPTION
When the git versioning system can't find a matching tag, it uses a standard '0.0.0-dev'. When it was looking for a tag that starts with `v*`, the default is `v0.0.0-dev`, which is then split on `v`, and so we lost the last v in `dev`, which is invalid to python.

This situation only happens when something is building the version from a checkout of the project without git metadata - a bare clone, a tarball download, something like that. It will now use a correct version.
