### PR TITLE
perf(api): Do not block the event loop when loading JSONv6 protocols

### DIFF
--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -1,5 +1,8 @@
 """Protocol run control and management."""
+import asyncio
 from typing import Iterable, List, NamedTuple, Optional
+
+import anyio
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
@@ -104,13 +107,15 @@ class ProtocolRunner:
             protocol_source=protocol_source
         )
         for definition in labware_definitions:
+            # Assume adding a labware definition is fast and there are not many labware
+            # definitions, so we don't need to yield here.
             self._protocol_engine.add_labware_definition(definition)
 
         if isinstance(config, JsonProtocolConfig):
             schema_version = config.schema_version
 
             if schema_version >= LEGACY_JSON_SCHEMA_VERSION_CUTOFF:
-                self._load_json(protocol_source)
+                await self._load_json(protocol_source)
             else:
                 self._load_legacy(protocol_source, labware_definitions)
 
@@ -159,19 +164,37 @@ class ProtocolRunner:
         commands = self._protocol_engine.state_view.commands.get_all()
         return ProtocolRunResult(commands=commands, state_summary=run_data)
 
-    def _load_json(self, protocol_source: ProtocolSource) -> None:
-        # fixme(mm, 2022-12-23): This does I/O and compute-bound parsing that will block
-        # the event loop. Jira RSS-165.
-        protocol = self._json_file_reader.read(protocol_source)
-        commands = self._json_translator.translate_commands(protocol)
+    async def _load_json(self, protocol_source: ProtocolSource) -> None:
+        protocol = await anyio.to_thread.run_sync(
+            self._json_file_reader.read,
+            protocol_source,
+        )
 
+        commands = await anyio.to_thread.run_sync(
+            self._json_translator.translate_commands,
+            protocol,
+        )
+
+        # Add commands and liquids to the ProtocolEngine.
+        #
+        # We yield on every iteration so that loading large protocols doesn't block the
+        # event loop. With a 24-step 10k-command protocol (See RQA-443), adding all the
+        # commands can take 3 to 7 seconds.
+        #
+        # It wouldn't be safe to do this in a worker thread because each addition
+        # invokes the ProtocolEngine's ChangeNotifier machinery, which is not
+        # thread-safe.
         if feature_flags.enable_load_liquid():
-            liquids = self._json_translator.translate_liquids(protocol)
+            liquids = await anyio.to_thread.run_sync(
+                self._json_translator.translate_liquids, protocol
+            )
             for liquid in liquids:
                 self._protocol_engine.add_liquid(liquid=liquid)
-
+                await _yield()
         for command in commands:
             self._protocol_engine.add_command(request=command)
+            await _yield()
+
         self._task_queue.set_run_func(func=self._protocol_engine.wait_until_complete)
 
     def _load_python(self, protocol_source: ProtocolSource) -> None:
@@ -215,3 +238,8 @@ class ProtocolRunner:
             protocol=protocol,
             context=context,
         )
+
+
+async def _yield() -> None:
+    """Yield execution to the event loop, giving other tasks a chance to run."""
+    await asyncio.sleep(0)


### PR DESCRIPTION
# Overview

This fixes blocking I/O and blocking compute work inside `ProtocolRunner` when it loads a JSONv6 protocol.

This should improve `robot-server` responsiveness when uploading, analyzing, and creating runs from large JSONv6 protocols.

This work goes towards RQA-443.

# Changelog

Do not block the event loop when:

* Reading the JSON protocol file.
* Parsing the JSON file into a Pydantic model.
* Translating the JSONv6 commands and liquids to Protocol Engine commands and liquids.
* Adding the commands and liquids to the `ProtocolEngine`.

To keep the hotfix diff small and reduce QA overhead, this only fixes the problems for large *JSONv6* protocols. The same problems remain for older JSON protocols and for Python protocols.

# Test Plan

I've tested this alongside #12038 by:

1. Pushing the fixes to an OT-2
2. Creating a run from a JSON protocol in the Opentrons App
3. Monitoring the Chrome dev tools' network tab

Without this PR, there were a few points where the server became unresponsive, and polls from the app were held up for minutes at a time.

With this PR (and #12038), that's mostly fixed. The server promptly handles polls from the app throughout most of the protocol upload and run creation process.

I think stalls are still happening in some places, but I haven't had a chance to narrow down exactly where and why. I think it might be RSS-175, but I haven't confirmed.

# Review requests

I feel like there are smart thoughts to be had about the thread safety thing that I mentioned in the `# comment`. But they are not being produced by me at this time. Perhaps you will have better luck?

# Risk assessment

Low. Changes are well contained and covered by existing unit and integration tests. There's theoretically a risk that the additional overhead of `asyncio.sleep(0)` will slow down protocol analysis, but from the test results in #12038, I don't think that will be a problem in practice.
