### PR TITLE
refactor(api): fix unreleased regression in tip length load

### DIFF
--- a/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
@@ -1,9 +1,13 @@
 import json
 import typing
 import logging
+import importlib
 from pydantic import ValidationError
 from dataclasses import asdict
 
+import pytest
+
+import opentrons
 from opentrons import config, types
 
 from .. import file_operators as io, types as local_types
@@ -14,6 +18,12 @@ from opentrons.types import Mount, Point
 from opentrons.util.helpers import utc_now
 
 log = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def reload_module() -> None:
+    importlib.reload(opentrons.calibration_storage)
+
 
 # Delete Pipette Offset Calibrations
 

--- a/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
@@ -1,13 +1,9 @@
 import json
 import typing
 import logging
-import importlib
 from pydantic import ValidationError
 from dataclasses import asdict
 
-import pytest
-
-import opentrons
 from opentrons import config, types
 
 from .. import file_operators as io, types as local_types
@@ -18,12 +14,6 @@ from opentrons.types import Mount, Point
 from opentrons.util.helpers import utc_now
 
 log = logging.getLogger(__name__)
-
-
-@pytest.fixture(autouse=True, scope="module")
-def reload_module() -> None:
-    importlib.reload(opentrons.calibration_storage)
-
 
 # Delete Pipette Offset Calibrations
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
@@ -117,18 +117,22 @@ def save_pipette_offset_calibration(
         )
 
 
+# TODO(mc, 2023-02-16): this function is not covered by unit tests
 # TODO (lc 09-26-2022) We should ensure that only LabwareDefinition models are passed
 # into this function instead of a mixture of TypeDicts and BaseModels
 def load_tip_length_for_pipette(
     pipette_id: str, tiprack: typing.Union["TypeDictLabwareDef", LabwareDefinition]
 ) -> TipLengthCalibration:
     if isinstance(tiprack, LabwareDefinition):
-        tiprack = typing.cast("TypeDictLabwareDef", tiprack.dict())
+        tiprack = typing.cast("TypeDictLabwareDef", tiprack.dict(exclude_none=True))
+
     tip_length_data = load_tip_length_calibration(pipette_id, tiprack)
+
     # TODO (lc 09-26-2022) We shouldn't have to do a hash twice. We should figure out what
     # information we actually need from the labware definition and pass it into
     # the `load_tip_length_calibration` function.
     tiprack_hash = helpers.hash_labware_def(tiprack)
+
     return TipLengthCalibration(
         tip_length=tip_length_data.tipLength,
         source=tip_length_data.source,

--- a/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
@@ -76,5 +76,5 @@ class LabwareDataProvider:
             ).tip_length
 
         except TipLengthCalNotFound as e:
-            log.debug("No calibrated tip length found for {pipette_serial}", exc_info=e)
+            log.warn(f"No calibrated tip length found for {pipette_serial}", exc_info=e)
             return None

--- a/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
@@ -76,5 +76,7 @@ class LabwareDataProvider:
             ).tip_length
 
         except TipLengthCalNotFound as e:
-            log.warn(f"No calibrated tip length found for {pipette_serial}", exc_info=e)
+            log.warning(
+                f"No calibrated tip length found for {pipette_serial}", exc_info=e
+            )
             return None

