### PR TITLE
feat(app): add useNetworkConnection hook to fetch connection status f…

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -214,5 +214,7 @@
   "display_sleep_settings": "Display Sleep Settings",
   "display_brightness": "Display Brightness",
   "display_text_size": "Display Text Size",
-  "device_reset": "Device Reset"
+  "device_reset": "Device Reset",
+  "not_connected": "Not connected",
+  "connected_via": "Connected via {{networkInterface}}"
 }

--- a/app/src/pages/OnDeviceDisplay/hooks/__tests__/useNetworkConnection.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/hooks/__tests__/useNetworkConnection.test.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react'
+
+import { when, resetAllWhenMocks } from 'jest-when'
+import { Provider } from 'react-redux'
+import { createStore, Store } from 'redux'
+import { renderHook } from '@testing-library/react-hooks'
+import { I18nextProvider } from 'react-i18next'
+
+import { i18n } from '../../../../i18n'
+import * as Networking from '../../../../redux/networking'
+import * as Fixtures from '../../../../redux/networking/__fixtures__'
+
+import { useNetworkConnection } from '..'
+
+jest.mock('../../../../redux/networking/selectors')
+
+const mockRobotName = 'robot-name'
+const mockWifiList = [
+  { ...Fixtures.mockWifiNetwork, ssid: 'foo', active: true },
+  { ...Fixtures.mockWifiNetwork, ssid: 'bar' },
+  {
+    ...Fixtures.mockWifiNetwork,
+    ssid: 'baz',
+    securityType: Networking.SECURITY_NONE,
+  },
+]
+
+const mockWifi = {
+  ipAddress: '127.0.0.100',
+  subnetMask: '255.255.255.230',
+  macAddress: 'WI:FI:00:00:00:00',
+  type: Networking.INTERFACE_WIFI,
+}
+
+const mockEthernet = {
+  ipAddress: '127.0.0.101',
+  subnetMask: '255.255.255.231',
+  macAddress: 'US:B0:00:00:00:00',
+  type: Networking.INTERFACE_ETHERNET,
+}
+
+const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
+  typeof Networking.getWifiList
+>
+const mockGetNetworkInterface = Networking.getNetworkInterfaces as jest.MockedFunction<
+  typeof Networking.getNetworkInterfaces
+>
+
+const store: Store<any> = createStore(jest.fn(), {})
+
+// ToDo (kj:0202/2023) USB test cases will be added when USB is out
+describe('useNetworkConnection', () => {
+  let wrapper: React.FunctionComponent<{}>
+
+  beforeEach(() => {
+    wrapper = ({ children }) => (
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>{children}</Provider>
+      </I18nextProvider>
+    )
+
+    when(mockGetWifiList)
+      .calledWith(undefined as any, mockRobotName)
+      .mockReturnValue(mockWifiList)
+    when(mockGetNetworkInterface)
+      .calledWith(undefined as any, mockRobotName)
+      .mockReturnValue({ wifi: mockWifi, ethernet: mockEthernet })
+  })
+
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
+  it('should return network connection information - wifi and ethernet are connected', () => {
+    const { result } = renderHook(() => useNetworkConnection(mockRobotName), {
+      wrapper,
+    })
+    expect(result.current.activeSsid).toBe('foo')
+    expect(result.current.isWifiConnected).toBe(true)
+    expect(result.current.isEthernetConnected).toBe(true)
+    expect(result.current.connectionStatus).toBe(
+      'Connected via Wi-Fi and Ethernet'
+    )
+  })
+
+  it('should return network connection information - only wifi is connected and ethernet is connected', () => {
+    when(mockGetNetworkInterface)
+      .calledWith(undefined as any, mockRobotName)
+      .mockReturnValue({ wifi: mockWifi, ethernet: null })
+    const { result } = renderHook(() => useNetworkConnection(mockRobotName), {
+      wrapper,
+    })
+    expect(result.current.activeSsid).toBe('foo')
+    expect(result.current.isWifiConnected).toBe(true)
+    expect(result.current.isEthernetConnected).toBe(false)
+    expect(result.current.connectionStatus).toBe('foo')
+  })
+
+  it('should return network connection information - only ethernet is connected', () => {
+    when(mockGetNetworkInterface)
+      .calledWith(undefined as any, mockRobotName)
+      .mockReturnValue({ wifi: null, ethernet: mockEthernet })
+    const { result } = renderHook(() => useNetworkConnection(mockRobotName), {
+      wrapper,
+    })
+    expect(result.current.isWifiConnected).toBe(false)
+    expect(result.current.isEthernetConnected).toBe(true)
+    expect(result.current.connectionStatus).toBe('Connected via Ethernet')
+  })
+
+  it('should return network connection information - wifi and ethernet are not connected', () => {
+    when(mockGetNetworkInterface)
+      .calledWith(undefined as any, mockRobotName)
+      .mockReturnValue({ wifi: null, ethernet: null })
+    const { result } = renderHook(() => useNetworkConnection(mockRobotName), {
+      wrapper,
+    })
+    expect(result.current.isWifiConnected).toBe(false)
+    expect(result.current.isEthernetConnected).toBe(false)
+    expect(result.current.connectionStatus).toBe('Not connected')
+  })
+})

