### PR TITLE
build(app): fix artifacts exclusion for other app

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -273,7 +273,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-2
         run: |
           mkdir to_upload
-          rm ./opentrons-*/Opentrons-OT3*
+          rm -rf ./opentrons-ot3-*
           cp ./opentrons-*/* ./to_upload/
           aws s3 sync --acl=public-read to_upload/ s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
 
@@ -300,7 +300,7 @@ jobs:
       - name: 'deploy builds to s3'
         run: |
           mkdir to_upload
-          cp ./opentrons-*/Opentrons-OT3* ./to_upload
+          cp ./opentrons-ot3-*/* ./to_upload
           aws --profile=deploy s3 sync --acl=public-read to_upload s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
       - name: 'detect build data for notification'
         id: names


### PR DESCRIPTION
The same github workflow builds and optionally deploys app builds for robot-stack and ot3. This process was almost right but had two bugs in it, both around the intermediate artifact handling that links building the app and deploying it.

The robot-stack and ot3 apps are built in separate jobs. There is one job per combination of OS and stack - so ot3 on linux, robot stack on mac, ot3 on windows, etc. Each is a separate job. Each builds the app and an electron-updater release manifest. The app artifact is always copied to artifact storage; the release manifest is copied if and only if this is a release build for this stack. The app and optional release manifest are put in the same directory, which is zipped up and named opentrons-$os.zip for the robot stack and opentrons-ot3-$os.zip for the ot3 stack.

There is a separate deploy job for each stack. Each deploy job depends on the build jobs for its stack, and therefore is guaranteed not to run unless the build jobs for its stack have completed successfully. However, there is no causal link between each stack's deploy job and the other stack's build jobs, and artifact storage is shared - so when each deploy job runs, it will certainly have its own stack's artifacts, but may also have all, some, or none of the other stack's artifacts.

That means that each deploy job must make sure that it does not deploy the other stack's artifacts, and here are the bugs:

- the OT3 deploy job only copies over OT3 artifacts. However, it did this by copying over only the app artifacts themselves, and thus while it would only copy over the _OT3_ app, it will only ever copy over the OT3 _app_ - not the release manifest. Therefore, release jobs will not result in app update notifications.
- The OT2 deploy job removes the OT3 artifacts before copying over the remaining files. However, it did this by removing only the app artifacts themselves, and thus while it would not copy over the _OT3_ app, it would only not copy over the OT3 _app_ - any release manifests in the OT3 artifacts would get deployed to the robot-stack storage.

Both these bugs can be fixed by specifying "ot3 artifact" by the name of the folder it unzips to rather than the name of the specific files inside that folder.

## Testing and Review

As you can tell from a 500 word PR description accompanying a two-line change, this is an annoying area of code to deal with and needs to be deeply inspected for knock-on effects.

Unfortunately, the only way to test this I believe is to do some releases. Let's do those _as alphas_ to make sure they don't get out, and let's try and do them in a time that won't obstruct robot stack release testing if they go wrong.

You can check whether OT3 builds were mistakenly uploaded to the OT-2 bucket by checking this link: http://s3.amazonaws.com/opentrons-app/builds/alpha-linux.yml and inspecting the file your browser downloads

You can check whether an OT3 build got uploaded correctly to the OT-3 bucket by checking this link: http://ot3-development.builds.opentrons.com/app/alpha-linux.yml and inspecting the file your browser downloads (or noticing that it's an access error because it hasn't successfully been uploaded yet)
