### PR TITLE
feat(app): create critical exit warning and wire up go back btn

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -68,5 +68,7 @@
   "detach_z_axis_screw_again": "You need to loosen the screw before you can attach the 96-Channel Pipette",
   "cancel_attachment": "Cancel attachment",
   "detach_and_retry": "Detach and retry",
-  "attach_and_retry": "Attach and retry"
+  "attach_and_retry": "Attach and retry",
+  "critical_unskippable_step": "This is a critical step that cannot be skipped",
+  "must_detach_mounting_plate": "You must detach the mounting plate before using other pipettes."
 }

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -59,5 +59,6 @@
   "alphabetical": "Alphabetical",
   "reverse": "Reverse alphabetical",
   "next": "Next",
-  "something_went_wrong": "something went wrong"
+  "something_went_wrong": "something went wrong",
+  "return": "return"
 }

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -24,11 +24,7 @@ export const CheckPipetteButton = (
     robotName
   )
   React.useEffect(() => {
-    if (isPending) {
-      setPending(true)
-    } else {
-      setPending(false)
-    }
+    setPending(isPending)
   }, [isPending, setPending])
 
   React.useEffect(() => {

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -25,7 +25,9 @@ export const CheckPipetteButton = (
   )
   React.useEffect(() => {
     if (isPending) {
-      setPending(isPending)
+      setPending(true)
+    } else {
+      setPending(false)
     }
   }, [isPending, setPending])
 

--- a/app/src/organisms/PipetteWizardFlows/UnskippableModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/UnskippableModal.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { COLORS, TEXT_TRANSFORM_CAPITALIZE } from '@opentrons/components'
+import { PrimaryButton } from '../../atoms/buttons'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+
+interface UnskippableModalProps {
+  goBack: () => void
+}
+
+export function UnskippableModal(props: UnskippableModalProps): JSX.Element {
+  const { goBack } = props
+  const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
+  return (
+    <SimpleWizardBody
+      iconColor={COLORS.warningEnabled}
+      header={t('critical_unskippable_step')}
+      subHeader={t('must_detach_mounting_plate')}
+      isSuccess={false}
+    >
+      <PrimaryButton onClick={goBack} textTransform={TEXT_TRANSFORM_CAPITALIZE}>
+        {t('shared:return')}
+      </PrimaryButton>
+    </SimpleWizardBody>
+  )
+}

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -233,6 +233,28 @@ describe('PipetteWizardFlows', () => {
     //   expect(props.closeFlow).toHaveBeenCalled()
     // })
   })
+  it('renders 3rd page and clicking back button redirects to the first page', async () => {
+    const { getByText, getByRole } = render(props)
+    //  first page
+    getByText('Before you begin')
+    getByRole('button', { name: 'Get started' }).click()
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalled()
+      expect(mockCreateRun).toHaveBeenCalled()
+    })
+    // second page
+    getByText('Attach Calibration Probe')
+    getByRole('button', { name: 'Initiate calibration' }).click()
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalled()
+    })
+    //  third page
+    getByText('Remove Calibration Probe')
+    getByRole('button', { name: 'back' }).click()
+    //   first page
+    getByText('Before you begin')
+  })
+
   it('renders the correct information, calling the correct commands for the detach flow', () => {
     props = {
       ...props,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -604,7 +604,7 @@ describe('PipetteWizardFlows', () => {
       )
     })
   })
