### PR TITLE
refactor(robot-server): Make run and protocol limits configurable at launch

### DIFF
--- a/robot-server/robot_server/deletion_planner.py
+++ b/robot-server/robot_server/deletion_planner.py
@@ -32,11 +32,7 @@ Actual storage access is handled elsewhere.
 
 
 from typing import Sequence, Set
-from typing_extensions import Final, Protocol as InterfaceShape
-
-
-MAXIMUM_RUNS: Final = 20
-MAXIMUM_UNUSED_PROTOCOLS: Final = 5
+from typing_extensions import Protocol as InterfaceShape
 
 
 class ProtocolSpec(InterfaceShape):
@@ -55,9 +51,7 @@ class ProtocolSpec(InterfaceShape):
 
 
 class ProtocolDeletionPlanner:  # noqa: D101
-    def __init__(
-        self, maximum_unused_protocols: int = MAXIMUM_UNUSED_PROTOCOLS
-    ) -> None:
+    def __init__(self, maximum_unused_protocols: int) -> None:
         """Return a configured protocol deletion planner.
 
         Args:
@@ -101,7 +95,7 @@ class ProtocolDeletionPlanner:  # noqa: D101
 
 
 class RunDeletionPlanner:  # noqa: D101
-    def __init__(self, maximum_runs: int = MAXIMUM_RUNS) -> None:
+    def __init__(self, maximum_runs: int) -> None:
         """Return a configured run deletion planner.
 
         Args:

--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -19,6 +19,7 @@ from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.deletion_planner import ProtocolDeletionPlanner
 from robot_server.hardware import get_robot_type
 from robot_server.persistence import get_sql_engine, get_persistence_directory
