### PR TITLE
chore(app-shell-odd): mount file system before starting robot app service

### DIFF
--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -72,7 +72,7 @@ push-ot3: dist-ot3
 	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
 	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
 	scp -r $(ssh_opts) ./opentrons-robot-app.tar.gz root@$(host):
-	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ && systemctl start opentrons-robot-app && mount -o remount,ro /"
+	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app"
 	rm -rf opentrons-robot-app.tar.gz
 
 # development


### PR DESCRIPTION
# Overview
Mounting the file system after starting the robot app service on the OT-3 was causing a mount error since the process keeps open files for writing. This PR mounts the file system before starting the service. 

closes RCORE-522

# Changelog

- Mount file system before starting robot app service


# Review requests

Run `make -C app-shell-odd push-ot3 host=ROBOT_IP` and make sure you're able successfully push the app to the an OT-3

# Risk assessment

Low