### PR TITLE
feat(app): error handling when pipette fails to attach or detach

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -67,5 +67,6 @@
   "z_axis_still_attached": "Z-axis Screw Still Secure",
   "detach_z_axis_screw_again": "You need to loosen the screw before you can attach the 96-Channel Pipette",
   "cancel_attachment": "Cancel attachment",
-  "detach_and_retry": "Detach and retry"
+  "detach_and_retry": "Detach and retry",
+  "attach_and_retry": "Attach and retry"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -66,5 +66,6 @@
   "all_pipette_detached": "All Pipettes Successfully Detached",
   "z_axis_still_attached": "Z-axis Screw Still Secure",
   "detach_z_axis_screw_again": "You need to loosen the screw before you can attach the 96-Channel Pipette",
-  "cancel_attachment": "Cancel attachment"
+  "cancel_attachment": "Cancel attachment",
+  "detach_and_retry": "Detach and retry"
 }

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -58,5 +58,6 @@
   "sort_by": "Sort by",
   "alphabetical": "Alphabetical",
   "reverse": "Reverse alphabetical",
-  "next": "Next"
+  "next": "Next",
+  "something_went_wrong": "something went wrong"
 }

--- a/app/src/molecules/SimpleWizardBody/__tests__/SimpleWizardBody.test.tsx
+++ b/app/src/molecules/SimpleWizardBody/__tests__/SimpleWizardBody.test.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { COLORS, renderWithProviders } from '@opentrons/components'
+import { Skeleton } from '../../../atoms/Skeleton'
 import { SimpleWizardBody } from '..'
