### PR TITLE
refactor(app): remove invalid type warnings for strings from pages

### DIFF
--- a/app/src/pages/AppSettings/index.tsx
+++ b/app/src/pages/AppSettings/index.tsx
@@ -50,7 +50,9 @@ export function AppSettings(): JSX.Element {
         backgroundColor={COLORS.white}
         height="100%"
         width="100%"
-        border={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGreyEnabled}`}
+        border={`${String(SPACING.spacingXXS)} ${String(
+          BORDERS.styleSolid
+        )} ${String(COLORS.medGreyEnabled)}`}
         borderRadius={BORDERS.radiusSoftCorners}
         minHeight="95%"
       >

--- a/app/src/pages/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Devices/DeviceDetails/index.tsx
@@ -43,7 +43,7 @@ export function DeviceDetails(): JSX.Element | null {
         <Flex
           alignItems={ALIGN_CENTER}
           backgroundColor={COLORS.white}
-          border={`1px solid ${COLORS.medGreyEnabled}`}
+          border={`1px solid ${String(COLORS.medGreyEnabled)}`}
           borderRadius="3px"
           flexDirection={DIRECTION_COLUMN}
           marginBottom={SPACING.spacing4}

--- a/app/src/pages/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Devices/DevicesLanding/index.tsx
@@ -65,7 +65,10 @@ export function DevicesLanding(): JSX.Element {
     ].length === 0
 
   return (
-    <Box minWidth={SIZE_6} padding={`${SPACING.spacing3} ${SPACING.spacing4}`}>
+    <Box
+      minWidth={SIZE_6}
+      padding={`${String(SPACING.spacing3)} ${String(SPACING.spacing4)}`}
+    >
       <Flex
         justifyContent={JUSTIFY_SPACE_BETWEEN}
         alignItems={ALIGN_CENTER}

--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -191,15 +191,17 @@ export function ProtocolRunDetails(): JSX.Element | null {
           </Flex>
           <Box
             backgroundColor={COLORS.white}
-            border={`${SPACING.spacingXXS} ${BORDERS.styleSolid} ${COLORS.medGreyEnabled}`}
+            border={`${String(SPACING.spacingXXS)} ${String(
+              BORDERS.styleSolid
+            )} ${String(COLORS.medGreyEnabled)}`}
             // remove left upper corner border radius when first tab is active
             borderRadius={`${
               protocolRunDetailsTab === 'setup'
                 ? '0'
-                : BORDERS.radiusSoftCorners
-            } ${BORDERS.radiusSoftCorners} ${BORDERS.radiusSoftCorners} ${
+                : String(BORDERS.radiusSoftCorners)
+            } ${String(BORDERS.radiusSoftCorners)} ${String(
               BORDERS.radiusSoftCorners
-            }`}
+            )} ${String(BORDERS.radiusSoftCorners)}`}
           >
             {protocolRunDetailsContent}
           </Box>

--- a/app/src/pages/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Devices/RobotSettings/index.tsx
@@ -113,11 +113,11 @@ export function RobotSettings(): JSX.Element | null {
         marginBottom={SPACING.spacing4}
         width="100%"
       >
-        <Box padding={`0 ${SPACING.spacing4}`}>
+        <Box padding={`0 ${String(SPACING.spacing4)}`}>
           <Box
             color={COLORS.black}
             css={TYPOGRAPHY.h1Default}
-            padding={`${SPACING.spacing5} 0`}
+            padding={`${String(SPACING.spacing5)} 0`}
           >
             {t('robot_settings')}
           </Box>
@@ -162,7 +162,9 @@ export function RobotSettings(): JSX.Element | null {
           </Flex>
         </Box>
         <Line />
-        <Box padding={`${SPACING.spacing5} ${SPACING.spacing4}`}>
+        <Box
+          padding={`${String(SPACING.spacing5)} ${String(SPACING.spacing4)}`}
+        >
           <ApiHostProvider
             hostname={robot?.ip ?? null}
             port={robot?.port ?? null}

--- a/app/src/pages/Labware/index.tsx
+++ b/app/src/pages/Labware/index.tsx
@@ -215,7 +215,7 @@ export function Labware(): JSX.Element {
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing2}>
           {labware.map((labware, index) => (
             <LabwareCard
-              key={`${labware.definition.metadata.displayName}${index}`}
+              key={`${String(labware.definition.metadata.displayName)}${index}`}
               labware={labware}
               onClick={() => {
                 setCurrentLabwareDef(labware)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add String() to remove warnings from pages
The lines I added `String()` should be `string` since most of them are CSS property values for test cases(not null / not undefined).


This is part of RAUT-74
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- remove warnings that are related string type from pages
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
