### PR TITLE
feat(usb-bridge): toy node client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ UPDATE_SERVER_DIR := update-server
 ROBOT_SERVER_DIR := robot-server
 HARDWARE_DIR := hardware
 USB_BRIDGE_DIR := usb-bridge
+NODE_USB_BRIDGE_CLIENT_DIR := usb-bridge/node-client
 
 PYTHON_DIRS := $(API_DIR) $(UPDATE_SERVER_DIR) $(NOTIFY_SERVER_DIR) $(ROBOT_SERVER_DIR) $(SHARED_DATA_DIR)/python $(G_CODE_TESTING_DIR) $(HARDWARE_DIR) $(USB_BRIDGE_DIR)
 
@@ -93,6 +94,7 @@ clean: clean-js clean-py
 .PHONY: clean-js
 clean-js: clean-ts
 	$(MAKE) -C $(DISCOVERY_CLIENT_DIR) clean
+	$(MAKE) -C $(NODE_USB_BRIDGE_CLIENT_DIR) clean
 	$(MAKE) -C $(COMPONENTS_DIR) clean
 
 PYTHON_CLEAN_TARGETS := $(addsuffix -py-clean, $(PYTHON_DIRS))

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "step-generation",
       "webpack-config",
       "api-client",
-      "react-api-client"
+      "react-api-client",
+      "usb-bridge/node-client"
     ]
   },
   "config": {

--- a/usb-bridge/node-client/.gitignore
+++ b/usb-bridge/node-client/.gitignore
@@ -1,0 +1,14 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+*.tern-port
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.tsbuildinfo
+.npm
+.eslintcache
+lib/

--- a/usb-bridge/node-client/Makefile
+++ b/usb-bridge/node-client/Makefile
@@ -1,0 +1,29 @@
+# opentrons node-usb-bridge-client makefile
+
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+# TODO(mc, 2021-02-12): this may be unnecessary by using `yarn run` instead
+SHELL := bash
+
+# outputs
+main_out := lib/index.js lib/index.js.map
+cli_out := lib/cli.js lib/cli.js.map
+
+# standard targets
+#####################################################################
+
+.PHONY: all
+all: clean lib
+
+.PHONY: clean
+clean:
+	yarn shx rm -rf $(main_out) $(cli_out)
+
+# artifacts
+#####################################################################
+
+.PHONY: lib
+lib: export NODE_ENV := production
+lib: $(main_out) $(cli_out)
+
+$(main_out) $(cli_out): src/index.ts src/usb-agent.ts src/cli.ts webpack.config.js tsconfig.json Makefile
+	yarn webpack

--- a/usb-bridge/node-client/README.md
+++ b/usb-bridge/node-client/README.md
@@ -1,0 +1,11 @@
+# node USB bridge client
+
+> Node.js client for sending HTTP via a USB serial connection
+
+## overview
+
+## api
+
+```
+
+```

--- a/usb-bridge/node-client/bin/index.js
+++ b/usb-bridge/node-client/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict'
+require('../lib/cli')

--- a/usb-bridge/node-client/package.json
+++ b/usb-bridge/node-client/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@opentrons/node-usb-bridge-client",
+  "version": "0.0.0-dev",
+  "description": "Node.js client for sending HTTP over a USB serial connection",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "source": "src/index.ts",
+  "bin": {
+    "usb-curl": "bin/index.js"
+  },
+  "scripts": {
+    "usb-curl": "bin/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Opentrons/opentrons.git"
+  },
+  "author": "Opentrons Labworks <engineering@opentrons.com> (https://opentrons.com)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Opentrons/opentrons/issues"
+  },
+  "homepage": "https://github.com/Opentrons/opentrons#readme",
+  "dependencies": {
+    "serialport": "^10.5.0",
+    "yargs": "^15.4.0",
+    "node-fetch": "^2.6.0",
+    "agent-base": "^6.0.0"
+  }
+}

