### PR TITLE
refactor(hardware): Update appropriate revision

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -235,13 +235,10 @@ class OT3Controller:
 
         log.info("Firmware updates are available.")
         self.update_required = True
-        update_details = {
-            node_id: str(update.filepath)
-            for node_id, update in firmware_updates.items()
-        }
+
         updater = firmware_update.RunUpdate(
             messenger=self._messenger,
-            update_details=update_details,
+            update_details=firmware_updates,
             retry_count=3,
             timeout_seconds=20,
             erase=True,

--- a/hardware/opentrons_hardware/firmware_update/utils.py
+++ b/hardware/opentrons_hardware/firmware_update/utils.py
@@ -2,18 +2,46 @@
 
 
 from dataclasses import dataclass
+from typing_extensions import Final
 from enum import Enum
 import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Union
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Set,
+    Union,
+    Tuple,
+    Iterable,
+    Iterator,
+)
 from opentrons_hardware.firmware_bindings.constants import NodeId, PipetteType
-
 from opentrons_hardware.hardware_control.network import DeviceInfoCache
 
 
-_FIRMWARE_MANIFEST_PATH = os.path.abspath("/usr/lib/firmware/opentrons-firmware.json")
+_FIRMWARE_MANIFEST_PATH: Final = os.path.abspath(
+    "/usr/lib/firmware/opentrons-firmware.json"
+)
+
+_DEFAULT_PCBA_REVS: Final[Dict[NodeId, str]] = {
+    NodeId.head: "c2",
+    NodeId.head_bootloader: "c2",
+    NodeId.gantry_x: "c1",
+    NodeId.gantry_x_bootloader: "c1",
+    NodeId.gantry_y: "c1",
+    NodeId.gantry_y_bootloader: "c1",
+    NodeId.gripper: "c1",
+    NodeId.gripper_bootloader: "c1",
+}
+
+_DEFAULT_PCBA_REVS_PIPETTE: Final[Dict[PipetteType, str]] = {
+    PipetteType.pipette_single: "c2",
+    PipetteType.pipette_multi: "c2",
+    PipetteType.pipette_96: "c1",
+}
 
 log = logging.getLogger(__name__)
 
@@ -72,14 +100,12 @@ class UpdateInfo:
         version: int,
         shortsha: str,
         files_by_revision: Dict[str, str],
-        filepath: Optional[str] = None,
     ) -> None:
         """Constructor."""
         self.update_type = update_type
         self.version = version
         self.shortsha = shortsha
         self.files_by_revision = files_by_revision
-        self.filepath = filepath
 
     def __repr__(self) -> str:
         """Readable representation of class."""
