### PR TITLE
fix(update-server): Check the update size before writing to the unused partition.

### DIFF
--- a/update-server/tests/openembedded/test_updater.py
+++ b/update-server/tests/openembedded/test_updater.py
@@ -27,6 +27,7 @@ def test_update_valid_part_switch(
         root_FS_intf=mock_root_fs_interface,
         part_mngr=mock_partition_manager_valid_switch,
     )
+    mock_root_fs_interface.write_update = mock.Mock(return_value=(True, ""))
     # lambda just mocks progress callback,
     # 2 here has no significance whatsoever.
     updater.decomp_and_write("/mmc/blk0p1", lambda x: x(2))
@@ -53,6 +54,7 @@ def test_update_invalid_part_switch(
         part_mngr=mock_partition_manager_invalid_switch,
     )
 
+    mock_root_fs_interface.write_update = mock.Mock(return_value=(True, ""))
     updater.decomp_and_write("/mmc/blk0p1", lambda x: x(2))
     mock_partition_manager_invalid_switch.find_unused_partition.assert_called()
     mock_root_fs_interface.write_update.assert_called()
@@ -85,6 +87,7 @@ def test_decomp_and_write(
         part_mngr=mock_partition_manager_valid_switch,
     )
 
+    mock_root_fs_interface.write_update = mock.Mock(return_value=(True, ""))
     updater.decomp_and_write("test_path", lambda x: x(2))
     mock_partition_manager_valid_switch.find_unused_partition.assert_called()
     mock_root_fs_interface.write_update.assert_called()
@@ -127,9 +130,15 @@ def test_lzma(testing_partition, tmpdir):
             total_size += len(chunk)
             if len(chunk) != chunk_size:
                 break
-    root_FS_intf.write_update(rfs_path, p, cb, chunk_size)
-    if total_size % chunk_size != 0:
-        calls = int(total_size / chunk_size) + 1
-    else:
-        calls = total_size / chunk_size
-    assert cb.call_count == calls
+    with mock.patch(
+        "otupdate.openembedded.update_actions.PartitionManager.get_partition_size",
+        mock.Mock(return_value=99999999),
+    ):
+        success, msg = root_FS_intf.write_update(rfs_path, p, cb, chunk_size)
+        if total_size % chunk_size != 0:
+            calls = int(total_size / chunk_size) + 1
+        else:
+            calls = total_size / chunk_size
+        assert cb.call_count == calls
+        assert success
+        assert msg == ""


### PR DESCRIPTION
# Overview

The builds produced by oe-core were not taking into account the rootfs maximum size before generating an image (PR fix for this issue [here](https://github.com/Opentrons/oe-core/pull/59)), and the update-server did not take into account the unused partition size before writing an update. So we had no protection against installing an update that was too big for the original partition size, which meant the OT3 would be bricked if such an update was installed. This pr addresses the issue on the update-server so it checks the available space the unused partition has before writing the update, if the update is too large the update is canceled, but the device is not bricked.

# Test Plan

- [ ] Make sure the update fails when writing an update file that is too large for the unused partition.
- [ ] Make sure the update passes for update files smaller than the unused partition. 

# Changelog

- Add get_partition_size to PartitionManager to check the size of a partition
- Changed the return value of RootFSInterface.write_update to Tuple[bool, str] so we can check if the update failed or not.
- Check the size of the unused partition before writing the update to it and return False if so
- Raise `RuntimeError` if RootFSInterface.write_update fails for some reason.

# Review requests

- Thoughts? Concerns?