### PR TITLE
perf(api): Regularly yield to the event loop when executing Protocol Engine commands

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/queue_worker.py
@@ -73,3 +73,7 @@ class QueueWorker:
             )
 
             await self._command_executor.execute(command_id=command_id)
+
+            # Yield to the event loop in case we're executing a long run of commands
+            # that never yields internally. For example, a long run of comment commands.
+            await asyncio.sleep(0)


### PR DESCRIPTION
# Overview

When a `ProtocolEngine` executes its list of commands, this PR ensures it yields to the event loop regularly. This improves robot server responsiveness while it's analyzing a JSON protocol.

We need to do this so that if there's a long runs of commands that happens to never yield internally, it won't block the event loop. Imagine a long run of `loadLiquid`s or `comment`s, for example. Although they're defined as `async def`, they'll never yield to the event loop because they never do anything with the hardware API.

This is related to @sfoster1's #12023, which solves a similar problem in simulating hardware APIs. I think this PR is a good-enough solution for the problem at both layers, and #12023 is the proper solution for the problem at the hardware API layer. So this PR is merging into `hotfix_6.2.1`, #12023 is merging into `edge`, and eventually we'll have both PRs in `edge`.

With neither PR, I'm seeing event loop blockages of 100-300 ms on my dev machine. I assume they're worse on an actual OT-2.

This work goes towards RQA-443.

# Test Plan

I've done this:

1. `make dev PYTHONASYNCIODEBUG=1`
4. Upload a large protocol through Postman. (I used the one from RQA-443.)
5. Confirm that the log shows no warnings like this, which do show up without this PR.
    ```
    Executing <Task pending coro=<QueueWorker._run_commands() running at .../queue_worker.py:75> created at .../tasks.py:351> took 0.119 seconds
    ```

I've also tested on a dev server that the `asyncio.sleep(0)` overhead does not appreciably affect protocol simulation time. It was actually a bit faster in my test—21 seconds instead of 26 seconds. I don't think this PR truly makes things faster, though. The "improvement" is probably just measurement noise.

This code is also well-covered by existing unit and integration tests.

# Review requests

* Do we understand and agree with this change, in principle?
* Does the comment sufficiently explain why this is necessary?

# Risk assessment

Low. Functional coverage is good, and I've tested performance manually.