### PR TITLE
chore(build): Start OT3 builds when a release tag is pushed to the monorepo.

### DIFF
--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -17,8 +17,8 @@ on:
 jobs:
   handle-release:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    name: "Start an OT-3 build for a tag push"
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    name: "Start an OT-3 release build for tag ${{ github.ref }}."
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -7,7 +7,7 @@ on:
       - chore_release-*
       - release*
     tags:
-      - v*
+      - ot3@*
   pull_request:
     types:
       - opened
@@ -15,47 +15,26 @@ on:
       - labeled
 
 jobs:
-  handle-push:
+  handle-release:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'push'
-    name: "Start an OT-3 build for a branch push"
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    name: "Start an OT-3 build for a tag push"
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+            GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: main
           inputs: |
             {
               "oe-core-ref": "-",
               "monorepo-ref": "${{ github.ref }}",
+              "monorepo-tag": "${{ github.tag }}",
               "infra-stage": "stage-prod"
             }
 
 
-  handle-pr:
-    runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
-    name: "Start an OT-3 build for a requested PR"
-    steps:
-      - name: 'start build'
-        uses: octokit/request-action@v2.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
-        with:
-          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
-          owner: opentrons
-          repo: oe-core
-          workflow-id: build-ot3-actions.yml
-          ref: main
-          inputs: |
-            {
-              "oe-core-ref": "-",
-              "monorepo-ref": "refs/heads/${{ github.head_ref }}",
-              "infra-stage": "stage-prod"
-            }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -29,7 +29,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: main
+          ref: RCORE-468_add_releases_json
           inputs: |
             {
               "oe-core-ref": "-",

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -56,7 +56,7 @@ jobs:
           ref: RCORE-468_add_releases_json
           inputs: |
             {
-              "oe-core-ref": "-",
+              "oe-core-ref": "RCORE-468_add_releases_json",
               "monorepo-ref": "refs/heads/${{ github.head_ref }}",
               "infra-stage": "stage-prod"
             }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -30,7 +30,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: main
+          ref: RCORE-468_add_releases_json
           inputs: |
             {
               "oe-core-ref": "-",

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -34,7 +34,6 @@ jobs:
             {
               "oe-core-ref": "-",
               "monorepo-ref": "${{ github.ref }}",
-              "monorepo-tag": "${{ github.tag }}",
               "infra-stage": "stage-prod"
             }
 

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -29,6 +29,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
+          ref: main
           inputs: |
             {
               "oe-core-ref": "-",

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -7,6 +7,7 @@ on:
       - chore_release-*
       - release*
     tags:
+      - v*
       - ot3@*
   pull_request:
     types:
@@ -15,15 +16,38 @@ on:
       - labeled
 
 jobs:
-  handle-release:
+  handle-push:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    name: "Start an OT-3 release build for tag ${{ github.ref }}."
+    if: github.event_name == 'push'
+    name: "Start an OT-3 build for a branch/tag push"
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-            GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: main
+          inputs: |
+            {
+              "oe-core-ref": "-",
+              "monorepo-ref": "${{ github.ref }}",
+              "infra-stage": "stage-prod"
+            }
+
+
+  handle-pr:
+    runs-on: 'ubuntu-latest'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
+    name: "Start an OT-3 build for a requested PR"
+    steps:
+      - name: 'start build'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
@@ -33,9 +57,6 @@ jobs:
           inputs: |
             {
               "oe-core-ref": "-",
-              "monorepo-ref": "${{ github.ref }}",
-              "infra-stage": "stage-prod",
-              "build-type": "develop"
+              "monorepo-ref": "refs/heads/${{ github.head_ref }}",
+              "infra-stage": "stage-prod"
             }
-
-

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -30,7 +30,7 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: RCORE-468_add_releases_json
+          ref: main
           inputs: |
             {
               "oe-core-ref": "-",
@@ -53,10 +53,10 @@ jobs:
           owner: opentrons
           repo: oe-core
           workflow-id: build-ot3-actions.yml
-          ref: RCORE-468_add_releases_json
+          ref: main
           inputs: |
             {
-              "oe-core-ref": "RCORE-468_add_releases_json",
+              "oe-core-ref": "-",
               "monorepo-ref": "refs/heads/${{ github.head_ref }}",
               "infra-stage": "stage-prod"
             }

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -34,7 +34,8 @@ jobs:
             {
               "oe-core-ref": "-",
               "monorepo-ref": "${{ github.ref }}",
-              "infra-stage": "stage-prod"
+              "infra-stage": "stage-prod",
+              "build-type": "develop"
             }
 
 


### PR DESCRIPTION
# Overview

The OT3 release builds need to be triggered based on when the monorepo creates a release tag, so let's make sure we start a special build when that happens.

# Changelog

- Start ot3 release build on tag pushes matching "ot3@*"

# Review requests
- [ ] Create a fake release tag and make sure an ot3 build is generated on the oe-core repo.
- [ ] Make sure the release build is posted to slack

# Risk assessment
Low