### PR TITLE
fix(calibration-storage): add workaround for datetime encoder with pydantic models

### DIFF
--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -127,12 +127,18 @@ def delete_tip_length_calibration(tiprack: str, pipette_id: str) -> None:
     :param pipette: pipette serial number
     """
     tip_lengths = tip_lengths_for_pipette(pipette_id)
+
     if tiprack in tip_lengths:
         # maybe make modify and delete same file?
         del tip_lengths[tiprack]
         tip_length_dir = config.get_tip_length_cal_path()
         if tip_lengths:
-            io.save_to_file(tip_length_dir, pipette_id, tip_lengths)
+            # This is a workaround since pydantic doesn't have a nice way to
+            # add encoders when converting to a dict.
+            dict_of_tip_lengths = {}
+            for key, item in tip_lengths.items():
+                dict_of_tip_lengths[key] = json.loads(item.json())
+            io.save_to_file(tip_length_dir, pipette_id, dict_of_tip_lengths)
         else:
             io.delete_file(tip_length_dir / f"{pipette_id}.json")
     else:

--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -22,6 +22,17 @@ log = logging.getLogger(__name__)
 # Get Tip Length Calibration
 
 
+def _conver_tip_length_model_to_dict(
+    to_dict: typing.Dict[str, v1.TipLengthModel]
+) -> typing.Dict[str, typing.Any]:
+    # This is a workaround since pydantic doesn't have a nice way to
+    # add encoders when converting to a dict.
+    dict_of_tip_lengths = {}
+    for key, item in to_dict.items():
+        dict_of_tip_lengths[key] = json.loads(item.json())
+    return dict_of_tip_lengths
+
+
 def tip_lengths_for_pipette(
     pipette_id: str,
 ) -> typing.Dict[str, v1.TipLengthModel]:
@@ -133,11 +144,7 @@ def delete_tip_length_calibration(tiprack: str, pipette_id: str) -> None:
         del tip_lengths[tiprack]
         tip_length_dir = config.get_tip_length_cal_path()
         if tip_lengths:
-            # This is a workaround since pydantic doesn't have a nice way to
-            # add encoders when converting to a dict.
-            dict_of_tip_lengths = {}
-            for key, item in tip_lengths.items():
-                dict_of_tip_lengths[key] = json.loads(item.json())
+            dict_of_tip_lengths = _conver_tip_length_model_to_dict(tip_lengths)
             io.save_to_file(tip_length_dir, pipette_id, dict_of_tip_lengths)
         else:
             io.delete_file(tip_length_dir / f"{pipette_id}.json")
@@ -228,9 +235,5 @@ def save_tip_length_calibration(
 
     all_tip_lengths.update(tip_length_cal)
 
-    # This is a workaround since pydantic doesn't have a nice way to
-    # add encoders when converting to a dict.
-    dict_of_tip_lengths = {}
-    for key, item in all_tip_lengths.items():
-        dict_of_tip_lengths[key] = json.loads(item.json())
+    dict_of_tip_lengths = _conver_tip_length_model_to_dict(all_tip_lengths)
     io.save_to_file(tip_length_dir_path, pip_id, dict_of_tip_lengths)

--- a/api/src/opentrons/calibration_storage/ot3/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot3/tip_length.py
@@ -118,7 +118,12 @@ def delete_tip_length_calibration(tiprack: str, pipette_id: str) -> None:
         del tip_lengths[tiprack]
         tip_length_directory = config.get_tip_length_cal_path()
         if tip_lengths:
-            io.save_to_file(tip_length_directory, pipette_id, tip_lengths)
+            # This is a workaround since pydantic doesn't have a nice way to
+            # add encoders when converting to a dict.
+            dict_of_tip_lengths = {}
+            for key, item in tip_lengths.items():
+                dict_of_tip_lengths[key] = json.loads(item.json())
+            io.save_to_file(tip_length_directory, pipette_id, dict_of_tip_lengths)
         else:
             io.delete_file(tip_length_directory / f"{pipette_id}.json")
     else:

--- a/api/src/opentrons/calibration_storage/ot3/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot3/tip_length.py
@@ -20,6 +20,17 @@ log = logging.getLogger(__name__)
 # Get Tip Length Calibration
 
 
+def _conver_tip_length_model_to_dict(
+    to_dict: typing.Dict[str, v1.TipLengthModel]
+) -> typing.Dict[str, typing.Any]:
+    # This is a workaround since pydantic doesn't have a nice way to
+    # add encoders when converting to a dict.
+    dict_of_tip_lengths = {}
+    for key, item in to_dict.items():
+        dict_of_tip_lengths[key] = json.loads(item.json())
+    return dict_of_tip_lengths
+
+
 @typing.no_type_check
 def tip_lengths_for_pipette(
     pipette_id: str,
@@ -118,11 +129,7 @@ def delete_tip_length_calibration(tiprack: str, pipette_id: str) -> None:
         del tip_lengths[tiprack]
         tip_length_directory = config.get_tip_length_cal_path()
         if tip_lengths:
-            # This is a workaround since pydantic doesn't have a nice way to
-            # add encoders when converting to a dict.
-            dict_of_tip_lengths = {}
-            for key, item in tip_lengths.items():
-                dict_of_tip_lengths[key] = json.loads(item.json())
+            dict_of_tip_lengths = _conver_tip_length_model_to_dict(tip_lengths)
             io.save_to_file(tip_length_directory, pipette_id, dict_of_tip_lengths)
         else:
             io.delete_file(tip_length_directory / f"{pipette_id}.json")
@@ -167,9 +174,5 @@ def save_tip_length_calibration(
 
     all_tip_lengths.update(tip_length_cal)
 
-    # This is a workaround since pydantic doesn't have a nice way to
-    # add encoders when converting to a dict.
-    dict_of_tip_lengths = {}
-    for key, item in all_tip_lengths.items():
-        dict_of_tip_lengths[key] = json.loads(item.json())
+    dict_of_tip_lengths = _conver_tip_length_model_to_dict(all_tip_lengths)
     io.save_to_file(tip_length_dir_path, pip_id, dict_of_tip_lengths)

--- a/api/tests/opentrons/calibration_storage/test_tip_length.py
+++ b/api/tests/opentrons/calibration_storage/test_tip_length.py
@@ -21,7 +21,9 @@ def reload_module(robot_model: "RobotModel") -> None:
 
 @pytest.fixture
 def starting_calibration_data(
-    ot_config_tempdir: Any, minimal_labware_def: "LabwareDefinition"
+    ot_config_tempdir: Any,
+    minimal_labware_def: "LabwareDefinition",
+    minimal_labware_def2: "LabwareDefinition",
 ) -> None:
     """
     Starting calibration data fixture.
