### PR TITLE
refactor(api): Improve error messages for JSONv6 and PAPIv2.14 protocols

### DIFF
--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -22,7 +22,10 @@ from .module_contexts import (
 )
 from ._liquid import Liquid
 
-from .create_protocol_context import create_protocol_context
+from .create_protocol_context import (
+    create_protocol_context,
+    ProtocolEngineCoreRequiredError,
+)
 
 __all__ = [
     "MAX_SUPPORTED_VERSION",
@@ -38,5 +41,7 @@ __all__ = [
     "Labware",
     "Well",
     "Liquid",
+    # For internal Opentrons use only:
     "create_protocol_context",
+    "ProtocolEngineCoreRequiredError",
 ]

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -31,6 +31,13 @@ from .core.legacy_simulator.legacy_protocol_core import LegacyProtocolCoreSimula
 from .core.engine import ENGINE_CORE_API_VERSION, ProtocolCore
 
 
+class ProtocolEngineCoreRequiredError(Exception):
+    """Raised when a Protocol Engine core was required, but not provided.
+
+    This can happen when creating a ProtocolContext with a high api_version.
+    """
+
+
 def create_protocol_context(
     api_version: APIVersion,
     *,
@@ -91,10 +98,10 @@ def create_protocol_context(
         labware_offset_provider = NullLabwareOffsetProvider()
 
     if api_version >= ENGINE_CORE_API_VERSION:
-        # TODO(mc, 2022-8-22): replace assertion with strict typing
-        assert (
-            protocol_engine is not None and protocol_engine_loop is not None
-        ), "ProtocolEngine PAPI core is enabled, but no ProtocolEngine given."
+        # TODO(mc, 2022-8-22): replace raise with strict typing
+        raise ProtocolEngineCoreRequiredError(
+            "ProtocolEngine PAPI core is enabled, but no ProtocolEngine given."
+        )
 
         engine_client_transport = ChildThreadTransport(
             engine=protocol_engine, loop=protocol_engine_loop

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -294,7 +294,7 @@ def bundle_from_sim(
     )
 
 
-def simulate(
+def simulate(  # noqa: C901
     protocol_file: TextIO,
     file_name: Optional[str] = None,
     custom_labware_paths: Optional[List[str]] = None,

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -13,6 +13,7 @@ from opentrons.protocols.parse import (
     API_VERSION_FOR_JSON_V5_AND_BELOW,
     MAX_SUPPORTED_JSON_SCHEMA_VERSION,
     version_from_static_python_info,
+    JSONSchemaVersionTooNewError,
 )
 from opentrons.protocols.types import (
     JsonProtocol,
@@ -344,12 +345,7 @@ def test_validate_json(get_json_protocol_fixture, get_labware_fixture):
     # valid data that has no schema should fail
     with pytest.raises(RuntimeError, match="deprecated"):
         validate_json({"protocol-schema": "1.0.0"})
-    with pytest.raises(
-        RuntimeError,
-        match="Please update your OT-2 App"
-        + " "
-        + "and robot server to the latest version and try again",
-    ):
+    with pytest.raises(JSONSchemaVersionTooNewError):
         validate_json({"schemaVersion": str(MAX_SUPPORTED_JSON_SCHEMA_VERSION + 1)})
     labware = get_labware_fixture("fixture_12_trough_v2")
     with pytest.raises(RuntimeError, match="labware"):


### PR DESCRIPTION
# Overview

The known bug RCORE-535/RESC-81 may get worse in the upcoming v6.3.0 release, because more people will be using JSONv6 protocols, and people will start using Python API v2.14 protocols.

As a stopgap, improve the error messages for anyone who runs into RCORE-535.

# Changelog

Changed error messages when you 

|        | Old                                                                                                                                                                                                   | New                                                                                                                                                                                                                                                                                     |
|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **Python** | ProtocolEngine PAPI core is enabled, but no ProtocolEngine given.                                                                                                                                     | Python protocols with apiLevels higher than 2.13 cannot currently be simulated with the opentrons_simulate command-line tool, the opentrons.simulate.simulate() function, or the opentrons.simulate.get_protocol_api() function. Use a lower apiLevel or use the Opentrons App instead. |
| **JSON**   | The protocol you are trying to open is a JSONv6 protocol and is not supported by your current robot server version. Please update your OT-2 App and robot server to the latest version and try again. | Protocols created by recent versions of Protocol Designer cannot currently be simulated with the opentrons_simulate command-line tool or the opentrons.simulate.simulate() function. Use the Opentrons App instead.                                                                     |

With variants for `opentrons_execute` et. al. instead of `opentrons_simulate`.

# Test Plan

I've smoke-tested this by manually running `opentrons_simulate` with a Python and JSON protocol.

# Review requests

Do the new error messages make sense?

# Risk assessment

Low.