### PR TITLE
fix(app): show loading state modal while starting dashboard calibrations

### DIFF
--- a/app/src/pages/Devices/CalibrationDashboard/hooks/__tests__/useDashboardCalibrateDeck.test.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/__tests__/useDashboardCalibrateDeck.test.tsx
@@ -3,6 +3,7 @@ import uniqueId from 'lodash/uniqueId'
 import { mountWithStore, renderWithProviders } from '@opentrons/components'
 import { act } from 'react-dom/test-utils'
 
+import { LoadingState } from '../../../../../organisms/CalibrationPanels'
 import * as RobotApi from '../../../../../redux/robot-api'
 import * as Sessions from '../../../../../redux/sessions'
 import { i18n } from '../../../../../i18n'
@@ -112,5 +113,28 @@ describe('useDashboardCalibrateDeck hook', () => {
     mockGetRobotSessionOfType.mockReturnValue(null)
     wrapper.setProps({})
     expect(CalWizardComponent).toBe(null)
+  })
+
+  it('loading state modal should appear while session is being created', () => {
+    const seshId = 'fake-session-id'
+    const mockDeckCalSession = {
+      id: seshId,
+      ...mockDeckCalibrationSessionAttributes,
+      details: {
+        ...mockDeckCalibrationSessionAttributes.details,
+        currentStep: Sessions.DECK_STEP_SESSION_STARTED,
+      },
+    }
+    const { wrapper } = mountWithStore(<TestUseDashboardCalibrateDeck />, {
+      initialState: { robotApi: {} },
+    })
+    mockGetRobotSessionOfType.mockReturnValue(mockDeckCalSession)
+    mockGetRequestById.mockReturnValue({
+      status: RobotApi.PENDING,
+    })
+    act(() => startCalibration())
+    wrapper.setProps({})
+    expect(CalWizardComponent).not.toBe(null)
+    expect(LoadingState).not.toBe(null)
   })
 })

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/__tests__/useDashboardCalibratePipOffset.test.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/__tests__/useDashboardCalibratePipOffset.test.tsx
@@ -3,6 +3,7 @@ import uniqueId from 'lodash/uniqueId'
 import { mountWithStore, renderWithProviders } from '@opentrons/components'
 import { act } from 'react-dom/test-utils'
 
+import { LoadingState } from '../../../../../organisms/CalibrationPanels'
 import * as RobotApi from '../../../../../redux/robot-api'
 import * as Sessions from '../../../../../redux/sessions'
 import { mockPipetteOffsetCalibrationSessionAttributes } from '../../../../../redux/sessions/__fixtures__'
@@ -146,5 +147,33 @@ describe('useDashboardCalibratePipOffset hook', () => {
     wrapper.setProps({})
     expect(CalWizardComponent).toBe(null)
     expect(onComplete).toHaveBeenCalled()
+  })
+
+  it('loading state modal should appear while session is being created', () => {
+    const seshId = 'fake-session-id'
+    const mockDeckCalSession = {
+      id: seshId,
+      ...mockPipetteOffsetCalibrationSessionAttributes,
+      details: {
+        ...mockPipetteOffsetCalibrationSessionAttributes.details,
+        currentStep: Sessions.PIP_OFFSET_STEP_SESSION_STARTED,
+      },
+    }
+    const { wrapper } = mountWithStore(<TestUseDashboardCalibratePipOffset />, {
+      initialState: { robotApi: {} },
+    })
+    mockGetRobotSessionOfType.mockReturnValue(mockDeckCalSession)
+    mockGetRequestById.mockReturnValue({
+      status: RobotApi.PENDING,
+    })
+    act(() =>
+      startCalibration({
+        params: { mount: mountString },
+        withIntent: INTENT_CALIBRATE_PIPETTE_OFFSET,
+      })
+    )
+    wrapper.setProps({})
+    expect(CalWizardComponent).not.toBe(null)
+    expect(LoadingState).not.toBe(null)
   })
 })

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/__tests__/useDashboardCalibrateTipLength.test.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/__tests__/useDashboardCalibrateTipLength.test.tsx
@@ -3,6 +3,7 @@ import uniqueId from 'lodash/uniqueId'
 import { mountWithStore, renderWithProviders } from '@opentrons/components'
 import { act } from 'react-dom/test-utils'
 
