### PR TITLE
feat(odd): pipette flow prep work in Attached Instruments Dashboard

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -22,6 +22,7 @@ import { RobotSettingsDashboard } from '../pages/OnDeviceDisplay/RobotSettingsDa
 import { ProtocolDashboard } from '../pages/OnDeviceDisplay/ProtocolDashboard'
 import { ProtocolDetails } from '../pages/OnDeviceDisplay/ProtocolDetails'
 import { UpdateRobot } from '../pages/OnDeviceDisplay/UpdateRobot'
+import { AttachInstrumentsDashboard } from '../pages/OnDeviceDisplay/AttachInstrumentsDashboard'
 import { Welcome } from '../pages/OnDeviceDisplay/Welcome'
 import { PortalRoot as ModalPortalRoot } from './portal'
 
@@ -107,7 +108,7 @@ export const onDeviceDisplayRoutes: RouteProps[] = [
     Component: () => (
       <>
         <BackButton />
-        <Box>attach instruments</Box>
+        <AttachInstrumentsDashboard />
       </>
     ),
     exact: true,

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -105,14 +105,8 @@ export const onDeviceDisplayRoutes: RouteProps[] = [
     path: '/protocols/:runId/run',
   },
   {
-    Component: () => (
-      <>
-        <BackButton />
-        <AttachInstrumentsDashboard />
-      </>
-    ),
+    Component: AttachInstrumentsDashboard,
     exact: true,
-    // 'Attach Instruments Dashboard',
     name: 'Instruments',
     navLinkTo: '/attach-instruments',
     path: '/attach-instruments',

--- a/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
@@ -9,6 +9,7 @@ import { ConnectViaEthernet } from '../../pages/OnDeviceDisplay/ConnectViaEthern
 import { ConnectViaUSB } from '../../pages/OnDeviceDisplay/ConnectViaUSB'
 import { ConnectViaWifi } from '../../pages/OnDeviceDisplay/ConnectViaWifi'
 import { NetworkSetupMenu } from '../../pages/OnDeviceDisplay/NetworkSetupMenu'
+import { AttachInstrumentsDashboard } from '../../pages/OnDeviceDisplay/AttachInstrumentsDashboard'
 import { RobotDashboard } from '../../pages/OnDeviceDisplay/RobotDashboard'
 import { RobotSettingsDashboard } from '../../pages/OnDeviceDisplay/RobotSettingsDashboard'
 import { ProtocolDashboard } from '../../pages/OnDeviceDisplay/ProtocolDashboard'
@@ -23,6 +24,7 @@ jest.mock('../../pages/OnDeviceDisplay/RobotDashboard')
 jest.mock('../../pages/OnDeviceDisplay/RobotSettingsDashboard')
 jest.mock('../../pages/OnDeviceDisplay/ProtocolDashboard')
 jest.mock('../../pages/OnDeviceDisplay/ProtocolSetup')
+jest.mock('../../pages/OnDeviceDisplay/AttachInstrumentsDashboard')
 
 const mockNetworkSetupMenu = NetworkSetupMenu as jest.MockedFunction<
   typeof NetworkSetupMenu
@@ -48,6 +50,9 @@ const mockProtocolSetup = ProtocolSetup as jest.MockedFunction<
 const mockRobotSettingsDashboard = RobotSettingsDashboard as jest.MockedFunction<
   typeof RobotSettingsDashboard
 >
+const mockAttachInstrumentsDashboard = AttachInstrumentsDashboard as jest.MockedFunction<
+  typeof AttachInstrumentsDashboard
+>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -60,6 +65,9 @@ const render = (path = '/') => {
 
 describe('OnDeviceDisplayApp', () => {
   beforeEach(() => {
+    mockAttachInstrumentsDashboard.mockReturnValue(
+      <div>Mock AttachInstrumentsDashboard</div>
+    )
     mockNetworkSetupMenu.mockReturnValue(<div>Mock NetworkSetupMenu</div>)
     mockConnectViaEthernet.mockReturnValue(<div>Mock ConnectViaEthernet</div>)
     mockConnectViaUSB.mockReturnValue(<div>Mock ConnectViaUSB</div>)
@@ -110,5 +118,9 @@ describe('OnDeviceDisplayApp', () => {
   it('renders a RobotSettingsDashboard component from /robot-settings', () => {
     const [{ getByText }] = render('/robot-settings')
     getByText('Mock RobotSettingsDashboard')
+  })
+  it('renders a AttachInstrumentsDashboard component from /attach-instruments', () => {
+    const [{ getByText }] = render('/attach-instruments')
+    getByText('Mock AttachInstrumentsDashboard')
   })
 })

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -120,7 +120,6 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     >
       {showAttachPipette ? (
         <ChoosePipette
-          robotName={robotName}
           proceed={handleAttachPipette}
           setSelectedPipette={setSelectedPipette}
           selectedPipette={selectedPipette}

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import {
   ALIGN_FLEX_END,
   BORDERS,
@@ -23,17 +22,15 @@ import { Portal } from '../../App/portal'
 import { ModalShell } from '../../molecules/Modal'
 import { WizardHeader } from '../../molecules/WizardHeader'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { getAttachedPipettes } from '../../redux/pipettes'
 import singleChannelAndEightChannel from '../../assets/images/change-pip/single-channel-and-eight-channel.png'
+import { useAttachedPipettes } from '../Devices/hooks'
 import { ExitModal } from './ExitModal'
 import { FLOWS } from './constants'
 import { getIsGantryEmpty } from './utils'
 
-import type { State } from '../../redux/types'
 import type { SelectablePipettes } from './types'
 
 interface ChoosePipetteProps {
-  robotName: string
   proceed: () => void
   selectedPipette: SelectablePipettes
   setSelectedPipette: React.Dispatch<React.SetStateAction<SelectablePipettes>>
@@ -64,18 +61,9 @@ const selectedOptionStyles = css`
 `
 
 export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
-  const {
-    robotName,
-    selectedPipette,
-    setSelectedPipette,
-    proceed,
-    exit,
-  } = props
+  const { selectedPipette, setSelectedPipette, proceed, exit } = props
   const { t } = useTranslation('pipette_wizard_flows')
-  const attachedPipettesByMount = useSelector((state: State) =>
-    getAttachedPipettes(state, robotName)
-  )
-
+  const attachedPipettesByMount = useAttachedPipettes()
   const isGantryEmpty = getIsGantryEmpty(attachedPipettesByMount)
   const [setShowExit, showExit] = React.useState<boolean>(false)
   const proceedButtonText: string = t('next')

--- a/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
@@ -10,16 +10,16 @@ import {
   mockAttachedGen3Pipette,
   mockGen3P1000PipetteSpecs,
 } from '../../../redux/pipettes/__fixtures__'
-import { getAttachedPipettes } from '../../../redux/pipettes'
+import { useAttachedPipettes } from '../../Devices/hooks'
 import { ChoosePipette } from '../ChoosePipette'
 import { getIsGantryEmpty } from '../utils'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
-jest.mock('../../../redux/pipettes')
 jest.mock('../utils')
+jest.mock('../../Devices/hooks')
 
-const mockGetAttachedPipettes = getAttachedPipettes as jest.MockedFunction<
-  typeof getAttachedPipettes
+const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
+  typeof useAttachedPipettes
 >
 const mockGetIsGantryEmpty = getIsGantryEmpty as jest.MockedFunction<
   typeof getIsGantryEmpty
@@ -40,13 +40,12 @@ describe('ChoosePipette', () => {
   let props: React.ComponentProps<typeof ChoosePipette>
   beforeEach(() => {
     mockGetIsGantryEmpty.mockReturnValue(true)
-    mockGetAttachedPipettes.mockReturnValue({ left: null, right: null })
+    mockUseAttachedPipettes.mockReturnValue({ left: null, right: null })
     props = {
       proceed: jest.fn(),
       exit: jest.fn(),
       setSelectedPipette: jest.fn(),
       selectedPipette: SINGLE_MOUNT_PIPETTES,
-      robotName: 'otie',
     }
   })
   it('returns the correct information, buttons work as expected', () => {
@@ -118,14 +117,14 @@ describe('ChoosePipette', () => {
   })
   it('renders the correct text for the 96 channel button when there is a left pipette attached', () => {
     mockGetIsGantryEmpty.mockReturnValue(false)
-    mockGetAttachedPipettes.mockReturnValue({ left: mockPipette, right: null })
+    mockUseAttachedPipettes.mockReturnValue({ left: mockPipette, right: null })
     props = { ...props, selectedPipette: NINETY_SIX_CHANNEL }
     const { getByText } = render(props)
     getByText('Detach mock pipette display name and attach 96-Channel pipette')
   })
   it('renders the correct text for the 96 channel button when there is a right pipette attached', () => {
     mockGetIsGantryEmpty.mockReturnValue(false)
-    mockGetAttachedPipettes.mockReturnValue({ left: null, right: mockPipette })
+    mockUseAttachedPipettes.mockReturnValue({ left: null, right: mockPipette })
     props = { ...props, selectedPipette: NINETY_SIX_CHANNEL }
     const { getByText } = render(props)
     getByText('Detach mock pipette display name and attach 96-Channel pipette')

--- a/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { usePipettesQuery } from '@opentrons/react-api-client'
+import { useAttachedPipettes } from '../../organisms/Devices/hooks'
 import {
   LEFT,
   NINETY_SIX_CHANNEL,
@@ -33,9 +33,7 @@ export const AttachInstrumentsDashboard = (): JSX.Element => {
     setSelectedPipette,
   ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
   const [showAttachPipette, setShowAttachPipette] = React.useState(false)
-  const attachedPipettes = usePipettesQuery({
-    refetchInterval: 5000,
-  })?.data ?? { left: undefined, right: undefined }
+  const attachedPipettes = useAttachedPipettes()
   const isNinetySixChannelAttached = getIs96ChannelPipetteAttached(
     attachedPipettes.left ?? null
   )
@@ -72,7 +70,6 @@ export const AttachInstrumentsDashboard = (): JSX.Element => {
     <Flex flexDirection={DIRECTION_COLUMN}>
       {showAttachPipette ? (
         <ChoosePipette
-          robotName={robotName}
           proceed={handleAttachPipette}
           setSelectedPipette={setSelectedPipette}
           selectedPipette={selectedPipette}

--- a/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { usePipettesQuery } from '@opentrons/react-api-client'
+import {
+  LEFT,
+  NINETY_SIX_CHANNEL,
+  RIGHT,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
+import { Btn, DIRECTION_COLUMN, Flex } from '@opentrons/components'
+import { FLOWS } from '../../organisms/PipetteWizardFlows/constants'
+import { PipetteWizardFlows } from '../../organisms/PipetteWizardFlows'
+import { ChoosePipette } from '../../organisms/PipetteWizardFlows/ChoosePipette'
+import { getIs96ChannelPipetteAttached } from '../../organisms/Devices/utils'
+import { getLocalRobot } from '../../redux/discovery'
+
+import type {
+  PipetteWizardFlow,
+  SelectablePipettes,
+} from '../../organisms/PipetteWizardFlows/types'
+import type { Mount } from '../../redux/pipettes/types'
+
+export const AttachInstrumentsDashboard = (): JSX.Element => {
+  const [
+    pipetteWizardFlow,
+    setPipetteWizardFlow,
+  ] = React.useState<PipetteWizardFlow | null>(null)
+  const localRobot = useSelector(getLocalRobot)
+  const robotName = localRobot?.name != null ? localRobot.name : 'no name'
+  const [mount, setMount] = React.useState<Mount>(LEFT)
+  const [
+    selectedPipette,
+    setSelectedPipette,
+  ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
+  const [showAttachPipette, setShowAttachPipette] = React.useState(false)
+  const attachedPipettes = usePipettesQuery({
+    refetchInterval: 5000,
+  })?.data ?? { left: undefined, right: undefined }
+  const isNinetySixChannelAttached = getIs96ChannelPipetteAttached(
+    attachedPipettes.left ?? null
+  )
+  const handlePipette = (mount: Mount): void => {
+    setMount(mount)
+    switch (mount) {
+      case LEFT: {
+        if (attachedPipettes.left != null) {
+          setPipetteWizardFlow(FLOWS.DETACH)
+        } else {
+          setShowAttachPipette(true)
+        }
+        break
+      }
+      case RIGHT: {
+        if (attachedPipettes.right != null) {
+          setPipetteWizardFlow(FLOWS.DETACH)
+        } else {
+          setShowAttachPipette(true)
+        }
+        break
+      }
+    }
+  }
+  const handleCalibrate = (mount: Mount): void => {
+    setPipetteWizardFlow(FLOWS.CALIBRATE)
+    setMount(mount)
+  }
+  const handleAttachPipette = (): void => {
+    setShowAttachPipette(false)
+    setPipetteWizardFlow(FLOWS.ATTACH)
+  }
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      {showAttachPipette ? (
+        <ChoosePipette
+          robotName={robotName}
+          proceed={handleAttachPipette}
+          setSelectedPipette={setSelectedPipette}
+          selectedPipette={selectedPipette}
+          exit={() => setShowAttachPipette(false)}
+        />
+      ) : null}
+      {pipetteWizardFlow != null ? (
+        <PipetteWizardFlows
+          flowType={pipetteWizardFlow}
+          mount={
+            //  hardcoding in LEFT mount for whenever a 96 channel is selected
+            selectedPipette === NINETY_SIX_CHANNEL ? LEFT : mount
+          }
+          closeFlow={() => setPipetteWizardFlow(null)}
+          selectedPipette={
+            isNinetySixChannelAttached ? NINETY_SIX_CHANNEL : selectedPipette
+          }
+          robotName={robotName}
+        />
+      ) : null}
+      <Btn onClick={() => handlePipette(LEFT)}>
+        {attachedPipettes.left != null
+          ? 'detach left pipette'
+          : 'attach left pipette'}
+      </Btn>
+      {attachedPipettes.left != null ? (
+        <Btn onClick={() => handleCalibrate(LEFT)}>
+          {'calibrate left pipette'}
+        </Btn>
+      ) : null}
+      <Btn onClick={() => handlePipette(RIGHT)}>
+        {attachedPipettes.right != null
+          ? 'detach right pipette'
+          : 'attach right pipette'}
+      </Btn>
+      {attachedPipettes.right != null ? (
+        <Btn onClick={() => handleCalibrate(RIGHT)}>
+          {'calibrate right pipette'}
+        </Btn>
+      ) : null}
+    </Flex>
+  )
+}

--- a/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { useAttachedPipettes } from '../../organisms/Devices/hooks'
 import {
   LEFT,
   NINETY_SIX_CHANNEL,
   RIGHT,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
-import { Btn, DIRECTION_COLUMN, Flex } from '@opentrons/components'
+import { Btn, DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
+import { Navigation } from '../../organisms/OnDeviceDisplay/Navigation'
+import { onDeviceDisplayRoutes } from '../../App/OnDeviceDisplayApp'
+import { useAttachedPipettes } from '../../organisms/Devices/hooks'
 import { FLOWS } from '../../organisms/PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../../organisms/PipetteWizardFlows'
 import { ChoosePipette } from '../../organisms/PipetteWizardFlows/ChoosePipette'
@@ -67,7 +69,14 @@ export const AttachInstrumentsDashboard = (): JSX.Element => {
     setPipetteWizardFlow(FLOWS.ATTACH)
   }
   return (
-    <Flex flexDirection={DIRECTION_COLUMN}>
+    <Flex
+      padding={`${String(SPACING.spacing6)} ${String(
+        SPACING.spacingXXL
+      )} ${String(SPACING.spacingXXL)}`}
+      flexDirection={DIRECTION_COLUMN}
+    >
+      <Navigation routes={onDeviceDisplayRoutes} />
+
       {showAttachPipette ? (
         <ChoosePipette
           proceed={handleAttachPipette}

--- a/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
@@ -4,6 +4,7 @@ import { renderWithProviders } from '@opentrons/components'
 import { ChoosePipette } from '../../../organisms/PipetteWizardFlows/ChoosePipette'
 import { getIs96ChannelPipetteAttached } from '../../../organisms/Devices/utils'
 import { useAttachedPipettes } from '../../../organisms/Devices/hooks'
+import { Navigation } from '../../../organisms/OnDeviceDisplay/Navigation'
 import {
   mockAttachedGen3Pipette,
   mockGen3P1000PipetteSpecs,
@@ -19,6 +20,7 @@ jest.mock('../../../redux/discovery')
 jest.mock('../../../organisms/PipetteWizardFlows')
 jest.mock('../../../organisms/Devices/utils')
 jest.mock('../../../organisms/PipetteWizardFlows/ChoosePipette')
+jest.mock('../../../organisms/OnDeviceDisplay/Navigation')
 
 const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
   typeof useAttachedPipettes
@@ -35,6 +37,8 @@ const mockGetIs96ChannelPipetteAttached = getIs96ChannelPipetteAttached as jest.
 const mockChoosePipette = ChoosePipette as jest.MockedFunction<
   typeof ChoosePipette
 >
+const mockNavigation = Navigation as jest.MockedFunction<typeof Navigation>
+
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
@@ -50,6 +54,7 @@ const mockPipette: AttachedPipette = {
 }
 describe('AttachInstrumentsDashboard', () => {
   beforeEach(() => {
+    mockNavigation.mockReturnValue(<div>mock Navigation</div>)
     mockChoosePipette.mockReturnValue(<div>mock choose pipette</div>)
     mockGetIs96ChannelPipetteAttached.mockReturnValue(false)
     mockGetLocalRobot.mockReturnValue(mockConnectedRobot)
@@ -58,6 +63,10 @@ describe('AttachInstrumentsDashboard', () => {
   })
   afterEach(() => {
     jest.resetAllMocks()
+  })
+  it('should render the navigation', () => {
+    const [{ getByText }] = render()
+    getByText('mock Navigation')
   })
   it('should render attach pipette for both mounts when gantry is empty, clicking on btn renders choose pipette', () => {
     const [{ getByText }] = render()

--- a/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { renderWithProviders } from '@opentrons/components'
-import { usePipettesQuery } from '@opentrons/react-api-client'
 import { ChoosePipette } from '../../../organisms/PipetteWizardFlows/ChoosePipette'
 import { getIs96ChannelPipetteAttached } from '../../../organisms/Devices/utils'
+import { useAttachedPipettes } from '../../../organisms/Devices/hooks'
+import {
+  mockAttachedGen3Pipette,
+  mockGen3P1000PipetteSpecs,
+} from '../../../redux/pipettes/__fixtures__'
 import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
 import { PipetteWizardFlows } from '../../../organisms/PipetteWizardFlows'
 import { getLocalRobot } from '../../../redux/discovery'
 import { AttachInstrumentsDashboard } from '../AttachInstrumentsDashboard'
+import type { AttachedPipette } from '../../../redux/pipettes/types'
 
-jest.mock('@opentrons/react-api-client')
+jest.mock('../../../organisms/Devices/hooks')
 jest.mock('../../../redux/discovery')
 jest.mock('../../../organisms/PipetteWizardFlows')
 jest.mock('../../../organisms/Devices/utils')
 jest.mock('../../../organisms/PipetteWizardFlows/ChoosePipette')
 
-const mockUsePipettesQuery = usePipettesQuery as jest.MockedFunction<
-  typeof usePipettesQuery
+const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
+  typeof useAttachedPipettes
 >
 const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
   typeof getLocalRobot
@@ -37,17 +42,18 @@ const render = () => {
     </MemoryRouter>
   )
 }
+const mockPipette: AttachedPipette = {
+  ...mockAttachedGen3Pipette,
+  modelSpecs: {
+    ...mockGen3P1000PipetteSpecs,
+  },
+}
 describe('AttachInstrumentsDashboard', () => {
   beforeEach(() => {
     mockChoosePipette.mockReturnValue(<div>mock choose pipette</div>)
     mockGetIs96ChannelPipetteAttached.mockReturnValue(false)
     mockGetLocalRobot.mockReturnValue(mockConnectedRobot)
-    mockUsePipettesQuery.mockReturnValue({
-      data: {
-        left: null,
-        right: null,
-      },
-    } as any)
+    mockUseAttachedPipettes.mockReturnValue({ left: null, right: null })
     mockPipetteWizardFlows.mockReturnValue(<div>mock pipette wizard flows</div>)
   })
   afterEach(() => {
@@ -60,26 +66,10 @@ describe('AttachInstrumentsDashboard', () => {
     getByText('mock choose pipette')
   })
   it('shoud render detach pipette and calibrate pipette buttons, clicking on them renders wizard flow', () => {
-    mockUsePipettesQuery.mockReturnValue({
-      data: {
-        left: {
-          id: 'pipetteId',
-          name: `test-pipetteId`,
-          model: 'p1000_single_v3',
-          tip_length: 0,
-          mount_axis: 'z',
-          plunger_axis: 'b',
-        },
-        right: {
-          id: 'pipetteId',
-          name: `test-pipetteId`,
-          model: 'p1000_single_v3',
-          tip_length: 0,
-          mount_axis: 'y',
-          plunger_axis: 'a',
-        },
-      },
-    } as any)
+    mockUseAttachedPipettes.mockReturnValue({
+      left: mockPipette,
+      right: mockPipette,
+    })
     const [{ getByText }] = render()
     getByText('detach left pipette')
     getByText('calibrate left pipette')

--- a/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@opentrons/components'
+import { usePipettesQuery } from '@opentrons/react-api-client'
+import { ChoosePipette } from '../../../organisms/PipetteWizardFlows/ChoosePipette'
+import { getIs96ChannelPipetteAttached } from '../../../organisms/Devices/utils'
+import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
+import { PipetteWizardFlows } from '../../../organisms/PipetteWizardFlows'
+import { getLocalRobot } from '../../../redux/discovery'
+import { AttachInstrumentsDashboard } from '../AttachInstrumentsDashboard'
+
+jest.mock('@opentrons/react-api-client')
+jest.mock('../../../redux/discovery')
+jest.mock('../../../organisms/PipetteWizardFlows')
+jest.mock('../../../organisms/Devices/utils')
+jest.mock('../../../organisms/PipetteWizardFlows/ChoosePipette')
+
+const mockUsePipettesQuery = usePipettesQuery as jest.MockedFunction<
+  typeof usePipettesQuery
+>
+const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
+  typeof getLocalRobot
+>
+const mockPipetteWizardFlows = PipetteWizardFlows as jest.MockedFunction<
+  typeof PipetteWizardFlows
+>
+const mockGetIs96ChannelPipetteAttached = getIs96ChannelPipetteAttached as jest.MockedFunction<
+  typeof getIs96ChannelPipetteAttached
+>
+const mockChoosePipette = ChoosePipette as jest.MockedFunction<
+  typeof ChoosePipette
+>
+const render = () => {
+  return renderWithProviders(
+    <MemoryRouter>
+      <AttachInstrumentsDashboard />
+    </MemoryRouter>
+  )
+}
+describe('AttachInstrumentsDashboard', () => {
+  beforeEach(() => {
+    mockChoosePipette.mockReturnValue(<div>mock choose pipette</div>)
+    mockGetIs96ChannelPipetteAttached.mockReturnValue(false)
+    mockGetLocalRobot.mockReturnValue(mockConnectedRobot)
+    mockUsePipettesQuery.mockReturnValue({
+      data: {
+        left: null,
+        right: null,
+      },
+    } as any)
+    mockPipetteWizardFlows.mockReturnValue(<div>mock pipette wizard flows</div>)
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('should render attach pipette for both mounts when gantry is empty, clicking on btn renders choose pipette', () => {
+    const [{ getByText }] = render()
+    getByText('attach right pipette')
+    getByText('attach left pipette').click()
+    getByText('mock choose pipette')
+  })
+  it('shoud render detach pipette and calibrate pipette buttons, clicking on them renders wizard flow', () => {
+    mockUsePipettesQuery.mockReturnValue({
+      data: {
+        left: {
+          id: 'pipetteId',
+          name: `test-pipetteId`,
+          model: 'p1000_single_v3',
+          tip_length: 0,
+          mount_axis: 'z',
+          plunger_axis: 'b',
+        },
+        right: {
+          id: 'pipetteId',
+          name: `test-pipetteId`,
+          model: 'p1000_single_v3',
+          tip_length: 0,
+          mount_axis: 'y',
+          plunger_axis: 'a',
+        },
+      },
+    } as any)
+    const [{ getByText }] = render()
+    getByText('detach left pipette')
+    getByText('calibrate left pipette')
+    getByText('detach right pipette')
+    getByText('calibrate right pipette').click()
+    getByText('mock pipette wizard flows')
+  })
+})


### PR DESCRIPTION
closes RLIQ-331 and RLIQ-330

# Overview

This PR creates `AttachInstrumentsDashboard` for the ODD and adds plain text buttons to access the pipette flows: Attach pipette, detach pipette, calibrate pipette for single mount and 96-channel pipettes. It is kept in plain text since the designs are still being finalized. (this is the `AttachInstrumentsDashboard` page in [figma](https://www.figma.com/file/OIdG64Q5cgvEw82ish5Eee/Design-System-(ODD)?node-id=13%3A2499&t=XTx9RoH0qjk7vNiC-0)

Additionally, this migrates away from redux and uses `useAttachedPipettes` hook instead of `getAttachedPipettes` for components affected in the OT-3 pipette flow work - which, after Brian's refactor https://github.com/Opentrons/opentrons/pull/12140,  was only `ChoosePipette`.

# Test Plan

- run `make -C app dev OT_APP_IS_ON_DEVICE=1` to launch ODD, click on `Instruments` button in the ODD menu. You should see plain text in the center of the page for the different buttons for attaching/detaching/calibrating the pipettes. You should be able to click through the flows and they should work as expected like they do in the desktop app. 
- run through the flows on the desktop app, they should work as expected even with the refactors in `ChoosePipette`

# Changelog

- Create `AttachInstrumentsDashboard` and test - the UI is temporary until designs are finalized
- refactor out redux machinery in `ChoosePipette`, fix test

# Review requests

- review work on ODD and make sure flows work as expected. Also is `AttachInstrumentsDashboard` an appropriate name for the component?
- review on desktop app and make sure the refactor didn't affect anything

# Risk assessment

low