### PR TITLE
Unpin Python requirements

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -59,12 +59,12 @@ DESCRIPTION = (
 PACKAGES = find_packages(where="src")
 INSTALL_REQUIRES = [
     f"opentrons-shared-data=={VERSION}",
-    "aionotify==0.2.0",
-    "anyio==3.3.0",
-    "jsonschema==3.0.2",
+    "aionotify>=0.2.0,<0.3",
+    "anyio>=3.3.0,<4",
+    "jsonschema>=3.0.2,<4",
     "numpy>=1.15.1,<2",
-    "pydantic==1.8.2",
-    "pyserial==3.5",
+    "pydantic>=1.8.2,<2",
+    "pyserial>=3.5,<4",
     "typing-extensions>=4.0.0,<5",
     "click>=8.0.0,<9",
     'importlib-metadata >= 1.0 ; python_version < "3.8"',

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -131,9 +131,9 @@ DESCRIPTION = (
 )
 PACKAGES = find_packages(where=".", exclude=["tests"])
 INSTALL_REQUIRES = [
-    "jsonschema==3.0.2",
+    "jsonschema>=3.0.2,<4",
     "typing-extensions>=4.0.0,<5",
-    "pydantic==1.8.2",
+    "pydantic>=1.8.2,<2",
 ]
 
 


### PR DESCRIPTION
# Overview
Fixes #11905

# Changelog
- Allow dependency versions up to the next major version when pinning is not strictly necessary. This makes it easier to combine opentrons with other Python packages that have shared dependencies.