### PR TITLE
build: fix app-shell pushing to ot3 failing because of read-only rootfs

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -131,7 +131,7 @@ dist-ot3: package-deps
 push-ot3: dist-ot3
 	ssh $(ssh_opts) root@$(host) "systemctl stop opentrons-robot-app && mount -o remount,rw / && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
 	scp -r $(ssh_opts) ./dist/linux-arm64-unpacked/* root@$(host):/opt/opentrons-app
-	ssh $(ssh_opts) root@$(host) "mount -o ro / && systemctl start opentrons-robot-app"
+	ssh $(ssh_opts) root@$(host) "mount -o remount,ro / && systemctl start opentrons-robot-app"
 
 # Aliases matching github actions OS names for easier calling in
 # workflows

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -129,9 +129,9 @@ dist-ot3: package-deps
 
 .PHONY: push-ot3
 push-ot3: dist-ot3
-	ssh $(ssh_opts) root@$(host) "systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
+	ssh $(ssh_opts) root@$(host) "systemctl stop opentrons-robot-app && mount -o remount,rw / && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
 	scp -r $(ssh_opts) ./dist/linux-arm64-unpacked/* root@$(host):/opt/opentrons-app
-	ssh $(ssh_opts) root@$(host) "systemctl start opentrons-robot-app"
+	ssh $(ssh_opts) root@$(host) "mount -o ro / && systemctl start opentrons-robot-app"
 
 # Aliases matching github actions OS names for easier calling in
 # workflows


### PR DESCRIPTION
# Overview

app-shell push-ot3 does not use push.mk so it was still having the same read-only rootfs issue on the latest OT3 builds.

# Changelog

- set rootfs read-write when pushing app-shell, then read-only after files are extracted

# Review requests

- Make sure this makes sense

# Risk assessment

low, dev only