### PR TITLE
fix(app): fix error in send protocol to OT-3 catch block

### DIFF
--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -89,26 +89,33 @@ export function SendProtocolToOT3Slideout(
         })
         onCloseClick()
       })
-      .catch((error: AxiosError) => {
-        eatToast(toastId)
-        const { id, detail, title } = error?.response?.data.errors[0]
-        if (id === 'ProtocolFilesInvalid') {
-          makeToast(detail, ERROR_TOAST, {
-            closeButton: true,
-            disableTimeout: true,
-            heading: `${protocolDisplayName} ${title} on ${
-              selectedRobot?.name ?? ''
-            }`,
-          })
-        } else {
-          makeToast(selectedRobot?.name ?? '', ERROR_TOAST, {
-            closeButton: true,
-            disableTimeout: true,
-            heading: `${t('unsuccessfully_sent')} ${protocolDisplayName}`,
-          })
+      .catch(
+        (
+          error: AxiosError<{
+            errors: Array<{ id: string; detail: string; title: string }>
+          }>
+        ) => {
+          eatToast(toastId)
+          const [errorDetail] = error?.response?.data?.errors ?? []
+          const { id, detail, title } = errorDetail ?? {}
+          if (id != null && detail != null && title != null) {
+            makeToast(detail, ERROR_TOAST, {
+              closeButton: true,
+              disableTimeout: true,
+              heading: `${protocolDisplayName} ${title} - ${
+                selectedRobot?.name ?? ''
+              }`,
+            })
+          } else {
+            makeToast(selectedRobot?.name ?? '', ERROR_TOAST, {
+              closeButton: true,
+              disableTimeout: true,
+              heading: `${t('unsuccessfully_sent')} ${protocolDisplayName}`,
+            })
+          }
+          onCloseClick()
         }
-        onCloseClick()
-      })
+      )
   }
 
   return (


### PR DESCRIPTION
# Overview

this fixes the catch block of createProtocolAsync to protect against accessing properties of undefined in an error message.

<img width="1140" alt="Screen Shot 2023-01-13 at 12 00 36 PM" src="https://user-images.githubusercontent.com/29845468/213000978-bef388a0-e671-404d-ad33-6d169b2d46a7.png">
<img width="1136" alt="Screen Shot 2023-01-17 at 2 41 35 PM" src="https://user-images.githubusercontent.com/29845468/213001010-eeb0d16f-0440-41a4-aa02-f3f48b8188de.png">

# Test Plan

 - Manually verified that the app renders an error toast on OT-3 robots returning a 400 from the /protocols endpoint
 - Manually verified that the app still renders an error toast on OT-3 robots returning a 422 from the /protocols endpoint

# Changelog

 - Fixes error in send protocol to OT-3 catch block

# Review requests

# Risk assessment

low
