### PR TITLE
fix(hardware-testing: place firmware tar in writable directory during firmware update

### DIFF
--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -73,7 +73,6 @@ test-cov:
 
 .PHONY: test-integration
 test-integration:
-	$(python) -m hardware_testing.production_qc.pipette_assembly_qc_ot3 --operator test --simulate
 	$(python) protocols/ot2_p300_single_channel_gravimetric.py --simulate
 	$(python) -m hardware_testing.examples.custom_axis_settings_ot3 --simulate
 	$(python) -m hardware_testing.examples.endstop_encoder_ot3 --simulate
@@ -164,17 +163,8 @@ push-all-and-term: push-all term
 
 .PHONY: pull-data-ot3
 pull-data-ot3:
-	mkdir -p "./.pulled-data"
-	scp -r "root@$(host):/home/root/.opentrons/testing_data/$(test)" "./.pulled-data"
-
-define delete-test-data-cmd
-ssh -i $(2) $(3) root@$(1) \
-"rm -rf /home/root/.opentrons/testing_data/$(4)"
-endef
-
-.PHONY: delete-data-ot3
-delete-data-ot3:
-	$(call delete-test-data-cmd,$(host),$(br_ssh_key),$(ssh_opts),$(test))
+	mkdir -p ./.pulled-data
+	scp -r root@$(host):/home/root/.opentrons/testing_data/$(test) ./.pulled-data
 
 define push-and-update-fw
 scp -i $(2) $(3) ot3-firmware.tar.gz root@$(1):/data/$(notdir ot3-firmware.tar.gz)

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -73,6 +73,7 @@ test-cov:
 
 .PHONY: test-integration
 test-integration:
+	$(python) -m hardware_testing.production_qc.pipette_assembly_qc_ot3 --operator test --simulate
 	$(python) protocols/ot2_p300_single_channel_gravimetric.py --simulate
 	$(python) -m hardware_testing.examples.custom_axis_settings_ot3 --simulate
 	$(python) -m hardware_testing.examples.endstop_encoder_ot3 --simulate
@@ -163,17 +164,30 @@ push-all-and-term: push-all term
 
 .PHONY: pull-data-ot3
 pull-data-ot3:
-	mkdir -p ./.pulled-data
-	scp -r root@$(host):/data/testing_data/$(test) ./.pulled-data
+	mkdir -p "./.pulled-data"
+	scp -r "root@$(host):/home/root/.opentrons/testing_data/$(test)" "./.pulled-data"
 
-define extract-and-update-fw
+define delete-test-data-cmd
 ssh -i $(2) $(3) root@$(1) \
-"cd /opt/opentrons-robot-server &&\
-(rm -rf ot3-firmware || true) &&\
+"rm -rf /home/root/.opentrons/testing_data/$(4)"
+endef
+
+.PHONY: delete-data-ot3
+delete-data-ot3:
+	$(call delete-test-data-cmd,$(host),$(br_ssh_key),$(ssh_opts),$(test))
+
+define push-and-update-fw
+scp -i $(2) $(3) ot3-firmware.tar.gz root@$(1):/data/$(notdir ot3-firmware.tar.gz)
+ssh -i $(2) $(3) root@$(1) \
+"function cleanup () { rm -f /data/$(notdir ot3-firmware.tar.gz) && mount -o remount,ro / ; } ;\
+mount -o remount,rw / &&\
+cd /opt/opentrons-robot-server &&\
+(rm -rf ot3-firmware || true) && (rm -f ot3-firmware.tar.gz || true) &&\
+mv /data/ot3-firmware.tar.gz /opt/opentrons-robot-server &&\
 tar -xvf ot3-firmware.tar.gz &&\
 ls ./ot3-firmware &&\
 python3 -m hardware_testing.scripts.update_fw_ot3 --folder /opt/opentrons-robot-server/ot3-firmware &&\
-ls ./ot3-firmware"
+ls ./ot3-firmware && cleanup"
 endef
 
 .PHONY: sync-sw-ot3
@@ -185,8 +199,7 @@ sync-sw-ot3:
 
 .PHONY: sync-fw-ot3
 sync-fw-ot3:
-	scp ot3-firmware.tar.gz root@$(host):/opt/opentrons-robot-server
-	$(call extract-and-update-fw,$(host),$(br_ssh_key),$(ssh_opts))
+	$(call push-and-update-fw,$(host),$(br_ssh_key),$(ssh_opts))
 
 .PHONY: sync-ot3
 sync-ot3: sync-sw-ot3 sync-fw-ot3


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This PR placing the firmware TAR file in a writable directory during the firmware update process initiated by `make sync-fw-ot3`

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
