### PR TITLE
￼ fix(app): minimize command page length when only retrieving run total length

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -23,7 +23,6 @@ import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { useRunControls } from '../RunTimeControl/hooks'
-import { RUN_LOG_WINDOW_SIZE } from './constants'
 import { DownloadRunLogToast } from './DownloadRunLogToast'
 import { useTrackProtocolRunEvent } from './hooks'
 import { getBuildrootUpdateDisplayInfo } from '../../redux/buildroot'
@@ -57,7 +56,7 @@ export function HistoricalProtocolRunOverflowMenu(
 
   const commands = useAllCommandsQuery(
     runId,
-    { cursor: 0, pageLength: RUN_LOG_WINDOW_SIZE },
+    { cursor: 0, pageLength: 0},
     { staleTime: Infinity }
   )
   const runTotalCommandCount = commands?.data?.meta?.totalLength

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -56,7 +56,7 @@ export function HistoricalProtocolRunOverflowMenu(
 
   const commands = useAllCommandsQuery(
     runId,
-    { cursor: 0, pageLength: 0},
+    { cursor: 0, pageLength: 0 },
     { staleTime: Infinity }
   )
   const runTotalCommandCount = commands?.data?.meta?.totalLength


### PR DESCRIPTION
# Overview

Instead of fetching an entire window of commands from each run on the historic run details page to
prep the download run log button, fetch zero commands in order to retrieve the total run command
count.

re [RAUT-315](https://opentrons.atlassian.net/browse/RAUT-315)

# Test Plan

- confirm that downloading the run data from the overflow menu on the historic runs list still functions as expected.



[RAUT-315]: https://opentrons.atlassian.net/browse/RAUT-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