### PR TITLE
feat(hardware): support new revision values

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -1,7 +1,7 @@
 """Custom payload fields."""
 from __future__ import annotations
 
-from typing import Iterable, List, Iterator
+from typing import Iterable, List, Iterator, Optional, Tuple
 
 import binascii
 import enum
@@ -20,6 +20,124 @@ from opentrons_hardware.firmware_bindings.constants import (
     MoveStopCondition,
     GearMotorId,
 )
+
+
+class OptionalRevisionField(utils.BinaryFieldBase[bytes]):
+    """The revision indicator in a device info.
+
+    This is sized to hold 4 ASCII characters:
+    - the primary revision
+    - the secondary revision
+    - two as-yet unused characters for tertiary revisions or other indications
+
+    If we ever change the electrical revision format we'll need to change this
+    too.
+
+    We use characters here because different boards and different nodes can
+    have different valid revisions - consider that PCBA 1 might have revisions
+    A1, B2, C3... and PCBA 2 might have A2, B1, D.... due to maybe problems
+    or timing that prevented a given revision from being produced. Having
+    an enum that encompassed them all would waste space, and having a different
+    enum for every board would rapidly balloon. Since the revision is used only
+    for reporting and for looking up firmware, we can just make it the string.
+
+    """
+
+    NUM_BYTES = 4
+    FORMAT = f"{NUM_BYTES}s"
+
+    @property
+    def value(self) -> bytes:
+        """The value."""
+        val = b""
+        for elem in (self.primary, self.secondary):
+            if elem:
+                val = val + elem.encode()
+            else:
+                val = val + b"\x00"
+        if self.tertiary:
+            val = val + self.tertiary.encode()
+        else:
+            val = val + b"\x00\x00"
+        return val
+
+    @value.setter
+    def value(self, val: bytes) -> None:
+        self._primary, self._secondary, self._tertiary = self._parse(val)
+
+    @classmethod
+    def _revision_field_from_bytes(
+        cls, data: bytes, start: int, end: int
+    ) -> Optional[str]:
+        try:
+            present_bytes = data[start:end]
+        except IndexError:
+            present_bytes = b"\x00"
+        nonzero_bytes = bytes(b for b in present_bytes if b != 0)
+        try:
+            return nonzero_bytes.decode("utf-8") or None
+        except UnicodeDecodeError:
+            return None
+
+    @classmethod
+    def _parse(cls, data: bytes) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        primary = cls._revision_field_from_bytes(data, 0, 1)
+        secondary = cls._revision_field_from_bytes(data, 1, 2)
+        tertiary = cls._revision_field_from_bytes(data, 2, 4)
+        return primary, secondary, tertiary
+
+    @classmethod
+    def build(cls, data: bytes) -> "OptionalRevisionField":
+        """Create an OptionalRevisionField from a byte buffer.
+
+        The buffer should either have 4 bytes or no bytes. Devices with bootloaders
+        too old to express their revision will not fill this field, so the
+        deserializer must handle that.
+        """
+        return cls(*cls._parse(data))
+
+    def __init__(
+        self, primary: Optional[str], secondary: Optional[str], tertiary: Optional[str]
+    ) -> None:
+        """Build."""
+        self._primary = primary
+        self._secondary = secondary
+        self._tertiary = tertiary
+
+    @property
+    def primary(self) -> Optional[str]:
+        """The primary revision changes when traces change."""
+        return self._primary
+
+    @property
+    def secondary(self) -> Optional[str]:
+        """The secondary revision changes when functional parts change."""
+        return self._secondary
+
+    @property
+    def tertiary(self) -> Optional[str]:
+        """The tertiary revision changes when non-function parts change.
+
+        The tertiary revision almost never changes and is not usually tracked.
+        If a problem is discovered in the field that aligns with a tertiary
+        revision, we'll begin to track it. This field is normally None.
+        """
+        return self._tertiary
+
+    @property
+    def revision(self) -> Optional[str]:
+        """The relevant revision is primary + secondary.
+
+        It is only valid if both primary and secondary are valid and it forms
+        a string that can be used to look up appropriate firmware.
+        """
+        if not (self.primary is not None and self.secondary is not None):
+            return None
+        return f"{self.primary}{self.secondary}"
+
+    def __repr__(self) -> str:
+        """Repr."""
+        return f"{self.__class__.__name__}(primary={self.primary}, secondary={self.secondary}, tertiary={self.tertiary})"
 
 
 class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -149,7 +149,7 @@ class FirmwareShortSHADataField(utils.BinaryFieldBase[bytes]):
     increase this too.
     """
 
-    NUM_BYTES = 7
+    NUM_BYTES = 8
     FORMAT = f"{NUM_BYTES}s"
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -2,7 +2,7 @@
 # TODO (amit, 2022-01-26): Figure out why using annotations import ruins
 #  dataclass fields interpretation.
 #  from __future__ import annotations
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from . import message_definitions
 
 from .fields import (
@@ -25,6 +25,7 @@ from .fields import (
     MotorPositionFlagsField,
     MoveStopConditionField,
     GearMotorIdField,
+    OptionalRevisionField,
 )
 from .. import utils
 
@@ -63,12 +64,35 @@ class ErrorMessagePayload(EmptyPayload):
 
 
 @dataclass(eq=False)
-class DeviceInfoResponsePayload(EmptyPayload):
-    """Device info response."""
-
+class _DeviceInfoResponsePayloadBase(EmptyPayload):
     version: utils.UInt32Field
     flags: VersionFlagsField
     shortsha: FirmwareShortSHADataField
+
+
+@dataclass(eq=False)
+class DeviceInfoResponsePayload(_DeviceInfoResponsePayloadBase):
+    """Device info response."""
+
+    @classmethod
+    def build(cls, data: bytes) -> "DeviceInfoResponsePayload":
+        """Build a response payload from incoming bytes.
+
+        This override is required to handle optionally-present revision data.
+        """
+        consumed_by_super = _DeviceInfoResponsePayloadBase.get_size()
+        superdict = asdict(_DeviceInfoResponsePayloadBase.build(data))
+        message_index = superdict.pop("message_index")
+        inst = cls(
+            **superdict,
+            revision=OptionalRevisionField.build(
+                (data + b"\x00\x00\x00\x00")[consumed_by_super:]
+            ),
+        )
+        inst.message_index = message_index
+        return inst
+
+    revision: OptionalRevisionField
 
 
 @dataclass(eq=False)

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_fields.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_fields.py
@@ -1,0 +1,44 @@
+"""Fields tests."""
+import pytest
+from typing import Optional
+
+from opentrons_hardware.firmware_bindings.messages import fields
+
+
+@pytest.mark.parametrize(
+    argnames=["value_bytes", "primary", "secondary", "tertiary", "revision"],
+    argvalues=[
+        # primary+secondary, no tertiary - normal
+        [b"a1\x00\x00", "a", "1", None, "a1"],
+        # no content for this field - normal for old bootloaders
+        [b"", None, None, None, None],
+        # all fields filled - rare but possible
+        [b"a1.3", "a", "1", ".3", "a1"],
+        # present tertiary but only one byte of it
+        [b"a1\x003", "a", "1", "3", "a1"],
+        [b"a13\x00", "a", "1", "3", "a1"],
+        # primary but not secondary, secondary but not primary, should never happen
+        [b"\x001\x00\x00", None, "1", None, None],
+        [b"a\x00\x00\x00", "a", None, None, None],
+        # garbled data (errors swallowed)
+        [b"\xff\xff\x00\x00", None, None, None, None],
+        # incomplete data (missing fields become None)
+        [b"a1.", "a", "1", ".", "a1"],
+        [b"a1", "a", "1", None, "a1"],
+        [b"a", "a", None, None, None],
+        [b"", None, None, None, None],
+    ],
+)
+def test_revision_field(
+    value_bytes: bytes,
+    primary: Optional[str],
+    secondary: Optional[str],
+    tertiary: Optional[str],
+    revision: Optional[str],
+) -> None:
+    """The revision field should be buildable with some elements missing."""
+    parsed = fields.OptionalRevisionField.build(value_bytes)
+    assert parsed.primary == primary
+    assert parsed.secondary == secondary
+    assert parsed.tertiary == tertiary
+    assert parsed.revision == revision

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -39,3 +39,58 @@ def test_create_firmware_updata_data(
 def test_eeprom_field_from_string(value_str: str, expected: bytes) -> None:
     """It should convert to bytes from a string."""
     assert fields.EepromDataField.from_string(value_str).value == expected
+
+
+def test_old_get_device_info() -> None:
+    """A device info response without revision should parse."""
+    old = payloads._DeviceInfoResponsePayloadBase(
+        version=utils.UInt32Field(0x11223344),
+        flags=fields.VersionFlagsField(0x55667788),
+        shortsha=fields.FirmwareShortSHADataField(b"abcdef1"),
+    )
+    old.message_index = utils.UInt32Field(0)
+    ser = old.serialize()
+    reparsed_old = payloads.DeviceInfoResponsePayload.build(ser)
+    assert reparsed_old.version == old.version
+    assert reparsed_old.flags == old.flags
+    assert reparsed_old.shortsha == old.shortsha
+    assert reparsed_old.revision.primary is None
+    assert reparsed_old.revision.secondary is None
+    assert reparsed_old.revision.tertiary is None
+
+
+def test_padded_old_get_device_info() -> None:
+    """A device info with contentless bytes in revision place should parse."""
+    old = payloads._DeviceInfoResponsePayloadBase(
+        version=utils.UInt32Field(0x11223344),
+        flags=fields.VersionFlagsField(0x55667788),
+        shortsha=fields.FirmwareShortSHADataField(b"abcdef1"),
+    )
+    old.message_index = utils.UInt32Field(0)
+    ser = old.serialize() + b"\x00\x00\x00\x00\x00\x00"
+    reparsed_old = payloads.DeviceInfoResponsePayload.build(ser)
+    assert reparsed_old.version == old.version
+    assert reparsed_old.flags == old.flags
+    assert reparsed_old.shortsha == old.shortsha
+    assert reparsed_old.revision.primary is None
+    assert reparsed_old.revision.secondary is None
+    assert reparsed_old.revision.tertiary is None
+
+
+def test_new_get_device_info() -> None:
+    """A device info with a filled-out revision field should parse."""
+    new = payloads.DeviceInfoResponsePayload(
+        version=utils.UInt32Field(0x11223344),
+        flags=fields.VersionFlagsField(0x55667788),
+        shortsha=fields.FirmwareShortSHADataField(b"abcdef1"),
+        revision=fields.OptionalRevisionField.build(b"a1\x00\x00"),
+    )
+    new.message_index = utils.UInt32Field(0)
+    ser = new.serialize()
+    reparsed_new = payloads.DeviceInfoResponsePayload.build(ser)
+    assert reparsed_new.version == new.version
+    assert reparsed_new.flags == new.flags
+    assert reparsed_new.shortsha == new.shortsha
+    assert reparsed_new.revision.primary == new.revision.primary
+    assert reparsed_new.revision.secondary == new.revision.secondary
+    assert reparsed_new.revision.tertiary == new.revision.tertiary

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -46,7 +46,7 @@ def test_old_get_device_info() -> None:
     old = payloads._DeviceInfoResponsePayloadBase(
         version=utils.UInt32Field(0x11223344),
         flags=fields.VersionFlagsField(0x55667788),
-        shortsha=fields.FirmwareShortSHADataField(b"abcdef1"),
+        shortsha=fields.FirmwareShortSHADataField(b"abcdef12"),
     )
     old.message_index = utils.UInt32Field(0)
     ser = old.serialize()
@@ -64,7 +64,7 @@ def test_padded_old_get_device_info() -> None:
     old = payloads._DeviceInfoResponsePayloadBase(
         version=utils.UInt32Field(0x11223344),
         flags=fields.VersionFlagsField(0x55667788),
-        shortsha=fields.FirmwareShortSHADataField(b"abcdef1"),
+        shortsha=fields.FirmwareShortSHADataField(b"abcdef12"),
     )
     old.message_index = utils.UInt32Field(0)
     ser = old.serialize() + b"\x00\x00\x00\x00\x00\x00"
@@ -82,7 +82,7 @@ def test_new_get_device_info() -> None:
     new = payloads.DeviceInfoResponsePayload(
         version=utils.UInt32Field(0x11223344),
         flags=fields.VersionFlagsField(0x55667788),
-        shortsha=fields.FirmwareShortSHADataField(b"abcdef1"),
+        shortsha=fields.FirmwareShortSHADataField(b"abcdef12"),
         revision=fields.OptionalRevisionField.build(b"a1\x00\x00"),
     )
     new.message_index = utils.UInt32Field(0)

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -38,6 +38,7 @@ async def test_messaging(
                     version=UInt32Field(0),
                     flags=fields.VersionFlagsField(0),
                     shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
+                    revision=fields.OptionalRevisionField.build(b""),
                 )
             )
             can_message_notifier.notify(
@@ -86,6 +87,7 @@ async def test_retry(
                 version=UInt32Field(0),
                 flags=fields.VersionFlagsField(0),
                 shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
+                revision=fields.OptionalRevisionField.build(b""),
             )
         ),
         None,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -57,6 +57,7 @@ class MockStatusResponder:
                         version=utils.UInt32Field(0),
                         flags=fields.VersionFlagsField(0),
                         shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
+                        revision=fields.OptionalRevisionField.build(b""),
                     )
                 )
                 asyncio.get_running_loop().call_soon(


### PR DESCRIPTION
DeviceInfo now has (or will have) revision information, but at least some devices - DVT bootloaders - will not have, and can never have, revision information. That means we need to tolerate messages that don't have that data, whether they express it as 0s or as cutting off early.

Add the new data; add the handling for not having the data; and add it within the framework of our lovely payload dataclasses, which is a little awkward.

Also, we are and always have been sending 8 bytes of git sha, so adjust the python to match.

This can be merged in any order relative to https://github.com/Opentrons/ot3-firmware/pull/567 because current behavior in python is to ignore extra data in a CAN message, so if you run a firmware that sends its revision without this PR the revision will be gracefully ignored; but it is necessary to properly read the data from https://github.com/Opentrons/ot3-firmware/pull/567

Closes RET-1321

## Test Plan
- [x] Check that it still parses responses without the revision data (any current firmware)
- [x] Check that it parses responses with revision data (need a firmware branch for this)