### PR TITLE
fix(robot-server): do not use nested dataclasses in models

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -1,6 +1,7 @@
 import typing
 from dataclasses import dataclass
 from datetime import datetime
+
 from opentrons.config import feature_flags as ff
 from opentrons.config.robot_configs import (
     default_pipette_offset,
@@ -35,8 +36,8 @@ class GripperCalibrationOffset:
     """
     Class to store gripper offset calibration with gripper info
 
-        TODO(lc 09/15/2022) this can probably be combined with
-        pipette offset mount.
+    TODO(lc 09/15/2022) this can probably be combined with
+    pipette offset mount.
     """
 
     offset: Point

--- a/robot-server/robot_server/instruments/instrument_models.py
+++ b/robot-server/robot_server/instruments/instrument_models.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import enum
 from typing_extensions import Literal
 from typing import Optional, TypeVar, Union, Generic
+from datetime import datetime
 from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
 
-from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
-    GripperCalibrationOffset,
-)
-from opentrons.types import Mount
 
+from opentrons.types import Mount
+from opentrons.calibration_storage.types import SourceType
+from opentrons.protocol_engine.types import Vec3f
 from opentrons_shared_data.pipette.dev_types import (
     PipetteName,
     PipetteModel,
@@ -60,13 +60,21 @@ class _GenericInstrument(GenericModel, Generic[InstrumentModelT, InstrumentDataT
     data: InstrumentDataT
 
 
+class GripperCalibrationData(BaseModel):
+    """A gripper's calibration data."""
+
+    offset: Vec3f
+    source: SourceType
+    last_modified: Optional[datetime] = None
+
+
 class GripperData(BaseModel):
     """Data from attached gripper."""
 
     jawState: str = Field(..., description="Gripper Jaw state.")
     # TODO (spp, 2023-01-03): update calibration field as decided after
     #  spike https://opentrons.atlassian.net/browse/RSS-167
-    calibratedOffset: Optional[GripperCalibrationOffset] = Field(
+    calibratedOffset: Optional[GripperCalibrationData] = Field(
         None, description="Calibrated gripper offset."
     )
 

--- a/robot-server/robot_server/instruments/router.py
+++ b/robot-server/robot_server/instruments/router.py
@@ -12,6 +12,7 @@ from robot_server.service.json_api import (
 )
 
 from opentrons.types import Mount
+from opentrons.protocol_engine.types import Vec3f
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.dev_types import PipetteDict, GripperDict
@@ -24,6 +25,7 @@ from .instrument_models import (
     GripperData,
     Gripper,
     AttachedInstrument,
+    GripperCalibrationData,
 )
 
 instruments_router = APIRouter()
@@ -47,13 +49,22 @@ def _pipette_dict_to_pipette_res(pipette_dict: PipetteDict, mount: Mount) -> Pip
 
 def _gripper_dict_to_gripper_res(gripper_dict: GripperDict) -> Gripper:
     """Convert GripperDict to Gripper response model."""
+    calibration_data = gripper_dict["calibration_offset"]
     return Gripper.construct(
         mount=MountType.EXTENSION.as_string(),
         instrumentModel=GripperModelStr(str(gripper_dict["model"])),
         serialNumber=gripper_dict["gripper_id"],
         data=GripperData(
             jawState=gripper_dict["state"].name.lower(),
-            calibratedOffset=gripper_dict["calibration_offset"],
+            calibratedOffset=GripperCalibrationData.construct(
+                offset=Vec3f(
+                    x=calibration_data.offset.x,
+                    y=calibration_data.offset.y,
+                    z=calibration_data.offset.z,
+                ),
+                source=calibration_data.source,
+                last_modified=calibration_data.last_modified,
+            ),
         ),
     )
 

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -12,6 +12,7 @@ from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
 )
 from opentrons.hardware_control.types import GripperJawState
+from opentrons.protocol_engine.types import Vec3f
 from opentrons.types import Point, Mount
 from opentrons_shared_data.gripper.gripper_definition import (
     GripperModelStr,
@@ -24,6 +25,7 @@ from robot_server.instruments.instrument_models import (
     GripperData,
     Pipette,
     PipetteData,
+    GripperCalibrationData,
 )
 from robot_server.instruments.router import get_attached_instruments
 
@@ -101,7 +103,7 @@ async def test_get_all_attached_instruments(
             "calibration_offset": GripperCalibrationOffset(
                 offset=Point(x=1, y=2, z=3),
                 source=SourceType.default,
-                status=CalibrationStatus(),
+                status=CalibrationStatus(markedBad=False),
                 last_modified=None,
             ),
         }
@@ -153,10 +155,9 @@ async def test_get_all_attached_instruments(
             serialNumber="GripperID321",
             data=GripperData(
                 jawState="unhomed",
-                calibratedOffset=GripperCalibrationOffset(
-                    offset=Point(x=1, y=2, z=3),
+                calibratedOffset=GripperCalibrationData(
+                    offset=Vec3f(x=1, y=2, z=3),
                     source=SourceType.default,
-                    status=CalibrationStatus(),
                     last_modified=None,
                 ),
             ),

--- a/robot-server/tests/integration/system/test_openapi.tavern.yaml
+++ b/robot-server/tests/integration/system/test_openapi.tavern.yaml
@@ -1,0 +1,12 @@
+--- # FastAPI will only 2xx on this endpoint if the response is a valid OAS
+test_name: GET openapi.json
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Raw openapi.json endpoint is served and json is received
+    request:
+      url: "{host:s}:{port:d}/openapi.json"
+      method: GET
+    response:
+      status_code: 200


### PR DESCRIPTION
Closes RSS-182

# Overview

There's [a bug](https://github.com/tiangolo/fastapi/issues/3608) in the version of fastapi we are using that prevents fastapi from creating a response that uses dataclasses with non-json encodable attributes (like `dataclass`, `datetime` and `path`). This causes errors when generating the openapi docs for our `/instruments` endpoint on the robot-server. Since we cannot yet update our fastapi version to get the upstream fix, this PR eliminates the issue by not using nested dataclasses or `datetime` in the server's models.

The bug affects usage of `datetime` inside of vanilla dataclasses as well which we use inside of `CalibrationStatus`. We could try to fix this in our code but this field is slated for removal anyway(correct me if I'm wrong @Laura-Danielle) so I just removed the status field from the new `GripperCalibrationData` pydantic model. 

# Test Plan

- start a dev server and test that `/docs` populates the server's openapi docs
- push on an OT3 and test that `/instruments` endpoint still works as expected
- PR #12116 adds a tavern test that should pass once this fix is merged. Maybe we should merge it into this PR..

# Changelog

- added a new `GripperCalibrationData` model to `instruments_models` which doesn't use the status field

# Review requests

- usual code review

# Risk assessment

Low
