### PR TITLE
fix(ot3): handle multiple responses for a tip action request

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -11,6 +11,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     ErrorCode,
     MotorPositionFlags,
     ErrorSeverity,
+    GearMotorId,
 )
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition
@@ -319,13 +320,20 @@ class MoveScheduler:
         self._durations: List[float] = []
         self._stop_condition: List[MoveStopCondition] = []
         self._start_at_index = start_at_index
+        self._expected_tip_action_motors = []
 
         for move_group in move_groups:
             move_set = set()
             duration = 0.0
             for seq_id, move in enumerate(move_group):
+                movesteps = list(move.values())
                 move_set.update(set((k.value, seq_id) for k in move.keys()))
-                duration += float(list(move.values())[0].duration_sec)
+                duration += float(movesteps[0].duration_sec)
+                if any(isinstance(g, MoveGroupTipActionStep) for g in movesteps):
+                    self._expected_tip_action_motors = [
+                        GearMotorId.left,
+                        GearMotorId.right,
+                    ]
                 for step in move_group[seq_id]:
                     self._stop_condition.append(move_group[seq_id][step].stop_condition)
 
@@ -414,7 +422,10 @@ class MoveScheduler:
             self._remove_move_group(message, arbitration_id)
             self._handle_move_completed(message)
         elif isinstance(message, TipActionResponse):
-            self._remove_move_group(message, arbitration_id)
+            gear_id = GearMotorId(message.payload.gear_motor_id.value)
+            self._expected_tip_action_motors.remove(gear_id)
+            if len(self._expected_tip_action_motors) == 0:
+                self._remove_move_group(message, arbitration_id)
             self._handle_move_completed(message)
         elif isinstance(message, ErrorMessage):
             self._handle_error(message, arbitration_id)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,8 +1,9 @@
 """Tests for the move scheduler."""
 import pytest
+import logging
 from typing import List, Any, Tuple
 from numpy import float64, float32, int32
-from mock import AsyncMock, call, MagicMock
+from mock import AsyncMock, call, MagicMock, patch
 import asyncio
 from opentrons_hardware.firmware_bindings import ArbitrationId, ArbitrationIdParts
 
@@ -10,6 +11,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
     ErrorCode,
     ErrorSeverity,
+    PipetteTipActionType,
 )
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     MessageListenerCallback,
@@ -23,6 +25,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     EmptyPayload,
     AddLinearMoveRequestPayload,
     MoveCompletedPayload,
+    TipActionResponsePayload,
     ExecuteMoveGroupRequestPayload,
     HomeRequestPayload,
     ErrorMessagePayload,
@@ -32,6 +35,8 @@ from opentrons_hardware.firmware_bindings.messages.fields import (
     MoveStopConditionField,
     ErrorSeverityField,
     ErrorCodeField,
+    GearMotorIdField,
+    PipetteTipActionTypeField,
 )
 from opentrons_hardware.hardware_control.constants import (
     interrupts_per_sec,
@@ -40,6 +45,7 @@ from opentrons_hardware.hardware_control.motion import (
     MoveGroups,
     MoveGroupSingleAxisStep,
     MoveGroupSingleGripperStep,
+    MoveGroupTipActionStep,
     MoveType,
     MoveStopCondition,
 )
@@ -96,6 +102,23 @@ def move_group_single() -> MoveGroups:
                     distance_mm=float64(246),
                     velocity_mm_sec=float64(2),
                     duration_sec=float64(1),
+                )
+            }
+        ]
+    ]
+
+
+@pytest.fixture
+def move_group_tip_action() -> MoveGroups:
+    """Move group with one move."""
+    return [
+        [
+            {
+                NodeId.pipette_left: MoveGroupTipActionStep(
+                    velocity_mm_sec=float64(2),
+                    duration_sec=float64(1),
+                    action=PipetteTipActionType.clamp,
+                    stop_condition=MoveStopCondition.none,
                 )
             }
         ]
@@ -431,19 +454,120 @@ class MockSendMoveCompleter:
                 self._move_groups[message.payload.group_id.value - self._start_at_index]
             ):
                 for node, move in moves.items():
