### PR TITLE
build(fix): set correct rootfs mount options for push-no-restart-ot3

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -178,9 +178,10 @@ push: push-no-restart
 push-no-restart-ot3: sdist
 	echo $(sdist_file)
 	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,opentrons,src)
-	ssh $(ssh_opts) root@$(host) "mkdir -p /usr/local/bin"
+	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && mkdir -p /usr/local/bin"
 	scp $(ssh_opts) ./src/opentrons/hardware_control/scripts/ot3repl root@$(host):/usr/local/bin/ot3repl
 	scp $(ssh_opts) ./src/opentrons/hardware_control/scripts/ot3gripper root@$(host):/usr/local/bin/ot3gripper
+	ssh $(ssh_opts) root@$(host) "mount -o remount,ro /"
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3


### PR DESCRIPTION
# Overview

Another push-ot3 issue caused by read-only rootfs

# Changelog

- set correct rootfs mount options for push-no-restart-ot3

# Review requests
Try this on an OT3 and make sure we can use
- [ ]   **make push-ot3 host=robot-ip** at the top level, /opentrons dir
- [ ] **make -C submodule push-ot3 host=robot-ip** at the top level, /opentrons dir
- [ ] **make push-ot3 host=robot-ip** at submodule level, /opentrons/robot-server, etc


# Risk assessment
low, dev only