### PR TITLE
docs(api): Officially remove the `height` parameter of `MagneticModuleContext.engage()`

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -243,7 +243,6 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
-- The ``height`` parameter of :py:meth:`.MagneticModuleContext.engage` will be deprecated. Use ``offset`` or ``height_from_base`` instead.
 - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` will be deprecated. Configure your pipettes pick-up settings with the Opentrons App, instead.
 - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
     - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
@@ -252,3 +251,4 @@ Upcoming, not yet released.
     - The ``model`` and ``type`` properties of this interface will be replaced by :py:meth:`.ModuleContext.model` and :py:meth:`.ModuleContext.type`, respectively
 - :py:meth:`.ProtocolContext.load_labware` will favor loading custom labware over Opentrons defaults if a name shadows a default and no namespace is included.
  - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well instead of on the edge closest to the front of the machine.
+ 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -243,6 +243,7 @@ Upcoming, not yet released.
 - :py:class:`.Labware` and :py:class:`.Well` objects will adhere to the protocol's API level setting. Prior to this version, they incorrectly ignore the setting.
 - :py:meth:`.ModuleContext.load_labware_object` will be deprecated.
 - :py:meth:`.MagneticModuleContext.calibrate` will be deprecated.
+- The ``height`` parameter of :py:meth:`.MagneticModuleContext.engage` will be deprecated. Use ``offset`` or ``height_from_base`` instead.
 - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` will be deprecated. Configure your pipettes pick-up settings with the Opentrons App, instead.
 - Several internal properties of :py:class:`.Labware`, :py:class:`.Well`, and :py:class:`.ModuleContext` will be deprecated and/or removed:
     - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration``, which are holdovers from a calibration system that no longer exists.
@@ -251,4 +252,3 @@ Upcoming, not yet released.
     - The ``model`` and ``type`` properties of this interface will be replaced by :py:meth:`.ModuleContext.model` and :py:meth:`.ModuleContext.type`, respectively
 - :py:meth:`.ProtocolContext.load_labware` will favor loading custom labware over Opentrons defaults if a name shadows a default and no namespace is included.
  - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well instead of on the edge closest to the front of the machine.