--- a/app/src/pages/OnDeviceDisplay/hooks/index.ts
+++ b/app/src/pages/OnDeviceDisplay/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useNetworkConnection'

--- a/app/src/pages/OnDeviceDisplay/hooks/useNetworkConnection.ts
+++ b/app/src/pages/OnDeviceDisplay/hooks/useNetworkConnection.ts
@@ -1,0 +1,86 @@
+import { useDispatch, useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+
+import { useInterval } from '@opentrons/components'
+
+import {
+  fetchStatus,
+  fetchWifiList,
+  getNetworkInterfaces,
+  getWifiList,
+} from '../../../redux/networking'
+
+import type { Dispatch, State } from '../../../redux/types'
+
+export interface NetworkConnection {
+  isWifiConnected: boolean
+  isEthernetConnected: boolean
+  isUsbConnected: boolean
+  connectionStatus: string
+  activeSsid?: string
+}
+
+const CONNECTION_POLL_MS = 10000 // Note: (kj:02/02/2023) temp value
+
+export function useNetworkConnection(robotName: string): NetworkConnection {
+  const { t } = useTranslation('device_settings')
+  const dispatch = useDispatch<Dispatch>()
+  let connectionStatus: string = ''
+  const list = useSelector((state: State) => getWifiList(state, robotName))
+  const { wifi, ethernet } = useSelector((state: State) =>
+    getNetworkInterfaces(state, robotName)
+  )
+  const activeSsid = list.find(nw => nw.active)?.ssid
+
+  useInterval(
+    () => {
+      dispatch(fetchStatus(robotName))
+      dispatch(fetchWifiList(robotName))
+    },
+    CONNECTION_POLL_MS,
+    true
+  )
+
+  const isWifiConnected = wifi?.ipAddress != null
+  const isEthernetConnected = ethernet?.ipAddress != null
+  // ToDo (kj:02/02/2023) Add USB connection when USB is ready
+  const isUsbConnected = false
+
+  if (isWifiConnected) {
+    connectionStatus = t('connected_via', { networkInterface: t('wifi') })
+  }
+
+  if (isEthernetConnected) {
+    // Note (kj:0202/2023) currently use "and" to make things easy
+    // and Copy not started
+    connectionStatus =
+      connectionStatus.length === 0
+        ? t('connected_via', { networkInterface: t('ethernet') })
+        : `${connectionStatus} and ${t('ethernet')}`
+  }
+
+  if (isUsbConnected) {
+    // Note (kj:0202/2023) currently use "and" to make things easy
+    // and Copy not started
+    connectionStatus =
+      connectionStatus.length === 0
+        ? t('connected_via', { networkInterface: t('usb') })
+        : `${connectionStatus} and ${t('usb')}`
+  }
+
+  if (isWifiConnected && !isEthernetConnected && !isUsbConnected) {
+    connectionStatus = activeSsid != null ? activeSsid : ''
+  }
+
+  if (!isWifiConnected && !isEthernetConnected && !isUsbConnected) {
+    connectionStatus = t('not_connected')
+  }
+
+  return {
+    isWifiConnected,
+    isEthernetConnected,
+    isUsbConnected,
+    connectionStatus,
+    activeSsid,
+  }
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add useNetworkConnection hook to fetch connection status for RobotSettingsDashboard.

Networking Settings Button in RobotSettingsDashboard needs to show the network connection with the following rules.
This hook is for doing that.
https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3576004690/RobotSettings+Dashboard#Network-Settings

This will Close RCORE-575
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add a new custom hook and test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
