### PR TITLE
test(api): speed up ot3 hardware controller tests

### DIFF
--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -710,16 +710,20 @@ async def test_set_run_current(
     expected_call: List[Any],
 ):
     with patch(
-        "opentrons.hardware_control.backends.ot3controller.set_run_current",
-        spec=current_settings.set_run_current,
-    ) as mocked_currents:
-        await mock_present_nodes.update_to_default_current_settings(gantry_load)
-        await mock_present_nodes.set_active_current(active_current)
-        mocked_currents.assert_called_once_with(
-            mocked_currents.call_args_list[0][0][0],
-            expected_call[0],
-            use_tip_motor_message_for=expected_call[1],
-        )
+        "opentrons.hardware_control.backends.ot3controller.set_currents",
+        spec=current_settings.set_currents,
+    ):
+        with patch(
+            "opentrons.hardware_control.backends.ot3controller.set_run_current",
+            spec=current_settings.set_run_current,
+        ) as mocked_currents:
+            await mock_present_nodes.update_to_default_current_settings(gantry_load)
+            await mock_present_nodes.set_active_current(active_current)
+            mocked_currents.assert_called_once_with(
+                mocked_currents.call_args_list[0][0][0],
+                expected_call[0],
+                use_tip_motor_message_for=expected_call[1],
+            )
 
 
 @pytest.mark.parametrize(
@@ -744,16 +748,20 @@ async def test_set_hold_current(
     expected_call: List[Any],
 ):
     with patch(
-        "opentrons.hardware_control.backends.ot3controller.set_hold_current",
-        spec=current_settings.set_hold_current,
-    ) as mocked_currents:
-        await mock_present_nodes.update_to_default_current_settings(gantry_load)
-        await mock_present_nodes.set_hold_current(hold_current)
-        mocked_currents.assert_called_once_with(
-            mocked_currents.call_args_list[0][0][0],
-            expected_call[0],
-            use_tip_motor_message_for=expected_call[1],
-        )
+        "opentrons.hardware_control.backends.ot3controller.set_currents",
+        spec=current_settings.set_currents,
+    ):
+        with patch(
+            "opentrons.hardware_control.backends.ot3controller.set_hold_current",
+            spec=current_settings.set_hold_current,
+        ) as mocked_currents:
+            await mock_present_nodes.update_to_default_current_settings(gantry_load)
+            await mock_present_nodes.set_hold_current(hold_current)
+            mocked_currents.assert_called_once_with(
+                mocked_currents.call_args_list[0][0][0],
+                expected_call[0],
+                use_tip_motor_message_for=expected_call[1],
+            )
 
 
 async def test_update_required_flag(


### PR DESCRIPTION

# Overview

There are a few issues with the OT-3 hardware controller backend tests, but two tests in particular were taking >20s per parametrization to run. By mocking out one of the backend functions (which is already mocked out in other tests), we can speed up these tests from >20s to around 1 second. On my local machine, this knocks the overall time for the file from ~2:30 to ~1:10.

These tests (and possibly `ot3controller.py`) need more attention! This is just to speed up some extremely slow tests in the short term.

# Test Plan

Just make sure CI passes.

# Changelog

- Mocked out `set_currents` in `test_set_run_current` and `test_set_hold_current`


# Risk assessment

Low, just tests.
