### PR TITLE
chore(usb-bridge): add usb-bridge tests to test-py, add restart to push-ot3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ push-ot3:
 	$(MAKE) -C $(NOTIFY_SERVER_DIR) push-no-restart-ot3
 	$(MAKE) -C $(ROBOT_SERVER_DIR) push-ot3
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push-ot3
+	$(MAKE) -C $(USB_BRIDGE_DIR) push-ot3
 
 
 .PHONY: term
@@ -181,6 +182,7 @@ test-py: test-py-windows
 	$(MAKE) -C $(ROBOT_SERVER_DIR) test
 	$(MAKE) -C $(NOTIFY_SERVER_DIR) test
 	$(MAKE) -C $(G_CODE_TESTING_DIR) test
+	$(MAKE) -C $(USB_BRIDGE_DIR) test
 
 .PHONY: test-js
 test-js:

--- a/usb-bridge/Makefile
+++ b/usb-bridge/Makefile
@@ -71,4 +71,4 @@ sdist: clean
 .PHONY: push-ot3
 push-ot3: sdist
 	$(call push-python-sdist,$(host),,$(br_ssh_opts),dist/$(sdist_file),/opt/ot3usb,ot3usb)
-	# todo (fs, 2022-09-15): add a restart when appropriate
+	$(call restart-service,$(host),,$(br_ssh_opts),opentrons-usb-bridge)


### PR DESCRIPTION

# Overview

Now that the openembedded build includes a functioning systemctl service, the makefile should restart the daemon after pushing an updated python package.

# Changelog

* Added a systemctl restart to the `push-ot3` target for the usb-bridge
* Added the ot3usb folder to the top level `test-py` `push-ot3` targets

# Review requests


# Risk assessment

Low. The systemctl restart is only used during development, and the tests were already being executed by CI.