### PR TITLE
refactor(api): move `ModuleGeometry` to legacy protocol core module

### DIFF
--- a/api/src/opentrons/protocol_api/core/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/deck.py
@@ -17,14 +17,10 @@ from opentrons.hardware_control.modules.types import ModuleType
 from opentrons.protocols.api_support.constants import deck_type
 from opentrons.protocols.api_support.labware_like import LabwareLike
 
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry,
-    ThermocyclerGeometry,
-)
-
 from ...deck import CalibrationPosition
 from ...labware import load as load_lw, Labware
 from .labware import LabwareImplementation
+from .module_geometry import ModuleGeometry, ThermocyclerGeometry
 from . import deck_conflict
 
 _log = logging.getLogger(__name__)

--- a/api/src/opentrons/protocol_api/core/protocol_api/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/deck_conflict.py
@@ -15,11 +15,8 @@ from opentrons.motion_planning.adjacent_slots_getters import (
 )
 from opentrons.protocol_api.labware import Labware
 from opentrons.protocol_api.core.labware import AbstractLabware
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry,
-    ThermocyclerGeometry,
-    HeaterShakerGeometry,
-)
+
+from .module_geometry import ModuleGeometry, ThermocyclerGeometry, HeaterShakerGeometry
 
 if TYPE_CHECKING:
     from .deck import DeckItem

