### PR TITLE
refactor(api, hardware): hardware controller to keep track of motor status

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -208,7 +208,7 @@ class OT3Controller:
 
     def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:
         return all(
-            self._motor_status.get(axis_to_node(a)) is not None
+            isinstance(self._motor_status.get(axis_to_node(a)), MotorStatus)
             and self._motor_status.get(axis_to_node(a)).motor_ok
             for a in axes
         )

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 import logging
 from copy import deepcopy
 from typing import (
+    Callable,
     Dict,
     List,
     Optional,
@@ -207,10 +208,12 @@ class OT3Controller:
         self._module_controls = module_controls
 
     def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:
+        get_stat: Callable[
+            [Sequence[OT3Axis]], List[Optional[MotorStatus]]
+        ] = lambda ax: [self._motor_status.get(axis_to_node(a)) for a in ax]
         return all(
-            isinstance(self._motor_status.get(axis_to_node(a)), MotorStatus)
-            and self._motor_status.get(axis_to_node(a)).motor_ok
-            for a in axes
+            isinstance(status, MotorStatus) and status.motor_ok
+            for status in get_stat(axes)
         )
 
     async def update_position(self) -> OT3AxisMap[float]:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -186,8 +186,9 @@ class OT3Simulator:
 
     async def update_motor_status(self) -> None:
         """Retreieve motor and encoder status and position from all present nodes"""
+        # Simulate condition at boot, status would not be ok
         self._motor_status.update(
-            (node, MotorStatus(True, True)) for node in self._present_nodes
+            (node, MotorStatus(False, False)) for node in self._present_nodes
         )
 
     def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -5,6 +5,7 @@ import asyncio
 from contextlib import asynccontextmanager
 import logging
 from typing import (
+    Callable,
     Dict,
     List,
     Optional,
@@ -190,7 +191,9 @@ class OT3Simulator:
         )
 
     def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:
-        get_stat = lambda ax: [self._motor_status.get(axis_to_node(a)) for a in ax]
+        get_stat: Callable[
+            [Sequence[OT3Axis]], List[Optional[MotorStatus]]
+        ] = lambda ax: [self._motor_status.get(axis_to_node(a)) for a in ax]
         return all(
             isinstance(status, MotorStatus) and status.motor_ok
             for status in get_stat(axes)

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -190,10 +190,10 @@ class OT3Simulator:
         )
 
     def check_ready_for_movement(self, axes: Sequence[OT3Axis]) -> bool:
+        get_stat = lambda ax: [self._motor_status.get(axis_to_node(a)) for a in ax]
         return all(
-            self._motor_status.get(axis_to_node(a)) is not None
-            and self._motor_status.get(axis_to_node(a)).motor_ok
-            for a in axes
+            isinstance(status, MotorStatus) and status.motor_ok
+            for status in get_stat(axes)
         )
 
     async def update_position(self) -> OT3AxisMap[float]:

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -12,7 +12,10 @@ from opentrons.hardware_control.types import (
 )
 import numpy as np
 
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorId,
+)
 from opentrons_hardware.hardware_control.motion_planning import (
     AxisConstraints,
     SystemConstraints,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -504,6 +504,7 @@ class OT3API(
                 )
 
         await self._backend.probe_network()
+        await self._backend.update_motor_status()
         await self.set_gantry_load(
             self._gantry_load_from_instruments(self.get_all_attached_instr())
         )

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -292,6 +292,12 @@ class CurrentConfig:
         return self.hold_current, self.run_current
 
 
+@dataclass(frozen=True)
+class MotorStatus:
+    motor_ok: bool
+    encoder_ok: bool
+
+
 class DoorState(enum.Enum):
     OPEN = False
     CLOSED = True

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 from itertools import chain
 from mock import AsyncMock, patch
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
@@ -20,6 +20,7 @@ from opentrons.hardware_control.types import (
     OT3Mount,
     InvalidPipetteName,
     InvalidPipetteModel,
+    MotorStatus,
 )
 from opentrons_hardware.firmware_bindings.utils import UInt8Field
 
@@ -147,7 +148,7 @@ async def test_home_execute(
 ):
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
     # nothing has been homed
-    assert len(controller._homed_nodes) == 0
+    assert not controller._motor_status
 
     commanded_homes = set(axes)
     await controller.home(axes)
@@ -162,7 +163,7 @@ async def test_home_execute(
     assert not commanded_homes
 
     # all commanded axes have been homed
-    assert controller._homed_nodes == set(axis_to_node(ax) for ax in axes)
+    assert all(controller._motor_status[axis_to_node(ax)].motor_ok for ax in axes)
     assert controller.check_ready_for_movement(axes)
 
 
@@ -172,7 +173,7 @@ async def test_home_prioritize_mount(
 ):
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
     # nothing has been homed
-    assert not len(controller._homed_nodes)
+    assert not controller._motor_status
 
     await controller.home(axes)
     has_xy = len({OT3Axis.X, OT3Axis.Y} & set(axes)) > 0
@@ -188,7 +189,7 @@ async def test_home_prioritize_mount(
         assert len(run) == 1
 
     # all commanded axes have been homed
-    assert controller._homed_nodes == set(axis_to_node(ax) for ax in axes)
+    assert all(controller._motor_status[axis_to_node(ax)].motor_ok for ax in axes)
     assert controller.check_ready_for_movement(axes)
 
 
@@ -197,7 +198,7 @@ async def test_home_build_runners(
     controller: OT3Controller, mock_move_group_run, axes, mock_present_nodes
 ):
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
-    assert not len(controller._homed_nodes)
+    assert not controller._motor_status
 
     await controller.home(axes)
     has_pipette = len(set(OT3Axis.pipette_axes()) & set(axes)) > 0
@@ -218,7 +219,7 @@ async def test_home_build_runners(
         mock_move_group_run.assert_awaited_once()
 
     # all commanded axes have been homed
-    assert controller._homed_nodes == set(axis_to_node(ax) for ax in axes)
+    assert all(controller._motor_status[axis_to_node(ax)].motor_ok for ax in axes)
     assert controller.check_ready_for_movement(axes)
 
 
@@ -244,8 +245,7 @@ async def test_home_only_present_nodes(
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
 
     # nothing has been homed
-    assert not len(controller._homed_nodes)
-
+    assert not controller._motor_status
     await controller.home(axes)
 
     for call in mock_move_group_run.call_args_list:
@@ -267,8 +267,7 @@ async def test_home_only_present_nodes(
     for node, pos in controller._position.items():
         assert pos == expected_position[node]
     # check that the homed axis is tracked by _homed_nodes
-    assert len(controller._homed_nodes) == len(homed_position.keys())
-    assert controller._homed_nodes == homed_position.keys()
+    assert controller._motor_status.keys() == homed_position.keys()
 
 
 async def test_probing(
@@ -515,3 +514,37 @@ async def test_get_limit_switches(controller: OT3Controller) -> None:
         assert passed_nodes == {NodeId.gantry_x, NodeId.gantry_y}
         assert OT3Axis.X in res
         assert OT3Axis.Y in res
+
+
+@pytest.mark.parametrize(
+    "motor_status,ready",
+    [
+        ({}, False),
+        ({NodeId.gripper_g: MotorStatus(True, True)}, False),
+        (
+            {
+                NodeId.gantry_x: MotorStatus(True, True),
+                NodeId.gantry_y: MotorStatus(True, True),
+                NodeId.head_l: MotorStatus(False, True),
+            },
+            False,
+        ),
+        (
+            {
+                NodeId.gantry_x: MotorStatus(True, True),
+                NodeId.gantry_y: MotorStatus(True, True),
+                NodeId.head_l: MotorStatus(True, True),
+            },
+            True,
+        ),
+    ],
+)
+async def test_ready_for_movement(
+    controller: OT3Controller,
+    motor_status: MotorStatus,
+    ready: bool,
+) -> None:
+    controller._motor_status = motor_status
+
+    axes = [OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L]
+    assert controller.check_ready_for_movement(axes) == ready

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -126,7 +126,7 @@ home_test_params = [
 def move_group_run_side_effect(controller, axes_to_home):
     """Return homed position for axis that is present and was commanded to home."""
     gantry_homes = {
-        axis_to_node(ax): (0.0, 0.0)
+        axis_to_node(ax): (0.0, 0.0, True, True)
         for ax in OT3Axis.gantry_axes()
         if ax in axes_to_home and axis_to_node(ax) in controller._present_nodes
     }
@@ -134,7 +134,7 @@ def move_group_run_side_effect(controller, axes_to_home):
         yield gantry_homes
 
     pipette_homes = {
-        axis_to_node(ax): (0.0, 0.0)
+        axis_to_node(ax): (0.0, 0.0, True, True)
         for ax in OT3Axis.pipette_axes()
         if ax in axes_to_home and axis_to_node(ax) in controller._present_nodes
     }

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from itertools import chain
 from mock import AsyncMock, patch
 from opentrons.hardware_control.backends.ot3controller import OT3Controller

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -249,7 +249,7 @@ async def test_move_to_without_homing_first(
         instr_data = AttachedGripper(config=gripper_config, id="test")
         await ot3_hardware.cache_gripper(instr_data)
 
-    ot3_hardware._backend._homed_nodes = set()
+    ot3_hardware._backend._motor_status = {}
     assert not ot3_hardware._backend.check_ready_for_movement(homed_axis)
 
     await ot3_hardware.move_to(

--- a/hardware/opentrons_hardware/hardware_control/motor_position_status.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_position_status.py
@@ -1,0 +1,72 @@
+"""Utilities for gathering motor position/status for an OT3 axis."""
+import asyncio
+from typing import Set, Tuple
+import logging
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    MultipleMessagesWaitableCallback,
+)
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    MotorPositionRequest,
+    MotorPositionResponse,
+)
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    MessageId,
+    MotorPositionFlags,
+)
+
+from .types import NodeMap
+
+
+log = logging.getLogger(__name__)
+
+
+MotorPositionStatus = NodeMap[Tuple[float, float, bool, bool]]
+
+
+async def _parser_motor_position_response(
+    reader: MultipleMessagesWaitableCallback, expected: Set[NodeId]
+) -> MotorPositionStatus:
+    seen: Set[NodeId] = set()
+    data: MotorPositionStatus = {}
+    while not expected.issubset(seen):
+        async for response, arb_id in reader:
+            assert isinstance(response, MotorPositionResponse)
+            node = NodeId(arb_id.parts.originating_node_id)
+            data[node] = (
+                float(response.payload.current_position.value / 1000.0),
+                float(response.payload.encoder_position.value) / 1000.0,
+                bool(
+                    response.payload.position_flags.value
+                    & MotorPositionFlags.stepper_position_ok
+                ),
+                bool(
+                    response.payload.position_flags.value
+                    & MotorPositionFlags.encoder_position_ok
+                ),
+            )
+    return data
+
+
+async def get_motor_position(
+    can_messenger: CanMessenger, nodes: Set[NodeId], timeout: float = 1.0
+) -> MotorPositionStatus:
+    def _listener_filter(arbitration_id: ArbitrationId) -> bool:
+        return (NodeId(arbitration_id.parts.originating_node_id) in nodes) and (
+            MessageId(arbitration_id.parts.message_id)
+            == MotorPositionResponse.message_id
+        )
+
+    with MultipleMessagesWaitableCallback(can_messenger, _listener_filter) as reader:
+        await can_messenger.send(
+            node_id=NodeId.broadcast, message=MotorPositionRequest()
+        )
+        try:
+            return await asyncio.wait_for(
+                _parser_motor_position_response(),
+                timeout,
+            )
+        except asyncio.TimeoutError:
+            log.warning("Motor position timed out")

--- a/hardware/opentrons_hardware/hardware_control/motor_position_status.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_position_status.py
@@ -58,6 +58,8 @@ async def _parser_motor_position_response(
 async def get_motor_position(
     can_messenger: CanMessenger, nodes: Set[NodeId], timeout: float = 1.0
 ) -> MotorPositionStatus:
+    """Request node to respond with motor and encoder status."""
+
     def _listener_filter(arbitration_id: ArbitrationId) -> bool:
         return (NodeId(arbitration_id.parts.originating_node_id) in nodes) and (
             MessageId(arbitration_id.parts.message_id)

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -162,11 +162,11 @@ class MoveGroupRunner:
                     float(completion.payload.encoder_position_um.value) / 1000.0,
                     bool(
                         completion.payload.position_flags.value
-                        & MotorPositionFlags.stepper_position_ok
+                        & MotorPositionFlags.stepper_position_ok.value
                     ),
                     bool(
                         completion.payload.position_flags.value
-                        & MotorPositionFlags.encoder_position_ok
+                        & MotorPositionFlags.encoder_position_ok.value
                     ),
                 )
             )
@@ -177,7 +177,7 @@ class MoveGroupRunner:
                 reversed(
                     sorted(poslist, key=lambda position_element: position_element[0])
                 )
-            )[1:3]
+            )[1:]
             for node, poslist in position.items()
         }
 

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -77,7 +77,7 @@ async def capacitive_probe(
         do_log=log_sensor_values,
     ):
         position = await runner.run(can_messenger=messenger)
-        return position[mover]
+        return position[mover][:2]
 
 
 async def capacitive_pass(

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -123,7 +123,9 @@ async def test_move_integration(
     ]
     home_runner = MoveGroupRunner([home_move])
     position = await home_runner.run(can_messenger)
-    assert position == {motor_node: (0.0, 0.0) for motor_node in all_motor_nodes}
+    assert position == {
+        motor_node: (0.0, 0.0, False, False) for motor_node in all_motor_nodes
+    }
     # these moves test position accumulation to reasonably realistic values
     # and have to do it over a kind of long time so that the velocities are low
     # enough that the pipettes, with their extremely high steps/mm values,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -805,7 +805,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     ),
                 ),
             ],
-            {NodeId.gantry_x: (10, 40)},
+            {NodeId.gantry_x: (10, 40, False, False)},
         ),
         (
             # multiple axes with different numbers of completions
@@ -850,7 +850,10 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     ),
                 ),
             ],
