### PR TITLE
fix(robot-server): properly select default cursor for /commands endpoint

### DIFF
--- a/api/src/opentrons/ordered_set.py
+++ b/api/src/opentrons/ordered_set.py
@@ -1,11 +1,17 @@
 """A set that preserves the order in which elements are added."""
 
 
-from typing import Dict, Generic, Hashable, Iterable, Iterator, TypeVar
+from typing import Dict, Generic, Hashable, Iterable, Iterator, TypeVar, Union, overload
 from typing_extensions import Literal
 
 
 _SetElementT = TypeVar("_SetElementT", bound=Hashable)
+
+_DefaultValueT = TypeVar("_DefaultValueT")
+
+
+class _NOT_SPECIFIED:
+    """Value not specified sentinel."""
 
 
 # Implemented as a standalone class for clarity.
@@ -20,6 +26,7 @@ class OrderedSet(Generic[_SetElementT]):
 
     def __init__(self, source_iterable: Iterable[_SetElementT] = tuple()) -> None:
         self._elements: Dict[_SetElementT, Literal[True]] = {}
+
         for element in source_iterable:
             self.add(element)
 
@@ -49,6 +56,38 @@ class OrderedSet(Generic[_SetElementT]):
     def clear(self) -> None:
         """Remove all elements from the set."""
         self._elements.clear()
+
+    @overload
+    def head(self) -> _SetElementT:
+        ...
+
+    @overload
+    def head(
+        self, default_value: _DefaultValueT
+    ) -> Union[_SetElementT, _DefaultValueT]:
+        ...
+
+    def head(
+        self, default_value: Union[_DefaultValueT, _NOT_SPECIFIED] = _NOT_SPECIFIED()
+    ) -> Union[_SetElementT, _DefaultValueT]:
+        """Get the head of the set.
+
+        Args:
+            default_value: A value to return if set is empty.
+
+        Returns:
+            The head of the set, or the default value, if specified.
+
+        Raises:
+            IndexError: set is empty and default was not specified.
+        """
+        try:
+            return next(iter(self))
+        except StopIteration as e:
+            if isinstance(default_value, _NOT_SPECIFIED):
+                raise IndexError("Set is empty") from e
+
+        return default_value
 
     def __iter__(self) -> Iterator[_SetElementT]:
         """Enable iteration over all elements in the set.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -402,10 +402,17 @@ class CommandView(HasState[CommandState]):
         # to something that isn't just an OrderedDict
         all_command_ids = self._state.all_command_ids
         commands_by_id = self._state.commands_by_id
+        running_command_id = self._state.running_command_id
+        queued_command_ids = self._state.queued_command_ids
         total_length = len(all_command_ids)
 
         if cursor is None:
-            cursor = total_length - length
+            if running_command_id is not None:
+                cursor = commands_by_id[running_command_id].index
+            elif len(queued_command_ids) > 0:
+                cursor = commands_by_id[queued_command_ids.head()].index - 1
+            else:
+                cursor = total_length - length
 
         # start is inclusive, stop is exclusive
         actual_cursor = max(0, min(cursor, total_length - 1))
@@ -466,13 +473,13 @@ class CommandView(HasState[CommandState]):
             raise RunStoppedError("Engine was stopped")
 
         # if there is a setup command queued, prioritize it
-        next_setup_cmd = next(iter(self._state.queued_setup_command_ids), None)
+        next_setup_cmd = self._state.queued_setup_command_ids.head(None)
         if self._state.queue_status != QueueStatus.PAUSED and next_setup_cmd:
             return next_setup_cmd
 
         # if the queue is running, return the next protocol command
         if self._state.queue_status == QueueStatus.RUNNING:
-            return next(iter(self._state.queued_command_ids), None)
+            return self._state.queued_command_ids.head(None)
 
         # otherwise we've got nothing to do
         return None

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -395,7 +395,8 @@ class CommandView(HasState[CommandState]):
     ) -> CommandSlice:
         """Get a subset of commands around a given cursor.
 
-        If the cursor is omitted, return the tail of `length` of the collection.
+        If the cursor is omitted, a cursor will be selected automatically
+        based on the currently running or most recently executed command."
         """
         # TODO(mc, 2022-01-31): this is not the most performant way to implement
         # this; if this becomes a problem, change or the underlying data structure

--- a/api/tests/opentrons/test_ordered_set.py
+++ b/api/tests/opentrons/test_ordered_set.py
@@ -71,6 +71,7 @@ def test_initialization_by_iterable() -> None:
     subject_2 = OrderedSet[int]()
     for element in source_iterable:
         subject_2.add(element)
+
     assert subject_1 == subject_2
 
 
@@ -120,3 +121,19 @@ def test_clear() -> None:
     subject = OrderedSet([1, 2, 3, 4, 5])
     subject.clear()
     assert list(subject) == []
+
+
+def test_head() -> None:
+    """It should return the head of the set."""
+    subject = OrderedSet([1, 2])
+
+    assert subject.head() == 1
+    subject.remove(1)
+
+    assert subject.head() == 2
+    subject.remove(2)
+
+    with pytest.raises(IndexError):
+        subject.head()
+
+    assert subject.head(default_value=42) == 42

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -236,7 +236,7 @@ async def get_run_commands(
         description=(
             "The starting index of the desired first command in the list."
             " If unspecified, a cursor will be selected automatically"
-            " based on the next queued or most recently executed command."
+            " based on the currently running or most recently executed command."
         ),
     ),
     pageLength: int = Query(

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -236,7 +236,7 @@ async def get_run_commands(
         description=(
             "The starting index of the desired first command in the list."
             " If unspecified, a cursor will be selected automatically"
-            " based on the next queued or more recently executed command."
+            " based on the next queued or most recently executed command."
         ),
     ),
     pageLength: int = Query(


### PR DESCRIPTION
## Overview

The robot-server's `GET .../commands` endpoint was not adhering to its own cursor selector specification:

> The starting index of the desired first command in the list.
> If unspecified, a cursor will be selected automatically
> based on the currently running or most recently executed command.

This PR fixes the behavior so it adheres to the quoted specification.

Closes RLAB-301

## Test Plan

1. Start a run with a JSONv6 protocol
2. `GET /runs/:run_id/commands`
3. Response should be the head of the protocol commands, rather than the tail

## Risk assessment

Low