--- a/usb-bridge/node-client/src/cli.ts
+++ b/usb-bridge/node-client/src/cli.ts
@@ -1,0 +1,112 @@
+import Yargs from 'yargs'
+import { buildUSBAgent } from './usb-agent'
+import fetch from 'node-fetch'
+
+import type { MiddlewareFunction } from 'yargs'
+
+type LogLevel =
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'http'
+  | 'verbose'
+  | 'debug'
+  | 'silly'
+
+const LOG_LVLS: LogLevel[] = [
+  'error',
+  'warn',
+  'info',
+  'http',
+  'verbose',
+  'debug',
+  'silly',
+]
+
+type Logger = Record<LogLevel, (message: string, meta?: unknown) => void>
+
+interface Argv {
+  logLevel: LogLevel | string
+}
+
+interface CurlArgv extends Argv {
+  serialPath: string
+  method: string
+  httpPath: string
+}
+
+const createLogger = (argv: Argv): Logger => {
+  const level = (LOG_LVLS as string[]).indexOf(argv.logLevel)
+
+  return {
+    error: level >= 0 ? console.error : () => {},
+    warn: level >= 1 ? console.warn : () => {},
+    info: level >= 2 ? console.info : () => {},
+    http: level >= 3 ? console.debug : () => {},
+    verbose: level >= 4 ? console.debug : () => {},
+    debug: level >= 5 ? console.debug : () => {},
+    silly: level >= 6 ? console.debug : () => {},
+  }
+}
+
+const debugLogArgvMiddleware: MiddlewareFunction<Argv> = (argv): void => {
+  const log = createLogger(argv)
+  log.debug(`Calling ${argv.$0} with argv:`, argv)
+
+  // @ts-expect-error(mc, 2021-02-16): this return is probably unnecessary, remove
+  return argv
+}
+
+function curl(argv: CurlArgv): void {
+  const log = createLogger(argv)
+  log.verbose(`building agent for ${argv.serialPath}`)
+  const agent = buildUSBAgent({ serialPort: argv.serialPath })
+  const fakePath = `http://www.company.com/${argv.httpPath}`
+  log.info(`starting fetch to ${fakePath}`)
+  fetch(fakePath, {
+    method: argv.method,
+    agent: agent,
+    headers: {
+      'opentrons-version': '2',
+    },
+  })
+    .then(res => res.text())
+    .then(text => console.log(text))
+    .finally(() => {
+        log.info('done, closing connection')
+        agent.destroy()
+    })
+}
+
+Yargs.options({
+  logLevel: {
+    describe: 'Log level',
+    alias: 'l',
+    choices: [...LOG_LVLS, 'off'],
+    default: 'info',
+  },
+})
+  .middleware([debugLogArgvMiddleware])
+  .command(
+    'usb-curl <serialPath> <method> <httpPath>',
+    'Provide a curl-like interface that will make a request via the specified USB serial',
+    yargs => {
+      yargs.positional('serialPath', {
+        describe: 'Path to serial port to communicate with',
+        type: 'string',
+      })
+      yargs.positional('method', {
+        describe: 'HTTP method',
+        type: 'string',
+      })
+      yargs.positional('httpPath', {
+        describe: 'Path to query',
+        type: 'string',
+      })
+    },
+    curl
+  )
+  .strict()
+  .version(_PKG_VERSION_)
+  .help()
+  .parse()

--- a/usb-bridge/node-client/src/index.ts
+++ b/usb-bridge/node-client/src/index.ts
@@ -1,0 +1,5 @@
+import { buildUSBAgent } from './usb-agent'
+import type { AgentOptions } from './usb-agent'
+
+export { buildUSBAgent }
+export type { AgentOptions }

--- a/usb-bridge/node-client/src/types.ts
+++ b/usb-bridge/node-client/src/types.ts
@@ -1,0 +1,10 @@
+export type LogLevel =
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'http'
+  | 'verbose'
+  | 'debug'
+  | 'silly'
+
+export type Logger = Record<LogLevel, (message: string, meta?: unknown) => void>

