### PR TITLE
fix(ot3): use correct timer interrupt frequency for the tip motors

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/constants.py
+++ b/hardware/opentrons_hardware/hardware_control/constants.py
@@ -4,5 +4,8 @@ from typing_extensions import Final
 brushed_motor_interrupts_per_sec: Final = 32000
 """The number of gripper motor interrupts per second."""
 
+tip_interrupts_per_sec: Final = 100000
+"""The number of tip motor interrupts per second."""
+
 interrupts_per_sec: Final = 200000
 """The number of motor interrupts per second."""

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -36,7 +36,11 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     TipActionRequestPayload,
     EmptyPayload,
 )
-from .constants import interrupts_per_sec, tip_interrupts_per_sec, brushed_motor_interrupts_per_sec
+from .constants import (
+    interrupts_per_sec,
+    tip_interrupts_per_sec,
+    brushed_motor_interrupts_per_sec,
+)
 from opentrons_hardware.hardware_control.motion import (
     MoveGroups,
     MoveGroupSingleAxisStep,
@@ -284,7 +288,9 @@ class MoveGroupRunner:
             group_id=UInt8Field(group),
             seq_id=UInt8Field(seq),
             duration=UInt32Field(int(step.duration_sec * tip_interrupts_per_sec)),
-            velocity=self._convert_velocity(step.velocity_mm_sec, tip_interrupts_per_sec),
+            velocity=self._convert_velocity(
+                step.velocity_mm_sec, tip_interrupts_per_sec
+            ),
             action=PipetteTipActionTypeField(step.action),
             request_stop_condition=MoveStopConditionField(step.stop_condition),
         )

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -36,7 +36,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     TipActionRequestPayload,
     EmptyPayload,
 )
-from .constants import interrupts_per_sec, brushed_motor_interrupts_per_sec
+from .constants import interrupts_per_sec, tip_interrupts_per_sec, brushed_motor_interrupts_per_sec
 from opentrons_hardware.hardware_control.motion import (
     MoveGroups,
     MoveGroupSingleAxisStep,
@@ -283,8 +283,8 @@ class MoveGroupRunner:
         tip_action_payload = TipActionRequestPayload(
             group_id=UInt8Field(group),
             seq_id=UInt8Field(seq),
-            duration=UInt32Field(int(step.duration_sec * interrupts_per_sec)),
-            velocity=self._convert_velocity(step.velocity_mm_sec, interrupts_per_sec),
+            duration=UInt32Field(int(step.duration_sec * tip_interrupts_per_sec)),
+            velocity=self._convert_velocity(step.velocity_mm_sec, tip_interrupts_per_sec),
             action=PipetteTipActionTypeField(step.action),
             request_stop_condition=MoveStopConditionField(step.stop_condition),
         )


### PR DESCRIPTION
## Overview

When I reduced the tip motor frequency, I did not change the calculation on the python side. This caused the movements to be off by a factor of two.
