### PR TITLE
refactor(api): deprecate Well.geometry property

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/point_calculations.py
+++ b/api/src/opentrons/protocol_api/core/engine/point_calculations.py
@@ -1,0 +1,24 @@
+from typing import Tuple
+
+from opentrons.types import Point
+
+
+def get_relative_offset(
+    point: Point,
+    size: Tuple[float, float, float],
+    x_ratio: float,
+    y_ratio: float,
+    z_ratio: float,
+) -> Point:
+    """Gets a relative offset for a deck coordinate based on percentage of the radius of each axis."""
+    x_size, y_size, z_size = size
+
+    x_offset = x_size / 2.0 * x_ratio
+    y_offset = y_size / 2.0 * y_ratio
+    z_offset = z_size / 2.0 * z_ratio
+
+    return Point(
+        x=point.x + x_offset,
+        y=point.y + y_offset,
+        z=point.z + z_offset,
+    )

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -6,10 +6,10 @@ from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocols.api_support.util import APIVersionError
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Point
 
 from ..well import AbstractWellCore
+from ..protocol_api.well_geometry import WellGeometry
 
 
 class WellCore(AbstractWellCore):

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -41,7 +41,7 @@ class WellCore(AbstractWellCore):
     @property
     def geometry(self) -> WellGeometry:
         """Get the well's geometry information interface."""
