### PR TITLE
fix(robot-server): allow tip rack to be defaulted for tip length cal session

### DIFF
--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -42,7 +42,7 @@ class TipCalibrationUserFlow:
         hardware: HardwareControlAPI,
         mount: Mount,
         has_calibration_block: bool,
-        tip_rack: LabwareDefinition,
+        tip_rack: Optional[LabwareDefinition] = None,
     ):
         self._hardware = hardware
         self._mount = mount
@@ -235,11 +235,16 @@ class TipCalibrationUserFlow:
             await self.return_tip()
         await self._hardware.home()
 
-    def _get_tip_rack_lw(self, tip_rack_def: LabwareDefinition) -> labware.Labware:
+    def _get_tip_rack_lw(
+        self, tip_rack_def: Optional[LabwareDefinition]
+    ) -> labware.Labware:
+        position = self._deck.position_for(TIP_RACK_SLOT)
+        if tip_rack_def is None:
+            pip_vol = self._hw_pipette.config.max_volume
+            tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
+            return labware.load(tr_load_name, position)
         try:
-            return labware.load_from_definition(
-                tip_rack_def, self._deck.position_for(TIP_RACK_SLOT)
-            )
+            return labware.load_from_definition(tip_rack_def, position)
         except Exception:
             raise RobotServerError(definition=CalibrationError.BAD_LABWARE_DEF)
 

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -47,9 +47,7 @@ class TipLengthCalibration(BaseSession):
         self._shutdown_coroutine = shutdown_handler
 
     @staticmethod
-    def _verify_tip_rack(
-        tip_rack_def: Union[Any, None]
-    ) -> Optional[LabwareDefinition]:
+    def _verify_tip_rack(tip_rack_def: Union[Any, None]) -> Optional[LabwareDefinition]:
         if tip_rack_def:
             labware.verify_definition(tip_rack_def)
             return cast(LabwareDefinition, tip_rack_def)

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -1,5 +1,6 @@
 from typing import cast, Awaitable, Optional
 from opentrons.types import Mount
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from robot_server.robot.calibration.tip_length.user_flow import TipCalibrationUserFlow
 from robot_server.robot.calibration.models import SessionCreateParams
 from robot_server.robot.calibration.tip_length.models import TipCalibrationSessionStatus
@@ -54,9 +55,7 @@ class TipLengthCalibration(BaseSession):
         mount = instance_meta.create_params.mount
         tip_rack_def = instance_meta.create_params.tipRackDefinition
         if tip_rack_def:
-            verified_definition = labware.verify_definition(tip_rack_def)
-        else:
-            raise SessionCreationException("No tiprack def provided")
+            labware.verify_definition(tip_rack_def)
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
@@ -68,7 +67,7 @@ class TipLengthCalibration(BaseSession):
                 hardware=configuration.hardware,
                 mount=Mount[mount.upper()],
                 has_calibration_block=has_calibration_block,
-                tip_rack=verified_definition,
+                tip_rack=cast(LabwareDefinition, tip_rack_def),
             )
         except AssertionError as e:
             raise SessionCreationException(str(e))

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -52,8 +52,8 @@ class TipLengthCalibration(BaseSession):
     ) -> Optional[LabwareDefinition]:
         if tip_rack_def:
             labware.verify_definition(tip_rack_def)
-            return (cast(LabwareDefinition, tip_rack_def),)
-        return tip_rack_def
+            return cast(LabwareDefinition, tip_rack_def)
+        return None
 
     @classmethod
     async def create(

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -1,4 +1,4 @@
-from typing import cast, Awaitable, Optional, Any, Dict
+from typing import cast, Awaitable, Optional, Any, Union
 from opentrons.types import Mount
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from robot_server.robot.calibration.tip_length.user_flow import TipCalibrationUserFlow
@@ -48,7 +48,7 @@ class TipLengthCalibration(BaseSession):
 
     @staticmethod
     def _verify_tip_rack(
-        tip_rack_def: Dict[str, Any] | Any | None
+        tip_rack_def: Union[Any, None]
     ) -> Optional[LabwareDefinition]:
         if tip_rack_def:
             labware.verify_definition(tip_rack_def)

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -124,6 +124,19 @@ def mock_user_flow_with_custom_tiprack(mock_hw, custom_tiprack_def, request):
 
 
 @pytest.fixture(params=[True, False])
+def mock_user_flow_with_default_tiprack(mock_hw, request):
+    has_calibration_block = request.param
+    mount = next(k for k, v in mock_hw.hardware_instruments.items() if v)
+    m = TipCalibrationUserFlow(
+        hardware=mock_hw,
+        mount=mount,
+        has_calibration_block=has_calibration_block,
+    )
+
+    yield m
+
+
+@pytest.fixture(params=[True, False])
 def mock_user_flow_all_combos(mock_hw_all_combos, request):
     has_calibration_block = request.param
     hw = mock_hw_all_combos
@@ -331,6 +344,12 @@ async def test_save_custom_tiprack_def(
     assert os.path.exists(
         config.get_custom_tiprack_def_path() / "custom/minimal_labware_def/1.json"
     )
+
+
+async def test_default_tiprack_def(mock_user_flow_with_default_tiprack):
+    uf = mock_user_flow_with_default_tiprack
+
+    assert uf._tip_rack.load_name == "opentrons_96_tiprack_300ul"
 
 
 @pytest.mark.parametrize(argnames="mount", argvalues=[Mount.RIGHT, Mount.LEFT])


### PR DESCRIPTION
# Overview

To match the behavior of the soon-to-be-unused "extended pipette offset calibration", allow tip length calibration sessions to receive no explicit tip rack definition in create params, and instead default to the standard tip rack for the mounted pipette.

# Review requests

- create a tip length calibration session without a tip rack definition in the create params

# Risk assessment
med (old untouched code)
