### PR TITLE
build(app): use Set-AuthenticodeSignature

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -76,6 +76,7 @@ module.exports = async () => ({
     target: ['nsis'],
     publisherName: 'Opentrons Labworks Inc.',
     icon: project === 'robot-stack' ? 'build/icon.ico' : 'build/three.ico',
+    sign: path.join(__dirname, './scripts/sign-windows.js')
   },
   nsis: {
     oneClick: false,

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -76,7 +76,7 @@ module.exports = async () => ({
     target: ['nsis'],
     publisherName: 'Opentrons Labworks Inc.',
     icon: project === 'robot-stack' ? 'build/icon.ico' : 'build/three.ico',
-    sign: path.join(__dirname, './scripts/sign-windows.js')
+    sign: path.join(__dirname, './scripts/sign-windows.js'),
   },
   nsis: {
     oneClick: false,

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -1,0 +1,27 @@
+'use strict'
+const path = require('path')
+const {mkdtemp, open} = require('fs/promises')
+const {promisify} = require("util")
+const exec = promisify(require('child_process').exec)
+
+exports.default = async function (configuration) {
+  const {toSignPath = path, cscInfo} = configuration
+  if (!Object.hasOwnProperty(configuration, 'cscInfo')) {
+    console.log('No codesign configuration, not signing')
+    return
+  }
+  const {file, password} = cscInfo
+  const certContent = atob(file)
+  const tempdir = mkdtemp('keyfile')
+  const certTempPath = path.join(tempdir, 'key.pfx')
+  const certFile = await open(certTempPath)
+  await certFile.writeFile(cert)
+  await certFile.close()
+
+  await exec(
+    `Set-AuthenticodeSignature -Certificate \$(Get-PfxCertificate -FilePath ${certTempPath} -Password ${password} ) -FilePath ${toSignPath}`,
+    {
+      stdio: 'inherit',
+    }
+  )
+}

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -1,24 +1,27 @@
 'use strict'
-const path = require('path')
+const {join} = require('path')
 const { mkdtemp, open } = require('fs/promises')
 const { promisify } = require('util')
 const exec = promisify(require('child_process').exec)
 
-const certEncodedContent = process.env.WIN_CSC_LINK
-const certPassword = process.env.WIN_CSC_KEY_PASSWORD
-
 exports.default = async function (configuration) {
-  const { toSignPath = path } = configuration
+  if (!Object.hasOwnProperty(process.env, 'WIN_CSC_LINK')) {
+    console.log('No certificate, skipping signing')
+  }
+  const { path } = configuration
+
+  const certEncodedContent = process.env.WIN_CSC_LINK
+  const certPassword = process.env.WIN_CSC_KEY_PASSWORD
   console.log(`Signing ${toSignPath} using powershell commandlets`)
   const certContent = atob(certEncodedContent)
   const tempdir = await mkdtemp('keyfile')
-  const certTempPath = path.join(tempdir, 'key.pfx')
+  const certTempPath = join(tempdir, 'key.pfx')
   const certFile = await open(certTempPath, 'w')
   await certFile.writeFile(certContent)
   await certFile.close()
 
   await exec(
-    `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${certPassword} ) -FilePath ${toSignPath}`,
+    `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${certPassword}) -FilePath ${path}`,
     {
       stdio: 'inherit',
       shell: 'powershell.exe'

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -12,7 +12,7 @@ exports.default = async function (configuration) {
 
   const certEncodedContent = process.env.WIN_CSC_LINK
   const certPassword = process.env.WIN_CSC_KEY_PASSWORD
-  console.log(`Signing ${toSignPath} using powershell commandlets`)
+  console.log(`Signing ${path} using powershell commandlets`)
   const certContent = atob(certEncodedContent)
   const tempdir = await mkdtemp('keyfile')
   const certTempPath = join(tempdir, 'key.pfx')

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -4,8 +4,8 @@ const { mkdtemp, open } = require('fs/promises')
 const { promisify } = require('util')
 const exec = promisify(require('child_process').exec)
 
-const certEncodedContent = process.env('WIN_CSC_LINK')
-const certPassword = process.env('WIN_CSC_KEY_PASSWORD')
+const certEncodedContent = process.env.WIN_CSC_LINK
+const certPassword = process.env.WIN_CSC_KEY_PASSWORD
 
 exports.default = async function (configuration) {
   const { toSignPath = path } = configuration

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -11,7 +11,7 @@ exports.default = async function (configuration) {
   const { toSignPath = path } = configuration
   console.log(`Signing ${toSignPath} using powershell commandlets`)
   const certContent = atob(certEncodedContent)
-  const tempdir = mkdtemp('keyfile')
+  const tempdir = await mkdtemp('keyfile')
   const certTempPath = path.join(tempdir, 'key.pfx')
   const certFile = await open(certTempPath)
   await certFile.writeFile(certContent)

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -21,6 +21,7 @@ exports.default = async function (configuration) {
     `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${certPassword} ) -FilePath ${toSignPath}`,
     {
       stdio: 'inherit',
+      shell: 'powershell.exe'
     }
   )
 }

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -13,7 +13,7 @@ exports.default = async function (configuration) {
   const certContent = atob(certEncodedContent)
   const tempdir = await mkdtemp('keyfile')
   const certTempPath = path.join(tempdir, 'key.pfx')
-  const certFile = await open(certTempPath)
+  const certFile = await open(certTempPath, 'w')
   await certFile.writeFile(certContent)
   await certFile.close()
 

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -1,25 +1,25 @@
 'use strict'
 const path = require('path')
-const {mkdtemp, open} = require('fs/promises')
-const {promisify} = require("util")
+const { mkdtemp, open } = require('fs/promises')
+const { promisify } = require('util')
 const exec = promisify(require('child_process').exec)
 
 exports.default = async function (configuration) {
-  const {toSignPath = path, cscInfo} = configuration
+  const { toSignPath = path, cscInfo } = configuration
   if (!Object.hasOwnProperty(configuration, 'cscInfo')) {
     console.log('No codesign configuration, not signing')
     return
   }
-  const {file, password} = cscInfo
+  const { file, password } = cscInfo
   const certContent = atob(file)
   const tempdir = mkdtemp('keyfile')
   const certTempPath = path.join(tempdir, 'key.pfx')
   const certFile = await open(certTempPath)
-  await certFile.writeFile(cert)
+  await certFile.writeFile(certContent)
   await certFile.close()
 
   await exec(
-    `Set-AuthenticodeSignature -Certificate \$(Get-PfxCertificate -FilePath ${certTempPath} -Password ${password} ) -FilePath ${toSignPath}`,
+    `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${password} ) -FilePath ${toSignPath}`,
     {
       stdio: 'inherit',
     }

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -4,14 +4,13 @@ const { mkdtemp, open } = require('fs/promises')
 const { promisify } = require('util')
 const exec = promisify(require('child_process').exec)
 
+const certEncodedContent = process.env('WIN_CSC_LINK')
+const certPassword = process.env('WIN_CSC_KEY_PASSWORD')
+
 exports.default = async function (configuration) {
-  const { toSignPath = path, cscInfo } = configuration
-  if (!Object.hasOwnProperty(configuration, 'cscInfo')) {
-    console.log('No codesign configuration, not signing')
-    return
-  }
-  const { file, password } = cscInfo
-  const certContent = atob(file)
+  const { toSignPath = path } = configuration
+  console.log(`Signing ${toSignPath} using powershell commandlets`)
+  const certContent = atob(certEncodedContent)
   const tempdir = mkdtemp('keyfile')
   const certTempPath = path.join(tempdir, 'key.pfx')
   const certFile = await open(certTempPath)
@@ -19,7 +18,7 @@ exports.default = async function (configuration) {
   await certFile.close()
 
   await exec(
-    `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${password} ) -FilePath ${toSignPath}`,
+    `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${certPassword} ) -FilePath ${toSignPath}`,
     {
       stdio: 'inherit',
     }

--- a/app-shell/scripts/sign-windows.js
+++ b/app-shell/scripts/sign-windows.js
@@ -1,5 +1,5 @@
 'use strict'
-const {join} = require('path')
+const { join } = require('path')
 const { mkdtemp, open } = require('fs/promises')
 const { promisify } = require('util')
 const exec = promisify(require('child_process').exec)
@@ -24,7 +24,7 @@ exports.default = async function (configuration) {
     `Set-AuthenticodeSignature -Certificate $(Get-PfxCertificate -FilePath ${certTempPath} -Password ${certPassword}) -FilePath ${path}`,
     {
       stdio: 'inherit',
-      shell: 'powershell.exe'
+      shell: 'powershell.exe',
     }
   )
 }


### PR DESCRIPTION
# Overview

We've been using electron's built in code signature process on windows, which relies on signtool
( https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool ) and frequently randomly fails.

There is another way to sign an executable on windows: the powershell commandlet Set-AuthenticodeSignature:
https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-authenticodesignature

Perhaps this will spuriously fail less.


# Test Plan

- Get the app building
- Inspect the result with posh Get-AuthenticodeSignature and see if it matches
- See if you can run it without a scary warning
- Run a couple builds and see if it randomly fails