### PR TITLE
feat(app): Remove vestigial calibration launching UI

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -85,18 +85,7 @@ export const PipetteOverflowMenu = (
           </MenuItem>
         ) : (
           <>
-            {enableCalibrationWizards ? (
-              // Only show calibration option [RAUT-93]
-              isPipetteCalibrated ? null : (
-                <MenuItem
-                  key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
-                  onClick={() => handleCalibrate()}
-                  data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${pipetteDisplayName}_${mount}`}
-                >
-                  {t(calibratePipetteText)}
-                </MenuItem>
-              )
-            ) : (
+            {!enableCalibrationWizards && (
               <MenuItem
                 key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
                 onClick={() => handleCalibrate()}

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -103,12 +103,12 @@ describe('PipetteOverflowMenu', () => {
     expect(props.handleCalibrate).toHaveBeenCalled()
   })
 
-  it('should render calibrate pipette offset text when the calibration wizard feature flag is set and no calibration exists', () => {
+  it('should not render calibrate pipette offset text when the calibration wizard feature flag is set and no calibration exists', () => {
     mockUseFeatureFlag.mockReturnValue(true)
-    const { getByRole } = render(props)
-    const calibrate = getByRole('button', { name: 'Calibrate pipette offset' })
-    fireEvent.click(calibrate)
-    expect(props.handleCalibrate).toHaveBeenCalled()
+    const { queryByRole } = render(props)
+    expect(
+      queryByRole('button', { name: 'Calibrate pipette offset' })
+    ).not.toBeInTheDocument()
   })
 
   it('does not render recalibrate pipette offset text when the calibration wizard feature flag is set', () => {
@@ -145,13 +145,13 @@ describe('PipetteOverflowMenu', () => {
     expect(props.handleCalibrate).toHaveBeenCalled()
   })
 
-  it('should render calibrate pipette text for OT-3 pipette when the calibration wizard feature flag is set and no calibration exists', () => {
+  it('should not render calibrate pipette text for OT-3 pipette when the calibration wizard feature flag is set and no calibration exists', () => {
     mockIsOT3Pipette.mockReturnValue(true)
     mockUseFeatureFlag.mockReturnValue(true)
-    const { getByRole } = render(props)
-    const calibrate = getByRole('button', { name: 'Calibrate pipette' })
-    fireEvent.click(calibrate)
-    expect(props.handleCalibrate).toHaveBeenCalled()
+    const { queryByRole } = render(props)
+    expect(
+      queryByRole('button', { name: 'Calibrate pipette' })
+    ).not.toBeInTheDocument()
   })
 
   it('does not render recalibrate pipette text for OT-3 pipette when the calibration wizard feature flag is set', () => {

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -261,16 +261,6 @@ export function OverflowMenu({
           right={0}
           flexDirection={DIRECTION_COLUMN}
         >
-          {enableCalibrationWizards &&
-            calType === 'pipetteOffset' &&
-            applicablePipetteOffsetCal == null && (
-              <MenuItem
-                onClick={e => handleCalibration(calType, e)}
-                disabled={disabledReason !== null}
-              >
-                {t('calibrate_pipette')}
-              </MenuItem>
-            )}
           {!enableCalibrationWizards && mount != null && (
             <MenuItem
               onClick={e => handleCalibration(calType, e)}

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/OverflowMenu.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__test__/OverflowMenu.test.tsx
@@ -145,14 +145,12 @@ describe('OverflowMenu', () => {
     getByText('Download calibration data')
   })
 
-  it('should render Overflow tip length calibration button when the calibration wizard feature flag is set and no calibration exists', () => {
+  it('should not render Overflow tip length calibration button when the calibration wizard feature flag is set and no calibration exists', () => {
     mockUseFeatureFlag.mockReturnValue(true)
-    const [{ getByLabelText, getByText }] = render(props)
+    const [{ getByLabelText, queryByText }] = render(props)
     const button = getByLabelText('CalibrationOverflowMenu_button')
     fireEvent.click(button)
-    const calibrationButton = getByText('Calibrate Pipette Offset')
-    fireEvent.click(calibrationButton)
-    expect(startCalibration).toHaveBeenCalled()
+    expect(queryByText('Calibrate Pipette Offset')).not.toBeInTheDocument()
   })
 
   it('should not render Overflow tip length recalibration button when the calibration wizard feature flag is set', () => {


### PR DESCRIPTION

# Overview

The Calibration Dashboard is meant to be the main location that individual Calibration Wizards (deck, pipette offset, tip length calibration). In support of guiding users towards the dashboard for navigating the dependencies of each calibration type, we would like to remove the ability to launch, any of deck, pipette offset, and tip length, calibrations from the robot settings calibration tab.

Closes RAUT-306

# Test Plan

Tested manually and enforced with unit tests.

# Changelog

- Removed launch calibration option from PipetteOverflowMenu
- Removed launch calibration option from CalibrationDetails OverflowMenu

# Review requests

With the feature flag on, the pipette cards' overflow menus should not have any menu item that calls the handleCalibrate function. The same goes for the overflow menus on the tip length calibration and pipette offset calibration items on the robot settings page.

# Risk assessment

Low risk. This removes extraneous methods for reaching calibration, leaving the proper flow intact. It is also hidden behind a feature flag.
