### PR TITLE
fix(api): Set active current properly for drop tip on the 96 channel

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -767,6 +767,10 @@ class PipetteHandlerProvider:
             instrument.current_tiprack_diameter = 0.0
             instrument.remove_tip()
 
+        is_96_chan = instrument.channels.value == 96
+        drop_tip_current_axis = (
+            OT3Axis.Q if is_96_chan else OT3Axis.of_main_tool_actuator(mount)
+        )
         seq_builder_ot3 = self._droptip_sequence_builder(
             bottom,
             droptip,
@@ -775,15 +779,11 @@ class PipetteHandlerProvider:
                     mount
                 ): instrument.plunger_motor_current.run
             },
-            {
-                OT3Axis.of_main_tool_actuator(
-                    mount
-                ): instrument.drop_configurations.current
-            },
+            {drop_tip_current_axis: instrument.drop_configurations.current},
             speed,
             home_after,
             (OT3Axis.of_main_tool_actuator(mount),),
-            instrument.channels.value == 96,
+            is_96_chan,
         )
 
         seq_ot3 = seq_builder_ot3()

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -658,7 +658,7 @@ class PipetteHandlerProvider:
                     pick_up_motor_actions=TipMotorPickUpTipSpec(
                         # Move onto the posts
                         tiprack_down=top_types.Point(0, 0, -5),
-                        tiprack_up=top_types.Point(0, 0, 7),
+                        tiprack_up=top_types.Point(0, 0, 2),
                         pick_up_distance=instrument.pick_up_configurations.distance,
                         speed=instrument.pick_up_configurations.speed,
                         currents={OT3Axis.Q: instrument.pick_up_configurations.current},

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -85,7 +85,7 @@ def test_plan_check_pick_up_tip_with_presses_argument(
             96,
             TipMotorPickUpTipSpec(
                 tiprack_down=types.Point(0, 0, -5),
-                tiprack_up=types.Point(0, 0, 7),
+                tiprack_up=types.Point(0, 0, 2),
                 pick_up_distance=0,
                 speed=10,
                 currents={OT3Axis.Q: 1},


### PR DESCRIPTION
# Overview

Since separating out the current commands for tip motors from the plunger motors, we did not update
the drop tip motors to use the correct axis. Thus, the active current wasn't getting set for drop
tip commands.

# Risk assessment

Low