### PR TITLE
feat(api): add thermocycler plate lift to hardware controller

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/abstract.py
+++ b/api/src/opentrons/drivers/thermocycler/abstract.py
@@ -31,6 +31,10 @@ class AbstractThermocyclerDriver(ABC):
         ...
 
     @abstractmethod
+    async def lift_plate(self) -> None:
+        """Send the Plate Lift command."""
+
+    @abstractmethod
     async def get_lid_status(self) -> ThermocyclerLidStatus:
         """Send get lid status command"""
         ...

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 class GCODE(str, Enum):
     OPEN_LID = "M126"
     CLOSE_LID = "M127"
+    PLATE_LIFT = "M128"
     GET_LID_STATUS = "M119"
     SET_LID_TEMP = "M140"
     GET_LID_TEMP = "M141"
@@ -308,6 +309,14 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         await trigger_connection.close()
         await self._connection.close()
 
+    async def lift_plate(self) -> None:
+        """Send the Plate Lift command.
+
+        NOT SUPPORTED on TC Gen1."""
+        raise NotImplementedError(
+            "Gen1 Thermocyclers do not support the Plate Lift command."
+        )
+
 
 class ThermocyclerDriverV2(ThermocyclerDriver):
     """
@@ -345,3 +354,10 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
         # No response expected, USB connection should terminate after this
         await self._connection.send_dfu_command(command=c)
         await self._connection.close()
+
+    async def lift_plate(self) -> None:
+        """Send the Plate Lift command."""
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
+            gcode=GCODE.PLATE_LIFT
+        )
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -3,6 +3,8 @@ from typing import Optional, Dict
 from opentrons.util.async_helpers import ensure_yield
 from opentrons.drivers.thermocycler.abstract import AbstractThermocyclerDriver
 from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
+from opentrons.hardware_control.modules.types import ThermocyclerModuleModel
+from opentrons.drivers.asyncio.communication.errors import ErrorResponse
 
 
 class SimulatingDriver(AbstractThermocyclerDriver):
@@ -39,6 +41,14 @@ class SimulatingDriver(AbstractThermocyclerDriver):
     @ensure_yield
     async def close_lid(self) -> None:
         self._lid_status = ThermocyclerLidStatus.CLOSED
+
+    @ensure_yield
+    async def lift_plate(self) -> None:
+        if self._model == ThermocyclerModuleModel.THERMOCYCLER_V1.value:
+            raise NotImplementedError()
+        if self._lid_status != ThermocyclerLidStatus.OPEN:
+            raise ErrorResponse(port="sim_port", response="Lid is not open")
+        self._lid_status = ThermocyclerLidStatus.OPEN
 
     @ensure_yield
     async def get_lid_status(self) -> ThermocyclerLidStatus:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -221,7 +221,13 @@ class Thermocycler(mod_abc.AbstractModule):
         return ThermocyclerLidStatus.CLOSED
 
     async def lift_plate(self) -> str:
-        """If the lid is open, lift the plate."""
+        """If the lid is open, lift the plate.
+
+        Note that this should always be preceded by an `open` call. If the
+        lid is not open, the Thermocycler will respond with an error message.
+
+        Returns: Thermocycler lid status after running the command.
+        """
         await self.wait_for_is_running()
         await self._driver.lift_plate()
         await self._wait_for_lid_status(ThermocyclerLidStatus.OPEN)

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -220,6 +220,13 @@ class Thermocycler(mod_abc.AbstractModule):
         await self._wait_for_lid_status(ThermocyclerLidStatus.CLOSED)
         return ThermocyclerLidStatus.CLOSED
 
+    async def lift_plate(self) -> str:
+        """If the lid is open, lift the plate."""
+        await self.wait_for_is_running()
+        await self._driver.lift_plate()
+        await self._wait_for_lid_status(ThermocyclerLidStatus.OPEN)
+        return ThermocyclerLidStatus.OPEN
+
     async def set_temperature(
         self,
         temperature: float,

--- a/api/tests/opentrons/drivers/thermocycler/test_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_driver.py
@@ -62,6 +62,14 @@ async def test_close_lid(
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
+async def test_plate_lift(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
+    """It should raise an exception."""
+    with pytest.raises(NotImplementedError):
+        await subject.lift_plate()
+
+
 async def test_get_lid_status(
     subject: driver.ThermocyclerDriver, connection: AsyncMock
 ) -> None:

--- a/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
@@ -47,6 +47,19 @@ async def test_close_lid(
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
+async def test_plate_lift(
+    subject: driver.ThermocyclerDriverV2, connection: AsyncMock
+) -> None:
+    """It should send a Plate Lift command."""
+    await subject.lift_plate()
+
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M128"
+    )
+
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
+
+
 async def test_get_lid_status(
     subject: driver.ThermocyclerDriverV2, connection: AsyncMock
 ) -> None:

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -15,6 +15,7 @@ async def build_module(
     port: int,
     execution_manager: ExecutionManager,
     poll_interval_seconds: Optional[float] = None,
+    sim_model: Optional[str] = None,
 ) -> ModuleType:
     """Build a module emulator connected to a RFC-2217 network serial port.
 
