### PR TITLE
refactor(ot3): modify 96 channel pick up and drop tip behavior

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -75,7 +75,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.Y: 500,
         OT3AxisKind.Z: 35,
         OT3AxisKind.P: 5,
-        OT3AxisKind.Q: 40,
+        OT3AxisKind.Q: 5.5,
     },
     low_throughput={
         OT3AxisKind.X: 500,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -398,8 +398,7 @@ class OT3Controller:
             await self.tip_action(
                 [OT3Axis.Q],
                 self.axis_bounds[OT3Axis.Q][1] - self.axis_bounds[OT3Axis.Q][0],
-                -1
-                * self._configuration.motion_settings.default_max_speed.high_throughput[
+                self._configuration.motion_settings.default_max_speed.high_throughput[
                     OT3Axis.to_kind(OT3Axis.Q)
                 ],
             )
@@ -440,6 +439,8 @@ class OT3Controller:
         speed: float,
         tip_action: str = "home",
     ) -> None:
+        if tip_action == "home":
+            speed = speed * -1
         move_group = create_tip_action_group(
             axes, distance, speed, cast(PipetteAction, tip_action)
         )

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -438,7 +438,7 @@ class OT3Controller:
         axes: Sequence[OT3Axis],
         distance: float,
         speed: float,
-        tip_action: str = "drop",
+        tip_action: str = "home",
     ) -> None:
         move_group = create_tip_action_group(
             axes, distance, speed, cast(PipetteAction, tip_action)

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -43,7 +43,7 @@ from opentrons_hardware.hardware_control.motion import (
 GRIPPER_JAW_HOME_TIME: float = 10
 GRIPPER_JAW_GRIP_TIME: float = 10
 
-PipetteAction = Literal["pick_up", "drop"]
+PipetteAction = Literal["clamp", "home"]
 
 # TODO: These methods exist to defer uses of NodeId to inside
 # method bodies, which won't be evaluated until called. This is needed

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -12,7 +12,6 @@ from opentrons_shared_data.pipette.pipette_definition import (
     PipetteTipType,
     PlungerPositions,
     MotorConfigurations,
-    PickUpTipConfigurations,
     SupportedTipsDefinition,
     TipHandlingConfigurations,
     PipetteModelType,
@@ -164,11 +163,13 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         return self._plunger_motor_current
 
     @property
-    def pick_up_configurations(self) -> PickUpTipConfigurations:
+    def pick_up_configurations(self) -> TipHandlingConfigurations:
         return self._pick_up_configurations
 
     @pick_up_configurations.setter
-    def pick_up_configurations(self, pick_up_configs: PickUpTipConfigurations) -> None:
+    def pick_up_configurations(
+        self, pick_up_configs: TipHandlingConfigurations
+    ) -> None:
         self._pick_up_configurations = pick_up_configs
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -657,7 +657,7 @@ class PipetteHandlerProvider:
                     retract_target=instrument.pick_up_configurations.distance,
                     pick_up_motor_actions=TipMotorPickUpTipSpec(
                         # Move onto the posts
-                        tiprack_down=top_types.Point(0, 0, -5),
+                        tiprack_down=top_types.Point(0, 0, -7),
                         tiprack_up=top_types.Point(0, 0, 2),
                         pick_up_distance=instrument.pick_up_configurations.distance,
                         speed=instrument.pick_up_configurations.speed,
@@ -757,8 +757,14 @@ class PipetteHandlerProvider:
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.DROPTIP)
 
+        is_96_chan = instrument.channels.value == 96
+
         bottom = instrument.plunger_positions.bottom
-        droptip = instrument.plunger_positions.drop_tip
+        droptip = (
+            instrument.drop_configurations.distance
+            if is_96_chan
+            else instrument.plunger_positions.drop_tip
+        )
         speed = instrument.drop_configurations.speed
         shakes: List[Tuple[top_types.Point, Optional[float]]] = []
 
@@ -767,7 +773,6 @@ class PipetteHandlerProvider:
             instrument.current_tiprack_diameter = 0.0
             instrument.remove_tip()
 
-        is_96_chan = instrument.channels.value == 96
         drop_tip_current_axis = (
             OT3Axis.Q if is_96_chan else OT3Axis.of_main_tool_actuator(mount)
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1361,7 +1361,14 @@ class OT3API(
                 [OT3Axis.of_main_tool_actuator(mount)],
                 pipette_spec.pick_up_distance,
                 pipette_spec.speed,
-                "pick_up",
+                "clamp",
+            )
+            # back clamps off the adapter posts
+            await self._backend.tip_action(
+                [OT3Axis.of_main_tool_actuator(mount)],
+                pipette_spec.pick_up_distance,
+                pipette_spec.speed,
+                "home",
             )
             # Move to pick up position
             target_up = target_position_from_relative(
@@ -1457,7 +1464,7 @@ class OT3API(
                     [OT3Axis.of_main_tool_actuator(mount)],
                     move.target_position,
                     move.speed,
-                    "drop",
+                    "clamp",
                 )
             else:
                 target_pos = target_position_from_plunger(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -581,7 +581,7 @@ async def test_ready_for_movement(
 
 
 async def test_tip_action(controller: OT3Controller, mock_move_group_run) -> None:
-    await controller.tip_action([OT3Axis.P_L], 33, -5.5, tip_action="pick_up")
+    await controller.tip_action([OT3Axis.P_L], 33, -5.5, tip_action="clamp")
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:
@@ -594,7 +594,7 @@ async def test_tip_action(controller: OT3Controller, mock_move_group_run) -> Non
 
     mock_move_group_run.reset_mock()
 
-    await controller.tip_action([OT3Axis.P_L], 33, -5.5, tip_action="drop")
+    await controller.tip_action([OT3Axis.P_L], 33, -5.5, tip_action="home")
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -4,7 +4,7 @@ from typing import Iterator, Union, Dict, Tuple, List
 from typing_extensions import Literal
 from math import copysign
 import pytest
-from mock import AsyncMock, patch, Mock
+from mock import AsyncMock, patch, Mock, call
 from opentrons.config.types import GantryLoad, CapacitivePassSettings
 from opentrons.hardware_control.dev_types import AttachedGripper, OT3AttachedPipette
 from opentrons.hardware_control.instruments.ot3.gripper_handler import (
@@ -794,7 +794,12 @@ async def test_pick_up_tip_full_tiprack(
         pipette_handler.plan_check_pick_up_tip.assert_called_once_with(
             OT3Mount.LEFT, 40.0, None, None
         )
-        tip_action.assert_called_once_with([OT3Axis.P_L], 0, 0, "pick_up")
+        tip_action.assert_has_calls(
+            calls=[
+                call([OT3Axis.P_L], 0, 0, "clamp"),
+                call([OT3Axis.P_L], 0, 0, "home"),
+            ]
+        )
 
 
 async def test_drop_tip_full_tiprack(
@@ -827,7 +832,7 @@ async def test_drop_tip_full_tiprack(
         )
         await ot3_hardware.drop_tip(Mount.LEFT)
         pipette_handler.plan_check_drop_tip.assert_called_once_with(OT3Mount.LEFT, True)
-        tip_action.assert_called_once_with([OT3Axis.P_L], 1, 1, "drop")
+        tip_action.assert_called_once_with([OT3Axis.P_L], 1, 1, "clamp")
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -344,8 +344,8 @@ async def test_capacitive_probe(
     )
 
     original = moving.set_in_point(here, 0)
-    for call in mock_move_to.call_args_list:
-        this_point = moving.set_in_point(call[0][1], 0)
+    for probe_call in mock_move_to.call_args_list:
+        this_point = moving.set_in_point(probe_call[0][1], 0)
         assert this_point == original
 
 

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -84,7 +84,7 @@ def test_plan_check_pick_up_tip_with_presses_argument(
             0,
             96,
             TipMotorPickUpTipSpec(
-                tiprack_down=types.Point(0, 0, -5),
+                tiprack_down=types.Point(0, 0, -7),
                 tiprack_up=types.Point(0, 0, 2),
                 pick_up_distance=0,
                 speed=10,

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -257,8 +257,8 @@ class GearMotorId(int, Enum):
 class PipetteTipActionType(int, Enum):
     """Tip action types."""
 
-    pick_up = 0x0
-    drop = 0x01
+    clamp = 0x0
+    home = 0x01
 
 
 @unique

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -161,7 +161,7 @@ def create_tip_action_step(
     step: MoveGroupStep = {}
     stop_condition = (
         MoveStopCondition.limit_switch
-        if action == PipetteTipActionType.drop
+        if action == PipetteTipActionType.home
         else MoveStopCondition.none
     )
     for axis_node in present_nodes:

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -390,7 +390,7 @@ class MoveScheduler:
             self._event.set()
             raise RuntimeError("Firmware Error Received", message)
 
-    def _handle_move_completed(self, message: MoveCompleted) -> None:
+    def _handle_move_completed(self, message: _AcceptableMoves) -> None:
         group_id = message.payload.group_id.value - self._start_at_index
         ack_id = message.payload.ack_id.value
         try:

--- a/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
+++ b/hardware/opentrons_hardware/scripts/high_throughput_tip_handling.py
@@ -74,7 +74,7 @@ async def run(args: argparse.Namespace) -> None:
                         velocity_mm_sec=float64(5.5),
                         duration_sec=float64(2.5),
                         stop_condition=MoveStopCondition.none,
-                        action=PipetteTipActionType.pick_up,
+                        action=PipetteTipActionType.clamp,
                     )
                 }
             ]
@@ -88,7 +88,7 @@ async def run(args: argparse.Namespace) -> None:
                         velocity_mm_sec=float64(-5.5),
                         duration_sec=float64(6),
                         stop_condition=MoveStopCondition.limit_switch,
-                        action=PipetteTipActionType.drop,
+                        action=PipetteTipActionType.home,
                     )
                 }
             ]

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -8,11 +8,12 @@
     "presses": 0.0,
     "speed": 5.5,
     "increment": 0.0,
-    "distance": 13.75
+    "distance": 19.0
   },
   "dropTipConfigurations": {
     "current": 1.5,
-    "speed": 10
+    "speed": 10,
+    "distance": 25.5
   },
   "plungerMotorConfigurations": {
     "idle": 0.3,

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -12,8 +12,8 @@
   },
   "dropTipConfigurations": {
     "current": 1.5,
-    "speed": 10,
-    "distance": 25.5
+    "speed": 5.5,
+    "distance": 26.5
   },
   "plungerMotorConfigurations": {
     "idle": 0.3,

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/1_0.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.2,
       "aspirate": {
         "default": [
           [0.4148, -1705.1015, 20.5455],
@@ -107,7 +107,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.2,
       "aspirate": {
         "default": [
           [0.8314, -2.9322, 24.0741],
@@ -205,7 +205,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.2,
       "aspirate": {
         "default": [
           [0.7511, 3.9556, 6.455],

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -158,18 +158,15 @@ class TipHandlingConfigurations(BaseModel):
         ...,
         description="The speed to move the z or plunger axis for tip pickup or drop off.",
     )
-
-
-class PickUpTipConfigurations(TipHandlingConfigurations):
     presses: int = Field(
-        ..., description="The number of tries required to force pick up a tip."
+        default=0.0, description="The number of tries required to force pick up a tip."
     )
     increment: float = Field(
-        ...,
+        default=0.0,
         description="The increment to move the pipette down for force tip pickup retries.",
     )
     distance: float = Field(
-        ..., description="The distance to begin a pick up tip from."
+        default=0.0, description="The distance to begin a pick up tip from."
     )
 
 
@@ -208,7 +205,7 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
     display_category: PipetteGenerationType = Field(
         ..., description="The product model of the pipette.", alias="displayCategory"
     )
-    pick_up_tip_configurations: PickUpTipConfigurations = Field(
+    pick_up_tip_configurations: TipHandlingConfigurations = Field(
         ..., alias="pickUpTipConfigurations"
     )
     drop_tip_configurations: TipHandlingConfigurations = Field(


### PR DESCRIPTION
# Overview

The "drop tip" command truly was just moving to the home position and the "pick up" direction should actually control both pick up and drop tip. In this PR, the behavior for both pick up and drop tip are modified as well as distances.

For pick up tip we first need to "clamp" the tips to the pipette and then back off (or just home) the clamp motors to release the tiprack adapter. For drop tip we should just need to further bring the platform of the 96 channel down by moving the clamp motor a longer distance.

TBD on whether we should just home the clamp motors immediately after a drop tip or not.