### PR TITLE
docs(api): guidance on simulation in Python API 2.14

### DIFF
--- a/api/docs/v2/example_protocols/dilution_tutorial.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial.py
@@ -1,7 +1,7 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.0',
+    'apiLevel': '2.13',
     'protocolName': 'Serial Dilution Tutorial',
     'description': '''This protocol is the outcome of following the
                    Python Protocol API Tutorial located at

--- a/api/docs/v2/example_protocols/dilution_tutorial.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial.py
@@ -1,7 +1,7 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.12',
+    'apiLevel': '2.0',
     'protocolName': 'Serial Dilution Tutorial',
     'description': '''This protocol is the outcome of following the
                    Python Protocol API Tutorial located at

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi.py
@@ -1,7 +1,7 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.0',
+    'apiLevel': '2.13',
     'protocolName': 'Serial Dilution Tutorial',
     'description': '''This protocol is the outcome of following the
                    Python Protocol API Tutorial located at

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi.py
@@ -1,7 +1,7 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.12',
+    'apiLevel': '2.0',
     'protocolName': 'Serial Dilution Tutorial',
     'description': '''This protocol is the outcome of following the
                    Python Protocol API Tutorial located at

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -55,20 +55,19 @@ For this tutorial, you’ll write very little Python outside of the ``run()`` fu
 Metadata
 ^^^^^^^^
 
-Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version <version-table>` of the API the protocol requires. If you plan to share your protocols, you should specify the lowest API version that includes all the features your protocol uses. For this tutorial, you can just use the latest version of the API:
+Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version <version-table>` of the API the protocol requires. If you plan to share your protocols, you should specify the lowest API version that includes all the features your protocol uses. This tutorial only uses features that have been present in every minor version of the API v2, so specify:
 
 .. code-block:: python
-    :substitutions:
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.0'}
 
-You can use this dictionary to include any other information you like. The fields ``protocolName``, ``description``, and ``author`` are all displayed in the Opentrons App, so it’s a good idea to expand your metadata dictionary to include them:
+You can include any other information you like in the metadata dictionary. The fields ``protocolName``, ``description``, and ``author`` are all displayed in the Opentrons App, so it’s a good idea to expand the dictionary to include them:
 
 .. code-block:: python
     :substitutions:
 
     metadata = {
-        'apiLevel': '|apiLevel|',
+        'apiLevel': '2.0',
         'protocolName': 'Serial Dilution Tutorial',
         'description': '''This protocol is the outcome of following the 
                        Python Protocol API Tutorial located at 

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -55,11 +55,11 @@ For this tutorial, you’ll write very little Python outside of the ``run()`` fu
 Metadata
 ^^^^^^^^
 
-Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version <version-table>` of the API the protocol requires. If you plan to share your protocols, you should specify the lowest API version that includes all the features your protocol uses. This tutorial only uses features that have been present in every minor version of the API v2, so specify:
+Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version <version-table>` of the API the protocol requires. The `scripts <https://github.com/Opentrons/opentrons/blob/edge/api/docs/v2/example_protocols/>`_ for this tutorial were validated against API version 2.13, so specify:
 
 .. code-block:: python
 
-    metadata = {'apiLevel': '2.0'}
+    metadata = {'apiLevel': '2.13'}
 
 You can include any other information you like in the metadata dictionary. The fields ``protocolName``, ``description``, and ``author`` are all displayed in the Opentrons App, so it’s a good idea to expand the dictionary to include them:
 
@@ -67,7 +67,7 @@ You can include any other information you like in the metadata dictionary. The f
     :substitutions:
 
     metadata = {
-        'apiLevel': '2.0',
+        'apiLevel': '2.13',
         'protocolName': 'Serial Dilution Tutorial',
         'description': '''This protocol is the outcome of following the 
                        Python Protocol API Tutorial located at 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -38,6 +38,10 @@ The version you specify determines the features and behaviors available to your 
 
 In general, consider what features you need in your protocol and keep the API level as low as possible. Using the lowest API version is good protocol design, as it helps the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software.
 
+.. note::
+
+    Python protocols with an ``apiLevel`` of 2.14 can't currently be simulated with the ``opentrons_simulate`` command-line tool, the :py:func:`opentrons.simulate.simulate` function, or the :py:func:`opentrons.simulate.get_protocol_api` function. If your protocol doesn't rely on new functionality added in version 2.14, use a lower ``apiLevel``. For protocols that require 2.14, analyze your protocol with the Opentrons App instead.
+
 
 Maximum Supported Versions
 --------------------------

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -36,7 +36,7 @@ Version specification is required by the system. If you do not specify a target 
 
 The version you specify determines the features and behaviors available to your protocol. For example, support for the Heater-Shaker Module was added in version 2.13, so you can't specify a lower version and then call ``HeaterShakerContext`` methods without causing an error. This protects you from accidentally using features not present in your specified API version, and keeps your protocol portable between API versions.
 
-In general, consider what features you need in your protocol and keep the API level as low as possible. Using the lowest API version is good protocol design, as it helps the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software.
+When choosing an API level, consider what features you need and how widely you plan to share your protocol. On the one hand, using the highest available version will give your protocol access to all the latest features of the API. On the other hand, using the lowest possible version lets the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software. Specifying version 2.14 would limit the protocol to robots running 6.2.0 or higher.
 
 .. note::
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -36,7 +36,7 @@ Version specification is required by the system. If you do not specify a target 
 
 The version you specify determines the features and behaviors available to your protocol. For example, support for the Heater-Shaker Module was added in version 2.13, so you can't specify a lower version and then call ``HeaterShakerContext`` methods without causing an error. This protects you from accidentally using features not present in your specified API version, and keeps your protocol portable between API versions.
 
-When choosing an API level, consider what features you need and how widely you plan to share your protocol. On the one hand, using the highest available version will give your protocol access to all the latest features of the API. On the other hand, using the lowest possible version lets the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software. Specifying version 2.14 would limit the protocol to robots running 6.2.0 or higher.
+When choosing an API level, consider what features you need and how widely you plan to share your protocol. On the one hand, using the highest available version will give your protocol access to all the latest :ref:`features and fixes <version-notes>`. On the other hand, using the lowest possible version lets the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software. Specifying version 2.14 would limit the protocol to robots running 6.2.0 or higher.
 
 .. note::
 
@@ -101,6 +101,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 |     2.14    |          6.3.0               |
 +-------------+------------------------------+
+
+.. _version-notes:
 
 Changes in API Versions
 -----------------------


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Updates to the Python API docs to help users avoid pitfalls regarding the inability to simulate protocols specifying `apiLevel` 2.14.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Checked the docs in the sandbox
  - [Tutorial](http://sandbox.docs.opentrons.com/docs-214-sim-behavior/v2/tutorial.html)
  - [Versioning](http://sandbox.docs.opentrons.com/docs-214-sim-behavior/v2/versioning.html)

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Versioning
  - Reframed guidance for choosing `apiLevel` as balance between latest-and-greatest vs cross-compatibility
  - Added note based on error text for `opentrons_simulate`
- Tutorial
  - Changed `apiLevel` to static `2.13` and said "this is what works for this Tutorial, use it"

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Does this satisfy our needs to bridge from the present to a future where `opentrons_simulate` is available again _without further changes until it's back_?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Nil, docs only