### PR TITLE
fix(api): OT3 recover previous loc after making sure the robot is ready for movement

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -763,7 +763,7 @@ class OT3API(
     async def home_and_recover_position(
         self, mount: OT3Mount, axes_moving: List[OT3Axis]
     ) -> None:
-        origin = await self.gantry_position(mount)
+        origin = await self.gantry_position(mount, refresh=True)
         await self._cache_and_maybe_retract_mount(mount)
         await self._move_gripper_to_idle_position(mount)
         await self.home(axes_moving)

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -7,6 +7,36 @@ and expose it to a python commandline.
 import os
 from functools import wraps
 import asyncio
+import logging
+from logging.config import dictConfig
+
+
+log = logging.getLogger(__name__)
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "basic",
+            "filename": "/var/log/repl.log",
+            "maxBytes": 5000000,
+            "level": logging.INFO,
+            "backupCount": 3,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["file_handler"],
+            "level": logging.INFO,
+        },
+    },
+}
+
 
 has_robot_server = True
 if os.environ.get("OPENTRONS_SIMULATION"):
@@ -109,6 +139,7 @@ def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
 if __name__ == "__main__":
     if has_robot_server:
         stop_server()
+    dictConfig(LOG_CONFIG)
     api_tm = build_api()
     do_interact(api_tm)
     api_tm.clean_up()

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -201,6 +201,7 @@ async def test_find_deck_checks_z_only(
     mock_move_to: AsyncMock,
     mount: OT3Mount,
 ) -> None:
+    await ot3_hardware.home()
     await find_deck_position(ot3_hardware, mount)
     config_point = Point(*ot3_hardware.config.calibration.z_offset.point)
     first_move_point = mock_move_to.call_args_list[0][0][1]


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We now conditionally home all axes that are about to move before a move execution to make sure the stepper motor positions are accurate (see #11752). 

What I forgot to do is to get the robot to move back to the original position after homing, fixing it here now.