+import { LoadingState } from '../../../../../organisms/CalibrationPanels'
 import * as RobotApi from '../../../../../redux/robot-api'
 import * as Sessions from '../../../../../redux/sessions'
 import { mockTipLengthCalibrationSessionAttributes } from '../../../../../redux/sessions/__fixtures__'
@@ -203,5 +204,33 @@ describe('useDashboardCalibrateTipLength hook', () => {
       ...Sessions.deleteSession(robotName, seshId),
       meta: { requestId: expect.any(String) },
     })
+  })
+
+  it('loading state modal should appear while session is being created', () => {
+    const seshId = 'fake-session-id'
+    const mockDeckCalSession = {
+      id: seshId,
+      ...mockTipLengthCalibrationSessionAttributes,
+      details: {
+        ...mockTipLengthCalibrationSessionAttributes.details,
+        currentStep: Sessions.TIP_LENGTH_STEP_SESSION_STARTED,
+      },
+    }
+    const { wrapper } = mountWithStore(<TestUseDashboardCalibrateTipLength />, {
+      initialState: { robotApi: {} },
+    })
+    mockGetRobotSessionOfType.mockReturnValue(mockDeckCalSession)
+    mockGetRequestById.mockReturnValue({
+      status: RobotApi.PENDING,
+    })
+    act(() =>
+      startCalibration({
+        params: { mount: mountString },
+        hasBlockModalResponse: null,
+      })
+    )
+    wrapper.setProps({})
+    expect(CalWizardComponent).not.toBe(null)
+    expect(LoadingState).not.toBe(null)
   })
 })

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck.tsx
@@ -99,9 +99,7 @@ export function useDashboardCalibrateDeck(
       {startingSession ? (
         <ModalShell
           width="47rem"
-          header={
-            <WizardHeader title={t('deck_calibration')} onExit={() => {}} />
-          }
+          header={<WizardHeader title={t('deck_calibration')} />}
         >
           <LoadingState />
         </ModalShell>

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 
 import { Portal } from '../../../../App/portal'
+import { ModalShell } from '../../../../molecules/Modal'
+import { WizardHeader } from '../../../../molecules/WizardHeader'
 import { CalibrateDeck } from '../../../../organisms/CalibrateDeck'
+import { LoadingState } from '../../../../organisms/CalibrationPanels'
 import * as RobotApi from '../../../../redux/robot-api'
 import * as Sessions from '../../../../redux/sessions'
 import { getDeckCalibrationSession } from '../../../../redux/sessions/deck-calibration/selectors'
@@ -25,6 +29,7 @@ export function useDashboardCalibrateDeck(
   const trackedRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
   const jogRequestId = React.useRef<string | null>(null)
+  const { t } = useTranslation('robot_calibration')
 
   const deckCalSession: DeckCalibrationSession | null = useSelector(
     (state: State) => {
@@ -91,13 +96,24 @@ export function useDashboardCalibrateDeck(
 
   let Wizard: JSX.Element | null = (
     <Portal level="top">
-      <CalibrateDeck
-        session={deckCalSession}
-        robotName={robotName}
-        showSpinner={showSpinner}
-        dispatchRequests={dispatchRequests}
-        isJogging={isJogging}
-      />
+      {startingSession ? (
+        <ModalShell
+          width="47rem"
+          header={
+            <WizardHeader title={t('deck_calibration')} onExit={() => {}} />
+          }
+        >
+          <LoadingState />
+        </ModalShell>
+      ) : (
+        <CalibrateDeck
+          session={deckCalSession}
+          robotName={robotName}
+          showSpinner={showSpinner}
+          dispatchRequests={dispatchRequests}
+          isJogging={isJogging}
+        />
+      )}
     </Portal>
   )
 

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibratePipOffset.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibratePipOffset.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
-import { SpinnerModalPage } from '@opentrons/components'
-
 import { Portal } from '../../../../App/portal'
+import { ModalShell } from '../../../../molecules/Modal'
+import { WizardHeader } from '../../../../molecules/WizardHeader'
 import { CalibratePipetteOffset } from '../../../../organisms/CalibratePipetteOffset'
+import { LoadingState } from '../../../../organisms/CalibrationPanels'
 import * as RobotApi from '../../../../redux/robot-api'
 import * as Sessions from '../../../../redux/sessions'
 import { getPipetteOffsetCalibrationSession } from '../../../../redux/sessions/pipette-offset-calibration/selectors'
@@ -49,7 +50,7 @@ export function useDashboardCalibratePipOffset(
   const jogRequestId = React.useRef<string | null>(null)
   const spinnerRequestId = React.useRef<string | null>(null)
   const dispatch = useDispatch()
-  const { t } = useTranslation(['device_settings', 'shared'])
+  const { t } = useTranslation('robot_calibration')
 
   const pipOffsetCalSession: PipetteOffsetCalibrationSession | null = useSelector(
     (state: State) => {
@@ -170,16 +171,17 @@ export function useDashboardCalibratePipOffset(
   let Wizard: JSX.Element | null = (
     <Portal level="top">
       {startingSession ? (
-        <SpinnerModalPage
-          titleBar={{
-            title: t('pipette_offset_calibration'),
-            back: {
-              disabled: true,
-              title: t('shared:exit'),
-              children: t('shared:exit'),
-            },
-          }}
-        />
+        <ModalShell
+          width="47rem"
+          header={
+            <WizardHeader
+              title={t('pipette_offset_calibration')}
+              onExit={() => {}}
+            />
+          }
+        >
+          <LoadingState />
+        </ModalShell>
       ) : (
         <CalibratePipetteOffset
           session={pipOffsetCalSession}

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibratePipOffset.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibratePipOffset.tsx
@@ -173,12 +173,7 @@ export function useDashboardCalibratePipOffset(
       {startingSession ? (
         <ModalShell
           width="47rem"
-          header={
-            <WizardHeader
-              title={t('pipette_offset_calibration')}
-              onExit={() => {}}
-            />
-          }
+          header={<WizardHeader title={t('pipette_offset_calibration')} />}
         >
           <LoadingState />
         </ModalShell>

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
@@ -168,12 +168,7 @@ export function useDashboardCalibrateTipLength(
       {startingSession ? (
         <ModalShell
           width="47rem"
-          header={
-            <WizardHeader
-              title={t('tip_length_calibration')}
-              onExit={() => {}}
-            />
-          }
+          header={<WizardHeader title={t('tip_length_calibration')} />}
         >
           <LoadingState />
         </ModalShell>

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
@@ -2,11 +2,12 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
-import { SpinnerModalPage } from '@opentrons/components'
-
 import { Portal } from '../../../../App/portal'
+import { WizardHeader } from '../../../../molecules/WizardHeader'
+import { ModalShell } from '../../../../molecules/Modal'
 import { CalibrateTipLength } from '../../../../organisms/CalibrateTipLength'
 import { AskForCalibrationBlockModal } from '../../../../organisms/CalibrateTipLength/AskForCalibrationBlockModal'
+import { LoadingState } from '../../../../organisms/CalibrationPanels'
 import * as RobotApi from '../../../../redux/robot-api'
 import * as Sessions from '../../../../redux/sessions'
 import { tipLengthCalibrationStarted } from '../../../../redux/analytics'
@@ -49,7 +50,7 @@ export function useDashboardCalibrateTipLength(
     | null
   >(null)
   const dispatch = useDispatch()
-  const { t } = useTranslation(['protocol_setup', 'shared'])
+  const { t } = useTranslation('robot_calibration')
 
   const sessionType = Sessions.SESSION_TYPE_TIP_LENGTH_CALIBRATION
   const withIntent = INTENT_TIP_LENGTH_OUTSIDE_PROTOCOL
@@ -165,16 +166,17 @@ export function useDashboardCalibrateTipLength(
         />
       ) : null}
       {startingSession ? (
-        <SpinnerModalPage
-          titleBar={{
-            title: t('tip_length_calibration'),
-            back: {
-              disabled: true,
-              title: t('shared:exit'),
-              children: t('shared:exit'),
-            },
-          }}
-        />
+        <ModalShell
+          width="47rem"
+          header={
+            <WizardHeader
+              title={t('tip_length_calibration')}
+              onExit={() => {}}
+            />
+          }
+        >
+          <LoadingState />
+        </ModalShell>
       ) : null}
       <CalibrateTipLength
         session={tipLengthCalibrationSession}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

ensure that the loading state modal is rendered while waiting for a calibration session to be created from the DashboardCalibration page

closes RAUT-313

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Launch the Deck calibration wizard from the Calibration Dashboard and observe the loading state modal with the correct calibration title

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Adds the ModalShell component with the LoadingState component as a child to each returned DashboardCalibration Wizard to match the styling of the wizard spinner
- Adds tests for the branch that results in the LoadingState being rendered

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the spinner page appears after clicking the "calibrate" or "recalibrate" button, on a task list item, until the wizard component actually renders

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
