### PR TITLE
build(monorepo): do not run linter on compiled files 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,7 @@
 
 # typescript
 app-shell/lib/**
+app-shell-odd/lib/**
 discovery-client/lib/**
 **/lib/**/*.d.ts
 **/lib/**/*.json

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,16 +1,10 @@
 **/node_modules/**
 **/coverage/**
-**/dist/**
+**/dist/**/*
+**/lib/**/*
 **/build/**
 **/venv/**
 .opentrons_config
-
-# typescript
-app-shell/lib/**
-app-shell-odd/lib/**
-discovery-client/lib/**
-**/lib/**/*.d.ts
-**/lib/**/*.json
 
 # prettier
 **/package.json


### PR DESCRIPTION
# Overview

This PR prevents the linter from running on transpiled JS from the app-shell-odd

# Changelog

- Do not lint transpiled JS from app-shell-odd

# Risk assessment

Low