### PR TITLE
chore(release): Note the fix for large protocol uploads in the release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -12,7 +12,7 @@ Welcome to the v6.2.1 release of the OT-2 software! This hotfix release addresse
 
 ### Bug Fixes
 
-- When you upload a protocol file larger than 2 MiB, you will no longer get an error saying "Protocol run could not be created on the robot."
+- When you upload a protocol file larger than 2 megabytes, you will no longer get an error saying "Protocol run could not be created on the robot."
 - When you upload a protocol to an OT-2 that already has a lot of big protocols stored, the OT-2 will no longer show connection errors and become unresponsive for several minutes.
 - When a Thermocycler GEN2 is run for 50 days without a power cycle, it will no longer miscalculate hold times.
 - When you upload a Python protocol that contains an aspirate or dispense with an effective volume of 0 µL, it will no longer get stuck analyzing forever.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -12,6 +12,7 @@ Welcome to the v6.2.1 release of the OT-2 software! This hotfix release addresse
 
 ### Bug Fixes
 
+- When you upload a protocol file larger than 2 MiB, you will no longer get an error saying "Protocol run could not be created on the robot."
 - When you upload a protocol to an OT-2 that already has a lot of big protocols stored, the OT-2 will no longer show connection errors and become unresponsive for several minutes.
 - When a Thermocycler GEN2 is run for 50 days without a power cycle, it will no longer miscalculate hold times.
 - When you upload a Python protocol that contains an aspirate or dispense with an effective volume of 0 µL, it will no longer get stuck analyzing forever.


### PR DESCRIPTION
# Overview

In the robot software release notes for the v6.2.1 hotfix, describe our fix for RSS-92.

This should have been in #11993, but I accidentally omitted it.

# Review requests

* Have I forgotten anything else?
* Is the wording good?
* Is the error message correct? I got it by testing this on a random v6.2.0 robot here in the office.

# Risk assessment

No risk. Changes are only to human-readable documentation.