--- a/usb-bridge/node-client/src/typings/global.d.ts
+++ b/usb-bridge/node-client/src/typings/global.d.ts
@@ -1,0 +1,1 @@
+declare const _PKG_VERSION_: string

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -1,0 +1,22 @@
+import * as http from 'http'
+import agent from 'agent-base'
+import type { Duplex } from 'stream'
+
+import { SerialPort } from 'serialport'
+
+export interface AgentOptions {
+  serialPort: string
+}
+
+export function buildUSBAgent(opts: AgentOptions): http.Agent {
+  console.log(`path is ${opts.serialPort}`)
+  const port = new SerialPort({ path: opts.serialPort, baudRate: 115200 })
+  const usbAgent = agent(
+    (req: http.ClientRequest, opts: http.RequestOptions): Duplex => port
+  )
+  usbAgent.maxFreeSockets = 1
+  usbAgent.maxSockets = 1
+  usbAgent.maxTotalSockets = 1
+  usbAgent.destroy = () => port.close()
+  return usbAgent
+}

--- a/usb-bridge/node-client/tsconfig.json
+++ b/usb-bridge/node-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "references": [],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["typings", "src"]
+}

--- a/usb-bridge/node-client/webpack.config.js
+++ b/usb-bridge/node-client/webpack.config.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const path = require('path')
+const webpackMerge = require('webpack-merge')
+const { DefinePlugin } = require('webpack')
+const { nodeBaseConfig } = require('@opentrons/webpack-config')
+const { versionForProject } = require('../../scripts/git-version')
+
+const ENTRY_INDEX = path.join(__dirname, 'src/index.ts')
+const ENTRY_CLI = path.join(__dirname, 'src/cli.ts')
+const OUTPUT_PATH = path.join(__dirname, 'lib')
+const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
+
+module.exports = async () =>
+  webpackMerge(nodeBaseConfig, {
+    entry: {
+      index: ENTRY_INDEX,
+      cli: ENTRY_CLI,
+    },
+    output: { path: OUTPUT_PATH },
+    plugins: [
+      new DefinePlugin({
+        _PKG_VERSION_: JSON.stringify(await versionForProject(project)),
+      }),
+    ],
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,6 +2187,7 @@
     "@opentrons/react-api-client" "link:react-api-client"
     "@opentrons/shared-data" "link:shared-data"
     "@thi.ng/paths" "1.6.5"
+    "@types/uuid" "^3.4.7"
     classnames "2.2.5"
     connected-react-router "6.8.0"
     core-js "3.2.1"
@@ -2370,6 +2371,90 @@
   integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
   dependencies:
     any-observable "^0.3.0"
+
+"@serialport/binding-mock@10.2.2":
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/@serialport/binding-mock/-/binding-mock-10.2.2.tgz#d322a8116a97806addda13c62f50e73d16125874"
+  integrity sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==
+  dependencies:
+    "@serialport/bindings-interface" "^1.2.1"
+    debug "^4.3.3"
+
+"@serialport/bindings-cpp@10.8.0":
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz#79507b57022ac264e963e7fbf3647a3821569a20"
+  integrity sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==
+  dependencies:
+    "@serialport/bindings-interface" "1.2.2"
+    "@serialport/parser-readline" "^10.2.1"
+    debug "^4.3.2"
+    node-addon-api "^5.0.0"
+    node-gyp-build "^4.3.0"
+
+"@serialport/bindings-interface@1.2.2", "@serialport/bindings-interface@^1.2.1":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz#c4ae9c1c85e26b02293f62f37435478d90baa460"
+  integrity sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==
+
+"@serialport/parser-byte-length@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz#f3d4c1c7923222df2f3d3c7c8aaaa207fe373b49"
+  integrity sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w==
+
+"@serialport/parser-cctalk@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz#0ee88db0768a361b7cfb9a394b74e480c38e1992"
+  integrity sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA==
+
+"@serialport/parser-delimiter@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz#b0d93100cdfd0619d020a427d652495073f3b828"
+  integrity sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==
+
+"@serialport/parser-inter-byte-timeout@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz#8665ee5e6138f794ac055e83ef2d1c3653a577c0"
+  integrity sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ==
+
+"@serialport/parser-packet-length@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz#4c4d733bdff8cc4749f2bd750e42e66f8f478def"
+  integrity sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw==
+
+"@serialport/parser-readline@10.5.0", "@serialport/parser-readline@^10.2.1":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-readline/-/parser-readline-10.5.0.tgz#df23365ae7f45679b1735deae26f72ba42802862"
+  integrity sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==
+  dependencies:
+    "@serialport/parser-delimiter" "10.5.0"
+
+"@serialport/parser-ready@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-ready/-/parser-ready-10.5.0.tgz#1d9029f57b1abd664cb468e21bfccf7b44c6e8ea"
+  integrity sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA==
+
+"@serialport/parser-regex@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-regex/-/parser-regex-10.5.0.tgz#f98eab6e3d9bc99086269e9acf39a82db36d245f"
+  integrity sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw==
+
+"@serialport/parser-slip-encoder@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz#cb79ac0fda1fc87f049690ff7b498c787da67991"
+  integrity sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw==
+
+"@serialport/parser-spacepacket@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz#2fc077c0ec16a9532c511ad5f2ab12d588796bc7"
+  integrity sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg==
+
+"@serialport/stream@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/stream/-/stream-10.5.0.tgz#cda8fb3e8d03094b0962a3d14b73adfcd591be58"
+  integrity sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==
+  dependencies:
+    "@serialport/bindings-interface" "1.2.2"
+    debug "^4.3.2"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -4493,7 +4578,7 @@ address@^1.0.1:
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
-agent-base@6, agent-base@^6.0.2:
+agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -7734,7 +7819,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.3, debug@^4.3.4:
+debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -14900,6 +14985,11 @@ node-addon-api@^3.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
 node-api-version@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.1.4.tgz#1ed46a485e462d55d66b5aa1fe2821720dedf080"
@@ -14927,6 +15017,13 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.6.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -14948,6 +15045,11 @@ node-gyp-build@^4.2.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
   integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
+
+node-gyp-build@^4.3.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
+  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
 node-gyp@^9.0.0:
   version "9.3.0"
@@ -18874,6 +18976,26 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialport@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/serialport/-/serialport-10.5.0.tgz#b85f614def6e8914e5865c798b0555330903a0f8"
+  integrity sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==
+  dependencies:
+    "@serialport/binding-mock" "10.2.2"
+    "@serialport/bindings-cpp" "10.8.0"
+    "@serialport/parser-byte-length" "10.5.0"
+    "@serialport/parser-cctalk" "10.5.0"
+    "@serialport/parser-delimiter" "10.5.0"
+    "@serialport/parser-inter-byte-timeout" "10.5.0"
+    "@serialport/parser-packet-length" "10.5.0"
+    "@serialport/parser-readline" "10.5.0"
+    "@serialport/parser-ready" "10.5.0"
+    "@serialport/parser-regex" "10.5.0"
+    "@serialport/parser-slip-encoder" "10.5.0"
+    "@serialport/parser-spacepacket" "10.5.0"
+    "@serialport/stream" "10.5.0"
+    debug "^4.3.3"
+
 serve-favicon@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.5.0.tgz#935d240cdfe0f5805307fdfe967d88942a2cbcf0"
@@ -22290,7 +22412,7 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.4.1:
+yargs@^15.4.0, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
Adds a silly node client that uses
https://www.npmjs.com/package/agent-base to build an http agent that redirects everything through a node serialport stream https://serialport.io/docs/api-serialport including working through node-fetch (although right now you have to mess with the url).

Many things to continue working on but this works shockingly well

To try it yourself:
- check out this branch
- run `make setup-js`
- go to `usb-bridge/node-client` and run `make lib`
- plug in a robot's USB cable and figure out which serial port it got somehow
- run `yarn run usb-curl usb-curl /path/to/serialport GET instruments` (note: yes, you have to put `usb-curl` in there twice because I have no idea what i'm doing with yargs; yes, no leading / on instruments because I haven't gotten to url parsing yet)
- hit ctrl-c once you see the stuff print because i'm not terminating the stream properly