### PR TITLE
ci(app,app-shell): Don't cancel other platforms' builds if one platform fails

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -94,6 +94,8 @@ jobs:
     strategy:
       matrix:
         os: ['windows-2019', 'ubuntu-22.04', 'macos-latest']
+      # If building on one platform fails, keep building on other platforms.
+      fail-fast: false  
     name: 'opentrons app backend unit tests and build'
     needs: ['js-unit-test']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Overview

In CI, we run unit tests for the app backend, and then build the app. We do this independently for Linux, macOS, and Windows. Currently, if any part of that fails on any platform, ongoing builds on the other platforms are canceled.

This PR changes that so that the other platforms continue on independently. Same gist as Opentrons/ot2-factory-tools#123. See [the GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast).

Upsides:

* If there's a bug in the app backend that only affects some platforms, it will be easier to identify which ones.
* If there's a flakey CI problem with one platform, it won't interrupt the other platforms' builds. So fewer jobs will have to be retried, and we can get to an "all green" state more quickly.

Downsides:

* If there's a bug in the app backend on all 3 platforms, it will trigger 3 failures when 1 may have sufficed.

# Review requests

* Do we agree with the upside/downside tradeoff?
* Is there anywhere else we might want this change?

# Risk assessment

This shouldn't have any risk. It doesn't affect build environments—just the behavior for when builds are canceled.