@@ -136,50 +162,154 @@ def _generate_firmware_info(
         return None
 
 
+def _revision_for_core_or_gripper(device_info: DeviceInfoCache) -> str:
+    """Returns the appropriate defaulted revision for a non-pipette.
+
+    The default revision can be determined solely from the node id. This is needed
+    because PCBAs of the default revision were built before revision handling was
+    introduced, and cannot be updated because too many were made.
+    """
+    return device_info.revision.main or _DEFAULT_PCBA_REVS[device_info.node_id]
+
+
+def _revision_for_pipette(
+    pipette_type: PipetteType, device_info: DeviceInfoCache
+) -> str:
+    """Returns the appropriate defaulted revision for a pipette.
+
+    The default revision can be determined solely from the pipette type. This is
+    needed because PCBAs of the default revision were built before revision handling
+    was introduced, and cannot be updated because too many were made.
+    """
+    return device_info.revision.main or _DEFAULT_PCBA_REVS_PIPETTE[pipette_type]
+
+
+def _update_details_for_device(
+    attached_pipettes: Dict[NodeId, PipetteType],
+    version_cache: DeviceInfoCache,
+) -> Tuple[FirmwareUpdateType, str]:
+    if version_cache.node_id in attached_pipettes:
+        pipette_type = attached_pipettes[version_cache.node_id]
+        return FirmwareUpdateType.from_pipette(pipette_type), _revision_for_pipette(
+            pipette_type, version_cache
+        )
+    else:
+        return FirmwareUpdateType.from_node(
+            version_cache.node_id
+        ), _revision_for_core_or_gripper(version_cache)
+
+
+def _update_type_for_device(
+    attached_pipettes: Dict[NodeId, PipetteType],
+    version_cache: DeviceInfoCache,
+) -> Union[Tuple[FirmwareUpdateType, str], Tuple[None, None]]:
+    try:
+        update_type, revision = _update_details_for_device(
+            attached_pipettes, version_cache
+        )
+    except KeyError:
+        log.error(
+            f"Node {version_cache.node_id.name} (pipette {attached_pipettes.get(version_cache.node_id, None)}) "
+            "has no revision or default revision"
+        )
+        return None, None
+    return update_type, revision
+
+
+def _update_types_from_devices(
+    attached_pipettes: Dict[NodeId, PipetteType],
+    devices: Iterable[DeviceInfoCache],
+) -> Iterator[Tuple[DeviceInfoCache, FirmwareUpdateType, str]]:
+    for version_cache in devices:
+        log.debug(f"Checking firmware update for {version_cache.node_id.name}")
+        update_type, rev = _update_type_for_device(attached_pipettes, version_cache)
+        if not rev or not update_type:
+            continue
+        yield (version_cache, update_type, rev)
+
+
+def _devices_with_force(
+    device_info: Dict[NodeId, DeviceInfoCache], force: Set[NodeId]
+) -> Iterator[DeviceInfoCache]:
+    known_nodes = set(device_info.keys())
+    check_nodes = known_nodes.intersection(force) if force else known_nodes
+    return (device_info[node] for node in check_nodes)
+
+
+def _should_update(
+    version_cache: DeviceInfoCache,
+    update_info: UpdateInfo,
+    force: bool,
+) -> bool:
+    if force:
+        log.info(f"Update required for {version_cache.node_id} (forced)")
+        return True
+    if version_cache.shortsha != update_info.shortsha:
+        log.info(
+            f"Update required for {version_cache.node_id} (reported sha {version_cache.shortsha} != {update_info.shortsha})"
+        )
+        return True
+    log.info(
+        f"No update required for {version_cache.node_id}, sha {version_cache.shortsha} matches and not forced"
+    )
+    return False
+
+
+def _update_info_for_type(
+    known_firmware: Dict[FirmwareUpdateType, UpdateInfo],
+    update_type: Optional[FirmwareUpdateType],
+) -> Optional[UpdateInfo]:
+    # Given the update_type find the corresponding updateInfo, monadically on update_info
+    if not update_type:
+        return None
+    try:
+        update_info = known_firmware[update_type]
+    except KeyError:
+        log.error(f"No firmware update found with update type {update_type}")
+        return None
+    return update_info
+
+
+def _update_files_from_types(
+    info: Iterable[Tuple[NodeId, Dict[str, str], str]]
+) -> Iterator[Tuple[NodeId, str]]:
+    for node, files_by_revision, revision in info:
+        # if we have a force set, we always update (we're only checking nodes in the force set anyway)
+        try:
+            yield node, files_by_revision[revision]
+        except KeyError:
+            log.error(f"No available firmware for revision {revision}")
+
+
+def _info_for_required_updates(
+    force: bool,
+    known_firmware: Dict[FirmwareUpdateType, UpdateInfo],
+    details: Iterable[Tuple[DeviceInfoCache, FirmwareUpdateType, str]],
+) -> Iterator[Tuple[NodeId, Dict[str, str], str]]:
+    for version_cache, update_type, rev in details:
+        update_info = _update_info_for_type(known_firmware, update_type)
+        if not update_info:
+            continue
+        if _should_update(version_cache, update_info, force):
+            yield version_cache.node_id, update_info.files_by_revision, rev
+
+
 def check_firmware_updates(
     device_info: Dict[NodeId, DeviceInfoCache],
     attached_pipettes: Dict[NodeId, PipetteType],
     nodes: Optional[Set[NodeId]] = None,
-) -> Dict[NodeId, UpdateInfo]:
-    """Returns a dict of NodeIds that require a firmware update."""
-    nodes = nodes or set()
+) -> Dict[NodeId, str]:
+    """Returns a dict of NodeIds that require a firmware update and the path to the file to update them."""
+    forced_nodes = nodes or set()
+
     known_firmware = load_firmware_manifest()
     if known_firmware is None:
         log.error("Could not load the known firmware.")
         return