-        raise NotImplementedError("WellCore.geometry not implemented")
+        raise APIVersionError("WellCore.geometry has been deprecated.")
 
     @property
     def diameter(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -1,5 +1,5 @@
 """ProtocolEngine-based Well core implementations."""
-from typing import Optional
+from typing import Optional, cast
 
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
@@ -123,11 +123,15 @@ class WellCore(AbstractWellCore):
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
         center = self.get_center()
-        return self._engine_client.state.labware.from_center_cartesian(
-            labware_id=self._labware_id,
-            well_name=self._name,
-            center=center,
-            x=x,
-            y=y,
-            z=z,
+        if self.diameter is not None:
+            x_size = y_size = self.diameter
+        else:
+            # If diameter is None we know these values will be floats
+            x_size = cast(float, self.length)
+            y_size = cast(float, self.width)
+
+        return Point(
+            x=center.x + (x * (x_size / 2.0)),
+            y=center.y + (y * (y_size / 2.0)),
+            z=center.z + (z * (self.depth / 2.0)),
         )

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -115,7 +115,7 @@ class WellCore(AbstractWellCore):
     # Make this change carefully with respect to the robot-server because
     # `WellOrigin` is a public enum that may be persisted
     def get_center(self) -> Point:
-        """Get the coordinate of the well's center, with a z-offset."""
+        """Get the coordinate of the well's center."""
         well_height = self._engine_client.state.geometry.get_well_height(
             labware_id=self.labware_id, well_name=self._name
         )

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -1,5 +1,5 @@
 """ProtocolEngine-based Well core implementations."""
-from typing import Optional, cast
+from typing import Optional
 
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
@@ -123,15 +123,11 @@ class WellCore(AbstractWellCore):
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
         center = self.get_center()
-        if self.diameter is not None:
-            x_size = y_size = self.diameter
-        else:
-            # If diameter is None we know these values will be floats
-            x_size = cast(float, self.length)
-            y_size = cast(float, self.width)
-
-        return Point(
-            x=center.x + (x * (x_size / 2.0)),
-            y=center.y + (y * (y_size / 2.0)),
-            z=center.z + (z * (self.depth / 2.0)),
+        return self._engine_client.state.labware.from_center_cartesian(
+            labware_id=self._labware_id,
+            well_name=self._name,
+            center=center,
+            x=x,
+            y=y,
+            z=z,
         )

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -9,7 +9,6 @@ from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import Point
 
 from ..well import AbstractWellCore
-from ..protocol_api.well_geometry import WellGeometry
 
 
 class WellCore(AbstractWellCore):
@@ -37,11 +36,6 @@ class WellCore(AbstractWellCore):
     def labware_id(self) -> str:
         """Get the ID of the well's parent labware."""
         return self._labware_id
-
-    @property
-    def geometry(self) -> WellGeometry:
-        """Get the well's geometry information interface."""
-        raise APIVersionError("WellCore.geometry has been deprecated.")
 
     @property
     def diameter(self) -> Optional[float]:

--- a/api/src/opentrons/protocol_api/core/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/labware.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 from opentrons.calibration_storage import helpers
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 
 from opentrons.types import DeckSlotName, Location, Point
@@ -10,6 +9,7 @@ from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDe
 
 from ..labware import AbstractLabware, LabwareLoadParams
 from .well import WellImplementation
+from .well_geometry import WellGeometry
 
 
 # URIs of labware whose definitions accidentally specify an engage height

--- a/api/src/opentrons/protocol_api/core/protocol_api/well.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Point
 
+from .well_geometry import WellGeometry
 from ..well import AbstractWellCore
 
 

--- a/api/src/opentrons/protocol_api/core/protocol_api/well.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well.py
@@ -1,4 +1,6 @@
 """Legacy Well core implementation."""
+from typing import Optional
+
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
 from opentrons.protocols.geometry.well_geometry import WellGeometry
@@ -38,8 +40,28 @@ class WellImplementation(AbstractWellCore):
 
     @geometry.setter
     def geometry(self, well_geometry: WellGeometry) -> None:
-        """Upate the well's geometry interface."""
+        """Update the well's geometry interface."""
         self._geometry = well_geometry
+
+    @property
+    def diameter(self) -> Optional[float]:
+        """Get the well's diameter, if circular."""
+        return self._geometry.diameter
+
+    @property
+    def length(self) -> Optional[float]:
+        """Get the well's length, if rectangular."""
+        return self._geometry.length
+
+    @property
+    def width(self) -> Optional[float]:
+        """Get the well's width, if rectangular."""
+        return self._geometry.width
+
+    @property
+    def depth(self) -> float:
+        """Get the well's depth."""
+        return self._geometry.depth
 
     def has_tip(self) -> bool:
         """Whether the well contains a tip."""
@@ -80,6 +102,10 @@ class WellImplementation(AbstractWellCore):
     def get_center(self) -> Point:
         """Get the coordinate of the well's center."""
         return self._geometry.center()
+
+    def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
+        """Gets point in deck coordinates based on percentage of the radius of each axis."""
+        return self._geometry.from_center_cartesian(x, y, z)
 
     # TODO(mc, 2022-10-28): is this used and/or necessary?
     def __repr__(self) -> str:

--- a/api/src/opentrons/protocol_api/core/protocol_api/well_geometry.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well_geometry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, cast, Any, TYPE_CHECKING
+from typing import Optional, cast, TYPE_CHECKING
 
 from opentrons.types import Point
 from opentrons_shared_data.labware.dev_types import (
@@ -10,7 +10,7 @@ from opentrons_shared_data.labware.dev_types import (
 )
 
 if TYPE_CHECKING:
-    from ..labware import AbstractLabware
+    from .labware import LabwareImplementation
 
 
 class WellGeometry:
@@ -18,7 +18,7 @@ class WellGeometry:
         self,
         well_props: WellDefinition,
         parent_point: Point,
-        parent_object: AbstractLabware[Any],
+        parent_object: LabwareImplementation,
     ):
         """
         Construct a well geometry object.
@@ -62,7 +62,7 @@ class WellGeometry:
         self._depth = well_props["depth"]
 
     @property
-    def parent(self) -> AbstractLabware[Any]:
+    def parent(self) -> LabwareImplementation:
         return self._parent
 
     @property

--- a/api/src/opentrons/protocol_api/core/protocol_api/well_geometry.py
+++ b/api/src/opentrons/protocol_api/core/protocol_api/well_geometry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, cast, TYPE_CHECKING
-
+from typing import Optional, cast, Any, TYPE_CHECKING
 
 from opentrons.types import Point
 from opentrons_shared_data.labware.dev_types import (
@@ -11,7 +10,7 @@ from opentrons_shared_data.labware.dev_types import (
 )
 
 if TYPE_CHECKING:
-    from opentrons.protocol_api.core.labware import AbstractLabware
+    from ..labware import AbstractLabware
 
 
 class WellGeometry:
@@ -19,7 +18,7 @@ class WellGeometry:
         self,
         well_props: WellDefinition,
         parent_point: Point,
-        parent_object: AbstractLabware,
+        parent_object: AbstractLabware[Any],
     ):
         """
         Construct a well geometry object.
@@ -63,7 +62,7 @@ class WellGeometry:
         self._depth = well_props["depth"]
 
     @property
-    def parent(self) -> AbstractLabware:
+    def parent(self) -> AbstractLabware[Any]:
         return self._parent
 
     @property

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -1,7 +1,7 @@
 """Abstract interface for Well core implementations."""
 
 from abc import ABC, abstractmethod
-from typing import TypeVar
+from typing import TypeVar, Optional
 
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Point
@@ -14,6 +14,26 @@ class AbstractWellCore(ABC):
     @abstractmethod
     def geometry(self) -> WellGeometry:
         """Get the well's geometry information interface."""
+
+    @property
+    @abstractmethod
+    def diameter(self) -> Optional[float]:
+        """Get the well's diameter, if circular."""
+
+    @property
+    @abstractmethod
+    def length(self) -> Optional[float]:
+        """Get the well's length, if rectangular."""
+
+    @property
+    @abstractmethod
+    def width(self) -> Optional[float]:
+        """Get the well's width, if rectangular."""
+
+    @property
+    @abstractmethod
+    def depth(self) -> float:
+        """Get the well's depth."""
 
     @abstractmethod
     def has_tip(self) -> bool:
@@ -54,6 +74,10 @@ class AbstractWellCore(ABC):
     @abstractmethod
     def get_center(self) -> Point:
         """Get the coordinate of the well's center."""
+
+    @abstractmethod
+    def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
+        """Gets point in deck coordinates based on percentage of the radius of each axis."""
 
 
 WellCoreType = TypeVar("WellCoreType", bound=AbstractWellCore)

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -3,8 +3,9 @@
 from abc import ABC, abstractmethod
 from typing import TypeVar, Optional
 
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Point
+
+from .protocol_api.well_geometry import WellGeometry
 
 
 class AbstractWellCore(ABC):

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -5,16 +5,9 @@ from typing import TypeVar, Optional
 
 from opentrons.types import Point
 
-from .protocol_api.well_geometry import WellGeometry
-
 
 class AbstractWellCore(ABC):
     """Well core interface."""
-
-    @property
-    @abstractmethod
-    def geometry(self) -> WellGeometry:
-        """Get the well's geometry information interface."""
 
     @property
     @abstractmethod

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -18,7 +18,7 @@ from opentrons_shared_data.labware.dev_types import LabwareDefinition, LabwarePa
 
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.api_support.util import requires_version
+from opentrons.protocols.api_support.util import requires_version, APIVersionError
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 # TODO(mc, 2022-09-02): re-exports provided for backwards compatibility
@@ -34,6 +34,7 @@ from . import validation
 from .core import well_grid
 from .core.labware import AbstractLabware
 from .core.protocol_api.labware import LabwareImplementation as LegacyLabwareCore
+from .core.protocol_api.well import WellImplementation as LegacyWellCore
 from .core.protocol_api.well_geometry import WellGeometry
 
 if TYPE_CHECKING:
@@ -108,7 +109,9 @@ class Well:
 
     @property
     def geometry(self) -> WellGeometry:
-        return self._impl.geometry
+        if isinstance(self._impl, LegacyWellCore):
+            return self._impl.geometry
+        raise APIVersionError("WellCore.geometry has been deprecated.")
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -111,7 +111,7 @@ class Well:
     def geometry(self) -> WellGeometry:
         if isinstance(self._impl, LegacyWellCore):
             return self._impl.geometry
-        raise APIVersionError("WellCore.geometry has been deprecated.")
+        raise APIVersionError("Well.geometry has been deprecated.")
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -20,7 +20,6 @@ from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import requires_version
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 
 # TODO(mc, 2022-09-02): re-exports provided for backwards compatibility
 # remove when their usage is no longer needed
@@ -35,6 +34,7 @@ from . import validation
 from .core import well_grid
 from .core.labware import AbstractLabware
 from .core.protocol_api.labware import LabwareImplementation as LegacyLabwareCore
+from .core.protocol_api.well_geometry import WellGeometry
 
 if TYPE_CHECKING:
     from .core.common import LabwareCore, WellCore

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -113,7 +113,7 @@ class Well:
     @property  # type: ignore
     @requires_version(2, 0)
     def diameter(self) -> Optional[float]:
-        return self.geometry.diameter
+        return self._impl.diameter
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -122,7 +122,7 @@ class Well:
         The length of a well, if the labware has
         square wells.
         """
-        return self.geometry._length
+        return self._impl.length
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -131,7 +131,7 @@ class Well:
         The width of a well, if the labware has
         square wells.
         """
-        return self.geometry._width
+        return self._impl.width
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -139,7 +139,7 @@ class Well:
         """
         The depth of a well in a labware.
         """
-        return self.geometry._depth
+        return self._impl.depth
 
     @property
     def display_name(self) -> str:
@@ -202,7 +202,7 @@ class Well:
         :return: a :py:class:`opentrons.types.Point` representing the specified
                  location in absolute deck coordinates
         """
-        return self.geometry.from_center_cartesian(x, y, z)
+        return self._impl.from_center_cartesian(x, y, z)
 
     def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """

--- a/api/src/opentrons/protocol_api_experimental/well.py
+++ b/api/src/opentrons/protocol_api_experimental/well.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 
-from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocol_api.core.protocol_api.well_geometry import WellGeometry
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 
 from .types import Location, Point

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3, SlotDefV3
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -319,31 +319,6 @@ class LabwareView(HasState[LabwareState]):
             raise errors.WellDoesNotExistError(
                 f"{well_name} does not exist in {labware_id}."
             ) from e
-
-    def from_center_cartesian(
-        self,
-        labware_id: str,
-        well_name: str,
-        center: Point,
-        x: float,
-        y: float,
-        z: float,
-    ) -> Point:
-        """Gets point in deck coordinates based on percentage of the radius of each axis."""
-        well_definition = self.get_well_definition(labware_id, well_name)
-
-        if well_definition.diameter is not None:
-            x_size = y_size = well_definition.diameter
-        else:
-            # If diameter is None we know these values will be floats
-            x_size = cast(float, well_definition.xDimension)
-            y_size = cast(float, well_definition.yDimension)
-
-        return Point(
-            x=center.x + (x * (x_size / 2.0)),
-            y=center.y + (y * (y_size / 2.0)),
-            z=center.z + (z * (well_definition.depth / 2.0)),
-        )
 
     def validate_liquid_allowed_in_labware(
         self, labware_id: str, wells: Mapping[str, Any]

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union, Tuple, cast
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3, SlotDefV3
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -319,6 +319,21 @@ class LabwareView(HasState[LabwareState]):
             raise errors.WellDoesNotExistError(
                 f"{well_name} does not exist in {labware_id}."
             ) from e
+
+    def get_well_size(
+        self, labware_id: str, well_name: Optional[str] = None
+    ) -> Tuple[float, float, float]:
+        """Get a well's size in x, y, z dimensions based on its shape."""
+        well_definition = self.get_well_definition(labware_id, well_name)
+
+        if well_definition.diameter is not None:
+            x_size = y_size = well_definition.diameter
+        else:
+            # If diameter is None we know these values will be floats
+            x_size = cast(float, well_definition.xDimension)
+            y_size = cast(float, well_definition.yDimension)
+
+        return x_size, y_size, well_definition.depth
 
     def validate_liquid_allowed_in_labware(
         self, labware_id: str, wells: Mapping[str, Any]

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -321,9 +321,18 @@ class LabwareView(HasState[LabwareState]):
             ) from e
 
     def get_well_size(
-        self, labware_id: str, well_name: Optional[str] = None
+        self, labware_id: str, well_name: str
     ) -> Tuple[float, float, float]:
-        """Get a well's size in x, y, z dimensions based on its shape."""
+        """Get a well's size in x, y, z dimensions based on its shape.
+
+        Args:
+            labware_id: Labware identifier.
+            well_name: Name of well in labware.
+
+        Returns:
+            A tuple of dimensions in x, y, and z. If well is circular,
+            the x and y dimensions will both be set to the diameter.
+        """
         well_definition = self.get_well_definition(labware_id, well_name)
 
         if well_definition.diameter is not None:

--- a/api/src/opentrons/protocols/geometry/well_geometry.py
+++ b/api/src/opentrons/protocols/geometry/well_geometry.py
@@ -74,6 +74,18 @@ class WellGeometry:
     def diameter(self) -> Optional[float]:
         return self._diameter
 
+    @property
+    def length(self) -> Optional[float]:
+        return self._length
+
+    @property
+    def width(self) -> Optional[float]:
+        return self._width
+
+    @property
+    def depth(self) -> float:
+        return self._depth
+
     def top(self, z: float = 0.0) -> Point:
         return self._position + Point(0, 0, z)
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_point_calculations.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_point_calculations.py
@@ -1,0 +1,17 @@
+"""Tests for Protocol API point calculation."""
+from opentrons.types import Point
+
+from opentrons.protocol_api.core.engine import point_calculations as subject
+
+
+def test_get_relative_offset() -> None:
+    """It should get a relative offset given a point, size in x, y, z, and x, y, z ratios."""
+    result = subject.get_relative_offset(
+        point=Point(1.0, 2.0, 3.0),
+        size=(4, 8, 16),
+        x_ratio=0.5,
+        y_ratio=0.25,
+        z_ratio=0.125,
+    )
+
+    assert result == Point(2.0, 3.0, 4.0)

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -188,10 +188,14 @@ def test_depth(subject: WellCore) -> None:
     assert subject.depth == 42.0
 
 
-def test_from_center_cartesian(
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(diameter=2.0, depth=4.0)],  # type: ignore[call-arg]
+)
+def test_from_center_cartesian_circular(
     decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
 ) -> None:
-    """It should get the relative point from a specific well."""
+    """It should get the relative point from a circular well."""
     decoy.when(
         mock_engine_client.state.geometry.get_well_height(
             labware_id="labware-id", well_name="well-name"
@@ -208,17 +212,35 @@ def test_from_center_cartesian(
         )
     ).then_return(Point(1, 2, 3))
 
+    result = subject.from_center_cartesian(x=3, y=3, z=1.5)
+
+    assert result == Point(4, 5, 6)
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(xDimension=2.0, yDimension=3.0, depth=4.0)],  # type: ignore[call-arg]
+)
+def test_from_center_cartesian_rectangular(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
+) -> None:
+    """It should get the relative point from a rectangular well."""
     decoy.when(
-        mock_engine_client.state.labware.from_center_cartesian(
+        mock_engine_client.state.geometry.get_well_height(
+            labware_id="labware-id", well_name="well-name"
+        )
+    ).then_return(42.0)
+
+    decoy.when(
+        mock_engine_client.state.geometry.get_well_position(
             labware_id="labware-id",
             well_name="well-name",
-            center=Point(1, 2, 3),
-            x=4,
-            y=5,
-            z=6,
+            well_location=WellLocation(
+                origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=21)
+            ),
         )
-    ).then_return(Point(7, 8, 9))
+    ).then_return(Point(1, 2, 3))
 
-    result = subject.from_center_cartesian(x=4, y=5, z=6)
+    result = subject.from_center_cartesian(x=3, y=2, z=1.5)
 
-    assert result == Point(7, 8, 9)
+    assert result == Point(4, 5, 6)

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -1,4 +1,6 @@
 """Test for the ProtocolEngine-based well API core."""
+import inspect
+
 import pytest
 from decoy import Decoy
 
@@ -11,7 +13,16 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import Point
 
-from opentrons.protocol_api.core.engine import WellCore
+from opentrons.protocol_api.core.engine import WellCore, point_calculations
+
+
+@pytest.fixture(autouse=True)
+def patch_mock_point_calculations(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mock out point_calculations.py functions."""
+    for name, func in inspect.getmembers(point_calculations, inspect.isfunction):
+        monkeypatch.setattr(point_calculations, name, decoy.mock(func=func))
 
 
 @pytest.fixture
@@ -188,14 +199,10 @@ def test_depth(subject: WellCore) -> None:
     assert subject.depth == 42.0
 
 
-@pytest.mark.parametrize(
-    "well_definition",
-    [WellDefinition.construct(diameter=2.0, depth=4.0)],  # type: ignore[call-arg]
-)
-def test_from_center_cartesian_circular(
+def test_from_center_cartesian(
     decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
 ) -> None:
-    """It should get the relative point from a circular well."""
+    """It should get the relative point from the center of a well."""
     decoy.when(
         mock_engine_client.state.geometry.get_well_height(
             labware_id="labware-id", well_name="well-name"
@@ -212,35 +219,22 @@ def test_from_center_cartesian_circular(
         )
     ).then_return(Point(1, 2, 3))
 
-    result = subject.from_center_cartesian(x=3, y=3, z=1.5)
-
-    assert result == Point(4, 5, 6)
-
-
-@pytest.mark.parametrize(
-    "well_definition",
-    [WellDefinition.construct(xDimension=2.0, yDimension=3.0, depth=4.0)],  # type: ignore[call-arg]
-)
-def test_from_center_cartesian_rectangular(
-    decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
-) -> None:
-    """It should get the relative point from a rectangular well."""
     decoy.when(
-        mock_engine_client.state.geometry.get_well_height(
+        mock_engine_client.state.labware.get_well_size(
             labware_id="labware-id", well_name="well-name"
         )
-    ).then_return(42.0)
+    ).then_return((4, 5, 6))
 
     decoy.when(
-        mock_engine_client.state.geometry.get_well_position(
-            labware_id="labware-id",
-            well_name="well-name",
-            well_location=WellLocation(
-                origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=21)
-            ),
+        point_calculations.get_relative_offset(
+            point=Point(1, 2, 3),
+            size=(4, 5, 6),
+            x_ratio=7,
+            y_ratio=8,
+            z_ratio=9,
         )
-    ).then_return(Point(1, 2, 3))
+    ).then_return(Point(3, 2, 1))
 
-    result = subject.from_center_cartesian(x=3, y=2, z=1.5)
+    result = subject.from_center_cartesian(x=7, y=8, z=9)
 
-    assert result == Point(4, 5, 6)
+    assert result == Point(3, 2, 1)

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -150,3 +150,97 @@ def test_set_has_tip(subject: WellCore) -> None:
     """Trying to set the has tip state should raise an error."""
     with pytest.raises(APIVersionError):
         subject.set_has_tip(True)
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(diameter=123.4)],  # type: ignore[call-arg]
+)
+def test_diameter(subject: WellCore) -> None:
+    """It should get the diameter."""
+    assert subject.diameter == 123.4
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(xDimension=567.8)],  # type: ignore[call-arg]
+)
+def test_length(subject: WellCore) -> None:
+    """It should get the length."""
+    assert subject.length == 567.8
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(yDimension=987.6)],  # type: ignore[call-arg]
+)
+def test_width(subject: WellCore) -> None:
+    """It should get the width."""
+    assert subject.width == 987.6
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(depth=42.0)],  # type: ignore[call-arg]
+)
+def test_depth(subject: WellCore) -> None:
+    """It should get the depth."""
+    assert subject.depth == 42.0
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(diameter=2.0, depth=4.0)],  # type: ignore[call-arg]
+)
+def test_from_center_cartesian_circular(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
+) -> None:
+    """It should get the relative point from a circular well."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_well_height(
+            labware_id="labware-id", well_name="well-name"
+        )
+    ).then_return(42.0)
+
+    decoy.when(
+        mock_engine_client.state.geometry.get_well_position(
+            labware_id="labware-id",
+            well_name="well-name",
+            well_location=WellLocation(
+                origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=21)
+            ),
+        )
+    ).then_return(Point(1, 2, 3))
+
+    result = subject.from_center_cartesian(x=3, y=3, z=1.5)
+
+    assert result == Point(4, 5, 6)
+
+
+@pytest.mark.parametrize(
+    "well_definition",
+    [WellDefinition.construct(xDimension=2.0, yDimension=3.0, depth=4.0)],  # type: ignore[call-arg]
+)
+def test_from_center_cartesian_rectangular(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
+) -> None:
+    """It should get the relative point from a rectangular well."""
+    decoy.when(
+        mock_engine_client.state.geometry.get_well_height(
+            labware_id="labware-id", well_name="well-name"
+        )
+    ).then_return(42.0)
+
+    decoy.when(
+        mock_engine_client.state.geometry.get_well_position(
+            labware_id="labware-id",
+            well_name="well-name",
+            well_location=WellLocation(
+                origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=21)
+            ),
+        )
+    ).then_return(Point(1, 2, 3))
+
+    result = subject.from_center_cartesian(x=3, y=2, z=1.5)
+
+    assert result == Point(4, 5, 6)

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -188,14 +188,10 @@ def test_depth(subject: WellCore) -> None:
     assert subject.depth == 42.0
 
 
