### PR TITLE
feat(system-server): add persistent UUID generation

### DIFF
--- a/system-server/system_server/persistence/__init__.py
+++ b/system-server/system_server/persistence/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from fastapi import Depends
 from typing_extensions import Final
 import sqlalchemy
-
+from asyncio import Lock
 
 from .database import create_sql_engine
 from .tables import registration_table, migration_table
@@ -22,28 +22,33 @@ _DATABASE_FILE: Final = "system_server.db"
 _log = logging.getLogger(__name__)
 
 
+_persistence_dir_lock = Lock()
+_sql_lock = Lock()
+
+
 async def get_persistence_directory(
     app_state: AppState = Depends(get_app_state),
 ) -> Path:
     """Return the root persistence directory, creating it if necessary."""
-    persistence_dir = _persistence_directory_accessor.get_from(app_state)
+    async with _persistence_dir_lock:
+        persistence_dir = _persistence_directory_accessor.get_from(app_state)
 
-    if persistence_dir is None:
-        setting = get_settings().persistence_directory
+        if persistence_dir is None:
+            setting = get_settings().persistence_directory
 
-        # There is no appropriate default to this setting, so raise an
-        # exception and bail if it isn't specified.
-        if setting is None:
-            raise RuntimeError(
-                "No persistence path was specified.\n"
-                "Configure a persistence path with OT_SYSTEM_SERVER_persistence_directory"
+            # There is no appropriate default to this setting, so raise an
+            # exception and bail if it isn't specified.
+            if setting is None:
+                raise RuntimeError(
+                    "No persistence path was specified.\n"
+                    "Configure a persistence path with OT_SYSTEM_SERVER_persistence_directory"
+                )
+            persistence_dir = await create_persistent_directory(
+                None if setting == "automatically_make_temporary" else Path(setting)
             )
-        persistence_dir = await create_persistent_directory(
-            None if setting == "automatically_make_temporary" else Path(setting)
-        )
-        _persistence_directory_accessor.set_on(app_state, persistence_dir)
+            _persistence_directory_accessor.set_on(app_state, persistence_dir)
 
-    return persistence_dir
+        return persistence_dir
 
 
 async def get_sql_engine(
@@ -51,17 +56,18 @@ async def get_sql_engine(
     persistence_directory: Path = Depends(get_persistence_directory),
 ) -> sqlalchemy.engine.Engine:
     """Return a singleton SQL engine referring to a ready-to-use database."""
-    sql_engine = _sql_engine_accessor.get_from(app_state)
+    async with _sql_lock:
+        sql_engine = _sql_engine_accessor.get_from(app_state)
 
-    if sql_engine is None:
-        sql_engine = create_sql_engine(persistence_directory / _DATABASE_FILE)
-        _sql_engine_accessor.set_on(app_state, sql_engine)
+        if sql_engine is None:
+            sql_engine = create_sql_engine(persistence_directory / _DATABASE_FILE)
+            _sql_engine_accessor.set_on(app_state, sql_engine)
 
-    return sql_engine
-    # Rely on connections being cleaned up automatically when the process dies.
-    # FastAPI doesn't give us a convenient way to properly tie
-    # the lifetime of a dependency to the lifetime of the server app.
-    # https://github.com/tiangolo/fastapi/issues/617
+        return sql_engine
+        # Rely on connections being cleaned up automatically when the process dies.
+        # FastAPI doesn't give us a convenient way to properly tie
+        # the lifetime of a dependency to the lifetime of the server app.
+        # https://github.com/tiangolo/fastapi/issues/617
 
 
 __all__ = [

--- a/system-server/system_server/persistence/system_uuid.py
+++ b/system-server/system_server/persistence/system_uuid.py
@@ -1,0 +1,11 @@
+"""Generates a UUID in the persistence directory."""
+from uuid import UUID, uuid4
+from pathlib import Path
+
+
+async def get_system_uuid(path: Path) -> UUID:
+    """Get a saved UUID if it exists, or create a new one."""
+    if not path.exists():
+        path.write_bytes(data=uuid4().bytes)
+
+    return UUID(bytes=path.read_bytes())

--- a/system-server/system_server/router.py
+++ b/system-server/system_server/router.py
@@ -17,7 +17,7 @@ router = APIRouter()
 )
 async def refresh_system_db(
     sql: sqlalchemy.engine.Engine = Depends(get_sql_engine),
-    uuid: UUID = Depends(get_uuid)
+    uuid: UUID = Depends(get_uuid),
 ) -> responses.PlainTextResponse:
     """Silly fake endpoint to refresh our database."""
     return responses.PlainTextResponse(f"OK: {uuid}\n")

--- a/system-server/system_server/router.py
+++ b/system-server/system_server/router.py
@@ -1,7 +1,8 @@
 """Application routes."""
 from fastapi import APIRouter, Depends, responses
-from system_server.persistence import get_sql_engine
+from system_server.persistence import get_sql_engine, get_uuid
 import sqlalchemy
+from uuid import UUID
 
 router = APIRouter()
 
@@ -16,6 +17,7 @@ router = APIRouter()
 )
 async def refresh_system_db(
     sql: sqlalchemy.engine.Engine = Depends(get_sql_engine),
+    uuid: UUID = Depends(get_uuid)
 ) -> responses.PlainTextResponse:
     """Silly fake endpoint to refresh our database."""
-    return responses.PlainTextResponse("OK")
+    return responses.PlainTextResponse(f"OK: {uuid}\n")

--- a/system-server/tests/persistence/test_persistent_generation.py
+++ b/system-server/tests/persistence/test_persistent_generation.py
@@ -5,6 +5,7 @@ import os
 
 from system_server.persistence import (
     get_sql_engine,
+    get_uuid,
 )
 from system_server.persistence.persistent_directory import create_persistent_directory
 
@@ -46,3 +47,17 @@ async def test_persistent_directory_generation(tmpdir: Path) -> None:
     temp = await create_persistent_directory(None)
     assert temp.exists()
     assert str(temp).find("opentrons-system-server") > -1
+
+
+async def test_uuid_generation_on_init(tmpdir: Path) -> None:
+    """Test that the UUID is only created if it doesn't exist."""
+    app = FastAPI()
+
+    uuid = await get_uuid(app.state, Path(tmpdir))
+    expected = Path(tmpdir / "system_server_uuid")
+    assert expected.exists()
+
+    # Test that the old UUID is returned from app state
+    os.remove(str(expected))
+    assert uuid == await get_uuid(app.state, Path(tmpdir))
+    assert not expected.exists()

--- a/system-server/tests/persistence/test_uuid.py
+++ b/system-server/tests/persistence/test_uuid.py
@@ -1,0 +1,34 @@
+from system_server.persistence.system_uuid import get_system_uuid
+from pathlib import Path
+from uuid import UUID, uuid4
+
+
+async def test_get_new_uuid(tmpdir: Path) -> None:
+    """Case where no UUID exists."""
+    path = Path(tmpdir / "test_file")
+
+    uuid = await get_system_uuid(path)
+
+    assert path.read_bytes() == uuid.bytes
+
+    # Confirm that the generated UUID is a valid UUID4 value
+    uuid_check = UUID(bytes=path.read_bytes())
+    assert uuid_check.version == 4
+
+
+async def test_get_previous_uuid(tmpdir: Path) -> None:
+    """Case where a UUID exists."""
+    path = Path(tmpdir / "test_file")
+
+    expected = uuid4()
+
+    with open(path, "xb") as file:
+        file.write(expected.bytes)
+
+    result = await get_system_uuid(path)
+
+    assert result == expected
+
+    # Double check that nothing got written to the file!
+    with open(path, "rb") as file:
+        assert file.read() == expected.bytes


### PR DESCRIPTION

# Overview

This PR adds functionality for the system server to generate a persistent UUID. This will be used in future functionality as the key to sign JWT's for registration.

The UUID is saved as a binary file in the persistence directory (`/var/lib/opentrons-system-server` on all robots).

# Test Plan

Tested on an OT-2:

- Run `curl -X 'PUT' 'localhost:32950/system/refresh'`, got a UUID back in the message body.
- Ran it again, got the same UUID
- Checked that `/var/lib/opentrons-system-server/system_server_uuid` exists
- `systemctl restart opentrons-system-server`, then ran the `curl` command again and got the same UUID


# Changelog

- Added persistent UUID generation
- Added async locks on all persistent generation code to provide protection against possible resource duplication
- Added a dependency on the UUID for the placeholder `/system/refresh` endpoint for testing purposes

# Review requests


# Risk assessment

Low