### PR TITLE
feat(ot3): enable full tiprack pick up with the 96 channel

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -74,6 +74,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.Y: 500,
         OT3AxisKind.Z: 35,
         OT3AxisKind.P: 5,
+        OT3AxisKind.Q: 40,
     },
     low_throughput={
         OT3AxisKind.X: 500,
@@ -101,6 +102,7 @@ DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryL
         OT3AxisKind.Y: 1000,
         OT3AxisKind.Z: 100,
         OT3AxisKind.P: 10,
+        OT3AxisKind.Q: 10,
     },
     low_throughput={
         OT3AxisKind.X: 1000,
@@ -132,6 +134,7 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 10,
         OT3AxisKind.P: 10,
+        OT3AxisKind.Q: 10,
     },
     low_throughput={
         OT3AxisKind.X: 10,
@@ -163,6 +166,7 @@ DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.Y: 5,
         OT3AxisKind.Z: 5,
         OT3AxisKind.P: 5,
+        OT3AxisKind.Q: 5,
     },
     low_throughput={
         OT3AxisKind.X: 5,
@@ -192,6 +196,7 @@ DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLo
         OT3AxisKind.Y: 0.5,
         OT3AxisKind.Z: 0.8,
         OT3AxisKind.P: 0.3,
+        OT3AxisKind.Q: 0.3,
     },
     low_throughput={
         OT3AxisKind.X: 0.5,
@@ -221,6 +226,7 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
         OT3AxisKind.Y: 1.4,
         OT3AxisKind.Z: 1.4,
         OT3AxisKind.P: 2.0,
+        OT3AxisKind.Q: 2.0,
     },
     low_throughput={
         OT3AxisKind.X: 1.4,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -373,8 +373,16 @@ class OT3Controller:
         """
         return await self.home(axes)
 
-    async def tip_action(self, axes: Sequence[OT3Axis], distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
-        move_group = create_tip_action_group(axes, distance, speed, cast(PipetteAction, tip_action))
+    async def tip_action(
+        self,
+        axes: Sequence[OT3Axis],
+        distance: float = 33,
+        speed: float = -5.5,
+        tip_action: str = "drop",
+    ) -> None:
+        move_group = create_tip_action_group(
+            axes, distance, speed, cast(PipetteAction, tip_action)
+        )
         runner = MoveGroupRunner(move_groups=[move_group])
         positions = await runner.run(can_messenger=self._messenger)
         for axis, point in positions.items():

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -338,7 +338,7 @@ class OT3Controller:
         if OT3Axis.G in checked_axes:
             await self.gripper_home_jaw()
         if OT3Axis.Q in checked_axes:
-            await self.tip_action()
+            await self.tip_action([OT3Axis.Q])
         for position in positions:
             for axis, p in position.items():
                 self._position.update({axis: p[0]})
@@ -372,8 +372,8 @@ class OT3Controller:
         """
         return await self.home(axes)
 
-    async def tip_action(self, distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
-        move_group = create_tip_action_group(distance, speed, tip_action)
+    async def tip_action(self, axes: Sequence[OT3Axis], distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
+        move_group = create_tip_action_group(axes, distance, speed, tip_action)
         runner = MoveGroupRunner(move_groups=[move_group])
         positions = await runner.run(can_messenger=self._messenger)
         for axis, point in positions.items():

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -839,3 +839,6 @@ class OT3Controller:
         )
         self._position[axis_to_node(moving)] += distance_mm
         return data
+
+    async def tip_action() -> None:
+        return None

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -339,7 +339,14 @@ class OT3Controller:
         if OT3Axis.G in checked_axes:
             await self.gripper_home_jaw()
         if OT3Axis.Q in checked_axes:
-            await self.tip_action([OT3Axis.Q])
+            await self.tip_action(
+                [OT3Axis.Q],
+                self.axis_bounds[OT3Axis.Q][1] - self.axis_bounds[OT3Axis.Q][0],
+                -1
+                * self._configuration.motion_settings.default_max_speed.high_throughput[
+                    OT3Axis.to_kind(OT3Axis.Q)
+                ],
+            )
         for position in positions:
             for axis, p in position.items():
                 self._position.update({axis: p[0]})
@@ -376,8 +383,8 @@ class OT3Controller:
     async def tip_action(
         self,
         axes: Sequence[OT3Axis],
-        distance: float = 33,
-        speed: float = -5.5,
+        distance: float,
+        speed: float,
         tip_action: str = "drop",
     ) -> None:
         move_group = create_tip_action_group(
@@ -622,6 +629,7 @@ class OT3Controller:
             OT3Axis.X: phony_bounds,
             OT3Axis.Y: phony_bounds,
             OT3Axis.Z_G: phony_bounds,
+            OT3Axis.Q: phony_bounds,
         }
 
     def single_boundary(self, boundary: int) -> OT3AxisMap[float]:

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -33,6 +33,7 @@ from .ot3utils import (
     create_gripper_jaw_grip_group,
     create_gripper_jaw_home_group,
     create_gripper_jaw_hold_group,
+    create_tip_action_group,
 )
 
 try:
@@ -336,6 +337,8 @@ class OT3Controller:
         positions = await asyncio.gather(*coros)
         if OT3Axis.G in checked_axes:
             await self.gripper_home_jaw()
+        if OT3Axis.Q in checked_axes:
+            await self.tip_action()
         for position in positions:
             for axis, p in position.items():
                 self._position.update({axis: p[0]})
@@ -368,6 +371,14 @@ class OT3Controller:
             New position.
         """
         return await self.home(axes)
+
+    async def tip_action(self, distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
+        move_group = create_tip_action_group(distance, speed, tip_action)
+        runner = MoveGroupRunner(move_groups=[move_group])
+        positions = await runner.run(can_messenger=self._messenger)
+        for axis, point in positions.items():
+            self._position.update({axis: point[0]})
+            self._encoder_position.update({axis: point[1]})
 
     async def gripper_grip_jaw(
         self,
@@ -839,6 +850,3 @@ class OT3Controller:
         )
         self._position[axis_to_node(moving)] += distance_mm
         return data
-
-    async def tip_action() -> None:
-        return None

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -34,6 +34,7 @@ from .ot3utils import (
     create_gripper_jaw_home_group,
     create_gripper_jaw_hold_group,
     create_tip_action_group,
+    PipetteAction,
 )
 
 try:
@@ -373,7 +374,7 @@ class OT3Controller:
         return await self.home(axes)
 
     async def tip_action(self, axes: Sequence[OT3Axis], distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
-        move_group = create_tip_action_group(axes, distance, speed, tip_action)
+        move_group = create_tip_action_group(axes, distance, speed, cast(PipetteAction, tip_action))
         runner = MoveGroupRunner(move_groups=[move_group])
         positions = await runner.run(can_messenger=self._messenger)
         for axis, point in positions.items():

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -266,8 +266,16 @@ class OT3Simulator:
     ) -> None:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
 
-    async def tip_action(self, axes: Sequence[OT3Axis], distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
-        _ = create_tip_action_group(axes, distance, speed, cast(PipetteAction, tip_action))
+    async def tip_action(
+        self,
+        axes: Sequence[OT3Axis],
+        distance: float = 33,
+        speed: float = -5.5,
+        tip_action: str = "drop",
+    ) -> None:
+        _ = create_tip_action_group(
+            axes, distance, speed, cast(PipetteAction, tip_action)
+        )
 
     def _attached_to_mount(
         self, mount: OT3Mount, expected_instr: Optional[PipetteName]

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -28,6 +28,8 @@ from .ot3utils import (
     create_gripper_jaw_hold_group,
     create_gripper_jaw_grip_group,
     create_gripper_jaw_home_group,
+    create_tip_action_group,
+    PipetteAction,
 )
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -263,6 +265,9 @@ class OT3Simulator:
         encoder_position_um: int,
     ) -> None:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
+
+    async def tip_action(self, axes: Sequence[OT3Axis], distance: float = 33, speed: float = -5.5, tip_action: str="drop") -> None:
+        _ = create_tip_action_group(axes, distance, speed, cast(PipetteAction, tip_action))
 
     def _attached_to_mount(
         self, mount: OT3Mount, expected_instr: Optional[PipetteName]

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -13,7 +13,11 @@ from opentrons.hardware_control.types import (
 )
 import numpy as np
 
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorId, PipetteTipActionType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorId,
+    PipetteTipActionType,
+)
 from opentrons_hardware.hardware_control.motion_planning import (
     AxisConstraints,
     SystemConstraints,
@@ -238,15 +242,18 @@ def create_home_group(
     return move_group
 
 
-def create_tip_action_group(axes: Sequence[OT3Axis], distance: float, velocity: float, action: PipetteAction) -> MoveGroup:
+def create_tip_action_group(
+    axes: Sequence[OT3Axis], distance: float, velocity: float, action: PipetteAction
+) -> MoveGroup:
     current_nodes = [axis_to_node(ax) for ax in axes]
     step = create_tip_action_step(
         velocity={node_id: np.float64(velocity) for node_id in current_nodes},
         distance={node_id: np.float64(distance) for node_id in current_nodes},
         present_nodes=current_nodes,
-        action=PipetteTipActionType[action]
-        )
+        action=PipetteTipActionType[action],
+    )
     return [step]
+
 
 def create_gripper_jaw_grip_group(
     duty_cycle: float,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -240,6 +240,9 @@ def create_home_group(
     return move_group
 
 
+def create_tip_action_group():
+    return None
+
 def create_gripper_jaw_grip_group(
     duty_cycle: float,
     stop_condition: MoveStopCondition = MoveStopCondition.none,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -1,5 +1,5 @@
 """Shared utilities for ot3 hardware control."""
-from typing import Dict, Iterable, List, Tuple, TypeVar
+from typing import Dict, Iterable, List, Tuple, TypeVar, Sequence
 from typing_extensions import Literal
 from opentrons.config.types import OT3MotionSettings, OT3CurrentSettings, GantryLoad
 from opentrons.hardware_control.types import (
@@ -238,7 +238,7 @@ def create_home_group(
     return move_group
 
 
-def create_tip_action_group(axes: List[OT3Axis], distance: float, velocity: float, action: PipetteAction) -> MoveGroup:
+def create_tip_action_group(axes: Sequence[OT3Axis], distance: float, velocity: float, action: PipetteAction) -> MoveGroup:
     current_nodes = [axis_to_node(ax) for ax in axes]
     step = create_tip_action_step(
         velocity={node_id: np.float64(velocity) for node_id in current_nodes},

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -154,13 +154,7 @@ def get_current_settings(
 ) -> OT3AxisMap[CurrentConfig]:
     conf_by_pip = config.by_gantry_load(gantry_load)
     currents = {}
-    for axis_kind in [
-        OT3AxisKind.P,
-        OT3AxisKind.X,
-        OT3AxisKind.Y,
-        OT3AxisKind.Z,
-        OT3AxisKind.Z_G,
-    ]:
+    for axis_kind in conf_by_pip["hold_current"].keys():
         for axis in OT3Axis.of_kind(axis_kind):
             currents[axis] = CurrentConfig(
                 conf_by_pip["hold_current"][axis_kind],

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -244,10 +244,12 @@ def create_home_group(
     return move_group
 
 
-def create_tip_action_group(distance, velocity, action: PipetteAction) -> MoveGroup:
+def create_tip_action_group(axes: List[OT3Axis], distance: float, velocity: float, action: PipetteAction) -> MoveGroup:
+    current_nodes = [axis_to_node(ax) for ax in axes]
     step = create_tip_action_step(
-        velocity=velocity,
-        duration=abs(distance / velocity),
+        velocity={node_id: np.float64(velocity) for node_id in current_nodes},
+        distance={node_id: np.float64(distance) for node_id in current_nodes},
+        present_nodes=current_nodes,
         action=PipetteTipActionType[action]
         )
     return [step]

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -261,9 +261,11 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         # Temporary solution for the 96 channel critical point locations.
         # We should instead record every channel "critical point" in
         # the pipette configurations.
+        DIRECTION_VALUE = 1
         if self.channels.value == 96:
             NUM_ROWS = 12
             NUM_COLS = 8
+            DIRECTION_VALUE = -1
         elif self.channels.value == 8:
             NUM_ROWS = 1
             NUM_COLS = 8
@@ -271,8 +273,8 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             NUM_ROWS = 1
             NUM_COLS = 1
 
-        x_offset_to_right_nozzle = INTERNOZZLE_SPACING_MM * (NUM_ROWS - 1)
-        y_offset_to_front_nozzle = INTERNOZZLE_SPACING_MM * (NUM_COLS - 1)
+        x_offset_to_right_nozzle = DIRECTION_VALUE * INTERNOZZLE_SPACING_MM * (NUM_ROWS - 1)
+        y_offset_to_front_nozzle = DIRECTION_VALUE * INTERNOZZLE_SPACING_MM * (NUM_COLS - 1)
 
         if cp_override in [
             CriticalPoint.GRIPPER_JAW_CENTER,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -278,9 +278,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         x_offset_to_right_nozzle = (
             X_DIRECTION_VALUE * INTERNOZZLE_SPACING_MM * (NUM_ROWS - 1)
         )
-        y_offset_to_front_nozzle = (
-            INTERNOZZLE_SPACING_MM * (NUM_COLS - 1)
-        )
+        y_offset_to_front_nozzle = INTERNOZZLE_SPACING_MM * (NUM_COLS - 1)
 
         if cp_override in [
             CriticalPoint.GRIPPER_JAW_CENTER,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -261,11 +261,13 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         # Temporary solution for the 96 channel critical point locations.
         # We should instead record every channel "critical point" in
         # the pipette configurations.
-        DIRECTION_VALUE = 1
+        X_DIRECTION_VALUE = 1
+        Y_DIVISION = 2
         if self.channels.value == 96:
             NUM_ROWS = 12
             NUM_COLS = 8
-            DIRECTION_VALUE = -1
+            X_DIRECTION_VALUE = -1
+            Y_DIVISION = 3
         elif self.channels.value == 8:
             NUM_ROWS = 1
             NUM_COLS = 8
@@ -273,8 +275,12 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             NUM_ROWS = 1
             NUM_COLS = 1
 
-        x_offset_to_right_nozzle = DIRECTION_VALUE * INTERNOZZLE_SPACING_MM * (NUM_ROWS - 1)
-        y_offset_to_front_nozzle = DIRECTION_VALUE * INTERNOZZLE_SPACING_MM * (NUM_COLS - 1)
+        x_offset_to_right_nozzle = (
+            X_DIRECTION_VALUE * INTERNOZZLE_SPACING_MM * (NUM_ROWS - 1)
+        )
+        y_offset_to_front_nozzle = (
+            INTERNOZZLE_SPACING_MM * (NUM_COLS - 1)
+        )
 
         if cp_override in [
             CriticalPoint.GRIPPER_JAW_CENTER,
@@ -294,7 +300,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         if cp_override == CriticalPoint.XY_CENTER:
             mod_offset_xy = [
                 offsets[0] - x_offset_to_right_nozzle / 2,
-                offsets[1] - y_offset_to_front_nozzle / 2,
+                offsets[1] - y_offset_to_front_nozzle / Y_DIVISION,
                 offsets[2],
             ]
             cp_type = CriticalPoint.XY_CENTER

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -80,7 +80,7 @@ class ForcePickUpTipSpec:
 @dataclass(frozen=True)
 class TipMotorPickUpTipSpec:
     plunger_prep_pos: float
-    currents: Dict[OT3Axis, float]
+    plunger_currents: Dict[OT3Axis, float]
     tiprack_target: top_types.Point
     retract_target: float
     pick_up_distance: float
@@ -622,7 +622,7 @@ class PipetteHandlerProvider:
             return (
                 TipMotorPickUpTipSpec(
                 plunger_prep_pos=instrument.plunger_positions.bottom,
-                currents={
+                plunger_currents={
                     OT3Axis.of_main_tool_actuator(
                         mount
                     ): instrument.plunger_motor_current.run,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -12,7 +12,7 @@ from typing import (
     Sequence,
     Iterator,
     TypeVar,
-    Union
+    Union,
 )
 from typing_extensions import Final
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction
@@ -618,7 +618,7 @@ class PipetteHandlerProvider:
         def add_tip_to_instr() -> None:
             instrument.add_tip(tip_length=tip_length)
             instrument.set_current_volume(0)
-    
+
         if presses is None or presses < 0:
             checked_presses = instrument.pick_up_configurations.presses
         else:
@@ -647,27 +647,26 @@ class PipetteHandlerProvider:
         if instrument.channels.value == 96:
             return (
                 PickUpTipSpec(
-                plunger_prep_pos=instrument.plunger_positions.bottom,
-                plunger_currents={
-                    OT3Axis.of_main_tool_actuator(
-                        mount
-                    ): instrument.plunger_motor_current.run,
-                },
-                presses=[],
-                shake_off_list=[],
-                retract_target=instrument.pick_up_configurations.distance,
-                pick_up_motor_actions=TipMotorPickUpTipSpec(
-                    # Move onto the posts
-                    tiprack_down=top_types.Point(0, 0, 5),
-                    tiprack_up=top_types.Point(0, 0, -7),
-                    pick_up_distance=instrument.pick_up_configurations.distance,
-                    speed=instrument.pick_up_configurations.speed,
-                    currents={
-                        OT3Axis.Q: instrument.pick_up_configurations.current
-                    }
-                )
-
-            ), add_tip_to_instr)
+                    plunger_prep_pos=instrument.plunger_positions.bottom,
+                    plunger_currents={
+                        OT3Axis.of_main_tool_actuator(
+                            mount
+                        ): instrument.plunger_motor_current.run,
+                    },
+                    presses=[],
+                    shake_off_list=[],
+                    retract_target=instrument.pick_up_configurations.distance,
+                    pick_up_motor_actions=TipMotorPickUpTipSpec(
+                        # Move onto the posts
+                        tiprack_down=top_types.Point(0, 0, 5),
+                        tiprack_up=top_types.Point(0, 0, -7),
+                        pick_up_distance=instrument.pick_up_configurations.distance,
+                        speed=instrument.pick_up_configurations.speed,
+                        currents={OT3Axis.Q: instrument.pick_up_configurations.current},
+                    ),
+                ),
+                add_tip_to_instr,
+            )
         return (
             PickUpTipSpec(
                 plunger_prep_pos=instrument.plunger_positions.bottom,
@@ -693,7 +692,7 @@ class PipetteHandlerProvider:
                 retract_target=instrument.pick_up_configurations.distance
                 + check_incr * checked_presses
                 + 2,
-                pick_up_motor_actions=None
+                pick_up_motor_actions=None,
             ),
             add_tip_to_instr,
         )
@@ -727,7 +726,7 @@ class PipetteHandlerProvider:
         speed: float,
         home_after: bool,
         home_axes: Sequence[OT3Axis],
-        is_ht_pipette: bool = False
+        is_ht_pipette: bool = False,
     ) -> Callable[[], List[DropTipMove]]:
         def build() -> List[DropTipMove]:
             base = [
@@ -741,7 +740,7 @@ class PipetteHandlerProvider:
                     home_after=home_after,
                     home_after_safety_margin=abs(bottom_pos - droptip_pos),
                     home_axes=home_axes,
-                    is_ht_tip_action=is_ht_pipette
+                    is_ht_tip_action=is_ht_pipette,
                 ),
                 DropTipMove(  # always finish drop-tip at a known safe plunger position
                     target_position=bottom_pos, current=plunger_currents, speed=None
@@ -785,7 +784,7 @@ class PipetteHandlerProvider:
             speed,
             home_after,
             (OT3Axis.of_main_tool_actuator(mount),),
-            instrument.channels.value == 96
+            instrument.channels.value == 96,
         )
 
         seq_ot3 = seq_builder_ot3()

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -12,7 +12,6 @@ from typing import (
     Sequence,
     Iterator,
     TypeVar,
-    Union,
 )
 from typing_extensions import Final
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -657,8 +657,8 @@ class PipetteHandlerProvider:
                     retract_target=instrument.pick_up_configurations.distance,
                     pick_up_motor_actions=TipMotorPickUpTipSpec(
                         # Move onto the posts
-                        tiprack_down=top_types.Point(0, 0, 5),
-                        tiprack_up=top_types.Point(0, 0, -7),
+                        tiprack_down=top_types.Point(0, 0, -5),
+                        tiprack_up=top_types.Point(0, 0, 7),
                         pick_up_distance=instrument.pick_up_configurations.distance,
                         speed=instrument.pick_up_configurations.speed,
                         currents={OT3Axis.Q: instrument.pick_up_configurations.current},

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1304,7 +1304,7 @@ class OT3API(
         if self.gantry_load == GantryLoad.HIGH_THROUGHPUT:
             async with self._backend.restore_current():
                 await self._backend.set_active_current(
-                    {axis: current for axis, current in spec.currents.items()}
+                    {axis: current for axis, current in spec.plunger_currents.items()}
                 )
                 # Move to pick up position
                 target_down = target_position_from_relative(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1320,7 +1320,7 @@ class OT3API(
                 await self._move(target_down)
                 # perform pick up tip
                 await self._backend.tip_action(
-                    [OT3Axis.by_mount(mount)],
+                    [OT3Axis.of_main_tool_actuator(mount)],
                     spec.pick_up_motor_actions.pick_up_distance,
                     spec.pick_up_motor_actions.speed,
                     "pick_up",

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1400,7 +1400,10 @@ class OT3API(
                 # The speed check is needed because speed can sometimes be None.
                 # Not sure why
                 await self._backend.tip_action(
-                    [OT3Axis.of_main_tool_actuator(mount)], move.target_position, move.speed, "drop"
+                    [OT3Axis.of_main_tool_actuator(mount)],
+                    move.target_position,
+                    move.speed,
+                    "drop",
                 )
             else:
                 target_pos = target_position_from_plunger(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1312,7 +1312,7 @@ class OT3API(
                 )
                 await self._move(target_down)
                 # perform pick up tip
-                await self._backend.tip_action(spec.pick_up_distance, spec.speed, "pick_up")
+                await self._backend.tip_action([OT3Axis.by_mount(mount)], spec.pick_up_distance, spec.speed, "pick_up")
                 # # Move to pick up position
                 # target_up = target_position_from_relative(
                 #     realmount, spec.retract_target, self._current_position
@@ -1384,7 +1384,7 @@ class OT3API(
             )
 
             if move.is_ht_tip_action:
-                await self._backend.tip_action(move.target_position, move.speed, "drop")
+                await self._backend.tip_action([OT3Axis.by_mount(mount)], move.target_position, move.speed, "drop")
             else:
                 target_pos = target_position_from_plunger(
                     realmount, move.target_position, self._current_position)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1306,18 +1306,30 @@ class OT3API(
         if spec.pick_up_motor_actions:
             async with self._backend.restore_current():
                 await self._backend.set_active_current(
-                    {axis: current for axis, current in spec.pick_up_motor_actions.currents.items()}
+                    {
+                        axis: current
+                        for axis, current in spec.pick_up_motor_actions.currents.items()
+                    }
                 )
                 # Move to pick up position
                 target_down = target_position_from_relative(
-                    realmount, spec.pick_up_motor_actions.tiprack_down, self._current_position
+                    realmount,
+                    spec.pick_up_motor_actions.tiprack_down,
+                    self._current_position,
                 )
                 await self._move(target_down)
                 # perform pick up tip
-                await self._backend.tip_action([OT3Axis.by_mount(mount)], spec.pick_up_motor_actions.pick_up_distance, spec.pick_up_motor_actions.speed, "pick_up")
+                await self._backend.tip_action(
+                    [OT3Axis.by_mount(mount)],
+                    spec.pick_up_motor_actions.pick_up_distance,
+                    spec.pick_up_motor_actions.speed,
+                    "pick_up",
+                )
                 # # Move to pick up position
                 target_up = target_position_from_relative(
-                    realmount, spec.pick_up_motor_actions.tiprack_up, self._current_position
+                    realmount,
+                    spec.pick_up_motor_actions.tiprack_up,
+                    self._current_position,
                 )
                 await self._move(target_up)
 
@@ -1346,7 +1358,6 @@ class OT3API(
         await self.retract(realmount, spec.retract_target)
 
         _add_tip_to_instrs()
-
 
         if prep_after:
             await self.prepare_for_aspirate(realmount)
@@ -1385,11 +1396,16 @@ class OT3API(
                 }
             )
 
-            if move.is_ht_tip_action:
-                await self._backend.tip_action([OT3Axis.by_mount(mount)], move.target_position, move.speed, "drop")
+            if move.is_ht_tip_action and move.speed:
+                # The speed check is needed because speed can sometimes be None.
+                # Not sure why
+                await self._backend.tip_action(
+                    [OT3Axis.by_mount(mount)], move.target_position, move.speed, "drop"
+                )
             else:
                 target_pos = target_position_from_plunger(
-                    realmount, move.target_position, self._current_position)
+                    realmount, move.target_position, self._current_position
+                )
                 await self._move(
                     target_pos,
                     speed=move.speed,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1400,7 +1400,7 @@ class OT3API(
                 # The speed check is needed because speed can sometimes be None.
                 # Not sure why
                 await self._backend.tip_action(
-                    [OT3Axis.by_mount(mount)], move.target_position, move.speed, "drop"
+                    [OT3Axis.of_main_tool_actuator(mount)], move.target_position, move.speed, "drop"
                 )
             else:
                 target_pos = target_position_from_plunger(

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -111,6 +111,8 @@ class OT3AxisKind(enum.Enum):
     #: Plunger axis (of the left and right pipettes)
     Z_G = 4
     #: Gripper Z axis
+    Q = 5
+    #: High-throughput tip grabbing axis
     OTHER = 5
     #: The internal axes of high throughput pipettes, for instance
 

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -22,6 +22,7 @@ ot3_dummy_settings = {
                 "Y": 2,
                 "Z": 15,
                 "P": 15,
+                "Q": 5,
             },
             "two_low_throughput": {"X": 1.1, "Y": 2.2},
             "gripper": {
@@ -48,6 +49,7 @@ ot3_dummy_settings = {
                 "Y": 2,
                 "Z": 3,
                 "P": 4,
+                "Q": 5,
             },
             "two_low_throughput": {
                 "X": 4,
@@ -76,6 +78,7 @@ ot3_dummy_settings = {
                 "Y": 2,
                 "Z": 3,
                 "P": 6,
+                "Q": 5,
             },
             "two_low_throughput": {
                 "X": 1,
@@ -104,6 +107,7 @@ ot3_dummy_settings = {
                 "Y": 2,
                 "Z": 3,
                 "P": 6,
+                "Q": 5,
             },
             "two_low_throughput": {
                 "X": 0.5,
@@ -134,6 +138,7 @@ ot3_dummy_settings = {
                 "Y": 0.7,
                 "Z": 0.7,
                 "P": 0.8,
+                "Q": 0.3,
             },
             "two_low_throughput": {"X": 0.7, "Y": 0.7, "Z": 0.6},
             "gripper": {
@@ -159,6 +164,7 @@ ot3_dummy_settings = {
                 "Y": 0.5,
                 "Z": 0.4,
                 "P": 2.0,
+                "Q": 0.3,
             },
             "two_low_throughput": {"X": 9, "Y": 0.1, "Z": 0.6},
             "gripper": {

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -508,3 +508,29 @@ async def test_get_limit_switches(controller: OT3Controller) -> None:
         assert passed_nodes == {NodeId.gantry_x, NodeId.gantry_y}
         assert OT3Axis.X in res
         assert OT3Axis.Y in res
+
+
+async def test_tip_action(controller: OT3Controller, mock_move_group_run) -> None:
+    await controller.tip_action([OT3Axis.P_L], tip_action="pick_up")
+    for call in mock_move_group_run.call_args_list:
+        move_group_runner = call[0][0]
+        for move_group in move_group_runner._move_groups:
+            assert move_group  # don't pass in empty groups
+            assert len(move_group) == 1
+        # we should be sending this command to the pipette axes to process.
+        assert list(move_group[0].keys()) == [NodeId.pipette_left]
+        step = move_group[0][NodeId.pipette_left]
+        assert step.stop_condition == MoveStopCondition.none
+
+    mock_move_group_run.reset_mock()
+
+    await controller.tip_action([OT3Axis.P_L], tip_action="drop")
+    for call in mock_move_group_run.call_args_list:
+        move_group_runner = call[0][0]
+        for move_group in move_group_runner._move_groups:
+            assert move_group  # don't pass in empty groups
+            assert len(move_group) == 1
+        # we should be sending this command to the pipette axes to process.
+        assert list(move_group[0].keys()) == [NodeId.pipette_left]
+        step = move_group[0][NodeId.pipette_left]
+        assert step.stop_condition == MoveStopCondition.limit_switch

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -511,7 +511,7 @@ async def test_get_limit_switches(controller: OT3Controller) -> None:
 
 
 async def test_tip_action(controller: OT3Controller, mock_move_group_run) -> None:
-    await controller.tip_action([OT3Axis.P_L], tip_action="pick_up")
+    await controller.tip_action([OT3Axis.P_L], 33, -5.5, tip_action="pick_up")
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:
@@ -524,7 +524,7 @@ async def test_tip_action(controller: OT3Controller, mock_move_group_run) -> Non
 
     mock_move_group_run.reset_mock()
 
-    await controller.tip_action([OT3Axis.P_L], tip_action="drop")
+    await controller.tip_action([OT3Axis.P_L], 33, -5.5, tip_action="drop")
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1,6 +1,6 @@
 """ Tests for behaviors specific to the OT3 hardware controller.
 """
-from typing import cast, Iterator, Union, Dict, Tuple, List
+from typing import Iterator, Union, Dict, Tuple, List
 from typing_extensions import Literal
 from math import copysign
 import pytest

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -290,7 +290,7 @@ def test_flow_rate_setting(
         [
             lazy_fixture("hardware_pipette_ot3"),
             ot3_pipette_config.convert_pipette_model("p1000_96", "1.0"),
-            Point(-85.5, -57.0, -259.15),
+            Point(13.5, -46.5, -259.15),
             Point(-36.0, -88.5, -259.15),
         ],
     ],

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -8,17 +8,31 @@ from opentrons.hardware_control.instruments.ot2.pipette import Pipette
 from opentrons.hardware_control.instruments.ot2.pipette_handler import (
     PipetteHandlerProvider,
 )
+from opentrons.hardware_control.instruments.ot3.pipette import Pipette as OT3Pipette
+from opentrons.hardware_control.instruments.ot3.pipette_handler import (
+    PipetteHandlerProvider as OT3PipetteHandlerProvider,
+)
 
 
 @pytest.fixture
 def mock_pipette(decoy: Decoy) -> Pipette:
     return decoy.mock(cls=Pipette)
 
+@pytest.fixture
+def mock_pipette_ot3(decoy: Decoy) -> OT3Pipette:
+    return decoy.mock(cls=OT3Pipette)
+
 
 @pytest.fixture
 def subject(decoy: Decoy, mock_pipette: Pipette) -> PipetteHandlerProvider:
     inst_by_mount = {types.Mount.LEFT: mock_pipette, types.Mount.RIGHT: None}
     subject = PipetteHandlerProvider(attached_instruments=inst_by_mount)
+    return subject
+
+@pytest.fixture
+def subject_ot3(decoy: Decoy, mock_pipette: OT3Pipette) -> OT3PipetteHandlerProvider:
+    inst_by_mount = {types.Mount.LEFT: mock_pipette, types.Mount.RIGHT: None}
+    subject = OT3PipetteHandlerProvider(attached_instruments=inst_by_mount)
     return subject
 
 
@@ -49,6 +63,41 @@ def test_plan_check_pick_up_tip_with_presses_argument(
         )
 
     spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(
+        mount, tip_length, presses, increment
+    )
+
+    assert len(spec.presses) == expected_array_length
+
+
+@pytest.mark.parametrize(
+    "presses_input, expected_array_length, channels", [(0, 0, 96), (None, 3, 8), (3, 3, 1)]
+)
+def test_plan_check_pick_up_tip_with_presses_argument_ot3(
+    decoy: Decoy,
+    subject_ot3: PipetteHandlerProvider,
+    mock_pipette_ot3: Pipette,
+    presses_input: int,
+    expected_array_length: int,
+    channels: int
+) -> None:
+    """Should return an array with expected length."""
+    tip_length = 25.0
+    mount = types.Mount.LEFT
+    presses = presses_input
+    increment = None
+
+    decoy.when(mock_pipette_ot3.has_tip).then_return(False)
+    decoy.when(mock_pipette_ot3.config.quirks).then_return([])
+    decoy.when(mock_pipette_ot3.config.pick_up_distance).then_return(0)
+    decoy.when(mock_pipette_ot3.config.pick_up_increment).then_return(0)
+    decoy.when(mock_pipette_ot3.channels.value).then_return(channels)
+
+    if presses_input is None:
+        decoy.when(mock_pipette_ot3.config.pick_up_presses).then_return(
+            expected_array_length
+        )
+
+    spec, _add_tip_to_instrs = subject_ot3.plan_check_pick_up_tip(
         mount, tip_length, presses, increment
     )
 

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -18,6 +18,7 @@ from opentrons.hardware_control.instruments.ot3.pipette_handler import (
 def mock_pipette(decoy: Decoy) -> Pipette:
     return decoy.mock(cls=Pipette)
 
+
 @pytest.fixture
 def mock_pipette_ot3(decoy: Decoy) -> OT3Pipette:
     return decoy.mock(cls=OT3Pipette)
@@ -28,6 +29,7 @@ def subject(decoy: Decoy, mock_pipette: Pipette) -> PipetteHandlerProvider:
     inst_by_mount = {types.Mount.LEFT: mock_pipette, types.Mount.RIGHT: None}
     subject = PipetteHandlerProvider(attached_instruments=inst_by_mount)
     return subject
+
 
 @pytest.fixture
 def subject_ot3(decoy: Decoy, mock_pipette: OT3Pipette) -> OT3PipetteHandlerProvider:
@@ -70,7 +72,8 @@ def test_plan_check_pick_up_tip_with_presses_argument(
 
 
 @pytest.mark.parametrize(
-    "presses_input, expected_array_length, channels", [(0, 0, 96), (None, 3, 8), (3, 3, 1)]
+    "presses_input, expected_array_length, channels",
+    [(0, 0, 96), (None, 3, 8), (3, 3, 1)],
 )
 def test_plan_check_pick_up_tip_with_presses_argument_ot3(
     decoy: Decoy,
@@ -78,7 +81,7 @@ def test_plan_check_pick_up_tip_with_presses_argument_ot3(
     mock_pipette_ot3: Pipette,
     presses_input: int,
     expected_array_length: int,
-    channels: int
+    channels: int,
 ) -> None:
     """Should return an array with expected length."""
     tip_length = 25.0

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -159,22 +159,21 @@ def create_home_step(
 
 def create_tip_action_step(
     velocity: Dict[NodeId, np.float64],
-    duration: np.float64,
+    distance: Dict[NodeId, np.float64],
     present_nodes: Iterable[NodeId],
     action: PipetteTipActionType,
 ) -> MoveGroupStep:
     """Creates a step for tip handling actions that require motor movement."""
-    ordered_nodes = sorted(present_nodes, key=lambda node: node.value)
     step: MoveGroupStep = {}
     stop_condition = (
         MoveStopCondition.limit_switch
         if action == PipetteTipActionType.drop
         else MoveStopCondition.none
     )
-    for axis_node in ordered_nodes:
+    for axis_node in present_nodes:
         step[axis_node] = MoveGroupTipActionStep(
-            velocity_mm_sec=velocity.get(axis_node, np.float64(0)),
-            duration_sec=duration,
+            velocity_mm_sec=velocity[axis_node],
+            duration_sec=abs(distance[axis_node] / velocity[axis_node]),
             stop_condition=stop_condition,
             action=action,
         )

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -4,14 +4,14 @@
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {
-    "current": 0.4,
-    "presses": 1,
+    "current": 1.5,
+    "presses": 0.0,
     "speed": 10,
-    "increment": 0.5,
-    "distance": 1.0
+    "increment": 0.0,
+    "distance": 13.75
   },
   "dropTipConfigurations": {
-    "current": 1.0,
+    "current": 1.5,
     "speed": 10
   },
   "plungerMotorConfigurations": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -6,7 +6,7 @@
   "pickUpTipConfigurations": {
     "current": 1.5,
     "presses": 0.0,
-    "speed": 10,
+    "speed": 5.5,
     "increment": 0.0,
     "distance": 13.75
   },


### PR DESCRIPTION
# Overview

Last major track of work that needs to go in to the hardware controller. With this PR, now, by default the 96 channel will do a full tiprack pick up. We should probably make some changes to the shared data config for the movements before/after the tip rack full pickup, but I think we need to first figure out exactly what that movement will look like on the 96 channel.

# Changelog
- Add a tip action for homing if there is a 96 channel attached
- Add tests related to this
- Attempted to fix location of the drop tip location, though it still doesn't seem quite right (the other critical point was crashing in the _opposite_ direction of the other one).

# Review requests

Does this approach seem OK? Has been tested on an OT3.

# Risk assessment
Low. Should only occur for 96 channel pipettes.