### PR TITLE
fix(system-server): add to python_build_utils options

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -31,6 +31,7 @@ package_entries = {
     'notify-server': PackageEntry('notify_server'),
     'hardware': PackageEntry('opentrons_hardware'),
     'usb-bridge': PackageEntry('usb_bridge'),
+    'system-server': PackageEntry('system_server'),
 }
 
 project_entries = {


### PR DESCRIPTION
# Overview

system-server wasn't added to the `python_build_utils` options when it was added. This PR rectifies that error.

# Test Plan

- [x] Run `python3 scripts/python_build_utils.py system-server ot3 dump_br_version` and confirm it outputs a valid version
- [x] Run `python3 scripts/python_build_utils.py system-server ot3 normalize_version` and confirm it outputs a valid version

# Changelog

- Added system-server option to python_build_utils.py

# Review requests



# Risk assessment

Low