### PR TITLE
feat(app): Redirect user to calibration dashboard when done attaching a pipette

### DIFF
--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -42,6 +42,7 @@ import {
   EIGHT_CHANNEL_STEPS,
 } from './constants'
 
+import * as Config from '../../redux/config'
 import type { State, Dispatch } from '../../redux/types'
 import type { Mount } from '../../redux/pipettes/types'
 import type { WizardStep } from './types'
@@ -107,6 +108,10 @@ export function ChangePipette(props: Props): JSX.Element | null {
   const homePipAndExit = React.useCallback(
     () => dispatchApiRequests(home(robotName, PIPETTE, mount)),
     [dispatchApiRequests, robotName, mount]
+  )
+
+  const enableCalibrationWizards = Config.useFeatureFlag(
+    'enableCalibrationWizards'
   )
 
   const baseProps = {
@@ -263,7 +268,11 @@ export function ChangePipette(props: Props): JSX.Element | null {
     const toCalDashboard = (): void => {
       dispatchApiRequests(home(robotName, ROBOT))
       closeModal()
-      history.push(`/devices/${robotName}/robot-settings/calibration`)
+      history.push(
+        `/devices/${robotName}/robot-settings/calibration${
+          enableCalibrationWizards ? '/dashboard' : ''
+        }`
+      )
     }
 
     let wizardCurrentStep: number = 0

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
-import { getPipetteNameSpecs, PipetteNameSpecs } from '@opentrons/shared-data'
 import { useTranslation } from 'react-i18next'
+import { getPipetteNameSpecs, PipetteNameSpecs } from '@opentrons/shared-data'
 import { SPACING, TYPOGRAPHY } from '@opentrons/components'
+
 import {
   useDispatchApiRequests,
   getRequestById,


### PR DESCRIPTION

# Overview

This simple change redirects the user to the calibration dashboard instead of the calibration settings page when confirming a newly attached pipette.

It is hidden behind the "Use Calibration Wizards" feature flag for the time being.

Closes RLIQ-183

# Changelog

- Changed the redirection url and put the change behind the feature flag

# Review requests

Verify I've used the correct URL

# Risk assessment

There are no unit tests for the contents of the redirection url. There is a test to ensure the prop exists and is of the correct type, but not for the location itself. Given that the feature flag will be removed shortly, adding a test for this existing code and all of the infrastructure for using & not using the feature flag seemed like it would be wasted effort.
