### PR TITLE
fix(hardware_control): 96 channel Y critical point was too far forward for XY critical point

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -272,7 +272,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             NUM_ROWS = 12
             NUM_COLS = 8
             X_DIRECTION_VALUE = -1
-            Y_DIVISION = 3
         elif self.channels.value == 8:
             NUM_ROWS = 1
             NUM_COLS = 8
@@ -293,7 +292,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             raise InvalidMoveError(
                 f"Critical point {cp_override.name} is not valid for a pipette"
             )
-
         if not self.has_tip or cp_override == CriticalPoint.NOZZLE:
             cp_type = CriticalPoint.NOZZLE
             tip_length = 0.0

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -290,7 +290,7 @@ def test_flow_rate_setting(
         [
             lazy_fixture("hardware_pipette_ot3"),
             ot3_pipette_config.convert_pipette_model("p1000_96", "3.3"),
-            Point(13.5, -46.5, -259.15),
+            Point(13.5, -57.0, -259.15),
             Point(-36.0, -88.5, -259.15),
         ],
     ],


### PR DESCRIPTION
# Overview

Pretty straightforward. The XY critical point was off by ~10 mm in the Y for the 96 channel. Note, eventually we will support lookup for every single channel.

# Test Plan

- [x] Test with a 96 channel

# Risk assessment

Low. In development product.