+from robot_server.settings import get_settings
 
 from .protocol_auto_deleter import ProtocolAutoDeleter
 from .protocol_store import (
@@ -114,5 +115,7 @@ async def get_protocol_auto_deleter(
     """Get a `ProtocolAutoDeleter` to delete old protocols."""
     return ProtocolAutoDeleter(
         protocol_store=protocol_store,
-        deletion_planner=ProtocolDeletionPlanner(),
+        deletion_planner=ProtocolDeletionPlanner(
+            maximum_unused_protocols=get_settings().maximum_unused_protocols
+        ),
     )

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -10,6 +10,7 @@ from robot_server.app_state import AppState, AppStateAccessor, get_app_state
 from robot_server.hardware import get_hardware, get_robot_type
 from robot_server.persistence import get_sql_engine
 from robot_server.service.task_runner import get_task_runner, TaskRunner
+from robot_server.settings import get_settings
 from robot_server.deletion_planner import RunDeletionPlanner
 
 from .run_auto_deleter import RunAutoDeleter
@@ -69,5 +70,5 @@ async def get_run_auto_deleter(
     """Get an `AutoDeleter` to delete old runs."""
     return RunAutoDeleter(
         run_store=run_store,
-        deletion_planner=RunDeletionPlanner(),
+        deletion_planner=RunDeletionPlanner(maximum_runs=get_settings().maximum_runs),
     )

--- a/robot-server/robot_server/settings.py
+++ b/robot-server/robot_server/settings.py
@@ -42,12 +42,12 @@ class RobotServerSettings(BaseSettings):
     """
 
     simulator_configuration_file_path: typing.Optional[str] = Field(
-        None,
+        default=None,
         description="Path to a json file that describes the hardware simulator.",
     )
 
     notification_server_subscriber_address: str = Field(
-        "tcp://localhost:5555",
+        default="tcp://localhost:5555",
         description="The endpoint to subscribe to notification server topics.",
     )
 
@@ -62,7 +62,7 @@ class RobotServerSettings(BaseSettings):
         # and it's difficult to override this settings object for our unit tests.
         # Making this non-defaultable breaks tests that hit code with deep calls to
         # get_settings().
-        "automatically_make_temporary",
+        default="automatically_make_temporary",
         description=(
             "A directory for the server to store things persistently across boots."
             " If this directory doesn't already exist, the server will create it."
@@ -72,6 +72,25 @@ class RobotServerSettings(BaseSettings):
             "\n\n"
             "Note that the `opentrons` library is also responsible for persisting"
             " certain things, and it has its own configuration."
+        ),
+    )
+
+    maximum_runs: int = Field(
+        default=20,
+        gt=0,
+        description=(
+            "The maximum number of runs to allow HTTP clients to create before"
+            " auto-deleting old ones."
+        ),
+    )
+
+    maximum_unused_protocols: int = Field(
+        default=5,
+        gt=0,
+        description=(
+            'The maximum number of "unused protocols" to allow before auto-deleting'
+            ' old ones. A protocol is "unused" if it isn\'t used by any run that'
+            " currently exists."
         ),
     )
 

--- a/robot-server/settings_schema.json
+++ b/robot-server/settings_schema.json
@@ -39,6 +39,26 @@
           "format": "path"
         }
       ]
+    },
+    "maximum_runs": {
+      "title": "Maximum Runs",
+      "description": "The maximum number of runs to allow HTTP clients to create before auto-deleting old ones.",
+      "default": 20,
+      "exclusiveMinimum": 0,
+      "env_names": [
+        "ot_robot_server_maximum_runs"
+      ],
+      "type": "integer"
+    },
+    "maximum_unused_protocols": {
+      "title": "Maximum Unused Protocols",
+      "description": "The maximum number of \"unused protocols\" to allow before auto-deleting old ones. A protocol is \"unused\" if it isn't used by any run that currently exists.",
+      "default": 5,
+      "exclusiveMinimum": 0,
+      "env_names": [
+        "ot_robot_server_maximum_unused_protocols"
+      ],
+      "type": "integer"
     }
   },
   "additionalProperties": false

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -10,16 +10,24 @@ from typing import Optional
 
 class DevServer:
     def __init__(
-        self, port: str = "31950", persistence_directory: Optional[Path] = None
+        self,
+        port: str = "31950",
+        persistence_directory: Optional[Path] = None,
+        maximum_runs: Optional[int] = None,
+        maximum_unused_protocols: Optional[int] = None,
     ) -> None:
         """Initialize a dev server."""
+        self.port: str = port
+
         self.server_temp_directory: str = tempfile.mkdtemp()
         self.persistence_directory: Path = (
             persistence_directory
             if persistence_directory is not None
             else Path(tempfile.mkdtemp())
         )
-        self.port: str = port
+
+        self.maximum_runs = maximum_runs
+        self.maximum_unused_protocols = maximum_unused_protocols
 
     def __enter__(self) -> DevServer:
         return self
@@ -34,6 +42,20 @@ class DevServer:
 
     def start(self) -> None:
         """Run the robot server in a background process."""
+        # This environment is only for the subprocess so it should
+        # not have any side effects.
+        env = {
+            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
+            "OT_API_CONFIG_DIR": self.server_temp_directory,
+            "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),
+        }
+        if self.maximum_runs is not None:
+            env["OT_ROBOT_SERVER_maximum_runs"] = str(self.maximum_runs)
+        if self.maximum_unused_protocols is not None:
+            env["OT_ROBOT_SERVER_maximum_unused_protocols"] = str(
+                self.maximum_unused_protocols
+            )
+
         # In order to collect coverage we run using `coverage`.
         # `-a` is to append to existing `.coverage` file.
         # `--source` is the source code folder to collect coverage stats on.
@@ -54,15 +76,7 @@ class DevServer:
                 "--port",
                 f"{self.port}",
             ],
-            # This environment is only for the subprocess so it should
-            # not have any side effects.
-            env={
-                "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
-                "OT_API_CONFIG_DIR": self.server_temp_directory,
-                "OT_ROBOT_SERVER_persistence_directory": str(
-                    self.persistence_directory
-                ),
-            },
+            env=env,
             stdin=subprocess.DEVNULL,
             # The server will log to its stdout or stderr.
             # Let it inherit our stdout and stderr so pytest captures its logs.

--- a/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
@@ -1,17 +1,26 @@
 import secrets
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+
+import pytest
 
 from tests.integration.dev_server import DevServer
 from tests.integration.robot_client import RobotClient
 from tests.integration.protocol_files import get_py_protocol
 
 
-_NUM_PROTOCOLS_TO_UPLOAD = 10
-_NUM_PROTOCOLS_TO_EXPECT = 5
-
-
-async def test_protocols_auto_delete() -> None:
+@pytest.mark.parametrize(
+    ("num_to_configure_as_maximum", "num_to_upload", "num_to_expect"),
+    [
+        (None, 10, 5),  # Test that the server enforces a limit of 5 by default.
+        (3, 6, 3),
+    ],
+)
+async def test_protocols_auto_delete(
+    num_to_configure_as_maximum: Optional[int],
+    num_to_upload: int,
+    num_to_expect: int,
+) -> None:
     port = "15555"
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
@@ -19,22 +28,22 @@ async def test_protocols_auto_delete() -> None:
         assert (
             await robot_client.wait_until_dead()
         ), "Dev Robot is running and must not be."
-        with DevServer(port=port) as server:
+        with DevServer(
+            port=port, maximum_unused_protocols=num_to_configure_as_maximum
+        ) as server:
             server.start()
             assert (
                 await robot_client.wait_until_alive()
             ), "Dev Robot never became available."
 
             uploaded_protocol_ids = await _upload_protocols(
-                robot_client=robot_client, num_protocols=_NUM_PROTOCOLS_TO_UPLOAD
+                robot_client=robot_client, num_protocols=num_to_upload
             )
 
             fetched_protocol_ids = await _get_protocol_ids(robot_client=robot_client)
 
             # Last n elements of uploaded_protocol_ids.
-            protocol_ids_to_expect = uploaded_protocol_ids[
-                -1 * _NUM_PROTOCOLS_TO_EXPECT :
-            ]
+            protocol_ids_to_expect = uploaded_protocol_ids[-num_to_expect:]
 
             assert fetched_protocol_ids == protocol_ids_to_expect
 

--- a/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
@@ -1,14 +1,23 @@
-from typing import List
+from typing import List, Optional
+
+import pytest
 
 from tests.integration.dev_server import DevServer
 from tests.integration.robot_client import RobotClient
 
 
-_NUM_RUNS_TO_UPLOAD = 25
-_NUM_RUNS_TO_EXPECT = 20
-
-
-async def test_runs_auto_delete() -> None:
+@pytest.mark.parametrize(
+    ("num_to_configure_as_maximum", "num_to_upload", "num_to_expect"),
+    [
+        (None, 25, 20),  # Test that the server enforces a limit of 20 by default.
+        (3, 6, 3),
+    ],
+)
+async def test_runs_auto_delete(
+    num_to_configure_as_maximum: Optional[int],
+    num_to_upload: int,
+    num_to_expect: int,
+) -> None:
     port = "15555"
     async with RobotClient.make(
         host="http://localhost", port=port, version="*"
@@ -16,20 +25,20 @@ async def test_runs_auto_delete() -> None:
         assert (
             await robot_client.wait_until_dead()
         ), "Dev Robot is running and must not be."
-        with DevServer(port=port) as server:
+        with DevServer(port=port, maximum_runs=num_to_configure_as_maximum) as server:
             server.start()
             assert (
                 await robot_client.wait_until_alive()
             ), "Dev Robot never became available."
 
             created_run_ids = await _create_runs(
-                robot_client=robot_client, num_runs=_NUM_RUNS_TO_UPLOAD
+                robot_client=robot_client, num_runs=num_to_upload
             )
 
             fetched_run_ids = await _get_run_ids(robot_client=robot_client)
 
             # Last n elements of created_run_ids.
-            run_ids_to_expect = created_run_ids[-1 * _NUM_RUNS_TO_EXPECT :]
+            run_ids_to_expect = created_run_ids[-num_to_expect:]
 
             assert fetched_run_ids == run_ids_to_expect
 


### PR DESCRIPTION
# Overview

`robot-server` has upper limits on the number of runs and protocols. This PR moves those upper limits from hard-coded constants to parameters that can be set when the server is launched. This is intended to make it easier for us to experiment internally with different values.

Closes RCORE-569.

# Changelog

Add two new environment variables:

* `OT_ROBOT_SERVER_maximum_runs=<number>`
* `OT_ROBOT_SERVER_maximum_unused_protocols=<number>`

You can omit these, and `robot-server` will continue to use its current values of `20` and `5`, respectively.

Locally, you can experiment with different values by editing `robot_server/dev.env`, or by supplying them on the `make dev` command line, like `make dev OT_ROBOT_SERVER_maximum_runs=123`.

On an OT-2, you can experiment with different values by writing a `/data/robot.env` file like:

```
OT_ROBOT_SERVER_maximum_runs=123
OT_ROBOT_SERVER_maximum_protocols=123
```

If you do this, remember to delete the file when you're done testing. It will otherwise persist across reboots and software updates.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test plan

It shouldn't be necessary to manually test this PR. This is well-covered by automated tests.

# Review requests

This unfortunately adds ~10 seconds to the `robot-server` test suite because these tests require starting up a fresh isolated dev server. We should think about optimization if this starts to feel bothersome.

# Risk assessment

Low risk. This is well-covered by automated tests.
