### PR TITLE
feat(app): z axis screw error handling

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -63,5 +63,8 @@
   "gantry_empty_for_96_channel_success": "Now that both mounts are empty, you can begin the 96-Channel Pipette attachment process.",
   "attach_pip": "attach pipette",
   "attach_96_channel_plus_detach": "Detach {{pipetteName}} and Attach 96-Channel Pipette",
-  "all_pipette_detached": "All Pipettes Successfully Detached"
+  "all_pipette_detached": "All Pipettes Successfully Detached",
+  "z_axis_still_attached": "Z-axis Screw Still Attached",
+  "detach_z_axis_screw_again": "Please detach and Z-axis screw to proceed with attaching 96-channel pipette",
+  "cancel_attachment": "Cancel attachment"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -64,7 +64,7 @@
   "attach_pip": "attach pipette",
   "attach_96_channel_plus_detach": "Detach {{pipetteName}} and Attach 96-Channel Pipette",
   "all_pipette_detached": "All Pipettes Successfully Detached",
-  "z_axis_still_attached": "Z-axis Screw Still Attached",
-  "detach_z_axis_screw_again": "Please detach and Z-axis screw to proceed with attaching 96-channel pipette",
+  "z_axis_still_attached": "Z-axis Screw Still Secure",
+  "detach_z_axis_screw_again": "You need to loosen the screw before you can attach the 96-Channel Pipette",
   "cancel_attachment": "Cancel attachment"
 }

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -1,24 +1,61 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import capitalize from 'lodash/capitalize'
-import { SPACING } from '@opentrons/components'
+import {
+  COLORS,
+  SPACING,
+  TEXT_TRANSFORM_CAPITALIZE,
+} from '@opentrons/components'
 import { SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
 import unscrewCarriage from '../../assets/images/change-pip/unscrew-carriage.png'
 import { FLOWS } from './constants'
+import { CheckZAxisButton } from './CheckZaxisButton'
 
-import type { PipetteWizardStepProps } from './types'
+import type { PipetteWizardStepProps, ZAxisScrewStatus } from './types'
 
 export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
   const { goBack, proceed, flowType, selectedPipette } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
+  const [
+    zAxisScrewStatus,
+    setZAxisScrewStatus,
+  ] = React.useState<ZAxisScrewStatus>('unknown')
 
   //  this should never happen but to be safe
   if (selectedPipette === SINGLE_MOUNT_PIPETTES || flowType === FLOWS.CALIBRATE)
     return null
 
-  return (
+  React.useEffect(() => {
+    if (zAxisScrewStatus === 'attached' || zAxisScrewStatus === 'detached')
+      proceed()
+  }, [proceed, zAxisScrewStatus])
+
+  return zAxisScrewStatus === 'stillAttached' ? (
+    <SimpleWizardBody
+      iconColor={COLORS.errorEnabled}
+      header={t('z_axis_still_attached')}
+      subHeader={t('detach_z_axis_screw_again')}
+      isSuccess={false}
+    >
+      <SecondaryButton
+        onClick={() => setZAxisScrewStatus('unknown')}
+        marginRight={SPACING.spacing2}
+      >
+        {t('cancel_attachment')}
+      </SecondaryButton>
+      <PrimaryButton
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        //  TODO(jr 1/12/23): wire this up correctly when we wire up backend for checking z axis screw
+        onClick={() => setZAxisScrewStatus('attached')}
+      >
+        {t('shared:try_again')}
+      </PrimaryButton>
+    </SimpleWizardBody>
+  ) : (
     <GenericWizardTile
       header={t(
         flowType === FLOWS.ATTACH ? 'unscrew_carriage' : 'reattach_carriage'
@@ -44,9 +81,13 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
           }}
         />
       }
-      proceedButtonText={capitalize(t('shared:continue'))}
-      proceed={proceed}
       back={goBack}
+      proceedButton={
+        <CheckZAxisButton
+          proceedButtonText={capitalize(t('shared:continue'))}
+          setZAxisScrewStatus={setZAxisScrewStatus}
+        />
+      }
     />
   )
 }

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -24,12 +24,17 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
     zAxisScrewStatus,
     setZAxisScrewStatus,
   ] = React.useState<ZAxisScrewStatus>('unknown')
