### PR TITLE
feat(api-client): allow multiple commands per liquid/labware pair

### DIFF
--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -67,9 +67,26 @@ const mockLoadLiquidRunTimeCommands = [
       liquidId: '1',
       labwareId: 'mockLabwareId2',
       volumeByWell: {
-        A1: 33,
-        B1: 33,
-        C1: 33,
+        D3: 40,
+      },
+    },
+    result: {},
+    startedAt: '2022-09-07T19:47:42.786212+00:00',
+    completedAt: '2022-09-07T19:47:42.786285+00:00',
+  },
+  {
+    id: '1e03ae10-7e9b-465c-bc72-21ab5706bfb0',
+    createdAt: '2022-09-07T19:47:42.781323+00:00',
+    commandType: 'loadLiquid',
+    key: '48df9766-04ff-4927-9f2d-4efdcf0b3df8',
+    status: 'succeeded',
+    params: {
+      liquidId: '1',
+      labwareId: 'mockLabwareId2',
+      volumeByWell: {
+        A3: 33,
+        B3: 33,
+        C3: 33,
       },
     },
     result: {},
@@ -317,9 +334,10 @@ describe('parseLabwareInfoByLiquidId', () => {
         {
           labwareId: 'mockLabwareId2',
           volumeByWell: {
-            A1: 33,
-            B1: 33,
-            C1: 33,
+            A3: 33,
+            B3: 33,
+            C3: 33,
+            D3: 40,
           },
         },
       ],

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -280,7 +280,17 @@ export function parseLabwareInfoByLiquidId(
       }
       const labwareId = command.params.labwareId
       const volumeByWell = command.params.volumeByWell
-      acc[command.params.liquidId].push({ labwareId, volumeByWell })
+      const labwareIndex = acc[command.params.liquidId].findIndex(
+        i => i.labwareId === labwareId
+      )
+      if (labwareIndex >= 0) {
+        acc[command.params.liquidId][labwareIndex].volumeByWell = {
+          ...acc[command.params.liquidId][labwareIndex].volumeByWell,
+          ...volumeByWell,
+        }
+      } else {
+        acc[command.params.liquidId].push({ labwareId, volumeByWell })
+      }
       return acc
     },
     {}


### PR DESCRIPTION
fix RLIQ-287

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
PAPI implementation of load liquid commands may result in many commands for a single liquid/labware combination. We want to synthesize this data so the information is presented to the user per liquid or per labware as opposed to per command.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
1. Update the `parseLabwareInfoByLiquidId` util to combine all `volumeByWell` per liquid/labware pair into a single object
2. Update test

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Upload a protocol with multiple commands per liquid/labware pair and verify that they are synthesized in the various list and map view components.
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low