### PR TITLE
feat(app): display tabs for labware offset data when set in config

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -83,5 +83,8 @@
   "all_modules_and_labware_from_protocol": "All modules and labware used in the protocol",
   "module_in_slot": "{{module}} in {{slot}}",
   "run_labware_position_check": "run labware position check",
-  "get_labware_offset_data": "Get Labware Offset Data"
+  "get_labware_offset_data": "Get Labware Offset Data",
+  "table_view": "Table View",
+  "jupyter_notebook": "Jupyter Notebook",
+  "cli_ssh": "Command Line Interface (SSH)"
 }

--- a/app/src/molecules/PythonLabwareOffsetSnippet/index.tsx
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/index.tsx
@@ -8,7 +8,7 @@ import type { LabwareOffset } from '@opentrons/api-client'
 const JsonTextArea = styled.textarea`
   min-height: 12vh;
   width: 100%;
-  background-color: #F8F8F8;
+  background-color: #f8f8f8;
   border: ${BORDERS.lineBorder};
   border-radius: ${BORDERS.radiusSoftCorners};
   padding: ${SPACING.spacing3};

--- a/app/src/molecules/PythonLabwareOffsetSnippet/index.tsx
+++ b/app/src/molecules/PythonLabwareOffsetSnippet/index.tsx
@@ -1,16 +1,21 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import { TYPOGRAPHY, SPACING } from '@opentrons/components'
+import { TYPOGRAPHY, SPACING, BORDERS } from '@opentrons/components'
 import { createSnippet } from './createSnippet'
 import type { LegacySchemaAdapterOutput } from '@opentrons/shared-data'
 import type { LabwareOffset } from '@opentrons/api-client'
 
 const JsonTextArea = styled.textarea`
-  min-height: 30vh;
+  min-height: 12vh;
   width: 100%;
+  background-color: #F8F8F8;
+  border: ${BORDERS.lineBorder};
+  border-radius: ${BORDERS.radiusSoftCorners};
   padding: ${SPACING.spacing3};
+  margin: ${SPACING.spacing4} 0;
   font-size: ${TYPOGRAPHY.fontSizeCaption};
   font-family: monospace;
