### PR TITLE
feat(api): introduce Protocol API version 2.14

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -17,6 +17,8 @@ Protocols and Instruments
    :members:
    :exclude-members: delay
 
+.. autoclass:: opentrons.protocol_api.Liquid
+
 .. _protocol-api-labware:
 
 Labware and Wells
@@ -29,24 +31,25 @@ Labware and Wells
 
 Modules
 -------
+
 .. autoclass:: opentrons.protocol_api.TemperatureModuleContext
    :members:
-   :exclude-members: start_set_temperature, await_temperature, broker, geometry
+   :exclude-members: start_set_temperature, await_temperature, broker, geometry, load_labware_object
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.MagneticModuleContext
    :members:
-   :exclude-members: broker, geometry
+   :exclude-members: calibrate, broker, geometry, load_labware_object
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.ThermocyclerContext
    :members:
-   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, broker, geometry
+   :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, broker, geometry, load_labware_object
    :inherited-members:
    
 .. autoclass:: opentrons.protocol_api.HeaterShakerContext
    :members:
-   :exclude-members: broker, geometry
+   :exclude-members: broker, geometry, load_labware_object
    :inherited-members:
 
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -237,7 +237,7 @@ Version 2.13
 Version 2.14
 ++++++++++++
 
-This version a new protocol runtime. Several older parts of the Protocol API were deprecated as part of this switchover.
+This version introduces a new protocol runtime. Several older parts of the Protocol API were deprecated as part of this switchover.
 If you specify an API version of 2.13 or lower, your protocols will continue to execute on the old runtime.
 
 - Feature additions

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -265,6 +265,9 @@ If you specify an API version of 2.13 or lower, your protocols will continue to 
 
   - ``MagneticModuleContext.calibrate`` was deprecated since it was never needed nor implemented.
 
+  - The ``height`` parameter of :py:meth:`MagneticModuleContext.engage` was deprecated.
+    Use ``offset`` or ``height_from_base`` instead.
+
   - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration`` were removed,
     since they were holdovers from a calibration system that no longer exists.
  

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -237,25 +237,39 @@ Version 2.13
 Version 2.14
 ++++++++++++
 
-Protocol API v2.14 introduces a new protocol runtime. Several older parts of the Protocol API were deprecated as part of this switchover. If you specify an API version of 2.13 or lower, your protocols will continue to execute on the old rumtime.
+This version a new protocol runtime. Several older parts of the Protocol API were deprecated as part of this switchover.
+If you specify an API version of 2.13 or lower, your protocols will continue to execute on the old runtime.
 
 - Feature additions
-  - :py:meth:`.ProtocolContext.define_liquid` and :py:meth:`.Well.load_liquid` added to define different liquid types and add them to wells, respectively.
-- Bug fixes
-  - :py:class:`.Labware` and :py:class:`.Well` now adhere to the protocol's API level setting. Prior to this version, they incorrectly ignored the setting.
-  - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well instead of on the edge closest to the front of the machine.
-- Deprecations and removals
-  - :py:meth:`.ModuleContext.load_labware_object` was deprecated as an unnecessary internal method.
-  - :py:meth:`.MagneticModuleContext.calibrate` was deprecated since it was never needed nor implemented
-  - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` were deprecated.
-    - Configure your pipettes pick-up settings with the Opentrons App, instead.
-  - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` were deprecated:
-    - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration`` were removed, since they were holdovers from a calibration system that no longer exists.
-    - The ``Well.has_tip`` setter was deprecated, since it is not compat The corresponding ``Well.has_tip`` getter will not be deprecated. Use :py:meth:`.Labware.reset` to reset your tip rack's state, instead.
-  - :py:meth:`.ModuleContext.geometry` was deprecated
-    - The ``model`` and ``type`` properties of were replaced by :py:meth:`.ModuleContext.model` and :py:meth:`.ModuleContext.type`, respectively
-    - Otherwise, this was an internal interface that didn't have much use for Protocol API authors
-  - :py:meth:`.ProtocolContext.load_labware` will now favor loading custom labware over Opentrons defaults if a load name shadows a default and no namespace is included.
-    - We continue to recommend, however, that you name your own labware definitions with load names that do not match any Opentrons standard definitions.
 
+  - :py:meth:`.ProtocolContext.define_liquid` and :py:meth:`.Well.load_liquid` added
+    to define different liquid types and add them to wells, respectively.
+
+- Bug fixes
+
+  - :py:class:`.Labware` and :py:class:`.Well` now adhere to the protocol's API level setting.
+    Prior to this version, they incorrectly ignored the setting.
  
