### PR TITLE
fix(app): show successful wifi disconnect when request pending and robot not connectable

### DIFF
--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -11,6 +11,7 @@ import {
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   useHoverTooltip,
+  useInterval,
   useMountEffect,
 } from '@opentrons/components'
 
@@ -26,7 +27,7 @@ import { UpdateBuildroot } from '../../organisms/Devices/RobotSettings/UpdateBui
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { getBuildrootUpdateDisplayInfo } from '../../redux/buildroot'
 import { UNREACHABLE, CONNECTABLE, REACHABLE } from '../../redux/discovery'
-import { getCanDisconnect } from '../../redux/networking'
+import { fetchWifiList, getCanDisconnect } from '../../redux/networking'
 import { checkShellUpdate } from '../../redux/shell'
 import { restartRobot } from '../../redux/robot-admin'
 import { home, ROBOT } from '../../redux/robot-controls'
@@ -38,6 +39,8 @@ import type { Dispatch, State } from '../../redux/types'
 interface RobotOverviewOverflowMenuProps {
   robot: DiscoveredRobot
 }
+
+const LIST_REFRESH_MS = 10000
 
 export const RobotOverviewOverflowMenu = (
   props: RobotOverviewOverflowMenuProps
@@ -103,6 +106,8 @@ export const RobotOverviewOverflowMenu = (
   const isRobotOnWrongVersionOfSoftware =
     autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade'
   const isRobotUnavailable = isRobotBusy || robot?.status !== CONNECTABLE
+
+  useInterval(() => dispatch(fetchWifiList(robot.name)), LIST_REFRESH_MS, true)
 
   return (
     <Flex

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   Link,
   Icon,
-  useInterval,
   ALIGN_CENTER,
   DIRECTION_COLUMN,
   JUSTIFY_FLEX_END,
@@ -19,11 +18,9 @@ import {
 import { AlertPrimaryButton, PrimaryButton } from '../../../../atoms/buttons'
 import { StyledText } from '../../../../atoms/text'
 import { Modal } from '../../../../molecules/Modal'
-import {
-  fetchWifiList,
-  getWifiList,
-  postWifiDisconnect,
-} from '../../../../redux/networking'
+import { useRobot } from '../../../../organisms/Devices/hooks'
+import { CONNECTABLE } from '../../../../redux/discovery'
+import { getWifiList, postWifiDisconnect } from '../../../../redux/networking'
 import {
   dismissRequest,
   getRequestById,
@@ -39,8 +36,6 @@ export interface DisconnectModalProps {
   onCancel: () => unknown
   robotName: string
 }
-
-const LIST_REFRESH_MS = 10000
 
 export const DisconnectModal = ({
   onCancel,
@@ -88,25 +83,29 @@ export const DisconnectModal = ({
 
   const dispatch = useDispatch<Dispatch>()
 
-  useInterval(() => dispatch(fetchWifiList(robotName)), LIST_REFRESH_MS, true)
-
   let disconnectModalBody: string = t('are_you_sure_you_want_to_disconnect', {
     ssid,
   })
 
-  if (isRequestPending) {
+  // if the disconnect request is sent when there is no wired connection, we will not receive a success response to the request once wi-fi has disconnected
+  // check for connectable robot health status and presume successful disconnection if request pending and robot connectable
+  const { status } = useRobot(robotName) ?? {}
+  const isDisconnected =
+    isRequestSucceeded || (isRequestPending && status === CONNECTABLE)
+
+  if (isDisconnected) {
+    disconnectModalBody = t('disconnect_from_wifi_network_success')
+  } else if (isRequestPending) {
     disconnectModalBody = t('disconnecting_from_wifi_network', { ssid })
   } else if (isRequestFailed) {
     disconnectModalBody = t('disconnect_from_wifi_network_failure', { ssid })
-  } else if (isRequestSucceeded) {
-    disconnectModalBody = t('disconnect_from_wifi_network_success')
   }
 
   return (
     <Modal
       type="warning"
       title={
-        isRequestSucceeded
+        isDisconnected
           ? t('disconnected_from_wifi')
           : t('disconnect_from_ssid', { ssid })
       }
@@ -131,7 +130,7 @@ export const DisconnectModal = ({
           </StyledText>
         ) : null}
         <Flex justifyContent={JUSTIFY_FLEX_END} alignItems={ALIGN_CENTER}>
-          {isRequestSucceeded ? (
+          {isDisconnected ? (
             <PrimaryButton onClick={handleCancel}>{t('done')}</PrimaryButton>
           ) : (
             <>

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
@@ -88,10 +88,10 @@ export const DisconnectModal = ({
   })
 
   // if the disconnect request is sent when there is no wired connection, we will not receive a success response to the request once wi-fi has disconnected
-  // check for connectable robot health status and presume successful disconnection if request pending and robot connectable
+  // check for connectable robot health status and presume successful disconnection if request pending and robot not connectable
   const { status } = useRobot(robotName) ?? {}
   const isDisconnected =
-    isRequestSucceeded || (isRequestPending && status === CONNECTABLE)
+    isRequestSucceeded || (isRequestPending && status !== CONNECTABLE)
 
   if (isDisconnected) {
     disconnectModalBody = t('disconnect_from_wifi_network_success')

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/__tests__/DisconnectModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/__tests__/DisconnectModal.test.tsx
@@ -76,7 +76,7 @@ describe('DisconnectModal', () => {
       .mockReturnValue({} as RequestState)
     when(mockUseRobot)
       .calledWith(ROBOT_NAME)
-      .mockReturnValue(mockReachableRobot)
+      .mockReturnValue(mockConnectableRobot)
   })
 
   afterEach(() => {
@@ -104,13 +104,13 @@ describe('DisconnectModal', () => {
     getByRole('button', { name: 'cancel' })
   })
 
-  it('renders success body when request is pending and robot is connectable', () => {
+  it('renders success body when request is pending and robot is not connectable', () => {
     when(mockGetRequestById)
       .calledWith({} as State, LAST_ID)
       .mockReturnValue({ status: PENDING } as RequestState)
     when(mockUseRobot)
       .calledWith(ROBOT_NAME)
-      .mockReturnValue(mockConnectableRobot)
+      .mockReturnValue(mockReachableRobot)
     const { getByRole, getByText } = render()
 
     getByText('Disconnected from Wi-Fi')

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -76,11 +76,6 @@ export function RobotSettingsNetworking({
   useInterval(() => dispatch(fetchWifiList(robotName)), LIST_REFRESH_MS, true)
 
   React.useEffect(() => {
-    dispatch(fetchStatus(robotName))
-    dispatch(fetchWifiList(robotName))
-  }, [robotName, dispatch])
-
-  React.useEffect(() => {
     updateRobotStatus(isRobotBusy)
   }, [isRobotBusy, updateRobotStatus])
 

--- a/app/src/organisms/Devices/RobotSettings/SelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/SelectNetwork.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import last from 'lodash/last'
 
-import { useInterval } from '@opentrons/components'
-
 import * as RobotApi from '../../../redux/robot-api'
 import * as Networking from '../../../redux/networking'
 import { Portal } from '../../../App/portal'
@@ -23,8 +21,6 @@ interface TempSelectNetworkProps {
   robotName: string
   isRobotBusy: boolean
 }
-
-const LIST_REFRESH_MS = 10000
 
 export const SelectNetwork = ({
   robotName,
@@ -56,12 +52,6 @@ export const SelectNetwork = ({
       setChangeState({ ...changeState, ssid: options.ssid })
     }
   }
-
-  useInterval(
-    () => dispatch(Networking.fetchWifiList(robotName)),
-    LIST_REFRESH_MS,
-    true
-  )
 
   React.useEffect(() => {
     // if we're connecting to a network, ensure we get the info needed to

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -13,7 +13,7 @@ import { RobotSettingsNetworking } from '../RobotSettingsNetworking'
 
 import type { State } from '../../../../redux/types'
 
-jest.mock('../../../../redux/networking/selectors')
+jest.mock('../../../../redux/networking')
 jest.mock('../../../../redux/robot-api/selectors')
 jest.mock('../../hooks')
 jest.mock('../ConnectNetwork/DisconnectModal')
@@ -23,7 +23,9 @@ const mockUpdateRobotStatus = jest.fn()
 const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
   typeof Networking.getNetworkInterfaces
 >
-
+const mockFetchWifiList = Networking.fetchWifiList as jest.MockedFunction<
+  typeof Networking.fetchWifiList
+>
 const mockGetWifiList = Networking.getWifiList as jest.MockedFunction<
   typeof Networking.getWifiList
 >
@@ -76,6 +78,8 @@ const mockWifiList = [
 ]
 
 describe('RobotSettingsNetworking', () => {
+  jest.useFakeTimers()
+
   beforeEach(() => {
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, ROBOT_NAME)
@@ -274,5 +278,15 @@ describe('RobotSettingsNetworking', () => {
     const [{ queryByRole }] = render()
 
     expect(queryByRole('button', { name: 'Disconnect from Wi-Fi' })).toBeNull()
+  })
+
+  it('dispatches fetchWifiList on mount and on an interval', () => {
+    render()
+    expect(mockFetchWifiList).toHaveBeenNthCalledWith(1, ROBOT_NAME)
+    expect(mockFetchWifiList).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(20000)
+    expect(mockFetchWifiList).toHaveBeenNthCalledWith(2, ROBOT_NAME)
+    expect(mockFetchWifiList).toHaveBeenNthCalledWith(3, ROBOT_NAME)
+    expect(mockFetchWifiList).toHaveBeenCalledTimes(3)
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/__tests__/SelectNetwork.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/SelectNetwork.test.tsx
@@ -117,18 +117,6 @@ describe('<TemporarySelectNetwork />', () => {
     jest.useRealTimers()
   })
 
-  it('dispatches fetchWifiList on mount and on an interval', () => {
-    const expectedFetchList = Networking.fetchWifiList(mockRobotName)
-
-    render()
-    expect(dispatch).toHaveBeenNthCalledWith(1, expectedFetchList)
-    expect(dispatch).toHaveBeenCalledTimes(1)
-    jest.advanceTimersByTime(20000)
-    expect(dispatch).toHaveBeenNthCalledWith(2, expectedFetchList)
-    expect(dispatch).toHaveBeenNthCalledWith(3, expectedFetchList)
-    expect(dispatch).toHaveBeenCalledTimes(3)
-  })
-
   it('renders an <SelectSsid /> child with props from state', () => {
     const wrapper = render()
     const selectSsid = wrapper.find(SelectSsid)

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -14,7 +14,7 @@ import {
   mockReachableRobot,
   mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
-import { getCanDisconnect } from '../../../redux/networking'
+import { fetchWifiList, getCanDisconnect } from '../../../redux/networking'
 import { DisconnectModal } from '../../../organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal'
 import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
@@ -61,6 +61,9 @@ const mockDisconnectModal = DisconnectModal as jest.MockedFunction<
 const mockGetCanDisconnect = getCanDisconnect as jest.MockedFunction<
   typeof getCanDisconnect
 >
+const mockFetchWifiList = fetchWifiList as jest.MockedFunction<
+  typeof fetchWifiList
+>
 
 const render = (
   props: React.ComponentProps<typeof RobotOverviewOverflowMenu>
@@ -77,6 +80,8 @@ const render = (
 
 describe('RobotOverviewOverflowMenu', () => {
   let props: React.ComponentProps<typeof RobotOverviewOverflowMenu>
+  jest.useFakeTimers()
+
   beforeEach(() => {
     props = { robot: mockConnectableRobot }
     when(mockGetBuildrootUpdateDisplayInfo)
@@ -99,6 +104,7 @@ describe('RobotOverviewOverflowMenu', () => {
   })
   afterEach(() => {
     resetAllWhenMocks()
+    jest.resetAllMocks()
   })
 
   it('should render enabled buttons in the menu when the status is idle', () => {
@@ -275,5 +281,24 @@ describe('RobotOverviewOverflowMenu', () => {
     const btn = getByRole('button')
     fireEvent.click(btn)
     expect(getByRole('button', { name: 'Robot settings' })).toBeDisabled()
+  })
+
+  it('dispatches fetchWifiList on mount and on an interval', () => {
+    render({ robot: mockUnreachableRobot })
+    expect(mockFetchWifiList).toHaveBeenNthCalledWith(
+      1,
+      mockUnreachableRobot.name
+    )
+    expect(mockFetchWifiList).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(20000)
+    expect(mockFetchWifiList).toHaveBeenNthCalledWith(
+      2,
+      mockUnreachableRobot.name
+    )
+    expect(mockFetchWifiList).toHaveBeenNthCalledWith(
+      3,
+      mockUnreachableRobot.name
+    )
+    expect(mockFetchWifiList).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
# Overview

fixes the bug where the disconnect modal spins infinitely on successful disconnect. if the disconnect request is sent when there is no wired connection, we will not receive a success response to the request once wi-fi has disconnected. to fix, once the request is pending we check for connectable robot health status and presume successful disconnection if the request is pending and the robot is not connectable.

also removes some duplicative `fetchWifiList` polls in components, and adds a necessary poll to the robot overview overflow menu on the device details page.

closes RQA-513

# Test Plan

 - manually verified disconnect wifi modal flow wired and unwired on robot
 - updated unit tests for request pending/not connectable status

# Changelog

 - Shows successful wifi disconnect when request pending and robot not connectable

# Review requests

confirm infinite spin is fixed

# Risk assessment

low
