### PR TITLE
test(robot-server): Add unit tests for 0-length command slices

### DIFF
--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -432,6 +432,8 @@ def test_get_command_slice(
 @pytest.mark.parametrize(
     ("input_cursor", "input_length", "expected_cursor", "expected_command_ids"),
     [
+        (0, 0, 0, []),
+        (None, 0, 2, []),
         (0, 3, 0, ["pause-1", "pause-2", "pause-3"]),
         (0, 1, 0, ["pause-1"]),
         (1, 2, 1, ["pause-2", "pause-3"]),


### PR DESCRIPTION
# Overview

#12036 makes an optimization in the Opentrons App to query `GET /runs/{run_id}/commands` with `?pageLength=0` when we're only trying to fetch the number of commands, not the actual command data. This PR makes sure that case is covered in `robot-server` unit tests.

# Review requests

Based on your understanding of how `robot-server`'s pagination works, does this behavior look correct and intentional?

# Risk assessment

No risk. Changes are just to existing unit tests.
