### PR TITLE
refactor(app): Remove recalibrate option from POC and TLC overflow menus [RAUT-93]

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -16,6 +16,7 @@ import {
   PipetteModelSpecs,
   PipetteName,
 } from '@opentrons/shared-data'
+import * as Config from '../../../redux/config'
 import type { Mount } from '../../../redux/pipettes/types'
 
 interface PipetteOverflowMenuProps {
@@ -41,6 +42,10 @@ export const PipetteOverflowMenu = (
     handleSettingsSlideout,
     isPipetteCalibrated,
   } = props
+
+  const enableCalibrationWizards = Config.useFeatureFlag(
+    'enableCalibrationWizards'
+  )
 
   const pipetteName =
     pipetteSpecs?.name != null ? pipetteSpecs.name : t('empty')
@@ -80,19 +85,19 @@ export const PipetteOverflowMenu = (
           </MenuItem>
         ) : (
           <>
-            <MenuItem
-              key={`${String(pipetteDisplayName)}_${mount}_calibrate_offset`}
-              onClick={() => handleCalibrate()}
-              data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${String(
-                pipetteDisplayName
-              )}_${mount}`}
-            >
-              {t(
-                isPipetteCalibrated
-                  ? recalibratePipetteText
-                  : calibratePipetteText
-              )}
-            </MenuItem>
+            {enableCalibrationWizards ? null : (
+              <MenuItem
+                key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
+                onClick={() => handleCalibrate()}
+                data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${pipetteDisplayName}_${mount}`}
+              >
+                {t(
+                  isPipetteCalibrated
+                    ? recalibratePipetteText
+                    : calibratePipetteText
+                )}
+              </MenuItem>
+            )}
             <MenuItem
               key={`${String(pipetteDisplayName)}_${mount}_detach`}
               onClick={() => handleChangePipette()}

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -85,7 +85,18 @@ export const PipetteOverflowMenu = (
           </MenuItem>
         ) : (
           <>
-            {enableCalibrationWizards ? null : (
+            {enableCalibrationWizards ? (
+              // Only show calibration option [RAUT-93]
+              isPipetteCalibrated ? null : (
+                <MenuItem
+                  key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
+                  onClick={() => handleCalibrate()}
+                  data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${pipetteDisplayName}_${mount}`}
+                >
+                  {t(calibratePipetteText)}
+                </MenuItem>
+              )
+            ) : (
               <MenuItem
                 key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
                 onClick={() => handleCalibrate()}

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -103,14 +103,17 @@ describe('PipetteOverflowMenu', () => {
     expect(props.handleCalibrate).toHaveBeenCalled()
   })
 
+  it('should render calibrate pipette offset text when the calibration wizard feature flag is set and no calibration exists', () => {
+    mockUseFeatureFlag.mockReturnValue(true)
+    const { getByRole } = render(props)
+    const calibrate = getByRole('button', { name: 'Calibrate pipette offset' })
+    fireEvent.click(calibrate)
+    expect(props.handleCalibrate).toHaveBeenCalled()
+  })
+
   it('does not render recalibrate pipette offset text when the calibration wizard feature flag is set', () => {
     props = {
-      pipetteSpecs: mockLeftProtoPipette.modelSpecs,
-      mount: LEFT,
-      handleChangePipette: jest.fn(),
-      handleCalibrate: jest.fn(),
-      handleAboutSlideout: jest.fn(),
-      handleSettingsSlideout: jest.fn(),
+      ...props,
       isPipetteCalibrated: true,
     }
     mockUseFeatureFlag.mockReturnValue(true)
@@ -142,16 +145,19 @@ describe('PipetteOverflowMenu', () => {
     expect(props.handleCalibrate).toHaveBeenCalled()
   })
 
+  it('should render calibrate pipette text for OT-3 pipette when the calibration wizard feature flag is set and no calibration exists', () => {
+    mockIsOT3Pipette.mockReturnValue(true)
+    mockUseFeatureFlag.mockReturnValue(true)
+    const { getByRole } = render(props)
+    const calibrate = getByRole('button', { name: 'Calibrate pipette' })
+    fireEvent.click(calibrate)
+    expect(props.handleCalibrate).toHaveBeenCalled()
+  })
+
   it('does not render recalibrate pipette text for OT-3 pipette when the calibration wizard feature flag is set', () => {
     mockIsOT3Pipette.mockReturnValue(true)
-
     props = {
-      pipetteSpecs: mockLeftProtoPipette.modelSpecs,
-      mount: LEFT,
-      handleChangePipette: jest.fn(),
-      handleCalibrate: jest.fn(),
-      handleAboutSlideout: jest.fn(),
-      handleSettingsSlideout: jest.fn(),
+      ...props,
       isPipetteCalibrated: true,
     }
     mockUseFeatureFlag.mockReturnValue(true)

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -80,6 +80,10 @@ export function OverflowMenu({
   } = useMenuHandleClickOutside()
   const { isDeckCalibrated } = useDeckCalibrationData(robotName)
 
+  const enableCalibrationWizards = Config.useFeatureFlag(
+    'enableCalibrationWizards'
+  )
+
   const calsOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
   })
@@ -257,7 +261,17 @@ export function OverflowMenu({
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          {mount != null && (
+          {enableCalibrationWizards &&
+            calType === 'pipetteOffset' &&
+            applicablePipetteOffsetCal === null && (
+              <MenuItem
+                onClick={e => handleCalibration(calType, e)}
+                disabled={disabledReason !== null}
+              >
+                {t('calibrate_pipette')}
+              </MenuItem>
+            )}
+          {!enableCalibrationWizards && mount != null && (
             <MenuItem
               onClick={e => handleCalibration(calType, e)}
               disabled={disabledReason !== null}

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -263,7 +263,7 @@ export function OverflowMenu({
         >
           {enableCalibrationWizards &&
             calType === 'pipetteOffset' &&
-            applicablePipetteOffsetCal === null && (
+            applicablePipetteOffsetCal == null && (
               <MenuItem
                 onClick={e => handleCalibration(calType, e)}
                 disabled={disabledReason !== null}

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { when } from 'jest-when'
 import { fireEvent, screen } from '@testing-library/react'
 import { saveAs } from 'file-saver'
 import { OT3_PIPETTES } from '@opentrons/shared-data'
@@ -6,6 +7,7 @@ import { renderWithProviders, Mount } from '@opentrons/components'
 
 import { i18n } from '../../../../i18n'
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
+import { useFeatureFlag } from '../../../../redux/config'
 import { PipetteWizardFlows } from '../../../PipetteWizardFlows'
 import { useCalibratePipetteOffset } from '../../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import {
@@ -42,17 +44,20 @@ jest.mock('../../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../../organisms/Devices/hooks')
 jest.mock('../../../PipetteWizardFlows')
 
+const mockPipetteWizardFlow = PipetteWizardFlows as jest.MockedFunction<
+  typeof PipetteWizardFlows
+>
 const mockUseCalibratePipetteOffset = useCalibratePipetteOffset as jest.MockedFunction<
   typeof useCalibratePipetteOffset
->
-const mockUseRunStatuses = useRunStatuses as jest.MockedFunction<
-  typeof useRunStatuses
 >
 const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
   typeof useDeckCalibrationData
 >
-const mockPipetteWizardFlow = PipetteWizardFlows as jest.MockedFunction<
-  typeof PipetteWizardFlows
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
+const mockUseRunStatuses = useRunStatuses as jest.MockedFunction<
+  typeof useRunStatuses
 >
 
 const RUN_STATUSES = {
@@ -82,6 +87,9 @@ describe('OverflowMenu', () => {
       isDeckCalibrated: true,
       deckCalibrationData: mockDeckCalData,
     })
+    when(mockUseFeatureFlag)
+      .calledWith('enableCalibrationWizards')
+      .mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -135,6 +143,20 @@ describe('OverflowMenu', () => {
     fireEvent.click(button)
     getByText('Recalibrate Tip Length and Pipette Offset')
     getByText('Download calibration data')
+  })
+
+  it('should not render Overflow tip length recalibration button when the calibration wizard feature flag is set', () => {
+    props = {
+      ...props,
+      calType: 'tipLength',
+    }
+    mockUseFeatureFlag.mockReturnValue(true)
+    const [{ getByLabelText, queryByText }] = render(props)
+    const button = getByLabelText('CalibrationOverflowMenu_button')
+    fireEvent.click(button)
+    expect(
+      queryByText('Recalibrate Tip Length and Pipette Offset')
+    ).not.toBeInTheDocument()
   })
 
   it('should not render calibrate menu item when mount is undefined', () => {

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -145,6 +145,16 @@ describe('OverflowMenu', () => {
     getByText('Download calibration data')
   })
 
+  it('should render Overflow tip length calibration button when the calibration wizard feature flag is set and no calibration exists', () => {
+    mockUseFeatureFlag.mockReturnValue(true)
+    const [{ getByLabelText, getByText }] = render(props)
+    const button = getByLabelText('CalibrationOverflowMenu_button')
+    fireEvent.click(button)
+    const calibrationButton = getByText('Calibrate Pipette Offset')
+    fireEvent.click(calibrationButton)
+    expect(startCalibration).toHaveBeenCalled()
+  })
+
   it('should not render Overflow tip length recalibration button when the calibration wizard feature flag is set', () => {
     props = {
       ...props,


### PR DESCRIPTION
# Overview

The "recalibrate" option has been removed from the pipette offset calibration and tip length calibration overflow menus on the robot settings page when the enableCalibrationWizards feature flag is enabled.

closes RAUT-93

# Changelog

-- Look for 'enableCalibrationWizards' feature flag and do not display recalibration options for both the pipette offset calibration and tip length calibration overflow menus.

# Review requests

* POC and TLC overflow menus render correctly
* POC and TLC overflow menu "delete" and "download" options function as expected

# Risk assessment

Very low risk at this point since it is hidden behind the feature flag. Further calibration work will also be affecting these venues.


[RAUT-93]: https://opentrons.atlassian.net/browse/RAUT-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