### PR TITLE
refactor(engine): add position field to movement command results

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -9,6 +9,7 @@ from .pipetting_common import (
     FlowRateMixin,
     WellLocationMixin,
     BaseLiquidHandlingResult,
+    DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
@@ -25,7 +26,7 @@ class AspirateParams(PipetteIdMixin, VolumeMixin, FlowRateMixin, WellLocationMix
     pass
 
 
-class AspirateResult(BaseLiquidHandlingResult):
+class AspirateResult(BaseLiquidHandlingResult, DestinationPositionResult):
     """Result data from execution of an Aspirate command."""
 
     pass
@@ -39,7 +40,7 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]
 
     async def execute(self, params: AspirateParams) -> AspirateResult:
         """Move to and aspirate from the requested well."""
-        volume = await self._pipetting.aspirate(
+        result = await self._pipetting.aspirate(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -48,7 +49,7 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]
             flow_rate=params.flowRate,
         )
 
-        return AspirateResult(volume=volume)
+        return AspirateResult(volume=result.volume, position=result.destination)
 
 
 class Aspirate(BaseCommand[AspirateParams, AspirateResult]):

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -49,7 +49,7 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]
             flow_rate=params.flowRate,
         )
 
-        return AspirateResult(volume=result.volume, position=result.destination)
+        return AspirateResult(volume=result.volume, position=result.position)
 
 
 class Aspirate(BaseCommand[AspirateParams, AspirateResult]):

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 from pydantic import BaseModel
 
-from .pipetting_common import PipetteIdMixin, FlowRateMixin, WellLocationMixin
+from .pipetting_common import PipetteIdMixin, FlowRateMixin, WellLocationMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 from opentrons.hardware_control import HardwareControlAPI
@@ -23,7 +23,7 @@ class BlowOutParams(PipetteIdMixin, FlowRateMixin, WellLocationMixin):
     pass
 
 
-class BlowOutResult(BaseModel):
+class BlowOutResult(DestinationPositionResult):
     """Result data from the execution of a blow-out command."""
 
     pass
@@ -52,7 +52,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
             attached_pipettes=self._hardware_api.attached_instruments,
         )
 
-        await self._movement.move_to_well(
+        destination = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -64,7 +64,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
         ):
             await self._hardware_api.blow_out(mount=hw_pipette.mount)
 
-        return BlowOutResult()
+        return BlowOutResult(position=destination)
 
 
 class BlowOut(BaseCommand[BlowOutParams, BlowOutResult]):

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -56,7 +56,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
             attached_pipettes=self._hardware_api.attached_instruments,
         )
 
-        destination = await self._movement.move_to_well(
+        position = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -68,7 +68,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
         ):
             await self._hardware_api.blow_out(mount=hw_pipette.mount)
 
-        return BlowOutResult(position=destination)
+        return BlowOutResult(position=position)
 
 
 class BlowOut(BaseCommand[BlowOutParams, BlowOutResult]):

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
-from pydantic import BaseModel
 
-from .pipetting_common import PipetteIdMixin, FlowRateMixin, WellLocationMixin, DestinationPositionResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    FlowRateMixin,
+    WellLocationMixin,
+    DestinationPositionResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 from opentrons.hardware_control import HardwareControlAPI

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -43,7 +43,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, DispenseResult]
 
     async def execute(self, params: DispenseParams) -> DispenseResult:
         """Move to and dispense to the requested well."""
-        destination = await self._movement.move_to_well(
+        position = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -55,7 +55,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, DispenseResult]
             flow_rate=params.flowRate,
         )
 
-        return DispenseResult(volume=volume, position=destination)
+        return DispenseResult(volume=volume, position=position)
 
 
 class Dispense(BaseCommand[DispenseParams, DispenseResult]):

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -9,6 +9,7 @@ from .pipetting_common import (
     FlowRateMixin,
     WellLocationMixin,
     BaseLiquidHandlingResult,
+    DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
@@ -25,7 +26,7 @@ class DispenseParams(PipetteIdMixin, VolumeMixin, FlowRateMixin, WellLocationMix
     pass
 
 
-class DispenseResult(BaseLiquidHandlingResult):
+class DispenseResult(BaseLiquidHandlingResult, DestinationPositionResult):
     """Result data from the execution of a Dispense command."""
 
     pass
@@ -42,7 +43,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, DispenseResult]
 
     async def execute(self, params: DispenseParams) -> DispenseResult:
         """Move to and dispense to the requested well."""
-        await self._movement.move_to_well(
+        destination = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -54,7 +55,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, DispenseResult]
             flow_rate=params.flowRate,
         )
 
-        return DispenseResult(volume=volume)
+        return DispenseResult(volume=volume, position=destination)
 
 
 class Dispense(BaseCommand[DispenseParams, DispenseResult]):

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -45,7 +45,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
 
     async def execute(self, params: DropTipParams) -> DropTipResult:
         """Move to and drop a tip using the requested pipette."""
-        destination = await self._pipetting.drop_tip(
+        position = await self._pipetting.drop_tip(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -53,7 +53,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
             home_after=params.homeAfter,
         )
 
-        return DropTipResult(position=destination)
+        return DropTipResult(position=position)
 
 
 class DropTip(BaseCommand[DropTipParams, DropTipResult]):

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin
+from .pipetting_common import PipetteIdMixin, WellLocationMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ class DropTipParams(PipetteIdMixin, WellLocationMixin):
     )
 
 
-class DropTipResult(BaseModel):
+class DropTipResult(DestinationPositionResult):
     """Result data from the execution of a DropTip command."""
 
     pass
@@ -41,7 +41,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
 
     async def execute(self, params: DropTipParams) -> DropTipResult:
         """Move to and drop a tip using the requested pipette."""
-        await self._pipetting.drop_tip(
+        destination = await self._pipetting.drop_tip(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -49,7 +49,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
             home_after=params.homeAfter,
         )
 
-        return DropTipResult()
+        return DropTipResult(position=destination)
 
 
 class DropTip(BaseCommand[DropTipParams, DropTipResult]):

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -1,10 +1,14 @@
 """Drop tip command request, result, and implementation models."""
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin, DestinationPositionResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    WellLocationMixin,
+    DestinationPositionResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -4,8 +4,9 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from ..types import MovementAxis, DeckPoint
+from ..types import MovementAxis
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .pipetting_common import DestinationPositionResult
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -28,16 +29,10 @@ class MoveRelativeParams(BaseModel):
     )
 
 
-class MoveRelativeResult(BaseModel):
+class MoveRelativeResult(DestinationPositionResult):
     """Result data from the execution of a MoveRelative command."""
 
-    position: DeckPoint = Field(
-        ...,
-        description=(
-            "The (x,y,z) coordinates of the pipette's critical point in deck space"
-            " after the move was completed."
-        ),
-    )
+    pass
 
 
 class MoveRelativeImplementation(

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -1,12 +1,12 @@
 """Move to coordinates command request, result, and implementation models."""
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from typing import Optional, Type, TYPE_CHECKING
 from typing_extensions import Literal
 
 from ..types import DeckPoint
-from .pipetting_common import PipetteIdMixin, MovementMixin
+from .pipetting_common import PipetteIdMixin, MovementMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ class MoveToCoordinatesParams(PipetteIdMixin, MovementMixin):
     )
 
 
-class MoveToCoordinatesResult(BaseModel):
+class MoveToCoordinatesResult(DestinationPositionResult):
     """Result data from the execution of a MoveToCoordinates command."""
 
     pass