+  resize: none;
 `
 interface PythonLabwareOffsetSnippetProps {
   mode: 'jupyter' | 'cli'
@@ -30,7 +35,5 @@ export function PythonLabwareOffsetSnippet(
     }
   }, [mode, JSON.stringify(labwareOffsets)])
 
-  if (protocol == null || labwareOffsets == null || snippet == null) return null
-
-  return <JsonTextArea readOnly value={snippet} spellCheck={false} />
+  return <JsonTextArea readOnly value={snippet ?? ''} spellCheck={false} />
 }

--- a/app/src/molecules/RoundTab/index.tsx
+++ b/app/src/molecules/RoundTab/index.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+import {
+  BORDERS,
+  Btn,
+  COLORS,
+  DISPLAY_BLOCK,
+  POSITION_ABSOLUTE,
+  POSITION_RELATIVE,
+  SIZE_1,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+const defaultTabStyle = css`
+  ${TYPOGRAPHY.pSemiBold}
+  border-radius: ${BORDERS.radiusSoftCorners} ${BORDERS.radiusSoftCorners} 0 0;
+  border-top: ${BORDERS.transparentLineBorder};
+  border-left: ${BORDERS.transparentLineBorder};
+  border-right: ${BORDERS.transparentLineBorder};
+  padding: ${SPACING.spacing3} ${SPACING.spacing4};
+  position: ${POSITION_RELATIVE};
+`
+
+const inactiveTabStyle = css`
+  color: ${COLORS.darkGreyEnabled};
+
+  &:hover {
+    color: ${COLORS.darkGreyEnabled};
+    background-color: ${COLORS.fundamentalsBackgroundShade};
+  }
+`
+
+const currentTabStyle = css`
+  ${TYPOGRAPHY.pSemiBold}
+  background-color: ${COLORS.white};
+  border-top: ${BORDERS.lineBorder};
+  border-left: ${BORDERS.lineBorder};
+  border-right: ${BORDERS.lineBorder};
+  color: ${COLORS.blueEnabled};
+
+  /* extend below the tab when active to flow into the content */
+  &:after {
+    position: ${POSITION_ABSOLUTE};
+    display: ${DISPLAY_BLOCK};
+    content: '';
+    background-color: ${COLORS.white};
+    top: 100;
+    left: 0;
+    height: ${SIZE_1};
+    width: 100%;
+  }
+`
+
+interface RoundTabProps extends React.ComponentProps<typeof Btn> {
+  isCurrent: boolean
+}
+export function RoundTab({
+  isCurrent,
+  children,
+  ...restProps
+}: RoundTabProps): JSX.Element {
+  return (
+    <Btn
+      {...restProps}
+      css={
+        isCurrent
+          ? css`
+              ${defaultTabStyle}
+              ${currentTabStyle}
+            `
+          : css`
+              ${defaultTabStyle}
+              ${inactiveTabStyle}
+            `
+      }
+    >
+      {children}
+    </Btn>
+  )
+}

--- a/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
@@ -3,7 +3,14 @@ import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
 import { ApplyHistoricOffsets } from '..'
+import { getIsLabwareOffsetCodeSnippetsOn } from '../../../redux/config'
 import type { OffsetCandidate } from '../hooks/useOffsetCandidatesForAnalysis'
+
+jest.mock('../../../redux/config')
+
+const mockGetIsLabwareOffsetCodeSnippetsOn = getIsLabwareOffsetCodeSnippetsOn as jest.MockedFunction<
+  typeof getIsLabwareOffsetCodeSnippetsOn
+>
 
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',
@@ -115,5 +122,14 @@ describe('ApplyHistoricOffsets', () => {
       'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
     )
     expect(queryByText('location')).toBeNull()
+  })
+
+  it('renders tabbed offset data with snippets when config option is selected', () => {
+    mockGetIsLabwareOffsetCodeSnippetsOn.mockReturnValue(true)
+    const [{ getByText }] = render()
+    getByText('View data').click()
+    expect(getByText('Table View')).toBeTruthy()
+    expect(getByText('Jupyter Notebook')).toBeTruthy()
+    expect(getByText('Command Line Interface (SSH)')).toBeTruthy()
   })
 })

--- a/app/src/organisms/ApplyHistoricOffsets/index.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/index.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 import {
   Flex,
   Link,
@@ -12,10 +14,12 @@ import {
 } from '@opentrons/components'
 import { Portal } from '../../App/portal'
 import { ModalHeader, ModalShell } from '../../molecules/Modal'
+import { PythonLabwareOffsetSnippet } from '../../molecules/PythonLabwareOffsetSnippet'
+import { LabwareOffsetTabs } from '../LabwareOffsetTabs'
 import { StyledText } from '../../atoms/text'
-import { useTranslation } from 'react-i18next'
 import { LabwareOffsetTable } from './LabwareOffsetTable'
 import { CheckboxField } from '../../atoms/CheckboxField'
+import { getIsLabwareOffsetCodeSnippetsOn } from '../../redux/config'
 import type { LabwareOffset } from '@opentrons/api-client'
 
 const HOW_OFFSETS_WORK_SUPPORT_URL =
@@ -36,6 +40,23 @@ export function ApplyHistoricOffsets(
   const { offsetCandidates, shouldApplyOffsets, setShouldApplyOffsets } = props
   const [showOffsetDataModal, setShowOffsetDataModal] = React.useState(false)
   const { t } = useTranslation('labware_position_check')
+  const isLabwareOffsetCodeSnippetsOn = useSelector(
+    getIsLabwareOffsetCodeSnippetsOn
+  )
+  const JupyterSnippet = (
+    <PythonLabwareOffsetSnippet
+      mode="jupyter"
+      labwareOffsets={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+      protocol={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+    />
+  )
+  const CommandLineSnippet = (
+    <PythonLabwareOffsetSnippet
+      mode="cli"
+      labwareOffsets={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+      protocol={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+    />
+  )
   return (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
       <CheckboxField
@@ -83,7 +104,17 @@ export function ApplyHistoricOffsets(
                 {t('see_how_offsets_work')}
               </Link>
               {offsetCandidates.length > 0 ? (
-                <LabwareOffsetTable offsetCandidates={offsetCandidates} />
+                isLabwareOffsetCodeSnippetsOn ? (
+                  <LabwareOffsetTabs
+                    TableComponent={
+                      <LabwareOffsetTable offsetCandidates={offsetCandidates} />
+                    }
+                    JupyterComponent={JupyterSnippet}
+                    CommandLineComponent={CommandLineSnippet}
+                  />
+                ) : (
+                  <LabwareOffsetTable offsetCandidates={offsetCandidates} />
+                )
               ) : null}
             </Flex>
           </ModalShell>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
@@ -155,7 +155,7 @@ export function CurrentOffsetsModal(
             CommandLineComponent={CommandLineSnippet}
           />
         ) : (
-          TableComponent 
+          TableComponent
         )}
         <Flex
           width="100%"

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
@@ -27,7 +27,9 @@ import { getIsLabwareOffsetCodeSnippetsOn } from '../../../../redux/config'
 import { ModalHeader, ModalShell } from '../../../../molecules/Modal'
 import { PrimaryButton } from '../../../../atoms/buttons'
 import { Tooltip } from '../../../../atoms/Tooltip'
+import { LabwareOffsetTabs } from '../../../LabwareOffsetTabs'
 import { OffsetVector } from '../../../../molecules/OffsetVector'
+import { PythonLabwareOffsetSnippet } from '../../../../molecules/PythonLabwareOffsetSnippet'
 import { useLPCDisabledReason } from '../../hooks'
 import { getLatestCurrentOffsets } from './utils'
 
@@ -77,7 +79,6 @@ export function CurrentOffsetsModal(
   } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const defsByURI = getLoadedLabwareDefinitionsByUri(commands)
-  const [showCodeSnippet, setShowCodeSnippet] = React.useState<boolean>(false)
   const isLabwareOffsetCodeSnippetsOn = useSelector(
     getIsLabwareOffsetCodeSnippetsOn
   )
@@ -86,6 +87,55 @@ export function CurrentOffsetsModal(
   })
   const lpcDisabledReason = useLPCDisabledReason(robotName, runId)
   const latestCurrentOffsets = getLatestCurrentOffsets(currentOffsets)
+
+  const TableComponent = (
+    <OffsetTable>
+      <thead>
+        <tr>
+          <OffsetTableHeader>{t('location')}</OffsetTableHeader>
+          <OffsetTableHeader>{t('labware')}</OffsetTableHeader>
+          <OffsetTableHeader>{t('labware_offset_data')}</OffsetTableHeader>
+        </tr>
+      </thead>
+      <tbody>
+        {latestCurrentOffsets.map(offset => {
+          const labwareDisplayName =
+            offset.definitionUri in defsByURI
+              ? getLabwareDisplayName(defsByURI[offset.definitionUri])
+              : offset.definitionUri
+          return (
+            <OffsetTableRow key={offset.id}>
+              <OffsetTableDatum>
+                {t('slot', { slotName: offset.location.slotName })}
+                {offset.location.moduleModel != null
+                  ? ` - ${getModuleDisplayName(offset.location.moduleModel)}`
+                  : null}
+              </OffsetTableDatum>
+              <OffsetTableDatum>{labwareDisplayName}</OffsetTableDatum>
+              <OffsetTableDatum>
+                <OffsetVector {...offset.vector} />
+              </OffsetTableDatum>
+            </OffsetTableRow>
+          )
+        })}
+      </tbody>
+    </OffsetTable>
+  )
+
+  const JupyterSnippet = (
+    <PythonLabwareOffsetSnippet
+      mode="jupyter"
+      labwareOffsets={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+      protocol={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+    />
+  )
+  const CommandLineSnippet = (
+    <PythonLabwareOffsetSnippet
+      mode="cli"
+      labwareOffsets={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+      protocol={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+    />
+  )
   return (
     <ModalShell
       maxWidth="40rem"
@@ -99,53 +149,14 @@ export function CurrentOffsetsModal(
         padding={SPACING.spacing6}
       >
         {isLabwareOffsetCodeSnippetsOn ? (
-          <Link
-            role="link"
-            css={TYPOGRAPHY.labelSemiBold}
-            color={COLORS.darkBlackEnabled}
-            onClick={() => setShowCodeSnippet(true)}
-          >
-            {t('get_labware_offset_data')}
-          </Link>
-        ) : null}
-        {showCodeSnippet ? (
-          <PrimaryButton onClick={() => setShowCodeSnippet(false)}>
-            TODO ADD JUPYTER/CLI SNIPPET SUPPORT
-          </PrimaryButton>
-        ) : null}
-        <OffsetTable>
-          <thead>
-            <tr>
-              <OffsetTableHeader>{t('location')}</OffsetTableHeader>
-              <OffsetTableHeader>{t('labware')}</OffsetTableHeader>
-              <OffsetTableHeader>{t('labware_offset_data')}</OffsetTableHeader>
-            </tr>
-          </thead>
-          <tbody>
-            {latestCurrentOffsets.map(offset => {
-              const labwareDisplayName =
-                offset.definitionUri in defsByURI
-                  ? getLabwareDisplayName(defsByURI[offset.definitionUri])
-                  : offset.definitionUri
-              return (
-                <OffsetTableRow key={offset.id}>
-                  <OffsetTableDatum>
-                    {t('slot', { slotName: offset.location.slotName })}
-                    {offset.location.moduleModel != null
-                      ? ` - ${getModuleDisplayName(
-                          offset.location.moduleModel
-                        )}`
-                      : null}
-                  </OffsetTableDatum>
-                  <OffsetTableDatum>{labwareDisplayName}</OffsetTableDatum>
-                  <OffsetTableDatum>
-                    <OffsetVector {...offset.vector} />
-                  </OffsetTableDatum>
-                </OffsetTableRow>
-              )
-            })}
-          </tbody>
-        </OffsetTable>
+          <LabwareOffsetTabs
+            TableComponent={TableComponent}
+            JupyterComponent={JupyterSnippet}
+            CommandLineComponent={CommandLineSnippet}
+          />
+        ) : (
+          { TableComponent }
+        )}
         <Flex
           width="100%"
           marginTop={SPACING.spacing6}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/CurrentOffsetsModal.tsx
@@ -155,7 +155,7 @@ export function CurrentOffsetsModal(
             CommandLineComponent={CommandLineSnippet}
           />
         ) : (
-          { TableComponent }
+          TableComponent 
         )}
         <Flex
           width="100%"

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/CurrentOffsetModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/CurrentOffsetModal.test.tsx
@@ -124,12 +124,13 @@ describe('CurrentOffsetsModal', () => {
     getByText('opentrons/opentrons_96_tiprack_10ul/1')
     getByText('Slot 2')
   })
-  //    TODO(jr, 12/20/22): finish this test when we add the jupyter snippet info
-  it('renders the Get labware offset data button, clicking on it renders the juypter snippet', () => {
+
+  it('renders tabbed offset data with snippets when config option is selected', () => {
     mockGetIsLabwareOffsetCodeSnippetsOn.mockReturnValue(true)
     const { getByText } = render(props)
-    getByText('Get Labware Offset Data').click()
-    getByText('TODO ADD JUPYTER/CLI SNIPPET SUPPORT')
+    expect(getByText('Table View')).toBeTruthy()
+    expect(getByText('Jupyter Notebook')).toBeTruthy()
+    expect(getByText('Command Line Interface (SSH)')).toBeTruthy()
   })
   it('renders the LPC button as disabled when there is a disabled reason', () => {
     mockUseLPCDisabledReason.mockReturnValue('mockDisabledReason')

--- a/app/src/organisms/LabwareOffsetTabs/__tests__/LabwareOffsetTabs.test.tsx
+++ b/app/src/organisms/LabwareOffsetTabs/__tests__/LabwareOffsetTabs.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { LabwareOffsetTabs } from '..'
+
+const mockTableComponent = <div>Table Component</div>
+const mockJupyterComponent = <div>Jupyter Component</div>
+const mockCLIComponent = <div>CLI Component</div>
+
+const render = () => {
+  return renderWithProviders(
+    <LabwareOffsetTabs
+      TableComponent={mockTableComponent}
+      JupyterComponent={mockJupyterComponent}
+      CommandLineComponent={mockCLIComponent}
+    />,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('LabwareOffsetTabs', () => {
+  it('renders the TableComponent by default', () => {
+    const { getByText } = render()
+    expect(getByText('Table Component')).toBeVisible()
+  })
+
+  it('renders the JupyterComponent when Juypter Notebook tab is clicked', () => {
+    const { getByText } = render()
+    getByText('Jupyter Notebook').click()
+    expect(getByText('Jupyter Component')).toBeVisible()
+  })
+
+  it('renders the CommandLineComponent when Command Line Interface tab is clicked', () => {
+    const { getByText } = render()
+    getByText('Command Line Interface (SSH)').click()
+    expect(getByText('CLI Component')).toBeVisible()
+  })
+})

--- a/app/src/organisms/LabwareOffsetTabs/index.tsx
+++ b/app/src/organisms/LabwareOffsetTabs/index.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  SPACING,
+  Box,
+  COLORS,
+  BORDERS,
+} from '@opentrons/components'
+
+import { StyledText } from '../../atoms/text'
+import { RoundTab } from '../../molecules/RoundTab'
+
+type TabOptions = 'table' | 'jupyter' | 'cli'
+
+export interface LabwareOffsetTabsProps {
+  TableComponent: JSX.Element
+  JupyterComponent: JSX.Element
+  CommandLineComponent: JSX.Element
+}
+
+export function LabwareOffsetTabs({
+  TableComponent,
+  JupyterComponent,
+  CommandLineComponent,
+}: LabwareOffsetTabsProps): JSX.Element {
+  const { t } = useTranslation()
+  const [currentTab, setCurrentTab] = React.useState<TabOptions>('table')
+
+  const activeTabComponent = {
+    table: TableComponent,
+    jupyter: JupyterComponent,
+    cli: CommandLineComponent,
+  }
+  return (
+    <Flex width="100%" height="100%" flexDirection={DIRECTION_COLUMN}>
+      <Flex>
+        <RoundTab
+          isCurrent={currentTab === 'table'}
+          onClick={() => setCurrentTab('table')}
+        >
+          <StyledText>{t('table_view')}</StyledText>
+        </RoundTab>
+        <RoundTab
+          isCurrent={currentTab === 'jupyter'}
+          onClick={() => setCurrentTab('jupyter')}
+        >
+          <StyledText>{t('jupyter_notebook')}</StyledText>
+        </RoundTab>
+        <RoundTab
+          isCurrent={currentTab === 'cli'}
+          onClick={() => setCurrentTab('cli')}
+        >
+          <StyledText>{t('cli_ssh')}</StyledText>
+        </RoundTab>
+      </Flex>
+      <Box
+        backgroundColor={COLORS.white}
+        border={BORDERS.lineBorder}
+        // remove left upper corner border radius when first tab is active
+        borderRadius={`${
+          currentTab === 'table' ? '0' : BORDERS.radiusSoftCorners
+        } ${BORDERS.radiusSoftCorners} ${BORDERS.radiusSoftCorners} ${
+          BORDERS.radiusSoftCorners
+        }`}
+        padding={`0 ${SPACING.spacing4}`}
+      >
+        {activeTabComponent[currentTab]}
+      </Box>
+    </Flex>
+  )
+}

--- a/app/src/organisms/LabwareOffsetTabs/index.tsx
+++ b/app/src/organisms/LabwareOffsetTabs/index.tsx
@@ -25,7 +25,7 @@ export function LabwareOffsetTabs({
   JupyterComponent,
   CommandLineComponent,
 }: LabwareOffsetTabsProps): JSX.Element {
-  const { t } = useTranslation()
+  const { t } = useTranslation('labware_position_check')
   const [currentTab, setCurrentTab] = React.useState<TabOptions>('table')
 
   const activeTabComponent = {

--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -60,7 +60,9 @@ export const ResultsSummary = (
   const labwareDefinitions = getLabwareDefinitionsFromCommands(
     protocolData.commands
   )
-  const isLabwareOffsetCodeSnippetsOn = useSelector(getIsLabwareOffsetCodeSnippetsOn)
+  const isLabwareOffsetCodeSnippetsOn = useSelector(
+    getIsLabwareOffsetCodeSnippetsOn
+  )
 
   const offsetsToApply = React.useMemo(() => {
     return workingOffsets.map<LabwareOffsetCreateData>(

--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import isEqual from 'lodash/isEqual'
@@ -26,6 +27,8 @@ import {
 } from '@opentrons/components'
 import { getCurrentOffsetForLabwareInLocation } from '../Devices/ProtocolRun/utils/getCurrentOffsetForLabwareInLocation'
 import { getLabwareDefinitionsFromCommands } from './utils/labware'
+import { PythonLabwareOffsetSnippet } from '../../molecules/PythonLabwareOffsetSnippet'
+import { getIsLabwareOffsetCodeSnippetsOn } from '../../redux/config'
 
 import type { ResultsSummaryStep, WorkingOffset } from './types'
 import type {
@@ -33,6 +36,7 @@ import type {
   LabwareOffsetCreateData,
 } from '@opentrons/api-client'
 import { getDisplayLocation } from './utils/getDisplayLocation'
+import { LabwareOffsetTabs } from '../LabwareOffsetTabs'
 
 const LPC_HELP_LINK_URL =
   'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
@@ -56,6 +60,7 @@ export const ResultsSummary = (
   const labwareDefinitions = getLabwareDefinitionsFromCommands(
     protocolData.commands
   )
+  const isLabwareOffsetCodeSnippetsOn = useSelector(getIsLabwareOffsetCodeSnippetsOn)
 
   const offsetsToApply = React.useMemo(() => {
     return workingOffsets.map<LabwareOffsetCreateData>(
@@ -92,6 +97,27 @@ export const ResultsSummary = (
     )
   }, [workingOffsets])
 
+  const TableComponent = (
+    <OffsetTable
+      offsets={offsetsToApply}
+      labwareDefinitions={labwareDefinitions}
+    />
+  )
+  const JupyterSnippet = (
+    <PythonLabwareOffsetSnippet
+      mode="jupyter"
+      labwareOffsets={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+      protocol={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+    />
+  )
+  const CommandLineSnippet = (
+    <PythonLabwareOffsetSnippet
+      mode="cli"
+      labwareOffsets={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+      protocol={null} // todo (jb 2-15-23) update the values passed in as part of the snippet updates
+    />
+  )
+
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
@@ -100,10 +126,18 @@ export const ResultsSummary = (
       minHeight="25rem"
     >
       <StyledText as="h1">{t('new_labware_offset_data')}</StyledText>
-      <OffsetTable
-        offsets={offsetsToApply}
-        labwareDefinitions={labwareDefinitions}
-      />
+      {isLabwareOffsetCodeSnippetsOn ? (
+        <LabwareOffsetTabs
+          TableComponent={TableComponent}
+          JupyterComponent={JupyterSnippet}
+          CommandLineComponent={CommandLineSnippet}
+        />
+      ) : (
+        <OffsetTable
+          offsets={offsetsToApply}
+          labwareDefinitions={labwareDefinitions}
+        />
+      )}
       <Flex
         width="100%"
         marginTop={SPACING.spacing6}

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ResultsSummary.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ResultsSummary.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { resetAllWhenMocks } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
+import { getIsLabwareOffsetCodeSnippetsOn } from '../../../redux/config'
 import { ResultsSummary } from '../ResultsSummary'
 import { SECTIONS } from '../constants'
 import { mockTipRackDefinition } from '../../../redux/custom-labware/__fixtures__'
@@ -10,6 +11,12 @@ import {
   mockExistingOffsets,
   mockWorkingOffsets,
 } from '../__fixtures__'
+
+jest.mock('../../../redux/config')
+
+const mockGetIsLabwareOffsetCodeSnippetsOn = getIsLabwareOffsetCodeSnippetsOn as jest.MockedFunction<
+  typeof getIsLabwareOffsetCodeSnippetsOn
+>
 
 const render = (props: React.ComponentProps<typeof ResultsSummary>) => {
   return renderWithProviders(<ResultsSummary {...props} />, {
@@ -58,5 +65,13 @@ describe('ResultsSummary', () => {
     getByRole('cell', { name: 'slot 3' })
     getByRole('cell', { name: 'X 1.0 Y 1.0 Z 1.0' })
     getByRole('cell', { name: 'X 3.0 Y 3.0 Z 3.0' })
+  })
+
+  it('renders tabbed offset data with snippets when config option is selected', () => {
+    mockGetIsLabwareOffsetCodeSnippetsOn.mockReturnValue(true)
+    const { getByText } = render(props)
+    expect(getByText('Table View')).toBeTruthy()
+    expect(getByText('Jupyter Notebook')).toBeTruthy()
+    expect(getByText('Command Line Interface (SSH)')).toBeTruthy()
   })
 })

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -19,11 +19,9 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
-  DISPLAY_BLOCK,
   DISPLAY_FLEX,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
-  POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SIZE_1,
   SIZE_5,
@@ -44,6 +42,7 @@ import { Divider } from '../../atoms/structure'
 import { StyledText } from '../../atoms/text'
 import { DeckThumbnail } from '../../molecules/DeckThumbnail'
 import { Modal } from '../../molecules/Modal'
+import { RoundTab } from '../../molecules/RoundTab'
 import { useTrackEvent } from '../../redux/analytics'
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 import { ChooseRobotToRunProtocolSlideout } from '../ChooseRobotToRunProtocolSlideout'
@@ -60,46 +59,6 @@ import { RobotConfigurationDetails } from './RobotConfigurationDetails'
 import type { JsonConfig, PythonConfig } from '@opentrons/shared-data'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
-
-const defaultTabStyle = css`
-  ${TYPOGRAPHY.pSemiBold}
-  border-radius: ${BORDERS.radiusSoftCorners} ${BORDERS.radiusSoftCorners} 0 0;
-  border-top: ${BORDERS.transparentLineBorder};
-  border-left: ${BORDERS.transparentLineBorder};
-  border-right: ${BORDERS.transparentLineBorder};
-  padding: ${SPACING.spacing3} ${SPACING.spacing4};
-  position: ${POSITION_RELATIVE};
-`
-
-const inactiveTabStyle = css`
-  color: ${COLORS.darkGreyEnabled};
-
-  &:hover {
-    color: ${COLORS.darkGreyEnabled};
-    background-color: ${COLORS.fundamentalsBackgroundShade};
-  }
-`
-
-const currentTabStyle = css`
-  ${TYPOGRAPHY.pSemiBold}
-  background-color: ${COLORS.white};
-  border-top: ${BORDERS.lineBorder};
-  border-left: ${BORDERS.lineBorder};
-  border-right: ${BORDERS.lineBorder};
-  color: ${COLORS.blueEnabled};
-
-  /* extend below the tab when active to flow into the content */
-  &:after {
-    position: ${POSITION_ABSOLUTE};
-    display: ${DISPLAY_BLOCK};
-    content: '';
-    background-color: ${COLORS.white};
-    top: 100;
-    left: 0;
-    height: ${SIZE_1};
-    width: 100%;
-  }
-`
 
 const GRID_STYLE = css`
   display: grid;
