### PR TITLE
refactor(api): rename implementation properties and init arguments to core

### DIFF
--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -151,12 +151,12 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         edges = build_edges(
             where=Well(
                 parent=Labware(
-                    implementation=location.geometry.parent,
+                    core=location.geometry.parent,
                     api_version=self._api_version,
                     protocol_core=None,  # type: ignore[arg-type]
                     core_map=None,  # type: ignore[arg-type]
                 ),
-                well_implementation=location,
+                core=location,
                 api_version=self._api_version,
             ),
             offset=v_offset,
@@ -215,16 +215,12 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
             from opentrons.protocol_api.labware import Labware, Well
 
             labware = Labware(
-                implementation=labware_core,
+                core=labware_core,
                 api_version=self._api_version,
                 protocol_core=None,  # type: ignore[arg-type]
                 core_map=None,  # type: ignore[arg-type]
             )
-            well = Well(
-                parent=labware,
-                well_implementation=well_core,
-                api_version=self._api_version,
-            )
+            well = Well(parent=labware, core=well_core, api_version=self._api_version)
 
             if LabwareLike(labware).is_fixed_trash():
                 location = well.top()

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_module_core.py
@@ -189,9 +189,7 @@ class LegacyMagneticModuleCore(LegacyModuleCore, AbstractMagneticModuleCore):
                 " using `height_from_base` or `height`"
             )
 