-
-    firmware_update_list: Dict[NodeId, UpdateInfo] = dict()
-    for node, version_cache in device_info.items():
-        # only check specified node if nodes are provided
-        if nodes and node not in nodes:
-            log.debug(f"Skipping unspecified node {node.name}")
-            continue
-
-        log.debug(f"Checking firmware update for {node.name}")
-        # Get the update type based on the pipette type
-        if node in attached_pipettes:
-            pipette_type = attached_pipettes[node]
-            update_type = FirmwareUpdateType.from_pipette(pipette_type)
-        else:
-            update_type = FirmwareUpdateType.from_node(node)
-        if update_type == FirmwareUpdateType.unknown:
-            log.error(f"Unknown firmware update type for {node.name}")
-            continue
-
-        # Given the update_type find the corresponding updateInfo
-        update_info = known_firmware.get(update_type)
-        if not update_info:
-            log.warning(f"No firmware update found for {node.name}")
-            continue
-
-        # force the update if this is node was specified
-        force = node in nodes
-        if force or version_cache.shortsha != update_info.shortsha:
-            log.info(
-                f"Subsystem {node.name} requires an update, device sha: {version_cache.shortsha} != update sha: {update_info.shortsha}"
-            )
-            # TODO (BA, 02/03/2022): Get the filepath based on the revision once we add it to GetDeviceInfoResponse.
-            # For now just select rev1.
-            update_info.filepath = update_info.files_by_revision["rev1"]
-            firmware_update_list[node] = update_info
-    return firmware_update_list
+    devices_to_check = _devices_with_force(device_info, forced_nodes)
+    update_types = _update_types_from_devices(attached_pipettes, devices_to_check)
+    update_info = _info_for_required_updates(
+        bool(forced_nodes), known_firmware, update_types
+    )
+    update_files = _update_files_from_types(update_info)
+    return {node: filepath for node, filepath in update_files}

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -3,6 +3,7 @@ import asyncio
 from dataclasses import dataclass
 import logging
 from typing import Any, Dict, Set, Optional, Union
+from .types import PCBARevision
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.drivers.can_bus.can_messenger import (
@@ -25,6 +26,7 @@ class DeviceInfoCache:
     version: int
     shortsha: str
     flags: Any
+    revision: PCBARevision
 
     def __repr__(self) -> str:
         """Readable representation of the device info."""
@@ -123,6 +125,9 @@ def _parse_device_info_response(
                 version=int(message.payload.version.value),
                 shortsha=message.payload.shortsha.value.decode(),
                 flags=message.payload.flags.value,
+                revision=PCBARevision(
+                    message.payload.revision.revision, message.payload.revision.tertiary
+                ),
             )
         except (ValueError, UnicodeDecodeError) as e:
             log.error(f"Could not parse DeviceInfoResponse {e}")

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -1,5 +1,6 @@
 """Types and definitions for hardware bindings."""
-from typing import Mapping, TypeVar, Dict, List
+from typing import Mapping, TypeVar, Dict, List, Optional
+from dataclasses import dataclass
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
 
@@ -10,3 +11,13 @@ NodeMap = Mapping[NodeId, MapPayload]
 NodeList = List[NodeId]
 
 NodeDict = Dict[NodeId, MapPayload]
+
+
+@dataclass
+class PCBARevision:
+    """The electrical revision of a PCBA."""
+
+    main: Optional[str]
+    #: A combination of primary and secondary used for looking up firmware
+    tertiary: Optional[str] = None
+    #: An often-not-present tertiary

--- a/hardware/tests/opentrons_hardware/drivers/can_bus/test_driver.py
+++ b/hardware/tests/opentrons_hardware/drivers/can_bus/test_driver.py
@@ -14,6 +14,7 @@ def bus_channel() -> str:
     return "test_channel"
 
 
+@pytest.mark.slow
 @pytest.fixture
 def can_bus(bus_channel: str) -> Bus:
     """A virtual can bus fixture."""

--- a/hardware/tests/opentrons_hardware/firmware_update/test_utils.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_utils.py
@@ -7,13 +7,18 @@ import secrets
 from typing import Any, Dict, Optional
 import mock
 import pytest
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId, PipetteType
+from opentrons_hardware.hardware_control.types import PCBARevision
 
 from opentrons_hardware.firmware_update.utils import (
     FirmwareUpdateType,
     UpdateInfo,
     load_firmware_manifest,
     check_firmware_updates,
+    _DEFAULT_PCBA_REVS,
+    _DEFAULT_PCBA_REVS_PIPETTE,
+    _update_type_for_device,
+    _update_files_from_types,
 )
 from opentrons_hardware.hardware_control.network import DeviceInfoCache
 
@@ -30,14 +35,16 @@ def mock_manifest() -> Dict[str, Any]:
             "head": {
                 "version": 2,
                 "shortsha": "25755efd",
-                "files_by_revision": {"rev1": "head-rev1.hex"},
+                "files_by_revision": {"c1": "head-c1.hex"},
             }
         },
     }
 
 
 def generate_device_info(
-    manifest: Dict[str, Any], random_sha: Optional[bool] = False
+    manifest: Dict[str, Any],
+    random_sha: Optional[bool] = False,
+    revision: Optional[str] = "c1",
 ) -> Dict[NodeId, DeviceInfoCache]:
     """Helper function to generate device info."""
     device_info_cache: Dict[NodeId, DeviceInfoCache] = {}
