### PR TITLE
fix(hardware): Move test script log location to /var/log since ot3 rootfs is mostly read-only

### DIFF
--- a/hardware/opentrons_hardware/scripts/can_control.py
+++ b/hardware/opentrons_hardware/scripts/can_control.py
@@ -102,7 +102,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "can_mon.log",
+            "filename": "/var/log/can_mon.log",
             "maxBytes": 5000000,
             "level": logging.WARNING,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/gripper.py
+++ b/hardware/opentrons_hardware/scripts/gripper.py
@@ -142,7 +142,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "gripper.log",
+            "filename": "/var/log/gripper.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/gripper_currents.py
+++ b/hardware/opentrons_hardware/scripts/gripper_currents.py
@@ -128,7 +128,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "gripper.log",
+            "filename": "/var/log/gripper.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/gripper_jaw.py
+++ b/hardware/opentrons_hardware/scripts/gripper_jaw.py
@@ -148,7 +148,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "gripper.log",
+            "filename": "/var/log/gripper.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/gripper_lifetime.py
+++ b/hardware/opentrons_hardware/scripts/gripper_lifetime.py
@@ -148,7 +148,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "gripper.log",
+            "filename": "/var/log/gripper.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/high_throughput_diagnostics.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_diagnostics.py
@@ -201,7 +201,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "HT_diagnostics.log",
+            "filename": "/var/log/HT_diagnostics.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
@@ -186,7 +186,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "HT_tip_handling.log",
+            "filename": "/var/log/HT_tip_handling.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/network_test.py
+++ b/hardware/opentrons_hardware/scripts/network_test.py
@@ -352,7 +352,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "network_test.log",
+            "filename": "/var/log/network_test.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/provision_gripper.py
+++ b/hardware/opentrons_hardware/scripts/provision_gripper.py
@@ -147,7 +147,7 @@ def log_config(log_level: int) -> Tuple[logging.Logger, logging.Logger]:
                 "main_log_handler": {
                     "class": "logging.handlers.RotatingFileHandler",
                     "formatter": "basic",
-                    "filename": "provision_gripper_debug.log",
+                    "filename": "/var/log/provision_gripper_debug.log",
                     "maxBytes": 5000000,
                     "level": log_level,
                     "backupCount": 3,
@@ -160,7 +160,7 @@ def log_config(log_level: int) -> Tuple[logging.Logger, logging.Logger]:
                 "trace_log_handler": {
                     "class": "logging.handlers.RotatingFileHandler",
                     "formatter": "basic",
-                    "filename": "provision_gripper.log",
+                    "filename": "/var/log/provision_gripper.log",
                     "maxBytes": 5000000,
                     "level": logging.INFO,
                     "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/provision_pipette.py
+++ b/hardware/opentrons_hardware/scripts/provision_pipette.py
@@ -177,7 +177,7 @@ def log_config(log_level: int) -> Tuple[logging.Logger, logging.Logger]:
                 "trace_log_handler": {
                     "class": "logging.handlers.RotatingFileHandler",
                     "formatter": "basic",
-                    "filename": "provision_pipette.log",
+                    "filename": "/var/log/provision_pipette.log",
                     "maxBytes": 5000000,
                     "level": logging.INFO,
                     "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/provision_pipette.py
+++ b/hardware/opentrons_hardware/scripts/provision_pipette.py
@@ -164,7 +164,7 @@ def log_config(log_level: int) -> Tuple[logging.Logger, logging.Logger]:
                 "main_log_handler": {
                     "class": "logging.handlers.RotatingFileHandler",
                     "formatter": "basic",
-                    "filename": "provision_pipette_debug.log",
+                    "filename": "/var/log/provision_pipette_debug.log",
                     "maxBytes": 5000000,
                     "level": log_level,
                     "backupCount": 3,

--- a/hardware/opentrons_hardware/scripts/sensors.py
+++ b/hardware/opentrons_hardware/scripts/sensors.py
@@ -200,7 +200,7 @@ LOG_CONFIG = {
         "file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "basic",
-            "filename": "sensors.log",
+            "filename": "/var/log/sensors.log",
             "maxBytes": 5000000,
             "level": logging.INFO,
             "backupCount": 3,


### PR DESCRIPTION
# Overview

The rootfs on the OT3 is read-only with the exception of a few directories (userfs, var, data), which means when we try and write logs outside of those directories we get a 'read-only' error message and our process most likely fails.

# Changelog

Move script logs from /opt/... to /var/log since /opt is read-only for the following files
- provission_pippete.py
- privission_gripper.py
- can_control.py
- gripper.py
- gripper_currents.py
- gripper_jaw.py
- gripper_lifetime.py
- high_throughput_diagnostics.py
- high_throughput_tip_handling.py
- scripts/network_test.py
- scripts/sensors.py

# Review requests

- [ ] make sure script logs are written to /var/log/

# Risk assessment
Low