### PR TITLE
chore(makefile): do not push ODD app by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ push-ot3:
 	$(MAKE) -C $(NOTIFY_SERVER_DIR) push-no-restart-ot3
 	$(MAKE) -C $(ROBOT_SERVER_DIR) push-ot3
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push-ot3
-	$(MAKE) -C $(APP_SHELL_ODD_DIR) push-ot3
 	$(MAKE) -C $(USB_BRIDGE_DIR) push-ot3
 
 


### PR DESCRIPTION
# Overview

The hardware + embedded folks are reporting that they don't need to push the app to the OT-3, and that it's annoying to have the app included as part of the top level push command because it takes the most time. 

This PR just removes the app from being pushed to the OT-3 by default. If folks want to push the ODD app to an OT-3, they can run the `push-ot3` make command from the `app-shell-odd` directory.

# Risk assessment

Low