### PR TITLE
fix(app, odd): early exits no longer flash wrong screens

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -135,8 +135,8 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               ? LEFT
               : (mount as PipetteMount)
           }
+          setSelectedPipette={setSelectedPipette}
           closeFlow={() => setPipetteWizardFlow(null)}
-          robotName={robotName}
           selectedPipette={
             pipetteName === 'p1000_96' ? NINETY_SIX_CHANNEL : selectedPipette
           }

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -19,6 +19,9 @@ export const CheckPipetteButton = (
       onSuccess: () => {
         proceed()
       },
+      onSettled: () => {
+        setPending(false)
+      },
     }
   )
 

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -16,9 +16,6 @@ export const CheckPipetteButton = (
     { refresh: true },
     {
       enabled: false,
-      onSuccess: () => {
-        proceed()
-      },
       onSettled: () => {
         setPending(false)
       },
@@ -34,7 +31,9 @@ export const CheckPipetteButton = (
       disabled={isDisabled}
       onClick={() => {
         refetch()
-          .then(() => {})
+          .then(() => {
+            proceed()
+          })
           .catch(() => {})
       }}
     >

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -25,7 +25,6 @@ describe('AttachProbe', () => {
   let props: React.ComponentProps<typeof AttachProbe>
   beforeEach(() => {
     props = {
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -50,7 +50,6 @@ describe('BeforeBeginning', () => {
   beforeEach(() => {
     props = {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import {
   LEFT,
@@ -15,7 +16,6 @@ import { FLOWS } from '../constants'
 import { Carriage } from '../Carriage'
 
 import type { AttachedPipette } from '../../../redux/pipettes/types'
-import { fireEvent, waitFor } from '@testing-library/react'
 
 const render = (props: React.ComponentProps<typeof Carriage>) => {
   return renderWithProviders(<Carriage {...props} />, {
@@ -30,7 +30,6 @@ describe('Carriage', () => {
   let props: React.ComponentProps<typeof Carriage>
   beforeEach(() => {
     props = {
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -40,7 +40,6 @@ describe('DetachPipette', () => {
   let props: React.ComponentProps<typeof DetachPipette>
   beforeEach(() => {
     props = {
-      robotName: 'otie',
       selectedPipette: SINGLE_MOUNT_PIPETTES,
       mount: LEFT,
       goBack: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachProbe.test.tsx
@@ -32,7 +32,6 @@ describe('DetachProbe', () => {
   beforeEach(() => {
     props = {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountPipette.test.tsx
@@ -36,7 +36,6 @@ describe('MountPipette', () => {
   beforeEach(() => {
     props = {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -31,7 +31,6 @@ describe('MountingPlate', () => {
   let props: React.ComponentProps<typeof MountingPlate>
   beforeEach(() => {
     props = {
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -11,7 +11,6 @@ import {
   useCreateRunMutation,
   useStopRunMutation,
   usePipettesQuery,
-  // useDeleteRunMutation,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
 import { useChainRunCommands } from '../../../resources/runs/hooks'
@@ -58,9 +57,6 @@ const mockUseCreateRunMutation = useCreateRunMutation as jest.MockedFunction<
 const mockUseStopRunMutation = useStopRunMutation as jest.MockedFunction<
   typeof useStopRunMutation
 >
-// const mockUseDeleteRunMutation = useDeleteRunMutation as jest.MockedFunction<
-//   typeof useDeleteRunMutation
-// >
 const mockUseCloseCurrentRun = useCloseCurrentRun as jest.MockedFunction<
   typeof useCloseCurrentRun
 >
@@ -86,7 +82,6 @@ const mockPipette: AttachedPipette = {
 describe('PipetteWizardFlows', () => {
   let props: React.ComponentProps<typeof PipetteWizardFlows>
   let mockCreateRun: jest.Mock
-  // let mockDeleteRun = jest.fn()
   let mockStopRun: jest.Mock
   let mockCloseCurrentRun: jest.Mock
   let refetchPromise: Promise<void>
@@ -97,11 +92,10 @@ describe('PipetteWizardFlows', () => {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
       flowType: FLOWS.CALIBRATE,
       mount: LEFT,
-      robotName: 'otie',
       closeFlow: jest.fn(),
+      setSelectedPipette: jest.fn(),
     }
     mockCreateRun = jest.fn()
-    // mockDeleteRun = jest.fn()
     mockStopRun = jest.fn()
     mockCloseCurrentRun = jest.fn()
     refetchPromise = Promise.resolve()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -40,7 +40,6 @@ describe('Results', () => {
   beforeEach(() => {
     props = {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
-      robotName: 'otie',
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -18,6 +18,7 @@ import {
   useCreateRunMutation,
   useStopRunMutation,
 } from '@opentrons/react-api-client'
+
 import { ModalShell } from '../../molecules/Modal'
 import { Portal } from '../../App/portal'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
@@ -37,21 +38,28 @@ import { DetachPipette } from './DetachPipette'
 import { Carriage } from './Carriage'
 import { MountingPlate } from './MountingPlate'
 import { UnskippableModal } from './UnskippableModal'
+
 import type { PipetteMount } from '@opentrons/shared-data'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
 
 interface PipetteWizardFlowsProps {
   flowType: PipetteWizardFlow
   mount: PipetteMount
-  robotName: string
   selectedPipette: SelectablePipettes
   closeFlow: () => void
+  setSelectedPipette: React.Dispatch<React.SetStateAction<SelectablePipettes>>
 }
 
 export const PipetteWizardFlows = (
   props: PipetteWizardFlowsProps
 ): JSX.Element | null => {
-  const { flowType, mount, closeFlow, robotName, selectedPipette } = props
+  const {
+    flowType,
+    mount,
+    closeFlow,
+    selectedPipette,
+    setSelectedPipette,
+  } = props
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('pipette_wizard_flows')
   const attachedPipettes = useAttachedPipettes()
@@ -115,6 +123,7 @@ export const PipetteWizardFlows = (
     }
   }
   const handleCleanUpAndClose = (): void => {
+    setSelectedPipette(SINGLE_MOUNT_PIPETTES)
     setIsExiting(true)
     chainRunCommands(
       [
@@ -154,12 +163,15 @@ export const PipetteWizardFlows = (
     attachedPipettes,
     setShowErrorMessage,
     errorMessage,
-    robotName,
     selectedPipette,
     isOnDevice,
   }
   const exitModal = (
-    <ExitModal goBack={cancelExit} proceed={confirmExit} flowType={flowType} />
+    <ExitModal
+      goBack={cancelExit}
+      proceed={handleCleanUpAndClose}
+      flowType={flowType}
+    />
   )
   const [
     showUnskippableStepModal,

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -136,6 +136,7 @@ export const PipetteWizardFlows = (
     ).then(() => {
       if (runId !== '') stopRun(runId)
       setIsExiting(false)
+      closeFlow()
     })
   }
   const {

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -83,7 +83,6 @@ export interface PipetteWizardStepProps {
   attachedPipettes: AttachedPipettesByMount
   setShowErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
   errorMessage: string | null
-  robotName: string
   selectedPipette: SelectablePipettes
   isOnDevice: boolean | null
 }

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -31,6 +31,7 @@ import { FLOWS } from '../../PipetteWizardFlows/constants'
 
 import type { PipetteName } from '@opentrons/shared-data'
 import type { DeleteCalRequestParams } from '@opentrons/api-client'
+import type { SelectablePipettes } from '../../PipetteWizardFlows/types'
 
 interface OverflowMenuProps {
   calType: 'pipetteOffset' | 'tipLength'
@@ -125,6 +126,10 @@ export function OverflowMenu({
   }, [isRunning, updateRobotStatus])
 
   const { deleteCalibration } = useDeleteCalibrationMutation()
+  const [
+    selectedPipette,
+    setSelectedPipette,
+  ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
 
   const handleDeleteCalibration = (e: React.MouseEvent): void => {
     e.preventDefault()
@@ -162,9 +167,8 @@ export function OverflowMenu({
           flowType={FLOWS.CALIBRATE}
           mount={mount}
           closeFlow={() => setShowPipetteWizardFlows(false)}
-          robotName={robotName}
-          //  TODO(jr/12/1/22): only single mount pipettes can be calibrated here for now
-          selectedPipette={SINGLE_MOUNT_PIPETTES}
+          selectedPipette={selectedPipette}
+          setSelectedPipette={setSelectedPipette}
         />
       ) : null}
       {showOverflowMenu ? (

--- a/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/AttachInstrumentsDashboard.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import {
   LEFT,
   NINETY_SIX_CHANNEL,
@@ -12,7 +11,6 @@ import { FLOWS } from '../../organisms/PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../../organisms/PipetteWizardFlows'
 import { ChoosePipette } from '../../organisms/PipetteWizardFlows/ChoosePipette'
 import { getIs96ChannelPipetteAttached } from '../../organisms/Devices/utils'
-import { getLocalRobot } from '../../redux/discovery'
 
 import type {
   PipetteWizardFlow,
@@ -25,8 +23,6 @@ export const AttachInstrumentsDashboard = (): JSX.Element => {
     pipetteWizardFlow,
     setPipetteWizardFlow,
   ] = React.useState<PipetteWizardFlow | null>(null)
-  const localRobot = useSelector(getLocalRobot)
-  const robotName = localRobot?.name != null ? localRobot.name : 'no name'
   const [mount, setMount] = React.useState<Mount>(LEFT)
   const [
     selectedPipette,
@@ -87,7 +83,7 @@ export const AttachInstrumentsDashboard = (): JSX.Element => {
           selectedPipette={
             isNinetySixChannelAttached ? NINETY_SIX_CHANNEL : selectedPipette
           }
-          robotName={robotName}
+          setSelectedPipette={setSelectedPipette}
         />
       ) : null}
       {showAttachPipette || pipetteWizardFlow != null ? null : (

--- a/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/AttachInstrumentsDashboard.test.tsx
@@ -8,14 +8,11 @@ import {
   mockAttachedGen3Pipette,
   mockGen3P1000PipetteSpecs,
 } from '../../../redux/pipettes/__fixtures__'
-import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
 import { PipetteWizardFlows } from '../../../organisms/PipetteWizardFlows'
-import { getLocalRobot } from '../../../redux/discovery'
 import { AttachInstrumentsDashboard } from '../AttachInstrumentsDashboard'
 import type { AttachedPipette } from '../../../redux/pipettes/types'
 
 jest.mock('../../../organisms/Devices/hooks')
-jest.mock('../../../redux/discovery')
 jest.mock('../../../organisms/PipetteWizardFlows')
 jest.mock('../../../organisms/Devices/utils')
 jest.mock('../../../organisms/PipetteWizardFlows/ChoosePipette')
@@ -23,9 +20,6 @@ jest.mock('../../../organisms/OnDeviceDisplay/Navigation')
 
 const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
   typeof useAttachedPipettes
->
-const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
-  typeof getLocalRobot
 >
 const mockPipetteWizardFlows = PipetteWizardFlows as jest.MockedFunction<
   typeof PipetteWizardFlows
@@ -54,7 +48,6 @@ describe('AttachInstrumentsDashboard', () => {
   beforeEach(() => {
     mockChoosePipette.mockReturnValue(<div>mock choose pipette</div>)
     mockGetIs96ChannelPipetteAttached.mockReturnValue(false)
-    mockGetLocalRobot.mockReturnValue(mockConnectedRobot)
     mockUseAttachedPipettes.mockReturnValue({ left: null, right: null })
     mockPipetteWizardFlows.mockReturnValue(<div>mock pipette wizard flows</div>)
   })


### PR DESCRIPTION
closes RLIQ-332, RLIQ-333, RLIQ-334

# Overview

This addresses a handful of bugs related to the pipette flows. Including a small refactor in `PipetteWizardFlows` to remove the `robotName` prop.

# Test Plan

- On an Ot-3, go through a pipette flow. In order to cover the 3 bugs:
1. Launch attach flow and click on `96-channel`. Exit out of the flow on the next page. Launch the flow on the other mount, it should be the correct flow and not think that you are trying to attach a 96-channel
2. Launch any flow, early exit from the flow after the `BeforeBeginning` page. Clicking on the wizard header exit or the button exit from the exit modal should not flash another modal and should exit properly. (I believe this covers the 2 other bugs)

# Changelog

- remove `robotName` prop from `PipetteWizardFlows`, fix all parent components (`PipetteCard`, `OverflowMenu`, `AttachInstrumentsDashboard`)
- add `setSelectedPipette` prop to `PipetteWizardFlows`, fix all parent components
- add bug fixes throughout `PipetteWizardFlows`
- fix all affected tests 

# Review requests

- review that all the bugs are actually fixed

# Risk assessment

low