### PR TITLE
build(app-shell-odd): Create tarball of source files for ODD before copying to the robot.

### DIFF
--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -69,9 +69,11 @@ dist-ot3: package-deps
 
 .PHONY: push-ot3
 push-ot3: dist-ot3
+	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
 	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
-	scp -r $(ssh_opts) ./dist/linux-arm64-unpacked/* root@$(host):/opt/opentrons-app
-	ssh $(ssh_opts) root@$(host) "systemctl start opentrons-robot-app && mount -o remount,ro /"
+	scp -r $(ssh_opts) ./opentrons-robot-app.tar.gz root@$(host):
+	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ && systemctl start opentrons-robot-app && mount -o remount,ro /"
+	rm -rf opentrons-robot-app.tar.gz
 
 # development
 #####################################################################


### PR DESCRIPTION
# Overview

The On-Device-Display app is huge and our network sucks, so lets try and speed it up a bit by creating a tarball instead of scp individual files.

# Changelog

- create tarball of odd source and scp to host to be extracted

# Review requests
- [ ] make sure it works

# Risk assessment
low, dev only
