### PR TITLE
chore(api): further speed up ot3controller tests and add profiling

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -37,5 +37,6 @@ opentrons = { editable = true, path = "." }
 opentrons-hardware = { editable = true, path = "./../hardware" }
 # specify typing-extensions explicitly to force lockfile inclusion on Python >= 3.8
 typing-extensions = ">=4.0.0,<5"
+pytest-profiling = "~=1.7.0"
 # TODO(mc, 2022-03-31): upgrade sphinx, remove this subdep pin
 jinja2 = ">=2.3,<3.1"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b8dba6d817c3c78688317aaaf6f0bbfcb93808b668360648e1b698f3f3edc2e0"
+            "sha256": "b5109089cd4cdbf04b421cfdd0e8d1709734ef552f882422c22bab957c3250ce"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -101,11 +101,11 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a",
-                "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"
+                "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
+                "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.0.1"
+            "version": "==6.0.0"
         },
         "certifi": {
             "hashes": [
@@ -317,6 +317,14 @@
             "index": "pypi",
             "version": "==1.2.9"
         },
+        "gprof2dot": {
+            "hashes": [
+                "sha256:45b4d298bd36608fccf9511c3fd88a773f7a1abc04d6cd39445b11ba43133ec5",
+                "sha256:f165b3851d3c52ee4915eb1bd6cca571e5759823c2cd0f71a79bda93c2dc85d6"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==2022.7.29"
+        },
         "idna": {
             "hashes": [
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
@@ -338,7 +346,7 @@
                 "sha256:8a8a81bcf996e74fee46f0d16bd3eaa382a7eb20fd82445c3ad11f4090334116",
                 "sha256:dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d"
             ],
-            "markers": "python_version < '3.10' and python_version < '3.8'",
+            "markers": "python_version < '3.10'",
             "version": "==4.13.0"
         },
         "iniconfig": {
@@ -466,10 +474,10 @@
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+                "sha256:c8b707883a96efe9b4bb3aaf0dcc07e7e217d7d8368eec4db4049ee9e142f4fd"
             ],
-            "version": "==0.4.3"
+            "markers": "python_version >= '2.7'",
+            "version": "==0.4.4"
         },
         "numpy": {
             "hashes": [
@@ -537,11 +545,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
-                "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"
+                "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+                "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.3"
+            "version": "==0.11.0"
         },
         "pkginfo": {
             "hashes": [
@@ -553,11 +561,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
-                "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
+                "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9",
+                "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.6.2"
+            "version": "==3.0.0"
         },
         "pluggy": {
             "hashes": [
@@ -715,6 +723,16 @@
             "index": "pypi",
             "version": "==0.6.3"
         },
+        "pytest-profiling": {
+            "hashes": [
+                "sha256:3b255f9db36cb2dd7536a8e7e294c612c0be7f7850a7d30754878e4315d56600",
+                "sha256:6bce4e2edc04409d2f3158c16750fab8074f62d404cc38eeb075dff7fcbb996c",
+                "sha256:93938f147662225d2b8bd5af89587b979652426a8a6ffd7e73ec4a23e24b7f29",
+                "sha256:999cc9ac94f2e528e3f5d43465da277429984a1c237ae9818f8cfd0b06acb019"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
+        },
         "pytest-xdist": {
             "hashes": [
                 "sha256:2447a1592ab41745955fb870ac7023026f20a5f0bfccf1b52a879bd193d46450",
@@ -766,7 +784,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "sniffio": {
@@ -859,7 +877,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -919,7 +937,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "markers": "python_version < '3.8' and implementation_name == 'cpython' and python_version < '3.8'",
+            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
             "version": "==1.4.3"
         },
         "typeguard": {
@@ -1049,11 +1067,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-                "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"
+                "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6",
+                "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.11.0"
+            "version": "==3.13.0"
         }
     }
 }

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -5,7 +5,6 @@ the root of the project.
 """
 import pytest
 
-
 # Options must be added at the root level for pytest to properly
 # pick them up. Technically, the main conftest that we use in
 # tests/opentrons is not the root level.

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -268,10 +268,9 @@ class ThreadManager(Generic[WrappedObj]):
                 # so cancelled tasks can have a chance to complete.
                 async def clean_and_notify() -> None:
                     await wrapped_cleanup()
-                    # this sleep allows the wrapped loop to spin a couple
-                    # times to clean up the tasks we just cancelled. My kingdom
-                    # for an asyncio.spin_once()
-                    await asyncio.sleep(0.1)
+                    # this sleep allows the wrapped loop to spin to clean up the
+                    # tasks we just cancelled.
+                    await asyncio.sleep(0)
 
                 fut = asyncio.run_coroutine_threadsafe(clean_and_notify(), wrapped_loop)
                 fut.result()

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -102,7 +102,8 @@ def mock_driver(mock_messenger: AsyncMock) -> AbstractCanDriver:
 
 @pytest.fixture
 def controller(mock_config: OT3Config, mock_driver: AbstractCanDriver) -> OT3Controller:
-    return OT3Controller(mock_config, mock_driver)
+    with mock.patch("opentrons.hardware_control.backends.ot3controller.OT3GPIO"):
+        yield OT3Controller(mock_config, mock_driver)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -50,7 +50,7 @@ def emulation_app(emulator_settings: Settings) -> Iterator[None]:
         c = await ModuleStatusClient.connect(
             host="localhost",
             port=emulator_settings.module_server.port,
-            interval_seconds=1,
+            interval_seconds=0.1,
         )
         await wait_emulators(client=c, modules=modules, timeout=5)
         c.close()


### PR DESCRIPTION
Some of our tests are really slow and it's a pain to figure out why! This PR
- adds pytest-profiling ( https://pypi.org/project/pytest-profiling/ ) 
- uses its results to greatly speed up ot3controller tests

pytest-profiling is a pytest module that will automatically profile your tests for you if you
so wish. If you add --profile to your test command, it will dump out
top-ten calls by time, and it will dump more in-depth profiling data to
`prof/` which can be interpreted with the python stdlib pstats/ module.

Also, add some fixes based on findings from profiling:

## OT3 gpio sleep

The OT3 gpio drivers have a sleep(1) in their init method. This isn't
great, and will soon be removed - it was required for some nasty
interactions between estop initialization and our canbus driver when it
was initializing, and on later revs we don't need to handle the estop
line like this - but in the meantime we can patch it out.

This makes these tests take about a second in total instead of 80 seconds.

## threadmanager cleanup

In the cleanup of the thread manager, we were doing an
asyncio.sleep(0.1) to spin the loop to make sure some classes cleaned
up. Since then, we've learned that a 0-second sleep does the same thing.
Changing the 0.1 to 0 should not present any changes in behavior (and if
it does, they're in a cleanup method that is basically never run in
prod) and doubles the speed of the tests in hardware_control. it makes those
tests take 9s instead of 25s.

## Risk 
None, tests only (and no test behavior changes, either)
