### PR TITLE
feat(app): cal Dashboard active task open by default

### DIFF
--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -258,8 +258,6 @@ function Task({
   taskListLength,
   isComplete,
 }: TaskProps): JSX.Element {
-  const [isTaskOpen, setIsTaskOpen] = React.useState<boolean>(false)
-
   const [activeTaskIndex] = activeIndex ?? []
 
   // TODO(bh, 2022-10-18): pass booleans to children as props
@@ -268,13 +266,12 @@ function Task({
   const isActiveTask = activeTaskIndex === taskIndex
   const hasSubTasks = subTasks.length > 0
 
+  const [isTaskOpen, setIsTaskOpen] = React.useState<boolean>(
+    hasSubTasks && isActiveTask
+  )
+
   React.useEffect(() => {
-    if (hasSubTasks && isActiveTask) {
-      setIsTaskOpen(true)
-    }
-    if (hasSubTasks && !isActiveTask) {
-      setIsTaskOpen(false)
-    }
+    setIsTaskOpen(hasSubTasks && isActiveTask)
   }, [isActiveTask, hasSubTasks])
 
   return (

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -268,6 +268,15 @@ function Task({
   const isActiveTask = activeTaskIndex === taskIndex
   const hasSubTasks = subTasks.length > 0
 
+  React.useEffect(() => {
+    if (hasSubTasks && isActiveTask) {
+      setIsTaskOpen(true)
+    }
+    if (hasSubTasks && !isActiveTask) {
+      setIsTaskOpen(false)
+    }
+  }, [isActiveTask, hasSubTasks])
+
   return (
     <Flex key={title}>
       <ProgressTrackerItem


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

sets the current active task to the open state in the dashboard if it has subtasks

closes RAUT-320


https://user-images.githubusercontent.com/66637570/214877034-b7363cde-0fb7-45d6-8b88-89c320f30d88.mov

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Visited the Calibration Dashboard with both mounts having incomplete subtasks and ensured the correct task was open (chronologically, the Left mount). Ensured that no other opening/closing behavior of it or any other tasks was affected. Ensured that after completion of the left mount calibrations the left mount task closed and the right mount task opened

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Adds a `useEffect` to the Task component to update the `isTaskOpen` state based on the `hasSubTasks` and `isActiveTask` values

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
