### PR TITLE
fix(api): Safely map 0-volume aspirates and dispenses in Python protocols

### DIFF
--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -154,7 +154,9 @@ class LegacyCommandMapper:
                 elif isinstance(running_command, pe_commands.Aspirate):
                     completed_command = running_command.copy(
                         update={
-                            "result": pe_commands.AspirateResult.construct(
+                            # Don't .construct() result, because we want to validate
+                            # volume.
+                            "result": pe_commands.AspirateResult(
                                 volume=running_command.params.volume
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
@@ -164,7 +166,9 @@ class LegacyCommandMapper:
                 elif isinstance(running_command, pe_commands.Dispense):
                     completed_command = running_command.copy(
                         update={
-                            "result": pe_commands.DispenseResult.construct(
+                            # Don't .construct() result, because we want to validate
+                            # volume.
+                            "result": pe_commands.DispenseResult(
                                 volume=running_command.params.volume
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
@@ -368,7 +372,9 @@ class LegacyCommandMapper:
                     status=pe_commands.CommandStatus.RUNNING,
                     createdAt=now,
                     startedAt=now,
-                    params=pe_commands.AspirateParams.construct(
+                    # Don't .construct() params, because we want to validate
+                    # volume and flowRate.
+                    params=pe_commands.AspirateParams(
                         pipetteId=pipette_id,
                         labwareId=labware_id,
                         wellName=well_name,
@@ -384,7 +390,9 @@ class LegacyCommandMapper:
                     status=pe_commands.CommandStatus.RUNNING,
                     createdAt=now,
                     startedAt=now,
-                    params=pe_commands.DispenseParams.construct(
+                    # Don't .construct params, because we want to validate
+                    # volume and flowRate.
+                    params=pe_commands.DispenseParams(
                         pipetteId=pipette_id,
                         labwareId=labware_id,
                         wellName=well_name,
@@ -434,7 +442,8 @@ class LegacyCommandMapper:
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=now,
                 startedAt=now,
-                params=pe_commands.BlowOutParams.construct(
+                # Don't .construct() params, because we want to validate flowRate.
+                params=pe_commands.BlowOutParams(
                     pipetteId=pipette_id,
                     labwareId=labware_id,
                     wellName=well_name,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -364,9 +364,11 @@ class LegacyCommandMapper:
             well_name = well.well_name
             pipette_id = self._pipette_id_by_mount[mount]
 
-            # In edge cases, it's possible for a Python protocol to do dispense()
-            # or aspirate() with a volume of 0, which behaves roughly like move_to().
             if volume == 0:
+                # In edge cases, it's possible for a Python protocol to do dispense()
+                # or aspirate() with a volume of 0, which behaves roughly like
+                # move_to(). Protocol Engine aspirate and dispense commands must have
+                # volume > 0, so we can't map into those.
                 return pe_commands.MoveToWell.construct(
                     id=command_id,
                     key=command_id,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -246,7 +246,7 @@ class LegacyCommandMapper:
             command["name"] == legacy_command_types.ASPIRATE
             or command["name"] == legacy_command_types.DISPENSE
         ):
-            engine_command = self._build_liquid_handling_commands(
+            engine_command = self._build_liquid_handling_command(
                 command=command, command_id=command_id, now=now
             )
         elif command["name"] == legacy_command_types.BLOW_OUT:
@@ -338,7 +338,7 @@ class LegacyCommandMapper:
             ),
         )
 
-    def _build_liquid_handling_commands(
+    def _build_liquid_handling_command(
         self,
         command: Union[
             legacy_command_types.AspirateMessage, legacy_command_types.DispenseMessage
@@ -351,7 +351,7 @@ class LegacyCommandMapper:
         volume = command["payload"]["volume"]
         # TODO:(jr, 15.08.2022): aspirate and dispense commands with no specified labware
         # get filtered into custom. Refactor this in followup legacy command mapping
-        if isinstance(location, Location) and location.labware.is_well:
+        if location.labware.is_well:
             well = location.labware.as_well()
             slot = DeckSlotName(location.labware.first_parent())
             parent_module_id = self._module_id_by_slot.get(slot)

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -623,7 +623,7 @@ async def test_legacy_commands(big_protocol_file: Path) -> None:
     )
 
 
-ZERO_VOLUME_DISPENSE_PROTOCOL = """\
+ZERO_VOLUME_ASPIRATE_DISPENSE_PROTOCOL = """\
 metadata = {"apiLevel": "2.0"}
 
 def run(ctx):
@@ -635,28 +635,31 @@ def run(ctx):
 
     # Test:
 
-    # The falsey volume argument tells pipette.dispense() to use the pipette's current
+    # Not providing a volume tells pipette.dispense() to use the pipette's current
     # volume, which will be 0 because this is the first command.
-    pipette.dispense(0, well_plate["D6"])
+    pipette.dispense(location=well_plate["D6"])
+
+    # Aspirate the max available volume.
+    pipette.aspirate(location=well_plate["D7"])
+    # Aspirate the max available volume again, which should now be 0.
+    pipette.aspirate(location=well_plate["D7"])
 """
 
 
 @pytest.fixture
-def zero_volume_dispense_protocol_file(tmp_path: Path) -> Path:
-    """Return a file containing the zero-volume dispense protocol."""
+def zero_volume_aspirate_dispense_protocol_file(tmp_path: Path) -> Path:
+    """Return a file containing the zero-volume aspirate/dispense protocol."""
     path = tmp_path / "protocol-name.py"
-    path.write_text(ZERO_VOLUME_DISPENSE_PROTOCOL)
+    path.write_text(ZERO_VOLUME_ASPIRATE_DISPENSE_PROTOCOL)
     return path
 
 
-# TODO BEFORE MERGE:
-# Is there a way to trigger this bug on aspirate()?
 async def test_zero_volume_dispense_commands(
-    zero_volume_dispense_protocol_file: Path,
+    zero_volume_aspirate_dispense_protocol_file: Path,
 ) -> None:
-    """It should map zero-volume dispenses to MoveToWell commands."""
+    """It should map zero-volume dispenses to moveToWell commands."""
     result_commands = await simulate_and_get_commands(
-        zero_volume_dispense_protocol_file
+        zero_volume_aspirate_dispense_protocol_file
     )
 
     [
@@ -664,20 +667,29 @@ async def test_zero_volume_dispense_commands(
         load_well_plate,
         load_pipette,
         pick_up_tip,
-        move_to_well,
+        dispense_as_move_to_well,
+        aspirate_1,
+        aspirate_2_as_move_to_well,
     ] = result_commands
     assert isinstance(load_tip_rack, commands.LoadLabware)
     assert isinstance(load_well_plate, commands.LoadLabware)
     assert isinstance(load_pipette, commands.LoadPipette)
     assert isinstance(pick_up_tip, commands.PickUpTip)
-    assert isinstance(move_to_well, commands.MoveToWell)
+    assert isinstance(dispense_as_move_to_well, commands.MoveToWell)
+    assert isinstance(aspirate_1, commands.Aspirate)
+    assert isinstance(aspirate_2_as_move_to_well, commands.MoveToWell)
 
     assert load_well_plate.result is not None
     assert load_pipette.result is not None
-    assert move_to_well.params == commands.MoveToWellParams(
+    assert dispense_as_move_to_well.params == commands.MoveToWellParams(
         pipetteId=load_pipette.result.pipetteId,
         labwareId=load_well_plate.result.labwareId,
         wellName="D6",
+    )
+    assert aspirate_2_as_move_to_well.params == commands.MoveToWellParams(
+        pipetteId=load_pipette.result.pipetteId,
+        labwareId=load_well_plate.result.labwareId,
+        wellName="D7",
     )
 
 

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -47,6 +47,7 @@ metadata = {
 }
 
 def run(ctx):
+    # Labware and module loads:
     tip_rack_1 = ctx.load_labware(
         load_name="opentrons_96_tiprack_300ul",
         location="1",
@@ -63,6 +64,8 @@ def run(ctx):
     module_plate_1 = module_1.load_labware(
         "opentrons_96_aluminumblock_nest_wellplate_100ul"
     )
+
+    # Pipette loads:
     pipette_left = ctx.load_instrument(
         instrument_name="p300_single",
         mount="left",
@@ -72,6 +75,8 @@ def run(ctx):
         instrument_name="p300_multi",
         mount="right",
     )
+
+    # Tip pickups and drops with different kinds of locations:
     pipette_left.pick_up_tip(
         location=tip_rack_1.wells_by_name()["A1"],
     )
@@ -80,6 +85,8 @@ def run(ctx):
     )
     pipette_left.drop_tip()
     pipette_left.pick_up_tip()
+
+    # Liquid handling commands:
     pipette_left.aspirate(
         volume=40,
         rate=1.0,
@@ -117,6 +124,7 @@ def run(ctx):
     pipette_left.dispense(50, well_plate_1["F1"].top().move(point=Point(10, 10, 0)))
     pipette_left.aspirate(50, Location(point=Point(100, 100, 10), labware=well_plate_1))
     pipette_left.dispense(50, Location(point=Point(100, 100, 10), labware=well_plate_1))
+
     pipette_left.drop_tip(
         location=tip_rack_1.wells_by_name()["A1"]
     )
@@ -125,14 +133,14 @@ def run(ctx):
 
 @pytest.fixture
 def big_protocol_file(tmp_path: Path) -> Path:
-    """Put the pick up tip mapping test protocol on disk."""
+    """Put the big test protocol on disk."""
     path = tmp_path / "protocol-name.py"
     path.write_text(BIG_PROTOCOL)
     return path
 
 
-async def test_legacy_commands(big_protocol_file: Path) -> None:
-    """It should map legacy pick up tip commands."""
+async def test_big_protocol_commands(big_protocol_file: Path) -> None:
+    """It should map commands from the Python protocol."""
     commands_result = await simulate_and_get_commands(big_protocol_file)
 
     tiprack_1_result_captor = matchers.Captor()

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -691,6 +691,3 @@ async def test_zero_volume_dispense_commands(
         labwareId=load_well_plate.result.labwareId,
         wellName="D7",
     )
-
-
-# TODO BEFORE MERGE: Test invalid rates and volumes raise an exception?


### PR DESCRIPTION
# Overview

This fixes a regression in v6.2.0 that caused problems handling certain Python protocols. Closes RSS-168 and RESC-103.

In #11296, we started mapping Python protocols' liquid handling commands into their Protocol Engine counterparts. It turns out that this is not completely safe. Protocol Engine `aspirate` and `dispense` commands require `volume` to be greater than 0, but it's possible for a Python protocol's `aspirate()` or `dispense()` to have an effective volume of 0:

```python
metadata = {"apiLevel": "2.0"}

def run(ctx):
    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
    well_plate = ctx.load_labware("biorad_96_wellplate_200ul_pcr", 2)
    pipette = ctx.load_instrument("p300_single_gen2", mount="left", tip_racks=[tip_rack])
    pipette.pick_up_tip()

    # Not providing a volume tells pipette.dispense() to use the pipette's current
    # volume, which will be 0 because this is the first command.
    pipette.dispense(location=well_plate["D6"])
    # Aspirate the max available volume.
    pipette.aspirate(location=well_plate["D7"])
    # Aspirate the max available volume again, which should now be 0.
    pipette.aspirate(location=well_plate["D7"])
```

This caused `robot-server` to store numerically invalid Protocol Engine commands in its database, which caused HTTP 500 errors on certain requests.

The user-facing result of all this was that certain previously-valid Python protocols would analyze forever when uploaded to a robot.

# Changelog

* When a Python protocol's `aspirate()` or `dispense()` has an effective volume of 0, report it as a `moveToWell` Protocol Engine command. Avoid reporting it as an `aspirate` or `dispense` Protocol Engine command with an invalid `volume=0`.
* In various places in `LegacyCommandMapper` that were accidentally skipping numeric validation, make them not skip it. Before, numerically invalid commands could make their way into `robot-server`'s database. Now, they should cause an analysis error.

# Testing

Testing on a dev server should be sufficient for this.

* The customer protocol file in RESC-103 should now succeed through local analysis, on-robot analysis, and the actual run. In the run log, certain dispenses and aspirates will present as move-to-wells.
* Other Python protocols should continue to work the way they have been. In particular, normal aspirates and dispenses should continue to present as aspirates and dispenses.

# Code review requests

* In `LegacyCommandMapper`, did I miss any meaningful uses of `Model.construct(...)` that we should replace with `Model(...)`?
* Should we go ahead and remove *all* usage of `Model.construct(...)` in `LegacyCommandMapper`? This would be safer, but it would make protocol analysis slower.
* Should we add tests that feed `LegacyCommandMapper` numerically invalid `rate`s and `volume`s, and make sure it raises a validation error instead of returning unvalidated `Command`s? Or are we comfortable enough with the comments I added that we don't think there's much of a regression risk?

# Risk assessment

Low. Changes are well-contained.
