### PR TITLE
refactor(api): remove InstrumentContext.speed on PAPI v2.14

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -263,7 +263,7 @@ If you specify an API version of 2.13 or lower, your protocols will continue to 
 
   - ``InstrumentContext.speed`` property was removed.
     This property tried to allow setting a pipette's **plunger** speed in mm/s.
-    However, it could only appoximately set the plunger speed,
+    However, it could only approximately set the plunger speed,
     because the plunger's speed is a stepwise function of the volume.
     Use :py:attr:`.InstrumentContext.flow_rate` to set the flow rate in µL/s, instead.
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -3,7 +3,7 @@
 Versioning
 ==========
 
-The Python Protocol API has its own versioning system, which is separate from the versioning system used for the robot software and the Opentrons App. This allows you to specify the API version that your protocol requires without worrying about what robot software versions it will work with. 
+The Python Protocol API has its own versioning system, which is separate from the versioning system used for the robot software and the Opentrons App. This allows you to specify the API version that your protocol requires without worrying about what robot software versions it will work with.
 
 Major and Minor Versions
 ------------------------
@@ -12,7 +12,7 @@ The API uses a major and minor version number and does not use patch version num
 
 The major version of the API increases whenever there are significant structural or behavioral changes to protocols. For instance, major version 2 of the API was introduced because it required protocols to have a ``run`` function that takes a ``protocol`` argument rather than importing the ``robot``, ``instruments``, and ``labware`` modules. Protocols written with major version 1 of the API will not run without modification in major version 2. A similar level of structural change would require a major version 3. This documentation only deals with features found in major version 2 of the API; see the `archived version 1 documentation <https://docs.opentrons.com/v1/index.html>`_ for information on older protocols.
 
-The minor version of the API increases whenever there is new functionality that might change the way a protocol is written, or when a behavior changes in one aspect of the API but does not affect all protocols. For instance, adding support for a new hardware module, adding new parameters for a function, or deprecating a feature would increase the minor version of the API. 
+The minor version of the API increases whenever there is new functionality that might change the way a protocol is written, or when a behavior changes in one aspect of the API but does not affect all protocols. For instance, adding support for a new hardware module, adding new parameters for a function, or deprecating a feature would increase the minor version of the API.
 
 Specifying Versions
 -------------------
@@ -175,7 +175,7 @@ Version 2.6
 Version 2.7
 +++++++++++
 
-- Added :py:meth:`.InstrumentContext.pair_with`, an experimental feature for moving both pipettes simultaneously. 
+- Added :py:meth:`.InstrumentContext.pair_with`, an experimental feature for moving both pipettes simultaneously.
 
   .. note::
 
@@ -249,43 +249,57 @@ If you specify an API version of 2.13 or lower, your protocols will continue to 
 
   - :py:class:`.Labware` and :py:class:`.Well` now adhere to the protocol's API level setting.
     Prior to this version, they incorrectly ignored the setting.
- 
+
   - :py:meth:`.InstrumentContext.touch_tip` will end with the pipette tip in the center of the well
     instead of on the edge closest to the front of the machine.
 
   - :py:meth:`.ProtocolContext.load_labware` now prefers loading user-provided labware definitions
     rather than built-in definitions if no explicit ``namespace`` is specified.
 
-- Deprecations and removals
+- Removals
 
   - The ``presses`` and ``increment`` arguments of  :py:meth:`.InstrumentContext.pick_up_tip` were deprecated.
     Configure your pipette pick-up settings with the Opentrons App, instead.
 
-  - ``ModuleContext.load_labware_object`` was deprecated as an unnecessary internal method.
+  - ``InstrumentContext.speed`` property was removed.
+    This property tried to allow setting a pipette's **plunger** speed in mm/s.
+    However, it could only appoximately set the plunger speed,
+    because the plunger's speed is a stepwise function of the volume.
+    Use :py:attr:`.InstrumentContext.flow_rate` to set the flow rate in µL/s, instead.
 
-  - ``ModuleContext.geometry`` was deprecated in favor of
+  - ``ModuleContext.load_labware_object`` was removed as an unnecessary internal method.
+
+  - ``ModuleContext.geometry`` was removed in favor of
     :py:attr:`.ModuleContext.model` and :py:attr:`.ModuleContext.type`
 
-  - ``Well.geometry`` was deprecated as unnecessary.
+  - ``Well.geometry`` was removed as unnecessary.
 
-  - ``MagneticModuleContext.calibrate`` was deprecated since it was never needed nor implemented.
+  - ``MagneticModuleContext.calibrate`` was removed since it was never needed nor implemented.
 