-  it('renders the unskippable modal when you try to exit out of a 96 channel detach flow from an unskippable page', async () => {
+  it('renders the unskippable modal when you try to exit out of a 96 channel detach flow from a the detach pipette unskippable page', async () => {
     mockGetAttachedPipettes.mockReturnValue({
       left: {
         id: 'abc',
@@ -658,6 +658,52 @@ describe('PipetteWizardFlows', () => {
     })
     // page 2
     getByText('Unscrew and Remove 96 Channel Pipette')
+    getByLabelText('Exit').click()
+    getByText('mock unskippable modal')
+  })
+  it('renders the 96 channel attach flow carriage unskippable step page', async () => {
+    mockGetAttachedPipettes.mockReturnValue({ left: null, right: null })
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      selectedPipette: NINETY_SIX_CHANNEL,
+    }
+    mockGetPipetteWizardSteps.mockReturnValue([
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.CARRIAGE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNTING_PLATE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+    ])
+    const { getByText, getByRole, getByLabelText } = render(props)
+    // page 1
+    getByRole('button', { name: 'Move gantry to front' }).click()
+    await waitFor(() => {
+      expect(mockChainRunCommands).toHaveBeenCalled()
+      expect(mockCreateRun).toHaveBeenCalled()
+    })
+    // page 2
+    getByText('Unscrew Z Axis Carriage')
     getByLabelText('Exit').click()
     getByText('mock unskippable modal')
   })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -244,7 +244,7 @@ describe('PipetteWizardFlows', () => {
     })
     // second page
     getByText('Attach Calibration Probe')
-    getByRole('button', { name: 'Initiate calibration' }).click()
+    getByRole('button', { name: 'Begin calibration' }).click()
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalled()
     })
@@ -679,7 +679,7 @@ describe('PipetteWizardFlows', () => {
       expect(mockCreateRun).toHaveBeenCalled()
     })
     // page 2
-    getByText('Unscrew and Remove 96 Channel Pipette')
+    getByText('Loosen Screws and Detach 96-Channel Pipette')
     getByLabelText('Exit').click()
     getByText('mock unskippable modal')
   })
@@ -725,7 +725,7 @@ describe('PipetteWizardFlows', () => {
       expect(mockCreateRun).toHaveBeenCalled()
     })
     // page 2
-    getByText('Unscrew Z Axis Carriage')
+    getByText('Unscrew Z-axis Carriage')
     getByLabelText('Exit').click()
     getByText('mock unskippable modal')
   })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { UnskippableModal } from '../UnskippableModal'
