### PR TITLE
feat(app): tie new calibration dashboard into protocol run calibrations

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupDeckCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupDeckCalibration.tsx
@@ -34,7 +34,7 @@ export function SetupDeckCalibration({
   )
 
   const calibrateNowButton = (
-    <Link to={`/devices/${robotName}/robot-settings/calibration`}>
+    <Link to={`/devices/${robotName}/robot-settings/calibration/dashboard`}>
       <TertiaryButton>{t('calibrate_now_cta')}</TertiaryButton>
     </Link>
   )

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { Link as RRDLink } from 'react-router-dom'
 import {
@@ -20,11 +19,7 @@ import {
   WRAP,
 } from '@opentrons/components'
 
-import { Portal } from '../../../App/portal'
 import { TertiaryButton } from '../../../atoms/buttons'
-import { useCalibratePipetteOffset } from '../../../organisms/CalibratePipetteOffset/useCalibratePipetteOffset'
-import { AskForCalibrationBlockModal } from '../../../organisms/CalibrateTipLength/AskForCalibrationBlockModal'
-import { getHasCalibrationBlock } from '../../../redux/config'
 import { Banner } from '../../../atoms/Banner'
 import * as PipetteConstants from '../../../redux/pipettes/constants'
 import { useDeckCalibrationData, useIsOT3 } from '../hooks'
@@ -49,8 +44,6 @@ export function SetupPipetteCalibrationItem({
   runId,
 }: SetupPipetteCalibrationItemProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
-  const [showCalBlockModal, setShowCalBlockModal] = React.useState(false)
-  const configHasCalibrationBlock = useSelector(getHasCalibrationBlock)
   const deviceDetailsUrl = `/devices/${robotName}`
 
   const { isDeckCalibrated } = useDeckCalibrationData(robotName)
@@ -59,28 +52,6 @@ export function SetupPipetteCalibrationItem({
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_LEFT,
   })
-
-  const [
-    startPipetteOffsetCalibration,
-    PipetteOffsetCalibrationWizard,
-  ] = useCalibratePipetteOffset(robotName, { mount })
-
-  const startPipetteOffsetCalibrationBlockModal = (
-    hasBlockModalResponse: boolean | null
-  ): void => {
-    if (hasBlockModalResponse === null && configHasCalibrationBlock === null) {
-      setShowCalBlockModal(true)
-    } else {
-      startPipetteOffsetCalibration({
-        overrideParams: {
-          hasCalibrationBlock: Boolean(
-            configHasCalibrationBlock ?? hasBlockModalResponse
-          ),
-        },
-      })
-      setShowCalBlockModal(false)
-    }
-  }
 
   let button: JSX.Element | undefined
   let subText
@@ -139,15 +110,17 @@ export function SetupPipetteCalibrationItem({
           gridGap={SPACING.spacing3}
         >
           <Flex>{pipetteMismatchInfo}</Flex>
-          <TertiaryButton
-            onClick={() => startPipetteOffsetCalibrationBlockModal(null)}
-            disabled={!isDeckCalibrated}
-            id="PipetteCalibration_calibratePipetteButton"
-            {...targetProps}
+          <RRDLink
+            to={`/devices/${robotName}/robot-settings/calibration/dashboard`}
           >
-            {t('calibrate_now_cta')}
-          </TertiaryButton>
-
+            <TertiaryButton
+              disabled={!isDeckCalibrated}
+              id="PipetteCalibration_calibratePipetteButton"
+              {...targetProps}
+            >
+              {t('calibrate_now_cta')}
+            </TertiaryButton>
+          </RRDLink>
           {!isDeckCalibrated ? (
             <Tooltip {...tooltipProps}>
               <Box width={SIZE_4}>
@@ -176,18 +149,6 @@ export function SetupPipetteCalibrationItem({
         id={`PipetteCalibration_${mount}MountTitle`}
         runId={runId}
       />
-      {PipetteOffsetCalibrationWizard}
-      {showCalBlockModal && (
-        <Portal level="top">
-          <AskForCalibrationBlockModal
-            onResponse={hasBlockModalResponse => {
-              startPipetteOffsetCalibrationBlockModal(hasBlockModalResponse)
-            }}
-            titleBarTitle={t('pipette_offset_cal')}
-            closePrompt={() => setShowCalBlockModal(false)}
-          />
-        </Portal>
-      )}
     </>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
 import {
   Box,
   Flex,
   Link,
-  SpinnerModalPage,
   Tooltip,
-  useConditionalConfirm,
   useHoverTooltip,
   ALIGN_CENTER,
   SIZE_4,
@@ -17,30 +14,20 @@ import {
   COLORS,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { useDeleteCalibrationMutation } from '@opentrons/react-api-client'
 import { getLabwareDefURI } from '@opentrons/shared-data'
 
-import { Portal } from '../../../App/portal'
 import { TertiaryButton } from '../../../atoms/buttons'
 import {
-  CalibrateTipLength,
-  ConfirmRecalibrationModal,
-} from '../../CalibrateTipLength'
-import { AskForCalibrationBlockModal } from '../../CalibrateTipLength/AskForCalibrationBlockModal'
-import { tipLengthCalibrationStarted } from '../../../redux/analytics'
-import { getHasCalibrationBlock } from '../../../redux/config'
-import * as RobotApi from '../../../redux/robot-api'
-import * as Sessions from '../../../redux/sessions'
-import { getTipLengthCalibrationSession } from '../../../redux/sessions/tip-length-calibration/selectors'
-import { useDeckCalibrationData, useRunHasStarted } from '../hooks'
+  useAttachedPipettes,
+  useDeckCalibrationData,
+  usePipetteOffsetCalibrations,
+  useRunHasStarted,
+} from '../hooks'
+import { useDashboardCalibrateTipLength } from '../../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength'
 
 import type { Mount } from '@opentrons/components'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { RequestState } from '../../../redux/robot-api/types'
-import type {
-  SessionCommandString,
-  TipLengthCalibrationSession,
-} from '../../../redux/sessions/types'
-import type { State } from '../../../redux/types'
 
 export interface SetupTipLengthCalibrationButtonProps {
   robotName: string
@@ -52,11 +39,6 @@ export interface SetupTipLengthCalibrationButtonProps {
   disabled: boolean
 }
 
-// tip length calibration commands for which the full page spinner should not appear
-const spinnerCommandBlockList: SessionCommandString[] = [
-  Sessions.sharedCalCommands.JOG,
-]
-
 export function SetupTipLengthCalibrationButton({
   robotName,
   runId,
@@ -66,109 +48,34 @@ export function SetupTipLengthCalibrationButton({
   isExtendedPipOffset,
   disabled,
 }: SetupTipLengthCalibrationButtonProps): JSX.Element {
-  const createRequestId = React.useRef<string | null>(null)
-  const trackedRequestId = React.useRef<string | null>(null)
-  const jogRequestId = React.useRef<string | null>(null)
-  const dispatch = useDispatch()
   const { t } = useTranslation(['protocol_setup', 'shared'])
 
   const { isDeckCalibrated } = useDeckCalibrationData(robotName)
+  const [
+    tipLengthCalLauncher,
+    TipLengthCalWizard,
+  ] = useDashboardCalibrateTipLength(robotName)
+  const { deleteCalibration } = useDeleteCalibrationMutation()
+  const attachedPipettes = useAttachedPipettes()
+  const offsetCalibrations = usePipetteOffsetCalibrations(robotName)
 
-  const sessionType = isExtendedPipOffset
-    ? Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
-    : Sessions.SESSION_TYPE_TIP_LENGTH_CALIBRATION
+  const offsetCalsToDelete = offsetCalibrations?.filter(
+    cal =>
+      cal.pipette === attachedPipettes[mount]?.id &&
+      cal.tiprackUri === getLabwareDefURI(tipRackDefinition)
+  )
 
-  const dispatchAnalyticsEvent = (calBlock: boolean): void => {
-    dispatch(
-      tipLengthCalibrationStarted(
-        mount,
-        calBlock,
-        getLabwareDefURI(tipRackDefinition)
-      )
-    )
-  }
-
-  const [dispatchRequests] = RobotApi.useDispatchApiRequests(
-    dispatchedAction => {
-      if (
-        dispatchedAction.type === Sessions.ENSURE_SESSION &&
-        dispatchedAction.payload.sessionType === sessionType
-      ) {
-        // @ts-expect-error TODO: account for possible absence of requestId on meta
-        createRequestId.current = dispatchedAction.meta.requestId
-      } else if (
-        dispatchedAction.type === Sessions.CREATE_SESSION_COMMAND &&
-        dispatchedAction.payload.command.command ===
-          Sessions.sharedCalCommands.JOG
-      ) {
-        // @ts-expect-error TODO: account for possible absence of requestId on meta
-        jogRequestId.current = dispatchedAction.meta.requestId
-      } else if (
-        dispatchedAction.type !== Sessions.CREATE_SESSION_COMMAND ||
-        !spinnerCommandBlockList.includes(
-          dispatchedAction.payload.command.command
-        )
-      ) {
-        // @ts-expect-error TODO: account for possible absence of meta on action, requestId on meta
-        trackedRequestId.current = dispatchedAction.meta.requestId
+  const invalidateHandler = (): void => {
+    if (offsetCalsToDelete !== undefined) {
+      for (const cal of offsetCalsToDelete) {
+        deleteCalibration({
+          calType: 'pipetteOffset',
+          mount: cal.mount,
+          pipette_id: cal.pipette,
+        })
       }
     }
-  )
-
-  const tipLengthCalibrationSession: TipLengthCalibrationSession | null = useSelector(
-    (state: State) => {
-      return getTipLengthCalibrationSession(state, robotName)
-    }
-  )
-
-  const configHasCalibrationBlock = useSelector(getHasCalibrationBlock)
-  const [showCalBlockModal, setShowCalBlockModal] = React.useState(false)
-
-  const handleStart = (hasBlockModalResponse: boolean | null = null): void => {
-    if (hasBlockModalResponse === null && configHasCalibrationBlock === null) {
-      setShowCalBlockModal(true)
-    } else {
-      setShowCalBlockModal(false)
-      const sharedOptions = {
-        mount,
-        hasCalibrationBlock: Boolean(
-          configHasCalibrationBlock ?? hasBlockModalResponse
-        ),
-        tipRackDefinition,
-      }
-      const options = isExtendedPipOffset
-        ? { ...sharedOptions, shouldRecalibrateTipLength: true }
-        : sharedOptions
-      dispatchRequests(Sessions.ensureSession(robotName, sessionType, options))
-      dispatchAnalyticsEvent(sharedOptions.hasCalibrationBlock)
-    }
   }
-
-  const startingSession =
-    useSelector<State, RequestState | null>(state =>
-      createRequestId.current
-        ? RobotApi.getRequestById(state, createRequestId.current)
-        : null
-    )?.status === RobotApi.PENDING
-
-  const showSpinner =
-    useSelector<State, RequestState | null>(state =>
-      trackedRequestId.current
-        ? RobotApi.getRequestById(state, trackedRequestId.current)
-        : null
-    )?.status === RobotApi.PENDING
-
-  const isJogging =
-    useSelector((state: State) =>
-      jogRequestId.current
-        ? RobotApi.getRequestById(state, jogRequestId.current)
-        : null
-    )?.status === RobotApi.PENDING
-
-  const { confirm, showConfirmation, cancel } = useConditionalConfirm(
-    handleStart,
-    hasCalibrated
-  )
 
   const runHasStarted = useRunHasStarted(runId)
   const disableRecalibrate = runHasStarted || !isDeckCalibrated
@@ -199,7 +106,14 @@ export function SetupTipLengthCalibrationButton({
   ) : (
     <Link
       role="link"
-      onClick={() => confirm(null)}
+      onClick={() =>
+        tipLengthCalLauncher({
+          params: { mount, tipRackDefinition },
+          hasBlockModalResponse: null,
+          invalidateHandler:
+            offsetCalsToDelete !== undefined ? invalidateHandler : undefined,
+        })
+      }
       css={TYPOGRAPHY.labelSemiBold}
       id="TipRackCalibration_recalibrateTipRackLink"
     >
@@ -215,7 +129,11 @@ export function SetupTipLengthCalibrationButton({
         ) : (
           <>
             <TertiaryButton
-              onClick={() => handleStart(null)}
+              onClick={() => () =>
+                tipLengthCalLauncher({
+                  params: { mount, tipRackDefinition },
+                  hasBlockModalResponse: null,
+                })}
               id="TipRackCalibration_calibrateTipRackButton"
               disabled={disabled || !isDeckCalibrated}
               {...targetProps}
@@ -234,43 +152,7 @@ export function SetupTipLengthCalibrationButton({
           </>
         )}
       </Flex>
-      {showConfirmation && (
-        <Portal>
-          <ConfirmRecalibrationModal
-            confirm={confirm}
-            cancel={cancel}
-            tiprackDisplayName={tipRackDefinition.metadata.displayName}
-          />
-        </Portal>
-      )}
-      <Portal level="top">
-        {showCalBlockModal ? (
-          <AskForCalibrationBlockModal
-            onResponse={handleStart}
-            titleBarTitle={t('tip_length_calibration')}
-            closePrompt={() => setShowCalBlockModal(false)}
-          />
-        ) : null}
-        {startingSession ? (
-          <SpinnerModalPage
-            titleBar={{
-              title: t('tip_length_calibration'),
-              back: {
-                disabled: true,
-                title: t('shared:exit'),
-                children: t('shared:exit'),
-              },
-            }}
-          />
-        ) : null}
-        <CalibrateTipLength
-          session={tipLengthCalibrationSession}
-          robotName={robotName}
-          showSpinner={showSpinner}
-          dispatchRequests={dispatchRequests}
-          isJogging={isJogging}
-        />
-      </Portal>
+      {TipLengthCalWizard}
     </>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
@@ -129,11 +129,12 @@ export function SetupTipLengthCalibrationButton({
         ) : (
           <>
             <TertiaryButton
-              onClick={() => () =>
+              onClick={() =>
                 tipLengthCalLauncher({
                   params: { mount, tipRackDefinition },
                   hasBlockModalResponse: null,
-                })}
+                })
+              }
               id="TipRackCalibration_calibrateTipRackButton"
               disabled={disabled || !isDeckCalibrated}
               {...targetProps}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupDeckCalibration.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupDeckCalibration.test.tsx
@@ -45,7 +45,7 @@ describe('SetupDeckCalibration', () => {
     getByText('Deck Calibration')
     queryByText('Last calibrated:')
   })
-  it('renders a link to robot settings calibration tab if deck is not calibrated', () => {
+  it('renders a link to the calibration dashboard if deck is not calibrated', () => {
     when(mockUseDeckCalibrationData).calledWith(ROBOT_NAME).mockReturnValue({
       deckCalibrationData: null,
       isDeckCalibrated: false,
@@ -57,6 +57,6 @@ describe('SetupDeckCalibration', () => {
       getByRole('link', {
         name: 'Calibrate Now',
       }).getAttribute('href')
-    ).toBe('/devices/otie/robot-settings/calibration')
+    ).toBe('/devices/otie/robot-settings/calibration/dashboard')
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibrationItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibrationItem.test.tsx
@@ -4,32 +4,14 @@ import { when, resetAllWhenMocks } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../../i18n'
-import { useCalibratePipetteOffset } from '../../../../organisms/CalibratePipetteOffset/useCalibratePipetteOffset'
-import { AskForCalibrationBlockModal } from '../../../../organisms/CalibrateTipLength/AskForCalibrationBlockModal'
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
-import { getHasCalibrationBlock } from '../../../../redux/config'
 import { mockPipetteInfo } from '../../../../redux/pipettes/__fixtures__'
 import { useDeckCalibrationData } from '../../hooks'
 import { SetupPipetteCalibrationItem } from '../SetupPipetteCalibrationItem'
+import { MemoryRouter } from 'react-router-dom'
 
-jest.mock(
-  '../../../../organisms/CalibratePipetteOffset/useCalibratePipetteOffset'
-)
-jest.mock(
-  '../../../../organisms/CalibrateTipLength/AskForCalibrationBlockModal'
-)
-jest.mock('../../../../redux/config')
 jest.mock('../../hooks')
 
-const mockGetHasCalibrationBlock = getHasCalibrationBlock as jest.MockedFunction<
-  typeof getHasCalibrationBlock
->
-const mockUseCalibratePipetteOffset = useCalibratePipetteOffset as jest.MockedFunction<
-  typeof useCalibratePipetteOffset
->
-const mockAskForCalibrationBlockModal = AskForCalibrationBlockModal as jest.MockedFunction<
-  typeof AskForCalibrationBlockModal
->
 const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
   typeof useDeckCalibrationData
 >
@@ -48,28 +30,22 @@ describe('SetupPipetteCalibrationItem', () => {
     React.ComponentProps<typeof SetupPipetteCalibrationItem>
   > = {}) => {
     return renderWithProviders(
-      <SetupPipetteCalibrationItem
-        {...{
-          pipetteInfo,
-          index,
-          mount,
-          robotName,
-          runId,
-        }}
-      />,
+      <MemoryRouter>
+        <SetupPipetteCalibrationItem
+          {...{
+            pipetteInfo,
+            index,
+            mount,
+            robotName,
+            runId,
+          }}
+        />
+      </MemoryRouter>,
       { i18nInstance: i18n }
     )[0]
   }
 
-  let startWizard: any
-
   beforeEach(() => {
-    startWizard = jest.fn()
-    when(mockUseCalibratePipetteOffset).mockReturnValue([startWizard, null])
-    when(mockGetHasCalibrationBlock).mockReturnValue(null)
-    when(mockAskForCalibrationBlockModal).mockReturnValue(
-      <div>Mock AskForCalibrationBlockModal</div>
-    )
     when(mockUseDeckCalibrationData).calledWith(ROBOT_NAME).mockReturnValue({
       deckCalibrationData: mockDeckCalData,
       isDeckCalibrated: true,
@@ -85,7 +61,7 @@ describe('SetupPipetteCalibrationItem', () => {
     getByText(mockPipetteInfo.pipetteSpecs.displayName)
   })
 
-  it('renders the calibrate now button if pipette attached but not calibrated', () => {
+  it('renders a link to the calibration dashboard if pipette attached but not calibrated', () => {
     const { getByText, getByRole } = render({
       pipetteInfo: {
         ...mockPipetteInfo,
@@ -96,9 +72,11 @@ describe('SetupPipetteCalibrationItem', () => {
     })
 
     getByText('Not calibrated yet')
-    const calibrateNowButton = getByRole('button', { name: 'Calibrate Now' })
-    calibrateNowButton.click()
-    getByText('Mock AskForCalibrationBlockModal')
+    expect(
+      getByRole('link', {
+        name: 'Calibrate Now',
+      }).getAttribute('href')
+    ).toBe('/devices/otie/robot-settings/calibration/dashboard')
   })
   it('renders the pipette mismatch info if pipette calibrated but an inexact match', () => {
     const { getByText, getByRole } = render({

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupTipLengthCalibrationButton.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupTipLengthCalibrationButton.test.tsx
@@ -90,10 +90,17 @@ describe('SetupTipLengthCalibrationButton', () => {
     expect(getByText('Recalibrate')).toBeTruthy()
   })
 
-  it('button launches the tip length calibration wizard when clicked', () => {
+  it('button launches the tip length calibration wizard when clicked - no calibration', () => {
     const { getByText } = render()
     const calibrateBtn = getByText('Calibrate Now')
     calibrateBtn.click()
+    expect(mockTipLengthCalLauncher).toHaveBeenCalled()
+  })
+
+  it('button launches the tip length calibration wizard when clicked - recalibration', () => {
+    const { getByText } = render({ hasCalibrated: true })
+    const recalibrateBtn = getByText('Recalibrate')
+    recalibrateBtn.click()
     expect(mockTipLengthCalLauncher).toHaveBeenCalled()
   })
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupTipLengthCalibrationButton.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupTipLengthCalibrationButton.test.tsx
@@ -1,48 +1,36 @@
 import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
 
-import {
-  renderWithProviders,
-  useConditionalConfirm,
-} from '@opentrons/components'
+import { renderWithProviders } from '@opentrons/components'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 
 import { i18n } from '../../../../i18n'
-import { AskForCalibrationBlockModal } from '../../../../organisms/CalibrateTipLength/AskForCalibrationBlockModal'
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
-import { getHasCalibrationBlock } from '../../../../redux/config'
+import { mockTipLengthCalLauncher } from '../../hooks/__fixtures__/taskListFixtures'
 import { useDeckCalibrationData, useRunHasStarted } from '../../hooks'
+import { useDashboardCalibrateTipLength } from '../../../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength'
 import { SetupTipLengthCalibrationButton } from '../SetupTipLengthCalibrationButton'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 jest.mock('@opentrons/components/src/hooks')
-jest.mock(
-  '../../../../organisms/CalibrateTipLength/AskForCalibrationBlockModal'
-)
 jest.mock('../../../../organisms/RunTimeControl/hooks')
+jest.mock(
+  '../../../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength'
+)
 jest.mock('../../../../redux/config')
 jest.mock('../../../../redux/sessions/selectors')
 jest.mock('../../hooks')
 
-const mockUseConditionalConfirm = useConditionalConfirm as jest.MockedFunction<
-  typeof useConditionalConfirm
->
 const mockUseRunHasStarted = useRunHasStarted as jest.MockedFunction<
   typeof useRunHasStarted
->
-const mockGetHasCalibrationBlock = getHasCalibrationBlock as jest.MockedFunction<
-  typeof getHasCalibrationBlock
->
-const mockAskForCalibrationBlockModal = AskForCalibrationBlockModal as jest.MockedFunction<
-  typeof AskForCalibrationBlockModal
 >
 const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
   typeof useDeckCalibrationData
 >
-
-const mockConfirm = jest.fn()
-const mockCancel = jest.fn()
+const mockUseDashboardCalibrateTipLength = useDashboardCalibrateTipLength as jest.MockedFunction<
+  typeof useDashboardCalibrateTipLength
+>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
@@ -77,19 +65,14 @@ describe('SetupTipLengthCalibrationButton', () => {
 
   beforeEach(() => {
     when(mockUseRunHasStarted).calledWith(RUN_ID).mockReturnValue(false)
-    when(mockUseConditionalConfirm).mockReturnValue({
-      confirm: mockConfirm,
-      showConfirmation: true,
-      cancel: mockCancel,
-    })
-    when(mockGetHasCalibrationBlock).mockReturnValue(null)
-    when(mockAskForCalibrationBlockModal).mockReturnValue(
-      <div>Mock AskForCalibrationBlockModal</div>
-    )
     when(mockUseDeckCalibrationData).calledWith(ROBOT_NAME).mockReturnValue({
       deckCalibrationData: mockDeckCalData,
       isDeckCalibrated: true,
     })
+    mockUseDashboardCalibrateTipLength.mockReturnValue([
+      mockTipLengthCalLauncher,
+      null,
+    ])
   })
 
   afterEach(() => {
@@ -104,9 +87,14 @@ describe('SetupTipLengthCalibrationButton', () => {
 
   it('renders the recalibrate link if tip length calibrated and run unstarted', () => {
     const { getByText } = render({ hasCalibrated: true })
-    const recalibrate = getByText('Recalibrate')
-    recalibrate.click()
-    expect(mockConfirm).toBeCalled()
+    expect(getByText('Recalibrate')).toBeTruthy()
+  })
+
+  it('button launches the tip length calibration wizard when clicked', () => {
+    const { getByText } = render()
+    const calibrateBtn = getByText('Calibrate Now')
+    calibrateBtn.click()
+    expect(mockTipLengthCalLauncher).toHaveBeenCalled()
   })
 
   it('disables the recalibrate link if tip length calibrated and run started', () => {
@@ -114,6 +102,6 @@ describe('SetupTipLengthCalibrationButton', () => {
     const { getByText } = render({ hasCalibrated: true })
     const recalibrate = getByText('Recalibrate')
     recalibrate.click()
-    expect(mockConfirm).not.toBeCalled()
+    expect(mockTipLengthCalLauncher).not.toBeCalled()
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
**IN DRAFT WHILE I FIX AND ADD TESTS**

# Overview

directs the deck and pipette offset calibrations during protocol setup to the calibration dashboard.
Tip Length calibrations happen in-place using the same calibration setup for dashboard tip length
calibrations and remove related offset calibration data when necessary

closes [RAUT-326](https://opentrons.atlassian.net/browse/RAUT-326)


https://user-images.githubusercontent.com/66637570/218190762-0cc24ed0-c2a4-48fb-9c48-4e97abcda6d1.mov


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Start a protocol without calibrations complete. Calibrating the deck or pipette offset calibrations should take you to the calibration dashboard. The tip length calibration should launch in place. If there are offset calibrations for the tip rack a warning will be shown on the first page of the wizard and the offset will be deleted if the user advances. When all calibrations are complete the protocol setup should reflect that. If a tip length is recalibrated the "Calibrate" cta should show up for the offset calibration that was deleted.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- routes the user to the calibration dashboard when the deck calibration cta is clicked
- routes the user to the calibration dashboard when the offset calibration cta is clicked
- Removes the old wizard launching implementation from the `SetupTipLengthCalibrationButton` and replaces it with the `useDashboardCalibrateTipLength` hook's setup

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Ensure the logic looks sound and the behavior is as expected with a couple of distinct protocols/tips

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Med - if this doesn't work correctly users would be unable to successfully run protocols that require any calibration beforehand

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-326]: https://opentrons.atlassian.net/browse/RAUT-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