-  - The ``height`` parameter of :py:meth:`.MagneticModuleContext.engage` was deprecated.
+  - The ``height`` parameter of :py:meth:`.MagneticModuleContext.engage` was removed.
     Use ``offset`` or ``height_from_base`` instead.
 
   - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration`` were removed,
     since they were holdovers from a calibration system that no longer exists.
- 
-  - Various methods and setters were deprecated that could modify tip state outside of
+
+  - Various methods and setters were removed that could modify tip state outside of
     calls to :py:meth:`.InstrumentContext.pick_up_tip` and :py:meth:`.InstrumentContext.drop_tip`.
     This change allows the robot to track tip usage more completely and reliably.
     You may still use :py:meth:`.Labware.reset` to reset your tip rack's state.
 
-      - The :py:attr:`.Well.has_tip` **setter** was deprecated. **The getter is not deprecated.**
+      - The :py:attr:`.Well.has_tip` **setter** was removed. **The getter is still supported.**
 
       - Internal methods ``Labware.use_tips``, ``Labware.previous_tip``, and ``Labware.return_tips``
-        were deprecated.
+        were removed.
 
-  - The ``configuration`` argument of :py:meth:`.ProtocolContext.load_module` was deprecated
+  - The ``configuration`` argument of :py:meth:`.ProtocolContext.load_module` was removed
     because it made unsafe modifications to the protocol's geometry system,
     and the Thermocycler's "semi" configuration is not officially supported.