+
+jest.mock('../../../atoms/Skeleton')
+
+const mockSkeleton = Skeleton as jest.MockedFunction<typeof Skeleton>
 
 const render = (props: React.ComponentProps<typeof SimpleWizardBody>) => {
   return renderWithProviders(<SimpleWizardBody {...props} />)[0]
@@ -32,5 +37,14 @@ describe('SimpleWizardBody', () => {
     getByText('header')
     getByText('subheader')
     getByLabelText('ot-check')
+  })
+  it('renders a few skeletons  when it is pending', () => {
+    props = {
+      ...props,
+      isPending: true,
+    }
+    mockSkeleton.mockReturnValue(<div>mock skeleton</div>)
+    const { getAllByText } = render(props)
+    getAllByText('mock skeleton')
   })
 })

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -5,9 +5,11 @@ import {
   Flex,
   Icon,
   JUSTIFY_FLEX_END,
+  JUSTIFY_CENTER,
   SPACING,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
+import { Skeleton } from '../../atoms/Skeleton'
 
 interface Props {
   iconColor: string
@@ -15,10 +17,12 @@ interface Props {
   isSuccess: boolean
   children?: React.ReactNode
   subHeader?: string
+  isPending?: boolean
 }
+const BACKGROUND_SIZE = '47rem'
 
 export function SimpleWizardBody(props: Props): JSX.Element {
-  const { iconColor, children, header, subHeader, isSuccess } = props
+  const { iconColor, children, header, subHeader, isSuccess, isPending } = props
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
@@ -29,30 +33,51 @@ export function SimpleWizardBody(props: Props): JSX.Element {
         marginBottom="5.6875rem"
         marginTop="6.8125rem"
       >
-        <Icon
-          name={isSuccess ? 'ot-check' : 'ot-alert'}
-          size="2.5rem"
-          color={iconColor}
-          aria-label={isSuccess ? 'ot-check' : 'ot-alert'}
-        />
-        <StyledText
-          as="h1"
-          marginTop={SPACING.spacing5}
-          marginBottom={SPACING.spacing3}
-        >
-          {header}
-        </StyledText>
-        {subHeader != null ? (
-          <StyledText
-            as="p"
-            marginX="6.25rem"
-            textAlign={ALIGN_CENTER}
-            height="1.75rem"
+        {isPending ? (
+          <Flex
+            gridGap={SPACING.spacing5}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
           >
-            {subHeader}
-          </StyledText>
+            <Skeleton
+              width="6.25rem"
+              height="6.25rem"
+              backgroundSize={BACKGROUND_SIZE}
+            />
+            <Skeleton
+              width="18rem"
+              height="1.125rem"
+              backgroundSize={BACKGROUND_SIZE}
+            />
+          </Flex>
         ) : (
-          <Flex height="1.75rem" />
+          <>
+            <Icon
+              name={isSuccess ? 'ot-check' : 'ot-alert'}
+              size="2.5rem"
+              color={iconColor}
+              aria-label={isSuccess ? 'ot-check' : 'ot-alert'}
+            />
+            <StyledText
+              as="h1"
+              marginTop={SPACING.spacing5}
+              marginBottom={SPACING.spacing3}
+            >
+              {header}
+            </StyledText>
+            {subHeader != null ? (
+              <StyledText
+                as="p"
+                marginX="6.25rem"
+                textAlign={ALIGN_CENTER}
+                height="1.75rem"
+              >
+                {subHeader}
+              </StyledText>
+            ) : (
+              <Flex height="1.75rem" />
+            )}
+          </>
         )}
       </Flex>
       <Flex

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -1,17 +1,7 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
-import { fetchPipettes, FETCH_PIPETTES } from '../../redux/pipettes'
-import {
-  getRequestById,
-  useDispatchApiRequests,
-  PENDING,
-  SUCCESS,
-  FAILURE,
-} from '../../redux/robot-api'
+import { SUCCESS, FAILURE } from '../../redux/robot-api'
 import { PrimaryButton } from '../../atoms/buttons'
-
-import type { RequestState } from '../../redux/robot-api/types'
-import type { State } from '../../redux/types'
+import { useCheckPipettes } from './hooks'
 
 interface CheckPipetteButtonProps {
   robotName: string
@@ -30,26 +20,9 @@ export const CheckPipetteButton = (
     proceed,
     isDisabled,
   } = props
-  const fetchPipettesRequestId = React.useRef<string | null>(null)
-  const [dispatch] = useDispatchApiRequests(dispatchedAction => {
-    if (
-      dispatchedAction.type === FETCH_PIPETTES &&
-      'requestId' in dispatchedAction.meta &&
-      dispatchedAction.meta.requestId
-    ) {
-      fetchPipettesRequestId.current = dispatchedAction.meta.requestId
-    }
-  })
-  const handleCheckPipette = (): void =>
-    dispatch(fetchPipettes(robotName, true))
-  const requestStatus = useSelector<State, RequestState | null>(state =>
-    fetchPipettesRequestId.current
-      ? getRequestById(state, fetchPipettesRequestId.current)
-      : null
-  )?.status
-
-  const isPending = requestStatus === PENDING
-
+  const { handleCheckPipette, isPending, requestStatus } = useCheckPipettes(
+    robotName
+  )
   React.useEffect(() => {
     if (isPending) {
       setPending(isPending)

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -127,6 +127,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
     button = (
       <PrimaryButton
         onClick={handleCleanUpAndClose}
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
         disabled={isPending}
         aria-label="Results_errorExit"
       >

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -108,19 +108,23 @@ export const Results = (props: ResultsProps): JSX.Element => {
     </PrimaryButton>
   )
 
-  if (!isSuccess && flowType === FLOWS.ATTACH && numberOfTryAgains < 3) {
+  if (
+    !isSuccess &&
+    (flowType === FLOWS.ATTACH || flowType === FLOWS.DETACH) &&
+    numberOfTryAgains < 3
+  ) {
     button = (
       <PrimaryButton
         onClick={handleTryAgain}
         disabled={isPending}
         aria-label="Results_tryAgain"
       >
-        {t('detach_and_retry')}
+        {t(flowType === FLOWS.ATTACH ? 'detach_and_retry' : 'attach_and_retry')}
       </PrimaryButton>
     )
   } else if (
     !isSuccess &&
-    flowType === FLOWS.ATTACH &&
+    (flowType === FLOWS.ATTACH || flowType === FLOWS.DETACH) &&
     numberOfTryAgains <= 3
   ) {
     header = startCase(t('shared:something_went_wrong'))

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import startCase from 'lodash/startCase'
 import { COLORS, TEXT_TRANSFORM_CAPITALIZE } from '@opentrons/components'
 import { NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
 import { PrimaryButton } from '../../atoms/buttons'
+import { useDispatchApiRequest } from '../../redux/robot-api'
+import { fetchPipettes } from '../../redux/pipettes'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { FLOWS } from './constants'
+import { useCheckPipettes } from './hooks'
 import type { PipetteWizardStepProps } from './types'
 
 interface ResultsProps extends PipetteWizardStepProps {
@@ -23,8 +27,20 @@ export const Results = (props: ResultsProps): JSX.Element => {
     currentStepIndex,
     totalStepCount,
     selectedPipette,
+    robotName,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
+  const { handleCheckPipette, isPending } = useCheckPipettes(robotName)
+  const [dispatchRequest] = useDispatchApiRequest()
+  const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
+  //  when attachedPipettes updates with the try again button, if it is successful,
+  // the Results should automatically show the success screen
+  React.useEffect(() => {
+    if (robotName != null) {
+      dispatchRequest(fetchPipettes(robotName))
+    }
+  }, [dispatchRequest, robotName])
+
   let header: string = 'unknown results screen'
   let iconColor: string = COLORS.successEnabled
   let isSuccess: boolean = true
@@ -70,12 +86,53 @@ export const Results = (props: ResultsProps): JSX.Element => {
     }
   }
 
+  const handleTryAgain = (): void => {
+    handleCheckPipette()
+    setNumberOfTryAgains(numberOfTryAgains + 1)
+  }
+
   const handleProceed = (): void => {
     if (currentStepIndex === totalStepCount || !isSuccess) {
       handleCleanUpAndClose()
     } else {
       proceed()
     }
+  }
+  let button: JSX.Element = (
+    <PrimaryButton
+      textTransform={TEXT_TRANSFORM_CAPITALIZE}
+      onClick={handleProceed}
+      aria-label="Results_exit"
+    >
+      {buttonText}
+    </PrimaryButton>
+  )
+
+  if (!isSuccess && flowType === FLOWS.ATTACH && numberOfTryAgains < 3) {
+    button = (
+      <PrimaryButton
+        onClick={handleTryAgain}
+        disabled={isPending}
+        aria-label="Results_tryAgain"
+      >
+        {t('detach_and_retry')}
+      </PrimaryButton>
+    )
+  } else if (
+    !isSuccess &&
+    flowType === FLOWS.ATTACH &&
+    numberOfTryAgains <= 3
+  ) {
+    header = startCase(t('shared:something_went_wrong'))
+    button = (
+      <PrimaryButton
+        onClick={handleCleanUpAndClose}
+        disabled={isPending}
+        aria-label="Results_errorExit"
+      >
+        {t('shared:exit')}
+      </PrimaryButton>
+    )
   }
 
   return (
@@ -84,14 +141,9 @@ export const Results = (props: ResultsProps): JSX.Element => {
       header={header}
       isSuccess={isSuccess}
       subHeader={subHeader}
+      isPending={isPending}
     >
-      <PrimaryButton
-        textTransform={TEXT_TRANSFORM_CAPITALIZE}
-        onClick={handleProceed}
-        aria-label="Results_exit"
-      >
-        {buttonText}
-      </PrimaryButton>
+      {button}
     </SimpleWizardBody>
   )
 }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -14,8 +14,15 @@ import { i18n } from '../../../i18n'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { Results } from '../Results'
 import { FLOWS } from '../constants'
+import { useCheckPipettes } from '../hooks'
 
 import type { AttachedPipette } from '../../../redux/pipettes/types'
+
+jest.mock('../hooks')
+
+const mockUseCheckPipettes = useCheckPipettes as jest.MockedFunction<
+  typeof useCheckPipettes
+>
 
 const render = (props: React.ComponentProps<typeof Results>) => {
   return renderWithProviders(<Results {...props} />, {
@@ -28,6 +35,7 @@ const mockPipette: AttachedPipette = {
 }
 describe('Results', () => {
   let props: React.ComponentProps<typeof Results>
+  const mockCheckPipette = jest.fn()
   beforeEach(() => {
     props = {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
@@ -46,6 +54,10 @@ describe('Results', () => {
       currentStepIndex: 2,
       totalStepCount: 6,
     }
+    mockUseCheckPipettes.mockReturnValue({
+      handleCheckPipette: mockCheckPipette,
+      isPending: false,
+    })
   })
   it('renders the correct information when pipette cal is a success for calibrate flow', () => {
     const { getByText, getByRole, getByLabelText } = render(props)
@@ -84,8 +96,24 @@ describe('Results', () => {
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${String(COLORS.errorEnabled)}`
     )
-    const exit = getByRole('button', { name: 'Results_exit' })
-    fireEvent.click(exit)
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    expect(mockCheckPipette).toHaveBeenCalled()
+  })
+  it('renders the try again button when fail to attach and clicking on buton several times renders exit button', () => {
+    props = {
+      ...props,
+      attachedPipettes: { left: null, right: null },
+      flowType: FLOWS.ATTACH,
+    }
+    const { getByText, getByRole } = render(props)
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    expect(mockCheckPipette).toHaveBeenCalled()
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    expect(mockCheckPipette).toHaveBeenCalled()
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    //  critical error modal after tryAgain failing 2 times
+    getByText('Something Went Wrong')
+    getByRole('button', { name: 'Results_errorExit' }).click()
     expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard is a success for detach flow', () => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -106,6 +106,25 @@ describe('Results', () => {
       flowType: FLOWS.ATTACH,
     }
     const { getByText, getByRole } = render(props)
+    getByText('Detach and retry')
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    expect(mockCheckPipette).toHaveBeenCalled()
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    expect(mockCheckPipette).toHaveBeenCalled()
+    getByRole('button', { name: 'Results_tryAgain' }).click()
+    //  critical error modal after tryAgain failing 2 times
+    getByText('Something Went Wrong')
+    getByRole('button', { name: 'Results_errorExit' }).click()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
+  })
+  it('renders the try again button when fail to detach and clicking on buton several times renders exit button', () => {
+    props = {
+      ...props,
+      attachedPipettes: { left: mockPipette, right: null },
+      flowType: FLOWS.DETACH,
+    }
+    const { getByText, getByRole } = render(props)
+    getByText('Attach and retry')
     getByRole('button', { name: 'Results_tryAgain' }).click()
     expect(mockCheckPipette).toHaveBeenCalled()
     getByRole('button', { name: 'Results_tryAgain' }).click()
@@ -142,9 +161,7 @@ describe('Results', () => {
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${String(COLORS.errorEnabled)}`
     )
-    const exit = getByRole('button', { name: 'Results_exit' })
-    fireEvent.click(exit)
-    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
+    getByRole('button', { name: 'Results_tryAgain' })
   })
   it('renders the correct information when pipette wizard is a fail for 96 channel attach flow and gantry not empty', () => {
     props = {
@@ -157,9 +174,7 @@ describe('Results', () => {
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${String(COLORS.errorEnabled)}`
     )
-    const exit = getByRole('button', { name: 'Results_exit' })
-    fireEvent.click(exit)
-    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
+    getByRole('button', { name: 'Results_tryAgain' }).click()
   })
   it('renders the correct information when pipette wizard is a success for 96 channel attach flow and gantry not empty', () => {
     props = {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
@@ -4,17 +4,13 @@ import { renderHook } from '@testing-library/react-hooks'
 import { createStore, Store } from 'redux'
 
 import * as RobotApi from '../../../redux/robot-api'
-// import { fetchPipettes } from '../../../redux/pipettes'
+import { FETCH_PIPETTES } from '../../../redux/pipettes'
 import { useCheckPipettes } from '../hooks'
 
 import type { DispatchApiRequestType } from '../../../redux/robot-api'
 
 jest.mock('../../../redux/robot-api')
-jest.mock('../../../redux/pipettes')
 
-// const mockFetchPipettes = fetchPipettes as jest.MockedFunction<
-//   typeof fetchPipettes
-// >
 const mockUseDispatchApiRequests = RobotApi.useDispatchApiRequests as jest.MockedFunction<
   typeof RobotApi.useDispatchApiRequests
 >
@@ -41,25 +37,18 @@ describe('useCheckPipettes', () => {
     expect(result.current.requestStatus).toEqual(undefined)
     expect(dispatchApiRequest).not.toBeCalled()
   })
-  it('returns request pending', () => {
+  it('calls dispatch api request with a type FETCH_PIPETTES', () => {
     mockGetRequestById.mockReturnValue({
       status: RobotApi.PENDING,
     })
-    // const { result } = renderHook(() => useCheckPipettes('otie'), {
-    //   wrapper,
-    // })
-    // expect(result.current.isPending).toEqual(true)
-    // expect(result.current.requestStatus).toEqual(RobotApi.PENDING)
-    // expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
+    const { result } = renderHook(() => useCheckPipettes('otie'), {
+      wrapper,
+    })
+    result.current.handleCheckPipette()
+    expect(dispatchApiRequest).toBeCalledWith({
+      type: FETCH_PIPETTES,
+      payload: expect.anything(),
+      meta: expect.anything(),
+    })
   })
-  it.todo('returns request success')
-  // mockGetRequestById.mockReturnValue({
-  //   status: RobotApi.SUCCESS,
-  //   response: {
-  //     method: 'POST',
-  //     ok: true,
-  //     path: '/',
-  //     status: 200,
-  //   },
-  // })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { renderHook } from '@testing-library/react-hooks'
+import { createStore, Store } from 'redux'
+
+import * as RobotApi from '../../../redux/robot-api'
+// import { fetchPipettes } from '../../../redux/pipettes'
+import { useCheckPipettes } from '../hooks'
+
+import type { DispatchApiRequestType } from '../../../redux/robot-api'
+
+jest.mock('../../../redux/robot-api')
+jest.mock('../../../redux/pipettes')
+
+// const mockFetchPipettes = fetchPipettes as jest.MockedFunction<
+//   typeof fetchPipettes
+// >
+const mockUseDispatchApiRequests = RobotApi.useDispatchApiRequests as jest.MockedFunction<
+  typeof RobotApi.useDispatchApiRequests
+>
+const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
+  typeof RobotApi.getRequestById
+>
+const store: Store<any> = createStore(jest.fn(), {})
+
+describe('useCheckPipettes', () => {
+  let dispatchApiRequest: DispatchApiRequestType
+  let wrapper: React.FunctionComponent<{}>
+  beforeEach(() => {
+    dispatchApiRequest = jest.fn()
+    wrapper = ({ children }) => <Provider store={store}>{children}</Provider>
+    mockGetRequestById.mockReturnValue(null)
+    mockUseDispatchApiRequests.mockReturnValue([dispatchApiRequest, []])
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('returns request undefined when dispatch api request has not been called', () => {
+    const { result } = renderHook(() => useCheckPipettes('otie'), { wrapper })
+    expect(result.current.isPending).toEqual(false)
+    expect(result.current.requestStatus).toEqual(undefined)
+    expect(dispatchApiRequest).not.toBeCalled()
+  })
+  it('returns request pending', () => {
+    mockGetRequestById.mockReturnValue({
+      status: RobotApi.PENDING,
+    })
+    // const { result } = renderHook(() => useCheckPipettes('otie'), {
+    //   wrapper,
+    // })
+    // expect(result.current.isPending).toEqual(true)
+    // expect(result.current.requestStatus).toEqual(RobotApi.PENDING)
+    // expect(dispatchApiRequest).toBeCalledWith(mockFetchPipettes('otie'))
+  })
+  it.todo('returns request success')
+  // mockGetRequestById.mockReturnValue({
+  //   status: RobotApi.SUCCESS,
+  //   response: {
+  //     method: 'POST',
+  //     ok: true,
+  //     path: '/',
+  //     status: 200,
+  //   },
+  // })
+})

--- a/app/src/organisms/PipetteWizardFlows/hooks.ts
+++ b/app/src/organisms/PipetteWizardFlows/hooks.ts
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { fetchPipettes, FETCH_PIPETTES } from '../../redux/pipettes'
+import {
+  getRequestById,
+  useDispatchApiRequests,
+  PENDING,
+} from '../../redux/robot-api'
+import type { RequestState, RequestStatus } from '../../redux/robot-api/types'
+import type { State } from '../../redux/types'
+
+interface CheckPipettes {
+  handleCheckPipette: () => void
+  isPending: boolean
+  requestStatus?: RequestStatus
+}
+
+export function useCheckPipettes(robotName: string): CheckPipettes {
+  const fetchPipettesRequestId = React.useRef<string | null>(null)
+  const [dispatch] = useDispatchApiRequests(dispatchedAction => {
+    if (
+      dispatchedAction.type === FETCH_PIPETTES &&
+      'requestId' in dispatchedAction.meta &&
+      dispatchedAction.meta.requestId
+    ) {
+      fetchPipettesRequestId.current = dispatchedAction.meta.requestId
+    }
+  })
+  const handleCheckPipette = (): void =>
+    dispatch(fetchPipettes(robotName, true))
+  const requestStatus = useSelector<State, RequestState | null>(state =>
+    fetchPipettesRequestId.current
+      ? getRequestById(state, fetchPipettesRequestId.current)
+      : null
+  )?.status
+
+  const isPending = requestStatus === PENDING
+
+  console.log(requestStatus)
+
+  return {
+    handleCheckPipette,
+    isPending,
+    requestStatus,
+  }
+}

--- a/app/src/organisms/PipetteWizardFlows/hooks.ts
+++ b/app/src/organisms/PipetteWizardFlows/hooks.ts
@@ -33,10 +33,7 @@ export function useCheckPipettes(robotName: string): CheckPipettes {
       ? getRequestById(state, fetchPipettesRequestId.current)
       : null
   )?.status
-
   const isPending = requestStatus === PENDING
-
-  console.log(requestStatus)
 
   return {
     handleCheckPipette,


### PR DESCRIPTION
closes RLIQ-294

# Overview

When a pipette fails to attach, there is now a `try again` button. When you fail 2 times, the modal turns into the `Something Went Wrong` critical error with an `exit` button. Clicking the `exit` button closes and "cleans up" the flow (the pipette homes).

<img width="774" alt="Screen Shot 2023-01-18 at 11 04 09 AM" src="https://user-images.githubusercontent.com/66035149/213226424-87a8a27a-2766-4672-a629-f4eb8fd185e4.png">

<img width="771" alt="Screen Shot 2023-01-18 at 11 05 22 AM" src="https://user-images.githubusercontent.com/66035149/213226869-3f7c47b0-262a-4072-bf1c-5c5acc8614b2.png">

# Changelog

- pull the `fetchPipette` logic out of `CheckPipetteButton` and into a hook `useCheckPipettes`, create test
- add `Skeleton` to `SimpleWizardBody` and add to test
- simplify `CheckPipetteButton` to use the hook
- add hook to `Results` page to wire up the `Try Again` logic

# Review requests

- should probably test this on an actual robot. But in the emulator, test attaching a pipette and you should be able to go through the `Try again` scenarios and reach the `Something Went Wrong` error and clicking on the `exit` button should close the flow

# Risk assessment

low