@@ -122,34 +81,6 @@ const ZOOM_ICON_STYLE = css`
     box-shadow: 0 0 0 3px ${COLORS.fundamentalsFocus};
   }
 `
-
-interface RoundTabProps extends React.ComponentProps<typeof Btn> {
-  isCurrent: boolean
-}
-function RoundTab({
-  isCurrent,
-  children,
-  ...restProps
-}: RoundTabProps): JSX.Element {
-  return (
-    <Btn
-      {...restProps}
-      css={
-        isCurrent
-          ? css`
-              ${defaultTabStyle}
-              ${currentTabStyle}
-            `
-          : css`
-              ${defaultTabStyle}
-              ${inactiveTabStyle}
-            `
-      }
-    >
-      {children}
-    </Btn>
-  )
-}
 
 interface Metadata {
   [key: string]: any


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds a tabbed view to the three locations where labware offset data can be viewed/applied when the "Show Link to Get Labware Offset Data" that shows the table view of offset data as well as the Jupyter Notebook and CLI versions
closes RLAB-302

https://user-images.githubusercontent.com/66637570/219122395-07af9fd7-68c8-4067-85e6-5d5b4117b7ce.mov



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Turn on the "Show Link to Get Labware Offset Data" advanced setting and visit the 3 locations where labware offset data is shown and ensure the 3 tabbed view show up and show the correct data. (Note: the Jupyter and CLI tabs will be empty for now until follow up work on the snippets is complete)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Adds a RoundTab component to molecules
- Adds a LabwareOffsetTabs component to organisms
- Some style and minor updates to PythonLabwareOffsetSnippet
- adds the LabwareOffsetTabs component to the ResultsSummary, CurrentOffsetsModal, and ApplyHistoricOffsets components
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Verify the app behaves as described in the test plan and matches the designs

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