+
+const render = (props: React.ComponentProps<typeof UnskippableModal>) => {
+  return renderWithProviders(<UnskippableModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('UnskippableModal', () => {
+  let props: React.ComponentProps<typeof UnskippableModal>
+  it('returns the correct information for unskippable modal, pressing return button calls goBack prop', () => {
+    props = {
+      goBack: jest.fn(),
+    }
+    const { getByText, getByRole } = render(props)
+    getByText('This is a critical step that cannot be skipped')
+    getByText('You must detach the mounting plate before using other pipettes.')
+    getByRole('button', { name: 'return' }).click()
+    expect(props.goBack).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -71,9 +71,7 @@ export const PipetteWizardFlows = (
 
   const goBack = (): void => {
     setCurrentStepIndex(
-      currentStepIndex !== pipetteWizardSteps.length - 1
-        ? currentStepIndex - 1
-        : currentStepIndex
+      currentStepIndex !== pipetteWizardSteps.length - 1 ? 0 : currentStepIndex
     )
   }
   const { chainRunCommands, isCommandMutationLoading } = useChainRunCommands(

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -30,6 +30,7 @@ import { MountPipette } from './MountPipette'
 import { DetachPipette } from './DetachPipette'
 import { Carriage } from './Carriage'
 import { MountingPlate } from './MountingPlate'
+import { UnskippableModal } from './UnskippableModal'
 import type { PipetteMount } from '@opentrons/shared-data'
 import type { State } from '../../redux/types'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
@@ -157,6 +158,13 @@ export const PipetteWizardFlows = (
   const exitModal = (
     <ExitModal goBack={cancelExit} proceed={confirmExit} flowType={flowType} />
   )
+  const [
+    showUnskippableStepModal,
+    setIsUnskippableStep,
+  ] = React.useState<boolean>(false)
+  const unskippableModal = (
+    <UnskippableModal goBack={() => setIsUnskippableStep(false)} />
+  )
   let onExit
   if (currentStep == null) return null
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
@@ -231,9 +239,7 @@ export const PipetteWizardFlows = (
     )
   } else if (currentStep.section === SECTIONS.DETACH_PIPETTE) {
     onExit = confirmExit
-    modalContent = showConfirmExit ? (
-      exitModal
-    ) : (
+    modalContent = (
       <DetachPipette
         {...currentStep}
         {...calibrateBaseProps}
@@ -241,17 +247,22 @@ export const PipetteWizardFlows = (
         setPending={setIsFetchingPipettes}
       />
     )
+    if (showConfirmExit) {
+      modalContent = exitModal
+    } else if (showUnskippableStepModal) {
+      modalContent = unskippableModal
+    }
   } else if (currentStep.section === SECTIONS.CARRIAGE) {
     onExit = confirmExit
-    modalContent = showConfirmExit ? (
-      exitModal
+    modalContent = showUnskippableStepModal ? (
+      unskippableModal
     ) : (
       <Carriage {...currentStep} {...calibrateBaseProps} />
     )
   } else if (currentStep.section === SECTIONS.MOUNTING_PLATE) {
     onExit = confirmExit
-    modalContent = showConfirmExit ? (
-      exitModal
+    modalContent = showUnskippableStepModal ? (
+      unskippableModal
     ) : (
       <MountingPlate {...currentStep} {...calibrateBaseProps} />
     )
@@ -290,11 +301,20 @@ export const PipetteWizardFlows = (
     }
   }
 
+  const is96ChannelUnskippableStep =
+    currentStep.section === SECTIONS.CARRIAGE ||
+    currentStep.section === SECTIONS.MOUNTING_PLATE ||
+    (selectedPipette === NINETY_SIX_CHANNEL &&
+      currentStep.section === SECTIONS.DETACH_PIPETTE)
+
   let exitWizardButton = onExit
-  if (isRobotMoving) {
+  if (isRobotMoving || showUnskippableStepModal) {
     exitWizardButton = undefined
-  } else if (showConfirmExit || errorMessage != null)
+  } else if (is96ChannelUnskippableStep) {
+    exitWizardButton = () => setIsUnskippableStep(true)
+  } else if (showConfirmExit || errorMessage != null) {
     exitWizardButton = handleCleanUpAndClose
+  }
 
   return (
     <Portal level="top">


### PR DESCRIPTION
closes RLIQ-292 and RLIQ-293

# Overview

- Creates an unskippable step modal that whenever you try to exit a 96-channel flow during a critical step, the modal pops up and only allows you to return to that current step rather than exiting.

<img width="770" alt="Screen Shot 2023-01-11 at 1 29 41 PM" src="https://user-images.githubusercontent.com/66035149/211891377-59e1d434-39fd-4c3c-bab2-758ff0f1c1a4.png">

- wires up the `go back` button so no matter where in the flow, the user clicks `go back`, it will go back to the before beginning page in the flow.

- fix `CheckPipetteButton` bug regarding when `isPending` is being updated

# Changelog

- creates `UnskippableModal` and test. I could have added this logic to `ExitModal` but for the sake of simplicity, I figured the unskippable modals can be their own component.
- adds logic to parent component `PipetteWizardFlows`, basically creating a boolean `is96ChannelUnskippableStep` for whenever the section is an unskippable section, creates a test for that logic.
- change `goBack` logic in `PipetteWizardFlows` and add test case

# Review requests

- when going through the 96 channel flows, try exiting out of a critical step (`Carriage`, `Mounting Plate` or `detach 96 channel`), you should run into the unskippable modal. There should be no exit button on the modal. the return button should return you to the correct step.
- if you click on `go back` anywhere in the flow, it will go back to the first page. Need to test on a robot but I think that when you execute commands again when the robot is already in the correct position, the commands already won't be executed again.
- you should be able to exit out of the `WizardHeader` button anywhere in the flow and it should work properly 

# Risk assessment

low