### PR TITLE
perf(api): add asyncio yields to simulators

### DIFF
--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Dict
 from opentrons.util.async_helpers import ensure_yield
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver

--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -1,11 +1,8 @@
 import asyncio
 from typing import Dict
+from opentrons.util.async_helpers import ensure_yield
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
-
-
-async def _yield() -> None:
-    await asyncio.sleep(0)
 
 
 class SimulatingDriver(AbstractHeaterShakerDriver):
@@ -18,76 +15,80 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
         self._rpm = RPM(current=0, target=None)
         self._homing_status = True
 
+    @ensure_yield
     async def connect(self) -> None:
         pass
 
+    @ensure_yield
     async def disconnect(self) -> None:
         pass
 
+    @ensure_yield
     async def is_connected(self) -> bool:
         return True
 
+    @ensure_yield
     async def open_labware_latch(self) -> None:
         self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_OPEN
-        await _yield()
 
+    @ensure_yield
     async def close_labware_latch(self) -> None:
         self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_CLOSED
-        await _yield()
 
+    @ensure_yield
     async def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
-        await _yield()
         return self._labware_latch_state
 
+    @ensure_yield
     async def set_temperature(self, temperature: float) -> None:
         self._temperature.current = temperature
         self._temperature.target = temperature if temperature != 0.0 else None
-        await _yield()
 
+    @ensure_yield
     async def get_temperature(self) -> Temperature:
-        await _yield()
         return self._temperature
 
+    @ensure_yield
     async def set_rpm(self, rpm: int) -> None:
         self._rpm.target = rpm if rpm != 0 else None
         self._rpm.current = rpm
         self._homing_status = False
-        await _yield()
 
+    @ensure_yield
     async def get_rpm(self) -> RPM:
-        await _yield()
         return self._rpm
 
+    @ensure_yield
     async def home(self) -> None:
         self._rpm.target = None
         self._rpm.current = 0
         self._homing_status = True
-        await _yield()
 
+    @ensure_yield
     async def deactivate_heater(self) -> None:
         self._temperature.target = None
         self._temperature.current = 23
-        await _yield()
 
+    @ensure_yield
     async def deactivate_shaker(self) -> None:
         self._rpm.target = 0
         self._rpm.current = 0
-        await _yield()
 
+    @ensure_yield
     async def deactivate(self) -> None:
         self._temperature.target = None
         self._temperature.current = 23
         self._rpm.target = 0
         self._rpm.current = 0
-        await _yield()
 
+    @ensure_yield
     async def get_device_info(self) -> Dict[str, str]:
-        await _yield()
         return {
             "serial": "dummySerialHS",
             "model": "dummyModelHS",
             "version": "dummyVersionHS",
         }
 
+    @ensure_yield
     async def enter_programming_mode(self) -> None:
-        await _yield()
+        pass

--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -1,6 +1,11 @@
+import asyncio
 from typing import Dict
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
+
+
+async def _yield() -> None:
+    await asyncio.sleep(0)
 
 
 class SimulatingDriver(AbstractHeaterShakerDriver):
@@ -24,48 +29,60 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
 
     async def open_labware_latch(self) -> None:
         self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_OPEN
+        await _yield()
 
     async def close_labware_latch(self) -> None:
         self._labware_latch_state = HeaterShakerLabwareLatchStatus.IDLE_CLOSED
+        await _yield()
 
     async def get_labware_latch_status(self) -> HeaterShakerLabwareLatchStatus:
+        await _yield()
         return self._labware_latch_state
 
     async def set_temperature(self, temperature: float) -> None:
         self._temperature.current = temperature
         self._temperature.target = temperature if temperature != 0.0 else None
+        await _yield()
 
     async def get_temperature(self) -> Temperature:
+        await _yield()
         return self._temperature
 
     async def set_rpm(self, rpm: int) -> None:
         self._rpm.target = rpm if rpm != 0 else None
         self._rpm.current = rpm
         self._homing_status = False
