### PR TITLE
fix(hardware): better stall error handling

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motor_position_status.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_position_status.py
@@ -133,9 +133,11 @@ async def update_motor_position_estimation(
                 data[node] = await asyncio.wait_for(
                     _parser_update_motor_position_response(reader, node), timeout
                 )
-                if data[node][2] == False:
+                if not data[node][2]:
                     # If the stepper_ok flag isn't set, that means the node didn't update position.
-                    raise RuntimeError(f'Failed to update motor position for node: {node}')
+                    raise RuntimeError(
+                        f"Failed to update motor position for node: {node}"
+                    )
             except asyncio.TimeoutError:
                 log.warning("Update motor position estimation timed out")
                 raise StopAsyncIteration

--- a/hardware/opentrons_hardware/hardware_control/motor_position_status.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_position_status.py
@@ -133,6 +133,9 @@ async def update_motor_position_estimation(
                 data[node] = await asyncio.wait_for(
                     _parser_update_motor_position_response(reader, node), timeout
                 )
+                if data[node][2] == False:
+                    # If the stepper_ok flag isn't set, that means the node didn't update position.
+                    raise RuntimeError(f'Failed to update motor position for node: {node}')
             except asyncio.TimeoutError:
                 log.warning("Update motor position estimation timed out")
                 raise StopAsyncIteration

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -328,6 +328,7 @@ class MoveScheduler:
         self._completion_queue: asyncio.Queue[_CompletionPacket] = asyncio.Queue()
         self._event = asyncio.Event()
         self._error: Optional[ErrorMessage] = None
+        self._current_group: Optional[int] = None
 
     def _remove_move_group(
         self, message: _AcceptableMoves, arbitration_id: ArbitrationId
@@ -359,11 +360,27 @@ class MoveScheduler:
     def _handle_acknowledge(self, message: Acknowledgement) -> None:
         log.debug("recieved ack")
 
-    def _handle_error(self, message: ErrorMessage) -> None:
+    def _handle_error(
+        self, message: ErrorMessage, arbitration_id: ArbitrationId
+    ) -> None:
         self._error = message
-        self._event.set()
+        node_id = arbitration_id.parts.originating_node_id
+
+        if self._current_group is None:
+            # Without the _current_group variable, we have no idea what group
+            # to clear. Just have to flag the event and bail.
+            self._event.set()
+        else:
+            for move in self._moves[self._current_group].copy():
+                if move[0] == node_id:
+                    self._moves[self._current_group].discard(move)
+
+            if len(self._moves[self._current_group]) == 0:
+                # Only raise _event if this is the last active axis
+                self._event.set()
         log.warning(f"Error during move group: {message}")
         if message.payload.severity == ErrorSeverity.unrecoverable:
+            self._event.set()
             raise RuntimeError("Firmware Error Received", message)
 
     def _handle_move_completed(self, message: MoveCompleted) -> None:
@@ -413,7 +430,7 @@ class MoveScheduler:
             self._remove_move_group(message, arbitration_id)
             self._handle_tip_action(message)
         elif isinstance(message, ErrorMessage):
-            self._handle_error(message)
+            self._handle_error(message, arbitration_id)
         elif isinstance(message, Acknowledgement):
             self._handle_acknowledge(message)
 
@@ -432,6 +449,7 @@ class MoveScheduler:
             self._event.clear()
 
             log.info(f"Executing move group {group_id}.")
+            self._current_group = group_id - self._start_at_index
             error = await can_messenger.ensure_send(
                 node_id=NodeId.broadcast,
                 message=ExecuteMoveGroupRequest(


### PR DESCRIPTION
# Overview

While testing the encoder stall detection feature alongside the position estimation update command, an error popped up where the Update command wasn't actually taking effect. This seems to be related to sending it too soon after a stall event, which is probably related to the motors still being active.

This PR fixes two oversights:

1. When an error is received by the move group runner, the `_event` flag is only raise if that was the _last_ active axis. If other axes are still running, they are given a chance to finish their moves.
2. When the Update Motor Position command detects that an axis failed to update (i.e. the `stepper_ok` flag is false, which is how the firmware indicates that it can't update), it raises an exception instead of silently failing.

# Test Plan

Tested on Mr. with the following.

For the Update command changes:
- [x] Disable a motor axis and then send `api._update_position_estimation` with that axis. An exception should be raised.

For the move_group_runner changes:
- [x] Home the gantry and move it directly above a well plate (ideally 10's of mm)
- [x] Copy and paste the below command and confirm that both 1) the function doesn't return as soon as the stall occurs, but rather after the expected total time 2) no exception is raised from the `update` command

```
exec("""
try:
  api.move_rel(Mount.LEFT, Point(z=-200), _check_stalls=True)
except:
  api._update_position_estimation([OT3Axis.Z_L])""")
```

# Changelog

- Added error checking to `update_motor_position_estimation`
- Added logic to `move_group_runner` to wait to raise an exception until every axis has stopped moving

# Review requests


# Risk assessment

Low, only relates to error handling and mostly unused features.