-                    assert isinstance(move, MoveGroupSingleAxisStep)
-                    payload = MoveCompletedPayload(
-                        group_id=message.payload.group_id,
-                        seq_id=UInt8Field(seq_id),
-                        current_position_um=UInt32Field(int(move.distance_mm * 1000)),
-                        encoder_position_um=Int32Field(int(move.distance_mm * 4000)),
-                        position_flags=MotorPositionFlagsField(0),
-                        ack_id=UInt8Field(1),
-                    )
-                    arbitration_id = ArbitrationId(
-                        parts=ArbitrationIdParts(originating_node_id=node)
-                    )
-                    self._listener(md.MoveCompleted(payload=payload), arbitration_id)
+                    if isinstance(move, MoveGroupSingleAxisStep):
+                        payload = MoveCompletedPayload(
+                            group_id=message.payload.group_id,
+                            seq_id=UInt8Field(seq_id),
+                            current_position_um=UInt32Field(
+                                int(move.distance_mm * 1000)
+                            ),
+                            encoder_position_um=Int32Field(
+                                int(move.distance_mm * 4000)
+                            ),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(1),
+                        )
+                        arbitration_id = ArbitrationId(
+                            parts=ArbitrationIdParts(originating_node_id=node)
+                        )
+                        self._listener(
+                            md.MoveCompleted(payload=payload), arbitration_id
+                        )
+                    elif isinstance(move, MoveGroupTipActionStep):
+                        payload_1 = TipActionResponsePayload(
+                            group_id=message.payload.group_id,
+                            seq_id=UInt8Field(seq_id),
+                            current_position_um=UInt32Field(
+                                int(move.velocity_mm_sec * move.duration_sec * 1000)
+                            ),
+                            encoder_position_um=Int32Field(
+                                int(move.velocity_mm_sec * 0)
+                            ),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(1),
+                            action=PipetteTipActionTypeField(move.action.value),
+                            success=UInt8Field(1),
+                            gear_motor_id=GearMotorIdField(1),
+                        )
+                        arbitration_id = ArbitrationId(
+                            parts=ArbitrationIdParts(originating_node_id=node)
+                        )
+                        self._listener(
+                            md.TipActionResponse(payload=payload_1), arbitration_id
+                        )
+
+                        payload_2 = TipActionResponsePayload(
+                            group_id=message.payload.group_id,
+                            seq_id=UInt8Field(seq_id),
+                            current_position_um=UInt32Field(
+                                int(move.velocity_mm_sec * move.duration_sec * 1000)
+                            ),
+                            encoder_position_um=Int32Field(
+                                int(move.velocity_mm_sec * 0)
+                            ),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(1),
+                            action=PipetteTipActionTypeField(move.action.value),
+                            success=UInt8Field(1),
+                            gear_motor_id=GearMotorIdField(0),
+                        )
+
+                        self._listener(
+                            md.TipActionResponse(payload=payload_2), arbitration_id
+                        )
+
+    async def mock_send_failure(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+    ) -> None:
+        """Mock send function with incorrect number of responses."""
+        if isinstance(message, md.ExecuteMoveGroupRequest):
+            # Iterate through each move in each sequence and send a move
+            # completed for it.
+            payload = EmptyPayload()
+            payload.message_index = message.payload.message_index
+            arbitration_id = ArbitrationId(
+                parts=ArbitrationIdParts(originating_node_id=node_id)
+            )
+            self._listener(md.Acknowledgement(payload=payload), arbitration_id)
+            for seq_id, moves in enumerate(
+                self._move_groups[message.payload.group_id.value - self._start_at_index]
+            ):
+                for node, move in moves.items():
+                    if isinstance(move, MoveGroupTipActionStep):
+                        payload_1 = TipActionResponsePayload(
+                            group_id=message.payload.group_id,
+                            seq_id=UInt8Field(seq_id),
+                            current_position_um=UInt32Field(
+                                int(move.velocity_mm_sec * move.duration_sec * 1000)
+                            ),
+                            encoder_position_um=Int32Field(
+                                int(move.velocity_mm_sec * 0)
+                            ),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(1),
+                            action=PipetteTipActionTypeField(move.action.value),
+                            success=UInt8Field(1),
+                            gear_motor_id=GearMotorIdField(1),
+                        )
+                        arbitration_id = ArbitrationId(
+                            parts=ArbitrationIdParts(originating_node_id=node)
+                        )
+                        self._listener(
+                            md.TipActionResponse(payload=payload_1), arbitration_id
+                        )
+
+    async def mock_ensure_send_failure(
+        self,
+        node_id: NodeId,
+        message: MessageDefinition,
+        timeout: float = 3,
+        expected_nodes: List[NodeId] = [],
+    ) -> ErrorCode:
+        """Mock ensure_send function."""
+        await self.mock_send_failure(node_id, message)
+        return ErrorCode.ok
 
     async def mock_ensure_send(
         self,
@@ -550,6 +674,69 @@ async def test_single_move(
     )
     assert len(position) == 1
     assert position[0][1].payload.current_position_um.value == 246000
+
+
+async def test_tip_action_move_runner_receives_two_responses(
+    mock_can_messenger: AsyncMock, move_group_tip_action: MoveGroups
+) -> None:
+    """The magic call function should receive two responses for a tip action."""
+    with patch.object(MoveScheduler, "__call__") as mock_magic_call:
+        subject = MoveScheduler(move_groups=move_group_tip_action)
+        mock_sender = MockSendMoveCompleter(move_group_tip_action, subject)
+        mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
+        mock_can_messenger.send.side_effect = mock_sender.mock_send
+        await subject.run(can_messenger=mock_can_messenger)
+
+        assert isinstance(mock_magic_call.call_args_list[0][0][0], md.Acknowledgement)
+        assert isinstance(mock_magic_call.call_args_list[1][0][0], md.TipActionResponse)
+
+        assert mock_magic_call.call_args_list[1][0][
+            0
+        ].payload.gear_motor_id == GearMotorIdField(1)
+        assert isinstance(mock_magic_call.call_args_list[2][0][0], md.TipActionResponse)
+
+        assert mock_magic_call.call_args_list[2][0][
+            0
+        ].payload.gear_motor_id == GearMotorIdField(0)
+
+
+async def test_tip_action_move_runner_position_updated(
+    mock_can_messenger: AsyncMock, move_group_tip_action: MoveGroups
+) -> None:
+    """Two responses from a tip action move are properly handled."""
+    subject = MoveScheduler(move_groups=move_group_tip_action)
+    mock_sender = MockSendMoveCompleter(move_group_tip_action, subject)
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
+    mock_can_messenger.send.side_effect = mock_sender.mock_send
+    position = await subject.run(can_messenger=mock_can_messenger)
+    assert len(position) == 1
+    assert position[0][1].payload.current_position_um.value == 2000
+
+
+async def test_tip_action_move_runner_fail_receives_one_response(
+    mock_can_messenger: AsyncMock, move_group_tip_action: MoveGroups, caplog: Any
+) -> None:
+    """Tip action move should fail if one or less responses received."""
+    subject = MoveScheduler(move_groups=move_group_tip_action)
+    mock_sender = MockSendMoveCompleter(move_group_tip_action, subject)
+    mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send_failure
+    mock_can_messenger.send.side_effect = mock_sender.mock_send_failure
+
+    expected_warnings = [
+        (
+            "opentrons_hardware.hardware_control.move_group_runner",
+            30,
+            "Move set 0 timed out, expected duration 1.1",
+        ),
+        (
+            "opentrons_hardware.hardware_control.move_group_runner",
+            30,
+            "Expected nodes in group 0: [<NodeId.pipette_left: 96>]",
+        ),
+    ]
+    with caplog.at_level(logging.WARN):
+        await subject.run(can_messenger=mock_can_messenger)
+        assert caplog.record_tuples == expected_warnings
 
 
 async def test_multi_group_move(
@@ -1072,7 +1259,6 @@ async def test_multiple_move_error(
     mock_sender = MockSendMoveErrorCompleter(move_group_multiple_axes, subject)
     mock_can_messenger.ensure_send.side_effect = mock_sender.mock_ensure_send
     mock_can_messenger.send.side_effect = mock_sender.mock_send
-    print(subject._moves)
     with pytest.raises(RuntimeError):
         await subject.run(can_messenger=mock_can_messenger)
     assert mock_sender.call_count == 2


### PR DESCRIPTION
## Overview

The tip action request will actually send back two move responses (one for each "gear/tip" motor). We should properly handle this move and make sure the move times out if it doesn't receive a response from both motors.