### PR TITLE
fix(api): do not clear motor status ok flag.. for now

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -232,8 +232,16 @@ class OT3Controller:
         for axis, pos in response.items():
             self._position.update({axis: pos[0]})
             self._encoder_position.update({axis: pos[1]})
+            # if an axis has already been homed, we're not clearing the motor ok status flag
+            # TODO: (2023-01-10) This is just a temp fix so we're not blocking hardware testing,
+            # we should port the encoder position over to use as motor position if encoder status is ok
+            already_homed = (
+                self._motor_status[axis].motor_ok
+                if axis in self._motor_status.keys()
+                else False
+            )
             self._motor_status.update(
-                {axis: MotorStatus(motor_ok=pos[2], encoder_ok=pos[3])}
+                {axis: MotorStatus(motor_ok=pos[2] or already_homed, encoder_ok=pos[3])}
             )
 
     async def move(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We're running into an issue where the some motors are skipping randomly. (As of 1/10 5:30 PM, we believe it might be caused by external oscillators being mistakenly added to certain boards. Still waiting to further verify this theory.)

The `ready for movement` check introduced in #11752 is now constantly causing the robot to home all axes if one axis has skipped a few steps in the previous move. This PR serves as a temporary bandaid to mask this behavior so we're not blocking hardware testing.

We will create a better and perma fix once we find out the root cause of the motor issues. 
