### PR TITLE
fix(hardware): save can_comm / can_mon logs to read-write location

### DIFF
--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -265,7 +265,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "can_comm.log",
+            "filename": "/var/log/can_comm.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/can_mon.py
+++ b/hardware/opentrons_hardware/scripts/can_mon.py
@@ -152,7 +152,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "can_mon.log",
+            "filename": "/var/log/can_mon.log",
             "maxBytes": 5000000,
             "level": logging.WARNING,
             "backupCount": 3,


### PR DESCRIPTION
# Overview

Most of the rootfs is now read-only so we need to move the can_comm / can_mon log messages from /opt/opentrons/, which is read-only, to /var/log which is mounted to /userfs and is read-write.

Closes: [RCORE-496](https://opentrons.atlassian.net/browse/RCORE-496)

# Changelog

- save can_comm / can_mon logs to /var/log instead of /opt/opentrons/

# Review requests

- [x] Make sure we can start can_comm / can_mon

# Risk assessment

- Low, dev only change