### PR TITLE
fix(makefile): Allow different OpenSSH version names

### DIFF
--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -15,9 +15,6 @@ ssh-version-label=$(or $(filter %p1$(comma),$(ssh-version-words)), $(filter %p1,
 ssh-version-number=$(subst ., ,$(firstword $(subst p, ,$(ssh-version-label))))
 checked-ssh-version=$(if $(ssh-version-number),$(ssh-version-number),"$(warning Could not find ssh version for version $(ssh-version-output), scp flags may be wrong")))
 is-in-version=$(findstring $(firstword $(checked-ssh-version)),$(allowed-ssh-versions))
-$(info $$ssh-version-words $(ssh-version-words))
-$(info $$ssh-version-label $(ssh-version-label))
-$(info $$ssh-version-number $(ssh-version-number))
 # when using an OpenSSH version larger than 8.9,
 # we need to add a flag to use legacy scp with SFTP protocol
 scp-legacy-option-flag = $(if $(is-in-version),,-O)

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -11,10 +11,13 @@ comma=,
 # string manipulations to extract the int version number
 ssh-version-output = $(shell ssh -V 2>&1)
 ssh-version-words=$(subst _, ,$(filter OpenSSH_%, $(ssh-version-output)))
-ssh-version-label=$(filter %p1$(comma),$(ssh-version-words))
+ssh-version-label=$(or $(filter %p1$(comma),$(ssh-version-words)), $(filter %p1,$(ssh-version-words)))
 ssh-version-number=$(subst ., ,$(firstword $(subst p, ,$(ssh-version-label))))
 checked-ssh-version=$(if $(ssh-version-number),$(ssh-version-number),"$(warning Could not find ssh version for version $(ssh-version-output), scp flags may be wrong")))
 is-in-version=$(findstring $(firstword $(checked-ssh-version)),$(allowed-ssh-versions))
+$(info $$ssh-version-words $(ssh-version-words))
+$(info $$ssh-version-label $(ssh-version-label))
+$(info $$ssh-version-number $(ssh-version-number))
 # when using an OpenSSH version larger than 8.9,
 # we need to add a flag to use legacy scp with SFTP protocol
 scp-legacy-option-flag = $(if $(is-in-version),,-O)


### PR DESCRIPTION
# Overview

When filtering the OpenSSH version string, allow version name's without a comma. 

# Test Plan

Make push with different OS's and make sure they are able to push with or without the -O flag.

# Changelog

- When filtering the version number, if there is no match look for the version number without a comma. 

# Review requests

code looks good?

# Risk assessment

Low. Tested with a Mac and Ubuntu. (Ubuntu had the issue). Should work as it used too unless there is no match.
