### PR TITLE
fix(robot-server): Fix async concurrency hazards in lazy-initialized dependencies

### DIFF
--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -1,13 +1,14 @@
 """FastAPI dependencies for protocol endpoints."""
 
 
+from asyncio import Lock as AsyncLock
+from pathlib import Path
+from typing_extensions import Final
 import logging
 
+from anyio import Path as AsyncPath
 from fastapi import Depends
 from sqlalchemy.engine import Engine as SQLEngine
-from typing_extensions import Final
-from pathlib import Path
-from anyio import Path as AsyncPath
 
 from opentrons.protocol_reader import ProtocolReader
 from opentrons.protocol_runner import create_simulating_runner
@@ -28,8 +29,12 @@ _PROTOCOL_FILES_SUBDIRECTORY: Final = "protocols"
 
 _log = logging.getLogger(__name__)
 
+_protocol_store_init_lock = AsyncLock()
 _protocol_store_accessor = AppStateAccessor[ProtocolStore]("protocol_store")
+
 _analysis_store_accessor = AppStateAccessor[AnalysisStore]("analysis_store")
+
+_protocol_directory_init_lock = AsyncLock()
 _protocol_directory_accessor = AppStateAccessor[Path]("protocol_directory")
 
 
@@ -43,14 +48,14 @@ async def get_protocol_directory(
     persistence_directory: Path = Depends(get_persistence_directory),
 ) -> Path:
     """Get the directory to save protocol files, creating it if needed."""
-    protocol_directory = _protocol_directory_accessor.get_from(app_state)
+    async with _protocol_directory_init_lock:
+        protocol_directory = _protocol_directory_accessor.get_from(app_state)
+        if protocol_directory is None:
+            protocol_directory = persistence_directory / _PROTOCOL_FILES_SUBDIRECTORY
+            await AsyncPath(protocol_directory).mkdir(exist_ok=True)
+            _protocol_directory_accessor.set_on(app_state, protocol_directory)
 
