### PR TITLE
feat(app): implement calibrations complete dashboard screen

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -2,6 +2,7 @@
   "attached_pipettes": "attached pipette calibrations",
   "before_you_begin": "Before you begin",
   "calibrate": "Calibrate",
+  "calibrations_complete": "Calibrations complete!",
   "calibrate_deck": "calibrate deck",
   "calibration_dashboard": "Calibration Dashboard",
   "calibration_status": "Calibration Status",

--- a/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
+++ b/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
@@ -50,22 +50,8 @@ describe('CalibrationTaskList', () => {
     getByText('Right Mount')
   })
 
-  it('clicking the recalibrate CTAs triggers the calibration launchers', () => {
-    const [{ getByText, getAllByText }] = render()
-    getByText('Left Mount').click()
-    getByText('Right Mount').click()
-    const recalibrateButtons = getAllByText('Recalibrate') // [deck, left-tip-length, left-offset, right-tip-length, left-offset]
-    expect(recalibrateButtons).toHaveLength(5)
-
-    recalibrateButtons[0].click()
-    expect(mockDeckCalLauncher).toHaveBeenCalled()
-    recalibrateButtons[1].click()
-    expect(mockTipLengthCalLauncher).toHaveBeenCalled()
-    recalibrateButtons[2].click()
-    expect(mockPipOffsetCalLauncher).toHaveBeenCalled()
-    recalibrateButtons[3].click()
-    expect(mockTipLengthCalLauncher).toHaveBeenCalled()
-    recalibrateButtons[4].click()
-    expect(mockPipOffsetCalLauncher).toHaveBeenCalled()
+  it('does not show the Calibrations complete screen when viewing a completed task list', () => {
+    const [{ queryByText }] = render()
+    expect(queryByText('Calibrations complete!')).toBeFalsy()
   })
 })