--- a/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
@@ -1,0 +1,112 @@
+import inspect
+from datetime import datetime
+from typing import Union, cast
+
+import pytest
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
+from decoy import Decoy
+
+from opentrons_shared_data.labware.dev_types import (
+    LabwareUri,
+    LabwareDefinition as LabwareDefDict,
+)
+from opentrons_shared_data.labware.labware_definition import (
+    LabwareDefinition,
+    Parameters,
+)
+
+
+from opentrons import calibration_storage
+from opentrons.calibration_storage import helpers as calibration_storage_helpers
+from opentrons.calibration_storage.ot2.models import v1 as v1_models
+from opentrons.hardware_control.instruments.ot2 import instrument_calibration as subject
+
+
+@pytest.fixture(autouse=True)
+def _use_mock_calibration_storage(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mock out the opentrons.calibration_storage module."""
+    for name, func in inspect.getmembers(calibration_storage, inspect.isfunction):
+        monkeypatch.setattr(calibration_storage, name, decoy.mock(func=func))
+
+    for name, func in inspect.getmembers(
+        calibration_storage_helpers, inspect.isfunction
+    ):
+        monkeypatch.setattr(calibration_storage_helpers, name, decoy.mock(func=func))
+
+
+@pytest.fixture
+def tip_rack_dict() -> LabwareDefDict:
+    """Get a tip rack dictionary definition value object."""
+    return cast(
+        LabwareDefDict,
+        {"namespace": "test", "version": 1, "parameters": {"loadName": "cool-labware"}},
+    )
+
+
+@pytest.fixture
+def tip_rack_model() -> LabwareDefinition:
+    """Get a tip rack Pydantic model definition value object."""
+    return LabwareDefinition.construct(  # type: ignore[call-arg]
+        namespace="test",
+        version=1,
+        parameters=Parameters.construct(  # type: ignore[call-arg]
+            loadName="cool-labware",
+            tipOverlap=None,  # add a None value to validate serialization to dictionary
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "tip_rack_definition",
+    [
+        lazy_fixture("tip_rack_dict"),
+        lazy_fixture("tip_rack_model"),
+    ],
+)
+def test_load_tip_length(
+    decoy: Decoy,
+    tip_rack_dict: LabwareDefDict,
+    tip_rack_definition: Union[LabwareDefDict, LabwareDefinition],
+) -> None:
+    """Test that a tip length can be laoded for a pipette / tiprack combination."""
+    tip_length_data = v1_models.TipLengthModel(
+        tipLength=1.23,
+        lastModified=datetime(year=2023, month=1, day=1),
+        uri=LabwareUri("def456"),
+        source=subject.types.SourceType.factory,
+        status=v1_models.CalibrationStatus(
+            markedBad=True,
+            source=subject.types.SourceType.user,
+            markedAt=datetime(year=2023, month=2, day=2),
+        ),
+    )
+
+    decoy.when(
+        calibration_storage.load_tip_length_calibration(
+            pip_id="abc123", definition=tip_rack_dict
+        )
+    ).then_return(tip_length_data)
+
+    decoy.when(calibration_storage.helpers.hash_labware_def(tip_rack_dict)).then_return(
+        "asdfghjk"
+    )
+
+    result = subject.load_tip_length_for_pipette(
+        pipette_id="abc123", tiprack=tip_rack_definition
+    )
+
+    assert result == subject.TipLengthCalibration(
+        tip_length=1.23,
+        source=subject.types.SourceType.factory,
+        pipette="abc123",
+        tiprack="asdfghjk",
+        last_modified=datetime(year=2023, month=1, day=1),
+        uri=LabwareUri("def456"),
+        status=subject.types.CalibrationStatus(
+            markedBad=True,
+            source=subject.types.SourceType.user,
+            markedAt=datetime(year=2023, month=2, day=2),
+        ),
+    )

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -1,13 +1,23 @@
+import importlib
+from pathlib import Path
+
+import pytest
 import numpy as np
 
-from pathlib import Path
-from opentrons import config
-from opentrons.calibration_storage import file_operators as io, save_pipette_calibration
+from opentrons import config, calibration_storage
 
 from opentrons.hardware_control import robot_calibration
 from opentrons.hardware_control.instruments.ot2 import instrument_calibration
 from opentrons.util.helpers import utc_now
 from opentrons.types import Mount, Point
+
+
+# TODO(mc, 2023-02-17): this reload resolves test polution from repeated
+# reloads of this module in tests/opentrons/calibration_storage.
+# module reloads to be removed in https://github.com/Opentrons/opentrons/pull/12049
+@pytest.fixture(autouse=True, scope="module")
+def reload_module() -> None:
+    importlib.reload(calibration_storage)
 
 
 def test_migrate_affine_xy_to_attitude():
@@ -42,7 +52,7 @@ def test_save_calibration(ot_config_tempdir):
         "status": {"markedBad": False, "markedAt": None, "source": None},
     }
     robot_calibration.save_attitude_matrix(e, a, pip_id, lw_hash)
-    data = io.read_cal_file(pathway)
+    data = calibration_storage.file_operators.read_cal_file(pathway)
     data["last_modified"] = None
     assert data == expected
 
@@ -56,7 +66,7 @@ def test_load_calibration(ot_config_tempdir):
         "last_modified": utc_now(),
         "tiprack": "hash",
     }
-    io.save_to_file(pathway, "deck_calibration", data)
+    calibration_storage.file_operators.save_to_file(pathway, "deck_calibration", data)
     obj = robot_calibration.load_attitude_matrix()
     transform = [[1, 0, 1], [0, 1, -0.5], [0, 0, 1]]
     assert np.allclose(obj.attitude, transform)
@@ -70,7 +80,7 @@ def test_load_malformed_calibration(ot_config_tempdir):
         "tiprack": "hash",
         "statu": [1, 2, 3],
     }
-    io.save_to_file(pathway, "deck_calibration", data)
+    calibration_storage.file_operators.save_to_file(pathway, "deck_calibration", data)
     obj = robot_calibration.load_attitude_matrix()
     assert np.allclose(obj.attitude, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
@@ -87,7 +97,7 @@ def test_load_pipette_offset(ot_config_tempdir):
     mount = Mount.LEFT
     offset = Point(1, 2, 3)
 
-    save_pipette_calibration(
+    calibration_storage.save_pipette_calibration(
         offset, pip_id, mount, "hash", "opentrons/opentrons_96_tiprack_10ul/1"
     )
     obj = instrument_calibration.load_pipette_offset(pip_id, mount)


### PR DESCRIPTION
## Overview

This PR fixes a regression in `edge` from #11520 that broke the ProtocolEngine's ability to load calibrated tip lengths.

Closes RSS-193

## Test Plan

This bug is quite obvious if you run through LPC prior to running a pre-engine Python Protocol.

- During LPC, the engine will be unable to load a calibrated tip length, so it will fall back to using the tip rack's nominal tip length, which could be several `mm` different than the calibrated value
- This will cause over-compensation during LPC
- Then, when the legacy Python protocol is run, it will correctly load the calibrated tip length, which will likely cause the pipette to bottom out on the well.

I used `testasaur_v2.py` to observe the bug and test the fix.

## Changelog

- Revert unintentional change in how the `LabwareDefinition` model was turned into a plain dictionary for labware hashing
- Increase logging severity of miss when checking for calibrated tip length

## Review requests

I've tested this extensively on hardware, so a code review should suffice

## Risk assessment

Low, fixing a regression by reverting back to known good logic