-    if protocol_directory is None:
-        protocol_directory = persistence_directory / _PROTOCOL_FILES_SUBDIRECTORY
-        await AsyncPath(protocol_directory).mkdir(exist_ok=True)
-        _protocol_directory_accessor.set_on(app_state, protocol_directory)
-
-    return protocol_directory
+        return protocol_directory
 
 
 async def get_protocol_store(
@@ -60,20 +65,20 @@ async def get_protocol_store(
     protocol_reader: ProtocolReader = Depends(get_protocol_reader),
 ) -> ProtocolStore:
     """Get a singleton ProtocolStore to keep track of created protocols."""
-    protocol_store = _protocol_store_accessor.get_from(app_state)
+    async with _protocol_store_init_lock:
+        protocol_store = _protocol_store_accessor.get_from(app_state)
+        if protocol_store is None:
+            protocol_store = await ProtocolStore.rehydrate(
+                sql_engine=sql_engine,
+                protocols_directory=protocol_directory,
+                protocol_reader=protocol_reader,
+            )
+            _protocol_store_accessor.set_on(app_state, protocol_store)
 
-    if protocol_store is None:
-        protocol_store = await ProtocolStore.rehydrate(
-            sql_engine=sql_engine,
-            protocols_directory=protocol_directory,
-            protocol_reader=protocol_reader,
-        )
-        _protocol_store_accessor.set_on(app_state, protocol_store)
-
-    return protocol_store
+        return protocol_store
 
 
-def get_analysis_store(
+async def get_analysis_store(
     app_state: AppState = Depends(get_app_state),
     sql_engine: SQLEngine = Depends(get_sql_engine),
 ) -> AnalysisStore:

--- a/robot-server/robot_server/util.py
+++ b/robot-server/robot_server/util.py
@@ -68,9 +68,7 @@ def call_once(fn: AsyncFuncT) -> AsyncFuncT:
     async def wrapped(*args: Any, **kwargs: Any) -> Any:
         if not hasattr(wrapped, _CALL_ONCE_TASK_ATTR):
             setattr(
-                wrapped,
-                _CALL_ONCE_TASK_ATTR,
-                asyncio.create_task(fn(*args, **kwargs))
+                wrapped, _CALL_ONCE_TASK_ATTR, asyncio.create_task(fn(*args, **kwargs))
             )
 
         result_task = getattr(wrapped, _CALL_ONCE_TASK_ATTR)

--- a/robot-server/robot_server/util.py
+++ b/robot-server/robot_server/util.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import hashlib
 from dataclasses import dataclass
 from fastapi import UploadFile
@@ -47,7 +48,8 @@ def save_upload(directory: Path, upload_file: UploadFile) -> FileMeta:
     return FileMeta(path=path, content_hash=content_hash)
 
 
-CALL_ONCE_RESULT_ATTR: Final = "_call_once_result"
+_CALL_ONCE_TASK_ATTR: Final = "_call_once_task"
+
 
 AsyncFuncT = TypeVar("AsyncFuncT", bound=Callable[..., Awaitable[Any]])
 
@@ -55,7 +57,7 @@ AsyncFuncT = TypeVar("AsyncFuncT", bound=Callable[..., Awaitable[Any]])
 def call_once(fn: AsyncFuncT) -> AsyncFuncT:
     """
     Decorator used to ensure an async function is called only once. Subsequent
-     calls will return the result of ths initial call regardless of arguments.
+     calls will return the result of the initial call regardless of arguments.
 
      Intended for use in initializing a singleton.
 
@@ -64,10 +66,10 @@ def call_once(fn: AsyncFuncT) -> AsyncFuncT:
 
     @wraps(fn)
     async def wrapped(*args: Any, **kwargs: Any) -> Any:
-        if not hasattr(wrapped, CALL_ONCE_RESULT_ATTR):
-            result = await fn(*args, **kwargs)
-            setattr(wrapped, CALL_ONCE_RESULT_ATTR, result)
+        if not hasattr(wrapped, _CALL_ONCE_TASK_ATTR):
+            setattr(wrapped, _CALL_ONCE_TASK_ATTR, asyncio.create_task(fn(*args, **kwargs)))
 
-        return getattr(wrapped, CALL_ONCE_RESULT_ATTR)
+        result_task = getattr(wrapped, _CALL_ONCE_TASK_ATTR)
+        return await result_task
 
     return cast(AsyncFuncT, wrapped)

--- a/robot-server/robot_server/util.py
+++ b/robot-server/robot_server/util.py
@@ -67,7 +67,11 @@ def call_once(fn: AsyncFuncT) -> AsyncFuncT:
     @wraps(fn)
     async def wrapped(*args: Any, **kwargs: Any) -> Any:
         if not hasattr(wrapped, _CALL_ONCE_TASK_ATTR):
-            setattr(wrapped, _CALL_ONCE_TASK_ATTR, asyncio.create_task(fn(*args, **kwargs)))
+            setattr(
+                wrapped,
+                _CALL_ONCE_TASK_ATTR,
+                asyncio.create_task(fn(*args, **kwargs))
+            )
 
         result_task = getattr(wrapped, _CALL_ONCE_TASK_ATTR)
         return await result_task

--- a/robot-server/tests/test_util.py
+++ b/robot-server/tests/test_util.py
@@ -1,7 +1,8 @@
+import asyncio
 from datetime import timedelta, datetime
 
 import pytest
-from mock import patch, MagicMock
+from mock import patch
 from typing import Any, Iterator
 
 from robot_server import util
@@ -52,18 +53,38 @@ def test_duration_raises(mock_utc_now: datetime, mock_start_time: datetime) -> N
     assert t.end == mock_start_time + timedelta(days=1)
 
 
-async def test_call_once() -> None:
-    return_value: Any = dict()
-    mock = MagicMock(return_value=return_value)
+async def test_call_once_retains_first_return_value() -> None:
+    class ReturnType:
+        def __init__(self, arg: int) -> None:
+            self.arg = arg
 
     @util.call_once
-    async def f(arg1: Any) -> Any:
-        return mock(arg1)
+    async def to_be_called_once(arg: int) -> ReturnType:
+        return ReturnType(arg)
 
-    # Call wrapped twice
-    a = await f(1)
-    b = await f(2)
-    # Results are the same object
-    assert a is b is return_value
-    # Mock is only called once.
-    mock.assert_called_once_with(1)
+    result_1 = await to_be_called_once(1)
+    result_2 = await to_be_called_once(2)
+
+    # It should return the same object each time.
+    assert result_1 is result_2
+
+    # That object should be the one returned by the first call.
+    assert result_1.arg == result_2.arg == 1
+
+
+async def test_call_once_is_async_safe() -> None:
+    times_called = 0
+
+    @util.call_once
+    async def to_be_called_once() -> None:
+        # Give multiple calls a chance to run concurrently with each other.
+        await asyncio.sleep(0.01)
+
+        nonlocal times_called
+        times_called += 1
+
+    # Call the function a bunch of times to run concurrently.
+    await asyncio.gather(*[to_be_called_once() for _ in range(100)])
+
+    # Assert that the function body only actually executed one time.
+    assert times_called == 1


### PR DESCRIPTION
# Overview

In `robot-server`, when an HTTP endpoint needs something, it's often lazy-initialized. For example, the server will create its singleton `RunStore` only upon the first HTTP request that needs access to runs.

We believe there are concurrency hazards in our implementation of this, which this PR aims to fix.

Closes RSS-149.

# Fixes

* When we write a FastAPI dependency like this:
 
  ```python
  def get_my_dependency() -> MyDependency:
      ...
  ```
 
  Instead of like this:

  ```python
  async get_my_dependency() -> MyDependency:
      ...
  ```

   Then FastAPI will "helpfully" [implicitly run it in a thread pool](https://fastapi.tiangolo.com/async/#:~:text=If%20a%20dependency,the%20external%20threadpool.). This is wrong and bad, because our lazy initialization code uses global state and isn't designed to work with multiple threads.

  Our solution is to always write FastAPI dependencies as `async def` when they deal with global state.

* When we write a FastAPI dependency like this:

  ```python
  async def get_my_dependency() -> MyDependency:
      if not my_depenency_is_already_initialized:
          await initialize_my_dependency()  # Note the `await`.
      return get_already_initialized_my_dependency()
  ```

  Then there's a concurrency hazard:
  
  1. Some HTTP request comes in. It requests the dependency.
  2. It sees that the dependency hasn't been initialized yet. We start initializing the dependency.
  3. We reach the `await` in the middle of initializing the dependency. We yield back to the event loop.
  4. A second HTTP request comes in. It requests the same dependency.
  5. **It sees that the dependency hasn't been initialized yet. We start initializing the dependency again.**

  This can cause performance problems because of the redundant work, and behavioral problems because there will be multiple instances of something that's supposed to be a singleton.

  The solution is to rewrite the check-and-store sequence to be async-atomic.

# Review requests

Code review should be sufficient.

* Do the fixes make sense?
* Did I miss any other buggy FastAPI dependency functions?

# Risk assessment

Low as long as our integration tests keep passing.