+  const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
 
   React.useEffect(() => {
     if (zAxisScrewStatus === 'attached' || zAxisScrewStatus === 'detached')
       proceed()
   }, [proceed, zAxisScrewStatus])
 
+  const handleErrorTryAgain = (): void => {
+    setZAxisScrewStatus('attached')
+    setNumberOfTryAgains(numberOfTryAgains + 1)
+  }
   //  this should never happen but to be safe
   if (selectedPipette === SINGLE_MOUNT_PIPETTES || flowType === FLOWS.CALIBRATE)
     return null
@@ -47,13 +52,15 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
       >
         {t('cancel_attachment')}
       </SecondaryButton>
-      <PrimaryButton
-        textTransform={TEXT_TRANSFORM_CAPITALIZE}
-        //  TODO(jr 1/12/23): wire this up correctly when we wire up backend for checking z axis screw
-        onClick={() => setZAxisScrewStatus('attached')}
-      >
-        {t('shared:try_again')}
-      </PrimaryButton>
+      {numberOfTryAgains < 2 ? (
+        <PrimaryButton
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          //  TODO(jr 1/12/23): wire this up correctly when we wire up backend for checking z axis screw
+          onClick={handleErrorTryAgain}
+        >
+          {t('shared:try_again')}
+        </PrimaryButton>
+      ) : null}
     </SimpleWizardBody>
   ) : (
     <GenericWizardTile
@@ -85,7 +92,9 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
       proceedButton={
         <CheckZAxisButton
           proceedButtonText={capitalize(t('shared:continue'))}
+          numberOfTryAgains={numberOfTryAgains}
           setZAxisScrewStatus={setZAxisScrewStatus}
+          setNumberOfTryAgains={setNumberOfTryAgains}
         />
       }
     />

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -13,7 +13,7 @@ import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
 import unscrewCarriage from '../../assets/images/change-pip/unscrew-carriage.png'
 import { FLOWS } from './constants'
-import { CheckZAxisButton } from './CheckZAxisButton'
+import { CheckZAxisButton } from './CheckZaxisButton'
 
 import type { PipetteWizardStepProps, ZAxisScrewStatus } from './types'
 

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -13,7 +13,7 @@ import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
 import unscrewCarriage from '../../assets/images/change-pip/unscrew-carriage.png'
 import { FLOWS } from './constants'
-import { CheckZAxisButton } from './CheckZaxisButton'
+import { CheckZAxisButton } from './CheckZAxisButton'
 
 import type { PipetteWizardStepProps, ZAxisScrewStatus } from './types'
 

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -25,14 +25,14 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
     setZAxisScrewStatus,
   ] = React.useState<ZAxisScrewStatus>('unknown')
 
-  //  this should never happen but to be safe
-  if (selectedPipette === SINGLE_MOUNT_PIPETTES || flowType === FLOWS.CALIBRATE)
-    return null
-
   React.useEffect(() => {
     if (zAxisScrewStatus === 'attached' || zAxisScrewStatus === 'detached')
       proceed()
   }, [proceed, zAxisScrewStatus])
+
+  //  this should never happen but to be safe
+  if (selectedPipette === SINGLE_MOUNT_PIPETTES || flowType === FLOWS.CALIBRATE)
+    return null
 
   return zAxisScrewStatus === 'stillAttached' ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/CheckZaxisButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckZaxisButton.tsx
