### PR TITLE
feat(hardware-testing): FW update tool now includes 96 head firmware updates

### DIFF
--- a/hardware-testing/.flake8
+++ b/hardware-testing/.flake8
@@ -5,6 +5,7 @@
 max-line-length = 100
 
 # max cyclomatic complexity
+# NOTE: (andy s) increasing this from 9 to 15 b/c test scripts often handle all logic in main
 max-complexity = 15
 
 extend-ignore =

--- a/hardware-testing/.flake8
+++ b/hardware-testing/.flake8
@@ -5,7 +5,7 @@
 max-line-length = 100
 
 # max cyclomatic complexity
-max-complexity = 9
+max-complexity = 15
 
 extend-ignore =
     # ignore E203 because black might reformat it

--- a/hardware-testing/build_fw.sh
+++ b/hardware-testing/build_fw.sh
@@ -14,6 +14,7 @@ FW_PATH_GANTRY_Y="$REPO_DIR/build-cross/gantry/firmware/gantry-y-rev1.hex"
 FW_PATH_HEAD="$REPO_DIR/build-cross/head/firmware/head-rev1.hex"
 FW_PATH_PIPETTES_SINGLE="$REPO_DIR/build-cross/pipettes/firmware/pipettes-single-rev1.hex"
 FW_PATH_PIPETTES_MULTI="$REPO_DIR/build-cross/pipettes/firmware/pipettes-multi-rev1.hex"
+FW_PATH_PIPETTES_96="$REPO_DIR/build-cross/pipettes/firmware/pipettes-96-rev1.hex"
 FW_PATH_GRIPPER="$REPO_DIR/build-cross/gripper/firmware/gripper-rev1.hex"
 
 # build all the firmware
@@ -25,6 +26,7 @@ cmake --build --preset=gantry-y --target=gantry-y-rev1-flash || true
 cmake --build --preset=head --target=head-rev1-flash || true
 cmake --build --preset=pipettes-rev1 --target=pipettes-single-rev1-flash || true
 cmake --build --preset=pipettes-rev1 --target=pipettes-multi-rev1-flash || true
+cmake --build --preset=pipettes-rev1 --target=pipettes-96-rev1-flash || true
 cmake --build --preset=gripper --target=gripper-rev1-flash || true
 cd "$THIS_DIR" || exit
 
@@ -36,6 +38,7 @@ cp "$FW_PATH_GANTRY_Y" "$TEMP_DIR_NAME/gantry-y-rev1.hex"
 cp "$FW_PATH_HEAD" "$TEMP_DIR_NAME/head-rev1.hex"
 cp "$FW_PATH_PIPETTES_SINGLE" "$TEMP_DIR_NAME/pipettes-single-rev1.hex"
 cp "$FW_PATH_PIPETTES_MULTI" "$TEMP_DIR_NAME/pipettes-multi-rev1.hex"
+cp "$FW_PATH_PIPETTES_96" "$TEMP_DIR_NAME/pipettes-96-rev1.hex"
 cp "$FW_PATH_GRIPPER" "$TEMP_DIR_NAME/gripper-rev1.hex"
 
 # create a dummy file, simply named after the git hash

--- a/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
@@ -111,28 +111,19 @@ async def _main(directory: Path, is_simulating: bool, skip: SkipUpdateTarget) ->
                 _run_update_fw_command(
                     path=fw.path, target=fw.target, is_simulating=is_simulating
                 )
-    # flash single-channel pipettes
-    if FW_PIP_SINGLE.path:
-        for mount in singles:
-            if (mount == "left" and not skip.left) or (
-                mount == "right" and not skip.right
-            ):
-                _run_update_fw_command(
-                    path=FW_PIP_SINGLE.path,
-                    target=FW_PIP_SINGLE.target.format(mount=mount),
-                    is_simulating=is_simulating,
-                )
-    # flash multi-channel pipettes
-    if FW_PIP_MULTI.path:
-        for mount in multis:
-            if (mount == "left" and not skip.left) or (
-                mount == "right" and not skip.right
-            ):
-                _run_update_fw_command(
-                    path=FW_PIP_MULTI.path,
-                    target=FW_PIP_MULTI.target.format(mount=mount),
-                    is_simulating=is_simulating,
-                )
+    # flash single/multi channel pipettes
+    _pip_fw_and_target = {FW_PIP_SINGLE: singles, FW_PIP_MULTI: multis}
+    for fw, mnt_list in _pip_fw_and_target.items():
+        if not fw.path:
+            continue
+        for mount in mnt_list:
+            if (mount == "left" and skip.left) or (mount == "right" and skip.right):
+                continue
+            _run_update_fw_command(
+                path=fw.path,
+                target=fw.target.format(mount=mount),
+                is_simulating=is_simulating,
+            )
     # flash 96-channel pipette
     if has_96 and FW_PIP_96.path and not skip.left:
         _run_update_fw_command(

--- a/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/update_fw_ot3.py
@@ -136,7 +136,7 @@ async def _main(directory: Path, is_simulating: bool, skip: SkipUpdateTarget) ->
     # flash 96-channel pipette
     if has_96 and FW_PIP_96.path and not skip.left:
         _run_update_fw_command(
-            path=FW_PIP_MULTI.path,
+            path=FW_PIP_96.path,
             target=FW_PIP_96.target.format(mount="left"),
             is_simulating=is_simulating,
         )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

the `./build_fw.sh` script, as well as the `hardware_testing.scripts.update_fw` scripts, all build/upload/flash 96-head pipette firmware.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Build and flash 96-head firmware
- Optionally skip different nodes when running the update script
- Increase flake8 max-complexity from `9` to `15` (just like in #11995)

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