--- a/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/legacy_module_core.py
@@ -19,11 +19,6 @@ from opentrons.hardware_control.modules.types import (
     MagneticModuleModel,
     ThermocyclerStep,
 )
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry,
-    ThermocyclerGeometry,
-    HeaterShakerGeometry,
-)
 from opentrons.types import DeckSlotName, Location
 
 from ..module import (
@@ -35,6 +30,7 @@ from ..module import (
 )
 
 from .labware import LabwareImplementation
+from .module_geometry import ModuleGeometry, ThermocyclerGeometry, HeaterShakerGeometry
 from ...labware import Labware
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/protocol_context.py
@@ -12,14 +12,13 @@ from opentrons.hardware_control.modules import AbstractModule, ModuleModel, Modu
 from opentrons.hardware_control.types import DoorState, PauseType
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import AxisMaxSpeeds, UnsupportedAPIError
-from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols import labware as labware_definition
 
 from ...labware import Labware
 from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
 
-from . import legacy_module_core
+from . import legacy_module_core, module_geometry
 from .deck import Deck
 from .instrument_context import InstrumentContextImplementation
 from .labware_offset_provider import AbstractLabwareOffsetProvider

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -14,6 +14,8 @@ import logging
 from itertools import dropwhile
 from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple
 
+from opentrons_shared_data.labware.dev_types import LabwareDefinition, LabwareParameters
+
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import requires_version
@@ -32,16 +34,9 @@ from opentrons.protocols.labware import (  # noqa: F401
 from . import validation
 from .core import well_grid
 from .core.labware import AbstractLabware
-from .core.protocol_api.labware import LabwareImplementation
+from .core.protocol_api.labware import LabwareImplementation as LegacyLabwareCore
 
 if TYPE_CHECKING:
-    from opentrons.protocols.geometry.module_geometry import (  # noqa: F401
-        ModuleGeometry,
-    )
-    from opentrons_shared_data.labware.dev_types import (
-        LabwareDefinition,
-        LabwareParameters,
-    )
     from .core.common import LabwareCore, WellCore
 
 
@@ -834,7 +829,7 @@ def load_from_definition(
                       defaults to ``MAX_SUPPORTED_VERSION``.
     """
     return Labware(
-        implementation=LabwareImplementation(
+        implementation=LegacyLabwareCore(
             definition=definition,
             parent=parent,
             label=label,

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -12,8 +12,6 @@ from opentrons.commands.publisher import CommandPublisher, publish
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError, requires_version
 
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
-
 from .core.common import (
     ProtocolCore,
     ModuleCore,
@@ -24,6 +22,7 @@ from .core.common import (
 )
 from .core.core_map import LoadedCoreMap
 from .core.protocol_api.legacy_module_core import LegacyModuleCore
+from .core.protocol_api.module_geometry import ModuleGeometry as LegacyModuleGeometry
 from .core.protocol_api.labware import LabwareImplementation as LegacyLabwareCore
 
 from .module_validation_and_errors import (
@@ -194,14 +193,12 @@ class ModuleContext(CommandPublisher):
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
-    def geometry(self) -> ModuleGeometry:
+    def geometry(self) -> LegacyModuleGeometry:
         """The object representing the module as an item on the deck.
 
         .. deprecated:: 2.14
             Use properties of the :py:class:`ModuleContext` instead,
             like :py:meth:`model` and :py:meth:`type`
-
-        :returns: ModuleGeometry
         """
         if isinstance(self._core, LegacyModuleCore):
             return self._core.geometry

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional, Union, cast, Tuple, List, Set
 
 if TYPE_CHECKING:
     from opentrons.protocol_api.labware import Labware, Well
-    from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+    from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 
 
 WrappableLabwareLike = Union[
@@ -28,7 +28,9 @@ class LabwareLike:
         """
         # Import locally to avoid circular dependency
         from opentrons.protocol_api.labware import Labware, Well
-        from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+        from opentrons.protocol_api.core.protocol_api.module_geometry import (
+            ModuleGeometry,
+        )
 
         self._labware_like = labware_like
         self._type = LabwareLikeType.NONE
@@ -112,7 +114,9 @@ class LabwareLike:
         return cast(Labware, self.object)
 
     def as_module(self) -> "ModuleGeometry":
-        from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+        from opentrons.protocol_api.core.protocol_api.module_geometry import (
+            ModuleGeometry,
+        )
 
         return cast(ModuleGeometry, self.object)
 

--- a/api/src/opentrons/protocols/geometry/planning.py
+++ b/api/src/opentrons/protocols/geometry/planning.py
@@ -17,7 +17,7 @@ from opentrons.motion_planning import (
 
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocol_api.core.protocol_api.deck import Deck
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 
 
 MODULE_LOG = logging.getLogger(__name__)

--- a/api/src/opentrons/protocols/geometry/types.py
+++ b/api/src/opentrons/protocols/geometry/types.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class ThermocyclerConfiguration(str, Enum):
-    FULL = "full"
-    SEMI = "semi"

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -7,7 +7,7 @@ from .protocols.api_support.labware_like import LabwareLike
 
 if TYPE_CHECKING:
     from .protocol_api.labware import Labware, Well
-    from .protocols.geometry.module_geometry import ModuleGeometry
+    from .protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 
 
 class PipetteNotAttachedError(KeyError):

--- a/api/tests/opentrons/protocol_api/core/legacy/test_base_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_base_module_core.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 from opentrons.hardware_control import SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
@@ -22,7 +22,7 @@ def mock_geometry(decoy: Decoy) -> ModuleGeometry:
 @pytest.fixture
 def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[AbstractModule]:
     """Get a mock synchronous module hardware."""
-    return decoy.mock(name="SynchronousAdapater[AbstractModule]")  # type: ignore[no-any-return]
+    return decoy.mock(name="SynchronousAdapter[AbstractModule]")  # type: ignore[no-any-return]
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/core/legacy/test_deck.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_deck.py
@@ -6,8 +6,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control.modules import ModuleType
 
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
-
+from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 from opentrons.protocol_api.core.protocol_api import deck_conflict
 from opentrons.protocol_api.core.protocol_api.deck import Deck, DeckItem
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_deck_conflict.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 from opentrons_shared_data.labware.dev_types import LabwareUri
 
 from opentrons.protocol_api.labware import Labware
-from opentrons.protocols.geometry.module_geometry import (
+from opentrons.protocol_api.core.protocol_api.module_geometry import (
     ModuleGeometry,
     ThermocyclerGeometry,
     HeaterShakerGeometry,

--- a/api/tests/opentrons/protocol_api/core/legacy/test_heater_shaker_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_heater_shaker_core.py
@@ -12,8 +12,9 @@ from opentrons.hardware_control.modules.types import (
     TemperatureStatus,
     SpeedStatus,
 )
-from opentrons.protocols.geometry.module_geometry import HeaterShakerGeometry
-
+from opentrons.protocol_api.core.protocol_api.module_geometry import (
+    HeaterShakerGeometry,
+)
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
 )

--- a/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 from opentrons.hardware_control import SynchronousAdapter
 from opentrons.hardware_control.modules import MagDeck, MagneticStatus
 from opentrons.hardware_control.modules.types import MagneticModuleModel
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
@@ -25,7 +25,7 @@ def mock_geometry(decoy: Decoy) -> ModuleGeometry:
 @pytest.fixture
 def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[MagDeck]:
     """Get a mock module hardware control interface."""
-    return decoy.mock(name="SynchronousAdapater[AbstractModule]")  # type: ignore[no-any-return]
+    return decoy.mock(name="SynchronousAdapter[AbstractModule]")  # type: ignore[no-any-return]
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/core/legacy/test_module_geometry.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_module_geometry.py
@@ -1,3 +1,4 @@
+"""Tests for the legacy ModuleGeometry interface."""
 import pytest
 import mock
 
@@ -8,7 +9,7 @@ from opentrons.types import Location, Point
 
 from opentrons.hardware_control.modules.types import ModuleType, HeaterShakerModuleModel
 
-from opentrons.protocols.geometry.module_geometry import (
+from opentrons.protocol_api.core.protocol_api.module_geometry import (
     create_geometry,
     ModuleGeometry,
     HeaterShakerGeometry,
@@ -40,9 +41,10 @@ def v1_mag_module_schema_v3_definition() -> ModuleDefinitionV3:
         "displayName": "Sample Module",
         "quirks": [],
         "slotTransforms": {},
-        "compatibleWith": ["someSimilarModule"],
+        "compatibleWith": ["someSimilarModule"],  # type: ignore[list-item]
         "cornerOffsetFromSlot": {"x": 111, "y": 222, "z": 333},
         "twoDimensionalRendering": {},
+        "config": {},
     }
 
 
@@ -64,9 +66,10 @@ def minimal_heater_shaker_definition() -> ModuleDefinitionV3:
         "displayName": "Sample H/S Module",
         "quirks": [],
         "slotTransforms": {},
-        "compatibleWith": ["someSimilarModule"],
+        "compatibleWith": ["someSimilarModule"],  # type: ignore[list-item]
         "cornerOffsetFromSlot": {"x": 111, "y": 222, "z": 333},
         "twoDimensionalRendering": {},
+        "config": {},
     }
 
 
@@ -142,9 +145,11 @@ def test_create_geometry(
     assert str(load_result) == expected_repr
 
 
-def test_create_geometry_raises(v1_mag_module_schema_v3_definition) -> None:
+def test_create_geometry_raises(
+    v1_mag_module_schema_v3_definition: ModuleDefinitionV3,
+) -> None:
     """It raises when an invalid definition is passed."""
-    v1_mag_module_schema_v3_definition.update({"moduleType": "blahblahModuleType"})
+    v1_mag_module_schema_v3_definition.update({"moduleType": "blahblahModuleType"})  # type: ignore[typeddict-item]
 
     with pytest.raises(ValueError):
         create_geometry(
@@ -212,7 +217,6 @@ def test_hs_raises_when_moving_to_restricted_slots_while_shaking(
     expected_raise: ContextManager[Any],
 ) -> None:
     """It should raise if restricted movement around a heater-shaker is attempted while module is shaking."""
-
     with expected_raise:
         heater_shaker_geometry.flag_unsafe_move(
             to_slot=destination_slot,
@@ -249,7 +253,6 @@ def test_raises_when_moving_to_restricted_slots_while_latch_open(
     expected_raise: ContextManager[Any],
 ) -> None:
     """It should raise if restricted movement around a heater-shaker is attempted while latch is open."""
-
     with expected_raise:
         heater_shaker_geometry.flag_unsafe_move(
             to_slot=destination_slot,
@@ -306,7 +309,6 @@ def test_raises_on_restricted_movement_with_multi_channel(
     expected_raise: ContextManager[Any],
 ) -> None:
     """It should raise if restricted movement around a heater-shaker is attempted with a multi-channel pipette."""
-
     with expected_raise:
         heater_shaker_geometry.flag_unsafe_move(
             to_slot=destination_slot,
@@ -332,10 +334,7 @@ def test_does_not_raise_when_idle_and_latch_closed(
     heater_shaker_geometry: HeaterShakerGeometry,
     destination_slot: int,
 ) -> None:
-    """
-    It should not raise if single channel pipette moves anywhere near heater-shaker
-    when idle and latch closed.
-    """
+    """It should not raise if single channel pipette moves anywhere near heater-shaker when idle and latch closed."""
     with does_not_raise():
         heater_shaker_geometry.flag_unsafe_move(
             to_slot=destination_slot,
@@ -401,7 +400,6 @@ def test_pipette_is_blocking_shake_and_latch_movements_with_no_pipette_slot(
     mock_location: mock.MagicMock,
 ) -> None:
     """It should return True if pipette's last location slot is not known."""
-
     assert (
         heater_shaker_geometry.is_pipette_blocking_shake_movement(
             pipette_location=Location(point=Point(3, 2, 1), labware=None)

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -17,7 +17,7 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
 from opentrons.protocols import labware as mock_labware
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 
@@ -41,9 +41,9 @@ from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
 )
 
-from opentrons.protocols.geometry import module_geometry as mock_module_geometry
 from opentrons.protocol_api.core.protocol_api import (
     legacy_module_core as mock_legacy_module_core,
+    module_geometry as mock_module_geometry,
 )
 
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_temperature_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_temperature_module_core.py
@@ -8,7 +8,7 @@ from opentrons.hardware_control.modules.types import (
     TemperatureModuleModel,
     TemperatureStatus,
 )
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocol_api.core.protocol_api.module_geometry import ModuleGeometry
 
 from opentrons.protocol_api.core.protocol_api.protocol_context import (
     ProtocolContextImplementation,
@@ -28,7 +28,7 @@ def mock_geometry(decoy: Decoy) -> ModuleGeometry:
 @pytest.fixture
 def mock_sync_module_hardware(decoy: Decoy) -> SynchronousAdapter[TempDeck]:
     """Get a mock synchronous temperature module hardware."""
-    return decoy.mock(name="SynchronousAdapater[TempDeck]")  # type: ignore[no-any-return]
+    return decoy.mock(name="SynchronousAdapter[TempDeck]")  # type: ignore[no-any-return]
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_thermocycler_core.py
@@ -10,7 +10,9 @@ from opentrons.hardware_control.modules import Thermocycler, TemperatureStatus
 from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,
 )
-from opentrons.protocols.geometry.module_geometry import ThermocyclerGeometry
+from opentrons.protocol_api.core.protocol_api.module_geometry import (
+    ThermocyclerGeometry,
+)
 
 from opentrons.protocol_api.labware import Labware
 from opentrons.protocol_api.core.protocol_api.protocol_context import (

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -12,16 +12,16 @@ from opentrons.hardware_control.modules.types import (
     HeaterShakerModuleModel,
 )
 
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION, labware, validation
-from opentrons.protocols.geometry import module_geometry
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, labware, validation
+from opentrons.protocol_api.core.labware import AbstractLabware
+from opentrons.protocol_api.core.protocol_api import module_geometry
 from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
 from opentrons.protocol_api.core.protocol_api.well import WellImplementation
 
 from opentrons.calibration_storage import helpers
 from opentrons.types import Point, Location
-from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocol_api.core.labware import AbstractLabware
 
 test_data: Dict[str, WellDefinition] = {
     "circular_well_json": {

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -4,7 +4,7 @@ import pytest
 from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.protocol_api import labware
 from opentrons.protocols.api_support.labware_like import LabwareLike, LabwareLikeType
-from opentrons.protocols.geometry import module_geometry
+from opentrons.protocol_api.core.protocol_api import module_geometry
 from opentrons.protocol_api.core.protocol_api.deck import Deck
 from opentrons.types import Location
 

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -6,9 +6,9 @@ from opentrons.protocols.geometry.planning import (
     safe_height,
     should_dodge_thermocycler,
 )
+from opentrons.protocol_api.core.protocol_api import module_geometry
 from opentrons.protocol_api.core.protocol_api.deck import Deck
 from opentrons.protocol_api import labware
-from opentrons.protocols.geometry import module_geometry
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,


### PR DESCRIPTION
## Overview

This PR moves the `ModuleGeometry` class into `opentrons.protocol_api.core.protocol_api` to safely isolate it (and its circular dependencies) in the "legacy Protocol API logic" module.

Closes RCORE-423

## Changelog

See above

## Review requests

Smoke test running a protocol with modules on hardware.

## Risk assessment

Low


[RCORE-423]: https://opentrons.atlassian.net/browse/RCORE-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