### PR TITLE
feat(app): redesign calibration status banners

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -77,6 +77,7 @@
   "networking": "Networking",
   "new_features": "New Features",
   "not_calibrated": "Not calibrated yet",
+  "not_calibrated_short": "Not calibrated",
   "not_connected_via_wifi": "Not connected via Wi-Fi",
   "not_connected_via_wired_usb": "Not connected via wired USB",
   "password": "Password",

--- a/app/src/organisms/CalibrationStatusCard/__tests__/CalibrationStatusCard.test.tsx
+++ b/app/src/organisms/CalibrationStatusCard/__tests__/CalibrationStatusCard.test.tsx
@@ -1,10 +1,23 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
+import { resetAllWhenMocks } from 'jest-when'
 
 import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
 import { CalibrationStatusCard } from '..'
+import { useCalibrationTaskList } from '../../Devices/hooks'
+import {
+  expectedFailedTaskList,
+  expectedIncompleteDeckCalTaskList,
+  expectedTaskList,
+} from '../../Devices/hooks/__fixtures__/taskListFixtures'
+
+jest.mock('../../Devices/hooks')
+
+const mockUseCalibrationTaskList = useCalibrationTaskList as jest.MockedFunction<
+  typeof useCalibrationTaskList
+>
 
 const render = (props: React.ComponentProps<typeof CalibrationStatusCard>) => {
   return renderWithProviders(
@@ -20,6 +33,15 @@ const render = (props: React.ComponentProps<typeof CalibrationStatusCard>) => {
 const mockSetShowHowCalibrationWorksModal = jest.fn()
 
 describe('CalibrationStatusCard', () => {
+  beforeEach(() => {
+    mockUseCalibrationTaskList.mockReturnValue(expectedTaskList)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    resetAllWhenMocks()
+  })
+
   const props: React.ComponentProps<typeof CalibrationStatusCard> = {
     robotName: 'otie',
     setShowHowCalibrationWorksModal: mockSetShowHowCalibrationWorksModal,
@@ -34,9 +56,23 @@ describe('CalibrationStatusCard', () => {
     )
   })
 
-  it('renders a status label', () => {
+  it('renders a complete status label', () => {
+    const [{ getByText }] = render(props)
+    getByText('Calibration complete')
+  })
+
+  it('renders a missing status label', () => {
+    mockUseCalibrationTaskList.mockReturnValue(
+      expectedIncompleteDeckCalTaskList
+    )
     const [{ getByText }] = render(props)
     getByText('Missing calibration data')
+  })
+
+  it('renders a recommended status label', () => {
+    mockUseCalibrationTaskList.mockReturnValue(expectedFailedTaskList)
+    const [{ getByText }] = render(props)
+    getByText('Calibration recommended')
   })
 
   it('renders a "See how robot calibration works button"', () => {

--- a/app/src/organisms/CalibrationStatusCard/index.tsx
+++ b/app/src/organisms/CalibrationStatusCard/index.tsx
@@ -48,10 +48,7 @@ export function CalibrationStatusCard({
     statusLabelText = t('calibration_complete')
     // if we have tasks and they are all marked bad, then we should
     // strongly suggest they re-do those calibrations
-  } else if (
-    taskList.filter(tp => tp.subTasks.every(st => st.markedBad)).length ===
-    taskList.length
-  ) {
+  } else if (taskList.every(tp => tp.isComplete === true || tp.markedBad)) {
     statusLabelBackgroundColor = COLORS.warningEnabled
     statusLabelIconColor = COLORS.warningEnabled
     statusLabelText = t('calibration_recommended')

--- a/app/src/organisms/CalibrationStatusCard/index.tsx
+++ b/app/src/organisms/CalibrationStatusCard/index.tsx
@@ -20,6 +20,8 @@ import { TertiaryButton } from '../../atoms/buttons'
 import { StatusLabel } from '../../atoms/StatusLabel'
 import { StyledText } from '../../atoms/text'
 
+import { useCalibrationTaskList } from '../Devices/hooks'
+
 export interface CalibrationStatusCardProps {
   robotName: string
   setShowHowCalibrationWorksModal: (
@@ -32,6 +34,28 @@ export function CalibrationStatusCard({
   setShowHowCalibrationWorksModal,
 }: CalibrationStatusCardProps): JSX.Element {
   const { t } = useTranslation('robot_calibration')
+  const { activeIndex, taskList } = useCalibrationTaskList(robotName)
+
+  // start off assuming we are missing calibrations
+  let statusLabelBackgroundColor = COLORS.errorEnabled
+  let statusLabelIconColor = COLORS.errorEnabled
+  let statusLabelText = t('missing_calibration_data')
+
+  // if the tasklist is empty, though, all calibrations are good
+  if (activeIndex == null) {
+    statusLabelBackgroundColor = COLORS.successEnabled
+    statusLabelIconColor = COLORS.successEnabled
+    statusLabelText = t('calibration_complete')
+    // if we have tasks and they are all marked bad, then we should
+    // strongly suggest they re-do those calibrations
+  } else if (
+    taskList.filter(tp => tp.subTasks.every(st => st.markedBad)).length ===
+    taskList.length
+  ) {
+    statusLabelBackgroundColor = COLORS.warningEnabled
+    statusLabelIconColor = COLORS.warningEnabled
+    statusLabelText = t('calibration_recommended')
+  }
 
   return (
     <Flex
@@ -53,11 +77,11 @@ export function CalibrationStatusCard({
             {t('calibration_status')}
           </StyledText>
           <StatusLabel
-            status={t('missing_calibration_data')}
-            backgroundColor={`${String(COLORS.errorEnabled)}${String(
+            status={statusLabelText}
+            backgroundColor={`${String(statusLabelBackgroundColor)}${String(
               COLORS.opacity12HexCode
             )}`}
-            iconColor={COLORS.errorEnabled}
+            iconColor={statusLabelIconColor}
             textColor={COLORS.darkBlackEnabled}
             fontWeight={TYPOGRAPHY.fontWeightSemiBold}
             iconSize="0.313rem"

--- a/app/src/organisms/CalibrationStatusCard/index.tsx
+++ b/app/src/organisms/CalibrationStatusCard/index.tsx
@@ -34,7 +34,7 @@ export function CalibrationStatusCard({
   setShowHowCalibrationWorksModal,
 }: CalibrationStatusCardProps): JSX.Element {
   const { t } = useTranslation('robot_calibration')
-  const { activeIndex, taskList } = useCalibrationTaskList(robotName)
+  const { taskListStatus } = useCalibrationTaskList(robotName)
 
   // start off assuming we are missing calibrations
   let statusLabelBackgroundColor = COLORS.errorEnabled
@@ -42,13 +42,13 @@ export function CalibrationStatusCard({
   let statusLabelText = t('missing_calibration_data')
 
   // if the tasklist is empty, though, all calibrations are good
-  if (activeIndex == null) {
+  if (taskListStatus === 'complete') {
     statusLabelBackgroundColor = COLORS.successEnabled
     statusLabelIconColor = COLORS.successEnabled
     statusLabelText = t('calibration_complete')
     // if we have tasks and they are all marked bad, then we should
     // strongly suggest they re-do those calibrations
-  } else if (taskList.every(tp => tp.isComplete === true || tp.markedBad)) {
+  } else if (taskListStatus === 'bad') {
     statusLabelBackgroundColor = COLORS.warningEnabled
     statusLabelIconColor = COLORS.warningEnabled
     statusLabelText = t('calibration_recommended')

--- a/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
@@ -243,6 +243,7 @@ export const expectedTaskList: TaskListProps = {
       taskIndex: 2,
     },
   ],
+  taskListStatus: 'complete',
 }
 
 export const expectedFailedTaskList: TaskListProps = {
@@ -339,6 +340,7 @@ export const expectedFailedTaskList: TaskListProps = {
       taskIndex: 2,
     },
   ],
+  taskListStatus: 'bad',
 }
 
 export const expectedIncompleteDeckCalTaskList: TaskListProps = {
@@ -430,6 +432,7 @@ export const expectedIncompleteDeckCalTaskList: TaskListProps = {
       taskIndex: 2,
     },
   ],
+  taskListStatus: 'incomplete',
 }
 
 export const expectedIncompleteLeftMountTaskList: TaskListProps = {
@@ -517,6 +520,7 @@ export const expectedIncompleteLeftMountTaskList: TaskListProps = {
       taskIndex: 2,
     },
   ],
+  taskListStatus: 'incomplete',
 }
 
 export const expectedIncompleteRightMountTaskList: TaskListProps = {
@@ -604,4 +608,5 @@ export const expectedIncompleteRightMountTaskList: TaskListProps = {
       taskIndex: 2,
     },
   ],
+  taskListStatus: 'incomplete',
 }

--- a/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
@@ -245,6 +245,102 @@ export const expectedTaskList: TaskListProps = {
   ],
 }
 
+export const expectedFailedTaskList: TaskListProps = {
+  activeIndex: [2, 0],
+  taskList: [
+    // deck calibration task
+    {
+      subTasks: [],
+      taskListLength: TASK_COUNT,
+      activeIndex: [2, 0],
+      description: '',
+      title: 'Deck Calibration',
+      footer: `Last completed ${formatTimestamp(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        mockCompleteDeckCalibration.deckCalibrationData.lastModified!
+      )}`,
+      cta: { label: 'Recalibrate', onClick: () => {} },
+      isComplete: true,
+      taskIndex: 0,
+    },
+    // left mount calibration task
+    {
+      subTasks: [
+        // tip length calibration subtask
+        {
+          activeIndex: [2, 0],
+          description: '',
+          title: 'Tip Length Calibration',
+          footer: `Last completed ${formatTimestamp(
+            mockCompleteTipLengthCalibrations[0].lastModified
+          )}`,
+          cta: { label: 'Recalibrate', onClick: mockTipLengthCalLauncher },
+          isComplete: true,
+          taskIndex: 1,
+          subTaskIndex: 0,
+        },
+        // offset calibration subtask
+        {
+          activeIndex: [2, 0],
+          description: '',
+          title: 'Pipette Offset Calibration',
+          footer: `Last completed ${formatTimestamp(
+            mockCompletePipetteOffsetCalibrations[0].lastModified
+          )}`,
+          cta: { label: 'Recalibrate', onClick: mockPipOffsetCalLauncher },
+          isComplete: true,
+          taskIndex: 1,
+          subTaskIndex: 1,
+        },
+      ],
+      isComplete: true,
+      taskListLength: TASK_COUNT,
+      activeIndex: [2, 0],
+      description: 'Test Left Display Name, test-left',
+      title: 'Left Mount',
+      taskIndex: 1,
+    },
+    // right mount calibration task
+    {
+      subTasks: [
+        // tip length calibration subtask
+        {
+          activeIndex: [2, 0],
+          description: '',
+          title: 'Tip Length Calibration',
+          footer: `Last completed ${formatTimestamp(
+            mockCompleteTipLengthCalibrations[1].lastModified
+          )}`,
+          cta: { label: 'Recalibrate', onClick: mockTipLengthCalLauncher },
+          markedBad: true,
+          taskIndex: 2,
+          subTaskIndex: 0,
+        },
+        // offset calibration subtask
+        {
+          activeIndex: [2, 0],
+          description: '',
+          title: 'Pipette Offset Calibration',
+          footer: `Last completed ${formatTimestamp(
+            mockCompletePipetteOffsetCalibrations[1].lastModified
+          )}`,
+          cta: { label: 'Recalibrate', onClick: mockPipOffsetCalLauncher },
+          isComplete: true,
+          taskIndex: 2,
+          subTaskIndex: 1,
+        },
+      ],
+      isComplete: false,
+      markedBad: true,
+      taskListLength: TASK_COUNT,
+      activeIndex: [2, 0],
+      description: 'Test Right Display Name, test-right',
+      title: 'Right Mount',
+      taskIndex: 2,
+    },
+  ],
+}
+
 export const expectedIncompleteDeckCalTaskList: TaskListProps = {
   activeIndex: [0, 0],
   taskList: [

--- a/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
+++ b/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
@@ -91,6 +91,7 @@ export function useCalibrationTaskList(
     activeTaskIndices = [0, 0]
     deckTask.description = t('start_with_deck_calibration')
     deckTask.cta = { label: t('calibrate'), onClick: deckCalLauncher }
+    deckTask.markedBad = deckCalibrationData !== undefined
   }
 
   taskList.taskList.push(deckTask)
@@ -218,6 +219,7 @@ export function useCalibrationTaskList(
                 hasBlockModalResponse: null,
               }),
           }
+          tipLengthSubTask.markedBad = tipLengthCalForPipette !== undefined
         } else {
           // the tip length calibration is present and valid
           tipLengthSubTask.footer = t('robot_calibration:last_completed_on', {
@@ -256,6 +258,7 @@ export function useCalibrationTaskList(
                 withIntent: INTENT_CALIBRATE_PIPETTE_OFFSET,
               }),
           }
+          offsetSubTask.markedBad = offsetCalForPipette !== undefined
         } else {
           // the offset calibration is present and valid
           offsetSubTask.footer = t('robot_calibration:last_completed_on', {

--- a/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
+++ b/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
@@ -33,9 +33,9 @@ const CALIBRATION_DATA_POLL_MS = 5000
 
 export function useCalibrationTaskList(
   robotName: string,
-  pipOffsetCalLauncher: DashboardCalOffsetInvoker,
-  tipLengthCalLauncher: DashboardCalTipLengthInvoker,
-  deckCalLauncher: DashboardCalDeckInvoker
+  pipOffsetCalLauncher: DashboardCalOffsetInvoker = () => {},
+  tipLengthCalLauncher: DashboardCalTipLengthInvoker = () => {},
+  deckCalLauncher: DashboardCalDeckInvoker = () => {}
 ): TaskListProps {
   const { t } = useTranslation(['robot_calibration', 'devices_landing'])
   const dispatch = useDispatch()

--- a/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
+++ b/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
@@ -190,6 +190,8 @@ export function useCalibrationTaskList(
         pipetteTask.subTasks.push(tipLengthSubTask)
         pipetteTask.subTasks.push(offsetSubTask)
 
+        pipetteTask.markedBad = pipetteTask.subTasks.every(st => st.markedBad)
+
         taskList.taskList.push(pipetteTask)
 
         if (taskIndex < TASK_LIST_LENGTH - 1) {
@@ -278,6 +280,9 @@ export function useCalibrationTaskList(
         // We've got the appropriately constructed subtasks, push them to the pipette task, then the task list
         pipetteTask.subTasks.push(tipLengthSubTask)
         pipetteTask.subTasks.push(offsetSubTask)
+
+        pipetteTask.markedBad = pipetteTask.subTasks.every(st => st.markedBad)
+
         taskList.taskList.push(pipetteTask)
 
         if (taskIndex < TASK_LIST_LENGTH - 1) {

--- a/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
+++ b/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
@@ -44,6 +44,7 @@ export function useCalibrationTaskList(
   let activeTaskIndices: [number, number] | null = null
   const taskList: TaskListProps = {
     activeIndex: null,
+    taskListStatus: 'incomplete',
     taskList: [],
   }
   // 3 main tasks: Deck, Left Mount, and Right Mount Calibrations
@@ -294,5 +295,22 @@ export function useCalibrationTaskList(
   }
 
   taskList.activeIndex = activeTaskIndices
+
+  // Set top-level state of calibration status
+  // if the tasklist is empty, though, all calibrations are good
+
+  let calibrationStatus = 'incomplete'
+
+  if (activeTaskIndices == null) {
+    calibrationStatus = 'complete'
+    // if we have tasks and they are all marked bad, then we should
+    // strongly suggest they re-do those calibrations
+  } else if (
+    taskList.taskList.every(tp => tp.isComplete === true || tp.markedBad)
+  ) {
+    calibrationStatus = 'bad'
+  }
+  taskList.taskListStatus = calibrationStatus
+
   return taskList
 }

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -19,6 +19,7 @@ import { formatLastCalibrated, getDisplayNameForTipRack } from './utils'
 import { getCustomLabwareDefinitions } from '../../../redux/custom-labware'
 import { useAttachedPipettes, useIsOT3 } from '../../../organisms/Devices/hooks'
 
+import * as Config from '../../../redux/config'
 import type { State } from '../../../redux/types'
 import type { FormattedPipetteOffsetCalibration } from '..'
 
@@ -62,6 +63,10 @@ export function PipetteOffsetCalibrationItems({
   })
   const attachedPipettes = useAttachedPipettes()
   const isOT3 = useIsOT3(robotName)
+
+  const enableCalibrationWizards = Config.useFeatureFlag(
+    'enableCalibrationWizards'
+  )
 
   return (
     <StyledTable>
@@ -113,39 +118,49 @@ export function PipetteOffsetCalibrationItems({
                       </>
                     ) : (
                       <>
-                        {calibration.markedBad ?? false ? (
-                          <>
-                            <Icon
-                              name="alert-circle"
-                              backgroundColor={COLORS.warningBackgroundLight}
-                              color={COLORS.warningEnabled}
-                              size={SPACING.spacing4}
-                            />
-                            <StyledText
-                              as="p"
-                              marginLeft={SPACING.spacing2}
-                              width="100%"
-                              color={COLORS.warningText}
-                            >
-                              {t('recalibration_recommended')}
-                            </StyledText>
-                          </>
+                        {enableCalibrationWizards ? (
+                          <StyledText as="p">
+                            {t('not_calibrated_short')}
+                          </StyledText>
                         ) : (
                           <>
-                            <Icon
-                              name="alert-circle"
-                              backgroundColor={COLORS.errorBackgroundLight}
-                              color={COLORS.errorEnabled}
-                              size={SPACING.spacing4}
-                            />
-                            <StyledText
-                              as="p"
-                              marginLeft={SPACING.spacing2}
-                              width="100%"
-                              color={COLORS.errorText}
-                            >
-                              {t('missing_calibration')}
-                            </StyledText>
+                            {calibration.markedBad ?? false ? (
+                              <>
+                                <Icon
+                                  name="alert-circle"
+                                  backgroundColor={
+                                    COLORS.warningBackgroundLight
+                                  }
+                                  color={COLORS.warningEnabled}
+                                  size={SPACING.spacing4}
+                                />
+                                <StyledText
+                                  as="p"
+                                  marginLeft={SPACING.spacing2}
+                                  width="100%"
+                                  color={COLORS.warningText}
+                                >
+                                  {t('recalibration_recommended')}
+                                </StyledText>
+                              </>
+                            ) : (
+                              <>
+                                <Icon
+                                  name="alert-circle"
+                                  backgroundColor={COLORS.errorBackgroundLight}
+                                  color={COLORS.errorEnabled}
+                                  size={SPACING.spacing4}
+                                />
+                                <StyledText
+                                  as="p"
+                                  marginLeft={SPACING.spacing2}
+                                  width="100%"
+                                  color={COLORS.errorText}
+                                >
+                                  {t('missing_calibration')}
+                                </StyledText>
+                              </>
+                            )}
                           </>
                         )}
                       </>

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -120,7 +120,16 @@ export function PipetteOffsetCalibrationItems({
                       <>
                         {enableCalibrationWizards ? (
                           <StyledText as="p">
-                            {t('not_calibrated_short')}
+                            {calibration.lastCalibrated != null &&
+                            calibration.markedBad === true ? (
+                              <>
+                                {formatLastCalibrated(
+                                  calibration.lastCalibrated
+                                )}
+                              </>
+                            ) : (
+                              <>{t('not_calibrated_short')}</>
+                            )}
                           </StyledText>
                         ) : (
                           <>

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/PipetteOffsetCalibrationItems.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/PipetteOffsetCalibrationItems.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../organisms/Devices/hooks'
 import { PipetteOffsetCalibrationItems } from '../PipetteOffsetCalibrationItems'
 import { OverflowMenu } from '../OverflowMenu'
+import { formatLastCalibrated } from '../utils'
 
 import type { AttachedPipettesByMount } from '../../../../redux/pipettes/types'
 
@@ -179,7 +180,7 @@ describe('PipetteOffsetCalibrationItems', () => {
     getByText('Recalibration recommended')
   })
 
-  it('should not render icon and text when calibration recommended and when the calibration wizard feature flag is set', () => {
+  it('should only render last calibrated date text when calibration recommended and when the calibration wizard feature flag is set', () => {
     when(mockUseFeatureFlag)
       .calledWith('enableCalibrationWizards')
       .mockReturnValue(true)
@@ -196,7 +197,9 @@ describe('PipetteOffsetCalibrationItems', () => {
         },
       ],
     }
-    const [{ queryByText }] = render(props)
+    const [{ getByText, queryByText }] = render(props)
+    expect(queryByText('Not calibrated')).not.toBeInTheDocument()
     expect(queryByText('Recalibration recommended')).not.toBeInTheDocument()
+    getByText(formatLastCalibrated('2022-11-10T18:15:02'))
   })
 })

--- a/app/src/organisms/RobotSettingsCalibration/RobotSettingsDeckCalibration.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/RobotSettingsDeckCalibration.tsx
@@ -92,7 +92,7 @@ export function RobotSettingsDeckCalibration({
   }
 
   const deckCalibrationButtonText =
-    deckCalibrationStatus &&
+    deckCalibrationStatus != null &&
     deckCalibrationStatus !== Calibration.DECK_CAL_STATUS_IDENTITY
       ? t('recalibrate_deck')
       : t('calibrate_deck')
@@ -176,7 +176,7 @@ export function RobotSettingsDeckCalibration({
 
   return (
     <>
-      {deckCalibrationBanner}
+      {!enableCalibrationWizards && deckCalibrationBanner}
       <Box paddingTop={SPACING.spacing5} paddingBottom={SPACING.spacing5}>
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Box marginRight={SPACING.spacing6}>

--- a/app/src/organisms/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
@@ -53,7 +53,7 @@ export function RobotSettingsPipetteOffsetCalibration({
 
   return (
     <>
-      {showPipetteOffsetCalibrationBanner && (
+      {!enableCalibrationWizards && showPipetteOffsetCalibrationBanner && (
         <Banner
           type={pipetteOffsetCalBannerType === 'error' ? 'error' : 'warning'}
         >

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsDeckCalibration.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsDeckCalibration.test.tsx
@@ -123,6 +123,22 @@ describe('RobotSettingsDeckCalibration', () => {
     getByRole('button', { name: 'Calibrate now' })
   })
 
+  it('does not render the error banner when deck is not calibrated and when the calibration wizard feature flag is set', () => {
+    mockUseDeckCalibrationStatus.mockReturnValue(
+      Calibration.DECK_CAL_STATUS_IDENTITY
+    )
+    mockUseDeckCalibrationData.mockReturnValue({
+      deckCalibrationData: null,
+      isDeckCalibrated: false,
+    })
+    mockUseFeatureFlag.mockReturnValue(true)
+    const [{ queryByRole, queryByText }] = render()
+    expect(queryByText('Deck calibration missing')).not.toBeInTheDocument()
+    expect(
+      queryByRole('button', { name: 'Calibrate now' })
+    ).not.toBeInTheDocument()
+  })
+
   it('deck cal button should be disabled if a button disabled reason is provided', () => {
     const [{ getByRole }] = render({
       buttonDisabledReason: 'otie is unreachable',

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
@@ -9,6 +9,7 @@ import {
   mockPipetteOffsetCalibration2,
   mockPipetteOffsetCalibration3,
 } from '../../../redux/calibration/pipette-offset/__fixtures__'
+import { useFeatureFlag } from '../../../redux/config'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import {
   useIsOT3,
@@ -22,8 +23,12 @@ import { PipetteOffsetCalibrationItems } from '../CalibrationDetails/PipetteOffs
 import type { FormattedPipetteOffsetCalibration } from '..'
 
 jest.mock('../../../organisms/Devices/hooks')
+jest.mock('../../../redux/config')
 jest.mock('../CalibrationDetails/PipetteOffsetCalibrationItems')
 
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
 const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUsePipetteOffsetCalibrations = usePipetteOffsetCalibrations as jest.MockedFunction<
   typeof usePipetteOffsetCalibrations
@@ -70,6 +75,9 @@ describe('RobotSettingsPipetteOffsetCalibration', () => {
     mockPipetteOffsetCalibrationItems.mockReturnValue(
       <div>PipetteOffsetCalibrationItems</div>
     )
+    when(mockUseFeatureFlag)
+      .calledWith('enableCalibrationWizards')
+      .mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -110,11 +118,37 @@ describe('RobotSettingsPipetteOffsetCalibration', () => {
     getByText('Pipette Offset calibration missing')
   })
 
+  it('does not render the error banner when error props provided and when the calibration wizard feature flag is set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('enableCalibrationWizards')
+      .mockReturnValue(true)
+    const [{ queryByText }] = render({
+      showPipetteOffsetCalibrationBanner: true,
+      pipetteOffsetCalBannerType: 'error',
+    })
+    expect(
+      queryByText('Pipette Offset calibration missing')
+    ).not.toBeInTheDocument()
+  })
+
   it('renders the warning banner when warning props provided', () => {
     const [{ getByText }] = render({
       showPipetteOffsetCalibrationBanner: true,
       pipetteOffsetCalBannerType: 'warning',
     })
     getByText('Pipette Offset calibration recommended')
+  })
+
+  it('does not render the warning banner when warning props provided and when the calibration wizard feature flag is set', () => {
+    when(mockUseFeatureFlag)
+      .calledWith('enableCalibrationWizards')
+      .mockReturnValue(true)
+    const [{ queryByText }] = render({
+      showPipetteOffsetCalibrationBanner: true,
+      pipetteOffsetCalBannerType: 'warning',
+    })
+    expect(
+      queryByText('Pipette Offset calibration recommended')
+    ).not.toBeInTheDocument()
   })
 })

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -387,7 +387,7 @@ export function TaskList({
       <Flex
         alignItems={ALIGN_CENTER}
         gridGap={SPACING.spacing3}
-        paddingTop={SPACING.spacing4}
+        padding={SPACING.spacing4}
         paddingBottom={SPACING.spacing6}
       >
         <StyledText css={TYPOGRAPHY.h2SemiBold}>

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
 
 import {
   Flex,
@@ -18,7 +17,6 @@ import {
 } from '@opentrons/components'
 
 import { TertiaryButton } from '../../atoms/buttons'
-import { StatusLabel } from '../../atoms/StatusLabel'
 import { StyledText } from '../../atoms/text'
 
 import type { SubTaskProps, TaskListProps, TaskProps } from './types'
@@ -362,69 +360,27 @@ export function TaskList({
   activeIndex,
   taskList,
 }: TaskListProps): JSX.Element {
-  const { t } = useTranslation('robot_calibration')
-
-  // start off assuming we are missing calibrations
-  let statusLabelBackgroundColor = COLORS.errorEnabled
-  let statusLabelIconColor = COLORS.errorEnabled
-  let statusLabelText = t('missing_calibration_data')
-
-  // if the tasklist is empty, though, all calibrations are good
-  if (activeIndex == null) {
-    statusLabelBackgroundColor = COLORS.successEnabled
-    statusLabelIconColor = COLORS.successEnabled
-    statusLabelText = t('calibration_complete')
-    // if we have tasks and they are all marked bad, then we should
-    // strongly suggest they re-do those calibrations
-  } else if (taskList.every(tp => tp.isComplete === true || tp.markedBad)) {
-    statusLabelBackgroundColor = COLORS.warningEnabled
-    statusLabelIconColor = COLORS.warningEnabled
-    statusLabelText = t('calibration_recommended')
-  }
-
   return (
-    <>
-      <Flex
-        alignItems={ALIGN_CENTER}
-        gridGap={SPACING.spacing3}
-        padding={SPACING.spacing4}
-        paddingBottom={SPACING.spacing6}
-      >
-        <StyledText css={TYPOGRAPHY.h2SemiBold}>
-          {t('calibration_status')}
-        </StyledText>
-        <StatusLabel
-          status={statusLabelText}
-          backgroundColor={`${String(statusLabelBackgroundColor)}${String(
-            COLORS.opacity12HexCode
-          )}`}
-          iconColor={statusLabelIconColor}
-          textColor={COLORS.darkBlackEnabled}
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          iconSize="0.313rem"
-        />
-      </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
-        {taskList.map(
-          (
-            { title, description, cta, footer, subTasks, isComplete },
-            taskIndex
-          ) => (
-            <Task
-              key={title}
-              title={title}
-              description={description}
-              cta={cta}
-              footer={footer}
-              subTasks={subTasks}
-              activeIndex={activeIndex}
-              taskIndex={taskIndex}
-              taskListLength={taskList.length}
-              isComplete={isComplete}
-            />
-          )
-        )}
-      </Flex>
-    </>
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
+      {taskList.map(
+        (
+          { title, description, cta, footer, subTasks, isComplete },
+          taskIndex
+        ) => (
+          <Task
+            key={title}
+            title={title}
+            description={description}
+            cta={cta}
+            footer={footer}
+            subTasks={subTasks}
+            activeIndex={activeIndex}
+            taskIndex={taskIndex}
+            taskListLength={taskList.length}
+            isComplete={isComplete}
+          />
+        )
+      )}
+    </Flex>
   )
 }

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -384,7 +384,12 @@ export function TaskList({
 
   return (
     <>
-      <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+      <Flex
+        alignItems={ALIGN_CENTER}
+        gridGap={SPACING.spacing3}
+        paddingTop={SPACING.spacing4}
+        paddingBottom={SPACING.spacing6}
+      >
         <StyledText css={TYPOGRAPHY.h2SemiBold}>
           {t('calibration_status')}
         </StyledText>

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -376,10 +376,7 @@ export function TaskList({
     statusLabelText = t('calibration_complete')
     // if we have tasks and they are all marked bad, then we should
     // strongly suggest they re-do those calibrations
-  } else if (
-    taskList.filter(tp => tp.subTasks.every(st => st.markedBad)).length ===
-    taskList.length
-  ) {
+  } else if (taskList.every(tp => tp.isComplete === true || tp.markedBad)) {
     statusLabelBackgroundColor = COLORS.warningEnabled
     statusLabelIconColor = COLORS.warningEnabled
     statusLabelText = t('calibration_recommended')

--- a/app/src/organisms/TaskList/types.ts
+++ b/app/src/organisms/TaskList/types.ts
@@ -25,4 +25,5 @@ export interface TaskListProps {
   // null activeIndex: all tasks complete
   activeIndex: [number, number] | null
   taskList: TaskProps[]
+  taskListStatus: string | null
 }

--- a/app/src/organisms/TaskList/types.ts
+++ b/app/src/organisms/TaskList/types.ts
@@ -12,6 +12,7 @@ export interface SubTaskProps {
   cta?: SubTaskCTA
   footer?: string
   isComplete?: boolean
+  markedBad?: boolean
 }
 
 export interface TaskProps extends Omit<SubTaskProps, 'subTaskIndex'> {


### PR DESCRIPTION
# Overview

The calibration status banners have been moved from individual sections of the robot calibration settings page to the top there and the new calibration wizard page. This PR adds a flag to the task list so the banner can know which of the three states it should display (uncalibrated, recalibration recommended, successful), moves the banners to the right places, and tones down status text elsewhere.

All changes are safely tucked away behind the calibration wizard feature flag

# Changelog

- Remove status banners from deck and pipette sections
- Replace scary not calibrated warning with regular text for individual pipettes
- Add markedBad flag to subtasks in calibration task list
- Add status banner to calibration status card and task list

# Review requests

- "Missing calibration data" status appears on robot settings or in calibration dashboard when some calibration data is present, but not all
- "Calibration recommended" status only appears on robot settings or in calibration dashboard as a result of a failed calibration health check
- "Calibration complete" status appears on robot settings page and in dashboard only when all data present
- No calibration status banners shows up in the deck cal, tlc, or poc sections of the robot settings page
- When all calibrations are complete the only way a user can access the dashboard from the robot devices page is by clicking the menu overflow and clicking ‘Robot Settings’ > 'Launch Calibration'

Calibration for OT3 is currently broken in edge, so you'll have the easiest time verifying the various states with an OT2.

# Risk assessment

All changes are safely tucked away behind the calibration wizard feature flag, so risk to existing users is very low. The riskiest bit of logic is that which differentiates between calibration with missing data and calibration with data that is marked bad. Both are failing states, but the latter gets the "Calibration recommended" status.
