### PR TITLE
feat(system-server): add PyJWT as a dependency

### DIFF
--- a/system-server/Pipfile
+++ b/system-server/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 typing-extensions = "==3.10.0.0"
+pyjwt = "==2.6.0"
 
 [dev-packages]
 system_server = {path = ".", editable = true}

--- a/system-server/Pipfile.lock
+++ b/system-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f3f5960140befbb22a8cd0b03590cf7f68c2ee8dcac1d0734f0383338fee981e"
+            "sha256": "fb9be0bc176398cda2e820166d7bd242410b06d4fc9e8495f77ee00aff728675"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "pyjwt": {
+            "hashes": [
+                "sha256:69285c7e31fc44f68a1feb309e948e0df53259d579295e6cfe2b1792329f05fd",
+                "sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",

--- a/system-server/setup.py
+++ b/system-server/setup.py
@@ -45,7 +45,9 @@ KEYWORDS = ["robots", "automation", "lab"]
 DESCRIPTION = (
     "A server to provide an external interface to the robot.")
 PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = [
+    "pyjwt==2.6.0"
+]
 
 
 def read(*parts):


### PR DESCRIPTION


# Overview

The system server will utilize JSON Web Tokens for authentication, so a python library to work with them is important. PyJWT is among the most popular choices for this, and has the added benefit of being included in the `meta-python` layer in openembedded.

# Changelog

- Added PyJWT to pipfile and setup.py

# Review requests

- [ ] Any reason to use a different library?

# Risk assessment

Low