@@ -46,7 +53,11 @@ def generate_device_info(
         version = info["version"]
         shortsha = secrets.token_hex(4) if random_sha else info["shortsha"]
         device_info_cache.update(
-            {node_id: DeviceInfoCache(node_id, version, shortsha, None)}
+            {
+                node_id: DeviceInfoCache(
+                    node_id, version, shortsha, None, PCBARevision(revision, None)
+                )
+            }
         )
     return device_info_cache
 
@@ -65,6 +76,85 @@ def generate_update_info(
             {update_type: UpdateInfo(update_type, version, shortsha, files_by_revision)}
         )
     return update_info
+
+
+@pytest.mark.parametrize("node", list(NodeId))
+def all_nodes_covered_by_defaults(node: NodeId) -> None:
+    """Every non-pipette node should have a default for its node id and bootloader."""
+    assert node in _DEFAULT_PCBA_REVS or "pipette" in node.name
+
+
+@pytest.mark.parametrize("pipette_type", list(PipetteType))
+def all_pipette_types_covered_by_defaults(pipette: PipetteType) -> None:
+    """Every pipette type should have a default for its pipette type."""
+    assert pipette in _DEFAULT_PCBA_REVS_PIPETTE
+
+
+@pytest.mark.parametrize(
+    "node,default_rev",
+    [(node, default_rev) for node, default_rev in _DEFAULT_PCBA_REVS.items()],
+)
+@pytest.mark.parametrize("reported_rev", ["a1", "b2", None])
+def test_revision_defaulting_for_core(
+    node: NodeId, default_rev: str, reported_rev: Optional[str]
+) -> None:
+    """We should pass through non-default revs and default ones that are not present."""
+    _, rev = _update_type_for_device(
+        {},
+        DeviceInfoCache(node, 2, "abcdef12", None, PCBARevision(main=reported_rev)),
+    )
+    if reported_rev:
+        assert rev == reported_rev
+    else:
+        assert rev == default_rev
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        NodeId.pipette_left,
+        NodeId.pipette_left_bootloader,
+        NodeId.pipette_right,
+        NodeId.pipette_right_bootloader,
+    ],
+)
+@pytest.mark.parametrize(
+    "pipette_type,default_rev",
+    [
+        (pipette_type, default_rev)
+        for pipette_type, default_rev in _DEFAULT_PCBA_REVS_PIPETTE.items()
+    ],
+)
+@pytest.mark.parametrize("reported_rev", ["a1", "b2", None])
+def test_revision_defaulting_for_pipette(
+    node: NodeId,
+    pipette_type: PipetteType,
+    default_rev: str,
+    reported_rev: Optional[str],
+) -> None:
+    """We should pass through non-default revs and default ones that are not present."""
+    _, rev = _update_type_for_device(
+        {node: pipette_type},
+        DeviceInfoCache(node, 2, "abcdef12", None, PCBARevision(main=reported_rev)),
+    )
+    if reported_rev:
+        assert rev == reported_rev
+    else:
+        assert rev == default_rev
+
+
+def test_firmware_file_selected_for_revision() -> None:
+    """Given a device and revision, the right firmware file should be selected."""
+    stimulus = [
+        # a matching rev should be found
+        (NodeId.head, {"a1": "test-head.hex", "b1": "test-head-wrong.hex"}, "a1"),
+        # an empty revs dict should be ignored
+        (NodeId.gantry_x, {"": ""}, "a1"),
+        # a present but non matching revs dict should be ignored
+        (NodeId.gantry_y, {"b1": "test-gantry-y.hex"}, "c1"),
+    ]
+    response = list(_update_files_from_types(stimulus))
+    assert response == [(NodeId.head, "test-head.hex")]
 
 
 def test_load_firmware_manifest_success(mock_manifest: Dict[str, Any]) -> None:
