### PR TITLE
refactor(hardware): change MoveStopCondition.cap_sensor to MoveStopCondition.sync_line

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -279,7 +279,7 @@ class MoveStopCondition(int, Enum):
 
     none = 0x0
     limit_switch = 0x1
-    cap_sensor = 0x2
+    sync_line = 0x2
     encoder_position = 0x4
     gripper_force = 0x8
     stall = 0x10

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -31,7 +31,7 @@ class MoveType(int, Enum):
         mapping = {
             MoveStopCondition.none: cls.linear,
             MoveStopCondition.limit_switch: cls.home,
-            MoveStopCondition.cap_sensor: cls.calibration,
+            MoveStopCondition.sync_line: cls.calibration,
             MoveStopCondition.encoder_position: cls.linear,
             MoveStopCondition.gripper_force: cls.grip,
             MoveStopCondition.stall: cls.linear,

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -34,7 +34,7 @@ def _build_pass_step(mover: NodeId, distance: float, speed: float) -> MoveGroupS
         acceleration={},
         duration=float64(abs(distance / speed)),
         present_nodes=[mover],
-        stop_condition=MoveStopCondition.cap_sensor,
+        stop_condition=MoveStopCondition.sync_line,
     )
 
 

--- a/hardware/opentrons_hardware/scripts/liquid_sense_script.py
+++ b/hardware/opentrons_hardware/scripts/liquid_sense_script.py
@@ -261,7 +261,7 @@ async def run_test(messenger: CanMessenger, args: argparse.Namespace) -> None:
                 acceleration={},
                 duration=float64(args.mount_distance / args.mount_speed),
                 present_nodes=[target_z, target_pipette],
-                stop_condition=MoveStopCondition.cap_sensor,
+                stop_condition=MoveStopCondition.sync_line,
             ),
         ],
     ]

--- a/hardware/opentrons_hardware/scripts/sensor_pass.py
+++ b/hardware/opentrons_hardware/scripts/sensor_pass.py
@@ -126,7 +126,7 @@ async def run_test(messenger: CanMessenger, args: argparse.Namespace) -> None:
                 {},
                 float64(args.distance / args.speed),
                 [target_z],
-                MoveStopCondition.cap_sensor,
+                MoveStopCondition.sync_line,
             ),
         ],
     ]


### PR DESCRIPTION
# Overview 
This just changes `MoveStopCondition.cap_sensor` to `MoveStopCondition.sync_line`, so both the pressure and capacitive sensors can use one stop condition. 

Corresponds to [this firmware change](https://github.com/Opentrons/ot3-firmware/pull/554). 