### PR TITLE
fix(hardware): update motor positions from firmware before moving gantry

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -789,7 +789,7 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
 
         # Refresh current position
-        await self.current_position_ot3(mount=mount, refresh=True)
+        await self.current_position_ot3(mount=realmount, refresh=True)
 
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
         if not self._backend.check_ready_for_movement(axes_moving):
@@ -847,7 +847,7 @@ class OT3API(
             else:
                 await self.home(axes_moving)
         # Refresh current position
-        await self.current_position_ot3(mount=mount, refresh=True)
+        await self.current_position_ot3(mount=realmount, refresh=True)
         target_position = target_position_from_relative(
             realmount, delta, self._current_position
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -677,6 +677,7 @@ class OT3API(
     async def refresh_current_position_ot3(self) -> Dict[OT3Axis, float]:
         """Requests the current position and updates _current_position."""
         async with self._motion_lock:
+            await self._backend.update_motor_status()
             self._current_position = deck_from_machine(
                 await self._backend.update_position(),
                 self._transforms.deck_calibration.attitude,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -788,6 +788,9 @@ class OT3API(
         relative to the deck, at the specified speed."""
         realmount = OT3Mount.from_mount(mount)
 
+        # Refresh current position
+        await self.current_position_ot3(mount=mount, refresh=True)
+
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
         if not self._backend.check_ready_for_movement(axes_moving):
             await self.home(axes_moving)
@@ -843,7 +846,8 @@ class OT3API(
                 raise mhe
             else:
                 await self.home(axes_moving)
-
+        # Refresh current position
+        await self.current_position_ot3(mount=mount, refresh=True)
         target_position = target_position_from_relative(
             realmount, delta, self._current_position
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -667,16 +667,22 @@ class OT3API(
 
         elif not self._current_position and not refresh:
             raise MustHomeError("Current position is unknown; please home motors.")
+
+        if refresh:
+            await self.refresh_current_position_ot3()
+        return self._effector_pos_from_carriage_pos(
+            OT3Mount.from_mount(mount), self._current_position, critical_point
+        )
+
+    async def refresh_current_position_ot3(self) -> Dict[OT3Axis, float]:
+        """Requests the current position and updates _current_position."""
         async with self._motion_lock:
-            if refresh:
-                self._current_position = deck_from_machine(
-                    await self._backend.update_position(),
-                    self._transforms.deck_calibration.attitude,
-                    self._transforms.carriage_offset,
-                )
-            return self._effector_pos_from_carriage_pos(
-                OT3Mount.from_mount(mount), self._current_position, critical_point
+            self._current_position = deck_from_machine(
+                await self._backend.update_position(),
+                self._transforms.deck_calibration.attitude,
+                self._transforms.carriage_offset,
             )
+        return self._current_position
 
     async def encoder_current_position(
         self,
@@ -789,7 +795,7 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
 
         # Refresh current position
-        await self.current_position_ot3(mount=realmount, refresh=True)
+        await self.refresh_current_position_ot3()
 
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
         if not self._backend.check_ready_for_movement(axes_moving):
@@ -847,10 +853,8 @@ class OT3API(
             else:
                 await self.home(axes_moving)
         # Refresh current position
-        await self.current_position_ot3(mount=realmount, refresh=True)
-        target_position = target_position_from_relative(
-            realmount, delta, self._current_position
-        )
+        position = await self.refresh_current_position_ot3()
+        target_position = target_position_from_relative(realmount, delta, position)
         if fail_on_not_homed and not self._backend.check_ready_for_movement(
             [axis for axis in axes_moving if axis is not None]
         ):


### PR DESCRIPTION

# Overview

Movements on the OT3 are calculated using the cached position in the `ot3api` object. If a stall occurs and we command firmware to update the cached position, we need to explicitly grab this new cached value before moving so that the distance is appropriate.

# Changelog

In `move_to` and `move_rel`, request a refresh of the current motor positions before moving.

# Review requests

- [ ] Will this break anything I haven't considered?
- [ ] Is there a cleaner place to put this fix

# Risk assessment

Medium, if this is fundamentally incorrect then it will affect how the robot's motion control functions.