- 

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -24,6 +24,7 @@ from opentrons.protocol_engine.errors.exceptions import (
 )
 
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import APIVersionError
 
 from ..module import (
     AbstractModuleCore,
@@ -142,8 +143,11 @@ class MagneticModuleCore(ModuleCore, AbstractMagneticModuleCore):
             height_from_home: Distance from motor home position to raise the magnets.
         """
         if height_from_home is not None:
-            raise NotImplementedError(
-                "MagneticModuleCore.engage with height_from_home not implemented"
+            # This code path should only be reachable if a Python protocol does
+            # `magnetic_module.engage(height=<...>)`.
+            raise APIVersionError(
+                "The `height` parameter of MagneticModuleContext.engage() was removed in"
+                " apiLevel 2.14. Use `offset` or `height_from_base` instead."
             )
 
         assert height_from_base is not None, "Expected engage height"

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -146,8 +146,8 @@ class MagneticModuleCore(ModuleCore, AbstractMagneticModuleCore):
             # This code path should only be reachable if a Python protocol does
             # `magnetic_module.engage(height=<...>)`.
             raise APIVersionError(
-                "The `height` parameter of MagneticModuleContext.engage() was removed in"
-                " apiLevel 2.14. Use `offset` or `height_from_base` instead."
+                "The height parameter of MagneticModuleContext.engage() was removed in"
+                " apiLevel 2.14. Use offset or height_from_base instead."
             )
 
         assert height_from_base is not None, "Expected engage height"

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -24,7 +24,6 @@ from opentrons.protocol_engine.errors.exceptions import (
 )
 
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.api_support.util import APIVersionError
 
 from ..module import (
     AbstractModuleCore,
@@ -142,15 +141,16 @@ class MagneticModuleCore(ModuleCore, AbstractMagneticModuleCore):
             height_from_base: Distance from labware base to raise the magnets.
             height_from_home: Distance from motor home position to raise the magnets.
         """
-        if height_from_home is not None:
-            # This code path should only be reachable if a Python protocol does
-            # `magnetic_module.engage(height=<...>)`.
-            raise APIVersionError(
-                "The height parameter of MagneticModuleContext.engage() was removed in"
-                " apiLevel 2.14. Use offset or height_from_base instead."
-            )
 
-        assert height_from_base is not None, "Expected engage height"
+        # This core will only be used in apiLevels >=2.14, where
+        # MagneticModuleContext.engage(height=...) is no longer available.
+        # So these asserts should always pass.
+        assert (
+            height_from_home is None
+        ), "Expected engage height to be specified from base."
+        assert (
+            height_from_base is not None
+        ), "Expected engage height to be specified from base."
 
         self._engine_client.magnetic_module_engage(
             module_id=self._module_id, engage_height=height_from_base

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -380,6 +380,8 @@ class MagneticModuleContext(ModuleContext):
 
              This is the recommended way to adjust the magnets' height.
 
+             .. versionadded:: 2.2
+
            - ``offset`` – Move this many millimeters above (positive value) or below
              (negative value) the default height for the loaded labware. The sum of
              the default height and ``offset`` must be between 0 and 25.
@@ -389,13 +391,11 @@ class MagneticModuleContext(ModuleContext):
              labware, this may produce unpredictable results. You should normally use
              ``height_from_base`` instead.
 
-             This parameter may be deprecated in a future release of the Python API.
+             .. versionchanged:: 2.14
+                This parameter has been removed.
 
         You shouldn't specify more than one of these parameters. However, if you do,
         their order of precedence is ``height``, then ``height_from_base``, then ``offset``.
-
-        .. versionadded:: 2.2
-            The *height_from_base* parameter.
         """
         if height is not None:
             self._core.engage(height_from_home=height)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -37,6 +37,9 @@ from . import validation
 ENGAGE_HEIGHT_UNIT_CNV = 2
 
 
+_MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN = APIVersion(2, 14)
+
+
 _log = logging.getLogger(__name__)
 
 
@@ -398,6 +401,12 @@ class MagneticModuleContext(ModuleContext):
         their order of precedence is ``height``, then ``height_from_base``, then ``offset``.
         """
         if height is not None:
+            if self._api_version >= _MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN:
+                raise APIVersionError(
+                    "The height parameter of MagneticModuleContext.engage() was removed"
+                    " in {_MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN}."
+                    " Use offset or height_from_base instead."
+                )
             self._core.engage(height_from_home=height)
 
         # This version check has a bug:

--- a/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
@@ -6,6 +6,8 @@ from opentrons.hardware_control import SynchronousAdapter
 from opentrons.hardware_control.modules import MagDeck
 from opentrons.hardware_control.modules.types import MagneticStatus, ModuleType
 
+from opentrons.protocols.api_support.util import APIVersionError
+
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocol_engine.types import ModuleModel
 
@@ -67,8 +69,8 @@ def test_create(
 def test_engage_from_home_raises_exception(
     decoy: Decoy, subject: MagneticModuleCore, mock_engine_client: EngineClient
 ) -> None:
-    """Should raise a not implemented error."""
-    with pytest.raises(NotImplementedError):
+    """Should raise a descriptive error."""
+    with pytest.raises(APIVersionError):
         subject.engage(height_from_home=7.0)
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
@@ -65,15 +65,6 @@ def test_create(
     assert result.module_id == "1234"
     assert result.MODULE_TYPE == ModuleType.MAGNETIC
 
-
-def test_engage_from_home_raises_exception(
-    decoy: Decoy, subject: MagneticModuleCore, mock_engine_client: EngineClient
-) -> None:
-    """Should raise a descriptive error."""
-    with pytest.raises(APIVersionError):
-        subject.engage(height_from_home=7.0)
-
-
 def test_engage_from_base(
     decoy: Decoy, subject: MagneticModuleCore, mock_engine_client: EngineClient
 ) -> None:

--- a/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
@@ -6,8 +6,6 @@ from opentrons.hardware_control import SynchronousAdapter
 from opentrons.hardware_control.modules import MagDeck
 from opentrons.hardware_control.modules.types import MagneticStatus, ModuleType
 
-from opentrons.protocols.api_support.util import APIVersionError
-
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocol_engine.types import ModuleModel
 
@@ -64,6 +62,7 @@ def test_create(
 
     assert result.module_id == "1234"
     assert result.MODULE_TYPE == ModuleType.MAGNETIC
+
 
 def test_engage_from_base(
     decoy: Decoy, subject: MagneticModuleCore, mock_engine_client: EngineClient


### PR DESCRIPTION
# Overview

`magnetic_module.engage(height=...)` has long been discouraged in favor of `.engage(height_from_base=...)`.

In our current implementation of PAPIv2.14, using `height=...` raises a `NotImplementedError`. I'm surmising that at this point, we have no intention of supporting `height=...` in PAPIv2.14. So, this PR formally removes it.

This work is while I'm in the neighborhood for RCORE-539.

# Changelog

* Update the docs so they say the `height` parameter was removed in PAPIv2.14, instead of "will be deprecated in a future release."
* If someone tries to use the `height` parameter in PAPIv2.14, make sure it raises `APIVersionError` instead of `NotImplementedError`.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->


# Review requests

Have I correctly surmised our intent for the PAPIv2.14 release? Is this the correct thing for us to do?

# Risk assessment

Low.
