### PR TITLE
fix(app): reference moduleId from result not params for labware location lookup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/utils.ts
@@ -35,7 +35,7 @@ export function getLabwareSetupItemGroups(
           const loadModuleCommand = commands.find(
             (c): c is LoadModuleRunTimeCommand =>
               c.commandType === 'loadModule' &&
-              c.params.moduleId === location.moduleId
+              c.result.moduleId === location.moduleId
           )
           if (loadModuleCommand == null) {
             console.error(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
`moduleId` is not a required parameter for `loadModule` commands in python protocols, so we need to reference the `moduleId` from the `results`.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
Start a run with a python protocol that has labware situated on top of modules. On edge, you will likely see a lot of "could not find load module command for module with id..." errors in the console coming from the Setup Labware component. On this branch, those errors should be gone and the displayed labware locations should not include the module id's

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Reference `command.result.moduleId` instead of `command.params.moduleId` in `SetupLabware/utils`

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Test this out!

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low