### PR TITLE
feat(app): add download run log to protocol run header

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -84,6 +84,7 @@
   "clear_protocol": "Clear protocol",
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "download_run_log": "Download run log",
+  "download_run_log_title_case": "Download Run Log",
   "downloading_run_log": "Downloading run log",
   "jump_to_current_step": "Jump to current step",
   "run_has_diverged_from_predicted": "Run has diverged from predicted state. Cannot anticipate new steps.",

--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -84,7 +84,6 @@
   "clear_protocol": "Clear protocol",
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "download_run_log": "Download run log",
-  "download_run_log_title_case": "Download Run Log",
   "downloading_run_log": "Downloading run log",
   "jump_to_current_step": "Jump to current step",
   "run_has_diverged_from_predicted": "Run has diverged from predicted state. Cannot anticipate new steps.",

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -317,7 +317,7 @@ export function ProtocolRunHeader({
           </Flex>
         </Box>
       ) : null}
-      <RunProgressMeter {...{ makeHandleJumpToStep, runId }} />
+      <RunProgressMeter {...{ makeHandleJumpToStep, runId, robotName }} />
       {showConfirmCancelModal ? (
         <ConfirmCancelModal
           onClose={() => setShowConfirmCancelModal(false)}

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -126,7 +126,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
         >
           <Flex gridGap={SPACING.spacing2}>
             <Icon name="download" size={SIZE_1} />
-            <StyledText>Download Run Log</StyledText>
+            <StyledText>{t('download_run_log_title_case')}</StyledText>
           </Flex>
         </SecondaryButton>
       </Flex>

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -11,6 +11,8 @@ import {
   SPACING,
   Icon,
   SIZE_1,
+  Link,
+  ALIGN_CENTER,
 } from '@opentrons/components'
 import {
   RUN_STATUS_IDLE,
@@ -18,13 +20,13 @@ import {
   RUN_STATUS_FAILED,
   RUN_STATUS_FINISHING,
   RUN_STATUS_SUCCEEDED,
+  RUN_STATUS_RUNNING,
 } from '@opentrons/api-client'
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { StyledText } from '../../atoms/text'
 import { CommandText } from '../CommandText'
 import { useRunStatus } from '../RunTimeControl/hooks'
 import { ProgressBar } from '../../atoms/ProgressBar'
-import { SecondaryButton } from '../../atoms/buttons'
 import { useDownloadRunLog } from '../Devices/hooks'
 import { useLastRunCommandKey } from '../Devices/hooks/useLastRunCommandKey'
 import { InterventionTicks } from './InterventionTicks'
@@ -97,14 +99,14 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     )
   }
 
-  const onDownloadClick: React.MouseEventHandler<HTMLButtonElement> = e => {
+  const onDownloadClick: React.MouseEventHandler<HTMLAnchorElement> = e => {
+    if (downloadIsDisabled) return false
     e.preventDefault()
     e.stopPropagation()
     downloadRunLog()
   }
 
-  const downloadIsDisabled =
-    runStatus != null && !TERMINAL_RUN_STATUSES.includes(runStatus)
+  const downloadIsDisabled = runStatus === RUN_STATUS_RUNNING
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
@@ -117,18 +119,28 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
           }`}</StyledText>
           {currentStepContents}
         </Flex>
-        <SecondaryButton
-          disabled={downloadIsDisabled}
-          color={COLORS.darkBlackEnabled}
-          border={BORDERS.transparentLineBorder}
-          cursor={downloadIsDisabled ? '' : 'pointer'}
+        <Link
+          role="button"
+          css={css`
+            ${TYPOGRAPHY.darkLinkH4SemiBold}
+            &:hover {
+              color: ${
+                downloadIsDisabled
+                  ? COLORS.darkGreyEnabled
+                  : COLORS.darkBlackEnabled
+              };
+            }
+            cursor: ${downloadIsDisabled ? 'default' : 'pointer'};
+          }
+          `}
+          textTransform={TYPOGRAPHY.textTransformCapitalize}
           onClick={onDownloadClick}
         >
-          <Flex gridGap={SPACING.spacing2}>
+          <Flex gridGap={SPACING.spacing2} alignItems={ALIGN_CENTER}>
             <Icon name="download" size={SIZE_1} />
-            <StyledText>{t('download_run_log_title_case')}</StyledText>
+            {t('download_run_log')}
           </Flex>
-        </SecondaryButton>
+        </Link>
       </Flex>
       {analysis != null ? (
         <ProgressBar


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

adds a button to download the run log from the protocol run view

closes rlab-298


https://user-images.githubusercontent.com/66637570/219442656-aa215952-334e-4837-98c3-9df79276a1e5.mov



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Select a protocol and verify the download button is present but disabled, run the protocol, when the run is complete the button should be available and clicking it will download the run log

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added the "Download Run Log" button to the RunProgressMeter

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the behavior is correct per the test plan

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
