### PR TITLE
fix(shared-data): remove newLocation and strategy from schemav6

### DIFF
--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -64,12 +64,6 @@ class Params(BaseModel):
     height: Optional[float]
     offset: Optional[OffsetVector]
     profile: Optional[List[ProfileStep]]
-    # TODO: remove these 'newLocation' and 'strategy' params as soon as
-    # there is moveLabware support in PAPIv2, this is only to unblock
-    # internal testing of LPC with JSON protocols that include
-    # 'moveLabware' commands in the meantime
-    newLocation: Optional[Union[Location, Literal["offDeck"]]]
-    strategy: Optional[str]
     radius: Optional[float]
 
 


### PR DESCRIPTION
Closes RLAB-179

# Overview

These params were added for internal testing. They are no longer necessary (also should not go into 6.3)

# Review requests

- just code review

# Risk assessment

None.