@@ -33,6 +34,7 @@ async def build_module(
         usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
         hw_control_loop=asyncio.get_running_loop(),
         poll_interval_seconds=poll_interval_seconds,
+        sim_model=sim_model
     )
 
     return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -32,7 +32,7 @@ async def build_module(
         execution_manager=execution_manager,
         usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
         hw_control_loop=asyncio.get_running_loop(),
-        poll_interval_seconds=poll_interval_seconds
+        poll_interval_seconds=poll_interval_seconds,
     )
 
     return cast(ModuleType, module)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -15,7 +15,6 @@ async def build_module(
     port: int,
     execution_manager: ExecutionManager,
     poll_interval_seconds: Optional[float] = None,
-    sim_model: Optional[str] = None,
 ) -> ModuleType:
     """Build a module emulator connected to a RFC-2217 network serial port.
 
@@ -33,8 +32,7 @@ async def build_module(
         execution_manager=execution_manager,
         usb_port=USBPort(name="", port_number=1, device_path="", hub=1),
         hw_control_loop=asyncio.get_running_loop(),
-        poll_interval_seconds=poll_interval_seconds,
-        sim_model=sim_model
+        poll_interval_seconds=poll_interval_seconds
     )
 
     return cast(ModuleType, module)


### PR DESCRIPTION
# Overview

This PR adds functionality for the Thermocycler Plate Lift in the TC driver and the TC Hardware Control layer.

# Test Plan

Pushed this branch to an OT3 with a Thermocycler Gen2 plugged in and ran the following in ot3repl:

* `import asyncio`
* `tc = api.attached_modules[0]`
* `asyncio.run_coroutine_threadsafe(tc.open(), tc._loop).result()` -> TC should open
* `asyncio.run_coroutine_threadsafe(tc.lift_plate(), tc._loop).result()` -> TC should run plate lift
* `asyncio.run_coroutine_threadsafe(tc.close(), tc._loop).result()` -> TC should close
* `asyncio.run_coroutine_threadsafe(tc.lift_plate(), tc._loop).result()` -> should get an exception with an error message from the Thermocycler

Ran the following with a Gen1 plugged in:

* `import asyncio`
* `tc = api.attached_modules[0]`
* `asyncio.run_coroutine_threadsafe(tc.open(), tc._loop).result()` -> TC should open
* `asyncio.run_coroutine_threadsafe(tc.lift_plate(), tc._loop).result()` -> should get a `NotImplementedError` exception

All of the async functions only returned after the Thermocycler physically completed the respective action.

# Changelog

- Added plate lift to TC driver & simulator
- Added plate lift to TC hardware control
- Added tests for TC driver & hardware controller

# Review requests


# Risk assessment

Low, not wired up to anything for now