### PR TITLE
chore(hardware): Remove docstring content checks

### DIFF
--- a/hardware/.flake8
+++ b/hardware/.flake8
@@ -12,6 +12,15 @@ extend-ignore =
     # do not require type annotations for self nor cls
     ANN101,
     ANN102
+    # do not grammar pedant me any more
+    D400,
+    D401,
+    D403,
+    D404,
+    D415,
+    # there's no need to mandate docstrings in like __add__ (note that __init__
+    # is covered separately by D107)
+    D105,
 
 # configure flake8-docstrings
 # https://pypi.org/project/flake8-docstrings/


### PR DESCRIPTION
These were mostly annoying and entirely surface level and trip up so many PRs and who cares.

The removed ones are


D400 | First line should end with a period
D401 | First line should be in imperative mood
D401 | First line should be in imperative mood; try rephrasing
D403 | First word of the first line should be properly capitalized
D404 | First word of the docstring should not be This
D415 | First line should end with a period, question mark, or exclamation point
D105 | Missing docstring in magic method




