### PR TITLE
feat(app): add calibration status banners to robot details page

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -63,7 +63,7 @@
   "launch_calibration": "Launch calibration",
   "manage_pipettes": "manage pipettes",
   "missing_calibration_data": "Missing calibration data",
-  "missing_calibration_data_long": "Robot is missing calibration data.",
+  "missing_calibration_data_long": "Robot is missing calibration data",
   "need_help": "Need help?",
   "no_pipette": "No pipette attached",
   "no_tip_length": "Calibrate your pipette to see saved tip length",

--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -61,6 +61,7 @@
   "last_completed_on": "Last completed {{timestamp}}",
   "last_migrated": "Last known calibration migrated",
   "launch_calibration": "Launch calibration",
+  "launch_calibration_link_text": "Go to calibration",
   "manage_pipettes": "manage pipettes",
   "missing_calibration_data": "Missing calibration data",
   "missing_calibration_data_long": "Robot is missing calibration data",

--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -63,6 +63,7 @@
   "launch_calibration": "Launch calibration",
   "manage_pipettes": "manage pipettes",
   "missing_calibration_data": "Missing calibration data",
+  "missing_calibration_data_long": "Robot is missing calibration data.",
   "need_help": "Need help?",
   "no_pipette": "No pipette attached",
   "no_tip_length": "Calibrate your pipette to see saved tip length",

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -35,6 +35,7 @@ import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
 import {
   useCalibrationTaskList,
+  useIsRobotBusy,
   useIsRobotViewable,
   useLights,
   useRobot,
@@ -58,6 +59,7 @@ export function RobotOverview({
   ])
 
   const { taskListStatus } = useCalibrationTaskList(robotName)
+  const isRobotBusy = useIsRobotBusy({ poll: true })
 
   // start off assuming we are missing calibrations
   let showCalibrationStatusBanner = true
@@ -181,7 +183,7 @@ export function RobotOverview({
           <RobotOverviewOverflowMenu robot={robot} />
         </Box>
       </Flex>
-      {enableCalibrationWizards && showCalibrationStatusBanner && (
+      {enableCalibrationWizards && !isRobotBusy && showCalibrationStatusBanner && (
         <Flex
           paddingBottom={SPACING.spacing4}
           flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -191,7 +191,7 @@ export function RobotOverview({
             <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
               {calibrationStatusBannerText}
               <RouterLink
-                to={`/devices/${robotName}/robot-settings/calibration/dashboard`}
+                to={`/devices/${robotName}/robot-settings/calibration`}
               >
                 <StyledText
                   as="p"

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
+import { Link as RouterLink } from 'react-router-dom'
 
 import {
   Box,
@@ -187,7 +188,20 @@ export function RobotOverview({
           width="100%"
         >
           <Banner type={calibrationStatusBannerType as BannerType}>
-            {calibrationStatusBannerText}
+            <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+              {calibrationStatusBannerText}
+              <RouterLink
+                to={`/devices/${robotName}/robot-settings/calibration/dashboard`}
+              >
+                <StyledText
+                  as="p"
+                  color={COLORS.darkBlackEnabled}
+                  textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                >
+                  {t('robot_calibration:launch_calibration_link_text')}
+                </StyledText>
+              </RouterLink>
+            </Flex>
           </Banner>
         </Flex>
       )}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -32,7 +32,12 @@ import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import { RobotStatusHeader } from './RobotStatusHeader'
 import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
-import { useCalibrationTaskList, useIsRobotViewable, useLights, useRobot } from './hooks'
+import {
+  useCalibrationTaskList,
+  useIsRobotViewable,
+  useLights,
+  useRobot,
+} from './hooks'
 
 import type { State } from '../../redux/types'
 
@@ -45,24 +50,33 @@ interface RobotOverviewProps {
 export function RobotOverview({
   robotName,
 }: RobotOverviewProps): JSX.Element | null {
-  const { t } = useTranslation(['device_details', 'shared', 'robot_calibration'])
+  const { t } = useTranslation([
+    'device_details',
+    'shared',
+    'robot_calibration',
+  ])
 
-  const { activeIndex, taskList } = useCalibrationTaskList(robotName)
+  const { taskListStatus } = useCalibrationTaskList(robotName)
 
   // start off assuming we are missing calibrations
   let showCalibrationStatusBanner = true
-  let calibrationStatusBannerType = "error"
-  let calibrationStatusBannerText = t('robot_calibration:missing_calibration_data_long')
+  let calibrationStatusBannerType = 'error'
+  let calibrationStatusBannerText = t(
+    'robot_calibration:missing_calibration_data_long'
+  )
 
   // if the tasklist is empty, though, all calibrations are good
-  if (activeIndex == null) {
+  if (taskListStatus === 'complete') {
     showCalibrationStatusBanner = false
     // if we have tasks and they are all marked bad, then we should
     // strongly suggest they re-do those calibrations
-  } else if (taskList.every(tp => tp.isComplete === true || tp.markedBad)) {
-    calibrationStatusBannerType = "warning"
-    calibrationStatusBannerText = t('robot_calibration:recalibration_recommended')
+  } else if (taskListStatus === 'bad') {
+    calibrationStatusBannerType = 'warning'
+    calibrationStatusBannerText = t(
+      'robot_calibration:recalibration_recommended'
+    )
   }
+
   const [dispatchRequest] = useDispatchApiRequest()
 
   const enableCalibrationWizards = Config.useFeatureFlag(
@@ -95,7 +109,11 @@ export function RobotOverview({
       position={POSITION_RELATIVE}
       width="100%"
     >
-      <Flex flexDirection={DIRECTION_ROW} marginBottom={SPACING.spacing4} width="100%">
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        marginBottom={SPACING.spacing4}
+        width="100%"
+      >
         <img
           src={robotModel === 'OT-2' ? OT2_PNG : OT3_PNG}
           style={{ paddingTop: SPACING.spacing3, width: '6.25rem' }}
@@ -131,7 +149,9 @@ export function RobotOverview({
                     <ToggleButton
                       label={t('lights')}
                       toggledOn={lightsOn != null ? lightsOn : false}
-                      disabled={lightsOn === null || robot.status !== CONNECTABLE}
+                      disabled={
+                        lightsOn === null || robot.status !== CONNECTABLE
+                      }
                       onClick={toggleLights}
                       height="0.813rem"
                       id="RobotOverview_lightsToggle"
@@ -152,19 +172,25 @@ export function RobotOverview({
             </Flex>
           </Flex>
         </Box>
-        <Box position={POSITION_ABSOLUTE} top={SPACING.spacing2} right="-.75rem">
+        <Box
+          position={POSITION_ABSOLUTE}
+          top={SPACING.spacing2}
+          right="-.75rem"
+        >
           <RobotOverviewOverflowMenu robot={robot} />
         </Box>
       </Flex>
       {enableCalibrationWizards && showCalibrationStatusBanner && (
-          <Flex
-            paddingBottom={SPACING.spacing4}
-            flexDirection={DIRECTION_COLUMN}
-            width="100%"
-          >
-            <Banner type={calibrationStatusBannerType as BannerType}>{calibrationStatusBannerText}</Banner>
-          </Flex>
-        )}
+        <Flex
+          paddingBottom={SPACING.spacing4}
+          flexDirection={DIRECTION_COLUMN}
+          width="100%"
+        >
+          <Banner type={calibrationStatusBannerType as BannerType}>
+            {calibrationStatusBannerText}
+          </Banner>
+        </Flex>
+      )}
     </Flex>
   ) : null
 }

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -21,6 +21,7 @@ import {
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import OT3_PNG from '../../assets/images/OT3.png'
+import { Banner, BannerType } from '../../atoms/Banner'
 import { ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { useDispatchApiRequest } from '../../redux/robot-api'
@@ -30,7 +31,7 @@ import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import { RobotStatusHeader } from './RobotStatusHeader'
 import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
-import { useIsRobotViewable, useLights, useRobot } from './hooks'
+import { useCalibrationTaskList, useIsRobotViewable, useLights, useRobot } from './hooks'
 
 import type { State } from '../../redux/types'
 
@@ -43,7 +44,24 @@ interface RobotOverviewProps {
 export function RobotOverview({
   robotName,
 }: RobotOverviewProps): JSX.Element | null {
-  const { t } = useTranslation(['device_details', 'shared'])
+  const { t } = useTranslation(['device_details', 'shared', 'robot_calibration'])
+
+  const { activeIndex, taskList } = useCalibrationTaskList(robotName)
+
+  // start off assuming we are missing calibrations
+  let showCalibrationStatusBanner = true
+  let calibrationStatusBannerType = "error"
+  let calibrationStatusBannerText = t('robot_calibration:missing_calibration_data_long')
+
+  // if the tasklist is empty, though, all calibrations are good
+  if (activeIndex == null) {
+    showCalibrationStatusBanner = false
+    // if we have tasks and they are all marked bad, then we should
+    // strongly suggest they re-do those calibrations
+  } else if (taskList.every(tp => tp.isComplete === true || tp.markedBad)) {
+    calibrationStatusBannerType = "warning"
+    calibrationStatusBannerText = t('robot_calibration:recalibration_recommended')
+  }
   const [dispatchRequest] = useDispatchApiRequest()
 
   const robot = useRobot(robotName)
@@ -66,71 +84,82 @@ export function RobotOverview({
       alignItems={ALIGN_START}
       backgroundColor={COLORS.white}
       borderBottom={BORDERS.lineBorder}
-      flexDirection={DIRECTION_ROW}
+      flexDirection={DIRECTION_COLUMN}
       marginBottom={SPACING.spacing4}
       padding={SPACING.spacing3}
       position={POSITION_RELATIVE}
       width="100%"
     >
-      <img
-        src={robotModel === 'OT-2' ? OT2_PNG : OT3_PNG}
-        style={{ paddingTop: SPACING.spacing3, width: '6.25rem' }}
-        id="RobotOverview_robotImage"
-      />
-      <Box padding={SPACING.spacing3} width="100%">
-        <ReachableBanner robot={robot} />
-        {robot != null ? (
-          <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
-        ) : null}
-        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-          <RobotStatusHeader
-            name={robot.name}
-            local={robot.local}
-            robotModel={robotModel}
-          />
-          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              paddingRight={SPACING.spacing4}
-            >
-              <StyledText
-                as="h6"
-                color={COLORS.darkGreyEnabled}
-                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                paddingBottom={SPACING.spacing2}
-                textTransform={TYPOGRAPHY.textTransformUppercase}
+      <Flex flexDirection={DIRECTION_ROW} marginBottom={SPACING.spacing4} width="100%">
+        <img
+          src={robotModel === 'OT-2' ? OT2_PNG : OT3_PNG}
+          style={{ paddingTop: SPACING.spacing3, width: '6.25rem' }}
+          id="RobotOverview_robotImage"
+        />
+        <Box padding={SPACING.spacing3} width="100%">
+          <ReachableBanner robot={robot} />
+          {robot != null ? (
+            <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
+          ) : null}
+          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+            <RobotStatusHeader
+              name={robot.name}
+              local={robot.local}
+              robotModel={robotModel}
+            />
+            <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                paddingRight={SPACING.spacing4}
               >
-                {t('controls')}
-              </StyledText>
-              <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
-                <Flex paddingBottom={SPACING.spacing2}>
-                  <ToggleButton
-                    label={t('lights')}
-                    toggledOn={lightsOn != null ? lightsOn : false}
-                    disabled={lightsOn === null || robot.status !== CONNECTABLE}
-                    onClick={toggleLights}
-                    height="0.813rem"
-                    id="RobotOverview_lightsToggle"
-                  />
-                </Flex>
                 <StyledText
-                  as="p"
-                  color={
-                    isRobotViewable
-                      ? COLORS.darkBlackEnabled
-                      : COLORS.errorDisabled
-                  }
+                  as="h6"
+                  color={COLORS.darkGreyEnabled}
+                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                  paddingBottom={SPACING.spacing2}
+                  textTransform={TYPOGRAPHY.textTransformUppercase}
                 >
-                  {t('lights')}
+                  {t('controls')}
                 </StyledText>
+                <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+                  <Flex paddingBottom={SPACING.spacing2}>
+                    <ToggleButton
+                      label={t('lights')}
+                      toggledOn={lightsOn != null ? lightsOn : false}
+                      disabled={lightsOn === null || robot.status !== CONNECTABLE}
+                      onClick={toggleLights}
+                      height="0.813rem"
+                      id="RobotOverview_lightsToggle"
+                    />
+                  </Flex>
+                  <StyledText
+                    as="p"
+                    color={
+                      isRobotViewable
+                        ? COLORS.darkBlackEnabled
+                        : COLORS.errorDisabled
+                    }
+                  >
+                    {t('lights')}
+                  </StyledText>
+                </Flex>
               </Flex>
             </Flex>
           </Flex>
-        </Flex>
-      </Box>
-      <Box position={POSITION_ABSOLUTE} top={SPACING.spacing2} right="-.75rem">
-        <RobotOverviewOverflowMenu robot={robot} />
-      </Box>
+        </Box>
+        <Box position={POSITION_ABSOLUTE} top={SPACING.spacing2} right="-.75rem">
+          <RobotOverviewOverflowMenu robot={robot} />
+        </Box>
+      </Flex>
+      {showCalibrationStatusBanner && (
+          <Flex
+            paddingBottom={SPACING.spacing4}
+            flexDirection={DIRECTION_COLUMN}
+            width="100%"
+          >
+            <Banner type={calibrationStatusBannerType as BannerType}>{calibrationStatusBannerText}</Banner>
+          </Flex>
+        )}
     </Flex>
   ) : null
 }

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -24,6 +24,7 @@ import OT3_PNG from '../../assets/images/OT3.png'
 import { Banner, BannerType } from '../../atoms/Banner'
 import { ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
+import * as Config from '../../redux/config'
 import { useDispatchApiRequest } from '../../redux/robot-api'
 import { fetchLights } from '../../redux/robot-controls'
 import { CONNECTABLE, getRobotModelByName } from '../../redux/discovery'
@@ -63,6 +64,10 @@ export function RobotOverview({
     calibrationStatusBannerText = t('robot_calibration:recalibration_recommended')
   }
   const [dispatchRequest] = useDispatchApiRequest()
+
+  const enableCalibrationWizards = Config.useFeatureFlag(
+    'enableCalibrationWizards'
+  )
 
   const robot = useRobot(robotName)
   const robotModel = useSelector((state: State) =>
@@ -151,7 +156,7 @@ export function RobotOverview({
           <RobotOverviewOverflowMenu robot={robot} />
         </Box>
       </Flex>
-      {showCalibrationStatusBanner && (
+      {enableCalibrationWizards && showCalibrationStatusBanner && (
           <Flex
             paddingBottom={SPACING.spacing4}
             flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -17,6 +17,7 @@ import {
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SPACING,
+  TEXT_ALIGN_RIGHT,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
@@ -102,86 +103,89 @@ export function RobotOverview({
   )
 
   return robot != null ? (
-    <Flex
-      alignItems={ALIGN_START}
-      backgroundColor={COLORS.white}
-      borderBottom={BORDERS.lineBorder}
-      flexDirection={DIRECTION_COLUMN}
-      marginBottom={SPACING.spacing4}
-      padding={SPACING.spacing3}
-      position={POSITION_RELATIVE}
-      width="100%"
-    >
+    <>
       <Flex
-        flexDirection={DIRECTION_ROW}
-        marginBottom={SPACING.spacing4}
+        alignItems={ALIGN_START}
+        backgroundColor={COLORS.white}
+        flexDirection={DIRECTION_COLUMN}
+        padding={SPACING.spacing3}
+        position={POSITION_RELATIVE}
         width="100%"
       >
-        <img
-          src={robotModel === 'OT-2' ? OT2_PNG : OT3_PNG}
-          style={{ paddingTop: SPACING.spacing3, width: '6.25rem' }}
-          id="RobotOverview_robotImage"
-        />
-        <Box padding={SPACING.spacing3} width="100%">
-          <ReachableBanner robot={robot} />
-          {robot != null ? (
-            <UpdateRobotBanner robot={robot} marginBottom={SPACING.spacing3} />
-          ) : null}
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-            <RobotStatusHeader
-              name={robot.name}
-              local={robot.local}
-              robotModel={robotModel}
-            />
-            <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                paddingRight={SPACING.spacing4}
-              >
-                <StyledText
-                  as="h6"
-                  color={COLORS.darkGreyEnabled}
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  paddingBottom={SPACING.spacing2}
-                  textTransform={TYPOGRAPHY.textTransformUppercase}
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          marginBottom={SPACING.spacing4}
+          width="100%"
+        >
+          <img
+            src={robotModel === 'OT-2' ? OT2_PNG : OT3_PNG}
+            style={{ paddingTop: SPACING.spacing3, width: '6.25rem' }}
+            id="RobotOverview_robotImage"
+          />
+          <Box padding={SPACING.spacing3} width="100%">
+            <ReachableBanner robot={robot} />
+            {robot != null ? (
+              <UpdateRobotBanner
+                robot={robot}
+                marginBottom={SPACING.spacing3}
+              />
+            ) : null}
+            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+              <RobotStatusHeader
+                name={robot.name}
+                local={robot.local}
+                robotModel={robotModel}
+              />
+              <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  paddingRight={SPACING.spacing4}
                 >
-                  {t('controls')}
-                </StyledText>
-                <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
-                  <Flex paddingBottom={SPACING.spacing2}>
-                    <ToggleButton
-                      label={t('lights')}
-                      toggledOn={lightsOn != null ? lightsOn : false}
-                      disabled={
-                        lightsOn === null || robot.status !== CONNECTABLE
-                      }
-                      onClick={toggleLights}
-                      height="0.813rem"
-                      id="RobotOverview_lightsToggle"
-                    />
-                  </Flex>
                   <StyledText
-                    as="p"
-                    color={
-                      isRobotViewable
-                        ? COLORS.darkBlackEnabled
-                        : COLORS.errorDisabled
-                    }
+                    as="h6"
+                    color={COLORS.darkGreyEnabled}
+                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                    paddingBottom={SPACING.spacing2}
+                    textTransform={TYPOGRAPHY.textTransformUppercase}
                   >
-                    {t('lights')}
+                    {t('controls')}
                   </StyledText>
+                  <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+                    <Flex paddingBottom={SPACING.spacing2}>
+                      <ToggleButton
+                        label={t('lights')}
+                        toggledOn={lightsOn != null ? lightsOn : false}
+                        disabled={
+                          lightsOn === null || robot.status !== CONNECTABLE
+                        }
+                        onClick={toggleLights}
+                        height="0.813rem"
+                        id="RobotOverview_lightsToggle"
+                      />
+                    </Flex>
+                    <StyledText
+                      as="p"
+                      color={
+                        isRobotViewable
+                          ? COLORS.darkBlackEnabled
+                          : COLORS.errorDisabled
+                      }
+                    >
+                      {t('lights')}
+                    </StyledText>
+                  </Flex>
                 </Flex>
               </Flex>
             </Flex>
-          </Flex>
-        </Box>
-        <Box
-          position={POSITION_ABSOLUTE}
-          top={SPACING.spacing2}
-          right="-.75rem"
-        >
-          <RobotOverviewOverflowMenu robot={robot} />
-        </Box>
+          </Box>
+          <Box
+            position={POSITION_ABSOLUTE}
+            top={SPACING.spacing2}
+            right="-.75rem"
+          >
+            <RobotOverviewOverflowMenu robot={robot} />
+          </Box>
+        </Flex>
       </Flex>
       {enableCalibrationWizards && !isRobotBusy && showCalibrationStatusBanner && (
         <Flex
@@ -190,7 +194,12 @@ export function RobotOverview({
           width="100%"
         >
           <Banner type={calibrationStatusBannerType as BannerType}>
-            <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+            <Flex
+              alignItems={ALIGN_CENTER}
+              flexDirection={DIRECTION_ROW}
+              justifyContent={JUSTIFY_SPACE_BETWEEN}
+              width="100%"
+            >
               {calibrationStatusBannerText}
               <RouterLink
                 to={`/devices/${robotName}/robot-settings/calibration`}
@@ -198,6 +207,8 @@ export function RobotOverview({
                 <StyledText
                   as="p"
                   color={COLORS.darkBlackEnabled}
+                  paddingRight={SPACING.spacing4}
+                  textAlign={TEXT_ALIGN_RIGHT}
                   textDecoration={TYPOGRAPHY.textDecorationUnderline}
                 >
                   {t('robot_calibration:launch_calibration_link_text')}
@@ -207,6 +218,12 @@ export function RobotOverview({
           </Banner>
         </Flex>
       )}
-    </Flex>
+      <Flex
+        borderBottom={BORDERS.lineBorder}
+        marginBottom={SPACING.spacing4}
+        position={POSITION_RELATIVE}
+        width="100%"
+      />
+    </>
   ) : null
 }

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -193,20 +193,42 @@ describe('RobotOverview', () => {
     getByText('Mock UpdateRobotBanner')
   })
 
+  it('does not render a calibration status label when calibration is good and the calibration wizard feature flag is set', () => {
+    mockUseFeatureFlag.mockReturnValue(true)
+    const [{ queryByRole }] = render(props)
+    expect(
+      queryByRole('link', {
+        name: 'Go to calibration',
+      })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders a missing calibration status label when the calibration wizard feature flag is set', () => {
     mockUseCalibrationTaskList.mockReturnValue(
       expectedIncompleteDeckCalTaskList
     )
     mockUseFeatureFlag.mockReturnValue(true)
-    const [{ getByText }] = render(props)
+    const [{ getByRole, getByText }] = render(props)
     getByText('Robot is missing calibration data')
+    const calibrationDashboardLink = getByRole('link', {
+      name: 'Go to calibration',
+    })
+    expect(calibrationDashboardLink.getAttribute('href')).toEqual(
+      '/devices/opentrons-robot-name/robot-settings/calibration/dashboard'
+    )
   })
 
   it('renders a recommended recalibration status label when the calibration wizard feature flag is set', () => {
     mockUseCalibrationTaskList.mockReturnValue(expectedFailedTaskList)
     mockUseFeatureFlag.mockReturnValue(true)
-    const [{ getByText }] = render(props)
+    const [{ getByRole, getByText }] = render(props)
     getByText('Recalibration recommended')
+    const calibrationDashboardLink = getByRole('link', {
+      name: 'Go to calibration',
+    })
+    expect(calibrationDashboardLink.getAttribute('href')).toEqual(
+      '/devices/opentrons-robot-name/robot-settings/calibration/dashboard'
+    )
   })
 
   it('fetches lights status', () => {

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -214,7 +214,7 @@ describe('RobotOverview', () => {
       name: 'Go to calibration',
     })
     expect(calibrationDashboardLink.getAttribute('href')).toEqual(
-      '/devices/opentrons-robot-name/robot-settings/calibration/dashboard'
+      '/devices/opentrons-robot-name/robot-settings/calibration'
     )
   })
 
@@ -227,7 +227,7 @@ describe('RobotOverview', () => {
       name: 'Go to calibration',
     })
     expect(calibrationDashboardLink.getAttribute('href')).toEqual(
-      '/devices/opentrons-robot-name/robot-settings/calibration/dashboard'
+      '/devices/opentrons-robot-name/robot-settings/calibration'
     )
   })
 

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../redux/discovery/constants'
 import {
   useCalibrationTaskList,
+  useIsRobotBusy,
   useLights,
   useRobot,
   useRunStatuses,
@@ -81,6 +82,9 @@ const MOCK_STATE: State = {
 
 const mockUseCalibrationTaskList = useCalibrationTaskList as jest.MockedFunction<
   typeof useCalibrationTaskList
+>
+const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
+  typeof useIsRobotBusy
 >
 const mockUseLights = useLights as jest.MockedFunction<typeof useLights>
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
@@ -148,6 +152,7 @@ describe('RobotOverview', () => {
     mockUseCalibrationTaskList.mockReturnValue(expectedTaskList)
     mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
     mockUseFeatureFlag.mockReturnValue(false)
+    mockUseIsRobotBusy.mockReturnValue(false)
     mockUseLights.mockReturnValue({
       lightsOn: false,
       toggleLights: mockToggleLights,
@@ -229,6 +234,20 @@ describe('RobotOverview', () => {
     expect(calibrationDashboardLink.getAttribute('href')).toEqual(
       '/devices/opentrons-robot-name/robot-settings/calibration'
     )
+  })
+
+  it('does not render a calibration status label when robot is busy and the calibration wizard feature flag is set', () => {
+    mockUseCalibrationTaskList.mockReturnValue(
+      expectedIncompleteDeckCalTaskList
+    )
+    mockUseIsRobotBusy.mockReturnValue(true)
+    mockUseFeatureFlag.mockReturnValue(true)
+    const [{ queryByRole }] = render(props)
+    expect(
+      queryByRole('link', {
+        name: 'Go to calibration',
+      })
+    ).not.toBeInTheDocument()
   })
 
   it('fetches lights status', () => {

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -19,7 +19,13 @@ import {
   HEALTH_STATUS_OK,
   ROBOT_MODEL_OT3,
 } from '../../../redux/discovery/constants'
-import { useLights, useRobot, useRunStatuses } from '../hooks'
+import {
+  useCalibrationTaskList,
+  useLights,
+  useRobot,
+  useRunStatuses,
+} from '../hooks'
+import { expectedTaskList } from '../hooks/__fixtures__/taskListFixtures'
 import { UpdateRobotBanner } from '../../UpdateRobotBanner'
 import { RobotStatusHeader } from '../RobotStatusHeader'
 import { RobotOverview } from '../RobotOverview'
@@ -67,6 +73,9 @@ const MOCK_STATE: State = {
   },
 } as any
 
+const mockUseCalibrationTaskList = useCalibrationTaskList as jest.MockedFunction<
+  typeof useCalibrationTaskList
+>
 const mockUseLights = useLights as jest.MockedFunction<typeof useLights>
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
@@ -127,6 +136,7 @@ describe('RobotOverview', () => {
       autoUpdateDisabledReason: null,
       updateFromFileDisabledReason: null,
     })
+    mockUseCalibrationTaskList.mockReturnValue(expectedTaskList)
     mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
     mockUseLights.mockReturnValue({
       lightsOn: false,


### PR DESCRIPTION
# Overview

Two new calibration status banners (referred to in the ticket as "toasts" but shown in the designs as banners) have been added to the Robot Page in the Devices section.

Closes RAUT-95

# Test Plan

Tested during development with a mixture of manual testing of the appearance and content of the banners and comprehensive unit testing for the logic behind when they appear and what they contain.

# Changelog

- Add longer missing calibration and link to calibration texts
- Add calibration status banner with link to the settings calibration page
- Wrap banner in enableCalibrationWizards feature flag
- Use taskListStatus to drive calibration flavor of status banners
- Don't show banner when protocol is running
- Added tests for banner

# Review requests

- "Go to calibration" goes to the calibration settings on the [robot settings page]
- "Robot is missing calibration data" status renders correctly
- "Recalibration recommended" status only appears after failed calibration health check and renders correctly
- No toast appears when calibration is complete
- Statuses are not visible while robot is running a protocol

# Risk assessment

Low risk to the general users, as it is hidden behind a feature flag. It is also just one additional bit of info on calibration status and one additional way to reach calibration, so it would not block a user is it misbehaves.
