### PR TITLE
refactor(api): Forbid use of `Labware.set_offset()` on PAPIv2.14

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -89,8 +89,10 @@ class LabwareCore(AbstractLabware[WellCore]):
         return self._definition.parameters.quirks or []
 
     def set_calibration(self, delta: Point) -> None:
-        # TODO(jbl 2022-09-01): implement set calibration through the engine
-        pass
+        raise NotImplementedError(
+            "Setting a labware's calibration after it's been loaded"
+            " is not supported by Protocol Engine."
+        )
 
     def get_calibrated_offset(self) -> Point:
         return self._engine_client.state.geometry.get_labware_position(self._labware_id)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -449,21 +449,17 @@ class Labware:
         even if those labware are of the same type.
 
         .. caution::
-            If you're uploading a protocol via the Opentrons App, don't use this method.
-            Instead, use the Opentrons App's Labware Position Check.
-
-            This method is *only* for when you're using mechanisms like
+            This method is *only* for use with mechanisms like
             :obj:`opentrons.execute.get_protocol_api`, which lack an interactive way
             to adjust labware offsets. (See :ref:`advanced-control`.)
 
-            Using this method and the Opentrons App's Labware Position Check
-            at the same time will produce undefined behavior. We may choose
-            to define this behavior in a future release.
+            If you're uploading a protocol via the Opentrons App, don't use this method, 
+            because it will produce undefined behavior.
+            Instead, use Labware Position Check in the app.
 
-            .. note::
-                Because protocols with a :ref:`version <v2-versioning>` of 2.14
-                can currently *only* be uploaded via the Opentrons App, it doesn't make
-                sense to use this method with them. Trying to do so will raise an exception.
+            Because protocols using :ref:`version <v2-versioning>` 2.14 of the API
+            can currently *only* be uploaded via the Opentrons App, it doesn't make
+            sense to use this method with them. Trying to do so will raise an exception.
         """
         if self._api_version >= ENGINE_CORE_API_VERSION:
             # TODO(mm, 2023-02-13): See Jira RCORE-535.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -457,7 +457,7 @@ class Labware:
             because it will produce undefined behavior.
             Instead, use Labware Position Check in the app.
 
-            Because protocols using :ref:`version <v2-versioning>` 2.14 of the API
+            Because protocols using :ref:`API version <v2-versioning>` 2.14 or higher
             can currently *only* be uploaded via the Opentrons App, it doesn't make
             sense to use this method with them. Trying to do so will raise an exception.
         """
@@ -469,7 +469,7 @@ class Labware:
             # Therefore, in >=ENGINE_CORE_API_VERSION protocols,
             # there's no legitimate way to use this method.
             raise APIVersionError(
-                "Labware.set_offset() is not supported when apiLevel is 2.14."
+                "Labware.set_offset() is not supported when apiLevel is 2.14 or higher."
                 " Use a lower apiLevel"
                 " or use the Opentrons App's Labware Position Check."
             )

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -453,7 +453,7 @@ class Labware:
             :obj:`opentrons.execute.get_protocol_api`, which lack an interactive way
             to adjust labware offsets. (See :ref:`advanced-control`.)
 
-            If you're uploading a protocol via the Opentrons App, don't use this method, 
+            If you're uploading a protocol via the Opentrons App, don't use this method,
             because it will produce undefined behavior.
             Instead, use Labware Position Check in the app.
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -449,15 +449,36 @@ class Labware:
         even if those labware are of the same type.
 
         .. caution::
-            This method is *only* for Jupyter and command-line applications
-            of the Python Protocol API. Do not use this method in a protocol
-            uploaded via the Opentrons App.
+            If you're uploading a protocol via the Opentrons App, don't use this method.
+            Instead, use the Opentrons App's Labware Position Check.
+
+            This method is *only* for when you're using mechanisms like
+            :obj:`opentrons.execute.get_protocol_api`, which lack an interactive way
+            to adjust labware offsets. (See :ref:`advanced-control`.)
 
             Using this method and the Opentrons App's Labware Position Check
             at the same time will produce undefined behavior. We may choose
             to define this behavior in a future release.