-            {NodeId.gantry_x: (10, 40), NodeId.gantry_y: (30, 40)},
+            {
+                NodeId.gantry_x: (10, 40, False, False),
+                NodeId.gantry_y: (30, 40, False, False),
+            },
         ),
         (
             # empty base case
@@ -860,7 +863,8 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
     ],
 )
 def test_accumulate_move_completions(
-    completions: List[_CompletionPacket], position_map: NodeMap[Tuple[float, float]]
+    completions: List[_CompletionPacket],
+    position_map: NodeMap[Tuple[float, float, bool, bool]],
 ) -> None:
     """Build correct move results."""
     assert MoveGroupRunner._accumulate_move_completions(completions) == position_map


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR updates the `check_ready_for_movement` function in the hardware controller by tracking the motor status reported by each axis after a move.

At the beginning of each move, we evaluate the motor status for the axes that we're about to move. If any of the axes has a motor not ok flag, we will those homed before executing the actual move.



# Changelog
* Add `MotorStatus` dataclass with two fields: `motor_ok` and `encoder_ok` 
* Remove `homed_nodes` and use `MotorStatus` instead
* Add `get_motor_status` function in the hardware package
* Add backend method to update the motor status and calls the hardware get motor status function
* Each move complete from each axis now responds with its motor status, hardware controller status gets updated everytime

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