-@pytest.mark.parametrize(
-    "well_definition",
-    [WellDefinition.construct(diameter=2.0, depth=4.0)],  # type: ignore[call-arg]
-)
-def test_from_center_cartesian_circular(
+def test_from_center_cartesian(
     decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
 ) -> None:
-    """It should get the relative point from a circular well."""
+    """It should get the relative point from a specific well."""
     decoy.when(
         mock_engine_client.state.geometry.get_well_height(
             labware_id="labware-id", well_name="well-name"
@@ -212,35 +208,17 @@ def test_from_center_cartesian_circular(
         )
     ).then_return(Point(1, 2, 3))
 
-    result = subject.from_center_cartesian(x=3, y=3, z=1.5)
-
-    assert result == Point(4, 5, 6)
-
-
-@pytest.mark.parametrize(
-    "well_definition",
-    [WellDefinition.construct(xDimension=2.0, yDimension=3.0, depth=4.0)],  # type: ignore[call-arg]
-)
-def test_from_center_cartesian_rectangular(
-    decoy: Decoy, mock_engine_client: EngineClient, subject: WellCore
-) -> None:
-    """It should get the relative point from a rectangular well."""
     decoy.when(
-        mock_engine_client.state.geometry.get_well_height(
-            labware_id="labware-id", well_name="well-name"
-        )
-    ).then_return(42.0)
-
-    decoy.when(
-        mock_engine_client.state.geometry.get_well_position(
+        mock_engine_client.state.labware.from_center_cartesian(
             labware_id="labware-id",
             well_name="well-name",
-            well_location=WellLocation(
-                origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=21)
-            ),
+            center=Point(1, 2, 3),
+            x=4,
+            y=5,
+            z=6,
         )
-    ).then_return(Point(1, 2, 3))
+    ).then_return(Point(7, 8, 9))
 
-    result = subject.from_center_cartesian(x=3, y=2, z=1.5)
+    result = subject.from_center_cartesian(x=4, y=5, z=6)
 
-    assert result == Point(4, 5, 6)
+    assert result == Point(7, 8, 9)

--- a/api/tests/opentrons/protocol_api/test_well.py
+++ b/api/tests/opentrons/protocol_api/test_well.py
@@ -111,3 +111,44 @@ def test_has_tip(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
 
     decoy.when(mock_well_core.has_tip()).then_return(False)
     assert subject.has_tip is False
+
+
+def test_diameter(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
+    """It should get the diameter from the core."""
+    decoy.when(mock_well_core.diameter).then_return(12.3)
+
+    assert subject.diameter == 12.3
+
+
+def test_length(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
+    """It should get the length from the core."""
+    decoy.when(mock_well_core.length).then_return(45.6)
+
+    assert subject.length == 45.6
+
+
+def test_width(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
+    """It should get the width from the core."""
+    decoy.when(mock_well_core.width).then_return(78.9)
+
+    assert subject.width == 78.9
+
+
+def test_depth(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
+    """It should get the depth from the core."""
+    decoy.when(mock_well_core.depth).then_return(42.0)
+
+    assert subject.depth == 42.0
+
+
+def test_from_center_cartesian(
+    decoy: Decoy, mock_well_core: WellCore, subject: Well
+) -> None:
+    """It should get the calculated center cartesian point from the core."""
+    decoy.when(mock_well_core.from_center_cartesian(1, 2, 3)).then_return(
+        Point(4, 5, 6)
+    )
+
+    result = subject.from_center_cartesian(1, 2, 3)
+
+    assert result == Point(4, 5, 6)

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -299,7 +299,7 @@ def test_well_parent(corning_96_wellplate_360ul_flat) -> None:
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=parent.point,
-                parent_object=parent.labware.as_labware()._implementation,
+                parent_object=parent.labware.as_labware()._implementation,  # type: ignore[arg-type]
             ),
             display_name=well_name,
             has_tip=has_tip,

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -13,12 +13,12 @@ from opentrons.hardware_control.modules.types import (
 )
 
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, labware, validation
 from opentrons.protocol_api.core.labware import AbstractLabware
 from opentrons.protocol_api.core.protocol_api import module_geometry
 from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
 from opentrons.protocol_api.core.protocol_api.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well_geometry import WellGeometry
 
 from opentrons.calibration_storage import helpers
 from opentrons.types import Point, Location

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -255,6 +255,42 @@ def test_get_well_definition_get_first(well_plate_def: LabwareDefinition) -> Non
     assert result == expected_well_def
 
 
+def test_get_well_size_circular(well_plate_def: LabwareDefinition) -> None:
+    """It should return the well dimensions of a circular well."""
+    subject = get_labware_view(
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
+    )
+    expected_well_def = well_plate_def.wells["A2"]
+    expected_size = (
+        expected_well_def.diameter,
+        expected_well_def.diameter,
+        expected_well_def.depth,
+    )
+
+    result = subject.get_well_size(labware_id="plate-id", well_name="A2")
+
+    assert result == expected_size
+
+
+def test_get_well_size_rectangular(reservoir_def: LabwareDefinition) -> None:
+    """It should return the well dimensions of a rectangular well."""
+    subject = get_labware_view(
+        labware_by_id={"reservoir-id": reservoir},
+        definitions_by_uri={"some-reservoir-uri": reservoir_def},
+    )
+    expected_well_def = reservoir_def.wells["A2"]
+    expected_size = (
+        expected_well_def.xDimension,
+        expected_well_def.yDimension,
+        expected_well_def.depth,
+    )
+
+    result = subject.get_well_size(labware_id="reservoir-id", well_name="A2")
+
+    assert result == expected_size
+
+
 def test_labware_has_well(falcon_tuberack_def: LabwareDefinition) -> None:
     """It should return a list of wells from definition."""
     subject = get_labware_view(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -255,6 +255,34 @@ def test_get_well_definition_get_first(well_plate_def: LabwareDefinition) -> Non
     assert result == expected_well_def
 
 
+def test_from_center_cartesian_circular(well_plate_def: LabwareDefinition) -> None:
+    """It should get the relative point from a circular well."""
+    subject = get_labware_view(
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
+    )
+
+    result = subject.from_center_cartesian(
+        labware_id="plate-id", well_name="A1", center=Point(1, 2, 4), x=2, y=4, z=6
+    )
+
+    assert result == Point(x=7.86, y=15.72, z=36.01)
+
+
+def test_from_center_cartesian_rectangular(reservoir_def: LabwareDefinition) -> None:
+    """It should get the relative point from a circular well."""
+    subject = get_labware_view(
+        labware_by_id={"reservoir-id": reservoir},
+        definitions_by_uri={"some-reservoir-uri": reservoir_def},
+    )
+
+    result = subject.from_center_cartesian(
+        labware_id="reservoir-id", well_name="A1", center=Point(1, 2, 4), x=2, y=4, z=8
+    )
+
+    assert result == Point(x=9.2, y=144.4, z=111.4)
+
+
 def test_labware_has_well(falcon_tuberack_def: LabwareDefinition) -> None:
     """It should return a list of wells from definition."""
     subject = get_labware_view(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -255,34 +255,6 @@ def test_get_well_definition_get_first(well_plate_def: LabwareDefinition) -> Non
     assert result == expected_well_def
 
 
-def test_from_center_cartesian_circular(well_plate_def: LabwareDefinition) -> None:
-    """It should get the relative point from a circular well."""
-    subject = get_labware_view(
-        labware_by_id={"plate-id": plate},
-        definitions_by_uri={"some-plate-uri": well_plate_def},
-    )
-
-    result = subject.from_center_cartesian(
-        labware_id="plate-id", well_name="A1", center=Point(1, 2, 4), x=2, y=4, z=6
-    )
-
-    assert result == Point(x=7.86, y=15.72, z=36.01)
-
-
-def test_from_center_cartesian_rectangular(reservoir_def: LabwareDefinition) -> None:
-    """It should get the relative point from a circular well."""
-    subject = get_labware_view(
-        labware_by_id={"reservoir-id": reservoir},
-        definitions_by_uri={"some-reservoir-uri": reservoir_def},
-    )
-
-    result = subject.from_center_cartesian(
-        labware_id="reservoir-id", well_name="A1", center=Point(1, 2, 4), x=2, y=4, z=8
-    )
-
-    assert result == Point(x=9.2, y=144.4, z=111.4)
-
-
 def test_labware_has_well(falcon_tuberack_def: LabwareDefinition) -> None:
     """It should return a list of wells from definition."""
     subject = get_labware_view(

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -1,6 +1,6 @@
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocol_api.core.protocol_api.labware import LabwareImplementation
 from opentrons.protocol_api.core.protocol_api.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well_geometry import WellGeometry
 
 from unittest import mock
 from copy import deepcopy

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
-from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocol_api.core.protocol_api.well import WellImplementation
+from opentrons.protocol_api.core.protocol_api.well_geometry import WellGeometry
 from opentrons.types import Point
 from opentrons.protocol_api import InstrumentContext, labware, MAX_SUPPORTED_VERSION
 from opentrons.protocols.execution.execute_json_v5 import _move_to_well


### PR DESCRIPTION
# Overview

Closes RCORE-422.

This PR refactors the `Well` class to not use the `geometry` property for `diameter`, `length`, `width`, `depth`, and `from_center_cartesian`. Properties and methods have been added to the cores to access them from the public Well context and `geometry` will raise an `APIVersionError` if accessed using the protocol engine core.

# Changelog

- Refactored `Well` to not use `self.geometry` for `diameter`, `length`, `width`, `depth`, and `from_center_cartesian`
- Added above properties/method to Well cores and abstract class
- Raise an `APIVersionError` if `Well.geometry` is called using the engine core
- Moved `WellGeometry` to `opentrons.protocol_api.core.protocol_api`

# Review requests

Smoke test refactored properties with engine core

# Risk assessment

Low.