@@ -5,11 +5,21 @@ import type { ZAxisScrewStatus } from './types'
 interface CheckZAxisButtonProps {
   proceedButtonText: string
   setZAxisScrewStatus: React.Dispatch<React.SetStateAction<ZAxisScrewStatus>>
+  setNumberOfTryAgains: React.Dispatch<React.SetStateAction<number>>
+  numberOfTryAgains: number
 }
 export const CheckZAxisButton = (props: CheckZAxisButtonProps): JSX.Element => {
-  const { proceedButtonText, setZAxisScrewStatus } = props
+  const {
+    proceedButtonText,
+    setZAxisScrewStatus,
+    setNumberOfTryAgains,
+    numberOfTryAgains,
+  } = props
   //    TODO(jr, 1/12/23): add logic for checking z axis screw here
-  const handleCheckZAxis = (): void => setZAxisScrewStatus('stillAttached')
+  const handleCheckZAxis = (): void => {
+    setZAxisScrewStatus('stillAttached')
+    setNumberOfTryAgains(numberOfTryAgains + 1)
+  }
 
   return (
     <PrimaryButton onClick={handleCheckZAxis}>

--- a/app/src/organisms/PipetteWizardFlows/CheckZaxisButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckZaxisButton.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { PrimaryButton } from '../../atoms/buttons'
+import type { ZAxisScrewStatus } from './types'
+
+interface CheckZAxisButtonProps {
+  proceedButtonText: string
+  setZAxisScrewStatus: React.Dispatch<React.SetStateAction<ZAxisScrewStatus>>
+}
+export const CheckZAxisButton = (props: CheckZAxisButtonProps): JSX.Element => {
+  const { proceedButtonText, setZAxisScrewStatus } = props
+  //    TODO(jr, 1/12/23): add logic for checking z axis screw here
+  const handleCheckZAxis = (): void => setZAxisScrewStatus('stillAttached')
+
+  return (
+    <PrimaryButton onClick={handleCheckZAxis}>
+      {proceedButtonText}
+    </PrimaryButton>
+  )
+}

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -91,9 +91,9 @@ describe('Carriage', () => {
   it('renders the error z axis still attached modal when check z axis button still detects the attachment', async () => {
     const { getByText, getByRole } = render(props)
     getByRole('button', { name: 'Continue' }).click()
-    getByText('Z-axis Screw Still Attached')
+    getByText('Z-axis Screw Still Secure')
     getByText(
-      'Please detach and Z-axis screw to proceed with attaching 96-channel pipette'
+      'You need to loosen the screw before you can attach the 96-Channel Pipette'
     )
     getByRole('button', { name: 'try again' })
     getByRole('button', { name: 'Cancel attachment' })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import {
   LEFT,
@@ -51,11 +50,8 @@ describe('Carriage', () => {
       'Loosen the captive screw on the top right of the gantry carriage. This will release the right pipette mount, which should then freely move up and down.'
     )
     getByAltText('Unscrew gantry')
-    const proceedBtn = getByRole('button', { name: 'Continue' })
-    fireEvent.click(proceedBtn)
-    expect(props.proceed).toHaveBeenCalled()
-    const backBtn = getByLabelText('back')
-    fireEvent.click(backBtn)
+    getByRole('button', { name: 'Continue' })
+    getByLabelText('back').click()
     expect(props.goBack).toHaveBeenCalled()
   })
   it('returns the correct information, buttons work as expected when flow is detach', () => {
@@ -72,11 +68,8 @@ describe('Carriage', () => {
       'When reattached, the right mount should no longer freely move up and down.'
     )
     getByAltText('Reattach carriage')
-    const proceedBtn = getByRole('button', { name: 'Continue' })
-    fireEvent.click(proceedBtn)
-    expect(props.proceed).toHaveBeenCalled()
-    const backBtn = getByLabelText('back')
-    fireEvent.click(backBtn)
+    getByRole('button', { name: 'Continue' })
+    getByLabelText('back').click()
     expect(props.goBack).toHaveBeenCalled()
   })
   it('renders null if a single mount pipette is attached', () => {
@@ -87,7 +80,6 @@ describe('Carriage', () => {
     const { container } = render(props)
     expect(container.firstChild).toBeNull()
   })
-
   it('renders null if flow is calibrate is attached', () => {
     props = {
       ...props,
@@ -95,5 +87,15 @@ describe('Carriage', () => {
     }
     const { container } = render(props)
     expect(container.firstChild).toBeNull()
+  })
+  it('renders the error z axis still attached modal when check z axis button still detects the attachment', async () => {
+    const { getByText, getByRole } = render(props)
+    getByRole('button', { name: 'Continue' }).click()
+    getByText('Z-axis Screw Still Attached')
+    getByText(
+      'Please detach and Z-axis screw to proceed with attaching 96-channel pipette'
+    )
+    getByRole('button', { name: 'try again' })
+    getByRole('button', { name: 'Cancel attachment' })
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -98,4 +98,8 @@ describe('Carriage', () => {
     getByRole('button', { name: 'try again' })
     getByRole('button', { name: 'Cancel attachment' })
   })
+  //  TODO(jr 1/13/23): when z axis screw status is fully wired up, extend test cases for:
+  // 2nd case try again button where button disappears
+  // try again button click being a success
+  // cancel attachment click
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckZAxisButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckZAxisButton.test.tsx
@@ -12,11 +12,14 @@ describe('CheckZAxisButton', () => {
     props = {
       proceedButtonText: 'continue',
       setZAxisScrewStatus: jest.fn(),
+      numberOfTryAgains: 0,
+      setNumberOfTryAgains: jest.fn(),
     }
   })
-  it('clicking on the button calls setZAxisScrewStatus prop', () => {
+  it('clicking on the button calls setZAxisScrewStatus and setNumberOfTryAgains prop', () => {
     const { getByRole } = render(props)
     getByRole('button', { name: 'continue' }).click()
     expect(props.setZAxisScrewStatus).toHaveBeenCalled()
+    expect(props.setNumberOfTryAgains).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckZAxisButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckZAxisButton.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { CheckZAxisButton } from '../CheckZAxisButton'
+
+const render = (props: React.ComponentProps<typeof CheckZAxisButton>) => {
+  return renderWithProviders(<CheckZAxisButton {...props} />)[0]
+}
+
+describe('CheckZAxisButton', () => {
+  let props: React.ComponentProps<typeof CheckZAxisButton>
+  beforeEach(() => {
+    props = {
+      proceedButtonText: 'continue',
+      setZAxisScrewStatus: jest.fn(),
+    }
+  })
+  it('clicking on the button calls setZAxisScrewStatus prop', () => {
+    const { getByRole } = render(props)
+    getByRole('button', { name: 'continue' }).click()
+    expect(props.setZAxisScrewStatus).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckZAxisButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckZAxisButton.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
-import { CheckZAxisButton } from '../CheckZAxisButton'
+import { CheckZAxisButton } from '../CheckZaxisButton'
 
 const render = (props: React.ComponentProps<typeof CheckZAxisButton>) => {
   return renderWithProviders(<CheckZAxisButton {...props} />)[0]

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -69,6 +69,12 @@ export type CreateRunCommand = (
 
 export type SelectablePipettes = '96-Channel' | 'Single-Channel_and_8-Channel'
 
+export type ZAxisScrewStatus =
+  | 'detached'
+  | 'attached'
+  | 'stillAttached'
+  | 'unknown'
+
 export interface PipetteWizardStepProps {
   flowType: PipetteWizardFlow
   mount: PipetteMount


### PR DESCRIPTION
closes RLIQ-291

# Overview

This adds error handling to the `Carriage` component to let the user know that the z axis screw has not been completely removed. Had to stub in info since we are waiting for the backend to create a way to know the z axis screw status

Error modal when user has clicked on `Try again` < 2 times
<img width="769" alt="Screen Shot 2023-01-13 at 10 54 11 AM" src="https://user-images.githubusercontent.com/66035149/212364293-947070d3-c3ba-4670-a72a-3307458b62b9.png">

Error modal when user has clicked on `Try again`  twice
<img width="766" alt="Screen Shot 2023-01-13 at 10 54 22 AM" src="https://user-images.githubusercontent.com/66035149/212364470-b3d11d0c-a79b-49ee-8a1d-54e6673fac35.png">

# Changelog

- created a `CheckZaxisButton` and test to go back and wire up all the logic later
- created a type `zAxisScrewStatus` that can be refactored when we wire up, right now the statuses can be `unknown`, `attached, `detached`, and `stillAttached`
- created the error handling modal in the `Carriage` component and updated the test

# Review requests

- go through the 96-channel pipette flows, when you hit the `Carriage` page for z axis screw status, pressing on continue will launch the error modal. If you click on `try again`, it will get you to the next page. This is the stubbed in info for now. Let me know if I should change it so it always succeeds on the first try.
- if you want to test out the `Try again` button disappearing after failing twice, go to `line 35` in `Carriage` and change `attached` to `stillAttached` 

# Risk assessment

low