### PR TITLE
feat(ot3): add enableOT3FirmwareUpdates feature flag to gate firmware update functionality.

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -177,6 +177,14 @@ settings = [
         restart_required=True,
     ),
     SettingDefinition(
+        _id="enableProtocolEnginePAPICore",
+        title="Enable experimental execution core for Python protocols",
+        description=(
+            "This is an Opentrons-internal setting to test new execution logic."
+            " Do not enable."
+        ),
+    ),
+    SettingDefinition(
         _id="enableOT3FirmwareUpdates",
         title="Enable experimental OT-3 firmware updates",
         description=(
@@ -184,14 +192,6 @@ settings = [
             "new subsystem (head, gantry, etc) updates."
         ),
         restart_required=True,
-    ),
-    SettingDefinition(
-        _id="enableProtocolEnginePAPICore",
-        title="Enable experimental execution core for Python protocols",
-        description=(
-            "This is an Opentrons-internal setting to test new execution logic."
-            " Do not enable."
-        ),
     ),
 ]
 
@@ -509,6 +509,16 @@ def _migrate18to19(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate19to20(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 20 of the feature flags file.
+
+    - Adds the enableOT3FirmwareUpdates config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["enableOT3FirmwareUpdates"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -529,6 +539,7 @@ _MIGRATIONS = [
     _migrate16to17,
     _migrate17to18,
     _migrate18to19,
+    _migrate19to20,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -188,8 +188,7 @@ settings = [
         _id="enableOT3FirmwareUpdates",
         title="Enable experimental OT-3 firmware updates",
         description=(
-            "Do not enable. This is an Opentrons-internal setting to test "
-            "new subsystem (head, gantry, etc) updates."
+            "This is an Opentrons-internal setting to test new firmware updates."
         ),
         restart_required=True,
     ),

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -177,6 +177,15 @@ settings = [
         restart_required=True,
     ),
     SettingDefinition(
+        _id="enableOT3FirmwareUpdates",
+        title="Enable experimental OT-3 firmware updates",
+        description=(
+            "Do not enable. This is an Opentrons-internal setting to test "
+            "new subsystem (head, gantry, etc) updates."
+        ),
+        restart_required=True,
+    ),
+    SettingDefinition(
         _id="enableProtocolEnginePAPICore",
         title="Enable experimental execution core for Python protocols",
         description=(

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -31,13 +31,13 @@ def enable_ot3_hardware_controller() -> bool:
     return advs.get_setting_with_env_overload("enableOT3HardwareController")
 
 
-def enable_protocol_engine_papi_core() -> bool:
-    """Whether to use the ProtocolEngine core to execute Protocol API v2 protocols."""
-
-    return advs.get_setting_with_env_overload("enableProtocolEnginePAPICore")
-
-
 def enable_ot3_firmware_updates() -> bool:
     """Whether to enable firmware updates for the OT-3 subsystems."""
 
     return advs.get_setting_with_env_overload("enableOT3FirmwareUpdates")
+
+
+def enable_protocol_engine_papi_core() -> bool:
+    """Whether to use the ProtocolEngine core to execute Protocol API v2 protocols."""
+
+    return advs.get_setting_with_env_overload("enableProtocolEnginePAPICore")

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -31,13 +31,13 @@ def enable_ot3_hardware_controller() -> bool:
     return advs.get_setting_with_env_overload("enableOT3HardwareController")
 
 
-def enable_ot3_firmware_updates() -> bool:
-    """Whether to enable firmware updates for the OT-3 subsystems."""
-
-    return advs.get_setting_with_env_overload("enableOT3FirmwareUpdates")
-
-
 def enable_protocol_engine_papi_core() -> bool:
     """Whether to use the ProtocolEngine core to execute Protocol API v2 protocols."""
 
     return advs.get_setting_with_env_overload("enableProtocolEnginePAPICore")
+
+
+def enable_ot3_firmware_updates() -> bool:
+    """Whether to enable firmware updates for the OT-3 subsystems."""
+
+    return advs.get_setting_with_env_overload("enableOT3FirmwareUpdates")

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -35,3 +35,9 @@ def enable_protocol_engine_papi_core() -> bool:
     """Whether to use the ProtocolEngine core to execute Protocol API v2 protocols."""
 
     return advs.get_setting_with_env_overload("enableProtocolEnginePAPICore")
+
+
+def enable_ot3_firmware_updates() -> bool:
+    """Whether to enable firmware updates for the OT-3 subsystems."""
+
+    return advs.get_setting_with_env_overload("enableOT3FirmwareUpdates")

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 19
+    return 20
 
 
 @pytest.fixture
@@ -22,6 +22,7 @@ def default_file_settings() -> Dict[str, Any]:
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
         "enableProtocolEnginePAPICore": None,
+        "enableOT3FirmwareUpdates": None,
     }
 
 
@@ -237,6 +238,30 @@ def v18_config(v17_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v19_config(v18_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v18_config.copy()
+    r.pop("enableLoadLiquid")
+    r.update(
+        {
+            "_version": 19,
+        }
+    )
+    return r
+
+
+@pytest.fixture
+def v20_config(v19_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v19_config.copy()
+    r.update(
+        {
+            "_version": 19,
+            "enableOT3FirmwareUpdates": None,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -260,6 +285,8 @@ def v18_config(v17_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v16_config"),
         lazy_fixture("v17_config"),
         lazy_fixture("v18_config"),
+        lazy_fixture("v19_config"),
+        lazy_fixture("v20_config"),
     ],
 )
 def old_settings(request: pytest.FixtureRequest) -> Dict[str, Any]:
@@ -341,4 +368,5 @@ def test_ensures_config() -> None:
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
         "enableProtocolEnginePAPICore": None,
+        "enableOT3FirmwareUpdates": None,
     }

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -60,6 +60,12 @@ stages:
             description: !re_search 'Opentrons-internal setting to test new execution logic'
             restart_required: false
             value: !anything
+          - id: enableOT3FirmwareUpdates
+            old_id: Null
+            title: Enable experimental OT-3 firmware updates
+            description: !re_search 'This is an Opentrons-internal setting to test new firmware updates.'
+            restart_required: true
+            value: !anything
         links: !anydict
 
 ---


### PR DESCRIPTION
# Overview

We are in the middle of developing firmware updates for the OT3 subsystems, we need to be able to work on these features without interfering with the regular system. So let's add a feature flag to gate this functionality.

Closes: [RCORE-478](https://opentrons.atlassian.net/browse/RCORE-478)

# Test Plan

- [x] Make sure this causes no issues when enabled/disabled

# Changelog

- add `enableOT3FirmwareUpdates` feature flag

# Review requests

# Risk assessment

Low, OT3 work

[RCORE-478]: https://opentrons.atlassian.net/browse/RCORE-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