### PR TITLE
refactor(api): remove configuration parameter from load_module in 2.14

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -278,5 +278,5 @@ If you specify an API version of 2.13 or lower, your protocols will continue to 
     Configure your pipette pick-up settings with the Opentrons App, instead.
 
   - The ``configuration`` argument of :py:meth:`.ProtocolContext.load_module` was deprecated
-    because it made unsafe modifications to the protocol's geometry system when used,
+    because it made unsafe modifications to the protocol's geometry system,
     and the Thermocycler's "semi" configuration is not officially supported.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -276,3 +276,7 @@ If you specify an API version of 2.13 or lower, your protocols will continue to 
 
   - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` were deprecated.
     Configure your pipette pick-up settings with the Opentrons App, instead.
+
+  - The ``configuration`` argument of :py:meth:`.ProtocolContext.load_module` was deprecated
+    because it made unsafe modifications to the protocol's geometry system when used,
+    and the Thermocycler's "semi" configuration is not officially supported.

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -229,6 +229,8 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
         configuration: Optional[str],
     ) -> ModuleCore:
         """Load a module into the protocol."""
+        assert configuration is None, "Module `configuration` is deprecated"
+
         # TODO(mc, 2022-10-20): move to public ProtocolContext
         # once `Deck` and `ProtocolEngine` play nicely together
         if deck_slot is None:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -477,9 +477,7 @@ class ProtocolContext(CommandPublisher):
                 )
             if self._api_version >= ENGINE_CORE_API_VERSION:
                 raise APIVersionError(
-                    "The configuration parameter of load_module has been deprecated."
-                    " It did not function correctly,"
-                    ' and "semi" configration is not officially supported.'
+                    "The configuration parameter of load_module has been removed."
                 )
 
         requested_model = validation.ensure_module_model(module_name)

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -475,7 +475,7 @@ def test_load_module(
     result = subject.load_module(
         model=requested_model,
         deck_slot=DeckSlotName.SLOT_1,
-        configuration="",
+        configuration=None,
     )
 
     assert isinstance(result, expected_core_cls)
@@ -544,7 +544,7 @@ def test_load_module_thermocycler_with_no_location(
     result = subject.load_module(
         model=requested_model,
         deck_slot=None,
-        configuration="",
+        configuration=None,
     )
 
     assert isinstance(result, ThermocyclerModuleCore)
@@ -566,7 +566,7 @@ def test_load_module_no_location(
 ) -> None:
     """Should raise an InvalidModuleLocationError exception."""
     with pytest.raises(InvalidModuleLocationError):
-        subject.load_module(model=requested_model, deck_slot=None, configuration="")
+        subject.load_module(model=requested_model, deck_slot=None, configuration=None)
 
 
 @pytest.mark.parametrize("message", [None, "Hello, world!", ""])

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -462,7 +462,7 @@ def test_load_module_default_location(
 @pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
 def test_load_module_with_configuration(subject: ProtocolContext) -> None:
     """It should raise an APIVersionError if the deprecated `configuration` argument is used."""
-    with pytest.raises(APIVersionError, match="deprecated"):
+    with pytest.raises(APIVersionError, match="removed"):
         subject.load_module(
             module_name="spline reticulator",
             location=42,

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -12,6 +12,8 @@ from opentrons.types import Mount, DeckSlotName
 from opentrons.broker import Broker
 from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
 from opentrons.protocols.api_support import instrument as mock_instrument_support
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import (
     MAX_SUPPORTED_VERSION,
     ProtocolContext,
@@ -72,12 +74,21 @@ def mock_deck(decoy: Decoy) -> Deck:
 
 
 @pytest.fixture
+def api_version() -> APIVersion:
+    """The API version under test."""
+    return MAX_SUPPORTED_VERSION
+
+
+@pytest.fixture
 def subject(
-    mock_core: ProtocolCore, mock_core_map: LoadedCoreMap, mock_deck: Deck
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    mock_deck: Deck,
+    api_version: APIVersion,
 ) -> ProtocolContext:
     """Get a ProtocolContext test subject with its dependencies mocked out."""
     return ProtocolContext(
-        api_version=MAX_SUPPORTED_VERSION,
+        api_version=api_version,
         core=mock_core,
         core_map=mock_core_map,
         deck=mock_deck,
@@ -446,6 +457,17 @@ def test_load_module_default_location(
     result = subject.load_module(module_name="spline reticulator", location=42)
 
     assert isinstance(result, ModuleContext)
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
+def test_load_module_with_configuration(subject: ProtocolContext) -> None:
+    """It should raise an APIVersionError if the deprecated `configuration` argument is used."""
+    with pytest.raises(APIVersionError, match="deprecated"):
+        subject.load_module(
+            module_name="spline reticulator",
+            location=42,
+            configuration="semi",
+        )
 
 
 def test_loaded_modules(


### PR DESCRIPTION
## Overview

The `configuration` parameter to `load_module` was intended to add advanced support for the Thermocycler's "semi" configuration, where it straddles the edge of the deck so that it doesn't cover some slots that a Thermocycler typically covers.

Unfortunately, the implementation of `configuration` had two problems:

1. It didn't actually work; it did not configure the geometry well enough to ensure the robot would actually move properly to the correct location2. 
2. The way that it _did_ modify the geometry system was invasive, mutating values deep in the system in an unexpected (and therefore dangerous) manner. 

Due to these problems and a lack of desire from the organization to officially support the `semi` configuration, this PR drops support for `load_module("thermocycler", configuration="semi")` in Protocol API v2.14.

Closes RCORE-499.

## Test Plan

Nothing much needed for this one, it was pretty easy to cover with unit tests

## Changelog

- Remove support for the `configuration` parameter of `load_module`
- Update versioning documentation

## Review requests

- How does the change look?
- Did I miss any documentation updates?

## Risk assessment

Low, removal of feature in future API version that never worked, while leaving existing implementation in place for <= v2.13.
