### PR TITLE
fix(app): add disabled reasons and removal of some redux machinery

### DIFF
--- a/api-client/src/pipettes/getPipettes.ts
+++ b/api-client/src/pipettes/getPipettes.ts
@@ -2,8 +2,11 @@ import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
-import type { Pipettes } from './types'
+import type { Pipettes, GetPipettesParams } from './types'
 
-export function getPipettes(config: HostConfig): ResponsePromise<Pipettes> {
-  return request<Pipettes>(GET, `/pipettes`, null, config)
+export function getPipettes(
+  config: HostConfig,
+  params: GetPipettesParams
+): ResponsePromise<Pipettes> {
+  return request<Pipettes>(GET, `/pipettes`, null, config, params)
 }

--- a/api-client/src/pipettes/types.ts
+++ b/api-client/src/pipettes/types.ts
@@ -24,6 +24,9 @@ export type AttachedPipettesByMount = {
 
 export type Pipettes = FetchPipettesResponseBody
 
+export interface GetPipettesParams {
+  refresh?: boolean
+}
 // API response types
 
 export type FetchPipettesResponsePipette =

--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -48,5 +48,6 @@
   "detach_try_again": "Detach and try again",
   "detach_pipette_from_mount": "Detach Pipette from {{mount}} Mount",
   "pipette_setup": "Pipette Setup",
-  "mount": "{{mount}} mount"
+  "mount": "{{mount}} mount",
+  "robot_is_in_motion": "Robot is in motion"
 }

--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -48,6 +48,5 @@
   "detach_try_again": "Detach and try again",
   "detach_pipette_from_mount": "Detach Pipette from {{mount}} Mount",
   "pipette_setup": "Pipette Setup",
-  "mount": "{{mount}} mount",
-  "robot_is_in_motion": "Robot is in motion"
+  "mount": "{{mount}} mount"
 }

--- a/app/src/atoms/buttons/AlertPrimaryButton.tsx
+++ b/app/src/atoms/buttons/AlertPrimaryButton.tsx
@@ -22,4 +22,9 @@ export const AlertPrimaryButton = styled(NewAlertPrimaryBtn)`
   &:hover {
     box-shadow: 0 0 0;
   }
+
+  &:disabled {
+    background-color: ${COLORS.darkGreyDisabled};
+    color: ${COLORS.errorDisabled};
+  }
 `

--- a/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/CalibrationPanels/ChooseTipRack.tsx
@@ -76,9 +76,12 @@ export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {
     defaultTipracks,
   } = props
   const { t } = useTranslation(['robot_calibration', 'shared'])
