### PR TITLE
refactor(api): Deprecate presses and increment args when using PAPI pick_up_tip

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -269,6 +269,8 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
+- :py:meth:`.InstrumentContext.pick_up_tip.presses` will be deprecated.
+- :py:meth:`.InstrumentContext.pick_up_tip.increment` will be deprecated.
 - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
     - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
     - The ``Well.has_tip`` setter, which will cease to function in a future upgrade to the Python protocol execution system. The corresponding `Well.has_tip` getter will not be deprecated.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -269,7 +269,7 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
-- The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` will be deprecated. Configure your pipettes' pick-up settings with the Opentrons App, instead.
+- The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` will be deprecated. Configure your pipettes pick-up settings with the Opentrons App, instead.
 - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
     - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
     - The ``Well.has_tip`` setter, which will cease to function in a future upgrade to the Python protocol execution system. The corresponding `Well.has_tip` getter will not be deprecated.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -269,8 +269,7 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
-- :py:meth:`.InstrumentContext.pick_up_tip.presses` will be deprecated.
-- :py:meth:`.InstrumentContext.pick_up_tip.increment` will be deprecated.
+- The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` will be deprecated. Configure your pipettes' pick-up settings with the Opentrons App, instead.
 - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
     - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
     - The ``Well.has_tip`` setter, which will cease to function in a future upgrade to the Python protocol execution system. The corresponding `Well.has_tip` getter will not be deprecated.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -701,7 +701,9 @@ class InstrumentContext(publisher.CommandPublisher):
                           press (e.g.: if `presses=3` and `increment=1.0`, then
                           the first press will travel down into the tip by
                           3.5mm, the second by 4.5mm, and the third by 5.5mm).
-                          .. deprecated:: 2.14
+
+                        .. deprecated:: 2.14
+                            Use the Opentrons App to change pipette pick-up settings.
         :type increment: float
         :param prep_after: Whether the pipette plunger should prepare itself
                            to aspirate immediately after picking up a tip.
@@ -744,7 +746,10 @@ class InstrumentContext(publisher.CommandPublisher):
                 f" but you are using API {self._api_version}."
             )
 
-        if increment is not None and self._api_version >= _PRESSES_INCREMENT_DEPRECATE_FROM:
+        if (
+            increment is not None
+            and self._api_version >= _PRESSES_INCREMENT_DEPRECATE_FROM
+        ):
             raise APIVersionError(
                 f"increment is only available in API versions lower than {_PRESSES_INCREMENT_DEPRECATE_FROM},"
                 f" but you are using API {self._api_version}."

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -42,6 +42,8 @@ _log = logging.getLogger(__name__)
 
 _PREP_AFTER_ADDED_IN = APIVersion(2, 13)
 """The version after which the pick-up tip procedure should also prepare the plunger."""
+_PRESSES_INCREMENT_DEPRECATE_FROM = APIVersion(2, 14)
+"""The version after which the pick-up tip procedure should also prepare the plunger."""
 
 
 class InstrumentContext(publisher.CommandPublisher):
@@ -648,7 +650,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         return self
 
-    @requires_version(2, 0)
+    @requires_version(2, 0)  # noqa: C901
     def pick_up_tip(
         self,
         location: Union[types.Location, labware.Well, labware.Labware, None] = None,
@@ -691,11 +693,13 @@ class InstrumentContext(publisher.CommandPublisher):
                         will result in the pipette hovering over the tip but
                         not picking it up--generally not desirable, but could
                         be used for dry-run).
+                        .. deprecated:: 2.14
         :type presses: int
         :param increment: The additional distance to travel on each successive
                           press (e.g.: if `presses=3` and `increment=1.0`, then
                           the first press will travel down into the tip by
                           3.5mm, the second by 4.5mm, and the third by 5.5mm).
+                          .. deprecated:: 2.14
         :type increment: float
         :param prep_after: Whether the pipette plunger should prepare itself
                            to aspirate immediately after picking up a tip.
@@ -728,6 +732,22 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :returns: This instance
         """
+
+        if (
+            presses is not None
+            and self._api_version >= _PRESSES_INCREMENT_DEPRECATE_FROM
+        ):
+            raise APIVersionError(
+                f"presses is only available in API versions lower than {_PRESSES_INCREMENT_DEPRECATE_FROM},"
+                f" but you are using API {self._api_version}."
+            )
+
+        if increment is not None and self._api_version >= _PRESSES_INCREMENT_DEPRECATE_FROM:
+            raise APIVersionError(
+                f"increment is only available in API versions lower than {_PRESSES_INCREMENT_DEPRECATE_FROM},"
+                f" but you are using API {self._api_version}."
+            )
+
         if prep_after is not None and self._api_version < _PREP_AFTER_ADDED_IN:
             raise APIVersionError(
                 f"prep_after is only available in API {_PREP_AFTER_ADDED_IN} and newer,"

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -43,7 +43,7 @@ _log = logging.getLogger(__name__)
 _PREP_AFTER_ADDED_IN = APIVersion(2, 13)
 """The version after which the pick-up tip procedure should also prepare the plunger."""
 _PRESSES_INCREMENT_DEPRECATE_FROM = APIVersion(2, 14)
-"""The version after which the pick-up tip procedure should also prepare the plunger."""
+"""The version after which the pick-up tip procedure deprecates presses and increment arguments."""
 
 
 class InstrumentContext(publisher.CommandPublisher):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -42,7 +42,7 @@ _log = logging.getLogger(__name__)
 
 _PREP_AFTER_ADDED_IN = APIVersion(2, 13)
 """The version after which the pick-up tip procedure should also prepare the plunger."""
-_PRESSES_INCREMENT_DEPRECATE_FROM = APIVersion(2, 14)
+_PRESSES_INCREMENT_REMOVED_IN = APIVersion(2, 14)
 """The version after which the pick-up tip procedure deprecates presses and increment arguments."""
 
 
@@ -737,21 +737,15 @@ class InstrumentContext(publisher.CommandPublisher):
         :returns: This instance
         """
 
-        if (
-            presses is not None
-            and self._api_version >= _PRESSES_INCREMENT_DEPRECATE_FROM
-        ):
+        if presses is not None and self._api_version >= _PRESSES_INCREMENT_REMOVED_IN:
             raise APIVersionError(
-                f"presses is only available in API versions lower than {_PRESSES_INCREMENT_DEPRECATE_FROM},"
+                f"presses is only available in API versions lower than {_PRESSES_INCREMENT_REMOVED_IN},"
                 f" but you are using API {self._api_version}."
             )
 
-        if (
-            increment is not None
-            and self._api_version >= _PRESSES_INCREMENT_DEPRECATE_FROM
-        ):
+        if increment is not None and self._api_version >= _PRESSES_INCREMENT_REMOVED_IN:
             raise APIVersionError(
-                f"increment is only available in API versions lower than {_PRESSES_INCREMENT_DEPRECATE_FROM},"
+                f"increment is only available in API versions lower than {_PRESSES_INCREMENT_REMOVED_IN},"
                 f" but you are using API {self._api_version}."
             )
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -693,7 +693,9 @@ class InstrumentContext(publisher.CommandPublisher):
                         will result in the pipette hovering over the tip but
                         not picking it up--generally not desirable, but could
                         be used for dry-run).
+
                         .. deprecated:: 2.14
+                            Use the Opentrons App to change pipette pick-up settings.
         :type presses: int
         :param increment: The additional distance to travel on each successive
                           press (e.g.: if `presses=3` and `increment=1.0`, then


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RCORE-530.
Deprecate `presses` and `increment` in `InstrumentContext.pick_up_tip`

# Test Plan

upload a python protocol with version 2.14 and up and make sure you not able to use `presses` and `increment` in `InstrumentContext.pick_up_tip`.

```
from opentrons import protocol_api, types

metadata = {
    "apiLevel": "2.14",
}

def run(ctx: protocol_api.ProtocolContext) -> None:
    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 5)
    pipette = ctx.load_instrument("p20_single_gen2", types.Mount.RIGHT, [tip_rack])
    well = tip_rack.wells()[0]
    
    # offset the well to something obvious
    # to observe that the offset is not respected
    location = types.Location(point=types.Point(x=9, y=-9, z=0), labware=well)

    pipette.pick_up_tip(location, presses=3, increment=2.0)
    pipette.drop_tip()
```

# Changelog

- Raise an error when trying to use presses and increment for api versions higher than 2.14. 
- Added deprecated to docstring args.
- Added to versioning doc.

# Review requests

1. Did I miss anything?
2. Does the versioning doc make sense? 

# Risk assessment

Low. Deprecating arguments for the pick_up_tip end point in PAPI for versions higher than 2.14.
