### PR TITLE
refactor(app): remove invalid type warnings for strings from molecules

### DIFF
--- a/app/src/molecules/DeckThumbnail/index.tsx
+++ b/app/src/molecules/DeckThumbnail/index.tsx
@@ -111,7 +111,9 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
               ) : null}
               {labwareInSlot != null ? (
                 <g
-                  transform={`translate(${slot.position[0]},${slot.position[1]})`}
+                  transform={`translate(${String(slot.position[0])},${String(
+                    slot.position[1]
+                  )})`}
                 >
                   <LabwareRender
                     definition={labwareInSlot.result.definition}

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -111,7 +111,7 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
           <Btn onClick={back} disabled={backIsDisabled} aria-label="back">
             <StyledText
               css={
-                backIsDisabled
+                backIsDisabled ?? false
                   ? GO_BACK_BUTTON_DISABLED_STYLE
                   : GO_BACK_BUTTON_STYLE
               }

--- a/app/src/molecules/MiniCard/__tests__/MiniCard.test.tsx
+++ b/app/src/molecules/MiniCard/__tests__/MiniCard.test.tsx
@@ -27,10 +27,14 @@ describe('MiniCard', () => {
   it('renders the correct style unselectedOptionStyles', () => {
     const { getByText } = render(props)
     const miniCard = getByText('mock mini card')
-    expect(miniCard).toHaveStyle(`background-color: ${COLORS.white}`)
-    expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.medGreyEnabled}`)
-    expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
-    expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
+    expect(miniCard).toHaveStyle(`background-color: ${String(COLORS.white)}`)
+    expect(miniCard).toHaveStyle(
+      `border: 1px solid ${String(COLORS.medGreyEnabled)}`
+    )
+    expect(miniCard).toHaveStyle(
+      `border-radius: ${String(BORDERS.radiusSoftCorners)}`
+    )
+    expect(miniCard).toHaveStyle(`padding: ${String(SPACING.spacing3)}`)
     expect(miniCard).toHaveStyle(`width: 100%`)
     expect(miniCard).toHaveStyle(`cursor: pointer`)
   })
@@ -39,22 +43,28 @@ describe('MiniCard', () => {
     props.isSelected = true
     const { getByText } = render(props)
     const miniCard = getByText('mock mini card')
-    expect(miniCard).toHaveStyle(`background-color: ${COLORS.lightBlue}`)
-    expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.blueEnabled}`)
-    expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
-    expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
+    expect(miniCard).toHaveStyle(
+      `background-color: ${String(COLORS.lightBlue)}`
+    )
+    expect(miniCard).toHaveStyle(
+      `border: 1px solid ${String(COLORS.blueEnabled)}`
+    )
+    expect(miniCard).toHaveStyle(
+      `border-radius: ${String(BORDERS.radiusSoftCorners)}`
+    )
+    expect(miniCard).toHaveStyle(`padding: ${String(SPACING.spacing3)}`)
     expect(miniCard).toHaveStyle(`width: 100%`)
     expect(miniCard).toHaveStyle(`cursor: pointer`)
     expect(miniCard).toHaveStyleRule(
       'border',
-      `1px solid ${COLORS.blueEnabled}`,
+      `1px solid ${String(COLORS.blueEnabled)}`,
       {
         modifier: ':hover',
       }
     )
     expect(miniCard).toHaveStyleRule(
       'background-color',
-      `${COLORS.lightBlue}`,
+      `${String(COLORS.lightBlue)}`,
       {
         modifier: ':hover',
       }
@@ -67,23 +77,27 @@ describe('MiniCard', () => {
     const { getByText } = render(props)
     const miniCard = getByText('mock mini card')
     expect(miniCard).toHaveStyle(
-      `background-color: ${COLORS.errorBackgroundLight}`
+      `background-color: ${String(COLORS.errorBackgroundLight)}`
     )
-    expect(miniCard).toHaveStyle(`border: 1px solid ${COLORS.errorEnabled}`)
-    expect(miniCard).toHaveStyle(`border-radius: ${BORDERS.radiusSoftCorners}`)
-    expect(miniCard).toHaveStyle(`padding: ${SPACING.spacing3}`)
+    expect(miniCard).toHaveStyle(
+      `border: 1px solid ${String(COLORS.errorEnabled)}`
+    )
+    expect(miniCard).toHaveStyle(
+      `border-radius: ${String(BORDERS.radiusSoftCorners)}`
+    )
+    expect(miniCard).toHaveStyle(`padding: ${String(SPACING.spacing3)}`)
     expect(miniCard).toHaveStyle(`width: 100%`)
     expect(miniCard).toHaveStyle(`cursor: pointer`)
     expect(miniCard).toHaveStyleRule(
       'border',
-      `1px solid ${COLORS.errorEnabled}`,
+      `1px solid ${String(COLORS.errorEnabled)}`,
       {
         modifier: ':hover',
       }
     )
     expect(miniCard).toHaveStyleRule(
       'background-color',
-      `${COLORS.errorBackgroundLight}`,
+      `${String(COLORS.errorBackgroundLight)}`,
       {
         modifier: ':hover',
       }

--- a/app/src/molecules/Modal/index.tsx
+++ b/app/src/molecules/Modal/index.tsx
@@ -24,7 +24,9 @@ export const Modal = (props: ModalProps): JSX.Element => {
     onClose,
     closeOnOutsideClick,
     title,
-    childrenPadding = `${SPACING.spacing4} ${SPACING.spacing5} ${SPACING.spacing5}`,
+    childrenPadding = `${String(SPACING.spacing4)} ${String(
+      SPACING.spacing5
+    )} ${String(SPACING.spacing5)}`,
     children,
     ...styleProps
   } = props
@@ -51,7 +53,7 @@ export const Modal = (props: ModalProps): JSX.Element => {
     <ModalShell
       width={styleProps.width ?? '31.25rem'}
       header={modalHeader}
-      onOutsideClick={closeOnOutsideClick ? onClose : undefined}
+      onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
       marginLeft="7.125rem"
       {...props}

--- a/app/src/molecules/ModuleIcon/__tests__/ModuleIcon.test.tsx
+++ b/app/src/molecules/ModuleIcon/__tests__/ModuleIcon.test.tsx
@@ -54,14 +54,18 @@ describe('ModuleIcon', () => {
   it('renders SharedIcon with correct style', () => {
     const { getByTestId } = render(props)
     const module = getByTestId('ModuleIcon_ot-temperature-v2')
-    expect(module).toHaveStyle(`color: ${COLORS.darkGreyEnabled}`)
-    expect(module).toHaveStyle(`height: ${SPACING.spacing4}`)
-    expect(module).toHaveStyle(`width: ${SPACING.spacing4}`)
-    expect(module).toHaveStyle(`margin-left: ${SPACING.spacing1}`)
-    expect(module).toHaveStyle(`margin-right: ${SPACING.spacing1}`)
-    expect(module).toHaveStyleRule('color', `${COLORS.darkBlackEnabled}`, {
-      modifier: ':hover',
-    })
+    expect(module).toHaveStyle(`color: ${String(COLORS.darkGreyEnabled)}`)
+    expect(module).toHaveStyle(`height: ${String(SPACING.spacing4)}`)
+    expect(module).toHaveStyle(`width: ${String(SPACING.spacing4)}`)
+    expect(module).toHaveStyle(`margin-left: ${String(SPACING.spacing1)}`)
+    expect(module).toHaveStyle(`margin-right: ${String(SPACING.spacing1)}`)
+    expect(module).toHaveStyleRule(
+      'color',
+      `${String(COLORS.darkBlackEnabled)}`,
+      {
+        modifier: ':hover',
+      }
+    )
   })
 
   it('renders magnetic module icon', () => {

--- a/app/src/molecules/NavTab/__tests__/NavTab.test.tsx
+++ b/app/src/molecules/NavTab/__tests__/NavTab.test.tsx
@@ -38,16 +38,22 @@ describe('NavTab', () => {
     const tab = getByText('protocols')
     expect(tab).toHaveAttribute('href', '/protocols')
     expect(tab).toHaveStyle(
-      `padding: 0 ${SPACING.spacing2} ${SPACING.spacing3}`
+      `padding: 0 ${String(SPACING.spacing2)} ${String(SPACING.spacing3)}`
     )
-    expect(tab).toHaveStyle(`font-size: ${TYPOGRAPHY.fontSizeLabel}`)
-    expect(tab).toHaveStyle(`font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`)
-    expect(tab).toHaveStyle(`color: ${COLORS.darkGreyEnabled}`)
+    expect(tab).toHaveStyle(`font-size: ${String(TYPOGRAPHY.fontSizeLabel)}`)
+    expect(tab).toHaveStyle(
+      `font-weight: ${String(TYPOGRAPHY.fontWeightSemiBold)}`
+    )
+    expect(tab).toHaveStyle(`color: ${String(COLORS.darkGreyEnabled)}`)
     fireEvent.click(tab)
-    expect(tab).toHaveStyle(`color: ${COLORS.darkBlackEnabled}`)
-    expect(tab).toHaveStyle(`border-bottom-color: ${COLORS.blueEnabled}`)
-    expect(tab).toHaveStyle(`border-bottom-width: ${SPACING.spacing1}`)
-    expect(tab).toHaveStyle(`border-bottom-style: ${BORDERS.styleSolid}`)
+    expect(tab).toHaveStyle(`color: ${String(COLORS.darkBlackEnabled)}`)
+    expect(tab).toHaveStyle(
+      `border-bottom-color: ${String(COLORS.blueEnabled)}`
+    )
+    expect(tab).toHaveStyle(`border-bottom-width: ${String(SPACING.spacing1)}`)
+    expect(tab).toHaveStyle(
+      `border-bottom-style: ${String(BORDERS.styleSolid)}`
+    )
   })
 
   it('should navtab is disabled if disabled is true', () => {
@@ -56,11 +62,13 @@ describe('NavTab', () => {
     const tab = getByText('protocols')
     expect(tab.tagName.toLowerCase()).toBe('span')
     expect(tab).toHaveStyle(
-      `padding: 0 ${SPACING.spacing2} ${SPACING.spacing3}`
+      `padding: 0 ${String(SPACING.spacing2)} ${String(SPACING.spacing3)}`
     )
-    expect(tab).toHaveStyle(`font-size: ${TYPOGRAPHY.fontSizeLabel}`)
-    expect(tab).toHaveStyle(`font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`)
-    expect(tab).toHaveStyle(`color: ${COLORS.errorDisabled}`)
+    expect(tab).toHaveStyle(`font-size: ${String(TYPOGRAPHY.fontSizeLabel)}`)
+    expect(tab).toHaveStyle(
+      `font-weight: ${String(TYPOGRAPHY.fontWeightSemiBold)}`
+    )
+    expect(tab).toHaveStyle(`color: ${String(COLORS.errorDisabled)}`)
   })
 
   it('renders navtab when pass to / as to', () => {

--- a/app/src/molecules/OffsetVector/__tests__/OffsetVector.test.tsx
+++ b/app/src/molecules/OffsetVector/__tests__/OffsetVector.test.tsx
@@ -22,26 +22,32 @@ describe('OffsetVector', () => {
     const { getByText, getAllByRole } = render(props)
     expect(getAllByRole('heading', { level: 6 })).toHaveLength(6)
 
-    expect(getByText('X')).toHaveStyle(`margin-right: ${SPACING.spacing2}`)
     expect(getByText('X')).toHaveStyle(
-      `font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`
+      `margin-right: ${String(SPACING.spacing2)}`
+    )
+    expect(getByText('X')).toHaveStyle(
+      `font-weight: ${String(TYPOGRAPHY.fontWeightSemiBold)}`
     )
     const x = getByText('10.00')
-    expect(x).toHaveStyle(`margin-right: ${SPACING.spacing3}`)
+    expect(x).toHaveStyle(`margin-right: ${String(SPACING.spacing3)}`)
 
-    expect(getByText('Y')).toHaveStyle(`margin-right: ${SPACING.spacing2}`)
     expect(getByText('Y')).toHaveStyle(
-      `font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`
+      `margin-right: ${String(SPACING.spacing2)}`
+    )
+    expect(getByText('Y')).toHaveStyle(
+      `font-weight: ${String(TYPOGRAPHY.fontWeightSemiBold)}`
     )
     const y = getByText('20.00')
-    expect(y).toHaveStyle(`margin-right: ${SPACING.spacing3}`)
+    expect(y).toHaveStyle(`margin-right: ${String(SPACING.spacing3)}`)
 
-    expect(getByText('Z')).toHaveStyle(`margin-right: ${SPACING.spacing2}`)
     expect(getByText('Z')).toHaveStyle(
-      `font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`
+      `margin-right: ${String(SPACING.spacing2)}`
+    )
+    expect(getByText('Z')).toHaveStyle(
+      `font-weight: ${String(TYPOGRAPHY.fontWeightSemiBold)}`
     )
     const z = getByText('30.00')
-    expect(z).toHaveStyle(`margin-right: ${SPACING.spacing3}`)
+    expect(z).toHaveStyle(`margin-right: ${String(SPACING.spacing3)}`)
   })
 
   it('renders numbers using fixed-point notation', () => {

--- a/app/src/molecules/PythonLabwareOffsetSnippet/createSnippet.ts
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/createSnippet.ts
@@ -30,16 +30,22 @@ export function createSnippet(
           loadedLabware.definitionUri
         ].parameters
         if (command.params.location === 'offDeck') {
-          loadStatement = `labware_${labwareCount} = protocol.load_labware("${loadName}", location="offDeck")`
+          loadStatement = `labware_${labwareCount} = protocol.load_labware("${String(
+            loadName
+          )}", location="offDeck")`
         } else if ('slotName' in command.params.location) {
           // load labware on deck
           const { slotName } = command.params.location
-          loadStatement = `labware_${labwareCount} = protocol.load_labware("${loadName}", location="${slotName}")`
+          loadStatement = `labware_${labwareCount} = protocol.load_labware("${String(
+            loadName
+          )}", location="${String(slotName)}")`
         } else if ('moduleId' in command.params.location) {
           // load labware on module
           const moduleVariable =
             moduleVariableById[command.params.location.moduleId]
-          loadStatement = `labware_${labwareCount} = ${moduleVariable}.load_labware("${loadName}")`
+          loadStatement = `labware_${labwareCount} = ${moduleVariable}.load_labware("${String(
+            loadName
+          )}")`
         }
         const labwareDefUri = getLabwareDefinitionUri(
           command.result.labwareId,
@@ -65,9 +71,9 @@ export function createSnippet(
           const { x, y, z } = labwareOffset.vector
           addendum = [
             loadStatement,
-            `labware_${labwareCount}.set_offset(x=${x.toFixed(
-              2
-            )}, y=${y.toFixed(2)}, z=${z.toFixed(2)})`,
+            `labware_${labwareCount}.set_offset(x=${String(
+              x.toFixed(2)
+            )}, y=${String(y.toFixed(2))}, z=${String(z.toFixed(2))})`,
             '',
           ]
         }
@@ -83,7 +89,9 @@ export function createSnippet(
         const { model } = protocol.modules[command.params.moduleId]
         const { slotName } = command.params.location
         addendum = [
-          `${moduleVariable} = protocol.load_module("${model}", location="${slotName}")`,
+          `${moduleVariable} = protocol.load_module("${String(
+            model
+          )}", location="${String(slotName)}")`,
           '',
         ]
       }
@@ -95,9 +103,9 @@ export function createSnippet(
 
   return loadCommandLines.reduce<string>((acc, line) => {
     if (mode === 'jupyter') {
-      return `${acc}\n${line}`
+      return `${String(acc)}\n${String(line)}`
     } else {
-      return `${acc}\n${PYTHON_INDENT}${line}`
+      return `${String(acc)}\n${PYTHON_INDENT}${String(line)}`
     }
   }, `${mode === 'jupyter' ? JUPYTER_PREFIX : CLI_PREFIX}`)
 }

--- a/app/src/molecules/ReleaseNotes/index.tsx
+++ b/app/src/molecules/ReleaseNotes/index.tsx
@@ -21,7 +21,7 @@ export function ReleaseNotes(props: ReleaseNotesProps): JSX.Element {
 
   return (
     <div className={styles.release_notes}>
-      {source ? (
+      {source != null ? (
         renderer.processSync(source).contents
       ) : (
         <p>{DEFAULT_RELEASE_NOTES}</p>

--- a/app/src/molecules/WizardHeader/index.tsx
+++ b/app/src/molecules/WizardHeader/index.tsx
@@ -38,7 +38,7 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
   return (
     <Box backgroundColor={COLORS.white}>
       <Flex
-        padding={`${SPACING.spacing4} ${SPACING.spacing6}`}
+        padding={`${String(SPACING.spacing4)} ${String(SPACING.spacing6)}`}
         flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add String() to remove warnings from molecules
The lines I added `String()` should be `string` since most of them are CSS property values for test cases(not null / not undefined).


This is part of RAUT-74
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- remove warnings that are related string type from molecules
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