+  - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well
+    instead of on the edge closest to the front of the machine.
+
+  - :py:meth:`.ProtocolContext.load_labware` now prefers loading user-provided labware definitions
+    rather than built-in definitions if no explicit ``namespace`` is specified.
+
+- Deprecations and removals
+
+  - ``ModuleContext.load_labware_object`` was deprecated as an unnecessary internal method.
+
+  - ``ModuleContext.geometry`` was deprecated in favor of
+    :py:attr:`.ModuleContext.model` and :py:attr:`.ModuleContext.type`
+
+  - ``MagneticModuleContext.calibrate`` was deprecated since it was never needed nor implemented.
+
+  - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration`` were removed,
+    since they were holdovers from a calibration system that no longer exists.
+ 
+  - The :py:attr:`.Well.has_tip` setter was deprecated. The getter is not deprecated.
+    Use :py:meth:`.Labware.reset` to reset your tip rack's state, instead.
+
+  - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` were deprecated.
+    Configure your pipette pick-up settings with the Opentrons App, instead.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -95,7 +95,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 |     2.13    |          6.1.0               |
 +-------------+------------------------------+
-|     2.14    |        unreleased            |
+|     2.14    |          6.3.0               |
 +-------------+------------------------------+
 
 Changes in API Versions
@@ -237,18 +237,25 @@ Version 2.13
 Version 2.14
 ++++++++++++
 
-Upcoming, not yet released.
+Protocol API v2.14 introduces a new protocol runtime. Several older parts of the Protocol API were deprecated as part of this switchover. If you specify an API version of 2.13 or lower, your protocols will continue to execute on the old rumtime.
 
-- :py:meth:`.ProtocolContext.define_liquid` and :py:meth:`.Well.load_liquid` added will allow you to define different liquid types and add them to wells at the beginning of your protocol.
-- :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
-- :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
-- :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
-- The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` will be deprecated. Configure your pipettes pick-up settings with the Opentrons App, instead.
-- Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
-    - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
-    - The ``Well.has_tip`` setter, which will cease to function in a future upgrade to the Python protocol execution system. The corresponding ``Well.has_tip`` getter will not be deprecated.
-- :py:meth:`.ModuleContext.geometry` will be deprecated
-    - The ``model`` and ``type`` properties of this interface will be replaced by :py:meth:`.ModuleContext.model` and :py:meth:`.ModuleContext.type`, respectively
-- :py:meth:`.ProtocolContext.load_labware` will favor loading custom labware over Opentrons defaults if a name shadows a default and no namespace is included.
- - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well instead of on the edge closest to the front of the machine.
+- Feature additions
+  - :py:meth:`.ProtocolContext.define_liquid` and :py:meth:`.Well.load_liquid` added to define different liquid types and add them to wells, respectively.
+- Bug fixes
+  - :py:class:`.Labware` and :py:class:`.Well` now adhere to the protocol's API level setting. Prior to this version, they incorrectly ignored the setting.
+  - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well instead of on the edge closest to the front of the machine.
+- Deprecations and removals
+  - :py:meth:`.ModuleContext.load_labware_object` was deprecated as an unnecessary internal method.
+  - :py:meth:`.MagneticModuleContext.calibrate` was deprecated since it was never needed nor implemented
+  - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` were deprecated.
+    - Configure your pipettes pick-up settings with the Opentrons App, instead.
+  - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` were deprecated:
+    - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration`` were removed, since they were holdovers from a calibration system that no longer exists.
+    - The ``Well.has_tip`` setter was deprecated, since it is not compat The corresponding ``Well.has_tip`` getter will not be deprecated. Use :py:meth:`.Labware.reset` to reset your tip rack's state, instead.
+  - :py:meth:`.ModuleContext.geometry` was deprecated
+    - The ``model`` and ``type`` properties of were replaced by :py:meth:`.ModuleContext.model` and :py:meth:`.ModuleContext.type`, respectively
+    - Otherwise, this was an internal interface that didn't have much use for Protocol API authors
+  - :py:meth:`.ProtocolContext.load_labware` will now favor loading custom labware over Opentrons defaults if a load name shadows a default and no namespace is included.
+    - We continue to recommend, however, that you name your own labware definitions with load names that do not match any Opentrons standard definitions.
+
  

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -177,14 +177,6 @@ settings = [
         restart_required=True,
     ),
     SettingDefinition(
-        _id="enableProtocolEnginePAPICore",
-        title="Enable experimental execution core for Python protocols",
-        description=(
-            "This is an Opentrons-internal setting to test new execution logic."
-            " Do not enable."
-        ),
-    ),
-    SettingDefinition(
         _id="enableOT3FirmwareUpdates",
         title="Enable experimental OT-3 firmware updates",
         description=(
@@ -518,6 +510,16 @@ def _migrate19to20(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate20to21(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 21 of the feature flags file.
+
+    - Removes deprecated enableProtocolEnginePAPICore option
+    """
+    removals = ["enableProtocolEnginePAPICore"]
+    newmap = {k: v for k, v in previous.items() if k not in removals}
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -539,6 +541,7 @@ _MIGRATIONS = [
     _migrate17to18,
     _migrate18to19,
     _migrate19to20,
+    _migrate20to21,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -31,12 +31,6 @@ def enable_ot3_hardware_controller() -> bool:
     return advs.get_setting_with_env_overload("enableOT3HardwareController")
 
 
-def enable_protocol_engine_papi_core() -> bool:
-    """Whether to use the ProtocolEngine core to execute Protocol API v2 protocols."""
-
-    return advs.get_setting_with_env_overload("enableProtocolEnginePAPICore")
-
-
 def enable_ot3_firmware_updates() -> bool:
     """Whether to enable firmware updates for the OT-3 subsystems."""
 

--- a/api/src/opentrons/protocol_api/core/engine/__init__.py
+++ b/api/src/opentrons/protocol_api/core/engine/__init__.py
@@ -1,8 +1,21 @@
 """ProtocolEngine-based Protocol API implementation core."""
+from typing_extensions import Final
+
+from opentrons.protocols.api_support.types import APIVersion
+
 from .protocol import ProtocolCore
 from .instrument import InstrumentCore
 from .labware import LabwareCore
 from .module_core import ModuleCore
 from .well import WellCore
 
-__all__ = ["ProtocolCore", "InstrumentCore", "LabwareCore", "WellCore", "ModuleCore"]
+ENGINE_CORE_API_VERSION: Final = APIVersion(2, 14)
+
+__all__ = [
+    "ENGINE_CORE_API_VERSION",
+    "ProtocolCore",
+    "InstrumentCore",
+    "LabwareCore",
+    "WellCore",
+    "ModuleCore",
+]

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -10,7 +10,6 @@ from opentrons.protocol_engine.errors import LabwareNotOnDeckError, ModuleNotOnD
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.api_support.tip_tracker import TipTracker
-from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import DeckSlotName, Point
 
 from ..labware import AbstractLabware, LabwareLoadParams
@@ -76,9 +75,6 @@ class LabwareCore(AbstractLabware[WellCore]):
         """Get the load name or the label of the labware specified by a user."""
         return self._user_display_name or self.load_name
 
-    def set_name(self, new_name: str) -> None:
-        raise APIVersionError("LabwareCore.set_name has been deprecated")
-
     def get_definition(self) -> LabwareDefinitionDict:
         """Get the labware's definition as a plain dictionary."""
         return cast(LabwareDefinitionDict, self._definition.dict(exclude_none=True))
@@ -111,9 +107,6 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     def get_tip_length(self) -> float:
         return self._engine_client.state.labware.get_tip_length(self._labware_id)
-
-    def set_tip_length(self, length: float) -> None:
-        raise APIVersionError("LabwareCore.set_tip_length has been deprecated")
 
     def reset_tips(self) -> None:
         self._engine_client.reset_tips(labware_id=self.labware_id)

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -71,10 +71,6 @@ class AbstractLabware(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def set_name(self, new_name: str) -> None:
-        ...
-
-    @abstractmethod
     def get_definition(self) -> LabwareDefinitionDict:
         """Get the labware's definition as a plain dictionary."""
 
@@ -104,10 +100,6 @@ class AbstractLabware(ABC, Generic[WellCoreType]):
 
     @abstractmethod
     def get_tip_length(self) -> float:
-        ...
-
-    @abstractmethod
-    def set_tip_length(self, length: float) -> None:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -28,7 +28,7 @@ from .core.legacy.labware_offset_provider import (
     NullLabwareOffsetProvider,
 )
 from .core.legacy_simulator.legacy_protocol_core import LegacyProtocolCoreSimulator
-from .core.engine import ProtocolCore
+from .core.engine import ENGINE_CORE_API_VERSION, ProtocolCore
 
 
 def create_protocol_context(
@@ -90,7 +90,7 @@ def create_protocol_context(
     else:
         labware_offset_provider = NullLabwareOffsetProvider()
 
-    if api_version >= APIVersion(2, 14):
+    if api_version >= ENGINE_CORE_API_VERSION:
         # TODO(mc, 2022-8-22): replace assertion with strict typing
         assert (
             protocol_engine is not None and protocol_engine_loop is not None

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -15,6 +15,7 @@ from opentrons.hardware_control import (
 from opentrons.protocol_engine import ProtocolEngine
 from opentrons.protocol_engine.clients import SyncClient, ChildThreadTransport
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 from .protocol_context import ProtocolContext
 from .deck import Deck
@@ -68,6 +69,13 @@ def create_protocol_context(
     Returns:
         A ready-to-use ProtocolContext.
     """
+    if api_version > MAX_SUPPORTED_VERSION:
+        raise ValueError(
+            f"API version {api_version} is not supported by this robot software."
+            f" Please reduce your API version to {MAX_SUPPORTED_VERSION} or below"
+            f" or update your robot."
+        )
+
     sync_hardware: SynchronousAdapter[HardwareControlAPI]
     labware_offset_provider: AbstractLabwareOffsetProvider
     core: Union[ProtocolCore, LegacyProtocolCoreSimulator, LegacyProtocolCore]
@@ -82,8 +90,7 @@ def create_protocol_context(
     else:
         labware_offset_provider = NullLabwareOffsetProvider()
 
-    # TODO(mc, 2022-8-22): replace with API version check
-    if feature_flags.enable_protocol_engine_papi_core():
+    if api_version >= APIVersion(2, 14):
         # TODO(mc, 2022-8-22): replace assertion with strict typing
         assert (
             protocol_engine is not None and protocol_engine_loop is not None

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -31,9 +31,10 @@ from opentrons.protocols.labware import (  # noqa: F401
 )
 
 from . import validation
-from .core import well_grid
-from .core.labware import AbstractLabware
 from ._liquid import Liquid
+from .core import well_grid
+from .core.engine import ENGINE_CORE_API_VERSION
+from .core.labware import AbstractLabware
 from .core.module import AbstractModuleCore
 from .core.core_map import LoadedCoreMap
 from .core.legacy.legacy_labware_core import LegacyLabwareCore
@@ -376,7 +377,7 @@ class Labware:
         .. deprecated: 2.14
             Set the name of labware in `load_labware` instead.
         """
-        if self._api_version >= APIVersion(2, 14):
+        if self._api_version >= ENGINE_CORE_API_VERSION:
             raise APIVersionError("Labware.name setter has been deprecated")
 
         # TODO(mc, 2023-02-06): this assert should be enough for mypy
@@ -677,7 +678,7 @@ class Labware:
             Ensure tip length is set properly in your tip rack's definition
             and/or use the Opentrons App's tip length calibration feature.
         """
-        if self._api_version >= APIVersion(2, 14):
+        if self._api_version >= ENGINE_CORE_API_VERSION:
             raise APIVersionError("Labware.tip_length setter has been deprecated")
 
         # TODO(mc, 2023-02-06): this assert should be enough for mypy

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 
 from itertools import dropwhile
-from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple, cast
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition, LabwareParameters
 
@@ -35,9 +35,9 @@ from .core import well_grid
 from .core.labware import AbstractLabware
 from ._liquid import Liquid
 from .core.module import AbstractModuleCore
-from .core.legacy.legacy_labware_core import LegacyLabwareCore as LegacyLabwareCore
 from .core.core_map import LoadedCoreMap
-from .core.legacy.legacy_well_core import LegacyWellCore as LegacyWellCore
+from .core.legacy.legacy_labware_core import LegacyLabwareCore
+from .core.legacy.legacy_well_core import LegacyWellCore
 from .core.legacy.well_geometry import WellGeometry
 
 
@@ -210,9 +210,7 @@ class Well:
         """
         return self._core.from_center_cartesian(x, y, z)
 
-    # TODO (tz, 12-19-22): Limit to API version 2.14
-    # https://opentrons.atlassian.net/browse/RCORE-537
-    @requires_version(2, 13)
+    @requires_version(2, 14)
     def load_liquid(self, liquid: Liquid, volume: float) -> None:
         """
         Load a liquid into a well.
@@ -371,11 +369,20 @@ class Labware:
         load it, or the label of the labware specified by a user."""
         return self._core.get_name()
 
-    # TODO(jbl, 2022-12-06): deprecate officially when there is a PAPI version for the engine core
     @name.setter
     def name(self, new_name: str) -> None:
-        """Set the labware name"""
-        self._core.set_name(new_name)
+        """Set the labware name.
+
+        .. deprecated: 2.14
+            Set the name of labware in `load_labware` instead.
+        """
+        if self._api_version >= APIVersion(2, 14):
+            raise APIVersionError("Labware.name setter has been deprecated")
+
+        # TODO(mc, 2023-02-06): this assert should be enough for mypy
+        # investigate if upgrading mypy allows the `cast` to be removed
+        assert isinstance(self._core, LegacyLabwareCore)
+        cast(LegacyLabwareCore, self._core).set_name(new_name)
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
@@ -661,10 +668,22 @@ class Labware:
     def tip_length(self) -> float:
         return self._core.get_tip_length()
 
-    # TODO(jbl, 2022-12-06): deprecate officially when there is a PAPI version for the engine core
     @tip_length.setter
     def tip_length(self, length: float) -> None:
-        self._core.set_tip_length(length)
+        """
+        Set the tip rack's tip length.
+
+        .. deprecated: 2.14
+            Ensure tip length is set properly in your tip rack's definition
+            and/or use the Opentrons App's tip length calibration feature.
+        """
+        if self._api_version >= APIVersion(2, 14):
+            raise APIVersionError("Labware.tip_length setter has been deprecated")
+
+        # TODO(mc, 2023-02-06): this assert should be enough for mypy
+        # invvestigate if upgrading mypy allows the `cast` to be removed
+        assert isinstance(self._core, LegacyLabwareCore)
+        cast(LegacyLabwareCore, self._core).set_tip_length(length)
 
     # TODO(mc, 2022-11-09): implementation detail; deprecate public method
     def next_tip(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -65,30 +65,22 @@ class ModuleContext(CommandPublisher):
     def api_version(self) -> APIVersion:
         return self._api_version
 
-    @property
+    @property  # type: ignore[misc]
+    @requires_version(2, 14)
     def model(self) -> ModuleModel:
         """Get the module's model identifier."""
-        # TODO(jbl 2023-01-05) replace this was requires_version decorator when API version is bumped to 2.14
-        if isinstance(self._core, LegacyModuleCore):
-            raise APIVersionError("ModuleContext.model not supported for legacy core.")
         return cast(ModuleModel, self._core.get_model().value)
 
-    @property
+    @property  # type: ignore[misc]
+    @requires_version(2, 14)
     def type(self) -> ModuleType:
         """Get the module's general type identifier."""
-        # TODO(jbl 2023-01-05) replace this was requires_version decorator when API version is bumped to 2.14
-        if isinstance(self._core, LegacyModuleCore):
-            raise APIVersionError("ModuleContext.type not supported for legacy core.")
         return cast(ModuleType, self._core.MODULE_TYPE.value)
 
-    @property
+    @property  # type: ignore[misc]
+    @requires_version(2, 14)
     def serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
-        # TODO(jbl 2023-01-05) replace this was requires_version decorator when API version is bumped to 2.14
-        if isinstance(self._core, LegacyModuleCore):
-            raise APIVersionError(
-                "ModuleContext.serial_number not supported for legacy core."
-            )
         return self._core.get_serial_number()
 
     @requires_version(2, 0)
@@ -221,9 +213,8 @@ class ModuleContext(CommandPublisher):
         labware_core = self._protocol_core.get_labware_on_module(self._core)
         return self._core_map.get(labware_core)
 
-    # TODO (tz, 1-7-23): change this to version 2.14
     @property  # type: ignore[misc]
-    @requires_version(2, 13)
+    @requires_version(2, 14)
     def parent(self) -> str:
         """The name of the slot the module is on."""
         return self._core.get_deck_slot().value

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -22,6 +22,7 @@ from .core.common import (
     HeaterShakerCore,
 )
 from .core.core_map import LoadedCoreMap
+from .core.engine import ENGINE_CORE_API_VERSION
 from .core.legacy.legacy_module_core import LegacyModuleCore
 from .core.legacy.module_geometry import ModuleGeometry as LegacyModuleGeometry
 from .core.legacy.legacy_labware_core import LegacyLabwareCore as LegacyLabwareCore
@@ -348,7 +349,7 @@ class MagneticModuleContext(ModuleContext):
             "`MagneticModuleContext.calibrate` doesn't do anything useful"
             " and will no-op in Protocol API version 2.14 and higher."
         )
-        if self._api_version < APIVersion(2, 14):
+        if self._api_version < ENGINE_CORE_API_VERSION:
             self._core._sync_module_hardware.calibrate()  # type: ignore[attr-defined]
 
     @publish(command=cmds.magdeck_engage)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -17,7 +17,6 @@ from opentrons.protocols.api_support.util import (
     requires_version,
     APIVersionError,
 )
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 from .core.common import ModuleCore, ProtocolCore
 from ._liquid import Liquid
@@ -102,13 +101,6 @@ class ProtocolContext(CommandPublisher):
                              exposed as
                              :py:attr:`.ProtocolContext.bundled_data`
         """
-        if api_version > MAX_SUPPORTED_VERSION:
-            raise RuntimeError(
-                f"API version {api_version} is not supported by this robot software."
-                f" Please reduce your API version to {MAX_SUPPORTED_VERSION} or below"
-                f" or update your robot."
-            )
-
         super().__init__(broker)
         self._api_version = api_version
         self._core = core
@@ -752,9 +744,7 @@ class ProtocolContext(CommandPublisher):
         """
         self._core.set_rail_lights(on=on)
 
-    # TODO (tz, 12-19-22): Limit to api version 2.14.
-    # https://opentrons.atlassian.net/browse/RCORE-537
-    @requires_version(2, 13)
+    @requires_version(2, 14)
     def define_liquid(
         self, name: str, description: Optional[str], display_color: Optional[str]
     ) -> Liquid:

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -20,7 +20,6 @@ from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel as LegacyThermocyclerModuleModel,
     HeaterShakerModuleModel as LegacyHeaterShakerModuleModel,
 )
-from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_engine import ProtocolEngine
 from opentrons.protocol_reader import ProtocolSource, ProtocolFileRole
 
@@ -32,6 +31,7 @@ from opentrons.protocol_api import (
     Well as LegacyWell,
     create_protocol_context,
 )
+from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
 from opentrons.protocol_api.core.legacy.load_info import (
     LoadInfo as LegacyLoadInfo,
     InstrumentLoadInfo as LegacyInstrumentLoadInfo,
@@ -53,7 +53,7 @@ from opentrons.protocols.types import (
 # Note that even when simulation and execution are handled by the legacy machinery,
 # Protocol Engine still has some involvement for analyzing the simulation and
 # monitoring the execution.
-LEGACY_PYTHON_API_VERSION_CUTOFF = APIVersion(2, 14)
+LEGACY_PYTHON_API_VERSION_CUTOFF = ENGINE_CORE_API_VERSION
 
 
 # The earliest JSON protocol schema version where the protocol is executed directly by

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -53,7 +53,7 @@ from opentrons.protocols.types import (
 # Note that even when simulation and execution are handled by the legacy machinery,
 # Protocol Engine still has some involvement for analyzing the simulation and
 # monitoring the execution.
-LEGACY_PYTHON_API_VERSION_CUTOFF = APIVersion(3, 0)
+LEGACY_PYTHON_API_VERSION_CUTOFF = APIVersion(2, 14)
 
 
 # The earliest JSON protocol schema version where the protocol is executed directly by

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -8,14 +8,9 @@ from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.broker import Broker
 from opentrons.equipment_broker import EquipmentBroker
-from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons import protocol_reader
-from opentrons.protocol_reader import (
-    ProtocolSource,
-    PythonProtocolConfig,
-    JsonProtocolConfig,
-)
+from opentrons.protocol_reader import ProtocolSource, JsonProtocolConfig
 from opentrons.protocol_engine import ProtocolEngine, StateSummary, Command
 
 from .task_queue import TaskQueue
@@ -111,21 +106,13 @@ class ProtocolRunner:
             # definitions, so we don't need to yield here.
             self._protocol_engine.add_labware_definition(definition)
 
-        if isinstance(config, JsonProtocolConfig):
-            schema_version = config.schema_version
-
-            if schema_version >= LEGACY_JSON_SCHEMA_VERSION_CUTOFF:
-                await self._load_json(protocol_source)
-            else:
-                self._load_legacy(protocol_source, labware_definitions)
-
-        elif isinstance(config, PythonProtocolConfig):
-            api_version = config.api_version
-
-            if api_version >= LEGACY_PYTHON_API_VERSION_CUTOFF:
-                self._load_python(protocol_source)
-            else:
-                self._load_legacy(protocol_source, labware_definitions)
+        if (
+            isinstance(config, JsonProtocolConfig)
+            and config.schema_version >= LEGACY_JSON_SCHEMA_VERSION_CUTOFF
+        ):
+            await self._load_json(protocol_source)
+        else:
+            self._load_python_or_legacy_json(protocol_source, labware_definitions)
 
     def play(self) -> None:
         """Start or resume the run."""
@@ -201,18 +188,7 @@ class ProtocolRunner:
 
         self._task_queue.set_run_func(func=self._protocol_engine.wait_until_complete)
 
-    def _load_python(self, protocol_source: ProtocolSource) -> None:
-        # fixme(mm, 2022-12-23): This does I/O and compute-bound parsing that will block
-        # the event loop. Jira RSS-165.
-        protocol = self._python_file_reader.read(protocol_source)
-        context = self._python_context_creator.create(self._protocol_engine)
-        self._task_queue.set_run_func(
-            func=self._python_executor.execute,
-            protocol=protocol,
-            context=context,
-        )
-
-    def _load_legacy(
+    def _load_python_or_legacy_json(
         self,
         protocol_source: ProtocolSource,
         labware_definitions: Iterable[LabwareDefinition],
@@ -223,7 +199,7 @@ class ProtocolRunner:
         broker = None
         equipment_broker = None
 
-        if not feature_flags.enable_protocol_engine_papi_core():
+        if protocol.api_level < LEGACY_PYTHON_API_VERSION_CUTOFF:
             broker = Broker()
             equipment_broker = EquipmentBroker[LegacyLoadInfo]()
 

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 13)
+MAX_SUPPORTED_VERSION = APIVersion(2, 14)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 20
+    return 21
 
 
 @pytest.fixture
@@ -21,7 +21,6 @@ def default_file_settings() -> Dict[str, Any]:
         "enableDoorSafetySwitch": None,
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
-        "enableProtocolEnginePAPICore": None,
         "enableOT3FirmwareUpdates": None,
     }
 
@@ -96,12 +95,7 @@ def v5_config(v4_config: Dict[str, Any]) -> Dict[str, Any]:
 @pytest.fixture
 def v6_config(v5_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v5_config.copy()
-    r.update(
-        {
-            "_version": 6,
-            "enableTipLengthCalibration": True,
-        }
-    )
+    r.update({"_version": 6, "enableTipLengthCalibration": True})
     return r
 
 
@@ -242,11 +236,7 @@ def v18_config(v17_config: Dict[str, Any]) -> Dict[str, Any]:
 def v19_config(v18_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v18_config.copy()
     r.pop("enableLoadLiquid")
-    r.update(
-        {
-            "_version": 19,
-        }
-    )
+    r.update({"_version": 19})
     return r
 
 
@@ -255,10 +245,18 @@ def v20_config(v19_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v19_config.copy()
     r.update(
         {
-            "_version": 19,
+            "_version": 20,
             "enableOT3FirmwareUpdates": None,
         }
     )
+    return r
+
+
+@pytest.fixture
+def v21_config(v20_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v20_config.copy()
+    r.pop("enableProtocolEnginePAPICore")
+    r.update({"_version": 21})
     return r
 
 
@@ -287,6 +285,7 @@ def v20_config(v19_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v18_config"),
         lazy_fixture("v19_config"),
         lazy_fixture("v20_config"),
+        lazy_fixture("v21_config"),
     ],
 )
 def old_settings(request: pytest.FixtureRequest) -> Dict[str, Any]:
@@ -367,6 +366,5 @@ def test_ensures_config() -> None:
         "enableDoorSafetySwitch": None,
         "disableFastProtocolUpload": None,
         "enableOT3HardwareController": None,
-        "enableProtocolEnginePAPICore": None,
         "enableOT3FirmwareUpdates": None,
     }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -47,14 +47,9 @@ from opentrons.hardware_control import (
     ThreadManager,
     ThreadManagedHardware,
 )
-from opentrons.protocol_api import (
-    MAX_SUPPORTED_VERSION,
-    ProtocolContext,
-    Labware,
-    create_protocol_context,
-)
+from opentrons.protocol_api import ProtocolContext, Labware, create_protocol_context
 from opentrons.protocol_api.core.legacy.legacy_labware_core import LegacyLabwareCore
-
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import Location, Point
 
 
@@ -259,9 +254,7 @@ async def hardware(
 
 @pytest.fixture()
 def ctx(hardware: ThreadManagedHardware) -> ProtocolContext:
-    return create_protocol_context(
-        api_version=MAX_SUPPORTED_VERSION, hardware_api=hardware
-    )
+    return create_protocol_context(api_version=APIVersion(2, 13), hardware_api=hardware)
 
 
 @pytest.fixture()
@@ -634,7 +627,7 @@ def min_lw2_impl(minimal_labware_def2: LabwareDefinition) -> LegacyLabwareCore:
 def min_lw(min_lw_impl: LegacyLabwareCore) -> Labware:
     return Labware(
         core=min_lw_impl,
-        api_version=MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )
@@ -644,7 +637,7 @@ def min_lw(min_lw_impl: LegacyLabwareCore) -> Labware:
 def min_lw2(min_lw2_impl: LegacyLabwareCore) -> Labware:
     return Labware(
         core=min_lw2_impl,
-        api_version=MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -9,6 +9,7 @@ from opentrons.broker import Broker
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support import instrument as mock_instrument_support
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     InstrumentContext,
@@ -169,6 +170,7 @@ def test_move_to_well(
     )
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 13)])
 def test_pick_up_from_well(
     decoy: Decoy, mock_instrument_core: InstrumentCore, subject: InstrumentContext
 ) -> None:
@@ -190,6 +192,17 @@ def test_pick_up_from_well(
         ),
         times=1,
     )
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
+def test_pick_up_from_well_deprecated_args(
+    decoy: Decoy, mock_instrument_core: InstrumentCore, subject: InstrumentContext
+) -> None:
+    """It should pick up a specific tip."""
+    mock_well = decoy.mock(cls=Well)
+
+    with pytest.raises(APIVersionError):
+        subject.pick_up_tip(mock_well, presses=1, increment=2.0, prep_after=False)
 
 
 def test_aspirate(

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -964,7 +964,7 @@ def test_order_of_module_load():
     hw_temp2 = attached_modules[2]
 
     ctx1 = protocol_api.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=fake_hardware,
     )
 
@@ -981,7 +981,7 @@ def test_order_of_module_load():
     # hardware modules regardless of the slot it
     # was loaded into
     ctx2 = protocol_api.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=fake_hardware,
     )
 
@@ -1047,7 +1047,7 @@ def test_bundled_labware(get_labware_fixture, hardware):
     bundled_labware = {"fixture/fixture_96_plate/1": fixture_96_plate}
 
     ctx = papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=hardware,
         bundled_labware=bundled_labware,
     )
@@ -1063,7 +1063,7 @@ def test_bundled_labware_missing(get_labware_fixture, hardware):
         RuntimeError, match="No labware found in bundle with load name fixture_96_plate"
     ):
         ctx = papi.create_protocol_context(
-            api_version=papi.MAX_SUPPORTED_VERSION,
+            api_version=APIVersion(2, 13),
             hardware_api=hardware,
             bundled_labware=bundled_labware,
         )
@@ -1075,7 +1075,7 @@ def test_bundled_labware_missing(get_labware_fixture, hardware):
         RuntimeError, match="No labware found in bundle with load name fixture_96_plate"
     ):
         ctx = papi.create_protocol_context(
-            api_version=papi.MAX_SUPPORTED_VERSION,
+            api_version=APIVersion(2, 13),
             hardware_api=hardware,
             bundled_labware={},
             extra_labware=bundled_labware,
@@ -1086,7 +1086,7 @@ def test_bundled_labware_missing(get_labware_fixture, hardware):
 def test_bundled_data(hardware):
     bundled_data = {"foo": b"1,2,3"}
     ctx = papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=hardware,
         bundled_data=bundled_data,
     )
@@ -1098,7 +1098,7 @@ def test_extra_labware(get_labware_fixture, hardware):
     fixture_96_plate = get_labware_fixture("fixture_96_plate")
     bundled_labware = {"fixture/fixture_96_plate/1": fixture_96_plate}
     ctx = papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=hardware,
         extra_labware=bundled_labware,
     )
@@ -1113,14 +1113,14 @@ def test_api_version_checking(hardware):
         papi.MAX_SUPPORTED_VERSION.major,
         papi.MAX_SUPPORTED_VERSION.minor + 1,
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         papi.create_protocol_context(api_version=minor_over, hardware_api=hardware)
 
     major_over = APIVersion(
         papi.MAX_SUPPORTED_VERSION.major + 1,
         papi.MAX_SUPPORTED_VERSION.minor,
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         papi.create_protocol_context(api_version=major_over, hardware_api=hardware)
 
 

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -21,6 +21,7 @@ from opentrons.protocol_api.core.legacy.module_geometry import (
     PipetteMovementRestrictedByHeaterShakerError,
     models_compatible,
 )
+from opentrons.protocols.api_support.types import APIVersion
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
@@ -51,7 +52,7 @@ def ctx_with_tempdeck(
     mock_hardware.attached_modules = [mock_module_controller]
 
     return papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=mock_hardware,
     )
 
@@ -66,7 +67,7 @@ def ctx_with_magdeck(
     mock_hardware.attached_modules = [mock_module_controller]
 
     return papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=mock_hardware,
     )
 
@@ -81,7 +82,7 @@ async def ctx_with_thermocycler(
     mock_hardware.attached_modules = [mock_module_controller]
 
     return papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=mock_hardware,
     )
 
@@ -98,7 +99,7 @@ def ctx_with_heater_shaker(
     mock_hardware.attached_modules = [mock_module_controller]
 
     ctx = papi.create_protocol_context(
-        api_version=papi.MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),
         hardware_api=mock_hardware,
     )
     ctx.location_cache = mock_pipette_location

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -54,12 +54,6 @@ stages:
             description: !re_search 'Opentrons-internal setting to test new hardware'
             restart_required: true
             value: !anything
-          - id: enableProtocolEnginePAPICore
-            old_id: Null
-            title: Enable experimental execution core for Python protocols
-            description: !re_search 'Opentrons-internal setting to test new execution logic'
-            restart_required: false
-            value: !anything
           - id: enableOT3FirmwareUpdates
             old_id: Null
             title: Enable experimental OT-3 firmware updates


### PR DESCRIPTION
## Overview

This version of the Python Protocol API makes two main changes, along with various smaller changes:

- Introduces liquids into the PAPI for the first time
- Switches the execution runtime to the ProtocolEngine

Closes RCORE-537

## Test Plan

We're going to rely on the automated smoke tests pretty heavily for this one, but we should run smoke tests on hardware, too.

1. Take a testing protocol, like testosaur, and upgrade its API version to `2.14`
2. Validate analysis and run via the Opentrons App functions properly
    - Note: must use the dev app to avoid whitescreens
    - Note: app is not yet compatible with ProtocolEngine Python runs on `edge`

### Smoke testing protocol

```python
from opentrons import protocol_api, types

metadata = {
    "protocolName": "Testosaur",
    "author": "Opentrons <engineering@opentrons.com>",
    "description": 'A variant on "Dinosaur" for testing',
    "source": "Opentrons Repository",
    "apiLevel": "2.14",
}


def run(ctx: protocol_api.ProtocolContext) -> None:
    ctx.home()
    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
    right = ctx.load_instrument("p300_single", types.Mount.LEFT, [tr])
    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
    right.pick_up_tip()
    right.aspirate(100, lw.wells()[0].bottom())
    right.dispense(100, lw.wells()[1].bottom())
    right.drop_tip(tr.wells()[-1])

```

### Expected app behavior

This is a screenshot of my app after running the above protocol. I'm going to track down tickets for the app, if they exist, to ensure fixes are planned.

 
<img width="900" alt="Screen Shot 2023-02-07 at 1 09 17 PM" src="https://user-images.githubusercontent.com/2963448/217330516-655d397c-9d36-4532-ab38-85dfefd7ff05.png">



## Changelog

- Remove `enableProtocolEnginePAPICore` feature flag
- Add Protocol API version 2.14 to replace the above feature flag
- Update versioning documentation

## Review requests

Other than running whatever smoke tests you are able to run (even if they're just on the dev server), please give the versioning docs (`versioning.rst`) a look.

## Risk assessment

Medium! We've been testing with the feature flag for some time, but this PR promotes the engine-core to production