-  const pipSerial = usePipettesQuery({
-    refetchInterval: EQUIPMENT_POLL_MS,
-  })?.data?.[mount].id
+  const pipSerial = usePipettesQuery(
+    {},
+    {
+      refetchInterval: EQUIPMENT_POLL_MS,
+    }
+  )?.data?.[mount].id
 
   const pipetteOffsetCal = useSelector((state: State) =>
     robotName != null && pipSerial != null

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -35,14 +35,12 @@ export function CheckPipettesButton(
 
   const handleClick = (): void => {
     refetchPipettes()
-      .then(() => {})
+      .then(() => {
+        if (pipetteQueryStatus === 'success' && onDone != null) onDone()
+      })
       .catch(() => {})
   }
   const isPending = pipetteQueryStatus === 'loading'
-
-  React.useEffect(() => {
-    if (pipetteQueryStatus === 'success' && onDone != null) onDone()
-  }, [onDone, pipetteQueryStatus])
 
   const icon = (
     <Icon name="ot-spinner" height="1rem" spin marginRight={SPACING.spacing3} />

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { usePipettesQuery } from '@opentrons/react-api-client'
 import { useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
 import {
@@ -13,7 +14,6 @@ import {
 import { PrimaryButton } from '../../atoms/buttons'
 
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
-import { usePipettesQuery } from '@opentrons/react-api-client'
 
 export interface CheckPipetteButtonProps {
   robotName: string
@@ -80,7 +80,11 @@ export function CheckPipettesButton(
   }
 
   return (
-    <PrimaryButton onClick={handleClick} aria-label="Confirm">
+    <PrimaryButton
+      onClick={handleClick}
+      aria-label="Confirm"
+      disabled={isPending}
+    >
       <Flex
         flexDirection={DIRECTION_ROW}
         color={COLORS.white}

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -27,17 +27,16 @@ export function CheckPipettesButton(
 ): JSX.Element | null {
   const { onDone, children, actualPipette } = props
   const { t } = useTranslation('change_pipette')
-  const [refresh, setRefresh] = React.useState(true)
   const [isPending, setPending] = React.useState(false)
+
   const { refetch: refetchPipettes } = usePipettesQuery(
-    { refresh: refresh },
+    { refresh: true },
     {
       enabled: false,
       onSuccess: () => {
         onDone?.()
       },
       onSettled: () => {
-        setRefresh(false)
         setPending(false)
       },
     }

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -27,20 +27,28 @@ export function CheckPipettesButton(
 ): JSX.Element | null {
   const { onDone, children, actualPipette } = props
   const { t } = useTranslation('change_pipette')
-
-  const {
-    status: pipetteQueryStatus,
-    refetch: refetchPipettes,
-  } = usePipettesQuery()
+  const [refresh, setRefresh] = React.useState(true)
+  const [isPending, setPending] = React.useState(false)
+  const { refetch: refetchPipettes } = usePipettesQuery(
+    { refresh: refresh },
+    {
+      enabled: false,
+      onSuccess: () => {
+        onDone?.()
+      },
+      onSettled: () => {
+        setRefresh(false)
+        setPending(false)
+      },
+    }
+  )
 
   const handleClick = (): void => {
+    setPending(true)
     refetchPipettes()
-      .then(() => {
-        if (pipetteQueryStatus === 'success' && onDone != null) onDone()
-      })
+      .then(() => {})
       .catch(() => {})
   }
-  const isPending = pipetteQueryStatus === 'loading'
 
   const icon = (
     <Icon name="ot-spinner" height="1rem" spin marginRight={SPACING.spacing3} />

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -27,28 +27,21 @@ export function CheckPipettesButton(
 ): JSX.Element | null {
   const { onDone, children, actualPipette } = props
   const { t } = useTranslation('change_pipette')
-  const [isPending, setPending] = React.useState(false)
-
-  const { refetch: refetchPipettes } = usePipettesQuery(
+  const { isFetching: isPending, refetch: refetchPipettes } = usePipettesQuery(
     { refresh: true },
     {
       enabled: false,
       onSuccess: () => {
         onDone?.()
       },
-      onSettled: () => {
-        setPending(false)
-      },
+      onSettled: () => {},
     }
   )
-
   const handleClick = (): void => {
-    setPending(true)
     refetchPipettes()
       .then(() => {})
       .catch(() => {})
   }
-
   const icon = (
     <Icon name="ot-spinner" height="1rem" spin marginRight={SPACING.spacing3} />
   )

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -43,6 +43,7 @@ export interface ConfirmPipetteProps {
   tryAgain: () => void
   exit: () => void
   toCalibrationDashboard: () => void
+  isDisabled: boolean
 }
 
 export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
@@ -150,6 +151,7 @@ function TryAgainButton(props: ConfirmPipetteProps): JSX.Element {
     exit,
     setWrongWantedPipette,
     wrongWantedPipette,
+    isDisabled,
   } = props
   const { t } = useTranslation(['change_pipette', 'shared'])
 
@@ -159,10 +161,11 @@ function TryAgainButton(props: ConfirmPipetteProps): JSX.Element {
         <SecondaryButton
           marginRight={SPACING.spacing3}
           onClick={() => setWrongWantedPipette(actualPipette)}
+          disabled={isDisabled}
         >
           {t('use_attached_pipette')}
         </SecondaryButton>
-        <PrimaryButton onClick={tryAgain}>
+        <PrimaryButton onClick={tryAgain} disabled={isDisabled}>
           {t('detach_try_again')}
         </PrimaryButton>
       </>
@@ -170,7 +173,11 @@ function TryAgainButton(props: ConfirmPipetteProps): JSX.Element {
   } else if (!actualPipette) {
     return (
       <>
-        <SecondaryButton marginRight={SPACING.spacing3} onClick={exit}>
+        <SecondaryButton
+          marginRight={SPACING.spacing3}
+          onClick={exit}
+          disabled={isDisabled}
+        >
           {t('cancel_attachment')}
         </SecondaryButton>
         <CheckPipettesButton robotName={robotName}>
@@ -181,12 +188,17 @@ function TryAgainButton(props: ConfirmPipetteProps): JSX.Element {
   }
   return (
     <>
-      <SecondaryButton marginRight={SPACING.spacing3} onClick={exit}>
+      <SecondaryButton
+        marginRight={SPACING.spacing3}
+        onClick={exit}
+        disabled={isDisabled}
+      >
         {t('leave_attached')}
       </SecondaryButton>
       <PrimaryButton
         onClick={tryAgain}
         textTransform={TYPOGRAPHY.textTransformCapitalize}
+        disabled={isDisabled}
       >
         {t('shared:try_again')}
       </PrimaryButton>

--- a/app/src/organisms/ChangePipette/ExitModal.tsx
+++ b/app/src/organisms/ChangePipette/ExitModal.tsx
@@ -14,10 +14,11 @@ interface Props {
   back: () => void
   exit: () => void
   direction: Direction
+  isDisabled: boolean
 }
 
 export function ExitModal(props: Props): JSX.Element {
-  const { back, exit, direction } = props
+  const { back, exit, direction, isDisabled } = props
   const { t } = useTranslation(['change_pipette', 'shared'])
   const flow = direction === 'attach' ? t('attaching') : t('detaching')
 
@@ -28,12 +29,17 @@ export function ExitModal(props: Props): JSX.Element {
       subHeader={t('are_you_sure_exit', { direction: flow })}
       isSuccess={false}
     >
-      <SecondaryButton onClick={back} marginRight={SPACING.spacing2}>
+      <SecondaryButton
+        onClick={back}
+        marginRight={SPACING.spacing2}
+        disabled={isDisabled}
+      >
         {t('go_back')}
       </SecondaryButton>
       <AlertPrimaryButton
         textTransform={TEXT_TRANSFORM_CAPITALIZE}
         onClick={exit}
+        disabled={isDisabled}
       >
         {t('shared:exit')}
       </AlertPrimaryButton>

--- a/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ChangePipette.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent } from '@testing-library/react'
 import { when } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
-import { getAttachedPipettes } from '../../../redux/pipettes'
 import { i18n } from '../../../i18n'
 import { getHasCalibrationBlock } from '../../../redux/config'
 import { getMovementStatus } from '../../../redux/robot-controls'
@@ -14,6 +13,7 @@ import {
   SUCCESS,
   useDispatchApiRequests,
 } from '../../../redux/robot-api'
+import { useAttachedPipettes } from '../../Devices/hooks'
 import { PipetteSelection } from '../PipetteSelection'
 import { ExitModal } from '../ExitModal'
 import { ConfirmPipette } from '../ConfirmPipette'
@@ -41,7 +41,6 @@ jest.mock('@opentrons/shared-data', () => {
   }
 })
 jest.mock('../../../redux/config')
-jest.mock('../../../redux/pipettes')
 jest.mock('../../../redux/robot-controls')
 jest.mock('../../../redux/calibration')
 jest.mock('../../../redux/robot-api')
@@ -49,12 +48,13 @@ jest.mock('../PipetteSelection')
 jest.mock('../ExitModal')
 jest.mock('../../../molecules/InProgressModal/InProgressModal')
 jest.mock('../ConfirmPipette')
+jest.mock('../../Devices/hooks')
 
 const mockGetPipetteNameSpecs = getPipetteNameSpecs as jest.MockedFunction<
   typeof getPipetteNameSpecs
 >
-const mockGetAttachedPipettes = getAttachedPipettes as jest.MockedFunction<
-  typeof getAttachedPipettes
+const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
+  typeof useAttachedPipettes
 >
 const mockGetMovementStatus = getMovementStatus as jest.MockedFunction<
   typeof getMovementStatus
@@ -117,7 +117,7 @@ describe('ChangePipette', () => {
       closeModal: jest.fn(),
     }
     dispatchApiRequest = jest.fn()
-    mockGetAttachedPipettes.mockReturnValue({ left: null, right: null })
+    mockUseAttachedPipettes.mockReturnValue({ left: null, right: null })
     mockGetRequestById.mockReturnValue(null)
     mockGetCalibrationForPipette.mockReturnValue(null)
     mockGetHasCalibrationBlock.mockReturnValue(false)
@@ -207,7 +207,7 @@ describe('ChangePipette', () => {
         status: 200,
       },
     })
-    mockGetAttachedPipettes.mockReturnValue({
+    mockUseAttachedPipettes.mockReturnValue({
       left: mockAttachedPipettes as AttachedPipette,
       right: null,
     })
@@ -252,7 +252,7 @@ describe('ChangePipette', () => {
 
   it('renders the wizard pages for detaching a single channel pipette and goes through the whole flow', () => {
     mockConfirmPipette.mockReturnValue(<div>mock confirm pipette</div>)
-    mockGetAttachedPipettes.mockReturnValue({
+    mockUseAttachedPipettes.mockReturnValue({
       left: mockAttachedPipettes as AttachedPipette,
       right: null,
     })

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -43,6 +43,7 @@ describe('CheckPipettesButton', () => {
     const refetch = jest.fn(() => Promise.resolve())
     mockUsePipettesQuery.mockReturnValue({
       refetch,
+      isFetching: false,
     } as any)
     props = {
       robotName: 'otie',
@@ -59,6 +60,7 @@ describe('CheckPipettesButton', () => {
     const refetch = jest.fn(() => Promise.resolve())
     mockUsePipettesQuery.mockReturnValue({
       refetch,
+      isFetching: false,
     } as any)
     props = {
       robotName: 'otie',
@@ -72,10 +74,26 @@ describe('CheckPipettesButton', () => {
     expect(refetch).toHaveBeenCalled()
   })
 
+  it('renders button disabled when pipettes query status is loading', () => {
+    const refetch = jest.fn(() => Promise.resolve())
+    mockUsePipettesQuery.mockReturnValue({
+      refetch,
+      isFetching: true,
+    } as any)
+    props = {
+      robotName: 'otie',
+      onDone: jest.fn(),
+      actualPipette: MOCK_ACTUAL_PIPETTE,
+    }
+    const { getByLabelText } = render(props)
+    expect(getByLabelText('Confirm')).toBeDisabled()
+  })
+
   it('renders the confirm detachment btn and with children and clicking on it calls fetchPipettes', () => {
     const refetch = jest.fn(() => Promise.resolve())
     mockUsePipettesQuery.mockReturnValue({
       refetch,
+      isFetching: false,
     } as any)
     props = {
       ...props,

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { when, resetAllWhenMocks } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import { usePipettesQuery } from '@opentrons/react-api-client'
 import { renderWithProviders } from '@opentrons/components'
@@ -37,18 +36,14 @@ describe('CheckPipettesButton', () => {
     }
   })
   afterEach(() => {
-    resetAllWhenMocks()
     jest.resetAllMocks()
   })
 
   it('renders the confirm attachment btn and clicking on it calls fetchPipettes', () => {
     const refetch = jest.fn(() => Promise.resolve())
-    when(mockUsePipettesQuery)
-      .calledWith()
-      .mockReturnValue({
-        status: 'idle',
-        refetch,
-      } as any)
+    mockUsePipettesQuery.mockReturnValue({
+      refetch,
+    } as any)
     props = {
       robotName: 'otie',
       onDone: jest.fn(),
@@ -62,12 +57,9 @@ describe('CheckPipettesButton', () => {
 
   it('renders the confirm detachment btn and clicking on it calls fetchPipettes', () => {
     const refetch = jest.fn(() => Promise.resolve())
-    when(mockUsePipettesQuery)
-      .calledWith()
-      .mockReturnValue({
-        status: 'idle',
-        refetch,
-      } as any)
+    mockUsePipettesQuery.mockReturnValue({
+      refetch,
+    } as any)
     props = {
       robotName: 'otie',
       onDone: jest.fn(),
@@ -80,31 +72,11 @@ describe('CheckPipettesButton', () => {
     expect(refetch).toHaveBeenCalled()
   })
 
-  it('renders button disabled when pipettes query status is loading', () => {
-    const refetch = jest.fn(() => Promise.resolve())
-    when(mockUsePipettesQuery)
-      .calledWith()
-      .mockReturnValue({
-        status: 'loading',
-        refetch,
-      } as any)
-    props = {
-      robotName: 'otie',
-      onDone: jest.fn(),
-      actualPipette: MOCK_ACTUAL_PIPETTE,
-    }
-    const { getByLabelText } = render(props)
-    expect(getByLabelText('Confirm')).toBeDisabled()
-  })
-
   it('renders the confirm detachment btn and with children and clicking on it calls fetchPipettes', () => {
     const refetch = jest.fn(() => Promise.resolve())
-    when(mockUsePipettesQuery)
-      .calledWith()
-      .mockReturnValue({
-        status: 'idle',
-        refetch,
-      } as any)
+    mockUsePipettesQuery.mockReturnValue({
+      refetch,
+    } as any)
     props = {
       ...props,
       actualPipette: MOCK_ACTUAL_PIPETTE,

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -80,6 +80,23 @@ describe('CheckPipettesButton', () => {
     expect(refetch).toHaveBeenCalled()
   })
 
+  it('renders button disabled when pipettes query status is loading', () => {
+    const refetch = jest.fn(() => Promise.resolve())
+    when(mockUsePipettesQuery)
+      .calledWith()
+      .mockReturnValue({
+        status: 'loading',
+        refetch,
+      } as any)
+    props = {
+      robotName: 'otie',
+      onDone: jest.fn(),
+      actualPipette: MOCK_ACTUAL_PIPETTE,
+    }
+    const { getByLabelText } = render(props)
+    expect(getByLabelText('Confirm')).toBeDisabled()
+  })
+
   it('renders the confirm detachment btn and with children and clicking on it calls fetchPipettes', () => {
     const refetch = jest.fn(() => Promise.resolve())
     when(mockUsePipettesQuery)

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -101,6 +101,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -128,6 +129,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -163,6 +165,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -198,6 +201,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: MOCK_ACTUAL_PIPETTE,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -229,6 +233,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -264,6 +269,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: MOCK_WANTED_PIPETTE,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -294,6 +300,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: MOCK_WANTED_PIPETTE,
       confirmPipetteLevel: true,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -326,6 +333,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -361,6 +369,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -389,6 +398,7 @@ describe('ConfirmPipette', () => {
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
       setConfirmPipetteLevel: jest.fn(),
+      isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
@@ -401,5 +411,15 @@ describe('ConfirmPipette', () => {
     const pocBtn = getByRole('button', { name: 'Calibrate pipette offset' })
     fireEvent.click(pocBtn)
     expect(props.toCalibrationDashboard).toBeCalled()
+  })
+  it('should render buttons as disabled when robot is in motion/isDisabled is true', () => {
+    props = {
+      ...props,
+      success: false,
+      isDisabled: true,
+    }
+    const { getByRole } = render(props)
+    expect(getByRole('button', { name: 'Leave attached' })).toBeDisabled()
+    expect(getByRole('button', { name: 'try again' })).toBeDisabled()
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/ExitModal.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ExitModal.test.tsx
@@ -16,6 +16,7 @@ describe('ExitModal', () => {
       back: jest.fn(),
       exit: jest.fn(),
       direction: 'attach',
+      isDisabled: false,
     }
   })
   it('renders the correct information and buttons for attach when no pipette is attached', () => {
@@ -37,5 +38,15 @@ describe('ExitModal', () => {
     }
     const { getByText } = render(props)
     getByText('Are you sure you want to exit before detaching your pipette?')
+  })
+
+  it('renders buttons disabled when isDisbaled is true', () => {
+    props = {
+      ...props,
+      isDisabled: true,
+    }
+    const { getByRole } = render(props)
+    expect(getByRole('button', { name: 'Go back' })).toBeDisabled()
+    expect(getByRole('button', { name: 'exit' })).toBeDisabled()
   })
 })

--- a/app/src/organisms/ChangePipette/index.tsx
+++ b/app/src/organisms/ChangePipette/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import capitalize from 'lodash/capitalize'
 import { useSelector, useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -176,7 +177,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
     direction === DETACH
       ? t('detach_pipette', {
           pipette: actualPipette.displayName,
-          mount: mount[0].toUpperCase() + mount.slice(1),
+          mount: capitalize(mount),
         })
       : t('attach_pipette')
   let currentStep: number = 0
@@ -218,7 +219,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
         ? t('detach')
         : t('detach_pipette', {
             pipette: actualPipette?.displayName ?? wantedPipette?.displayName,
-            mount: mount[0].toUpperCase() + mount.slice(1),
+            mount: capitalize(mount),
           })
     } else {
       title = noPipetteSelectedAttach
@@ -250,7 +251,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
             actualPipette?.displayName != null
               ? t('detach_pipette', {
                   pipette: actualPipette.displayName,
-                  mount: mount[0].toUpperCase() + mount.slice(1),
+                  mount: capitalize(mount),
                 })
               : t('attach_pipette'),
         }}
@@ -284,7 +285,7 @@ export function ChangePipette(props: Props): JSX.Element | null {
     let wizardTitleConfirmPipette
     if (wantedPipette == null && actualPipette == null) {
       wizardTitleConfirmPipette = t('detach_pipette_from_mount', {
-        mount: mount[0].toUpperCase() + mount.slice(1),
+        mount: capitalize(mount),
       })
     } else if (wantedPipette == null && actualPipette != null) {
       wizardTitleConfirmPipette = t('detach')

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -42,9 +42,12 @@ export function InstrumentsAndModules({
 }: InstrumentsAndModulesProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
 
-  const attachedPipettes = usePipettesQuery({
-    refetchInterval: EQUIPMENT_POLL_MS,
-  })?.data ?? { left: undefined, right: undefined }
+  const attachedPipettes = usePipettesQuery(
+    {},
+    {
+      refetchInterval: EQUIPMENT_POLL_MS,
+    }
+  )?.data ?? { left: undefined, right: undefined }
   const isRobotViewable = useIsRobotViewable(robotName)
   const currentRunId = useCurrentRunId()
   const { isRunTerminal } = useRunStatuses()

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -148,7 +148,7 @@ export function ProtocolRunHeader({
   const isRunCurrent = Boolean(useRunQuery(runId)?.data?.data?.current)
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
   // NOTE: we are polling pipettes, though not using their value directly here
-  usePipettesQuery({ refetchInterval: EQUIPMENT_POLL_MS })
+  usePipettesQuery({}, { refetchInterval: EQUIPMENT_POLL_MS })
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
 
   React.useEffect(() => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
@@ -32,7 +32,7 @@ export function SetupPipetteCalibration({
   const { t } = useTranslation('protocol_setup')
   const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
 
-  usePipettesQuery({ refetchInterval: PIPETTE_POLL_FETCH_MS })
+  usePipettesQuery({}, { refetchInterval: PIPETTE_POLL_FETCH_MS })
   useAllPipetteOffsetCalibrationsQuery({
     refetchInterval: PIPETTE_POLL_FETCH_MS,
   })

--- a/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -177,7 +177,10 @@ describe('InstrumentsAndModules', () => {
     expect(mockUseAllPipetteOffsetCalibrationsQuery).toHaveBeenCalledWith({
       refetchInterval: 30000,
     })
-    expect(mockUsePipettesQuery).toHaveBeenCalledWith({ refetchInterval: 5000 })
+    expect(mockUsePipettesQuery).toHaveBeenCalledWith(
+      {},
+      { refetchInterval: 5000 }
+    )
     expect(mockUseModulesQuery).toHaveBeenCalledWith({ refetchInterval: 5000 })
   })
 })

--- a/app/src/organisms/Devices/hooks/__tests__/useAttachedPipetteCalibrations.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useAttachedPipetteCalibrations.test.tsx
@@ -68,7 +68,7 @@ describe('useAttachedPipetteCalibrations hook', () => {
 
   it('returns attached pipette calibrations when given a robot name', () => {
     when(mockUsePipettesQuery)
-      .calledWith({})
+      .calledWith({}, {})
       .mockReturnValue({
         data: {
           left: {

--- a/app/src/organisms/Devices/hooks/__tests__/useAttachedPipettes.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useAttachedPipettes.test.tsx
@@ -35,7 +35,7 @@ describe('useAttachedPipettes hook', () => {
 
   it('returns attached pipettes', () => {
     when(mockUsePipettesQuery)
-      .calledWith({})
+      .calledWith({}, {})
       .mockReturnValue({
         data: {
           left: pipetteResponseFixtureLeft,
@@ -58,7 +58,7 @@ describe('useAttachedPipettes hook', () => {
 
   it('returns attached pipettes polled every 5 seconds if poll true', () => {
     when(mockUsePipettesQuery)
-      .calledWith({ refetchInterval: 5000 })
+      .calledWith({}, { refetchInterval: 5000 })
       .mockReturnValue({
         data: {
           left: pipetteResponseFixtureLeft,

--- a/app/src/organisms/Devices/hooks/useAttachedPipettes.ts
+++ b/app/src/organisms/Devices/hooks/useAttachedPipettes.ts
@@ -11,6 +11,7 @@ export function useAttachedPipettes(
   poll: boolean = false
 ): AttachedPipettesByMount {
   const attachedPipettesResponse = usePipettesQuery(
+    {},
     poll ? { refetchInterval: PIPETTE_POLL_MS } : {}
   )?.data
   return Constants.PIPETTE_MOUNTS.reduce<AttachedPipettesByMount>(

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -17,19 +17,21 @@ export const CheckPipetteButton = (
   React.useEffect(() => {
     //  if requestStatus is error then the error modal will be in the results page
     if (status === 'success' || status === 'error') {
-      proceed()
       setPending(false)
     } else if (status === 'loading') {
       setPending(true)
     }
-  }, [proceed, status, setPending])
+  }, [status, setPending])
 
   return (
     <PrimaryButton
       disabled={isDisabled}
       onClick={() => {
+        setPending(status === 'loading')
         refetch()
-          .then(() => {})
+          .then(() => {
+            proceed()
+          })
           .catch(() => {})
       }}
     >

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -12,16 +12,14 @@ export const CheckPipetteButton = (
   props: CheckPipetteButtonProps
 ): JSX.Element => {
   const { proceedButtonText, proceed, setPending, isDisabled } = props
-  const [refresh, setRefresh] = React.useState(true)
   const { refetch } = usePipettesQuery(
-    { refresh: refresh },
+    { refresh: true },
     {
       enabled: false,
       onSuccess: () => {
         proceed()
       },
       onSettled: () => {
-        setRefresh(false)
         setPending(false)
       },
     }

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -12,26 +12,28 @@ export const CheckPipetteButton = (
   props: CheckPipetteButtonProps
 ): JSX.Element => {
   const { proceedButtonText, proceed, setPending, isDisabled } = props
-  const { status, refetch } = usePipettesQuery()
-
-  React.useEffect(() => {
-    //  if requestStatus is error then the error modal will be in the results page
-    if (status === 'success' || status === 'error') {
-      setPending(false)
-    } else if (status === 'loading') {
-      setPending(true)
+  const [refresh, setRefresh] = React.useState(true)
+  const { refetch } = usePipettesQuery(
+    { refresh: refresh },
+    {
+      enabled: false,
+      onSuccess: () => {
+        proceed()
+      },
+      onSettled: () => {
+        setRefresh(false)
+        setPending(false)
+      },
     }
-  }, [status, setPending])
+  )
 
   return (
     <PrimaryButton
       disabled={isDisabled}
       onClick={() => {
-        setPending(status === 'loading')
+        setPending(true)
         refetch()
-          .then(() => {
-            proceed()
-          })
+          .then(() => {})
           .catch(() => {})
       }}
     >

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -12,24 +12,24 @@ export const CheckPipetteButton = (
   props: CheckPipetteButtonProps
 ): JSX.Element => {
   const { proceedButtonText, proceed, setPending, isDisabled } = props
-  const { refetch } = usePipettesQuery(
+  const { refetch, isFetching } = usePipettesQuery(
     { refresh: true },
     {
       enabled: false,
       onSuccess: () => {
         proceed()
       },
-      onSettled: () => {
-        setPending(false)
-      },
     }
   )
+
+  React.useEffect(() => {
+    setPending(isFetching)
+  }, [isFetching, setPending])
 
   return (
     <PrimaryButton
       disabled={isDisabled}
       onClick={() => {
-        setPending(true)
         refetch()
           .then(() => {})
           .catch(() => {})

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -6,9 +6,9 @@ import {
   SPACING,
 } from '@opentrons/components'
 import { NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
-import { usePipettesQuery } from '@opentrons/react-api-client'
 import { PrimaryButton, SecondaryButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import { CheckPipetteButton } from './CheckPipetteButton'
 import { FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
 
@@ -30,12 +30,8 @@ export const Results = (props: ResultsProps): JSX.Element => {
     selectedPipette,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
-  const {
-    status: pipetteQueryStatus,
-    refetch: refetchPipettes,
-  } = usePipettesQuery()
   const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
-  const isPending = pipetteQueryStatus === 'loading'
+  const [isPending, setPending] = React.useState(false)
 
   let header: string = 'unknown results screen'
   let iconColor: string = COLORS.successEnabled
@@ -82,14 +78,6 @@ export const Results = (props: ResultsProps): JSX.Element => {
     }
   }
 
-  const handleTryAgain = (): void => {
-    refetchPipettes()
-      .then(() => {
-        setNumberOfTryAgains(numberOfTryAgains + 1)
-      })
-      .catch(() => {})
-  }
-
   const handleProceed = (): void => {
     if (currentStepIndex === totalStepCount || !isSuccess) {
       handleCleanUpAndClose()
@@ -120,15 +108,15 @@ export const Results = (props: ResultsProps): JSX.Element => {
         >
           {t('shared:exit')}
         </SecondaryButton>
-        <PrimaryButton
-          onClick={handleTryAgain}
-          disabled={isPending}
-          aria-label="Results_tryAgain"
-        >
-          {t(
+        <CheckPipetteButton
+          proceed={() => setNumberOfTryAgains(numberOfTryAgains + 1)}
+          proceedButtonText={t(
             flowType === FLOWS.ATTACH ? 'detach_and_retry' : 'attach_and_retry'
           )}
-        </PrimaryButton>
+          isDisabled={isPending}
+          setPending={setPending}
+          aria-label="Results_tryAgain"
+        ></CheckPipetteButton>
       </>
     )
   }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -115,8 +115,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
           )}
           isDisabled={isPending}
           setPending={setPending}
-          aria-label="Results_tryAgain"
-        ></CheckPipetteButton>
+        />
       </>
     )
   }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import { usePipettesQuery } from '@opentrons/react-api-client'
-import { when, resetAllWhenMocks } from 'jest-when'
 import { CheckPipetteButton } from '../CheckPipetteButton'
 
 const render = (props: React.ComponentProps<typeof CheckPipetteButton>) => {
@@ -24,15 +23,11 @@ describe('CheckPipetteButton', () => {
       setPending: jest.fn(),
       isDisabled: false,
     }
-    when(mockUsePipettesQuery)
-      .calledWith()
-      .mockReturnValue({
-        status: 'idle',
-        refetch,
-      } as any)
+    mockUsePipettesQuery.mockReturnValue({
+      refetch,
+    } as any)
   })
   afterEach(() => {
-    resetAllWhenMocks()
     jest.resetAllMocks()
   })
   it('clicking on the button calls refetch', () => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -96,57 +96,9 @@ describe('Results', () => {
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${String(COLORS.errorEnabled)}`
     )
-    getByRole('button', { name: 'Results_tryAgain' }).click()
+    getByRole('button', { name: 'Detach and retry' }).click()
     await act(() => pipettePromise)
     expect(mockRefetchPipette).toHaveBeenCalled()
-  })
-  it('renders the try again button when fail to attach and clicking on buton several times renders the warning subheader', async () => {
-    props = {
-      ...props,
-      attachedPipettes: { left: null, right: null },
-      flowType: FLOWS.ATTACH,
-    }
-    const { getByText, getByRole } = render(props)
-    getByText('exit')
-    getByText('Detach and retry')
-    getByRole('button', { name: 'Results_tryAgain' }).click()
-    await act(() => pipettePromise)
-    expect(mockRefetchPipette).toHaveBeenCalled()
-    getByRole('button', { name: 'Results_tryAgain' }).click()
-    await act(() => pipettePromise)
-    expect(mockRefetchPipette).toHaveBeenCalled()
-    getByRole('button', { name: 'Results_tryAgain' }).click()
-    await act(() => pipettePromise)
-    //  warning subheader after clicking on try again 3 times
-    getByText(
-      'There may be a problem with your pipette. Exit setup and contact Opentrons Support for assistance.'
-    )
-    getByRole('button', { name: 'Results_errorExit' }).click()
-    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
-  })
-  it('renders the try again button when fail to detach and clicking on buton several times renders the warning subheader', async () => {
-    props = {
-      ...props,
-      attachedPipettes: { left: mockPipette, right: null },
-      flowType: FLOWS.DETACH,
-    }
-    const { getByText, getByRole } = render(props)
-    getByText('exit')
-    getByText('Attach and retry')
-    getByRole('button', { name: 'Results_tryAgain' }).click()
-    await act(() => pipettePromise)
-    expect(mockRefetchPipette).toHaveBeenCalled()
-    getByRole('button', { name: 'Results_tryAgain' }).click()
-    await act(() => pipettePromise)
-    expect(mockRefetchPipette).toHaveBeenCalled()
-    getByRole('button', { name: 'Results_tryAgain' }).click()
-    await act(() => pipettePromise)
-    //  warning subheader after clicking on try again 3 times
-    getByText(
-      'There may be a problem with your pipette. Exit setup and contact Opentrons Support for assistance.'
-    )
-    getByRole('button', { name: 'Results_errorExit' }).click()
-    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard is a success for detach flow', () => {
     props = {
@@ -174,7 +126,7 @@ describe('Results', () => {
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${String(COLORS.errorEnabled)}`
     )
-    getByRole('button', { name: 'Results_tryAgain' })
+    getByRole('button', { name: 'Attach and retry' })
   })
   it('renders the correct information when pipette wizard is a fail for 96 channel attach flow and gantry not empty', async () => {
     props = {
@@ -187,7 +139,7 @@ describe('Results', () => {
     expect(getByLabelText('ot-alert')).toHaveStyle(
       `color: ${String(COLORS.errorEnabled)}`
     )
-    getByRole('button', { name: 'Results_tryAgain' }).click()
+    getByRole('button', { name: 'Attach and retry' }).click()
     await act(() => pipettePromise)
   })
   it('renders the correct information when pipette wizard is a success for 96 channel attach flow and gantry not empty', () => {

--- a/react-api-client/src/pipettes/__tests__/usePipettesQuery.test.tsx
+++ b/react-api-client/src/pipettes/__tests__/usePipettesQuery.test.tsx
@@ -59,7 +59,9 @@ describe('usePipettesQuery hook', () => {
 
   it('should return no data if the getPipettes request fails', () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
-    when(mockGetPipettes).calledWith(HOST_CONFIG).mockRejectedValue('oh no')
+    when(mockGetPipettes)
+      .calledWith(HOST_CONFIG, { refresh: false })
+      .mockRejectedValue('oh no')
 
     const { result } = renderHook(usePipettesQuery, { wrapper })
     expect(result.current.data).toBeUndefined()
@@ -68,7 +70,7 @@ describe('usePipettesQuery hook', () => {
   it('should return all current attached pipettes', async () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
     when(mockGetPipettes)
-      .calledWith(HOST_CONFIG)
+      .calledWith(HOST_CONFIG, { refresh: false })
       .mockResolvedValue({ data: PIPETTES_RESPONSE } as Response<Pipettes>)
 
     const { result, waitFor } = renderHook(usePipettesQuery, {

--- a/react-api-client/src/pipettes/usePipettesQuery.ts
+++ b/react-api-client/src/pipettes/usePipettesQuery.ts
@@ -2,15 +2,25 @@ import { useQuery } from 'react-query'
 import { getPipettes } from '@opentrons/api-client'
 import { useHost } from '../api'
 import type { UseQueryResult, UseQueryOptions } from 'react-query'
-import type { HostConfig, Pipettes } from '@opentrons/api-client'
+import type {
+  HostConfig,
+  Pipettes,
+  GetPipettesParams,
+} from '@opentrons/api-client'
+
+export const DEFAULT_PARAMS: GetPipettesParams = {
+  refresh: false,
+}
 
 export function usePipettesQuery(
+  params: GetPipettesParams = DEFAULT_PARAMS,
   options: UseQueryOptions<Pipettes> = {}
 ): UseQueryResult<Pipettes> {
   const host = useHost()
   const query = useQuery<Pipettes>(
     [host, 'pipettes'],
-    () => getPipettes(host as HostConfig).then(response => response.data),
+    () =>
+      getPipettes(host as HostConfig, params).then(response => response.data),
     { enabled: host !== null, ...options }
   )
 


### PR DESCRIPTION
closes RQA-516, RQA-515

# Overview

Cleans up `ChangePipette`, adds disabled prop to various buttons, removes a usage of redux machinery, fixes i18n interpolation bug, fixes pipette detection bug

# Test Plan

- With an OT-2, go through beginning of each flow, you should no longer see any warnings in console. Additionally, clicking on the buttons to check if pipette is attached/detached should disable when the action is pending
- With an OT-3, each attach and detach flow should properly detect whether the pipette was attached/detached within a few seconds

# Changelog

- remove usage of `getAttachedPipettes` in `ChangePipette`, now use react query `useAttachedPipettes` (this wasn't working right since we removed the `fetchPipette` in a previous PR)
- add disabled prop to various buttons, such as in `ExitModal`, `ConfirmPipette`, and `CheckPipetteButton`. Disabled reasons are when the robot is in motion or `status` is `loading` - this should disallow users to press the buttons multiple times when robot is in motion
- add `disabled` css state to `AlertPrimaryButton`
- fix interpolation bug in 18n key logic in `ChangePipette` that was causing a bunch of warnings in console
- add `refresh=true` param option to `usePipettesQuery` and utilize that option for both OT-2 and OT-2 attach/detach flows when checking to see whether the action has been completed

# Review requests

- make sure warnings in console are gone
- should disallow clicking buttons multiple times when cta is in action
- run through attach and detach for smoke testing

# Risk assessment

low