### PR TITLE
refactor(ot3): Return a motor id for the tip motors on the 96 channel

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -246,6 +246,14 @@ class SensorThresholdMode(int, Enum):
 
 
 @unique
+class GearMotorId(int, Enum):
+    """Tip action types."""
+
+    left = 0x0
+    right = 0x01
+
+
+@unique
 class PipetteTipActionType(int, Enum):
     """Tip action types."""
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -18,6 +18,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     MotorPositionFlags,
     ErrorSeverity,
     MoveStopCondition,
+    GearMotorId,
 )
 
 
@@ -224,6 +225,18 @@ class EepromDataField(utils.BinaryFieldBase[bytes]):
     def from_string(cls, t: str) -> EepromDataField:
         """Create from a string."""
         return cls(binascii.unhexlify(t)[: cls.NUM_BYTES])
+
+
+class GearMotorIdField(utils.UInt8Field):
+    """Gear Motor id for 96 channel."""
+
+    def __repr__(self) -> str:
+        """Print gear motor id for 96 channel."""
+        try:
+            gear_id = GearMotorId(self.value).name
+        except ValueError:
+            gear_id = str(self.value)
+        return f"{self.__class__.__name__}(value={gear_id})"
 
 
 class PipetteTipActionTypeField(utils.UInt8Field):

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -24,6 +24,7 @@ from .fields import (
     PipetteTipActionTypeField,
     MotorPositionFlagsField,
     MoveStopConditionField,
+    GearMotorIdField,
 )
 from .. import utils
 
@@ -492,6 +493,7 @@ class TipActionResponsePayload(MoveCompletedPayload):
 
     action: PipetteTipActionTypeField
     success: utils.UInt8Field
+    gear_motor_id: GearMotorIdField
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -34,6 +34,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     HomeRequestPayload,
     GripperMoveRequestPayload,
     TipActionRequestPayload,
+    EmptyPayload,
 )
 from .constants import interrupts_per_sec, brushed_motor_interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import (
@@ -191,7 +192,9 @@ class MoveGroupRunner:
         """
         await can_messenger.send(
             node_id=NodeId.broadcast,
-            message=ClearAllMoveGroupsRequest(),
+            message=ClearAllMoveGroupsRequest(
+                payload=EmptyPayload()
+            ),
         )
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -192,9 +192,7 @@ class MoveGroupRunner:
         """
         await can_messenger.send(
             node_id=NodeId.broadcast,
-            message=ClearAllMoveGroupsRequest(
-                payload=EmptyPayload()
-            ),
+            message=ClearAllMoveGroupsRequest(payload=EmptyPayload()),
         )
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:


### PR DESCRIPTION
# Overview
Adding in a motor id to the TipActionResponse to make motor movement debugging easier. 

# Changelog

- Add necessary changes to the payload of the TipAction Response

# Risk assessment

Low. Payload only change for the 96 channel.