+
+            .. note::
+                Because protocols with a :ref:`version <v2-versioning>` of 2.14
+                can currently *only* be uploaded via the Opentrons App, it doesn't make
+                sense to use this method with them. Trying to do so will raise an exception.
         """
-        self._core.set_calibration(Point(x=x, y=y, z=z))
+        if self._api_version >= ENGINE_CORE_API_VERSION:
+            # TODO(mm, 2023-02-13): See Jira RCORE-535.
+            #
+            # Until that issue is resolved, the only way to simulate or run a
+            # >=ENGINE_CORE_API_VERSION protocol is through the Opentrons App.
+            # Therefore, in >=ENGINE_CORE_API_VERSION protocols,
+            # there's no legitimate way to use this method.
+            raise APIVersionError(
+                "Labware.set_offset() is not supported when apiLevel is 2.14."
+                " Use a lower apiLevel"
+                " or use the Opentrons App's Labware Position Check."
+            )
+        else:
+            self._core.set_calibration(Point(x=x, y=y, z=z))
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -66,8 +66,9 @@ def test_get_load_params(subject: LabwareCore) -> None:
 
 
 def test_set_calibration(subject: LabwareCore) -> None:
-    """It should no-op if calibration is set."""
-    subject.set_calibration(Point(1, 2, 3))
+    """It should raise if you attempt to set calibration."""
+    with pytest.raises(NotImplementedError):
+        subject.set_calibration(Point(1, 2, 3))
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -194,3 +194,25 @@ def test_parent_module_context(
     )
 
     subject.parent == mock_temp_module_context
+
+
+@pytest.mark.parametrize("api_version", APIVersion(2, 13))
+def test_set_offset_succeeds_on_low_api_version(
+    decoy: Decoy,
+    subject: Labware,
+    mock_labware_core: LabwareCore,
+) -> None:
+    """It should pass the offset to the core, on low API versions."""
+    subject.set_offset(1, 2, 3)
+    decoy.verify(mock_labware_core.set_calibration(1, 2, 3))
+
+
+@pytest.mark.parametrize("api_version", APIVersion(2, 14))
+def test_set_offset_raises_on_high_api_version(
+    decoy: Decoy,
+    subject: Labware,
+    mock_labware_core: LabwareCore,
+) -> None:
+    """It should raise an error, on high API versions."""
+    with pytest.raises(APIVersionError):
+        subject.set_offset(1, 2, 3)

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -7,6 +7,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, Labware, Well
 from opentrons.protocol_api.core import well_grid
 from opentrons.protocol_api.core.common import (
@@ -18,7 +19,7 @@ from opentrons.protocol_api.core.common import (
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
 from opentrons.protocol_api import TemperatureModuleContext
 
-from opentrons.types import DeckSlotName
+from opentrons.types import DeckSlotName, Point
 
 
 @pytest.fixture(autouse=True)
@@ -196,7 +197,7 @@ def test_parent_module_context(
     subject.parent == mock_temp_module_context
 
 
-@pytest.mark.parametrize("api_version", APIVersion(2, 13))
+@pytest.mark.parametrize("api_version", [APIVersion(2, 13)])
 def test_set_offset_succeeds_on_low_api_version(
     decoy: Decoy,
     subject: Labware,
@@ -204,10 +205,10 @@ def test_set_offset_succeeds_on_low_api_version(
 ) -> None:
     """It should pass the offset to the core, on low API versions."""
     subject.set_offset(1, 2, 3)
-    decoy.verify(mock_labware_core.set_calibration(1, 2, 3))
+    decoy.verify(mock_labware_core.set_calibration(Point(1, 2, 3)))
 
 
-@pytest.mark.parametrize("api_version", APIVersion(2, 14))
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
 def test_set_offset_raises_on_high_api_version(
     decoy: Decoy,
     subject: Labware,

--- a/api/tests/opentrons/protocol_api_old/test_offsets.py
+++ b/api/tests/opentrons/protocol_api_old/test_offsets.py
@@ -1,6 +1,7 @@
 import typing
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION, labware
+from opentrons.protocol_api import labware
 from opentrons.protocol_api.core.legacy.legacy_labware_core import LegacyLabwareCore
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import Point, Location
 
 if typing.TYPE_CHECKING:
@@ -10,7 +11,7 @@ if typing.TYPE_CHECKING:
 def test_wells_rebuilt_with_offset(minimal_labware_def: "LabwareDefinition") -> None:
     test_labware = labware.Labware(
         core=LegacyLabwareCore(minimal_labware_def, Location(Point(0, 0, 0), "deck")),
-        api_version=MAX_SUPPORTED_VERSION,
+        api_version=APIVersion(2, 13),  # set_offset() is not implemented in 2.14.
         protocol_core=None,  # type: ignore[arg-type]
         core_map=None,  # type: ignore[arg-type]
     )


### PR DESCRIPTION
# Overview

Closes RCORE-538. See that ticket for background.

# Changelog

Python Protocol API behavior:

* Raise `APIVersionError` if an `"apiLevel": "2.14"` Python protocol tries to do `Labware.set_offset()`.

Docs:

* Explain the new behavior.
* (Somewhat pedantically) correct the documentation to refer to the whole cast of `opentrons.execute.get_protocol_api()` and friends, rather than just "Jupyter and command-line applications."

# Test plan

I have run v2.13 and v2.14 protocols through `pipenv run python -m opentrons.cli analyze` and made sure `Labware.set_offset()` raises, or doesn't raise, as described.

# Review requests

* Review docs at http://sandbox.docs.opentrons.com/RCORE-538/v2/new_protocol_api.html#opentrons.protocol_api.labware.Labware.set_offset.
* Is the note nested inside the warning a bit much?

# Risk assessment

Low.