@@ -175,17 +265,17 @@ def test_check_firmware_updates_available(mock_manifest: Dict[str, Any]) -> None
             "gantry-x": {
                 "version": 2,
                 "shortsha": "25755efd",
-                "files_by_revision": {"rev1": "gantry-x-rev1.hex"},
+                "files_by_revision": {"c1": "gantry-x-rev1.hex"},
             },
             "gantry-y": {
                 "version": 2,
                 "shortsha": "25755efd",
-                "files_by_revision": {"rev1": "gantry-y-rev1.hex"},
+                "files_by_revision": {"c1": "gantry-y-rev1.hex"},
             },
             "gripper": {
                 "version": 2,
                 "shortsha": "25755efd",
-                "files_by_revision": {"rev1": "gripper-rev1.hex"},
+                "files_by_revision": {"c1": "gripper-rev1.hex"},
             },
         }
     )
@@ -240,7 +330,11 @@ def test_load_firmware_manifest_is_empty(mock_manifest: Dict[str, Any]) -> None:
 
 def test_unknown_firmware_update_type(mock_manifest: Dict[str, Any]) -> None:
     """Don't do updates if the FirmwareUpdateType is unknown."""
-    device_info = {NodeId.head: DeviceInfoCache(NodeId.head, 2, "12345678", None)}
+    device_info = {
+        NodeId.head: DeviceInfoCache(
+            NodeId.head, 2, "12345678", None, PCBARevision(None)
+        )
+    }
     known_firmware_updates = generate_update_info(mock_manifest)
     known_firmware_updates.pop(FirmwareUpdateType.head)
     with mock.patch(

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -486,6 +486,7 @@ async def test_bind_to_sync(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     argnames=["sensor_type", "timeout"],
     argvalues=[
@@ -586,6 +587,7 @@ async def test_get_baseline(
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     argnames=["sensor_type", "timeout", "data_points"],
     argvalues=[
@@ -646,6 +648,7 @@ async def test_debug_poll(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     argnames=["sensor_type", "timeout"],
     argvalues=[


### PR DESCRIPTION
We have separate firmware for each revision of each device. We need to update devices with the firmware for their appropriate revision.

To that end, let's add the revision to the device info cache in the network subsystem so we can then pass it back down to the firmware update machinery and select the appropriate firmware file for the revision.

We also need to establish a map of default revisions because some devices won't have them. For instance, devices built during the DVT phase of ot-3 development were built in large numbers before we added the revision tracking to the firmware, so they won't have a revision and it's impractical to reflash them all with an ISP (since the revision is captured in the bootloader as well).

This required some refactoring in utils to keep function complexity down. Specifically, check_firmware_update was pretty complex (by mccabe complexity rules) because it was a linear series of transforms with each transform validity-checked. By turning this into a chained series of iterators and pushing down the validity into the iterators themselves, we can make each iterator independently testable.

## Testing
- [x] put this firmware on a robot, set the feature flag, and check that it updates appropriately

Closes RET-1323
