### PR TITLE
refactor(app): update calibration square terminology

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -17,7 +17,7 @@
   "pipette_calibration": "Pipette Calibration",
   "attach": "Attaching Pipette",
   "detach": "Detaching Pipette",
-  "calibration_probe_touching": "The calibration probe will touch the sides of the calibration divot in slot {{slotNumber}} to determine its exact position",
+  "calibration_probe_touching": "The calibration probe will touch the sides of the calibration square in slot {{slotNumber}} to determine its exact position",
   "choose_pipette": "Choose a pipette to attach",
   "next": "next",
   "single_or_8_channel": "{{single}} or {{eight}} pipette",

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -81,7 +81,7 @@ describe('AttachProbe', () => {
     const { getByText, getByAltText } = render(props)
     getByText('Stand Back, Pipette is Calibrating')
     getByText(
-      'The calibration probe will touch the sides of the calibration divot in slot 2 to determine its exact position'
+      'The calibration probe will touch the sides of the calibration square in slot 2 to determine its exact position'
     )
     getByAltText('Pipette is calibrating')
   })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Quick PR to reflect a part naming decision.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Ran `make test-js` and `make lint-js` locally.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Two lines: one in localization string, one in corresponding test.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

We all good?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

v v low, changed one word