+        await _yield()
 
     async def get_rpm(self) -> RPM:
+        await _yield()
         return self._rpm
 
     async def home(self) -> None:
         self._rpm.target = None
         self._rpm.current = 0
         self._homing_status = True
+        await _yield()
 
     async def deactivate_heater(self) -> None:
         self._temperature.target = None
         self._temperature.current = 23
+        await _yield()
 
     async def deactivate_shaker(self) -> None:
         self._rpm.target = 0
         self._rpm.current = 0
+        await _yield()
 
     async def deactivate(self) -> None:
         self._temperature.target = None
         self._temperature.current = 23
         self._rpm.target = 0
         self._rpm.current = 0
+        await _yield()
 
     async def get_device_info(self) -> Dict[str, str]:
+        await _yield()
         return {
             "serial": "dummySerialHS",
             "model": "dummyModelHS",
@@ -73,4 +90,4 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
         }
 
     async def enter_programming_mode(self) -> None:
-        pass
+        await _yield()

--- a/api/src/opentrons/drivers/mag_deck/simulator.py
+++ b/api/src/opentrons/drivers/mag_deck/simulator.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from typing import Dict, Optional
 
 from .abstract import AbstractMagDeckDriver
@@ -9,21 +11,27 @@ MAG_DECK_MODELS = {
 }
 
 
+async def _yield() -> None:
+    await asyncio.sleep(0)
+
+
 class SimulatingDriver(AbstractMagDeckDriver):
     def __init__(self, sim_model: Optional[str] = None) -> None:
         self._height = 0.0
         self._model = MAG_DECK_MODELS[sim_model] if sim_model else "mag_deck_v1.1"
 
     async def probe_plate(self) -> None:
-        pass
+        await _yield()
 
     async def home(self) -> None:
-        pass
+        await _yield()
 
     async def move(self, location: float) -> None:
         self._height = location
+        await _yield()
 
     async def get_device_info(self) -> Dict[str, str]:
