### PR TITLE
fix(api): Check module context parent is type string

### DIFF
--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -168,8 +168,8 @@ def test_parent(decoy: Decoy, mock_core: ModuleCore, subject: ModuleContext) -> 
     """Should get the parent slot name."""
     decoy.when(mock_core.get_deck_slot()).then_return(DeckSlotName.SLOT_1)
 
+    assert type(subject.parent) == str
     assert subject.parent == "1"
-    assert not isinstance(subject.parent, DeckSlotName)
 
 
 def test_module_model(

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -168,6 +168,7 @@ def test_parent(decoy: Decoy, mock_core: ModuleCore, subject: ModuleContext) -> 
     """Should get the parent slot name."""
     decoy.when(mock_core.get_deck_slot()).then_return(DeckSlotName.SLOT_1)
 
+    # TODO (tz, 1-17-23): make sure that the subject is not returning an Enum that subclasses str
     assert type(subject.parent) == str
     assert subject.parent == "1"
 


### PR DESCRIPTION
# Overview

Small fix for module context parent is type string.

# Changelog

change test to check of type str

# Risk assessment

None. change test assert. 