-        engage_height = labware._implementation.get_default_magnet_engage_height(
-            preserve_half_mm
-        )
+        engage_height = labware._core.get_default_magnet_engage_height(preserve_half_mm)
 
         if engage_height is None:
             raise ValueError(

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_module_core.py
@@ -95,7 +95,7 @@ class LegacyModuleCore(AbstractModuleCore):
         """Add a labware to the module."""
         labware = self.geometry.add_labware(
             Labware(
-                implementation=labware_core,
+                core=labware_core,
                 api_version=self._protocol_core.api_version,
                 protocol_core=None,  # type: ignore[arg-type]
                 core_map=None,  # type: ignore[arg-type]

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -347,7 +347,7 @@ class LegacyProtocolCore(
         if isinstance(trash, LegacyLabwareCore):
             return trash
         if isinstance(trash, Labware):
-            return cast(LegacyLabwareCore, trash._implementation)
+            return cast(LegacyLabwareCore, trash._core)
 
         raise RuntimeError("Robot must have a trash container in 12")
 
@@ -395,11 +395,7 @@ class LegacyProtocolCore(
     ) -> Optional[LegacyLabwareCore]:
         """Get the item on top of a given module, if any."""
         labware = module_core.geometry.labware
-        return (
-            cast(LegacyLabwareCore, labware._implementation)
-            if labware is not None
-            else None
-        )
+        return cast(LegacyLabwareCore, labware._core) if labware is not None else None
 
     def get_deck_definition(self) -> DeckDefinitionV3:
         """Get the geometry definition of the robot's deck."""

--- a/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
@@ -279,7 +279,7 @@ class ThermocyclerGeometry(ModuleGeometry):
         definition = labware._core.get_definition()
         definition["ordering"] = definition["ordering"][2::]
         return Labware(
-            implementation=LegacyLabwareCore(definition, super().location),
+            core=LegacyLabwareCore(definition, super().location),
             api_version=labware.api_version,
             protocol_core=None,  # type: ignore[arg-type]
             core_map=None,  # type: ignore[arg-type]

--- a/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
@@ -276,7 +276,7 @@ class ThermocyclerGeometry(ModuleGeometry):
         )
 
         # Block first three columns from being accessed
-        definition = labware._implementation.get_definition()
+        definition = labware._core.get_definition()
         definition["ordering"] = definition["ordering"][2::]
         return Labware(
             implementation=LegacyLabwareCore(definition, super().location),

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -180,16 +180,12 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
             from opentrons.protocol_api.labware import Labware, Well
 
             labware = Labware(
-                implementation=labware_core,
+                core=labware_core,
                 api_version=self._api_version,
                 protocol_core=None,  # type: ignore[arg-type]
                 core_map=None,  # type: ignore[arg-type]
             )
-            well = Well(
-                parent=labware,
-                well_implementation=well_core,
-                api_version=self._api_version,
-            )
+            well = Well(parent=labware, core=well_core, api_version=self._api_version)
 
             if LabwareLike(labware).is_fixed_trash():
                 location = well.top()

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -126,8 +126,8 @@ def create_protocol_context(
 
     return ProtocolContext(
         api_version=api_version,
+        core=cast(AbstractProtocolCore, core),
         broker=broker,
-        implementation=cast(AbstractProtocolCore, core),
         deck=deck,
         bundled_data=bundled_data,
     )

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -216,7 +216,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             self._implementation.aspirate(
                 location=move_to_location,
-                well_core=well._impl if well is not None else None,
+                well_core=well._core if well is not None else None,
                 volume=c_vol,
                 rate=rate,
                 flow_rate=flow_rate,
@@ -281,7 +281,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         if isinstance(location, labware.Well):
             well = location
-            if well.parent._implementation.is_fixed_trash():
+            if well.parent._core.is_fixed_trash():
                 move_to_location = location.top()
             else:
                 move_to_location = location.bottom(
@@ -328,7 +328,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 volume=c_vol,
                 rate=rate,
                 location=move_to_location,
-                well_core=well._impl if well is not None else None,
+                well_core=well._core if well is not None else None,
                 flow_rate=flow_rate,
             )
 
@@ -473,7 +473,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             self._implementation.blow_out(
                 location=checked_loc,
-                well_core=well._impl if well is not None else None,
+                well_core=well._core if well is not None else None,
                 move_to_well=move_to_well,
             )
 
@@ -566,7 +566,7 @@ class InstrumentContext(publisher.CommandPublisher):
             raise TypeError("location should be a Well, but it is {}".format(location))
 
         self._implementation.touch_tip(
-            location=well.as_well()._impl,
+            location=well.as_well()._core,
             radius=radius,
             v_offset=v_offset,
             speed=checked_speed,
@@ -800,7 +800,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             self._implementation.pick_up_tip(
                 location=move_to_location,
-                well_core=well._impl,
+                well_core=well._core,
                 presses=presses,
                 increment=increment,
                 prep_after=prep_after,
@@ -918,7 +918,7 @@ class InstrumentContext(publisher.CommandPublisher):
             command=cmds.drop_tip(instrument=self, location=well),
         ):
             self._implementation.drop_tip(
-                location=location, well_core=well._impl, home_after=home_after
+                location=location, well_core=well._core, home_after=home_after
             )
 
         self._last_tip_picked_up_from = None
@@ -1279,7 +1279,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
             self._implementation.move_to(
                 location=location,
-                well_core=well._impl if well is not None else None,
+                well_core=well._core if well is not None else None,
                 force_direct=force_direct,
                 minimum_z_height=minimum_z_height,
                 speed=speed,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -64,7 +64,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
     def __init__(
         self,
-        implementation: InstrumentCore,
+        core: InstrumentCore,
         protocol_core: ProtocolCore,
         broker: Broker,
         api_version: APIVersion,
@@ -75,7 +75,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         super().__init__(broker)
         self._api_version = api_version
-        self._core = implementation
+        self._core = core
         self._protocol_core = protocol_core
         self._tip_racks = tip_racks
         self._last_tip_picked_up_from: Union[labware.Well, None] = None

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -75,7 +75,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         super().__init__(broker)
         self._api_version = api_version
-        self._implementation = implementation
+        self._core = implementation
         self._protocol_core = protocol_core
         self._tip_racks = tip_racks
         self._last_tip_picked_up_from: Union[labware.Well, None] = None
@@ -120,11 +120,11 @@ class InstrumentContext(publisher.CommandPublisher):
         default, the speed of individual motions can be changed with the
         ``speed`` argument to :py:meth:`InstrumentContext.move_to`.
         """
-        return self._implementation.get_default_speed()
+        return self._core.get_default_speed()
 
     @default_speed.setter
     def default_speed(self, speed: float) -> None:
-        self._implementation.set_default_speed(speed)
+        self._core.set_default_speed(speed)
 
     @requires_version(2, 0)
     def aspirate(
@@ -201,8 +201,8 @@ class InstrumentContext(publisher.CommandPublisher):
                 reject_module=self.api_version >= APIVersion(2, 13),
             )
 
-        c_vol = self._implementation.get_available_volume() if not volume else volume
-        flow_rate = self._implementation.get_absolute_aspirate_flow_rate(rate)
+        c_vol = self._core.get_available_volume() if not volume else volume
+        flow_rate = self._core.get_absolute_aspirate_flow_rate(rate)
 
         with publisher.publish_context(
             broker=self.broker,
@@ -214,7 +214,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 rate=rate,
             ),
         ):
-            self._implementation.aspirate(
+            self._core.aspirate(
                 location=move_to_location,
                 well_core=well._core if well is not None else None,
                 volume=c_vol,
@@ -310,9 +310,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 reject_module=self.api_version >= APIVersion(2, 13),
             )
 
-        c_vol = self._implementation.get_current_volume() if not volume else volume
+        c_vol = self._core.get_current_volume() if not volume else volume
 
-        flow_rate = self._implementation.get_absolute_dispense_flow_rate(rate)
+        flow_rate = self._core.get_absolute_dispense_flow_rate(rate)
 
         with publisher.publish_context(
             broker=self.broker,
@@ -324,7 +324,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 flow_rate=flow_rate,
             ),
         ):
-            self._implementation.dispense(
+            self._core.dispense(
                 volume=c_vol,
                 rate=rate,
                 location=move_to_location,
@@ -383,10 +383,10 @@ class InstrumentContext(publisher.CommandPublisher):
                 volume, repetitions, location if location else "current position", rate
             )
         )
-        if not self._implementation.has_tip():
+        if not self._core.has_tip():
             raise hc.NoTipAttachedError("Pipette has no tip. Aborting mix()")
 
-        c_vol = self._implementation.get_available_volume() if not volume else volume
+        c_vol = self._core.get_available_volume() if not volume else volume
 
         with publisher.publish_context(
             broker=self.broker,
@@ -471,7 +471,7 @@ class InstrumentContext(publisher.CommandPublisher):
             broker=self.broker,
             command=cmds.blow_out(instrument=self, location=checked_loc),
         ):
-            self._implementation.blow_out(
+            self._core.blow_out(
                 location=checked_loc,
                 well_core=well._core if well is not None else None,
                 move_to_well=move_to_well,
@@ -528,7 +528,7 @@ class InstrumentContext(publisher.CommandPublisher):
             ``Placeable`` as the ``location`` parameter)
 
         """
-        if not self._implementation.has_tip():
+        if not self._core.has_tip():
             raise hc.NoTipAttachedError("Pipette has no tip to touch_tip()")
 
         checked_speed = self._determine_speed(speed)
@@ -565,7 +565,7 @@ class InstrumentContext(publisher.CommandPublisher):
         else:
             raise TypeError("location should be a Well, but it is {}".format(location))
 
-        self._implementation.touch_tip(
+        self._core.touch_tip(
             location=well.as_well()._core,
             radius=radius,
             v_offset=v_offset,
@@ -609,7 +609,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
 
         """
-        if not self._implementation.has_tip():
+        if not self._core.has_tip():
             raise hc.NoTipAttachedError("Pipette has no tip. Aborting air_gap")
 
         if height is None:
@@ -636,7 +636,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param home_after:
             See the ``home_after`` parameter of :py:obj:`drop_tip`.
         """
-        if not self._implementation.has_tip():
+        if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
 
         loc = self._last_tip_picked_up_from
@@ -798,7 +798,7 @@ class InstrumentContext(publisher.CommandPublisher):
             broker=self.broker,
             command=cmds.pick_up_tip(instrument=self, location=well),
         ):
-            self._implementation.pick_up_tip(
+            self._core.pick_up_tip(
                 location=move_to_location,
                 well_core=well._core,
                 presses=presses,
@@ -917,7 +917,7 @@ class InstrumentContext(publisher.CommandPublisher):
             broker=self.broker,
             command=cmds.drop_tip(instrument=self, location=well),
         ):
-            self._implementation.drop_tip(
+            self._core.drop_tip(
                 location=location, well_core=well._core, home_after=home_after
             )
 
@@ -931,12 +931,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :returns: This instance.
         """
 
-        mount_name = self._implementation.get_mount().name.lower()
+        mount_name = self._core.get_mount().name.lower()
 
         with publisher.publish_context(
             broker=self.broker, command=cmds.home(mount_name)
         ):
-            self._implementation.home()
+            self._core.home()
 
         return self
 
@@ -946,7 +946,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :returns: This instance.
         """
-        self._implementation.home_plunger()
+        self._core.home_plunger()
         return self
 
     @publisher.publish(command=cmds.distribute)
@@ -1277,7 +1277,7 @@ class InstrumentContext(publisher.CommandPublisher):
         with publish_ctx:
             _, well = location.labware.get_parent_labware_and_well()
 
-            self._implementation.move_to(
+            self._core.move_to(
                 location=location,
                 well_core=well._core if well is not None else None,
                 force_direct=force_direct,
@@ -1291,7 +1291,7 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 0)
     def mount(self) -> str:
         """Return the name of the mount this pipette is attached to"""
-        return self._implementation.get_mount().name.lower()
+        return self._core.get_mount().name.lower()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1318,7 +1318,7 @@ class InstrumentContext(publisher.CommandPublisher):
             instrument.speed.aspirate = 50
 
         """
-        return self._implementation.get_speed()
+        return self._core.get_speed()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1345,7 +1345,7 @@ class InstrumentContext(publisher.CommandPublisher):
             instrument.flow_rate.aspirate = 50
 
         """
-        return self._implementation.get_flow_rate()
+        return self._core.get_flow_rate()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1395,7 +1395,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The name string for the pipette (e.g. 'p300_single')
         """
-        return self._implementation.get_pipette_name()
+        return self._core.get_pipette_name()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1403,12 +1403,12 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The model string for the pipette (e.g. 'p300_single_v1.3')
         """
-        return self._implementation.get_model()
+        return self._core.get_model()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def min_volume(self) -> float:
-        return self._implementation.get_min_volume()
+        return self._core.get_min_volume()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1422,7 +1422,7 @@ class InstrumentContext(publisher.CommandPublisher):
         300 µL, but if it's using a 200 µL filter tip, its usable volume would
         be limited to 200 µL.
         """
-        return self._implementation.get_max_volume()
+        return self._core.get_max_volume()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1430,13 +1430,13 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The current amount of liquid, in microliters, held in the pipette.
         """
-        return self._implementation.get_current_volume()
+        return self._core.get_current_volume()
 
     @property  # type: ignore
     @requires_version(2, 7)
     def has_tip(self) -> bool:
         """Return whether this instrument has a tip attached or not."""
-        return self._implementation.has_tip()
+        return self._core.has_tip()
 
     @property
     def _has_tip(self) -> bool:
@@ -1444,7 +1444,7 @@ class InstrumentContext(publisher.CommandPublisher):
         Internal function used to check whether this instrument has a
         tip attached or not.
         """
-        return self._implementation.has_tip()
+        return self._core.has_tip()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1454,19 +1454,19 @@ class InstrumentContext(publisher.CommandPublisher):
         :raises: a :py:class:`.types.PipetteNotAttachedError` if the pipette is
                  no longer attached (should not happen).
         """
-        return self._implementation.get_hardware_state()
+        return self._core.get_hardware_state()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def channels(self) -> int:
         """The number of channels on the pipette."""
-        return self._implementation.get_channels()
+        return self._core.get_channels()
 
     @property  # type: ignore
     @requires_version(2, 2)
     def return_height(self) -> float:
         """The height to return a tip to its tiprack."""
-        return self._implementation.get_return_height()
+        return self._core.get_return_height()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -1494,8 +1494,8 @@ class InstrumentContext(publisher.CommandPublisher):
     def __repr__(self) -> str:
         return "<{}: {} in {}>".format(
             self.__class__.__name__,
-            self._implementation.get_model(),
-            self._implementation.get_mount().name,
+            self._core.get_model(),
+            self._core.get_mount().name,
         )
 
     def __str__(self) -> str:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -79,7 +79,7 @@ class Well:
             api_version = _IGNORE_API_VERSION_BREAKPOINT
 
         self._parent = parent
-        self._impl = well_implementation
+        self._core = well_implementation
         self._api_version = api_version
 
     @property  # type: ignore
@@ -96,7 +96,7 @@ class Well:
     @requires_version(2, 0)
     def has_tip(self) -> bool:
         """If parent labware is a tip rack, whether this well contains a tip."""
-        return self._impl.has_tip()
+        return self._core.has_tip()
 
     @has_tip.setter
     def has_tip(self, value: bool) -> None:
@@ -105,22 +105,22 @@ class Well:
             " and will raise an error in a future version of the Python Protocol API."
         )
 
-        self._impl.set_has_tip(value)
+        self._core.set_has_tip(value)
 
     @property
     def max_volume(self) -> float:
-        return self._impl.get_max_volume()
+        return self._core.get_max_volume()
 
     @property
     def geometry(self) -> WellGeometry:
-        if isinstance(self._impl, LegacyWellCore):
-            return self._impl.geometry
+        if isinstance(self._core, LegacyWellCore):
+            return self._core.geometry
         raise APIVersionError("Well.geometry has been deprecated.")
 
     @property  # type: ignore
     @requires_version(2, 0)
     def diameter(self) -> Optional[float]:
-        return self._impl.diameter
+        return self._core.diameter
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -129,7 +129,7 @@ class Well:
         The length of a well, if the labware has
         square wells.
         """
-        return self._impl.length
+        return self._core.length
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -138,7 +138,7 @@ class Well:
         The width of a well, if the labware has
         square wells.
         """
-        return self._impl.width
+        return self._core.width
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -146,16 +146,16 @@ class Well:
         """
         The depth of a well in a labware.
         """
-        return self._impl.depth
+        return self._core.depth
 
     @property
     def display_name(self) -> str:
-        return self._impl.get_display_name()
+        return self._core.get_display_name()
 
     @property  # type: ignore
     @requires_version(2, 7)
     def well_name(self) -> str:
-        return self._impl.get_name()
+        return self._core.get_name()
 
     @requires_version(2, 0)
     def top(self, z: float = 0.0) -> Location:
@@ -166,7 +166,7 @@ class Well:
                  front-left corner of slot 1 as (0,0,0)). If z is specified,
                  returns a point offset by z mm from top-center
         """
-        return Location(self._impl.get_top(z_offset=z), self)
+        return Location(self._core.get_top(z_offset=z), self)
 
     @requires_version(2, 0)
     def bottom(self, z: float = 0.0) -> Location:
@@ -177,7 +177,7 @@ class Well:
                  slot 1 as (0,0,0)). If z is specified, returns a point
                  offset by z mm from bottom-center
         """
-        return Location(self._impl.get_bottom(z_offset=z), self)
+        return Location(self._core.get_bottom(z_offset=z), self)
 
     @requires_version(2, 0)
     def center(self) -> Location:
@@ -186,7 +186,7 @@ class Well:
                  of the well relative to the deck (with the front-left corner
                  of slot 1 as (0,0,0))
         """
-        return Location(self._impl.get_center(), self)
+        return Location(self._core.get_center(), self)
 
     @requires_version(2, 8)
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
@@ -209,7 +209,7 @@ class Well:
         :return: a :py:class:`opentrons.types.Point` representing the specified
                  location in absolute deck coordinates
         """
-        return self._impl.from_center_cartesian(x, y, z)
+        return self._core.from_center_cartesian(x, y, z)
 
     def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """
@@ -222,7 +222,7 @@ class Well:
         return self.from_center_cartesian(x, y, z)
 
     def __repr__(self) -> str:
-        return self._impl.get_display_name()
+        return self._core.get_display_name()
 
     def __eq__(self, other: object) -> bool:
         """
@@ -285,7 +285,7 @@ class Labware:
             api_version = _IGNORE_API_VERSION_BREAKPOINT
 
         self._api_version = api_version
-        self._implementation: LabwareCore = implementation
+        self._core: LabwareCore = implementation
         self._protocol_core = protocol_core
         self._core_map = core_map
 
@@ -324,7 +324,7 @@ class Labware:
 
         :returns: The uri, ``"namespace/loadname/version"``
         """
-        return self._implementation.get_uri()
+        return self._core.get_uri()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
@@ -339,15 +339,13 @@ class Labware:
             Return type for module parent changed to :py:class:`ModuleContext`.
             Prior to this version, an internal geometry interface is returned.
         """
-        if isinstance(self._implementation, LegacyLabwareCore):
+        if isinstance(self._core, LegacyLabwareCore):
             # Type ignoring to preserve backwards compatibility
-            return self._implementation.get_geometry().parent.labware.object  # type: ignore
+            return self._core.get_geometry().parent.labware.object  # type: ignore
 
         assert self._protocol_core and self._core_map, "Labware initialized incorrectly"
 
-        labware_location = self._protocol_core.get_labware_location(
-            self._implementation
-        )
+        labware_location = self._protocol_core.get_labware_location(self._core)
 
         if isinstance(labware_location, AbstractModuleCore):
             return self._core_map.get(labware_location)
@@ -359,37 +357,37 @@ class Labware:
     def name(self) -> str:
         """Can either be the canonical name of the labware, which is used to
         load it, or the label of the labware specified by a user."""
-        return self._implementation.get_name()
+        return self._core.get_name()
 
     # TODO(jbl, 2022-12-06): deprecate officially when there is a PAPI version for the engine core
     @name.setter
     def name(self, new_name: str) -> None:
         """Set the labware name"""
-        self._implementation.set_name(new_name)
+        self._core.set_name(new_name)
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def load_name(self) -> str:
         """The API load name of the labware definition"""
-        return self._implementation.load_name
+        return self._core.load_name
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def parameters(self) -> "LabwareParameters":
         """Internal properties of a labware including type and quirks"""
-        return self._implementation.get_parameters()
+        return self._core.get_parameters()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def quirks(self) -> List[str]:
         """Quirks specific to this labware."""
-        return self._implementation.get_quirks()
+        return self._core.get_quirks()
 
-    # TODO(mc, 2022-09-23): use `self._implementation.get_default_magnet_engage_height`
+    # TODO(mc, 2022-09-23): use `self._core.get_default_magnet_engage_height`
     @property  # type: ignore
     @requires_version(2, 0)
     def magdeck_engage_height(self) -> Optional[float]:
-        p = self._implementation.get_parameters()
+        p = self._core.get_parameters()
         if not p["isMagneticModuleCompatible"]:
             return None
         else:
@@ -399,7 +397,7 @@ class Labware:
         """
         Called by save calibration in order to update the offset on the object.
         """
-        self._implementation.set_calibration(delta)
+        self._core.set_calibration(delta)
 
     @requires_version(2, 12)
     def set_offset(self, x: float, y: float, z: float) -> None:
@@ -421,12 +419,12 @@ class Labware:
             at the same time will produce undefined behavior. We may choose
             to define this behavior in a future release.
         """
-        self._implementation.set_calibration(Point(x=x, y=y, z=z))
+        self._core.set_calibration(Point(x=x, y=y, z=z))
 
     @property  # type: ignore
     @requires_version(2, 0)
     def calibrated_offset(self) -> Point:
-        return self._implementation.get_calibrated_offset()
+        return self._core.get_calibrated_offset()
 
     @requires_version(2, 0)
     def well(self, idx: Union[int, str]) -> Well:
@@ -634,12 +632,12 @@ class Labware:
         This is drawn from the 'dimensions'/'zDimension' elements of the
         labware definition and takes into account the calibration offset.
         """
-        return self._implementation.highest_z
+        return self._core.highest_z
 
     @property
     def _is_tiprack(self) -> bool:
         """as is_tiprack but not subject to version checking for speed"""
-        return self._implementation.is_tip_rack()
+        return self._core.is_tip_rack()
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
@@ -649,12 +647,12 @@ class Labware:
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def tip_length(self) -> float:
-        return self._implementation.get_tip_length()
+        return self._core.get_tip_length()
 
     # TODO(jbl, 2022-12-06): deprecate officially when there is a PAPI version for the engine core
     @tip_length.setter
     def tip_length(self, length: float) -> None:
-        self._implementation.set_tip_length(length)
+        self._core.set_tip_length(length)
 
     # TODO(mc, 2022-11-09): implementation detail; deprecate public method
     def next_tip(
@@ -676,9 +674,9 @@ class Labware:
         """
         assert num_tips > 0, f"num_tips must be positive integer, but got {num_tips}"
 
-        well_name = self._implementation.get_next_tip(
+        well_name = self._core.get_next_tip(
             num_tips=num_tips,
-            starting_tip=starting_tip._impl if starting_tip else None,
+            starting_tip=starting_tip._core if starting_tip else None,
         )
 
         return self._wells_by_name[well_name] if well_name is not None else None
@@ -708,22 +706,22 @@ class Labware:
 
         fail_if_full = self._api_version < APIVersion(2, 2)
 
-        self._implementation.get_tip_tracker().use_tips(
-            start_well=start_well._impl,
+        self._core.get_tip_tracker().use_tips(
+            start_well=start_well._core,
             num_channels=num_channels,
             fail_if_full=fail_if_full,
         )
 
     def __repr__(self) -> str:
-        return self._implementation.get_display_name()
+        return self._core.get_display_name()
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Labware):
             return NotImplemented
-        return self._implementation == other._implementation
+        return self._core == other._core
 
     def __hash__(self) -> int:
-        return hash((self._implementation, self._api_version))
+        return hash((self._core, self._api_version))
 
     # TODO(mc, 2022-11-09): implementation detail; deprecate public method
     def previous_tip(self, num_tips: int = 1) -> Optional[Well]:
@@ -740,9 +738,7 @@ class Labware:
         """
         # This logic is the inverse of :py:meth:`next_tip`
         assert num_tips > 0, "Bad call to previous_tip: num_tips <= 0"
-        well_core = self._implementation.get_tip_tracker().previous_tip(
-            num_tips=num_tips
-        )
+        well_core = self._core.get_tip_tracker().previous_tip(num_tips=num_tips)
         return self._wells_by_name[well_core.get_name()] if well_core else None
 
     # TODO(mc, 2022-11-09): implementation detail; deprecate public method
@@ -769,14 +765,14 @@ class Labware:
         """
         # This logic is the inverse of :py:meth:`use_tips`
         assert num_channels > 0, "Bad call to return_tips: num_channels <= 0"
-        self._implementation.get_tip_tracker().return_tips(
-            start_well=start_well._impl, num_channels=num_channels
+        self._core.get_tip_tracker().return_tips(
+            start_well=start_well._core, num_channels=num_channels
         )
 
     @requires_version(2, 0)
     def reset(self) -> None:
         """Reset all tips in a tiprack."""
-        self._implementation.reset_tips()
+        self._core.reset_tips()
 
 
 # TODO(mc, 2022-11-09): implementation detail, move to core

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -165,7 +165,7 @@ class ModuleContext(CommandPublisher):
             labware = self._core.add_labware_core(cast(LegacyLabwareCore, labware_core))
         else:
             labware = Labware(
-                implementation=labware_core,
+                core=labware_core,
                 api_version=self._api_version,
                 protocol_core=self._protocol_core,
                 core_map=self._core_map,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -110,7 +110,7 @@ class ProtocolContext(CommandPublisher):
 
         super().__init__(broker)
         self._api_version = api_version
-        self._implementation = implementation
+        self._core = implementation
         self._core_map = core_map or LoadedCoreMap()
         self._deck = deck or Deck(protocol_core=implementation, core_map=self._core_map)
         self._instruments: Dict[Mount, Optional[InstrumentContext]] = {
@@ -143,7 +143,7 @@ class ProtocolContext(CommandPublisher):
             "This function will be deprecated in later versions."
             "Please use with caution."
         )
-        return HardwareManager(hardware=self._implementation.get_hardware())
+        return HardwareManager(hardware=self._core.get_hardware())
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -198,7 +198,7 @@ class ProtocolContext(CommandPublisher):
                 protocol.max_speeds['X'] = None  # reset to default
 
         """
-        return self._implementation.get_max_speeds()
+        return self._core.get_max_speeds()
 
     @requires_version(2, 0)
     def commands(self) -> List[str]:
@@ -230,7 +230,7 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def is_simulating(self) -> bool:
-        return self._implementation.is_simulating()
+        return self._core.is_simulating()
 
     @requires_version(2, 0)
     def load_labware_from_definition(
@@ -253,7 +253,7 @@ class ProtocolContext(CommandPublisher):
                           as in the run log and the calibration view in the
                           Opentrons app.
         """
-        load_params = self._implementation.add_labware_definition(labware_def)
+        load_params = self._core.add_labware_definition(labware_def)
 
         return self.load_labware(
             load_name=load_params.load_name,
@@ -297,7 +297,7 @@ class ProtocolContext(CommandPublisher):
         load_name = validation.ensure_lowercase_name(load_name)
         deck_slot = validation.ensure_deck_slot(location)
 
-        labware_core = self._implementation.load_labware(
+        labware_core = self._core.load_labware(
             load_name=load_name,
             location=deck_slot,
             label=label,
@@ -308,7 +308,7 @@ class ProtocolContext(CommandPublisher):
         labware = Labware(
             implementation=labware_core,
             api_version=self._api_version,
-            protocol_core=self._implementation,
+            protocol_core=self._core,
             core_map=self._core_map,
         )
         self._core_map.add(labware_core, labware)
@@ -352,8 +352,7 @@ class ProtocolContext(CommandPublisher):
                   the locations.
         """
         labware_cores = (
-            (core.get_deck_slot(), core)
-            for core in self._implementation.get_labware_cores()
+            (core.get_deck_slot(), core) for core in self._core.get_labware_cores()
         )
 
         return {
@@ -425,8 +424,8 @@ class ProtocolContext(CommandPublisher):
             if drop_offset
             else None
         )
-        self._implementation.move_labware(
-            labware_core=labware._implementation,
+        self._core.move_labware(
+            labware_core=labware._core,
             new_location=location,
             use_gripper=use_gripper,
             use_pick_up_location_lpc_offset=use_pick_up_location_lpc_offset,
@@ -484,7 +483,7 @@ class ProtocolContext(CommandPublisher):
         requested_model = validation.ensure_module_model(module_name)
         deck_slot = None if location is None else validation.ensure_deck_slot(location)
 
-        module_core = self._implementation.load_module(
+        module_core = self._core.load_module(
             model=requested_model,
             deck_slot=deck_slot,
             configuration=configuration,
@@ -492,7 +491,7 @@ class ProtocolContext(CommandPublisher):
 
         module_context = _create_module_context(
             module_core=module_core,
-            protocol_core=self._implementation,
+            protocol_core=self._core,
             core_map=self._core_map,
             broker=self._broker,
             api_version=self._api_version,
@@ -520,7 +519,7 @@ class ProtocolContext(CommandPublisher):
         """
         return {
             core.get_deck_slot().as_int(): self._core_map.get(core)
-            for core in self._implementation.get_module_cores()
+            for core in self._core.get_module_cores()
         }
 
     @requires_version(2, 0)
@@ -556,7 +555,7 @@ class ProtocolContext(CommandPublisher):
         """
         instrument_name = validation.ensure_lowercase_name(instrument_name)
         is_96_channel = instrument_name == "p1000_96"
-        if is_96_channel and isinstance(self._implementation, ProtocolEngineCore):
+        if is_96_channel and isinstance(self._core, ProtocolEngineCore):
             checked_instrument_name = instrument_name
             checked_mount = Mount.LEFT
         else:
@@ -579,7 +578,7 @@ class ProtocolContext(CommandPublisher):
 
         # TODO (tz, 11-22-22): was added to support 96 channel pipette.
         #  Should remove when working on https://opentrons.atlassian.net/browse/RLIQ-255
-        instrument_core = self._implementation.load_instrument(
+        instrument_core = self._core.load_instrument(
             instrument_name=checked_instrument_name,  # type: ignore[arg-type]
             mount=checked_mount,
         )
@@ -594,7 +593,7 @@ class ProtocolContext(CommandPublisher):
         instrument = InstrumentContext(
             broker=self._broker,
             implementation=instrument_core,
-            protocol_core=self._implementation,
+            protocol_core=self._core,
             api_version=self._api_version,
             tip_racks=tip_racks,
             trash=self.fixed_trash,
@@ -643,7 +642,7 @@ class ProtocolContext(CommandPublisher):
         :param str msg: An optional message to show to connected clients. The
             Opentrons App will show this in the run log.
         """
-        self._implementation.pause(msg=msg)
+        self._core.pause(msg=msg)
 
     @publish(command=cmds.resume)
     @requires_version(2, 0)
@@ -656,7 +655,7 @@ class ProtocolContext(CommandPublisher):
            If you're looking for a way for your protocol to resume automatically
            after a period of time, use :py:meth:`delay`.
         """
-        self._implementation.resume()
+        self._core.resume()
 
     @publish(command=cmds.comment)
     @requires_version(2, 0)
@@ -669,7 +668,7 @@ class ProtocolContext(CommandPublisher):
         so cannot be used to communicate real-time information from the robot's
         actual run.
         """
-        self._implementation.comment(msg=msg)
+        self._core.comment(msg=msg)
 
     @publish(command=cmds.delay)
     @requires_version(2, 0)
@@ -687,21 +686,21 @@ class ProtocolContext(CommandPublisher):
         If both `seconds` and `minutes` are specified, they will be added.
         """
         delay_time = seconds + minutes * 60
-        self._implementation.delay(seconds=delay_time, msg=msg)
+        self._core.delay(seconds=delay_time, msg=msg)
 
     @requires_version(2, 0)
     def home(self) -> None:
         """Homes the robot."""
-        self._implementation.home()
+        self._core.home()
 
     @property
     def location_cache(self) -> Optional[Location]:
         """The cache used by the robot to determine where it last was."""
-        return self._implementation.get_last_location()
+        return self._core.get_last_location()
 
     @location_cache.setter
     def location_cache(self, loc: Optional[Location]) -> None:
-        self._implementation.set_last_location(loc)
+        self._core.set_last_location(loc)
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -731,14 +730,14 @@ class ProtocolContext(CommandPublisher):
         It has one well and should be accessed like labware in your protocol.
         e.g. ``protocol.fixed_trash['A1']``
         """
-        return self._core_map.get(self._implementation.fixed_trash)
+        return self._core_map.get(self._core.fixed_trash)
 
     def _load_fixed_trash(self) -> None:
-        fixed_trash_core = self._implementation.fixed_trash
+        fixed_trash_core = self._core.fixed_trash
         fixed_trash = Labware(
             implementation=fixed_trash_core,
             api_version=self._api_version,
-            protocol_core=self._implementation,
+            protocol_core=self._core,
             core_map=self._core_map,
         )
         self._core_map.add(fixed_trash_core, fixed_trash)
@@ -750,19 +749,19 @@ class ProtocolContext(CommandPublisher):
 
         :param bool on: If true, turn on rail lights; otherwise, turn off.
         """
-        self._implementation.set_rail_lights(on=on)
+        self._core.set_rail_lights(on=on)
 
     @property  # type: ignore
     @requires_version(2, 5)
     def rail_lights_on(self) -> bool:
         """Returns True if the rail lights are on"""
-        return self._implementation.get_rail_lights_on()
+        return self._core.get_rail_lights_on()
 
     @property  # type: ignore
     @requires_version(2, 5)
     def door_closed(self) -> bool:
         """Returns True if the robot door is closed"""
-        return self._implementation.door_closed()
+        return self._core.door_closed()
 
 
 def _create_module_context(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -82,7 +82,7 @@ class ProtocolContext(CommandPublisher):
     def __init__(
         self,
         api_version: APIVersion,
-        implementation: ProtocolCore,
+        core: ProtocolCore,
         broker: Optional[Broker] = None,
         core_map: Optional[LoadedCoreMap] = None,
         deck: Optional[Deck] = None,
@@ -91,7 +91,7 @@ class ProtocolContext(CommandPublisher):
         """Build a :py:class:`.ProtocolContext`.
 
         :param api_version: The API version to use.
-        :param implementation: The protocol implementation core.
+        :param core: The protocol implementation core.
         :param labware_offset_provider: Where this protocol context and its child
                                         module contexts will get labware offsets from.
         :param broker: An optional command broker to link to. If not
@@ -110,9 +110,9 @@ class ProtocolContext(CommandPublisher):
 
         super().__init__(broker)
         self._api_version = api_version
-        self._core = implementation
+        self._core = core
         self._core_map = core_map or LoadedCoreMap()
-        self._deck = deck or Deck(protocol_core=implementation, core_map=self._core_map)
+        self._deck = deck or Deck(protocol_core=core, core_map=self._core_map)
         self._instruments: Dict[Mount, Optional[InstrumentContext]] = {
             mount: None for mount in Mount
         }
@@ -306,7 +306,7 @@ class ProtocolContext(CommandPublisher):
         )
 
         labware = Labware(
-            implementation=labware_core,
+            core=labware_core,
             api_version=self._api_version,
             protocol_core=self._core,
             core_map=self._core_map,
@@ -591,9 +591,9 @@ class ProtocolContext(CommandPublisher):
             )
 
         instrument = InstrumentContext(
-            broker=self._broker,
-            implementation=instrument_core,
+            core=instrument_core,
             protocol_core=self._core,
+            broker=self._broker,
             api_version=self._api_version,
             tip_racks=tip_racks,
             trash=self.fixed_trash,
@@ -735,7 +735,7 @@ class ProtocolContext(CommandPublisher):
     def _load_fixed_trash(self) -> None:
         fixed_trash_core = self._core.fixed_trash
         fixed_trash = Labware(
-            implementation=fixed_trash_core,
+            core=fixed_trash_core,
             api_version=self._api_version,
             protocol_core=self._core,
             core_map=self._core_map,

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -262,7 +262,7 @@ def bundle_from_sim(
             isinstance(lw, opentrons.protocol_api.labware.Labware)
             and lw.uri not in bundled_labware
         ):
-            bundled_labware[lw.uri] = lw._implementation.get_definition()
+            bundled_labware[lw.uri] = lw._core.get_definition()
 
     return BundleContents(
         protocol.text,

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -633,7 +633,7 @@ def min_lw2_impl(minimal_labware_def2: LabwareDefinition) -> LegacyLabwareCore:
 @pytest.fixture()
 def min_lw(min_lw_impl: LegacyLabwareCore) -> Labware:
     return Labware(
-        implementation=min_lw_impl,
+        core=min_lw_impl,
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
@@ -643,7 +643,7 @@ def min_lw(min_lw_impl: LegacyLabwareCore) -> Labware:
 @pytest.fixture()
 def min_lw2(min_lw2_impl: LegacyLabwareCore) -> Labware:
     return Labware(
-        implementation=min_lw2_impl,
+        core=min_lw2_impl,
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]

--- a/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_magnetic_module_core.py
@@ -118,7 +118,7 @@ def test_engage_height_from_labware(
 ) -> None:
     """It should engage height from the labware's defined position."""
     decoy.when(
-        mock_geometry.labware._implementation.get_default_magnet_engage_height(False)  # type: ignore[union-attr]
+        mock_geometry.labware._core.get_default_magnet_engage_height(False)  # type: ignore[union-attr]
     ).then_return(32.0)
 
     subject.engage_to_labware(offset=10.0)
@@ -145,7 +145,7 @@ def test_engage_height_from_labware_no_engage_height(
 ) -> None:
     """It should raise if the labware is not magnetic module compatible."""
     decoy.when(
-        mock_geometry.labware._implementation.get_default_magnet_engage_height(),  # type: ignore[union-attr]
+        mock_geometry.labware._core.get_default_magnet_engage_height(),  # type: ignore[union-attr]
         ignore_extra_args=True,
     ).then_return(None)
 
@@ -163,7 +163,7 @@ def test_engage_height_from_labware_with_gen1(
     decoy.when(mock_geometry.model).then_return(MagneticModuleModel.MAGNETIC_V1)
 
     decoy.when(
-        mock_geometry.labware._implementation.get_default_magnet_engage_height(False)  # type: ignore[union-attr]
+        mock_geometry.labware._core.get_default_magnet_engage_height(False)  # type: ignore[union-attr]
     ).then_return(32.0)
 
     subject.engage_to_labware(offset=10.0)
@@ -181,7 +181,7 @@ def test_engage_height_from_labware_with_gen1_preserve_half_mm(
     decoy.when(mock_geometry.model).then_return(MagneticModuleModel.MAGNETIC_V1)
 
     decoy.when(
-        mock_geometry.labware._implementation.get_default_magnet_engage_height(True)  # type: ignore[union-attr]
+        mock_geometry.labware._core.get_default_magnet_engage_height(True)  # type: ignore[union-attr]
     ).then_return(32.0)
 
     subject.engage_to_labware(offset=10.0, preserve_half_mm=True)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -160,7 +160,7 @@ def test_move_to_well(
     decoy.verify(
         mock_instrument_core.move_to(
             location=location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             force_direct=False,
             minimum_z_height=None,
             speed=None,
@@ -183,7 +183,7 @@ def test_pick_up_from_well(
     decoy.verify(
         mock_instrument_core.pick_up_tip(
             location=top_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             presses=1,
             increment=2.0,
             prep_after=False,
@@ -209,7 +209,7 @@ def test_aspirate(
     decoy.verify(
         mock_instrument_core.aspirate(
             location=bottom_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             volume=42.0,
             rate=1.23,
             flow_rate=5.67,
@@ -232,7 +232,7 @@ def test_blow_out_to_well(
     decoy.verify(
         mock_instrument_core.blow_out(
             location=top_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             move_to_well=True,
         ),
         times=1,
@@ -255,7 +255,7 @@ def test_blow_out_to_location(
     decoy.verify(
         mock_instrument_core.blow_out(
             location=mock_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             move_to_well=True,
         ),
         times=1,
@@ -279,7 +279,7 @@ def test_blow_out_in_place(
     decoy.verify(
         mock_instrument_core.blow_out(
             location=location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             move_to_well=False,
         ),
         times=1,
@@ -321,7 +321,7 @@ def test_pick_up_tip_from_labware(
     decoy.verify(
         mock_instrument_core.pick_up_tip(
             location=top_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             presses=None,
             increment=None,
             prep_after=True,
@@ -342,7 +342,7 @@ def test_pick_up_tip_from_well_location(
     decoy.verify(
         mock_instrument_core.pick_up_tip(
             location=location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             presses=None,
             increment=None,
             prep_after=True,
@@ -375,7 +375,7 @@ def test_pick_up_tip_from_labware_location(
     decoy.verify(
         mock_instrument_core.pick_up_tip(
             location=top_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             presses=None,
             increment=None,
             prep_after=True,
@@ -411,7 +411,7 @@ def test_pick_up_from_associated_tip_racks(
     decoy.verify(
         mock_instrument_core.pick_up_tip(
             location=top_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             presses=None,
             increment=None,
             prep_after=True,
@@ -430,7 +430,7 @@ def test_drop_tip_to_well(
 
     decoy.verify(
         mock_instrument_core.drop_tip(
-            location=None, well_core=mock_well._impl, home_after=False
+            location=None, well_core=mock_well._core, home_after=False
         ),
         times=1,
     )
@@ -451,7 +451,7 @@ def test_drop_tip_to_trash(
 
     decoy.verify(
         mock_instrument_core.drop_tip(
-            location=None, well_core=mock_well._impl, home_after=True
+            location=None, well_core=mock_well._core, home_after=True
         ),
         times=1,
     )
@@ -471,13 +471,13 @@ def test_return_tip(
     decoy.verify(
         mock_instrument_core.pick_up_tip(
             location=top_location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             presses=None,
             increment=None,
             prep_after=True,
         ),
         mock_instrument_core.drop_tip(
-            location=None, well_core=mock_well._impl, home_after=True
+            location=None, well_core=mock_well._core, home_after=True
         ),
     )
 
@@ -501,7 +501,7 @@ def test_dispense_with_location(
     decoy.verify(
         mock_instrument_core.dispense(
             location=location,
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             volume=42.0,
             rate=1.0,
             flow_rate=3.0,
@@ -529,7 +529,7 @@ def test_dispense_with_well_location(
     decoy.verify(
         mock_instrument_core.dispense(
             location=Location(point=Point(1, 2, 3), labware=mock_well),
-            well_core=mock_well._impl,
+            well_core=mock_well._core,
             volume=42.0,
             rate=1.0,
             flow_rate=3.0,

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -79,7 +79,7 @@ def subject(
 ) -> InstrumentContext:
     """Get a ProtocolCore test subject with its dependencies mocked out."""
     return InstrumentContext(
-        implementation=mock_instrument_core,
+        core=mock_instrument_core,
         protocol_core=mock_protocol_core,
         broker=mock_broker,
         api_version=api_version,

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -66,10 +66,10 @@ def subject(
         well_grid.WellGrid(columns_by_name={}, rows_by_name={})
     )
     return Labware(
-        implementation=mock_labware_core,
+        core=mock_labware_core,
         api_version=api_version,
-        core_map=mock_map_core,
         protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
     )
 
 
@@ -123,7 +123,7 @@ def test_wells(
     decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
 
     subject = Labware(
-        implementation=mock_labware_core,
+        core=mock_labware_core,
         api_version=api_version,
         protocol_core=mock_protocol_core,
         core_map=mock_map_core,

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -77,7 +77,7 @@ def subject(
     """Get a ProtocolContext test subject with its dependencies mocked out."""
     return ProtocolContext(
         api_version=MAX_SUPPORTED_VERSION,
-        implementation=mock_core,
+        core=mock_core,
         core_map=mock_core_map,
         deck=mock_deck,
     )
@@ -312,7 +312,7 @@ def test_move_labware_to_slot(
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
     movable_labware = Labware(
-        implementation=mock_labware_core,
+        core=mock_labware_core,
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=mock_core,
         core_map=mock_core_map,
@@ -354,7 +354,7 @@ def test_move_labware_to_module(
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
     movable_labware = Labware(
-        implementation=mock_labware_core,
+        core=mock_labware_core,
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=mock_core,
         core_map=mock_core_map,
@@ -486,7 +486,7 @@ def test_bundled_data(
     """It should return bundled data."""
     subject = ProtocolContext(
         api_version=MAX_SUPPORTED_VERSION,
-        implementation=mock_core,
+        core=mock_core,
         core_map=mock_core_map,
         deck=mock_deck,
         bundled_data={"foo": b"ar"},

--- a/api/tests/opentrons/protocol_api/test_well.py
+++ b/api/tests/opentrons/protocol_api/test_well.py
@@ -33,11 +33,7 @@ def subject(
     mock_parent: Labware, mock_well_core: WellCore, api_version: APIVersion
 ) -> Well:
     """Get a Well test subject with its dependencies mocked out."""
-    return Well(
-        parent=mock_parent,
-        well_implementation=mock_well_core,
-        api_version=api_version,
-    )
+    return Well(parent=mock_parent, core=mock_well_core, api_version=api_version)
 
 
 @pytest.mark.parametrize("api_version", [APIVersion(2, 13)])

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -91,14 +91,14 @@ async def test_motion(ctx, hardware):
 
 def test_max_speeds(ctx, monkeypatch, hardware):
     ctx.home()
-    with mock.patch.object(ctx._implementation.get_hardware(), "move_to") as mock_move:
+    with mock.patch.object(ctx._core.get_hardware(), "move_to") as mock_move:
         instr = ctx.load_instrument("p10_single", Mount.RIGHT)
         instr.move_to(Location(Point(0, 0, 0), None))
         assert all(
             kwargs["max_speeds"] == {} for args, kwargs in mock_move.call_args_list
         )
 
-    with mock.patch.object(ctx._implementation.get_hardware(), "move_to") as mock_move:
+    with mock.patch.object(ctx._core.get_hardware(), "move_to") as mock_move:
         ctx.max_speeds["x"] = 10
         instr.move_to(Location(Point(0, 0, 1), None))
         assert all(
@@ -106,7 +106,7 @@ def test_max_speeds(ctx, monkeypatch, hardware):
             for args, kwargs in mock_move.call_args_list
         )
 
-    with mock.patch.object(ctx._implementation.get_hardware(), "move_to") as mock_move:
+    with mock.patch.object(ctx._core.get_hardware(), "move_to") as mock_move:
         ctx.max_speeds["x"] = None
         instr.move_to(Location(Point(1, 0, 1), None))
         assert all(
@@ -205,7 +205,7 @@ def test_move_uses_arc(ctx, monkeypatch, get_labware_def, hardware):
     ctx.home()
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move:
         right.move_to(lw.wells()[0].top())
         assert len(fake_move.call_args_list) == 3
@@ -219,7 +219,7 @@ def test_pipette_info(ctx):
     right = ctx.load_instrument("p300_multi", Mount.RIGHT)
     left = ctx.load_instrument("p1000_single", Mount.LEFT)
     assert right.type == "multi"
-    hardware = ctx._implementation.get_hardware()
+    hardware = ctx._core.get_hardware()
     name = hardware.attached_instruments[Mount.RIGHT]["name"]
     model = hardware.attached_instruments[Mount.RIGHT]["model"]
     assert right.name == name
@@ -239,7 +239,7 @@ def test_pick_up_and_drop_tip(ctx, get_labware_def):
 
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
     nozzle_offset = Point(*pipette.config.nozzle_offset)
     assert pipette.critical_point() == nozzle_offset
     target_location = tiprack["A1"].top()
@@ -265,7 +265,7 @@ def test_pick_up_without_prep_after(ctx, get_labware_def):
 
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
 
     # will not be prepared until after an aspirate
     instr.pick_up_tip(tiprack["A2"].top(), prep_after=False)
@@ -287,7 +287,7 @@ def test_pick_up_tip_old_version(hardware, get_labware_def):
 
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
 
     # will not be prepared until after an aspirate
     assert not pipette.has_tip
@@ -319,7 +319,7 @@ def test_return_tip_old_version(hardware, get_labware_def):
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
 
     target_location = tiprack["A1"].top()
     instr.pick_up_tip(target_location)
@@ -345,7 +345,7 @@ def test_return_tip(ctx, get_labware_def):
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
 
     target_location = tiprack["A1"].top()
     instr.pick_up_tip(target_location)
@@ -369,7 +369,7 @@ def test_use_filter_tips(ctx, get_labware_def):
     mount = Mount.LEFT
 
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
 
     assert pipette.available_volume == pipette.config.max_volume
 
@@ -395,7 +395,7 @@ def test_pick_up_tip_no_location(ctx, get_labware_def, pipette_model, tiprack_ki
 
     instr = ctx.load_instrument(pipette_model, mount, tip_racks=[tiprack1, tiprack2])
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware_instruments[mount]
+    pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
     nozzle_offset = Point(*pipette.config.nozzle_offset)
     assert pipette.critical_point() == nozzle_offset
 
@@ -454,9 +454,9 @@ def test_aspirate(ctx, get_labware_def):
     instr = ctx.load_instrument("p10_single", Mount.RIGHT, tip_racks=[tiprack])
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "aspirate"
+        ctx._core.get_hardware()._obj_to_adapt, "aspirate"
     ) as fake_hw_aspirate:
         instr.pick_up_tip()
         instr.aspirate(2.0, lw.wells()[0].bottom())
@@ -472,9 +472,9 @@ def test_aspirate(ctx, get_labware_def):
         )
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "aspirate"
+        ctx._core.get_hardware()._obj_to_adapt, "aspirate"
     ) as fake_hw_aspirate:
         instr.well_bottom_clearance.aspirate = 1.0
         instr.aspirate(2.0, lw.wells()[0])
@@ -486,11 +486,11 @@ def test_aspirate(ctx, get_labware_def):
         )
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "aspirate"
+        ctx._core.get_hardware()._obj_to_adapt, "aspirate"
     ) as fake_hw_aspirate:
-        hardware = ctx._implementation.get_hardware()
+        hardware = ctx._core.get_hardware()
         hardware._obj_to_adapt.hardware_instruments[Mount.RIGHT]._current_volume = 1
 
         instr.aspirate(2.0)
@@ -499,9 +499,9 @@ def test_aspirate(ctx, get_labware_def):
         instr.blow_out()
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "aspirate"
+        ctx._core.get_hardware()._obj_to_adapt, "aspirate"
     ) as fake_hw_aspirate:
         instr.aspirate(2.0)
         assert len(fake_move.call_args_list) == 2
@@ -524,9 +524,9 @@ def test_dispense(ctx, get_labware_def, monkeypatch):
     instr = ctx.load_instrument("p10_single", Mount.RIGHT)
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "dispense"
+        ctx._core.get_hardware()._obj_to_adapt, "dispense"
     ) as fake_hw_dispense:
 
         instr.dispense(2.0, lw.wells()[0].bottom())
@@ -541,9 +541,9 @@ def test_dispense(ctx, get_labware_def, monkeypatch):
         )
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "dispense"
+        ctx._core.get_hardware()._obj_to_adapt, "dispense"
     ) as fake_hw_dispense:
 
         instr.well_bottom_clearance.dispense = 2.0
@@ -555,9 +555,9 @@ def test_dispense(ctx, get_labware_def, monkeypatch):
         )
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move, mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "dispense"
+        ctx._core.get_hardware()._obj_to_adapt, "dispense"
     ) as fake_hw_dispense:
 
         instr.well_bottom_clearance.dispense = 2.0
@@ -672,7 +672,7 @@ def test_touch_tip_default_args(monkeypatch, hardware):
 
     instr.aspirate(10, lw.wells()[0])
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move:
         instr.touch_tip()
         z_offset = Point(0, 0, 1)  # default z offset of 1mm
@@ -692,7 +692,7 @@ def test_touch_tip_default_args(monkeypatch, hardware):
     # Check that the old api version initial well move has the same z height
     # as the calculated edges.
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move:
         instr.touch_tip(v_offset=1)
         assert fake_move.call_args_list[0][0][1].z != old_z
@@ -719,7 +719,7 @@ def test_touch_tip_new_default_args(ctx, monkeypatch):
     ]
 
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move:
         instr.touch_tip()
         for i in range(1, 5):
@@ -731,7 +731,7 @@ def test_touch_tip_new_default_args(ctx, monkeypatch):
     # Check that the new api version initial well move has the same z height
     # as the calculated edges.
     with mock.patch.object(
-        ctx._implementation.get_hardware()._obj_to_adapt, "move_to"
+        ctx._core.get_hardware()._obj_to_adapt, "move_to"
     ) as fake_move:
         instr.touch_tip(v_offset=1)
         assert fake_move.call_args_list[0][0][1].z != old_z
@@ -871,15 +871,13 @@ def test_transfer_options(ctx, monkeypatch):
 
 
 def test_flow_rate(ctx, monkeypatch):
-    old_sfm = ctx._implementation.get_hardware()
+    old_sfm = ctx._core.get_hardware()
 
     def pass_on(mount, aspirate=None, dispense=None, blow_out=None):
         old_sfm(mount, aspirate=None, dispense=None, blow_out=None)
 
     set_flow_rate = mock.Mock(side_effect=pass_on)
-    monkeypatch.setattr(
-        ctx._implementation.get_hardware(), "set_flow_rate", set_flow_rate
-    )
+    monkeypatch.setattr(ctx._core.get_hardware(), "set_flow_rate", set_flow_rate)
     instr = ctx.load_instrument("p300_single", Mount.RIGHT)
 
     ctx.home()
@@ -897,15 +895,13 @@ def test_flow_rate(ctx, monkeypatch):
 
 
 def test_pipette_speed(ctx, monkeypatch):
-    old_sfm = ctx._implementation.get_hardware()
+    old_sfm = ctx._core.get_hardware()
 
     def pass_on(mount, aspirate=None, dispense=None, blow_out=None):
         old_sfm(aspirate=None, dispense=None, blow_out=None)
 
     set_speed = mock.Mock(side_effect=pass_on)
-    monkeypatch.setattr(
-        ctx._implementation.get_hardware(), "set_pipette_speed", set_speed
-    )
+    monkeypatch.setattr(ctx._core.get_hardware(), "set_pipette_speed", set_speed)
     instr = ctx.load_instrument("p300_single", Mount.RIGHT)
 
     ctx.home()
@@ -1013,9 +1009,7 @@ def test_tip_length_for_caldata(ctx, decoy, monkeypatch):
     mock_load_tip_length = decoy.mock(func=instr_cal.load_tip_length_for_pipette)
     monkeypatch.setattr(instr_cal, "load_tip_length_for_pipette", mock_load_tip_length)
 
-    decoy.when(
-        mock_load_tip_length(None, tip_rack._implementation.get_definition())
-    ).then_return(
+    decoy.when(mock_load_tip_length(None, tip_rack._core.get_definition())).then_return(
         instr_cal.TipLengthCalibration(
             tip_length=2,
             last_modified=utc_now(),
@@ -1030,20 +1024,20 @@ def test_tip_length_for_caldata(ctx, decoy, monkeypatch):
     assert (
         instrument_support.tip_length_for(
             pipette=instr.hw_pipette,
-            tip_rack_definition=tip_rack._implementation.get_definition(),
+            tip_rack_definition=tip_rack._core.get_definition(),
         )
         == 2
     )
 
-    decoy.when(
-        mock_load_tip_length(None, tip_rack._implementation.get_definition())
-    ).then_raise(cs_types.TipLengthCalNotFound("oh no"))
+    decoy.when(mock_load_tip_length(None, tip_rack._core.get_definition())).then_raise(
+        cs_types.TipLengthCalNotFound("oh no")
+    )
 
     assert instrument_support.tip_length_for(
         pipette=instr.hw_pipette,
-        tip_rack_definition=tip_rack._implementation.get_definition(),
+        tip_rack_definition=tip_rack._core.get_definition(),
     ) == (
-        tip_rack._implementation.get_definition()["parameters"]["tipLength"]
+        tip_rack._core.get_definition()["parameters"]["tipLength"]
         - instr.hw_pipette["tip_overlap"]["opentrons/geb_96_tiprack_10ul/1"]
     )
 
@@ -1060,7 +1054,7 @@ def test_bundled_labware(get_labware_fixture, hardware):
 
     lw1 = ctx.load_labware("fixture_96_plate", 3, namespace="fixture")
     assert ctx.loaded_labwares[3] == lw1
-    assert ctx.loaded_labwares[3]._implementation.get_definition() == fixture_96_plate
+    assert ctx.loaded_labwares[3]._core.get_definition() == fixture_96_plate
 
 
 def test_bundled_labware_missing(get_labware_fixture, hardware):
@@ -1111,7 +1105,7 @@ def test_extra_labware(get_labware_fixture, hardware):
 
     ls1 = ctx.load_labware("fixture_96_plate", 3, namespace="fixture")
     assert ctx.loaded_labwares[3] == ls1
-    assert ctx.loaded_labwares[3]._implementation.get_definition() == fixture_96_plate
+    assert ctx.loaded_labwares[3]._core.get_definition() == fixture_96_plate
 
 
 def test_api_version_checking(hardware):

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -77,16 +77,16 @@ def get_labware_def(monkeypatch):
 async def test_motion(ctx, hardware):
     ctx.home()
     instr = ctx.load_instrument("p10_single", Mount.RIGHT)
-    old_pos = await hardware.current_position(instr._implementation.get_mount())
+    old_pos = await hardware.current_position(instr._core.get_mount())
     instr.home()
     assert instr.move_to(Location(Point(0, 0, 0), None)) is instr
     old_pos[Axis.X] = 0.0
     old_pos[Axis.Y] = 0.0
     old_pos[Axis.A] = 0.0
     old_pos[Axis.C] = 2.0
-    assert await hardware.current_position(
-        instr._implementation.get_mount()
-    ) == pytest.approx(old_pos)
+    assert await hardware.current_position(instr._core.get_mount()) == pytest.approx(
+        old_pos
+    )
 
 
 def test_max_speeds(ctx, monkeypatch, hardware):
@@ -182,8 +182,8 @@ def test_location_cache_two_pipettes_fails_pre_2_10(ctx, get_labware_def, hardwa
     ctx.home()
     left = ctx.load_instrument("p10_single", Mount.LEFT)
     right = ctx.load_instrument("p10_single", Mount.RIGHT)
-    left._implementation._api_version = APIVersion(2, 9)
-    right._implementation._api_version = APIVersion(2, 9)
+    left._core._api_version = APIVersion(2, 9)
+    right._core._api_version = APIVersion(2, 9)
 
     left_loc = Location(point=Point(1, 2, 3), labware="1")
     right_loc = Location(point=Point(3, 4, 5), labware="2")
@@ -764,7 +764,7 @@ def test_blow_out(ctx, monkeypatch):
         nonlocal move_location
         move_location = location
 
-    monkeypatch.setattr(instr._implementation, "move_to", fake_move)
+    monkeypatch.setattr(instr._core, "move_to", fake_move)
 
     instr.blow_out()
     # pipette should not move, if no location is passed

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -303,7 +303,7 @@ def test_well_parent(corning_96_wellplate_360ul_flat) -> None:
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=parent.point,
-                parent_object=parent.labware.as_labware()._implementation,  # type: ignore[arg-type]
+                parent_object=parent.labware.as_labware()._core,  # type: ignore[arg-type]
             ),
             display_name=well_name,
             has_tip=has_tip,

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -52,8 +52,7 @@ def test_well_init() -> None:
     has_tip = False
     well1 = labware.Well(
         parent=None,  # type: ignore[arg-type]
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=slot.point,
@@ -63,6 +62,7 @@ def test_well_init() -> None:
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
     assert well1.geometry.diameter == test_data[well_name]["diameter"]  # type: ignore[typeddict-item]
     assert well1.geometry._length is None
@@ -71,8 +71,7 @@ def test_well_init() -> None:
     well2_name = "rectangular_well_json"
     well2 = labware.Well(
         parent=None,  # type: ignore[arg-type]
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well2_name],
                 parent_point=slot.point,
@@ -82,6 +81,7 @@ def test_well_init() -> None:
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
     assert well2.geometry.diameter is None
     assert well2.geometry._length == test_data[well2_name]["xDimension"]  # type: ignore[typeddict-item]
@@ -94,8 +94,7 @@ def test_top() -> None:
     has_tip = False
     well = labware.Well(
         parent=None,  # type: ignore[arg-type]
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=slot.point,
@@ -105,6 +104,7 @@ def test_top() -> None:
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
     well_data = test_data[well_name]
     expected_x = well_data["x"] + slot.point.x
@@ -119,8 +119,7 @@ def test_bottom() -> None:
     has_tip = False
     well = labware.Well(
         parent=None,  # type: ignore[arg-type]
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=slot.point,
@@ -130,6 +129,7 @@ def test_bottom() -> None:
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
     well_data = test_data[well_name]
     expected_x = well_data["x"] + slot.point.x
@@ -144,8 +144,7 @@ def test_from_center_cartesian():
     has_tip = False
     well1 = labware.Well(
         parent=None,  # type: ignore[arg-type]
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=slot1.point,
@@ -155,6 +154,7 @@ def test_from_center_cartesian():
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
 
     percent1_x = 1
@@ -178,8 +178,7 @@ def test_from_center_cartesian():
     has_tip = False
     well2 = labware.Well(
         parent=None,  # type: ignore[arg-type]
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well2_name],
                 parent_point=slot2.point,
@@ -189,6 +188,7 @@ def test_from_center_cartesian():
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
     percent2_x = -0.25
     percent2_y = 0.1
@@ -216,7 +216,7 @@ def corning_96_wellplate_360ul_flat_def():
 @pytest.fixture
 def corning_96_wellplate_360ul_flat(corning_96_wellplate_360ul_flat_def):
     return labware.Labware(
-        implementation=LegacyLabwareCore(
+        core=LegacyLabwareCore(
             definition=corning_96_wellplate_360ul_flat_def,
             parent=Location(Point(0, 0, 0), "Test Slot"),
         ),
@@ -235,7 +235,7 @@ def opentrons_96_tiprack_300ul_def():
 @pytest.fixture
 def opentrons_96_tiprack_300ul(opentrons_96_tiprack_300ul_def):
     return labware.Labware(
-        implementation=LegacyLabwareCore(
+        core=LegacyLabwareCore(
             definition=opentrons_96_tiprack_300ul_def,
             parent=Location(Point(0, 0, 0), "Test Slot"),
         ),
@@ -298,8 +298,7 @@ def test_well_parent(corning_96_wellplate_360ul_flat) -> None:
     has_tip = True
     well = labware.Well(
         parent=lw,
-        api_version=MAX_SUPPORTED_VERSION,
-        well_implementation=LegacyWellCore(
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=parent.point,
@@ -309,6 +308,7 @@ def test_well_parent(corning_96_wellplate_360ul_flat) -> None:
             has_tip=has_tip,
             name="A1",
         ),
+        api_version=MAX_SUPPORTED_VERSION,
     )
     assert well.parent == lw
     assert well.top().labware.object == well
@@ -531,17 +531,13 @@ def test_tiprack_list():
     labware_name = "opentrons_96_tiprack_300ul"
     labware_def = labware.get_labware_definition(labware_name)
     tiprack = labware.Labware(
-        implementation=LegacyLabwareCore(
-            labware_def, Location(Point(0, 0, 0), "Test Slot")
-        ),
+        core=LegacyLabwareCore(labware_def, Location(Point(0, 0, 0), "Test Slot")),
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )
     tiprack_2 = labware.Labware(
-        implementation=LegacyLabwareCore(
-            labware_def, Location(Point(0, 0, 0), "Test Slot")
-        ),
+        core=LegacyLabwareCore(labware_def, Location(Point(0, 0, 0), "Test Slot")),
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
@@ -579,7 +575,7 @@ def test_uris():
     )
     assert helpers.uri_from_definition(defn) == uri
     lw = labware.Labware(
-        implementation=LegacyLabwareCore(defn, Location(Point(0, 0, 0), "Test Slot")),
+        core=LegacyLabwareCore(defn, Location(Point(0, 0, 0), "Test Slot")),
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
@@ -593,7 +589,7 @@ def test_labware_hash_func_same_implementation(minimal_labware_def) -> None:
     impl = LegacyLabwareCore(minimal_labware_def, Location(Point(0, 0, 0), "Test Slot"))
     s = set(
         labware.Labware(
-            implementation=impl,
+            core=impl,
             api_version=APIVersion(2, 3),
             protocol_core=None,  # type: ignore[arg-type]
             core_map=None,  # type: ignore[arg-type]
@@ -611,13 +607,13 @@ def test_labware_hash_func_same_implementation_different_version(
     impl = LegacyLabwareCore(minimal_labware_def, Location(Point(0, 0, 0), "Test Slot"))
 
     l1 = labware.Labware(
-        implementation=impl,
+        core=impl,
         api_version=APIVersion(2, 13),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )
     l2 = labware.Labware(
-        implementation=impl,
+        core=impl,
         api_version=APIVersion(2, 14),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
@@ -639,13 +635,13 @@ def test_labware_hash_func_diff_implementation_same_version(
     )
 
     l1 = labware.Labware(
-        implementation=impl1,
+        core=impl1,
         api_version=APIVersion(2, 3),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )
     l2 = labware.Labware(
-        implementation=impl2,
+        core=impl2,
         api_version=APIVersion(2, 3),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
@@ -659,7 +655,7 @@ def test_set_offset(decoy: Decoy) -> None:
     labware_impl = decoy.mock(cls=AbstractLabware)
     decoy.when(labware_impl.get_well_columns()).then_return([])
     subject = labware.Labware(
-        implementation=labware_impl,
+        core=labware_impl,
         api_version=APIVersion(2, 12),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]

--- a/api/tests/opentrons/protocol_api_old/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware_load.py
@@ -21,13 +21,9 @@ def test_load_to_slot(
     ][0]
     labware = ctx.load_labware(labware_name, "1")
 
-    assert labware._implementation.get_geometry().offset == types.Point(
-        *slot_1["position"]
-    )
+    assert labware._core.get_geometry().offset == types.Point(*slot_1["position"])
     other = ctx.load_labware(labware_name, 2)
-    assert other._implementation.get_geometry().offset == types.Point(
-        *slot_2["position"]
-    )
+    assert other._core.get_geometry().offset == types.Point(*slot_2["position"])
 
 
 def test_loaded(ctx: papi.ProtocolContext) -> None:
@@ -48,7 +44,7 @@ def test_get_mixed_case_labware_def() -> None:
 def test_load_label(ctx: papi.ProtocolContext) -> None:
     labware = ctx.load_labware(labware_name, "1", "my cool labware")
     assert "my cool labware" in str(labware)
-    assert labware._implementation.get_user_display_name() == "my cool labware"
+    assert labware._core.get_user_display_name() == "my cool labware"
 
 
 def test_deprecated_load(ctx: papi.ProtocolContext) -> None:

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -374,10 +374,7 @@ def test_module_load_labware(ctx_with_tempdeck):
         labware_def["cornerOffsetFromSlot"]["y"],
         labware_def["cornerOffsetFromSlot"]["z"],
     )
-    assert (
-        lw._implementation.get_geometry().offset
-        == lw_offset + mod.geometry.location.point
-    )
+    assert lw._core.get_geometry().offset == lw_offset + mod.geometry.location.point
     assert lw.name == labware_name
 
 

--- a/api/tests/opentrons/protocol_api_old/test_offsets.py
+++ b/api/tests/opentrons/protocol_api_old/test_offsets.py
@@ -9,10 +9,8 @@ if typing.TYPE_CHECKING:
 
 def test_wells_rebuilt_with_offset(minimal_labware_def: "LabwareDefinition") -> None:
     test_labware = labware.Labware(
+        core=LegacyLabwareCore(minimal_labware_def, Location(Point(0, 0, 0), "deck")),
         api_version=MAX_SUPPORTED_VERSION,
-        implementation=LegacyLabwareCore(
-            minimal_labware_def, Location(Point(0, 0, 0), "deck")
-        ),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )

--- a/api/tests/opentrons/protocol_api_old/test_offsets.py
+++ b/api/tests/opentrons/protocol_api_old/test_offsets.py
@@ -17,11 +17,11 @@ def test_wells_rebuilt_with_offset(minimal_labware_def: "LabwareDefinition") -> 
         core_map=None,  # type: ignore[arg-type]
     )
     old_well_top = test_labware.wells()[0].top().point
-    assert test_labware._implementation.get_geometry().offset == Point(10, 10, 5)
-    assert test_labware._implementation.get_calibrated_offset() == Point(10, 10, 5)
+    assert test_labware._core.get_geometry().offset == Point(10, 10, 5)
+    assert test_labware._core.get_calibrated_offset() == Point(10, 10, 5)
 
     test_labware.set_offset(x=2, y=2, z=2)
     new_well = test_labware.wells()[0]
     assert new_well.top().point != old_well_top
-    assert test_labware._implementation.get_geometry().offset == Point(10, 10, 5)
-    assert test_labware._implementation.get_calibrated_offset() == Point(12, 12, 7)
+    assert test_labware._core.get_geometry().offset == Point(10, 10, 5)
+    assert test_labware._core.get_calibrated_offset() == Point(12, 12, 7)

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -107,9 +107,7 @@ def test_first_parent(trough, module, mod_trough):
     # Set up recursion cycle test.
     mock_labware_geometry = MagicMock()
     mock_labware_geometry.parent = Location(point=None, labware=mod_trough)
-    mod_trough._implementation.get_geometry = MagicMock(
-        return_value=mock_labware_geometry
-    )
+    mod_trough._core.get_geometry = MagicMock(return_value=mock_labware_geometry)
 
     with pytest.raises(RuntimeError):
         # make sure we catch cycles

--- a/api/tests/opentrons/protocols/api_support/test_util.py
+++ b/api/tests/opentrons/protocols/api_support/test_util.py
@@ -102,7 +102,7 @@ def test_build_edges_left_pipette(ctx):
         test_lw["A12"],
         1.0,
         Mount.LEFT,
-        ctx._implementation.get_deck(),
+        ctx._core.get_deck(),
         version=APIVersion(2, 4),
     )
     assert res == left_pip_edges
@@ -118,7 +118,7 @@ def test_build_edges_left_pipette(ctx):
         test_lw2["A12"],
         1.0,
         Mount.LEFT,
-        ctx._implementation.get_deck(),
+        ctx._core.get_deck(),
         version=APIVersion(2, 4),
     )
     assert res2 == left_pip_edges
@@ -141,7 +141,7 @@ def test_build_edges_right_pipette(ctx):
         test_lw["A1"],
         1.0,
         Mount.RIGHT,
-        ctx._implementation._deck_layout,
+        ctx._core._deck_layout,
         version=APIVersion(2, 4),
     )
     assert res == right_pip_edges
@@ -158,7 +158,7 @@ def test_build_edges_right_pipette(ctx):
         test_lw2["A12"],
         1.0,
         Mount.RIGHT,
-        ctx._implementation.get_deck(),
+        ctx._core.get_deck(),
         version=APIVersion(2, 4),
     )
     assert res2 == right_pip_edges

--- a/api/tests/opentrons/protocols/api_support/test_util.py
+++ b/api/tests/opentrons/protocols/api_support/test_util.py
@@ -58,7 +58,7 @@ def test_max_speeds_userdict():
 def test_build_edges():
     lw_def = get_labware_definition("corning_96_wellplate_360ul_flat")
     test_lw = Labware(
-        implementation=LegacyLabwareCore(lw_def, Location(Point(0, 0, 0), None)),
+        core=LegacyLabwareCore(lw_def, Location(Point(0, 0, 0), None)),
         api_version=MAX_SUPPORTED_VERSION,
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -54,10 +54,10 @@ def test_get_well(minimal_labware_def2):
     deck = Location(Point(0, 0, 0), "deck")
     well_name = "A2"
     some_labware = labware.Labware(
-        implementation=LegacyLabwareCore(minimal_labware_def2, deck),
+        core=LegacyLabwareCore(minimal_labware_def2, deck),
         api_version=MAX_SUPPORTED_VERSION,
-        protocol_core=None,  # type: ignore[arg-type]
-        core_map=None,  # type: ignore[arg-type]
+        protocol_core=None,
+        core_map=None,
     )
     loaded_labware = {"someLabwareId": some_labware}
     params = {"labware": "someLabwareId", "well": well_name}
@@ -116,10 +116,10 @@ def test_get_location_with_offset_fixed_trash(minimal_labware_def2):
     trash_labware_def = deepcopy(minimal_labware_def2)
     trash_labware_def["parameters"]["quirks"] = ["fixedTrash"]
     trash_labware = labware.Labware(
-        implementation=LegacyLabwareCore(trash_labware_def, deck),
+        core=LegacyLabwareCore(trash_labware_def, deck),
         api_version=MAX_SUPPORTED_VERSION,
-        protocol_core=None,  # type: ignore[arg-type]
-        core_map=None,  # type: ignore[arg-type]
+        protocol_core=None,
+        core_map=None,
     )
 
     loaded_labware = {"someLabwareId": trash_labware}
@@ -208,10 +208,10 @@ def test_air_gap(minimal_labware_def2):
     deck = Location(Point(0, 0, 0), "deck")
     well_name = "A2"
     some_labware = labware.Labware(
-        implementation=LegacyLabwareCore(minimal_labware_def2, deck),
+        core=LegacyLabwareCore(minimal_labware_def2, deck),
         api_version=MAX_SUPPORTED_VERSION,
-        protocol_core=None,  # type: ignore[arg-type]
-        core_map=None,  # type: ignore[arg-type]
+        protocol_core=None,
+        core_map=None,
     )
     loaded_labware = {"someLabwareId": some_labware}
     params = {"labware": "someLabwareId", "well": well_name}
@@ -314,8 +314,8 @@ def test_dispense():
 def test_touch_tip():
     location = Location(Point(1, 2, 3), "deck")
     well = labware.Well(
-        parent=None,  # type: ignore[arg-type]
-        well_implementation=LegacyWellCore(
+        parent=None,
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 {
                     "shape": "circular",

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
@@ -12,8 +12,8 @@ def test_move_to_well_with_optional_params():
     instruments = {"somePipetteId": pipette_mock}
 
     well = labware.Well(
-        parent=None,  # type: ignore[arg-type]
-        well_implementation=LegacyWellCore(
+        parent=None,
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 {
                     "shape": "circular",
@@ -66,8 +66,8 @@ def test_move_to_well_without_optional_params():
     instruments = {"somePipetteId": pipette_mock}
 
     well = labware.Well(
-        parent=None,  # type: ignore[arg-type]
-        well_implementation=LegacyWellCore(
+        parent=None,
+        core=LegacyWellCore(
             well_geometry=WellGeometry(
                 {
                     "shape": "circular",

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -242,7 +242,7 @@ def test_execute_extra_labware(
     no_lw = execute.get_protocol_api("2.0")
 
     # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
-    assert not no_lw._implementation._extra_labware  # type: ignore[attr-defined]
+    assert not no_lw._core._extra_labware  # type: ignore[attr-defined]
     protocol.filelike.seek(0)
     monkeypatch.setattr(execute, "IS_ROBOT", True)
     monkeypatch.setattr(execute, "JUPYTER_NOTEBOOK_LABWARE_DIR", fixturedir)
@@ -255,9 +255,9 @@ def test_execute_extra_labware(
     # make sure the extra labware loaded by default is right
     ctx = execute.get_protocol_api("2.0")
     # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
-    assert len(
-        ctx._implementation._extra_labware.keys()  # type: ignore[attr-defined]
-    ) == len(os.listdir(fixturedir))
+    assert len(ctx._core._extra_labware.keys()) == len(  # type: ignore[attr-defined]
+        os.listdir(fixturedir)
+    )
 
     assert ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -110,7 +110,7 @@ def test_simulate_extra_labware(
         simulate.simulate(protocol.filelike, "custom_labware.py")
     no_lw = simulate.get_protocol_api("2.0")
     # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
-    assert not no_lw._implementation._extra_labware  # type: ignore[attr-defined]
+    assert not no_lw._core._extra_labware  # type: ignore[attr-defined]
     protocol.filelike.seek(0)
     monkeypatch.setattr(simulate, "IS_ROBOT", True)
     monkeypatch.setattr(simulate, "JUPYTER_NOTEBOOK_LABWARE_DIR", fixturedir)
@@ -121,9 +121,9 @@ def test_simulate_extra_labware(
     # make sure the extra labware loaded by default is right
     ctx = simulate.get_protocol_api("2.0")
     # TODO(mc, 2021-09-12): `_extra_labware` is not defined on `AbstractProtocol`
-    assert len(
-        ctx._implementation._extra_labware.keys()  # type: ignore[attr-defined]
-    ) == len(os.listdir(fixturedir))
+    assert len(ctx._core._extra_labware.keys()) == len(  # type: ignore[attr-defined]
+        os.listdir(fixturedir)
+    )
 
     assert ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 

--- a/hardware-testing/hardware_testing/opentrons_api/workarounds.py
+++ b/hardware-testing/hardware_testing/opentrons_api/workarounds.py
@@ -44,7 +44,7 @@ def apply_additional_offset_to_labware(
     """Apply additional offset to labware."""
     # NOTE: this will re-instantiate all the labware's WELLs
     #       so this must be ran before rest of protocol
-    labware_imp = labware._implementation
+    labware_imp = labware._core
     labware_delta = labware.calibrated_offset - labware_imp.get_geometry().offset
     labware.set_offset(
         x=labware_delta.x + x, y=labware_delta.y + y, z=labware_delta.z + z
@@ -111,7 +111,7 @@ def get_latest_offset_for_labware(
 
 def get_hw_api(ctx: ProtocolContext) -> SyncHardwareAPI:
     """Get HW API."""
-    return ctx._implementation.get_hardware()
+    return ctx._core.get_hardware()
 
 
 def store_robot_acceleration(

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -357,7 +357,7 @@ class CheckCalibrationUserFlow:
                 version=details.version,
                 parent=position,
             )
-            tiprack_def = tiprack._implementation.get_definition()
+            tiprack_def = tiprack._core.get_definition()
         else:
             tiprack_def = get_custom_tiprack_definition_for_tlc(pip_offset.uri)
         return load_tip_length_calibration(pipette.pipette_id, tiprack_def)
@@ -532,9 +532,9 @@ class CheckCalibrationUserFlow:
                 name=hw_pip.name,
                 tipLength=hw_pip.config.tip_length,
                 tipRackLoadName=info_pip.tip_rack.load_name,
-                tipRackDisplay=info_pip.tip_rack._implementation.get_definition()[
-                    "metadata"
-                ]["displayName"],
+                tipRackDisplay=info_pip.tip_rack._core.get_definition()["metadata"][
+                    "displayName"
+                ],
                 tipRackUri=info_pip.tip_rack.uri,
                 rank=info_pip.rank.value,
                 mount=str(info_pip.mount),
@@ -549,9 +549,9 @@ class CheckCalibrationUserFlow:
         # type of AttachedPipette.serial
         assert self.hw_pipette
         assert self.active_pipette
-        display_name = self.active_pipette.tip_rack._implementation.get_definition()[
-            "metadata"
-        ]["displayName"]
+        display_name = self.active_pipette.tip_rack._core.get_definition()["metadata"][
+            "displayName"
+        ]
         return CheckAttachedPipette(
             model=self.hw_pipette.model,
             name=self.hw_pipette.name,
@@ -670,7 +670,7 @@ class CheckCalibrationUserFlow:
             calibration = mark_bad_calibration.mark_bad(
                 self._tip_lengths[active_mount], cal_types.SourceType.calibration_check
             )
-            tip_definition = self.active_tiprack._implementation.get_definition()
+            tip_definition = self.active_tiprack._core.get_definition()
             tip_length_dict = create_tip_length_data(
                 definition=tip_definition,
                 length=calibration.tip_length,
@@ -834,7 +834,7 @@ class CheckCalibrationUserFlow:
         try:
             return load_tip_length_calibration(
                 pip_id,
-                self.active_tiprack._implementation.get_definition(),
+                self.active_tiprack._core.get_definition(),
             ).tipLength
         except cal_types.TipLengthCalNotFound:
             tip_overlap = self.hw_pipette.config.tip_overlap.get(

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -327,9 +327,7 @@ class DeckCalibrationUserFlow:
     def _save_attitude_matrix(self):
         e = tuplefy_cal_point_dicts(self._expected_points)
         a = tuplefy_cal_point_dicts(self._saved_points)
-        tiprack_hash = helpers.hash_labware_def(
-            self._tip_rack._implementation.get_definition()
-        )
+        tiprack_hash = helpers.hash_labware_def(self._tip_rack._core.get_definition())
         pip_id = self._hw_pipette.pipette_id
         assert pip_id
         robot_cal.save_attitude_matrix(
@@ -342,7 +340,7 @@ class DeckCalibrationUserFlow:
         try:
             return load_tip_length_calibration(
                 pip_id,
-                self._tip_rack._implementation.get_definition(),
+                self._tip_rack._core.get_definition(),
             ).tipLength
         except cal_types.TipLengthCalNotFound:
             tip_overlap = self._hw_pipette.config.tip_overlap.get(self._tip_rack.uri, 0)

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -131,7 +131,7 @@ class RequiredLabware(BaseModel):
         if not slot:
             # TODO(mc, 2021-09-08): lw.parent is not necessarily a slot
             slot = lw.parent  # type: ignore[assignment]
-        lw_def = lw._implementation.get_definition()
+        lw_def = lw._core.get_definition()
         return cls(
             # TODO(mc, 2020-09-17): DeckLocation does not match
             #  Union[int,str,None] expected by cls

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -304,7 +304,7 @@ class PipetteOffsetCalibrationUserFlow:
         try:
             return load_tip_length_calibration(
                 self._hw_pipette.pipette_id,
-                self._tip_rack._implementation.get_definition(),
+                self._tip_rack._core.get_definition(),
             ).tipLength
         except TipLengthCalNotFound:
             return None
@@ -438,7 +438,7 @@ class PipetteOffsetCalibrationUserFlow:
                     critical_point=CriticalPoint.FRONT_NOZZLE
                 )
             tiprack_hash = helpers.hash_labware_def(
-                self._tip_rack._implementation.get_definition()
+                self._tip_rack._core.get_definition()
             )
             offset = self._cal_ref_point - cur_pt
             save_pipette_calibration(

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -204,7 +204,7 @@ def save_tip_length_calibration(
     # tip length data, hence the empty string, we should remove it
     # from create_tip_length_data in a refactor
     tip_length_data = create_tip_length_data(
-        tip_rack._implementation.get_definition(), tip_length_offset
+        tip_rack._core.get_definition(), tip_length_offset
     )
     cal_storage_save_tip_length(pipette_id, tip_length_data)
 

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -216,7 +216,7 @@ def test_load_labware(mock_hw):
     ):
         uf = CheckCalibrationUserFlow(hardware=mock_hw, has_calibration_block=True)
         assert (
-            uf.active_tiprack._implementation.get_display_name()
+            uf.active_tiprack._core.get_display_name()
             == "Opentrons 96 Filter Tip Rack 200 µL on 8"
         )
         assert len(uf.get_required_labware()) == 2
@@ -242,10 +242,7 @@ def test_load_custom_tiprack(mock_hw, custom_tiprack_def, clear_custom_tiprack_d
         new=build_mock_stored_pipette_offset("custom_tiprack"),
     ):
         uf = CheckCalibrationUserFlow(hardware=mock_hw, has_calibration_block=True)
-        assert (
-            uf.active_tiprack._implementation.get_display_name()
-            == "minimal labware on 8"
-        )
+        assert uf.active_tiprack._core.get_display_name() == "minimal labware on 8"
         assert len(uf.get_required_labware()) == 2
 
 

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -604,9 +604,7 @@ async def test_save_pipette_calibration(mock_user_flow, mock_save_pipette):
     )
 
     await uf.save_offset()
-    tiprack_hash = helpers.hash_labware_def(
-        uf._tip_rack._implementation.get_definition()
-    )
+    tiprack_hash = helpers.hash_labware_def(uf._tip_rack._core.get_definition())
     offset = uf._cal_ref_point - Point(x=10, y=10, z=40)
     mock_save_pipette.assert_called_with(
         offset=offset,


### PR DESCRIPTION
# Overview

Finally closes closes https://opentrons.atlassian.net/browse/RCORE-79.
Changed public context `_impl` / `_implementation` properties to _core and corresponding constructer arguments to `core`.

# Test Plan

- Test against an OT-2 with core ff off.
- Upload a python protocols to test against PAPI (this PR needs heavy smoke tests on PAPI). 

```
from opentrons import protocol_api, types

metadata = {
    "apiLevel": "2.12",
}

def run(ctx: protocol_api.ProtocolContext) -> None:
    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 5)
    pipette = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tip_rack])
    well = tip_rack.wells()[0]
    
    # offset the well to something obvious
    # to observe that the offset is not respected
    location = types.Location(point=types.Point(x=9, y=-9, z=0), labware=well)

    pipette.pick_up_tip(location, presses=0)
    pipette.drop_tip()
```

```
metadata = {
    'protocolName': 'Heater-shaker test protocol w/ blocking commands',
    'author': 'Opentrons <protocols@opentrons.com>',
    'apiLevel': '2.13'
}

def run(context):
	# Load Heater-shaker module
	hs_mod = context.load_module("heaterShakerModuleV1", "1")

	# Load adapter + labware on module. Available labware:
	# - opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat
	# - opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt
	# - opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep
	# - opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat
	hs_plate = hs_mod.load_labware("opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat")

	# tiprack_300ul = [context.load_labware('opentrons_96_tiprack_300ul', 3)]
	# p20 = context.load_instrument('p300_single', 'right', tip_racks=tiprack_300ul)

	tiprack_10ul = [context.load_labware('opentrons_96_tiprack_300ul', 5)]
	p20 = context.load_instrument('p300_single_gen2', 'right', tip_racks=tiprack_10ul)

	reservoir = context.load_labware('agilent_1_reservoir_290ml', 4)

	hs_mod.open_labware_latch()
	
	hs_mod.set_and_wait_for_temperature(celsius=80)  # Waits until H/S is at 80C

	p20.pick_up_tip()
	p20.aspirate(10, reservoir['A1'])
	p20.dispense(10, hs_plate['A1'])
	p20.drop_tip()

	hs_mod.close_labware_latch()
	hs_mod.set_and_wait_for_shake_speed(rpm=500)	# Waits until H/S has reached 500rpm speed

	context.delay(minutes=1)

	hs_mod.deactivate_shaker()
	hs_mod.deactivate_heater()
```

```
import time

metadata = {
    'protocolName': 'Heater-shaker test protocol w/ non blocking commands',
    'author': 'Opentrons <protocols@opentrons.com>',
    'apiLevel': '2.13'
}

SHAKE_TIME_MINUTES = 1


def run(context):
	# Load Heater-shaker module
	hs_mod = context.load_module("heaterShakerModuleV1", 1)

	# Load adapter + labware on module. Available labware:
	# - opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat
	# - opentrons_96_pcr_plate_adapter_nest_wellplate_100ul_pcr_full_skirt
	# - opentrons_96_deepwell_adapter_nest_wellplate_2ml_deep
	# - opentrons_flat_plate_adapter_corning_384_wellplate_112ul_flat
	hs_plate = hs_mod.load_labware("opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat")
	other_plate = context.load_labware("biorad_96_wellplate_200ul_pcr", 6)

	tiprack_10ul = [context.load_labware('opentrons_96_tiprack_300ul', 5)]
	p20 = context.load_instrument('p300_single_gen2', 'right', tip_racks=tiprack_10ul)

	reservoir = context.load_labware('agilent_1_reservoir_290ml', 4)


	hs_mod.set_target_temperature(celsius=40)  # Sets target and moves on. Doesn't wait

	p20.pick_up_tip()
	p20.aspirate(10, reservoir['A1'])
	p20.dispense(10, hs_plate['A1'])
	p20.drop_tip()

	hs_mod.wait_for_temperature()					# Cannot specify a temperature. Waits for the previously set target temperature only

	saved_time = time.time()	# saves seconds since epoch (January 1, 1970, 00:00:00)

	hs_mod.close_labware_latch()
	hs_mod.set_and_wait_for_shake_speed(rpm=500)	# Waits until H/S has reached 500rpm speed

	p20.pick_up_tip()
	p20.aspirate(10, reservoir['A1'])
	p20.dispense(10, other_plate['A1'])
	p20.drop_tip()

	context.comment(msg=f"Waiting until shaken for {SHAKE_TIME_MINUTES}min.")

	if not context.is_simulating():
		while time.time() - saved_time < SHAKE_TIME_MINUTES * 60:		# Wait until SHAKE_TIME_MINUTES since saved_time
			time.sleep(1)

	hs_mod.deactivate_shaker()
	hs_mod.deactivate_heater()
```

```
from typing import cast
from opentrons import protocol_api, types

metadata = {
    "protocolName": "Mad Mag",
    "author": "Opentrons <engineering@opentrons.com>",
    "description": "A Magnetic Module Test",
    "source": "Opentrons Repository",
    "apiLevel": "2.10",
}

def run(ctx: protocol_api.ProtocolContext) -> None:
    mm = cast(protocol_api.TemperatureModuleContext, ctx.load_module("temperatureModuleV2", 3))
    labware = mm.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
    ctx.comment(f"labware parent is {labware.parent}")
    mm.set_temperature(37)

    print(mm.status)
```

- make sure logic works as expected. there should be no change. 

# Changelog

- Changed public context's `_impl`\`_implementation` to _core.
- Changed public context's constructers to accept `core` argument instead of `implementation`.

# Review requests

- Naming makes senes?
- Did I miss anything? 
- Any protocols in mind I can test with? 

# Risk assessment

Medium. Need to run smoke tests on an OT-2 with core ff off to make sure everything is working as expected. 