+
+- Known limitations
+
+  - :py:meth:`.Labware.set_offset` is not yet supported on this API version.
+    Run protocols via the Opentrons App, instead.
+
+  - :py:attr:`.ProtocolContext.max_speeds` is not yet supported on the API version.
+    Use :py:attr:`.InstrumentContext.default_speed` or the per-method `speed` argument, instead.

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -6,11 +6,7 @@ from typing import Optional, TYPE_CHECKING
 from opentrons.types import Location, Mount
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocols.api_support.util import (
-    PlungerSpeeds,
-    FlowRates,
-    find_value_for_api_version,
-)
+from opentrons.protocols.api_support.util import FlowRates, find_value_for_api_version
 from opentrons.protocol_engine import (
     DeckPoint,
     DropTipWellLocation,
@@ -472,9 +468,6 @@ class InstrumentCore(AbstractInstrument[WellCore]):
     def get_return_height(self) -> float:
         return self._engine_client.state.pipettes.get_return_tip_scale(self._pipette_id)
 
-    def get_speed(self) -> PlungerSpeeds:
-        raise NotImplementedError("InstrumentCore.get_speed not implemented")
-
     def get_flow_rate(self) -> FlowRates:
         return self._flow_rates
 
@@ -502,11 +495,3 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         if blow_out is not None:
             assert blow_out > 0
             self._blow_out_flow_rate = blow_out
-
-    def set_pipette_speed(
-        self,
-        aspirate: Optional[float] = None,
-        dispense: Optional[float] = None,
-        blow_out: Optional[float] = None,
-    ) -> None:
-        raise NotImplementedError("InstrumentCore.set_pipette_speed not implemented")

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -88,8 +88,7 @@ class LabwareCore(AbstractLabware[WellCore]):
 
     def set_calibration(self, delta: Point) -> None:
         raise NotImplementedError(
-            "Setting a labware's calibration after it's been loaded"
-            " is not supported by Protocol Engine."
+            "Setting a labware's calibration after it's been loaded is not supported."
         )
 
     def get_calibrated_offset(self) -> Point:

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -10,10 +10,8 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import DeckSlotName, Location, Mount, MountType, Point
 from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.modules import AbstractModule
-from opentrons.hardware_control.modules.types import (
-    ModuleModel,
-    ModuleType,
-)
+from opentrons.hardware_control.modules.types import ModuleModel, ModuleType
+from opentrons.hardware_control.types import DoorState
 from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.protocols.api_support.types import APIVersion
 
@@ -45,16 +43,13 @@ from .exceptions import InvalidModuleLocationError
 from . import load_labware_params
 
 
-# TODO(mc, 2022-08-24): many of these methods are likely unnecessary
-# in a ProtocolEngine world. As we develop this core, we should remove
-# and consolidate logic as we need to across all cores rather than
-# necessarily try to support every one of these behaviors in the engine.
 class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
     """Protocol API core using a ProtocolEngine.
 
     Args:
-        engine_client: A synchronous client to the ProtocolEngine
-            that is executing the protocol.
+        engine_client: A client to the ProtocolEngine that is executing the protocol.
+        api_version: The Python Protocol API versionat which  this core is operating.
+        sync_hardware: A SynchronousAdapter-wrapped Hardware Control API.
     """
 
     def __init__(
@@ -307,7 +302,7 @@ class ProtocolCore(AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]):
 
     def door_closed(self) -> bool:
         """Get whether the device's front door is closed."""
-        raise NotImplementedError("ProtocolCore.door_closed not implemented")
+        return self._sync_hardware.door_state == DoorState.CLOSED  # type: ignore[no-any-return]
 
     def get_last_location(
         self,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -7,7 +7,7 @@ from typing import Any, Generic, Optional, TypeVar
 
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocols.api_support.util import PlungerSpeeds, FlowRates
+from opentrons.protocols.api_support.util import FlowRates
 
 from .well import WellCoreType
 
@@ -196,10 +196,6 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
-    def get_speed(self) -> PlungerSpeeds:
-        ...
-
-    @abstractmethod
     def get_flow_rate(self) -> FlowRates:
         ...
 
@@ -216,15 +212,6 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     def set_flow_rate(
-        self,
-        aspirate: Optional[float] = None,
-        dispense: Optional[float] = None,
-        blow_out: Optional[float] = None,
-    ) -> None:
-        ...
-
-    @abstractmethod
-    def set_pipette_speed(
         self,
         aspirate: Optional[float] = None,
         dispense: Optional[float] = None,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -202,7 +202,19 @@ class ProtocolContext(CommandPublisher):
                                                # 10 mm/s
                 protocol.max_speeds['X'] = None  # reset to default
 
+        .. caution::
+            This property is not yet supported on
+            :ref:`API version <v2-versioning>` 2.14 or higher.
         """
+        if self._api_version >= ENGINE_CORE_API_VERSION:
+            # TODO(mc, 2023-02-23): per-axis max speeds not yet supported on the engine
+            # See https://opentrons.atlassian.net/browse/RCORE-373
+            raise APIVersionError(
+                "ProtocolContext.max_speeds is not supported at apiLevel 2.14 or higher."
+                " Use a lower apiLevel or set speeds using InstrumentContext.default_speed"
+                " or the per-method 'speed' argument."
+            )
+
         return self._core.get_max_speeds()
 
     @requires_version(2, 0)

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -23,9 +23,15 @@ from opentrons.hardware_control.types import Axis
 
 
 if TYPE_CHECKING:
-    from opentrons.protocol_api.core.instrument import AbstractInstrument
     from opentrons.protocol_api.labware import Well, Labware
+    from opentrons.protocol_api.core.engine.instrument import InstrumentCore
     from opentrons.protocol_api.core.legacy.deck import Deck
+    from opentrons.protocol_api.core.legacy.legacy_instrument_core import (
+        LegacyInstrumentCore,
+    )
+    from opentrons.protocol_api.core.legacy_simulator.legacy_instrument_core import (
+        LegacyInstrumentCoreSimulator,
+    )
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -138,7 +144,12 @@ def labware_column_shift(
 class FlowRates:
     """Utility class for rich setters/getters for flow rates"""
 
-    def __init__(self, instr: AbstractInstrument) -> None:
+    def __init__(
+        self,
+        instr: Union[
+            InstrumentCore, LegacyInstrumentCore, LegacyInstrumentCoreSimulator
+        ],
+    ) -> None:
         self._instr = instr
 
     def set_defaults(
@@ -214,7 +225,9 @@ def find_value_for_api_version(
 class PlungerSpeeds:
     """Utility class for rich setters/getters for speeds"""
 
-    def __init__(self, instr: AbstractInstrument) -> None:
+    def __init__(
+        self, instr: Union[LegacyInstrumentCore, LegacyInstrumentCoreSimulator]
+    ) -> None:
         self._instr = instr
 
     @property


### PR DESCRIPTION
This PR adds a version guard + error to the `InstrumentContext.speed` property setter used to set the pipette's **plunger speed**. We made this change, after some discussion, for the following reasons:

- **Name confusion**: `InstrumentContext.speed` sets plunger speed, while `InstrumentContext.default_speed` sets movement speed.
- **Inexact behavior**: Pipettes have a step-wise speed function that is determined by the current volume in the tip, and the HW API keeps track of flow rate in µL/s. Setting a "plunger speed" in mm/s via the Hardware API involves backing a flow rate out of the step-wise function using an arbitrarily selected volume, meaning the plunger speed that is actually used approximates the desired plunger speed without matching it exactly.
- **Implementation effort**: Setting the plunger speed in mm/s has some value for hardware validation testing, but seems to lack value for actual scientific protocols. Given the extra effort it would take to implement this concept on the ProtocolEngine system, and given the relative lack of user-value in a world where the `flow_rate` setter exists, we would rather not sink time into getting this corner of the Protocol API working in the 2.14 release. 

Closes RCORE-621

## Test Plan

No special testing required

## Changelog

- remove InstrumentContext.speed on PAPI v2.14
- update versioning docs
- knock out the last few remaining `NotImplementedError`s in the engine core while I was here

## Risk assessment

Low