@@ -35,8 +37,10 @@ def starting_calibration_data(
 
     tip_length1 = create_tip_length_data(minimal_labware_def, 22.0)
     tip_length2 = create_tip_length_data(minimal_labware_def, 31.0)
+    tip_length3 = create_tip_length_data(minimal_labware_def2, 31.0)
     save_tip_length_calibration("pip1", tip_length1)
     save_tip_length_calibration("pip2", tip_length2)
+    save_tip_length_calibration("pip1", tip_length3)
 
 
 def test_save_tip_length_calibration(
@@ -93,11 +97,11 @@ def test_delete_specific_tip_calibration(
         delete_tip_length_calibration,
     )
 
-    assert tip_lengths_for_pipette("pip1") != {}
+    assert len(tip_lengths_for_pipette("pip1").keys()) == 2
     assert tip_lengths_for_pipette("pip2") != {}
     tip_rack_hash = helpers.hash_labware_def(minimal_labware_def)
     delete_tip_length_calibration(tip_rack_hash, "pip1")
-    assert tip_lengths_for_pipette("pip1") == {}
+    assert len(tip_lengths_for_pipette("pip1").keys()) == 1
     assert tip_lengths_for_pipette("pip2") != {}
 
 


### PR DESCRIPTION
# Overview

Pydantic encoders for dicts never worked quite right in the calibration storage module. This was especially an issue in tip length calibration because of the way we store that data. <pipette_id>.json contains a json file of objects keyed by tiprack id. The workaround was present in the save tip length calibration functions, but not in the delete calibration tip length function. I never hit this use-case because I only tested the case of 1 tip length present per tiprack/pipette pairing.

# Test Plan

- [x] Test on an OT-2
       - Make sure the specific pipette has been calibrated for multiple types of tipracks
       - Delete only a single tiprack for that given pipette and see that it no longer 500s 

# Review requests

Please test on a robot if you can. I need to do a few other things.

# Risk assessment

Medium. This touches production code.