### PR TITLE
fix(hardware): let hardware controller recover from recoverable errors

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -358,17 +358,7 @@ class MoveScheduler:
     def _handle_acknowledge(self, message: Acknowledgement) -> None:
         log.debug("recieved ack")
 
-    def _handle_error(
-        self, message: ErrorMessage, arbitration_id: ArbitrationId
-    ) -> None:
-        # Remove anything related to this node!
-        node = arbitration_id.parts.originating_node_id
-        """
-        for g in self._moves:
-            for m in self._moves[g]:
-                if m[0] == node:
-                    self._moves[g].remove(m)
-        """
+    def _handle_error(self, message: ErrorMessage) -> None:
         for group in self._moves:
             group.clear()
         self._event.set()
@@ -422,7 +412,7 @@ class MoveScheduler:
             self._remove_move_group(message, arbitration_id)
             self._handle_tip_action(message)
         elif isinstance(message, ErrorMessage):
-            self._handle_error(message, arbitration_id)
+            self._handle_error(message)
         elif isinstance(message, Acknowledgement):
             self._handle_acknowledge(message)
 

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -362,6 +362,7 @@ class MoveScheduler:
     def _handle_error(self, message: ErrorMessage) -> None:
         self._error = message
         self._event.set()
+        log.warning(f"Error during move group: {message}")
         if message.payload.severity == ErrorSeverity.unrecoverable:
             raise RuntimeError("Firmware Error Received", message)
 
@@ -458,7 +459,6 @@ class MoveScheduler:
                     max(1.0, self._durations[group_id - self._start_at_index] * 1.1),
                 )
                 if self._error is not None:
-                    log.warning(f"Error during move group: {self._error}")
                     raise RuntimeError(f"Error during move group: {self._error}")
             except asyncio.TimeoutError:
                 log.warning(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -6,7 +6,11 @@ from mock import AsyncMock, call, MagicMock
 import asyncio
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
-from opentrons_hardware.firmware_bindings.constants import NodeId, ErrorCode
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    ErrorCode,
+    ErrorSeverity,
+)
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     MessageListenerCallback,
 )
@@ -21,10 +25,13 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     MoveCompletedPayload,
     ExecuteMoveGroupRequestPayload,
     HomeRequestPayload,
+    ErrorMessagePayload,
 )
 from opentrons_hardware.firmware_bindings.messages.fields import (
     MotorPositionFlagsField,
     MoveStopConditionField,
+    ErrorSeverityField,
+    ErrorCodeField,
 )
 from opentrons_hardware.hardware_control.constants import (
     interrupts_per_sec,
@@ -953,3 +960,75 @@ async def test_groups_from_nonzero_index(
             )
         ]
     )
+
+
+class MockSendMoveErrorCompleter:
+    """Side effect mock of CanMessenger.send that immediately sends an error."""
+
+    def __init__(
+        self,
+        move_groups: MoveGroups,
+        listener: MessageListenerCallback,
+        start_at_index: int = 0,
+    ) -> None:
+        """Constructor."""
+        self._move_groups = move_groups
+        self._listener = listener
+        self._start_at_index = start_at_index
+
+    @property
+    def groups(self) -> MoveGroups:
+        """Retrieve the groups, for instance from a child class."""
+        return self._move_groups
+
+    async def mock_send(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+    ) -> None:
+        """Mock send function."""
+        if isinstance(message, md.ExecuteMoveGroupRequest):
+            # Iterate through each move in each sequence and send a move
+            # completed for it.
+            payload = EmptyPayload()
+            payload.message_index = message.payload.message_index
+            arbitration_id = ArbitrationId(
+                parts=ArbitrationIdParts(originating_node_id=node_id)
+            )
+            self._listener(md.Acknowledgement(payload=payload), arbitration_id)
+            for seq_id, moves in enumerate(
+                self._move_groups[message.payload.group_id.value - self._start_at_index]
+            ):
+                for node, move in moves.items():
+                    assert isinstance(move, MoveGroupSingleAxisStep)
+                    payload = ErrorMessagePayload(
+                        severity=ErrorSeverityField(ErrorSeverity.recoverable),
+                        error_code=ErrorCodeField(ErrorCode.collision_detected),
+                    )
+                    arbitration_id = ArbitrationId(
+                        parts=ArbitrationIdParts(originating_node_id=node)
+                    )
+                    self._listener(md.ErrorMessage(payload=payload), arbitration_id)
+
+    async def mock_ensure_send(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+        timeout: float = 3,
+        expected_nodes: List[NodeId] = [],
+    ) -> ErrorCode:
+        """Mock ensure_send function."""
+        await self.mock_send(node_id, message)
+        return ErrorCode.ok
+
+
+async def test_single_move_error(
+    mock_can_messenger: AsyncMock, move_group_single: MoveGroups
+) -> None:
+    """It should send a start group command."""
+    subject = MoveScheduler(move_groups=move_group_single)
+    mock_sender = MockSendMoveErrorCompleter(move_group_single, subject)
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
+    mock_can_messenger.send.side_effect = mock_sender.mock_send
+    with pytest.raises(RuntimeError):
+        await subject.run(can_messenger=mock_can_messenger)


### PR DESCRIPTION
# Overview

Currently, the handling for any error messages during a move group throws an exception. A side effect of this is that all future move groups seem to hang forever (this may be due to the error-ed move group persisting in memory forever? I'm not 100% sure!).

In order to test the stall detection functionality, we need to be able to continue using the hardware controller after an error comes in. 

# Changelog

- If an error during a move group is recoverable, don't raise an exception
- Instead, cache the error and signal that the event is triggered
- In the run() function, if there's an error raise an exception to let the HC know that the move group failed

# Review requests

Tested that the following works (which did not work before the PR):
* Home the gantry
* Move Z axis down until pipette stalls out against a tip rack - you get a RunTimeException!
* Home gantry again, repeat as many times as you please

# Risk assessment

Should be low because this only affects error handling, which is a relatively unused part of the code at the moment. Only applies to Estop and Stall errors.