### PR TITLE
fix(api): Fix accidental error on any PAPIv2.14 protocol

### DIFF
--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -99,9 +99,10 @@ def create_protocol_context(
 
     if api_version >= ENGINE_CORE_API_VERSION:
         # TODO(mc, 2022-8-22): replace raise with strict typing
-        raise ProtocolEngineCoreRequiredError(
-            "ProtocolEngine PAPI core is enabled, but no ProtocolEngine given."
-        )
+        if protocol_engine is None or protocol_engine_loop is None:
+            raise ProtocolEngineCoreRequiredError(
+                "ProtocolEngine PAPI core is enabled, but no ProtocolEngine given."
+            )
 
         engine_client_transport = ChildThreadTransport(
             engine=protocol_engine, loop=protocol_engine_loop


### PR DESCRIPTION
# Overview

This fixes a regression I introduced in #12131 where any Python protocol with `"apiLevel": "2.14"` would raise an error before simulation. The bug is that I replaced a conditional `assert` with an unconditional `raise`.

Thanks @jbleon95 for identifying this! Keen eye.

# Test plan

I have done this:

1. Confirm `opentrons_simulate` still prints a nice error message with a PAPIv2.14 protocol.
2. Confirm `python -m opentrons.cli analyze` and robot-server can both simulate a PAPIv2.14 protocol

# Review requests

Code review should be sufficient. Does this fix make sense?

# Risk assessment

Low.

# Future work

We clearly need to extend our integration tests for PAPIv2.14 protocols. We'll do this in follow-up PRs.