+        await _yield()
         return {
             "serial": "dummySerialMD",
             "model": self._model,
@@ -37,13 +45,16 @@ class SimulatingDriver(AbstractMagDeckDriver):
         pass
 
     async def enter_programming_mode(self) -> None:
-        pass
+        await _yield()
 
     async def is_connected(self) -> bool:
+        await _yield()
         return True
 
     async def get_plate_height(self) -> float:
+        await _yield()
         return self._height
 
     async def get_mag_position(self) -> float:
+        await _yield()
         return self._height

--- a/api/src/opentrons/drivers/mag_deck/simulator.py
+++ b/api/src/opentrons/drivers/mag_deck/simulator.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from typing import Dict, Optional
 
 from .abstract import AbstractMagDeckDriver

--- a/api/src/opentrons/drivers/mag_deck/simulator.py
+++ b/api/src/opentrons/drivers/mag_deck/simulator.py
@@ -3,6 +3,7 @@ import asyncio
 from typing import Dict, Optional
 
 from .abstract import AbstractMagDeckDriver
+from opentrons.util.async_helpers import ensure_yield
 
 
 MAG_DECK_MODELS = {
@@ -11,50 +12,51 @@ MAG_DECK_MODELS = {
 }
 
 
-async def _yield() -> None:
-    await asyncio.sleep(0)
-
-
 class SimulatingDriver(AbstractMagDeckDriver):
     def __init__(self, sim_model: Optional[str] = None) -> None:
         self._height = 0.0
         self._model = MAG_DECK_MODELS[sim_model] if sim_model else "mag_deck_v1.1"
 
+    @ensure_yield
     async def probe_plate(self) -> None:
-        await _yield()
+        pass
 
+    @ensure_yield
     async def home(self) -> None:
-        await _yield()
+        pass
 
+    @ensure_yield
     async def move(self, location: float) -> None:
         self._height = location
-        await _yield()
 
+    @ensure_yield
     async def get_device_info(self) -> Dict[str, str]:
-        await _yield()
         return {
             "serial": "dummySerialMD",
             "model": self._model,
             "version": "dummyVersionMD",
         }
 
+    @ensure_yield
     async def connect(self) -> None:
         pass
 
+    @ensure_yield
     async def disconnect(self) -> None:
         pass
 
+    @ensure_yield
     async def enter_programming_mode(self) -> None:
-        await _yield()
+        pass
 
+    @ensure_yield
     async def is_connected(self) -> bool:
-        await _yield()
         return True
 
+    @ensure_yield
     async def get_plate_height(self) -> float:
-        await _yield()
         return self._height
 
+    @ensure_yield
     async def get_mag_position(self) -> float:
-        await _yield()
         return self._height

--- a/api/src/opentrons/drivers/temp_deck/simulator.py
+++ b/api/src/opentrons/drivers/temp_deck/simulator.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Optional, Dict
 
 from opentrons.util.async_helpers import ensure_yield

--- a/api/src/opentrons/drivers/temp_deck/simulator.py
+++ b/api/src/opentrons/drivers/temp_deck/simulator.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Optional, Dict
 
+from opentrons.util.async_helpers import ensure_yield
 from opentrons.drivers.types import Temperature
 from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver
 
@@ -10,43 +11,43 @@ TEMP_DECK_MODELS = {
 }
 
 
-async def _yield() -> None:
-    await asyncio.sleep(0)
-
-
 class SimulatingDriver(AbstractTempDeckDriver):
     def __init__(self, sim_model: Optional[str] = None):
         self._temp = Temperature(target=None, current=0)
         self._port: Optional[str] = None
         self._model = TEMP_DECK_MODELS[sim_model] if sim_model else "temp_deck_v1.1"
 
+    @ensure_yield
     async def set_temperature(self, celsius: float) -> None:
         self._temp.target = celsius
         self._temp.current = self._temp.target
-        await _yield()
 
+    @ensure_yield
     async def get_temperature(self) -> Temperature:
-        await _yield()
         return self._temp
 
+    @ensure_yield
     async def deactivate(self) -> None:
         self._temp = Temperature(target=None, current=23)
-        await _yield()
 
+    @ensure_yield
     async def connect(self) -> None:
         pass
 
+    @ensure_yield
     async def is_connected(self) -> bool:
         return True
 
+    @ensure_yield
     async def disconnect(self) -> None:
         pass
 
+    @ensure_yield
     async def enter_programming_mode(self) -> None:
-        await _yield()
+        pass
 
+    @ensure_yield
     async def get_device_info(self) -> Dict[str, str]:
-        await _yield()
         return {
             "serial": "dummySerialTD",
             "model": self._model,

--- a/api/src/opentrons/drivers/temp_deck/simulator.py
+++ b/api/src/opentrons/drivers/temp_deck/simulator.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Optional, Dict
 
 from opentrons.drivers.types import Temperature
@@ -9,6 +10,10 @@ TEMP_DECK_MODELS = {
 }
 
 
+async def _yield() -> None:
+    await asyncio.sleep(0)
+
+
 class SimulatingDriver(AbstractTempDeckDriver):
     def __init__(self, sim_model: Optional[str] = None):
         self._temp = Temperature(target=None, current=0)
@@ -18,12 +23,15 @@ class SimulatingDriver(AbstractTempDeckDriver):
     async def set_temperature(self, celsius: float) -> None:
         self._temp.target = celsius
         self._temp.current = self._temp.target
+        await _yield()
 
     async def get_temperature(self) -> Temperature:
+        await _yield()
         return self._temp
 
     async def deactivate(self) -> None:
         self._temp = Temperature(target=None, current=23)
+        await _yield()
 
     async def connect(self) -> None:
         pass
@@ -35,9 +43,10 @@ class SimulatingDriver(AbstractTempDeckDriver):
         pass
 
     async def enter_programming_mode(self) -> None:
-        pass
+        await _yield()
 
     async def get_device_info(self) -> Dict[str, str]:
+        await _yield()
         return {
             "serial": "dummySerialTD",
             "model": self._model,

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -1,12 +1,9 @@
 import asyncio
 from typing import Optional, Dict
 
+from opentrons.util.async_helpers import ensure_yield
 from opentrons.drivers.thermocycler.abstract import AbstractThermocyclerDriver
 from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
-
-
-async def _yield() -> None:
-    await asyncio.sleep(0)
 
 
 class SimulatingDriver(AbstractThermocyclerDriver):
@@ -24,31 +21,35 @@ class SimulatingDriver(AbstractThermocyclerDriver):
     def model(self) -> str:
         return self._model
 
+    @ensure_yield
     async def connect(self) -> None:
         pass
 
+    @ensure_yield
     async def disconnect(self) -> None:
         pass
 
+    @ensure_yield
     async def is_connected(self) -> bool:
         return True
 
+    @ensure_yield
     async def open_lid(self) -> None:
         self._lid_status = ThermocyclerLidStatus.OPEN
-        await _yield()
 
+    @ensure_yield
     async def close_lid(self) -> None:
         self._lid_status = ThermocyclerLidStatus.CLOSED
-        await _yield()
 
+    @ensure_yield
     async def get_lid_status(self) -> ThermocyclerLidStatus:
-        await _yield()
         return self._lid_status
 
+    @ensure_yield
     async def get_lid_temperature(self) -> Temperature:
-        await _yield()
         return self._lid_temperature
 
+    @ensure_yield
     async def set_plate_temperature(
         self,
         temp: float,
@@ -58,46 +59,46 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         self._plate_temperature.target = temp
         self._plate_temperature.current = temp
         self._plate_temperature.hold = 0
-        await _yield()
 
+    @ensure_yield
     async def get_plate_temperature(self) -> PlateTemperature:
-        await _yield()
         return self._plate_temperature
 
+    @ensure_yield
     async def set_ramp_rate(self, ramp_rate: float) -> None:
         self._ramp_rate = ramp_rate
-        await _yield()
 
+    @ensure_yield
     async def set_lid_temperature(self, temp: float) -> None:
         """Set the lid temperature in deg Celsius"""
         self._lid_temperature.target = temp
         self._lid_temperature.current = temp
-        await _yield()
 
+    @ensure_yield
     async def deactivate_lid(self) -> None:
         self._lid_temperature.target = None
         self._lid_temperature.current = self.DEFAULT_TEMP
-        await _yield()
 
+    @ensure_yield
     async def deactivate_block(self) -> None:
         self._plate_temperature.target = None
         self._plate_temperature.current = self.DEFAULT_TEMP
         self._plate_temperature.hold = None
         self._ramp_rate = None
-        await _yield()
 
+    @ensure_yield
     async def deactivate_all(self) -> None:
         await self.deactivate_lid()
         await self.deactivate_block()
-        await _yield()
 
+    @ensure_yield
     async def get_device_info(self) -> Dict[str, str]:
-        await _yield()
         return {
             "serial": "dummySerialTC",
             "model": "dummyModelTC",
             "version": "dummyVersionTC",
         }
 
+    @ensure_yield
     async def enter_programming_mode(self) -> None:
-        await _yield()
+        pass

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Optional, Dict
 
 from opentrons.util.async_helpers import ensure_yield

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -1,7 +1,12 @@
+import asyncio
 from typing import Optional, Dict
 
 from opentrons.drivers.thermocycler.abstract import AbstractThermocyclerDriver
 from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
+
+
+async def _yield() -> None:
+    await asyncio.sleep(0)
 
 
 class SimulatingDriver(AbstractThermocyclerDriver):
@@ -30,14 +35,18 @@ class SimulatingDriver(AbstractThermocyclerDriver):
 
     async def open_lid(self) -> None:
         self._lid_status = ThermocyclerLidStatus.OPEN
+        await _yield()
 
     async def close_lid(self) -> None:
         self._lid_status = ThermocyclerLidStatus.CLOSED
+        await _yield()
 
     async def get_lid_status(self) -> ThermocyclerLidStatus:
+        await _yield()
         return self._lid_status
 
     async def get_lid_temperature(self) -> Temperature:
+        await _yield()
         return self._lid_temperature
 
     async def set_plate_temperature(
@@ -49,33 +58,41 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         self._plate_temperature.target = temp
         self._plate_temperature.current = temp
         self._plate_temperature.hold = 0
+        await _yield()
 
     async def get_plate_temperature(self) -> PlateTemperature:
+        await _yield()
         return self._plate_temperature
 
     async def set_ramp_rate(self, ramp_rate: float) -> None:
         self._ramp_rate = ramp_rate
+        await _yield()
 
     async def set_lid_temperature(self, temp: float) -> None:
         """Set the lid temperature in deg Celsius"""
         self._lid_temperature.target = temp
         self._lid_temperature.current = temp
+        await _yield()
 
     async def deactivate_lid(self) -> None:
         self._lid_temperature.target = None
         self._lid_temperature.current = self.DEFAULT_TEMP
+        await _yield()
 
     async def deactivate_block(self) -> None:
         self._plate_temperature.target = None
         self._plate_temperature.current = self.DEFAULT_TEMP
         self._plate_temperature.hold = None
         self._ramp_rate = None
+        await _yield()
 
     async def deactivate_all(self) -> None:
         await self.deactivate_lid()
         await self.deactivate_block()
+        await _yield()
 
     async def get_device_info(self) -> Dict[str, str]:
+        await _yield()
         return {
             "serial": "dummySerialTC",
             "model": "dummyModelTC",
@@ -83,4 +100,4 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         }
 
     async def enter_programming_mode(self) -> None:
-        pass
+        await _yield()

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -518,7 +518,6 @@ class OT3Simulator:
     async def clean_up(self) -> None:
         """Clean up."""
         await _yield()
-        pass
 
     async def configure_mount(
         self, mount: OT3Mount, config: InstrumentHardwareConfigs

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -223,7 +223,7 @@ class OT3Simulator:
         """Get the encoder current position."""
         return axis_convert(self._encoder_position, 0.0)
 
-    @nsure_yield
+    @ensure_yield
     async def move(
         self,
         origin: Coordinates[OT3Axis, float],

--- a/api/src/opentrons/util/async_helpers.py
+++ b/api/src/opentrons/util/async_helpers.py
@@ -1,0 +1,57 @@
+"""
+util.async_helpers - various utilities for asyncio functions and tasks.
+"""
+
+from functools import wrap
+from typing import TypeVar, Callable, Awaitable, cast
+
+import asyncio
+
+async def asyncio_yield() -> None:
+    """
+    Ensure that the current task yields to the event loop.
+
+    The python async framework only switches between concurrently-running tasks when
+    the currently-running task hits a leaf call that requires waiting for an event on
+    the loop. That means that you can have a very long call of nice coroutines with
+    async def and await call() that still effectively "block" other concurrent tasks
+    from actually executing.
+
+    There's also not really a nice way to yield to the event loop explicitly. The best
+    way to do it is to drop in await asyncio.sleep(0), which will yield to the loop and
+    let something else run.
+
+    If you have an async call chain that is used in a tight loop and at no point contains
+    an await() call that will yield the loop - this will be anything that
+    - Involves touching a file descriptor that is registered with an asyncio protocol
+    - Involves waiting for a Future
+    - Involves waiting for another task
+    - Involves specifically invoking an asyncio scheduling operation like gather()
+    - Uses asyncio.sleep()
+
+    You should drop an await asyncio_yield() at the most frequent leaf call to make sure
+    that other tasks on the loop get a chance to run.
+    """
+    await asyncio.sleep(0)
+
+
+WrappedReturn = TypeVar("WrappedReturn", contravariant=True)
+WrappedCoro = TypeVar("WrappedCoro", bound=Callable[..., Awaitable[WrappedReturn]])
+
+def ensure_yield(async_def_func: WrappedCoro) -> WrappedCoro:
+    """
+    A decorator that makes sure that asyncio_yield() is called after the decorated async
+    function finishes executing.
+    """
+
+    # _wrapper can be typed using ParamSpec https://docs.python.org/3/library/typing.html#typing.ParamSpec
+    # when we either go to python 3.10 or bump typing_extensions to 4.2.0
+    # https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-420-april-17-2022
+    # Until then, we need the cast on line 57
+    @wrap(async_def_func)
+    async def _wrapper(*args, **kwargs):
+        ret = await async_def_func(*args, **kwargs)
+        await asyncio_yield()
+        return ret
+
+    return cast(WrappedCoro, _wrapper)

--- a/api/src/opentrons/util/async_helpers.py
+++ b/api/src/opentrons/util/async_helpers.py
@@ -3,14 +3,9 @@ util.async_helpers - various utilities for asyncio functions and tasks.
 """
 
 from functools import wraps
-from typing import TypeVar, Callable, Awaitable, cast, Any, TYPE_CHECKING
+from typing import TypeVar, Callable, Awaitable, cast
 
 import asyncio
-
-if TYPE_CHECKING:
-    from typing_extensions import ParamSpec
-    P = ParamSpec("P")
-    T = TypeVar("T")
 
 async def asyncio_yield() -> None:
     """
@@ -39,7 +34,11 @@ async def asyncio_yield() -> None:
     """
     await asyncio.sleep(0)
 
-def ensure_yield(async_def_func: "Callable[P, Awaitable[T]]") -> "T":
+
+WrappedReturn = TypeVar("WrappedReturn", contravariant=True)
+WrappedCoro = TypeVar("WrappedCoro", bound=Callable[..., Awaitable[WrappedReturn]])
+
+def ensure_yield(async_def_func: WrappedCoro) -> WrappedCoro:
     """
     A decorator that makes sure that asyncio_yield() is called after the decorated async
     function finishes executing.
@@ -49,11 +48,10 @@ def ensure_yield(async_def_func: "Callable[P, Awaitable[T]]") -> "T":
     # when we either go to python 3.10 or bump typing_extensions to 4.2.0
     # https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-420-april-17-2022
     # Until then, we need the cast on line 57
-
     @wraps(async_def_func)
-    async def _wrapper(*args: "P.args", **kwargs: "P.kwargs") -> "T":
+    async def _wrapper(*args, **kwargs):
         ret = await async_def_func(*args, **kwargs)
         await asyncio_yield()
         return ret
 
-    return _wrapper
+    return cast(WrappedCoro, _wrapper)


### PR DESCRIPTION
# Overview

The hardware simulators all work by doing extremely minimal work in their leaf functions. This is good and fast, except that it means that those leaf functions often don't ever actually yield to the asyncio loop. Tasks only yield when they hit a file io (including some asyncio functions, like sleep(), that defer back to the loop's select call). That means that if you simulate a long enough protocol, the task that runs the protocol won't ever yield back to the loop, and will starve other tasks.

To fix this, drop in a bunch of await asyncio.sleep(0) in the simulator leaf function calls, which should defer back to the loop and fix the issue.

# Test Plan
This is a simulator-only change so we don't have to actually run protocols, which is nice, but we should try to upload some.

I'm concerned a bit about performance here; defering back to the loop may make simulating take longer. We should:

- [x] Simulate all-module protocols on the robot with and without this and check performance
- [x] Simulate a very long protocol and see if it starves the loop


# Changelog

- Add a bunch of `asyncio.sleep(0)` to simulator leaf functions

# Review requests

- is this appropriate?

# Risk assessment

Low except from performaance.