--- a/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
+++ b/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
+import { StaticRouter } from 'react-router-dom'
 import { i18n } from '../../../i18n'
 import { CalibrationTaskList } from '..'
 import {
@@ -11,7 +12,6 @@ import {
   mockCompleteTipLengthCalibrations,
   mockCompletePipetteOffsetCalibrations,
 } from '../../Devices/hooks/__fixtures__/taskListFixtures'
-import { StaticRouter } from 'react-router-dom'
 
 jest.mock('../../Devices/hooks', () => {
   const actualHooks = jest.requireActual('../../Devices/hooks')

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -77,11 +77,7 @@ export function CalibrationTaskList({
             justifyContent={JUSTIFY_CENTER}
             alignItems={ALIGN_CENTER}
           >
-            <Icon
-              name="ot-check"
-              size="3rem"
-              color={COLORS.successEnabled}
-            />
+            <Icon name="ot-check" size="3rem" color={COLORS.successEnabled} />
             <StyledText as="h1" marginTop={SPACING.spacing5}>
               {t('calibrations_complete')}
             </StyledText>

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -9,7 +9,6 @@ import {
   Flex,
   Icon,
   JUSTIFY_CENTER,
-  JUSTIFY_FLEX_END,
   SPACING,
 } from '@opentrons/components'
 import { Modal } from '../../molecules/Modal'
@@ -51,10 +50,6 @@ export function CalibrationTaskList({
   )
 
   React.useEffect(() => {
-    console.log({ prevActiveIndex: prevActiveIndex.current })
-    if (prevActiveIndex.current == null && activeIndex == null) {
-      return
-    }
     if (prevActiveIndex.current !== null && activeIndex === null) {
       setShowCompletionScreen(true)
     }
@@ -69,14 +64,13 @@ export function CalibrationTaskList({
       }
       fullPage
       backgroundColor={COLORS.fundamentalsBackground}
-      childrenPadding={`${String(SPACING.spacing4)} ${String(
-        SPACING.spacing5
-      )} ${String(SPACING.spacing5)} ${
-        showCompletionScreen ? '' : String(SPACING.spacing2)
-      }`}
+      childrenPadding={`${SPACING.spacing4} ${SPACING.spacing5} ${SPACING.spacing5} ${SPACING.spacing2}`}
     >
       {showCompletionScreen ? (
-        <Flex flexDirection={DIRECTION_COLUMN} padding="4.375rem">
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          padding="4.25rem 4.25rem 4.25rem 5.5rem"
+        >
           <Flex
             flex="1"
             flexDirection={DIRECTION_COLUMN}
@@ -85,28 +79,20 @@ export function CalibrationTaskList({
           >
             <Icon
               name="ot-check"
-              size="2.775rem"
+              size="3rem"
               color={COLORS.successEnabled}
             />
             <StyledText as="h1" marginTop={SPACING.spacing5}>
               {t('calibrations_complete')}
             </StyledText>
-            <Flex
-              flex="0"
-              alignSelf={ALIGN_CENTER}
+            <PrimaryButton
               marginTop={SPACING.spacing5}
-              justifyContent={JUSTIFY_FLEX_END}
+              onClick={() =>
+                history.push(`/devices/${robotName}/robot-settings/calibration`)
+              }
             >
-              <PrimaryButton
-                onClick={() =>
-                  history.push(
-                    `/devices/${robotName}/robot-settings/calibration`
-                  )
-                }
-              >
-                {t('device_settings:done')}
-              </PrimaryButton>
-            </Flex>
+              {t('device_settings:done')}
+            </PrimaryButton>
           </Flex>
         </Flex>
       ) : (

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -2,7 +2,16 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
 
-import { COLORS, SPACING } from '@opentrons/components'
+import {
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_CENTER,
+  JUSTIFY_FLEX_END,
+  SPACING,
+} from '@opentrons/components'
 import { Modal } from '../../molecules/Modal'
 import { TaskList } from '../TaskList'
 
@@ -11,6 +20,8 @@ import { useCalibrationTaskList } from '../Devices/hooks'
 import type { DashboardCalOffsetInvoker } from '../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibratePipOffset'
 import type { DashboardCalTipLengthInvoker } from '../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength'
 import type { DashboardCalDeckInvoker } from '../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck'
+import { StyledText } from '../../atoms/text'
+import { PrimaryButton } from '../../atoms/buttons'
 
 interface CalibrationTaskListProps {
   robotName: string
@@ -25,7 +36,12 @@ export function CalibrationTaskList({
   tipLengthCalLauncher,
   deckCalLauncher,
 }: CalibrationTaskListProps): JSX.Element {
-  const { t } = useTranslation('robot_calibration')
+  const prevActiveIndex = React.useRef<[number, number] | null>(null)
+  const [
+    showCompletionScreen,
+    setShowCompletionScreen,
+  ] = React.useState<boolean>(false)
+  const { t } = useTranslation(['robot_calibration', 'device_settings'])
   const history = useHistory()
   const { activeIndex, taskList } = useCalibrationTaskList(
     robotName,
@@ -33,6 +49,17 @@ export function CalibrationTaskList({
     tipLengthCalLauncher,
     deckCalLauncher
   )
+
+  React.useEffect(() => {
+    console.log({ prevActiveIndex: prevActiveIndex.current })
+    if (prevActiveIndex.current == null && activeIndex == null) {
+      return
+    }
+    if (prevActiveIndex.current !== null && activeIndex === null) {
+      setShowCompletionScreen(true)
+    }
+    prevActiveIndex.current = activeIndex
+  }, [activeIndex])
 
   return (
     <Modal
@@ -44,9 +71,47 @@ export function CalibrationTaskList({
       backgroundColor={COLORS.fundamentalsBackground}
       childrenPadding={`${String(SPACING.spacing4)} ${String(
         SPACING.spacing5
-      )} ${String(SPACING.spacing5)} ${String(SPACING.spacing2)}`}
+      )} ${String(SPACING.spacing5)} ${
+        showCompletionScreen ? '' : String(SPACING.spacing2)
+      }`}
     >
-      <TaskList activeIndex={activeIndex} taskList={taskList} />
+      {showCompletionScreen ? (
+        <Flex flexDirection={DIRECTION_COLUMN} padding="4.375rem">
+          <Flex
+            flex="1"
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+            alignItems={ALIGN_CENTER}
+          >
+            <Icon
+              name="ot-check"
+              size="2.775rem"
+              color={COLORS.successEnabled}
+            />
+            <StyledText as="h1" marginTop={SPACING.spacing5}>
+              {t('calibrations_complete')}
+            </StyledText>
+            <Flex
+              flex="0"
+              alignSelf={ALIGN_CENTER}
+              marginTop={SPACING.spacing5}
+              justifyContent={JUSTIFY_FLEX_END}
+            >
+              <PrimaryButton
+                onClick={() =>
+                  history.push(
+                    `/devices/${robotName}/robot-settings/calibration`
+                  )
+                }
+              >
+                {t('device_settings:done')}
+              </PrimaryButton>
+            </Flex>
+          </Flex>
+        </Flex>
+      ) : (
+        <TaskList activeIndex={activeIndex} taskList={taskList} />
+      )}
     </Modal>
   )
 }

--- a/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
@@ -346,4 +346,82 @@ describe('useCalibrationTaskList hook', () => {
       expectedTaskList.taskList[2].subTasks[1].footer
     )
   })
+
+  it('passes the launcher function to cta onclick handlers for recalibration', () => {
+    when(mockUseAttachedPipettes)
+      .calledWith()
+      .mockReturnValue(mockAttachedPipettesResponse)
+    when(mockUseDeckCalibrationData)
+      .calledWith('otie')
+      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseTipLengthCalibrations)
+      .calledWith('otie')
+      .mockReturnValue(mockCompleteTipLengthCalibrations)
+    when(mockUsePipetteOffsetCalibrations)
+      .calledWith('otie')
+      .mockReturnValue(mockCompletePipetteOffsetCalibrations)
+
+    const { result } = renderHook(
+      () =>
+        useCalibrationTaskList(
+          'otie',
+          mockPipOffsetCalLauncher,
+          mockTipLengthCalLauncher,
+          mockDeckCalLauncher
+        ),
+      {
+        wrapper,
+      }
+    )
+
+    result.current.taskList[0].cta?.onClick()
+    expect(mockDeckCalLauncher).toHaveBeenCalledTimes(1)
+    result.current.taskList[1].subTasks[0].cta?.onClick()
+    expect(mockTipLengthCalLauncher).toHaveBeenCalledTimes(1)
+    result.current.taskList[1].subTasks[1].cta?.onClick()
+    expect(mockPipOffsetCalLauncher).toHaveBeenCalledTimes(1)
+    result.current.taskList[2].subTasks[0].cta?.onClick()
+    expect(mockTipLengthCalLauncher).toHaveBeenCalledTimes(2)
+    result.current.taskList[2].subTasks[1].cta?.onClick()
+    expect(mockPipOffsetCalLauncher).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes the launcher function to cta onclick handlers for calibration', () => {
+    when(mockUseAttachedPipettes)
+      .calledWith()
+      .mockReturnValue(mockAttachedPipettesResponse)
+    when(mockUseDeckCalibrationData)
+      .calledWith('otie')
+      .mockReturnValue(mockIncompleteDeckCalibration)
+    when(mockUseTipLengthCalibrations)
+      .calledWith('otie')
+      .mockReturnValue(mockIncompleteTipLengthCalibrations)
+    when(mockUsePipetteOffsetCalibrations)
+      .calledWith('otie')
+      .mockReturnValue(mockIncompletePipetteOffsetCalibrations)
+
+    const { result } = renderHook(
+      () =>
+        useCalibrationTaskList(
+          'otie',
+          mockPipOffsetCalLauncher,
+          mockTipLengthCalLauncher,
+          mockDeckCalLauncher
+        ),
+      {
+        wrapper,
+      }
+    )
+
+    result.current.taskList[0].cta?.onClick()
+    expect(mockDeckCalLauncher).toHaveBeenCalledTimes(1)
+    result.current.taskList[1].subTasks[0].cta?.onClick()
+    expect(mockTipLengthCalLauncher).toHaveBeenCalledTimes(1)
+    result.current.taskList[1].subTasks[1].cta?.onClick()
+    expect(mockPipOffsetCalLauncher).toHaveBeenCalledTimes(1)
+    result.current.taskList[2].subTasks[0].cta?.onClick()
+    expect(mockTipLengthCalLauncher).toHaveBeenCalledTimes(2)
+    result.current.taskList[2].subTasks[1].cta?.onClick()
+    expect(mockPipOffsetCalLauncher).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

adds a calibrations complete screen to the calibration dashboard once a user completes all calibrations 
closes RAUT-111


https://user-images.githubusercontent.com/66637570/214125543-c0bfaa9f-d437-44e5-a18a-4a5853c1cbbb.mov


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Loading the CalibrationDashboard with incomplete calibrations should show the task list, only once the final incomplete task is completed and the calibration statuses refresh should the "Calibrations complete!" screen render. Clicking the "Done" button should return you to the robot settings page. Viewing a list of completed calibrations in the Dashboard should not show the "Calibrations complete!" page

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Adds "Calibrations complete!" text to `robot_calibration.json`
- Adds the "Calibrations complete!" view to the `CalibrationTaskList` component

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the behavior matches what is described in the Test Plan section above

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