@@ -45,14 +45,14 @@ class MoveToCoordinatesImplementation(
 
     async def execute(self, params: MoveToCoordinatesParams) -> MoveToCoordinatesResult:
         """Move the requested pipette to the requested coordinates."""
-        await self._movement.move_to_coordinates(
+        destination = await self._movement.move_to_coordinates(
             pipette_id=params.pipetteId,
             deck_coordinates=params.coordinates,
             direct=params.forceDirect,
             additional_min_travel_z=params.minimumZHeight,
             speed=params.speed,
         )
-        return MoveToCoordinatesResult()
+        return MoveToCoordinatesResult(position=destination)
 
 
 class MoveToCoordinates(BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult]):

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -45,14 +45,14 @@ class MoveToCoordinatesImplementation(
 
     async def execute(self, params: MoveToCoordinatesParams) -> MoveToCoordinatesResult:
         """Move the requested pipette to the requested coordinates."""
-        destination = await self._movement.move_to_coordinates(
+        position = await self._movement.move_to_coordinates(
             pipette_id=params.pipetteId,
             deck_coordinates=params.coordinates,
             direct=params.forceDirect,
             additional_min_travel_z=params.minimumZHeight,
             speed=params.speed,
         )
-        return MoveToCoordinatesResult(position=destination)
+        return MoveToCoordinatesResult(position=position)
 
 
 class MoveToCoordinates(BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult]):

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin, MovementMixin
+from .pipetting_common import PipetteIdMixin, WellLocationMixin, MovementMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ class MoveToWellParams(PipetteIdMixin, WellLocationMixin, MovementMixin):
     pass
 
 
-class MoveToWellResult(BaseModel):
+class MoveToWellResult(DestinationPositionResult):
     """Result data from the execution of a MoveToWell command."""
 
     pass
@@ -33,7 +33,7 @@ class MoveToWellImplementation(AbstractCommandImpl[MoveToWellParams, MoveToWellR
 
     async def execute(self, params: MoveToWellParams) -> MoveToWellResult:
         """Move the requested pipette to the requested well."""
-        await self._movement.move_to_well(
+        destination = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -43,7 +43,7 @@ class MoveToWellImplementation(AbstractCommandImpl[MoveToWellParams, MoveToWellR
             speed=params.speed,
         )
 
-        return MoveToWellResult()
+        return MoveToWellResult(position=destination)
 
 
 class MoveToWell(BaseCommand[MoveToWellParams, MoveToWellResult]):

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -37,7 +37,7 @@ class MoveToWellImplementation(AbstractCommandImpl[MoveToWellParams, MoveToWellR
 
     async def execute(self, params: MoveToWellParams) -> MoveToWellResult:
         """Move the requested pipette to the requested well."""
-        destination = await self._movement.move_to_well(
+        position = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -47,7 +47,7 @@ class MoveToWellImplementation(AbstractCommandImpl[MoveToWellParams, MoveToWellR
             speed=params.speed,
         )
 
-        return MoveToWellResult(position=destination)
+        return MoveToWellResult(position=position)
 
 
 class MoveToWell(BaseCommand[MoveToWellParams, MoveToWellResult]):

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -1,10 +1,14 @@
 """Move to well command request, result, and implementation models."""
 from __future__ import annotations
-from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin, MovementMixin, DestinationPositionResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    WellLocationMixin,
+    MovementMixin,
+    DestinationPositionResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -1,10 +1,14 @@
 """Pick up tip command request, result, and implementation models."""
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin, DestinationPositionResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    WellLocationMixin,
+    DestinationPositionResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin
+from .pipetting_common import PipetteIdMixin, WellLocationMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ class PickUpTipParams(PipetteIdMixin, WellLocationMixin):
     pass
 
 
-class PickUpTipResult(BaseModel):
+class PickUpTipResult(DestinationPositionResult):
     """Result data from the execution of a PickUpTip."""
 
     # Tip volume has a default ONLY for parsing data from earlier versions, which did not include this in the result
@@ -39,14 +39,14 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, PickUpTipResu
 
     async def execute(self, params: PickUpTipParams) -> PickUpTipResult:
         """Move to and pick up a tip using the requested pipette."""
-        tip_volume = await self._pipetting.pick_up_tip(
+        result = await self._pipetting.pick_up_tip(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
             well_location=params.wellLocation,
         )
 
-        return PickUpTipResult(tipVolume=tip_volume)
+        return PickUpTipResult(tipVolume=result.volume, position=result.destination)
 
 
 class PickUpTip(BaseCommand[PickUpTipParams, PickUpTipResult]):

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -50,7 +50,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, PickUpTipResu
             well_location=params.wellLocation,
         )
 
-        return PickUpTipResult(tipVolume=result.volume, position=result.destination)
+        return PickUpTipResult(tipVolume=result.volume, position=result.position)
 
 
 class PickUpTip(BaseCommand[PickUpTipParams, PickUpTipResult]):

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -93,10 +93,10 @@ class BaseLiquidHandlingResult(BaseModel):
 
 
 class DestinationPositionResult(BaseModel):
-    """Mixin for command results that move a pipette"""
+    """Mixin for command results that move a pipette."""
 
-    position: DeckPoint = Field(  # TODO change this for the mix in
-        ...,
+    position: DeckPoint = Field(
+        DeckPoint(x=0, y=0, z=0),
         description=(
             "The (x,y,z) coordinates of the pipette's critical point in deck space"
             " after the move was completed."

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -2,7 +2,7 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 
-from ..types import WellLocation
+from ..types import WellLocation, DeckPoint
 
 
 class PipetteIdMixin(BaseModel):
@@ -89,4 +89,16 @@ class BaseLiquidHandlingResult(BaseModel):
         ...,
         description="Amount of liquid in uL handled in the operation.",
         gt=0,
+    )
+
+
+class DestinationPositionResult(BaseModel):
+    """Mixin for command results that move a pipette"""
+
+    position: DeckPoint = Field(  # TODO change this for the mix in
+        ...,
+        description=(
+            "The (x,y,z) coordinates of the pipette's critical point in deck space"
+            " after the move was completed."
+        ),
     )

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -66,7 +66,7 @@ class TouchTipImplementation(AbstractCommandImpl[TouchTipParams, TouchTipResult]
         if self._state_view.labware.is_tiprack(labware_id=params.labwareId):
             raise LabwareIsTipRackError("Cannot touch tip on tiprack")
 
-        destination = await self._pipetting.touch_tip(
+        position = await self._pipetting.touch_tip(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -75,7 +75,7 @@ class TouchTipImplementation(AbstractCommandImpl[TouchTipParams, TouchTipResult]
             speed=params.speed,
         )
 
-        return TouchTipResult(position=destination)
+        return TouchTipResult(position=position)
 
 
 class TouchTip(BaseCommand[TouchTipParams, TouchTipResult]):

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -1,10 +1,14 @@
 """Touch tip command request, result, and implementation models."""
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin, DestinationPositionResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    WellLocationMixin,
+    DestinationPositionResult,
+)
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 from ..errors import TouchTipDisabledError, LabwareIsTipRackError
 

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin, WellLocationMixin
+from .pipetting_common import PipetteIdMixin, WellLocationMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 from ..errors import TouchTipDisabledError, LabwareIsTipRackError
 
@@ -35,7 +35,7 @@ class TouchTipParams(PipetteIdMixin, WellLocationMixin):
     )
 
 
-class TouchTipResult(BaseModel):
+class TouchTipResult(DestinationPositionResult):
     """Result data from the execution of a TouchTip."""
 
     pass
@@ -62,7 +62,7 @@ class TouchTipImplementation(AbstractCommandImpl[TouchTipParams, TouchTipResult]
         if self._state_view.labware.is_tiprack(labware_id=params.labwareId):
             raise LabwareIsTipRackError("Cannot touch tip on tiprack")
 
-        await self._pipetting.touch_tip(
+        destination = await self._pipetting.touch_tip(
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
@@ -71,7 +71,7 @@ class TouchTipImplementation(AbstractCommandImpl[TouchTipParams, TouchTipResult]
             speed=params.speed,
         )
 
-        return TouchTipResult()
+        return TouchTipResult(position=destination)
 
 
 class TouchTip(BaseCommand[TouchTipParams, TouchTipResult]):

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -90,7 +90,7 @@ class MovementHandler:
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
-    ) -> None:
+    ) -> DeckPoint:
         """Move to a specific well."""
         await self._tc_movement_flagger.raise_if_labware_in_non_open_thermocycler(
             labware_parent=self._state_store.labware.get_location(labware_id=labware_id)
@@ -162,6 +162,10 @@ class MovementHandler:
                 critical_point=waypoint.critical_point,
                 speed=speed,
             )
+
+        final_point = waypoints[-1].position
+
+        return DeckPoint(x=final_point.x, y=final_point.y, z=final_point.z)
 
     async def move_relative(
         self,

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -275,7 +275,7 @@ class MovementHandler:
         direct: bool,
         additional_min_travel_z: Optional[float],
         speed: Optional[float] = None,
-    ) -> None:
+    ) -> DeckPoint:
         """Move pipette to a given deck coordinate."""
         pipette_location = self._state_store.motion.get_pipette_location(
             pipette_id=pipette_id,
@@ -319,3 +319,7 @@ class MovementHandler:
                 critical_point=waypoint.critical_point,
                 speed=speed,
             )
+
+        final_point = waypoints[-1].position
+
+        return DeckPoint(x=final_point.x, y=final_point.y, z=final_point.z)

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -163,7 +163,10 @@ class MovementHandler:
                 speed=speed,
             )
 
-        final_point = waypoints[-1].position
+        try:
+            final_point = waypoints[-1].position
+        except IndexError:
+            final_point = origin
 
         return DeckPoint(x=final_point.x, y=final_point.y, z=final_point.z)
 
@@ -320,6 +323,9 @@ class MovementHandler:
                 speed=speed,
             )
 
-        final_point = waypoints[-1].position
+        try:
+            final_point = waypoints[-1].position
+        except IndexError:
+            final_point = origin
 
         return DeckPoint(x=final_point.x, y=final_point.y, z=final_point.z)

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -293,7 +293,7 @@ class PipettingHandler:
 
         # this will handle raising if the thermocycler lid is in a bad state
         # so we don't need to put that logic elsewhere
-        await self._movement_handler.move_to_well(
+        well_position = await self._movement_handler.move_to_well(
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -307,9 +307,13 @@ class PipettingHandler:
                 abs_position=touch_point,
                 speed=speed,
             )
-        final_point = touch_points[-1]
+        try:
+            final_point = touch_points[-1]
+            position = DeckPoint(x=final_point.x, y=final_point.y, z=final_point.z)
+        except IndexError:
+            position = well_position
 
-        return DeckPoint(x=final_point.x, y=final_point.y, z=final_point.z)
+        return position
 
     @contextmanager
     def set_flow_rate(

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -24,7 +24,7 @@ class VolumePointResult:
     """The returned values of an aspirate or pick up tip operation."""
 
     volume: float
-    destination: DeckPoint
+    position: DeckPoint
 
 
 class PipettingHandler:
@@ -102,7 +102,7 @@ class PipettingHandler:
         )
 
         # move the pipette to the top of the tip
-        destination = await self._movement_handler.move_to_well(
+        position = await self._movement_handler.move_to_well(
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -128,7 +128,7 @@ class PipettingHandler:
             tip_volume=tip_volume,
         )
 
-        return VolumePointResult(volume=tip_volume, destination=destination)
+        return VolumePointResult(volume=tip_volume, position=position)
 
     async def add_tip(self, pipette_id: str, labware_id: str) -> None:
         """Manually add a tip to a pipette in the hardware API.
@@ -172,7 +172,7 @@ class PipettingHandler:
         )
 
         # move the pipette to tip drop location
-        destination = await self._movement_handler.move_to_well(
+        position = await self._movement_handler.move_to_well(
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -184,7 +184,7 @@ class PipettingHandler:
             mount=hw_pipette.mount,
             home_after=True if home_after is None else home_after,
         )
-        return destination
+        return position
 
     async def aspirate(
         self,
@@ -227,7 +227,7 @@ class PipettingHandler:
                 well_name=well_name,
             )
 
-        destination = await self._movement_handler.move_to_well(
+        position = await self._movement_handler.move_to_well(
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -238,7 +238,7 @@ class PipettingHandler:
         with self.set_flow_rate(pipette=hw_pipette, aspirate_flow_rate=flow_rate):
             await self._hardware_api.aspirate(mount=hw_pipette.mount, volume=volume)
 
-        return VolumePointResult(volume=volume, destination=destination)
+        return VolumePointResult(volume=volume, position=position)
 
     async def dispense_in_place(
         self,
@@ -300,11 +300,11 @@ class PipettingHandler:
             well_location=well_location,
         )
 
-        for position in touch_points:
+        for touch_point in touch_points:
             await self._hardware_api.move_to(
                 mount=pipette_location.mount.to_hw_mount(),
                 critical_point=pipette_location.critical_point,
-                abs_position=position,
+                abs_position=touch_point,
                 speed=speed,
             )
         final_point = touch_points[-1]

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -18,6 +18,7 @@ class _TipPickupData(NamedTuple):
     tip_diameter: float
     tip_volume: int
 
+
 @dataclass(frozen=True)
 class VolumePointResult:
     """The returned values of an aspirate or pick up tip operation."""
@@ -128,7 +129,6 @@ class PipettingHandler:
         )
 
         return VolumePointResult(volume=tip_volume, destination=destination)
-
 
     async def add_tip(self, pipette_id: str, labware_id: str) -> None:
         """Manually add a tip to a pipette in the hardware API.

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -47,7 +47,6 @@ async def create_simulating_runner(robot_type: RobotType) -> ProtocolRunner:
         config=ProtocolEngineConfig(
             robot_type=robot_type,
             ignore_pause=True,
-            # use_virtual_pipettes=True,
             use_virtual_modules=True,
             use_virtual_gripper=True,
         ),

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -47,6 +47,7 @@ async def create_simulating_runner(robot_type: RobotType) -> ProtocolRunner:
         config=ProtocolEngineConfig(
             robot_type=robot_type,
             ignore_pause=True,
+            # use_virtual_pipettes=True,
             use_virtual_modules=True,
             use_virtual_gripper=True,
         ),

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -138,7 +138,8 @@ class LegacyCommandMapper:
                     completed_command = running_command.copy(
                         update={
                             "result": pe_commands.PickUpTipResult.construct(
-                                tipVolume=command["payload"]["location"].max_volume  # type: ignore[typeddict-item]
+                                tipVolume=command["payload"]["location"].max_volume,  # type: ignore[typeddict-item]
+                                position=pe_types.DeckPoint(x=0, y=0, z=0)
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
@@ -147,7 +148,7 @@ class LegacyCommandMapper:
                 elif isinstance(running_command, pe_commands.DropTip):
                     completed_command = running_command.copy(
                         update={
-                            "result": pe_commands.DropTipResult.construct(),
+                            "result": pe_commands.DropTipResult.construct(position=pe_types.DeckPoint(x=0, y=0, z=0)),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
                         }
@@ -158,7 +159,8 @@ class LegacyCommandMapper:
                             # Don't .construct() result, because we want to validate
                             # volume.
                             "result": pe_commands.AspirateResult(
-                                volume=running_command.params.volume
+                                volume=running_command.params.volume,
+                                position=pe_types.DeckPoint(x=0, y=0, z=0)
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
@@ -170,7 +172,8 @@ class LegacyCommandMapper:
                             # Don't .construct() result, because we want to validate
                             # volume.
                             "result": pe_commands.DispenseResult(
-                                volume=running_command.params.volume
+                                volume=running_command.params.volume,
+                                position=pe_types.DeckPoint(x=0, y=0, z=0)
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
@@ -179,7 +182,7 @@ class LegacyCommandMapper:
                 elif isinstance(running_command, pe_commands.BlowOut):
                     completed_command = running_command.copy(
                         update={
-                            "result": pe_commands.BlowOutResult.construct(),
+                            "result": pe_commands.BlowOutResult.construct(position=pe_types.DeckPoint(x=0, y=0, z=0)),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
                         }

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -139,7 +139,7 @@ class LegacyCommandMapper:
                         update={
                             "result": pe_commands.PickUpTipResult.construct(
                                 tipVolume=command["payload"]["location"].max_volume,  # type: ignore[typeddict-item]
-                                position=pe_types.DeckPoint(x=0, y=0, z=0)
+                                position=pe_types.DeckPoint(x=0, y=0, z=0),
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
@@ -148,7 +148,9 @@ class LegacyCommandMapper:
                 elif isinstance(running_command, pe_commands.DropTip):
                     completed_command = running_command.copy(
                         update={
-                            "result": pe_commands.DropTipResult.construct(position=pe_types.DeckPoint(x=0, y=0, z=0)),
+                            "result": pe_commands.DropTipResult.construct(
+                                position=pe_types.DeckPoint(x=0, y=0, z=0)
+                            ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
                         }
@@ -160,7 +162,7 @@ class LegacyCommandMapper:
                             # volume.
                             "result": pe_commands.AspirateResult(
                                 volume=running_command.params.volume,
-                                position=pe_types.DeckPoint(x=0, y=0, z=0)
+                                position=pe_types.DeckPoint(x=0, y=0, z=0),
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
@@ -173,7 +175,7 @@ class LegacyCommandMapper:
                             # volume.
                             "result": pe_commands.DispenseResult(
                                 volume=running_command.params.volume,
-                                position=pe_types.DeckPoint(x=0, y=0, z=0)
+                                position=pe_types.DeckPoint(x=0, y=0, z=0),
                             ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
@@ -182,7 +184,9 @@ class LegacyCommandMapper:
                 elif isinstance(running_command, pe_commands.BlowOut):
                     completed_command = running_command.copy(
                         update={
-                            "result": pe_commands.BlowOutResult.construct(position=pe_types.DeckPoint(x=0, y=0, z=0)),
+                            "result": pe_commands.BlowOutResult.construct(
+                                position=pe_types.DeckPoint(x=0, y=0, z=0)
+                            ),
                             "status": pe_commands.CommandStatus.SUCCEEDED,
                             "completedAt": now,
                         }

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -11,7 +11,7 @@ from decoy import Decoy
 from opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
-from opentrons.protocol_engine import ProtocolEngine, commands
+from opentrons.protocol_engine import ProtocolEngine, commands, DeckPoint
 from opentrons.protocol_engine.errors import ErrorOccurrence, ProtocolEngineError
 from opentrons.protocol_engine.clients.transports import ChildThreadTransport
 
@@ -41,7 +41,7 @@ async def test_execute_command(
         labwareId="labware-id",
         wellName="A1",
     )
-    cmd_result = commands.MoveToWellResult()
+    cmd_result = commands.MoveToWellResult(position=DeckPoint(x=1, y=2, z=3))
     cmd_request = commands.MoveToWellCreate(params=cmd_data)
 
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -216,7 +216,7 @@ def test_move_to_well(
             speed=7.89,
         )
     )
-    response = commands.MoveToWellResult()
+    response = commands.MoveToWellResult(position=DeckPoint(x=4, y=5, z=6))
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 
@@ -276,7 +276,9 @@ def test_pick_up_tip(
             pipetteId="123", labwareId="456", wellName="A2", wellLocation=WellLocation()
         )
     )
-    response = commands.PickUpTipResult(tipVolume=78.9)
+    response = commands.PickUpTipResult(
+        tipVolume=78.9, position=DeckPoint(x=4, y=5, z=6)
+    )
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 
@@ -302,7 +304,7 @@ def test_drop_tip(
             homeAfter=True,
         )
     )
-    response = commands.DropTipResult()
+    response = commands.DropTipResult(position=DeckPoint(x=4, y=5, z=6))
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 
@@ -337,7 +339,9 @@ def test_aspirate(
         )
     )
 
-    result_from_transport = commands.AspirateResult(volume=67.89)
+    result_from_transport = commands.AspirateResult(
+        volume=67.89, position=DeckPoint(x=4, y=5, z=6)
+    )
 
     decoy.when(transport.execute_command(request=request)).then_return(
         result_from_transport
@@ -378,7 +382,7 @@ def test_dispense(
         )
     )
 
-    response = commands.DispenseResult(volume=1)
+    response = commands.DispenseResult(volume=1, position=DeckPoint(x=4, y=5, z=6))
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 
@@ -413,7 +417,7 @@ def test_touch_tip(
         )
     )
 
-    response = commands.TouchTipResult()
+    response = commands.TouchTipResult(position=DeckPoint(x=4, y=5, z=6))
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 
@@ -730,7 +734,7 @@ def test_blow_out(
         )
     )
 
-    response = commands.BlowOutResult()
+    response = commands.BlowOutResult(position=DeckPoint(x=4, y=5, z=6))
 
     decoy.when(transport.execute_command(request=request)).then_return(response)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -39,7 +39,7 @@ async def test_aspirate_implementation(
             volume=50,
             flow_rate=1.23,
         )
-    ).then_return(VolumePointResult(volume=42, destination=DeckPoint(x=1, y=2, z=3)))
+    ).then_return(VolumePointResult(volume=42, position=DeckPoint(x=1, y=2, z=3)))
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -1,8 +1,9 @@
 """Test aspirate commands."""
 from decoy import Decoy
 
-from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
+from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset, DeckPoint
 from opentrons.protocol_engine.execution import PipettingHandler
+from opentrons.protocol_engine.execution.pipetting import VolumePointResult
 
 from opentrons.protocol_engine.commands.aspirate import (
     AspirateParams,
@@ -38,8 +39,8 @@ async def test_aspirate_implementation(
             volume=50,
             flow_rate=1.23,
         )
-    ).then_return(42)
+    ).then_return(VolumePointResult(volume=42, destination=DeckPoint(x=1, y=2, z=3)))
 
     result = await subject.execute(data)
 
-    assert result == AspirateResult(volume=42)
+    assert result == AspirateResult(volume=42, position=DeckPoint(x=1, y=2, z=3))

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -1,7 +1,7 @@
 """Test pick up tip commands."""
 from decoy import Decoy
 
-from opentrons.protocol_engine import WellLocation, WellOffset
+from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint
 from opentrons.protocol_engine.execution import PipettingHandler
 
 from opentrons.protocol_engine.commands.drop_tip import (
@@ -25,11 +25,7 @@ async def test_drop_tip_implementation(
         wellLocation=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
     )
 
-    result = await subject.execute(data)
-
-    assert result == DropTipResult()
-
-    decoy.verify(
+    decoy.when(
         await pipetting.drop_tip(
             pipette_id="abc",
             labware_id="123",
@@ -37,4 +33,8 @@ async def test_drop_tip_implementation(
             well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
             home_after=None,
         )
-    )
+    ).then_return(DeckPoint(x=4, y=5, z=6))
+
+    result = await subject.execute(data)
+
+    assert result == DropTipResult(position=DeckPoint(x=4, y=5, z=6))

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
@@ -41,10 +41,7 @@ async def test_move_to_coordinates_implementation(
         speed=567.8,
     )
 
-    result = await subject.execute(params=params)
-
-    assert result == MoveToCoordinatesResult()
-    decoy.verify(
+    decoy.when(
         await movement.move_to_coordinates(
             pipette_id="pipette-id",
             deck_coordinates=DeckPoint(x=1.11, y=2.22, z=3.33),
@@ -52,4 +49,8 @@ async def test_move_to_coordinates_implementation(
             additional_min_travel_z=1234,
             speed=567.8,
         )
-    )
+    ).then_return(DeckPoint(x=4.44, y=5.55, z=6.66))
+
+    result = await subject.execute(params=params)
+
+    assert result == MoveToCoordinatesResult(position=DeckPoint(x=4.44, y=5.55, z=6.66))

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -1,7 +1,7 @@
 """Test move to well commands."""
 from decoy import Decoy
 
-from opentrons.protocol_engine import WellLocation, WellOffset
+from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint
 from opentrons.protocol_engine.execution import MovementHandler
 
 from opentrons.protocol_engine.commands.move_to_well import (
@@ -28,10 +28,7 @@ async def test_move_to_well_implementation(
         speed=7.89,
     )
 
-    result = await subject.execute(data)
-
-    assert result == MoveToWellResult()
-    decoy.verify(
+    decoy.when(
         await movement.move_to_well(
             pipette_id="abc",
             labware_id="123",
@@ -41,4 +38,8 @@ async def test_move_to_well_implementation(
             minimum_z_height=4.56,
             speed=7.89,
         )
-    )
+    ).then_return(DeckPoint(x=9, y=8, z=7))
+
+    result = await subject.execute(data)
+
+    assert result == MoveToWellResult(position=DeckPoint(x=9, y=8, z=7))

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -33,7 +33,7 @@ async def test_pick_up_tip_implementation(
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
         )
-    ).then_return(VolumePointResult(volume=45.6, destination=DeckPoint(x=7, y=8, z=9)))
+    ).then_return(VolumePointResult(volume=45.6, position=DeckPoint(x=7, y=8, z=9)))
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -1,8 +1,9 @@
 """Test pick up tip commands."""
 from decoy import Decoy
 
-from opentrons.protocol_engine import WellLocation, WellOffset
+from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint
 from opentrons.protocol_engine.execution import PipettingHandler
+from opentrons.protocol_engine.execution.pipetting import VolumePointResult
 
 from opentrons.protocol_engine.commands.pick_up_tip import (
     PickUpTipParams,
@@ -32,8 +33,8 @@ async def test_pick_up_tip_implementation(
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
         )
-    ).then_return(45.6)
+    ).then_return(VolumePointResult(volume=45.6, destination=DeckPoint(x=7, y=8, z=9)))
 
     result = await subject.execute(data)
 
-    assert result == PickUpTipResult(tipVolume=45.6)
+    assert result == PickUpTipResult(tipVolume=45.6, position=DeckPoint(x=7, y=8, z=9))

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -1,7 +1,7 @@
 """Test touch tip commands."""
 from decoy import Decoy
 
-from opentrons.protocol_engine import WellLocation, WellOffset
+from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint
 from opentrons.protocol_engine.execution import PipettingHandler
 from opentrons.protocol_engine.state import StateView
 
@@ -29,11 +29,7 @@ async def test_touch_tip_implementation(
         speed=42.0,
     )
 
-    result = await subject.execute(data)
-
-    assert result == TouchTipResult()
-
-    decoy.verify(
+    decoy.when(
         await pipetting.touch_tip(
             pipette_id="abc",
             labware_id="123",
@@ -42,4 +38,8 @@ async def test_touch_tip_implementation(
             radius=0.456,
             speed=42.0,
         )
-    )
+    ).then_return(DeckPoint(x=4, y=5, z=6))
+
+    result = await subject.execute(data)
+
+    assert result == TouchTipResult(position=DeckPoint(x=4, y=5, z=6))

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -173,7 +173,7 @@ async def test_move_to_well(
         [Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER), Waypoint(Point(4, 5, 6))]
     )
 
-    await subject.move_to_well(
+    result = await subject.move_to_well(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="B2",
@@ -182,6 +182,8 @@ async def test_move_to_well(
         minimum_z_height=12.3,
         speed=45.6,
     )
+
+    assert result == DeckPoint(x=4, y=5, z=6)
 
     decoy.verify(
         await thermocycler_movement_flagger.raise_if_labware_in_non_open_thermocycler(
@@ -319,6 +321,99 @@ async def test_move_to_well_from_starting_location(
             speed=39339.5,
         ),
     )
+
+
+async def test_move_to_well_no_waypoints(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    thermocycler_movement_flagger: ThermocyclerMovementFlagger,
+    heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
+    mock_hw_pipettes: MockPipettes,
+    subject: MovementHandler,
+) -> None:
+    """Move requests should return origin if no waypoints are returned from MotionView."""
+    well_location = WellLocation(
+        origin=WellOrigin.BOTTOM,
+        offset=WellOffset(x=0, y=0, z=1),
+    )
+    decoy.when(state_store.labware.get_location(labware_id="labware-id")).then_return(
+        DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+    decoy.when(
+        state_store.modules.get_heater_shaker_movement_restrictors()
+    ).then_return([])
+
+    decoy.when(state_store.geometry.get_ancestor_slot_name("labware-id")).then_return(
+        DeckSlotName.SLOT_1
+    )
+
+    decoy.when(
+        state_store.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes=mock_hw_pipettes.by_mount,
+        )
+    ).then_return(
+        HardwarePipette(mount=Mount.LEFT, config=mock_hw_pipettes.left_config)
+    )
+
+    decoy.when(state_store.labware.is_tiprack("labware-id")).then_return(False)
+
+    decoy.when(
+        state_store.motion.get_pipette_location(
+            pipette_id="pipette-id",
+            current_well=None,
+        )
+    ).then_return(
+        PipetteLocationData(
+            mount=MountType.LEFT,
+            critical_point=CriticalPoint.FRONT_NOZZLE,
+        )
+    )
+
+    decoy.when(
+        await hardware_api.gantry_position(
+            mount=Mount.LEFT,
+            critical_point=CriticalPoint.FRONT_NOZZLE,
+        )
+    ).then_return(Point(11, 22, 33))
+
+    decoy.when(hardware_api.get_instrument_max_height(mount=Mount.LEFT)).then_return(
+        42.0
+    )
+
+    decoy.when(
+        state_store.pipettes.get_movement_speed(
+            pipette_id="pipette-id", requested_speed=45.6
+        )
+    ).then_return(39339.5)
+
+    decoy.when(
+        state_store.motion.get_movement_waypoints_to_well(
+            origin=Point(11, 22, 33),
+            origin_cp=CriticalPoint.FRONT_NOZZLE,
+            max_travel_z=42.0,
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="B2",
+            well_location=well_location,
+            current_well=None,
+            force_direct=True,
+            minimum_z_height=12.3,
+        )
+    ).then_return([])
+
+    result = await subject.move_to_well(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=well_location,
+        force_direct=True,
+        minimum_z_height=12.3,
+        speed=45.6,
+    )
+
+    assert result == DeckPoint(x=11, y=22, z=33)
 
 
 class MoveRelativeSpec(NamedTuple):
@@ -605,13 +700,15 @@ async def test_move_to_coordinates(
         )
     ).then_return(39339.5)
 
-    await subject.move_to_coordinates(
+    result = await subject.move_to_coordinates(
         pipette_id="pipette-id",
         deck_coordinates=destination_deck,
         direct=True,
         additional_min_travel_z=1234,
         speed=567,
     )
+
+    assert result == DeckPoint(x=1, y=5, z=9)
 
     decoy.verify(
         await hardware_api.move_to(
@@ -627,6 +724,59 @@ async def test_move_to_coordinates(
             speed=39339.5,
         ),
     )
+
+
+async def test_move_to_coordinates_no_waypoints(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    subject: MovementHandler,
+) -> None:
+    """Test that move_to_coordinates correctly returns origin if no waypoints are returned from MotionView."""
+    decoy.when(
+        state_store.motion.get_pipette_location(
+            pipette_id="pipette-id",
+        )
+    ).then_return(
+        PipetteLocationData(
+            mount=MountType.RIGHT,
+            critical_point=CriticalPoint.XY_CENTER,
+        )
+    )
+
+    decoy.when(
+        await hardware_api.gantry_position(mount=Mount.RIGHT, critical_point=None)
+    ).then_return(Point(11, 22, 33))
+
+    decoy.when(
+        hardware_api.get_instrument_max_height(mount=Mount.RIGHT, critical_point=None)
+    ).then_return(5678)
+
+    decoy.when(
+        state_store.motion.get_movement_waypoints_to_coords(
+            origin=Point(11, 22, 33),
+            dest=Point(x=1, y=2, z=3),
+            max_travel_z=5678,
+            direct=True,
+            additional_min_travel_z=1234,
+        )
+    ).then_return([])
+
+    decoy.when(
+        state_store.pipettes.get_movement_speed(
+            pipette_id="pipette-id", requested_speed=567
+        )
+    ).then_return(39339.5)
+
+    result = await subject.move_to_coordinates(
+        pipette_id="pipette-id",
+        deck_coordinates=DeckPoint(x=1, y=2, z=3),
+        direct=True,
+        additional_min_travel_z=1234,
+        speed=567,
+    )
+
+    assert result == DeckPoint(x=11, y=22, z=33)
 
 
 async def test_home(

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -322,7 +322,7 @@ async def test_handle_aspirate_request_without_prep(
     )
 
     assert result.volume == 25
-    assert result.destination == DeckPoint(x=1, y=2, z=3)
+    assert result.position == DeckPoint(x=1, y=2, z=3)
 
     decoy.verify(
         hardware_api.set_flow_rate(
@@ -395,7 +395,7 @@ async def test_handle_aspirate_request_with_prep(
     )
 
     assert result.volume == 25
-    assert result.destination == DeckPoint(x=1, y=2, z=3)
+    assert result.position == DeckPoint(x=1, y=2, z=3)
 
     decoy.verify(
         await movement_handler.move_to_well(

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -9,7 +9,7 @@ from opentrons.hardware_control.types import CriticalPoint
 from opentrons.hardware_control.dev_types import PipetteDict
 
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset
+from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset, DeckPoint
 from opentrons.protocol_engine.state import (
     StateStore,
     TipGeometry,
@@ -302,7 +302,17 @@ async def test_handle_aspirate_request_without_prep(
         )
     ).then_return(True)
 
-    volume = await subject.aspirate(
+    decoy.when(
+        await movement_handler.move_to_well(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="C6",
+            well_location=well_location,
+            current_well=None,
+        ),
+    ).then_return(DeckPoint(x=1, y=2, z=3))
+
+    result = await subject.aspirate(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="C6",
@@ -311,16 +321,10 @@ async def test_handle_aspirate_request_without_prep(
         flow_rate=2.5,
     )
 
-    assert volume == 25
+    assert result.volume == 25
+    assert result.destination == DeckPoint(x=1, y=2, z=3)
 
     decoy.verify(
-        await movement_handler.move_to_well(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="C6",
-            well_location=well_location,
-            current_well=None,
-        ),
         hardware_api.set_flow_rate(
             mount=Mount.LEFT, aspirate=2.5, dispense=None, blow_out=None
         ),
@@ -367,25 +371,7 @@ async def test_handle_aspirate_request_with_prep(
         )
     ).then_return(False)
 
-    volume = await subject.aspirate(
-        pipette_id="pipette-id",
-        labware_id="labware-id",
-        well_name="C6",
-        well_location=well_location,
-        volume=25,
-        flow_rate=2.5,
-    )
-
-    assert volume == 25
-
-    decoy.verify(
-        await movement_handler.move_to_well(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="C6",
-            well_location=WellLocation(origin=WellOrigin.TOP),
-        ),
-        await hardware_api.prepare_for_aspirate(mount=Mount.LEFT),
+    decoy.when(
         await movement_handler.move_to_well(
             pipette_id="pipette-id",
             labware_id="labware-id",
@@ -397,6 +383,31 @@ async def test_handle_aspirate_request_with_prep(
                 well_name="C6",
             ),
         ),
+    ).then_return(DeckPoint(x=1, y=2, z=3))
+
+    result = await subject.aspirate(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="C6",
+        well_location=well_location,
+        volume=25,
+        flow_rate=2.5,
+    )
+
+    assert result.volume == 25
+    assert result.destination == DeckPoint(x=1, y=2, z=3)
+
+    decoy.verify(
+        await movement_handler.move_to_well(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="C6",
+            well_location=WellLocation(origin=WellOrigin.TOP),
+        )
+    )
+
+    decoy.verify(
+        await hardware_api.prepare_for_aspirate(mount=Mount.LEFT),
         hardware_api.set_flow_rate(
             mount=Mount.LEFT, aspirate=2.5, dispense=None, blow_out=None
         ),

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -9,6 +9,7 @@ from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import ErrorOccurrence, commands as cmd
 from opentrons.protocol_engine.types import (
     DeckPoint,
+    MovementAxis,
     WellLocation,
     LabwareLocation,
     LabwareMovementStrategy,
@@ -317,6 +318,49 @@ def create_move_to_well_command(
     )
 
 
+def create_move_to_coordinates_command(
+    pipette_id: str,
+    coordinates: DeckPoint = DeckPoint(x=0, y=0, z=0),
+) -> cmd.MoveToCoordinates:
+    """Get a completed MoveToWell command."""
+    params = cmd.MoveToCoordinatesParams(
+        pipetteId=pipette_id,
+        coordinates=coordinates,
+    )
+
+    result = cmd.MoveToCoordinatesResult(position=coordinates)
+
+    return cmd.MoveToCoordinates(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime.now(),
+        params=params,
+        result=result,
+    )
+
+
+def create_move_relative_command(
+    pipette_id: str,
+    axis: MovementAxis = MovementAxis.X,
+    distance: float = 42,
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
+) -> cmd.MoveRelative:
+    """Get a completed MoveToWell command."""
+    params = cmd.MoveRelativeParams(pipetteId=pipette_id, axis=axis, distance=distance)
+
+    result = cmd.MoveRelativeResult(position=destination)
+
+    return cmd.MoveRelative(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime.now(),
+        params=params,
+        result=result,
+    )
+
+
 def create_blow_out_command(
     pipette_id: str,
     flow_rate: float,
@@ -336,6 +380,36 @@ def create_blow_out_command(
     result = cmd.BlowOutResult(position=destination)
 
     return cmd.BlowOut(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime(year=2022, month=1, day=1),
+        params=params,
+        result=result,
+    )
+
+
+def create_touch_tip_command(
+    pipette_id: str,
+    labware_id: str = "labware-id",
+    well_name: str = "A1",
+    well_location: Optional[WellLocation] = None,
+    radius: float = 1.0,
+    speed: Optional[float] = None,
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
+) -> cmd.TouchTip:
+    """Get a completed BlowOut command."""
+    params = cmd.TouchTipParams(
+        pipetteId=pipette_id,
+        labwareId=labware_id,
+        wellName=well_name,
+        wellLocation=well_location or WellLocation(),
+        radius=radius,
+        speed=speed,
+    )
+    result = cmd.TouchTipResult(position=destination)
+
+    return cmd.TouchTip(
         id="command-id",
         key="command-key",
         status=cmd.CommandStatus.SUCCEEDED,

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -8,6 +8,7 @@ from opentrons.types import MountType
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import ErrorOccurrence, commands as cmd
 from opentrons.protocol_engine.types import (
+    DeckPoint,
     WellLocation,
     LabwareLocation,
     LabwareMovementStrategy,
@@ -164,6 +165,7 @@ def create_aspirate_command(
     labware_id: str = "labware-id",
     well_name: str = "A1",
     well_location: Optional[WellLocation] = None,
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
 ) -> cmd.Aspirate:
     """Get a completed Aspirate command."""
     params = cmd.AspirateParams(
@@ -174,7 +176,7 @@ def create_aspirate_command(
         volume=volume,
         flowRate=flow_rate,
     )
-    result = cmd.AspirateResult(volume=volume)
+    result = cmd.AspirateResult(volume=volume, position=destination)
 
     return cmd.Aspirate(
         id="command-id",
@@ -193,6 +195,7 @@ def create_dispense_command(
     labware_id: str = "labware-id",
     well_name: str = "A1",
     well_location: Optional[WellLocation] = None,
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
 ) -> cmd.Dispense:
     """Get a completed Dispense command."""
     params = cmd.DispenseParams(
@@ -203,7 +206,7 @@ def create_dispense_command(
         volume=volume,
         flowRate=flow_rate,
     )
-    result = cmd.DispenseResult(volume=volume)
+    result = cmd.DispenseResult(volume=volume, position=destination)
 
     return cmd.Dispense(
         id="command-id",
@@ -243,6 +246,7 @@ def create_pick_up_tip_command(
     labware_id: str = "labware-id",
     well_name: str = "A1",
     tip_volume: float = 123.4,
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
 ) -> cmd.PickUpTip:
     """Get a completed PickUpTip command."""
     data = cmd.PickUpTipParams(
@@ -251,7 +255,7 @@ def create_pick_up_tip_command(
         wellName=well_name,
     )
 
-    result = cmd.PickUpTipResult(tipVolume=tip_volume)
+    result = cmd.PickUpTipResult(tipVolume=tip_volume, position=destination)
 
     return cmd.PickUpTip(
         id="command-id",
@@ -267,6 +271,7 @@ def create_drop_tip_command(
     pipette_id: str,
     labware_id: str = "labware-id",
     well_name: str = "A1",
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
 ) -> cmd.DropTip:
     """Get a completed DropTip command."""
     params = cmd.DropTipParams(
@@ -275,7 +280,7 @@ def create_drop_tip_command(
         wellName=well_name,
     )
 
-    result = cmd.DropTipResult()
+    result = cmd.DropTipResult(position=destination)
 
     return cmd.DropTip(
         id="command-id",
@@ -291,6 +296,7 @@ def create_move_to_well_command(
     pipette_id: str,
     labware_id: str = "labware-id",
     well_name: str = "A1",
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
 ) -> cmd.MoveToWell:
     """Get a completed MoveToWell command."""
     params = cmd.MoveToWellParams(
@@ -299,7 +305,7 @@ def create_move_to_well_command(
         wellName=well_name,
     )
 
-    result = cmd.MoveToWellResult()
+    result = cmd.MoveToWellResult(position=destination)
 
     return cmd.MoveToWell(
         id="command-id",
@@ -317,6 +323,7 @@ def create_blow_out_command(
     labware_id: str = "labware-id",
     well_name: str = "A1",
     well_location: Optional[WellLocation] = None,
+    destination: DeckPoint = DeckPoint(x=0, y=0, z=0),
 ) -> cmd.BlowOut:
     """Get a completed BlowOut command."""
     params = cmd.BlowOutParams(
@@ -326,7 +333,7 @@ def create_blow_out_command(
         wellLocation=well_location or WellLocation(),
         flowRate=flow_rate,
     )
-    result = cmd.BlowOutResult()
+    result = cmd.BlowOutResult(position=destination)
 
     return cmd.BlowOut(
         id="command-id",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -34,9 +34,12 @@ from .command_fixtures import (
     create_dispense_in_place_command,
     create_pick_up_tip_command,
     create_drop_tip_command,
+    create_touch_tip_command,
     create_move_to_well_command,
     create_blow_out_command,
     create_move_labware_command,
+    create_move_to_coordinates_command,
+    create_move_relative_command,
 )
 
 
@@ -59,6 +62,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         movement_speed_by_id={},
         static_config_by_id={},
         flow_rates_by_id={},
+        deck_point_by_id={},
     )
 
 
@@ -381,7 +385,7 @@ def test_movement_commands_without_well_clear_current_well(
 def test_heater_shaker_command_without_movement(
     subject: PipetteStore, command: cmd.Command
 ) -> None:
-    """Heater Shaker commands that don't move pipettes shouldn't clear current_well."""
+    """Heater Shaker commands that don't move pipettes shouldn't clear current_well or deck point."""
     load_pipette_command = create_load_pipette_command(
         pipette_id="pipette-id",
         pipette_name=PipetteNameType.P300_SINGLE,
@@ -391,6 +395,7 @@ def test_heater_shaker_command_without_movement(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="well-name",
+        destination=DeckPoint(x=1, y=2, z=3),
     )
 
     subject.handle_action(UpdateCommandAction(command=load_pipette_command))
@@ -402,6 +407,8 @@ def test_heater_shaker_command_without_movement(
         labware_id="labware-id",
         well_name="well-name",
     )
+
+    assert subject.state.deck_point_by_id["pipette-id"] == DeckPoint(x=1, y=2, z=3)
 
 
 @pytest.mark.parametrize(
@@ -591,3 +598,178 @@ def test_tip_volume_by_id(subject: PipetteStore) -> None:
     subject.handle_action(UpdateCommandAction(command=pick_up_tip_command))
 
     assert subject.state.tip_volume_by_id["pipette-id"] == 42
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        create_aspirate_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            volume=1337,
+            flow_rate=1.23,
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_dispense_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            volume=1337,
+            flow_rate=1.23,
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_blow_out_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            flow_rate=1.23,
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_pick_up_tip_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_drop_tip_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_touch_tip_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_move_to_well_command(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="well-name",
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_move_to_coordinates_command(
+            pipette_id="pipette-id",
+            coordinates=DeckPoint(x=11, y=22, z=33),
+        ),
+        create_move_relative_command(
+            pipette_id="pipette-id",
+            destination=DeckPoint(x=11, y=22, z=33),
+        ),
+    ),
+)
+def test_movement_commands_update_deck_point(
+    command: cmd.Command,
+    subject: PipetteStore,
+) -> None:
+    """It should save the last used pipette, labware, and well for movement commands."""
+    load_pipette_command = create_load_pipette_command(
+        pipette_id="pipette-id",
+        pipette_name=PipetteNameType.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+
+    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
+    subject.handle_action(UpdateCommandAction(command=command))
+
+    assert subject.state.deck_point_by_id["pipette-id"] == DeckPoint(x=11, y=22, z=33)
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        cmd.Home(
+            id="command-id-2",
+            key="command-key-2",
+            status=cmd.CommandStatus.SUCCEEDED,
+            createdAt=datetime(year=2021, month=1, day=1),
+            params=cmd.HomeParams(),
+            result=cmd.HomeResult(),
+        ),
+        cmd.thermocycler.OpenLid(
+            id="command-id-2",
+            key="command-key-2",
+            status=cmd.CommandStatus.SUCCEEDED,
+            createdAt=datetime(year=2021, month=1, day=1),
+            params=cmd.thermocycler.OpenLidParams(moduleId="xyz"),
+            result=cmd.thermocycler.OpenLidResult(),
+        ),
+        cmd.thermocycler.CloseLid(
+            id="command-id-2",
+            key="command-key-2",
+            status=cmd.CommandStatus.SUCCEEDED,
+            createdAt=datetime(year=2021, month=1, day=1),
+            params=cmd.thermocycler.CloseLidParams(moduleId="xyz"),
+            result=cmd.thermocycler.CloseLidResult(),
+        ),
+        cmd.heater_shaker.SetAndWaitForShakeSpeed(
+            id="command-id-2",
+            key="command-key-2",
+            status=cmd.CommandStatus.SUCCEEDED,
+            createdAt=datetime(year=2021, month=1, day=1),
+            params=cmd.heater_shaker.SetAndWaitForShakeSpeedParams(
+                moduleId="xyz",
+                rpm=123,
+            ),
+            result=cmd.heater_shaker.SetAndWaitForShakeSpeedResult(
+                pipetteRetracted=True
+            ),
+        ),
+        cmd.heater_shaker.OpenLabwareLatch(
+            id="command-id-2",
+            key="command-key-2",
+            status=cmd.CommandStatus.SUCCEEDED,
+            createdAt=datetime(year=2021, month=1, day=1),
+            params=cmd.heater_shaker.OpenLabwareLatchParams(moduleId="xyz"),
+            result=cmd.heater_shaker.OpenLabwareLatchResult(pipetteRetracted=True),
+        ),
+        create_move_labware_command(
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            strategy=LabwareMovementStrategy.USING_GRIPPER,
+        ),
+    ),
+)
+def test_homing_commands_clear_deck_point(
+    command: cmd.Command,
+    subject: PipetteStore,
+) -> None:
+    """It should save the last used pipette, labware, and well for movement commands."""
+    load_left_pipette_command = create_load_pipette_command(
+        pipette_id="pipette-id-left",
+        pipette_name=PipetteNameType.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+    load_right_pipette_command = create_load_pipette_command(
+        pipette_id="pipette-id-right",
+        pipette_name=PipetteNameType.P300_SINGLE,
+        mount=MountType.RIGHT,
+    )
+    move_command_left_pipette = create_move_to_well_command(
+        pipette_id="pipette-id-left",
+        labware_id="labware-id",
+        well_name="well-name",
+        destination=DeckPoint(x=1, y=2, z=3),
+    )
+    move_command_right_pipette = create_move_to_well_command(
+        pipette_id="pipette-id-right",
+        labware_id="labware-id",
+        well_name="well-name",
+        destination=DeckPoint(x=4, y=5, z=6),
+    )
+
+    subject.handle_action(UpdateCommandAction(command=load_left_pipette_command))
+    subject.handle_action(UpdateCommandAction(command=load_right_pipette_command))
+    subject.handle_action(UpdateCommandAction(command=move_command_left_pipette))
+    subject.handle_action(UpdateCommandAction(command=move_command_right_pipette))
+
+    assert subject.state.deck_point_by_id["pipette-id-left"] == DeckPoint(x=1, y=2, z=3)
+    assert subject.state.deck_point_by_id["pipette-id-right"] == DeckPoint(
+        x=4, y=5, z=6
+    )
+
+    subject.handle_action(UpdateCommandAction(command=command))
+
+    assert subject.state.deck_point_by_id["pipette-id-left"] is None
+    assert subject.state.deck_point_by_id["pipette-id-right"] is None

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.types import (
     LoadedPipette,
     MotorAxis,
     FlowRates,
+    DeckPoint,
 )
 from opentrons.protocol_engine.state.pipettes import (
     PipetteState,
@@ -30,6 +31,7 @@ def get_pipette_view(
     movement_speed_by_id: Optional[Dict[str, Optional[float]]] = None,
     static_config_by_id: Optional[Dict[str, StaticPipetteConfig]] = None,
     flow_rates_by_id: Optional[Dict[str, FlowRates]] = None,
+    deck_point_by_id: Optional[Dict[str, Optional[DeckPoint]]] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""
     state = PipetteState(
@@ -41,6 +43,7 @@ def get_pipette_view(
         movement_speed_by_id=movement_speed_by_id or {},
         static_config_by_id=static_config_by_id or {},
         flow_rates_by_id=flow_rates_by_id or {},
+        deck_point_by_id=deck_point_by_id or {},
     )
 
     return PipetteView(state=state)
@@ -327,6 +330,17 @@ def test_get_movement_speed() -> None:
     assert (
         subject.get_movement_speed(pipette_id="pipette-without-movement-speed") is None
     )
+
+
+def test_get_deck_point() -> None:
+    """It should return the deck point for the given pipette."""
+    subject = get_pipette_view(
+        deck_point_by_id={
+            "pipette-id": DeckPoint(x=1, y=2, z=3),
+        }
+    )
+
+    assert subject.get_deck_point(pipette_id="pipette-id") == DeckPoint(x=1, y=2, z=3)
 
 
 def test_get_static_config() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -10,7 +10,7 @@ from opentrons_shared_data.labware.labware_definition import (
 
 from opentrons.protocol_engine import actions, commands
 from opentrons.protocol_engine.state.tips import TipStore, TipView
-from opentrons.protocol_engine.types import FlowRates
+from opentrons.protocol_engine.types import FlowRates, DeckPoint
 
 
 _tip_rack_parameters = LabwareParameters.construct(isTiprack=True)  # type: ignore[call-arg]
@@ -64,7 +64,7 @@ def pick_up_tip_command() -> commands.PickUpTip:
             labwareId="cool-labware",
             wellName="A1",
         ),
-        result=commands.PickUpTipResult.construct(),
+        result=commands.PickUpTipResult.construct(position=DeckPoint(x=0, y=0, z=0)),
     )
 
 
@@ -76,7 +76,7 @@ def drop_tip_command() -> commands.DropTip:
             labwareId="cool-labware",
             wellName="A1",
         ),
-        result=commands.DropTipResult.construct(),
+        result=commands.DropTipResult.construct(position=DeckPoint(x=0, y=0, z=0)),
     )
 
 

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine import (
     DeckSlotLocation,
     ModuleModel,
     ModuleLocation,
+    DeckPoint,
 )
 from opentrons.protocol_reader import ProtocolReader
 from opentrons.protocol_runner import create_simulating_runner
@@ -275,7 +276,9 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             labwareId=tiprack_1_id,
             wellName="A1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=0, y=0, z=0)
+        ),
     )
     assert commands_result[8] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
@@ -289,7 +292,9 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             labwareId=tiprack_2_id,
             wellName="A1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=0, y=0, z=0)
+        ),
     )
 
     assert commands_result[9] == commands.DropTip.construct(
@@ -304,7 +309,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             labwareId="fixedTrash",
             wellName="A1",
         ),
-        result=commands.DropTipResult(),
+        result=commands.DropTipResult(position=DeckPoint(x=0, y=0, z=0)),
     )
 
     assert commands_result[10] == commands.PickUpTip.construct(
@@ -319,7 +324,9 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             labwareId=tiprack_1_id,
             wellName="B1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=0, y=0, z=0)
+        ),
     )
     assert commands_result[11] == commands.Aspirate.construct(
         id=matchers.IsA(str),
@@ -335,7 +342,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=40,
             flowRate=150,
         ),
-        result=commands.AspirateResult(volume=40),
+        result=commands.AspirateResult(volume=40, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[12] == commands.Dispense.construct(
         id=matchers.IsA(str),
@@ -351,7 +358,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=35,
             flowRate=360,
         ),
-        result=commands.DispenseResult(volume=35),
+        result=commands.DispenseResult(volume=35, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[13] == commands.Aspirate.construct(
         id=matchers.IsA(str),
@@ -367,7 +374,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=40,
             flowRate=150.0,
         ),
-        result=commands.AspirateResult(volume=40),
+        result=commands.AspirateResult(volume=40, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[14] == commands.Dispense.construct(
         id=matchers.IsA(str),
@@ -383,7 +390,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=35,
             flowRate=300,
         ),
-        result=commands.DispenseResult(volume=35),
+        result=commands.DispenseResult(volume=35, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[15] == commands.BlowOut.construct(
         id=matchers.IsA(str),
@@ -398,7 +405,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             wellName="B1",
             flowRate=1000.0,
         ),
-        result=commands.BlowOutResult(),
+        result=commands.BlowOutResult(position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[16] == commands.Aspirate.construct(
         id=matchers.IsA(str),
@@ -414,7 +421,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=50,
             flowRate=150,
         ),
-        result=commands.AspirateResult(volume=50),
+        result=commands.AspirateResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[17] == commands.Dispense.construct(
         id=matchers.IsA(str),
@@ -430,7 +437,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=50,
             flowRate=300,
         ),
-        result=commands.DispenseResult(volume=50),
+        result=commands.DispenseResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[18] == commands.BlowOut.construct(
         id=matchers.IsA(str),
@@ -445,7 +452,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             wellName="B1",
             flowRate=1000.0,
         ),
-        result=commands.BlowOutResult(),
+        result=commands.BlowOutResult(position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[19] == commands.Aspirate.construct(
         id=matchers.IsA(str),
@@ -461,7 +468,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=300,
             flowRate=150,
         ),
-        result=commands.AspirateResult(volume=300),
+        result=commands.AspirateResult(volume=300, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[20] == commands.Dispense.construct(
         id=matchers.IsA(str),
@@ -477,7 +484,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=300,
             flowRate=300,
         ),
-        result=commands.DispenseResult(volume=300),
+        result=commands.DispenseResult(volume=300, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[21] == commands.BlowOut.construct(
         id=matchers.IsA(str),
@@ -492,7 +499,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             wellName="B1",
             flowRate=1000.0,
         ),
-        result=commands.BlowOutResult(),
+        result=commands.BlowOutResult(position=DeckPoint(x=0, y=0, z=0)),
     )
     #   TODO:(jr, 15.08.2022): this should map to move_to when move_to is mapped in a followup ticket RSS-62
     assert commands_result[22] == commands.Custom.construct(
@@ -567,7 +574,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=50,
             flowRate=150,
         ),
-        result=commands.AspirateResult(volume=50),
+        result=commands.AspirateResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
     assert commands_result[27] == commands.Dispense.construct(
         id=matchers.IsA(str),
@@ -583,7 +590,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             volume=50,
             flowRate=300,
         ),
-        result=commands.DispenseResult(volume=50),
+        result=commands.DispenseResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
     #   TODO:(jr, 15.08.2022): aspirate commands with no labware get filtered
     #   into custom. Refactor this in followup legacy command mapping
@@ -627,7 +634,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             labwareId=tiprack_1_id,
             wellName="A1",
         ),
-        result=commands.DropTipResult(),
+        result=commands.DropTipResult(position=DeckPoint(x=0, y=0, z=0)),
     )
 
 

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -25,6 +25,7 @@ from opentrons.protocol_engine import (
     ModuleDefinition,
     ModuleModel,
     commands,
+    DeckPoint,
 )
 from opentrons.protocol_reader import ProtocolReader
 from opentrons.protocol_runner import create_simulating_runner
@@ -94,7 +95,9 @@ async def test_runner_with_python(
             labwareId=labware_id_captor.value,
             wellName="A1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=0, y=0, z=0)
+        ),
     )
 
     assert expected_command in commands_result
@@ -147,7 +150,9 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
             labwareId="labware-id",
             wellName="A1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=14.38, y=74.24, z=64.69)
+        ),
     )
 
     assert expected_command in commands_result
@@ -202,7 +207,9 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
             labwareId=labware_id_captor.value,
             wellName="A1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=0, y=0, z=0)
+        ),
     )
 
     assert expected_command in commands_result
@@ -258,7 +265,9 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
             labwareId=labware_id_captor.value,
             wellName="A1",
         ),
-        result=commands.PickUpTipResult(tipVolume=300.0),
+        result=commands.PickUpTipResult(
+            tipVolume=300.0, position=DeckPoint(x=0, y=0, z=0)
+        ),
     )
 
     assert expected_command in commands_result

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -281,6 +281,7 @@ stages:
                       y: 0
                       z: 0
                 result:
+                  position: {'x': 146.88, 'y': 246.24, 'z': 64.69}
                   tipVolume: 10.0
                 startedAt: !anystr
                 completedAt: !anystr
@@ -302,6 +303,7 @@ stages:
                   volume: 5
                   flowRate: 3
                 result:
+                  position: {'x': 16.76, 'y': 75.28, 'z': 157.09}
                   volume: 5
                 startedAt: !anystr
                 completedAt: !anystr
@@ -333,6 +335,7 @@ stages:
                   volume: 4.5
                   flowRate: 2.5
                 result:
+                  position: {'x': 284.635, 'y': 56.025, 'z': 158.25}
                   volume: 4.5
                 startedAt: !anystr
                 completedAt: !anystr
@@ -353,7 +356,8 @@ stages:
                       z: 11
                   radius: 0.5
                   speed: 42.0
-                result: {}
+                result:
+                  position: {'x': 284.635, 'y': 56.025, 'z': 168.25}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -372,7 +376,8 @@ stages:
                       y: 0
                       z: 12
                   flowRate: 2
-                result: {}
+                result:
+                  position: {'x': 284.635, 'y': 56.025, 'z': 169.25}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -391,7 +396,8 @@ stages:
                       y: 0
                       z: 0
                   forceDirect: false
-                result: {}
+                result:
+                  position: {'x': 304.52500000000003, 'y': 56.025, 'z': 182.25}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -412,7 +418,8 @@ stages:
                   minimumZHeight: 35
                   forceDirect: true
                   speed: 12.3
-                result: {}
+                result:
+                  position: {'x': 306.52500000000003, 'y': 59.025, 'z': 167.25}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -430,7 +437,8 @@ stages:
                       x: 0
                       y: 0
                       z: 0
-                result: {}
+                result:
+                  position: {'x': 347.84000000000003, 'y': 325.06, 'z': 82.0}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -457,7 +465,8 @@ stages:
                   minimumZHeight: 35
                   forceDirect: true
                   speed: 12.3
-                result: {}
+                result:
+                  position: {'x': 0.0, 'y': 0.0, 'z': 0.0}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr


### PR DESCRIPTION
# Overview

Closes RCORE-623.

This PR adds a `position` field to all movement related PE commands (explicit move commands, tip handling and liquid handling) in the form of a `DeckPoint` representing the last deck coordinate the pipette has moved to. Handlers have been put into the `PipetteStore` to store this point, along with clearing it after a home operation has occurred.

# Test Plan

Since there are no behavioral changes to code, and everything is covered by Unit Tests, this PR was tested by smoke testing the below protocol on an actual robot, on API version 2.14.

```
from opentrons.types import Location

metadata = {
    'protocolName': 'Pipette Instrument Related Commands Test',
}

requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.14"
}

def run(context):
    p300rack = context.load_labware('opentrons_96_tiprack_300ul', 1)
    p300_l = context.load_instrument('p300_single_gen2', 'left', tip_racks=[p300rack])

    labware = context.load_labware("corning_96_wellplate_360ul_flat", 3)
    well1 = labware.wells()[0]
    well2 = labware.wells()[1]
    well3 = labware.wells()[2]

    p300_l.pick_up_tip()

    p300_l.aspirate(location=well1, volume=100)

    p300_l.dispense(location=well2)

    p300_l.blow_out(location=well1)

    p300_l.touch_tip(location=well3)

    p300_l.move_to(well1.bottom())

    # Test move to coordinates
    p300_l.move_to(Location(point=well1.top().point, labware=None))

    p300_l.drop_tip()
```

# Changelog

- Added a `position` field to `aspirate`, `dispense`, `blowout`, `touchTip`, `pickUpTip`, `dropTip`, `moveToWell` and `moveToCoordinates` results.
- Refactored move methods in `MovementHandler` and tip/liquid handling methods in `PipettingHandler` to return a `DeckPoint`
- Added handler for storing and clearing deck point in `PipetteStore` along with a getter in `PipetteView`

# Review requests

# Risk assessment

Low to medium, this PR does not change any actual logic, but does introduce a new field in the result for 8 commands in protocol engine.