### PR TITLE
 feat(app): add steps for 3 96-channel calibrate flow options

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -111,14 +111,14 @@ export const BeforeBeginning = (
             // @ts-expect-error pipetteName is required but missing in schema v6 type
             pipetteName: attachedPipettes[mount]?.name,
             pipetteId: pipetteId,
-            mount: mountInfo,
+            mount: mount,
           },
         },
         {
           // @ts-expect-error calibration type not yet supported
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
-            mount: mountInfo,
+            mount: mount,
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -111,14 +111,14 @@ export const BeforeBeginning = (
             // @ts-expect-error pipetteName is required but missing in schema v6 type
             pipetteName: attachedPipettes[mount]?.name,
             pipetteId: pipetteId,
-            mount: mount,
+            mount: mountInfo,
           },
         },
         {
           // @ts-expect-error calibration type not yet supported
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
-            mount: mount,
+            mount: mountInfo,
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -5,7 +5,6 @@ import { COLORS, TEXT_TRANSFORM_CAPITALIZE } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { FLOWS } from './constants'
-import { getIsGantryEmpty } from './utils'
 import type { PipetteWizardStepProps } from './types'
 
 interface ResultsProps extends PipetteWizardStepProps {

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  NINETY_SIX_CHANNEL,
-  SINGLE_MOUNT_PIPETTES,
-} from '@opentrons/shared-data'
 import { COLORS, TEXT_TRANSFORM_CAPITALIZE } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
@@ -23,7 +19,6 @@ export const Results = (props: ResultsProps): JSX.Element => {
     attachedPipettes,
     mount,
     handleCleanUpAndClose,
-    selectedPipette,
     currentStepIndex,
     totalStepCount,
   } = props

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
+import {
+  NINETY_SIX_CHANNEL,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
 import { COLORS, TEXT_TRANSFORM_CAPITALIZE } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
@@ -39,11 +42,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       if (attachedPipettes[mount] != null) {
         const pipetteName = attachedPipettes[mount]?.modelSpecs.displayName
         header = t('pipette_attached', { pipetteName: pipetteName })
-        if (selectedPipette === NINETY_SIX_CHANNEL) {
-          buttonText = t('shared:exit')
-        } else {
-          buttonText = t('cal_pipette')
-        }
+        buttonText = t('cal_pipette')
         // attachment flow fail
       } else {
         header = t('pipette_failed_to_attach')

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -5,6 +5,7 @@ import { COLORS, TEXT_TRANSFORM_CAPITALIZE } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { FLOWS } from './constants'
+import { getIsGantryEmpty } from './utils'
 import type { PipetteWizardStepProps } from './types'
 
 interface ResultsProps extends PipetteWizardStepProps {
@@ -25,7 +26,6 @@ export const Results = (props: ResultsProps): JSX.Element => {
     totalStepCount,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
-
   let header: string = 'unknown results screen'
   let iconColor: string = COLORS.successEnabled
   let isSuccess: boolean = true

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -511,4 +511,82 @@ describe('PipetteWizardFlows', () => {
     getByText('Loosen Screws and Detach')
     getByText('Continue')
   })
+  it('renders the correct information, calling the correct commands for the 96-channel calibration flow', async () => {
+    props = {
+      ...props,
+      flowType: FLOWS.CALIBRATE,
+      selectedPipette: NINETY_SIX_CHANNEL,
+    }
+    const { getByText, getByRole } = render(props)
+    //  first page
+    getByText('Calibrate 96-Channel pipette')
+    getByText('Before you begin')
+    getByText(
+      'To get started, remove labware from the rest of the deck and clean up the work area to make attachment and calibration easier. Also gather the needed equipment shown on the right hand side'
+    )
+    getByText(
+      'The calibration probe is included with the robot and should be stored on the right hand side of the door opening.'
+    )
+    getByRole('button', { name: 'Get started' }).click()
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+      expect(mockCreateRun).toHaveBeenCalled()
+    })
+    // second page
+    getByText('Step 1 / 3')
+    getByText('Attach Calibration Probe')
+    getByText(
+      'Take the calibration probe from its storage location. Make sure its latch is in the unlocked (straight) position. Press the probe firmly onto the pipette nozzle and then lock the latch. Then test that the probe is securely attached by gently pulling it back and forth.'
+    )
+    getByRole('button', { name: 'Initiate calibration' }).click()
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'calibration/calibratePipette',
+            params: { mount: LEFT },
+          },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+    })
+    //  third page
+    getByText('Step 2 / 3')
+    getByText('Remove Calibration Probe')
+    getByText(
+      'Unlatch the calibration probe, remove it from the pipette nozzle, and return it to its storage location.'
+    )
+    getByRole('button', { name: 'Complete calibration' }).click()
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: {},
+          },
+        ],
+        false
+      )
+    })
+  })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -150,12 +150,9 @@ describe('Results', () => {
     expect(props.proceed).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel', () => {
-    mockGetIsGantryEmpty.mockReturnValue(true)
     props = {
       ...props,
-      flowType: FLOWS.ATTACH,
-      selectedPipette: NINETY_SIX_CHANNEL,
-      currentStepIndex: 7,
+      flowType: FLOWS.CALIBRATE,
     }
     const { getByText, getByRole, getByLabelText } = render(props)
     getByText('Pipette Successfully Calibrated')
@@ -166,12 +163,11 @@ describe('Results', () => {
     expect(props.proceed).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel with pipette attached initially ', () => {
-    mockGetIsGantryEmpty.mockReturnValue(true)
     props = {
       ...props,
-      flowType: FLOWS.ATTACH,
-      selectedPipette: NINETY_SIX_CHANNEL,
+      flowType: FLOWS.CALIBRATE,
       currentStepIndex: 9,
+      totalStepCount: 9,
     }
     const { getByText, getByRole, getByLabelText } = render(props)
     getByText('Pipette Successfully Calibrated')
@@ -179,15 +175,14 @@ describe('Results', () => {
       `color: ${COLORS.successEnabled}`
     )
     getByRole('button', { name: 'Results_exit' }).click()
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard succeeds to calibrate in attach flow single mount', () => {
-    mockGetIsGantryEmpty.mockReturnValue(true)
     props = {
       ...props,
-      flowType: FLOWS.ATTACH,
-      selectedPipette: SINGLE_MOUNT_PIPETTES,
+      flowType: FLOWS.CALIBRATE,
       currentStepIndex: 5,
+      totalStepCount: 5,
     }
     const { getByText, getByRole, getByLabelText } = render(props)
     getByText('Pipette Successfully Calibrated')
@@ -195,6 +190,6 @@ describe('Results', () => {
       `color: ${COLORS.successEnabled}`
     )
     getByRole('button', { name: 'Results_exit' }).click()
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -149,4 +149,52 @@ describe('Results', () => {
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()
   })
+  it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel', () => {
+    mockGetIsGantryEmpty.mockReturnValue(true)
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      selectedPipette: NINETY_SIX_CHANNEL,
+      currentStepIndex: 7,
+    }
+    const { getByText, getByRole, getByLabelText } = render(props)
+    getByText('Pipette Successfully Calibrated')
+    expect(getByLabelText('ot-check')).toHaveStyle(
+      `color: ${COLORS.successEnabled}`
+    )
+    getByRole('button', { name: 'Results_exit' }).click()
+    expect(props.proceed).toHaveBeenCalled()
+  })
+  it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel with pipette attached initially ', () => {
+    mockGetIsGantryEmpty.mockReturnValue(true)
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      selectedPipette: NINETY_SIX_CHANNEL,
+      currentStepIndex: 9,
+    }
+    const { getByText, getByRole, getByLabelText } = render(props)
+    getByText('Pipette Successfully Calibrated')
+    expect(getByLabelText('ot-check')).toHaveStyle(
+      `color: ${COLORS.successEnabled}`
+    )
+    getByRole('button', { name: 'Results_exit' }).click()
+    expect(props.proceed).toHaveBeenCalled()
+  })
+  it('renders the correct information when pipette wizard succeeds to calibrate in attach flow single mount', () => {
+    mockGetIsGantryEmpty.mockReturnValue(true)
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      selectedPipette: SINGLE_MOUNT_PIPETTES,
+      currentStepIndex: 5,
+    }
+    const { getByText, getByRole, getByLabelText } = render(props)
+    getByText('Pipette Successfully Calibrated')
+    expect(getByLabelText('ot-check')).toHaveStyle(
+      `color: ${COLORS.successEnabled}`
+    )
+    getByRole('button', { name: 'Results_exit' }).click()
+    expect(props.proceed).toHaveBeenCalled()
+  })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -165,6 +165,21 @@ describe('getPipetteWizardSteps', () => {
         mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
     ] as PipetteWizardStep[]
 
     expect(
@@ -250,6 +265,21 @@ describe('getPipetteWizardSteps', () => {
         mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
     ] as PipetteWizardStep[]
 
     expect(
@@ -264,7 +294,29 @@ describe('getPipetteWizardSteps', () => {
   })
   //  TODO(jr, 12/5/22): fix this test when the calibrate steps are added
   it('returns the corect array of info for calibrate pipette 96 channel', () => {
-    const mockDetachPipetteFlowSteps = [] as PipetteWizardStep[]
+    const mockCalibrateFlowSteps = [
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
+    ] as PipetteWizardStep[]
+
     expect(
       getPipetteWizardSteps(
         FLOWS.CALIBRATE,
@@ -273,6 +325,6 @@ describe('getPipetteWizardSteps', () => {
         false,
         mockAttachedPipettesNotEmpty
       )
-    ).toStrictEqual(mockDetachPipetteFlowSteps)
+    ).toStrictEqual(mockCalibrateFlowSteps)
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -93,7 +93,7 @@ describe('getPipetteWizardSteps', () => {
       {
         section: SECTIONS.RESULTS,
         mount: LEFT,
-        flowType: FLOWS.ATTACH,
+        flowType: FLOWS.CALIBRATE,
       },
     ] as PipetteWizardStep[]
 

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -67,8 +67,24 @@ export const getPipetteWizardSteps = (
   } else if (selectedPipette === NINETY_SIX_CHANNEL) {
     switch (flowType) {
       case FLOWS.CALIBRATE: {
-        //  TODO(jr 12/1/22): add the calibrate flow steps
-        return []
+        return [
+          {
+            section: SECTIONS.BEFORE_BEGINNING,
+            mount: mount,
+            flowType: flowType,
+          },
+          {
+            section: SECTIONS.ATTACH_PROBE,
+            mount: mount,
+            flowType: flowType,
+          },
+          {
+            section: SECTIONS.DETACH_PROBE,
+            mount: mount,
+            flowType: flowType,
+          },
+          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+        ]
       }
       case FLOWS.ATTACH: {
         let detachMount = mount
@@ -112,6 +128,21 @@ export const getPipetteWizardSteps = (
               flowType: flowType,
             },
             { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+            {
+              section: SECTIONS.ATTACH_PROBE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.DETACH_PROBE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.RESULTS,
+              mount: mount,
+              flowType: FLOWS.CALIBRATE,
+            },
           ]
         } else {
           return [
@@ -135,7 +166,22 @@ export const getPipetteWizardSteps = (
               mount: mount,
               flowType: flowType,
             },
-            { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+            { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.ATTACH },
+            {
+              section: SECTIONS.ATTACH_PROBE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.DETACH_PROBE,
+              mount: mount,
+              flowType: flowType,
+            },
+            {
+              section: SECTIONS.RESULTS,
+              mount: mount,
+              flowType: FLOWS.CALIBRATE,
+            },
           ]
         }
       }

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -45,7 +45,11 @@ export const getPipetteWizardSteps = (
           { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
           { section: SECTIONS.ATTACH_PROBE, mount: mount, flowType: flowType },
           { section: SECTIONS.DETACH_PROBE, mount: mount, flowType: flowType },
-          { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.CALIBRATE },
+          {
+            section: SECTIONS.RESULTS,
+            mount: mount,
+            flowType: FLOWS.CALIBRATE,
+          },
         ]
       }
       case FLOWS.DETACH: {

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -45,7 +45,7 @@ export const getPipetteWizardSteps = (
           { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
           { section: SECTIONS.ATTACH_PROBE, mount: mount, flowType: flowType },
           { section: SECTIONS.DETACH_PROBE, mount: mount, flowType: flowType },
-          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+          { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.CALIBRATE },
         ]
       }
       case FLOWS.DETACH: {

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -1,10 +1,5 @@
 import { FLOWS, SECTIONS } from './constants'
-import {
-  SINGLE_MOUNT_PIPETTES,
-  NINETY_SIX_CHANNEL,
-  LEFT,
-  RIGHT,
-} from '@opentrons/shared-data'
+import { SINGLE_MOUNT_PIPETTES, LEFT, RIGHT } from '@opentrons/shared-data'
 import type {
   PipetteWizardStep,
   PipetteWizardFlow,
@@ -20,21 +15,21 @@ export const getPipetteWizardSteps = (
   isGantryEmpty: boolean,
   attachedPipettes: AttachedPipettesByMount
 ): PipetteWizardStep[] => {
-  if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-    switch (flowType) {
-      case FLOWS.CALIBRATE: {
-        return [
-          {
-            section: SECTIONS.BEFORE_BEGINNING,
-            mount: mount,
-            flowType: flowType,
-          },
-          { section: SECTIONS.ATTACH_PROBE, mount: mount, flowType: flowType },
-          { section: SECTIONS.DETACH_PROBE, mount: mount, flowType: flowType },
-          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
-        ]
-      }
-      case FLOWS.ATTACH: {
+  switch (flowType) {
+    case FLOWS.CALIBRATE: {
+      return [
+        {
+          section: SECTIONS.BEFORE_BEGINNING,
+          mount: mount,
+          flowType: flowType,
+        },
+        { section: SECTIONS.ATTACH_PROBE, mount: mount, flowType: flowType },
+        { section: SECTIONS.DETACH_PROBE, mount: mount, flowType: flowType },
+        { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+      ]
+    }
+    case FLOWS.ATTACH: {
+      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
         return [
           {
             section: SECTIONS.BEFORE_BEGINNING,
@@ -51,54 +46,14 @@ export const getPipetteWizardSteps = (
             flowType: FLOWS.CALIBRATE,
           },
         ]
-      }
-      case FLOWS.DETACH: {
-        return [
-          {
-            section: SECTIONS.BEFORE_BEGINNING,
-            mount: mount,
-            flowType: flowType,
-          },
-          {
-            section: SECTIONS.DETACH_PIPETTE,
-            mount: mount,
-            flowType: flowType,
-          },
-          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
-        ]
-      }
-    }
-  } else if (selectedPipette === NINETY_SIX_CHANNEL) {
-    switch (flowType) {
-      case FLOWS.CALIBRATE: {
-        return [
-          {
-            section: SECTIONS.BEFORE_BEGINNING,
-            mount: mount,
-            flowType: flowType,
-          },
-          {
-            section: SECTIONS.ATTACH_PROBE,
-            mount: mount,
-            flowType: flowType,
-          },
-          {
-            section: SECTIONS.DETACH_PROBE,
-            mount: mount,
-            flowType: flowType,
-          },
-          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
-        ]
-      }
-      case FLOWS.ATTACH: {
+      } else {
         let detachMount = mount
         if (attachedPipettes[LEFT] == null) {
           detachMount = RIGHT
         } else if (attachedPipettes[RIGHT] == null) {
           detachMount = LEFT
         }
-
-        //  for attaching 96 channel but a pipette is attached
+        //  pipette needs to be detached before attached 96 channel
         if (!isGantryEmpty) {
           return [
             {
@@ -148,6 +103,7 @@ export const getPipetteWizardSteps = (
               flowType: FLOWS.CALIBRATE,
             },
           ]
+          //  gantry empty to attach 96 channel
         } else {
           return [
             {
@@ -189,7 +145,24 @@ export const getPipetteWizardSteps = (
           ]
         }
       }
-      case FLOWS.DETACH: {
+    }
+    case FLOWS.DETACH: {
+      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+        return [
+          {
+            section: SECTIONS.BEFORE_BEGINNING,
+            mount: mount,
+            flowType: flowType,
+          },
+          {
+            section: SECTIONS.DETACH_PIPETTE,
+            mount: mount,
+            flowType: flowType,
+          },
+          { section: SECTIONS.RESULTS, mount: mount, flowType: flowType },
+        ]
+        //  96 channel detach
+      } else {
         return [
           {
             section: SECTIONS.BEFORE_BEGINNING,
@@ -215,8 +188,6 @@ export const getPipetteWizardSteps = (
         ]
       }
     }
-  } else {
-    return []
   }
   return []
 }


### PR DESCRIPTION
closes RLIQ-278

# Overview

Creates the 3 96-channel calibrate flows which are:
1. calibrate
2. attach then calibrate
3. detach other pipette, attach then calibrate

# Changelog

- add steps to `getPipetteWizardFlows` and test
- slight fix `Results` so the text says the correct thing depending on the flow
- add onto calibrate flow tests in `PipetteWizardFlows`

# Review requests

- on an ot-3, go through recalibrating, attach and calibrate, and detach, attach and calibrate. Flows should go to the correct modals with the correct text

# Risk assessment

low