### PR TITLE
fix(api): actually update OT3 instrument calibration offset in cache instrument

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -249,8 +249,8 @@ def _reload_gripper(
         # Same config, good enough
         return attached_instr
     else:
-        newdict = asdict(new_config)
-        olddict = asdict(attached_instr.config)
+        newdict = new_config.dict()
+        olddict = attached_instr.config.dict()
         changed: Set[str] = set()
         for k in newdict.keys():
             if newdict[k] != olddict[k]:
@@ -258,7 +258,10 @@ def _reload_gripper(
         if changed.intersection(RECONFIG_KEYS):
             # Something has changed that requires reconfig
             return Gripper(new_config, cal_offset, attached_instr._gripper_id)
-    return attached_instr
+        else:
+            # update just the cal offset
+            attached_instr._calibration_offset = cal_offset
+            return attached_instr
 
 
 def compare_gripper_config_and_check_skip(

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """ Classes and functions for gripper state tracking
 """
-from dataclasses import asdict
 import logging
 from typing import Any, Optional, Set
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -528,8 +528,9 @@ def _reload_and_check_skip(
             p = Pipette(new_config, pipette_offset, attached_instr._pipette_id)
             p.act_as(attached_instr.acting_as)
             return p, False
-    # Good to skip
-    return attached_instr, True
+        # Good to skip, just need to update calibration offset
+        attached_instr._pipette_offset = pipette_offset
+        return attached_instr, True
 
 
 def load_from_config_and_check_skip(

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -12,7 +12,6 @@ from opentrons.hardware_control.instruments.ot3 import (
     pipette as ot3_pipette,
     instrument_calibration as ot3_calibration,
 )
-from opentrons_shared_data.pipette.pipette_definition import PipetteConfigurations
 from opentrons.hardware_control import types
 from opentrons.config import pipette_config, ot3_pipette_config
 


### PR DESCRIPTION
Well, we currently check if the OT3 instrument config & calibration have been updated when we cache the same instruments in the hardware controller. But we didn't actually update the calibration offset. Now we do.