### PR TITLE
refactor(app): replace cal block request form link with support email mailto

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -13,7 +13,7 @@
   "calibrate_z_axis_on_trash": "Calibrate z-axis on trash bin",
   "calibrate_tip_on_block": "Calibrate tip on block",
   "calibrate_tip_on_trash": "Calibrate tip on trash bin",
-  "calibration_block_description": "<block>This block is a specially made tool that fits perfectly on your deck and helps with calibration.</block><block>If you do not have a Calibration Block, please <supportLink>email support</supportLink> so we can send you one. In your message, be sure to include your name, company or institution name, and shipping address. While you wait for the block to arrive, you can use the flat surface on the trash bin of your robot instead.</block>",
+  "calibration_block_description": "<block>This block is a specially made tool that fits perfectly on your deck and helps with calibration.</block><block>If you do not have a Calibration Block, please email <supportLink>support@opentrons.com</supportLink> so we can send you one. In your message, be sure to include your name, company or institution name, and shipping address. While you wait for the block to arrive, you can use the flat surface on the trash bin of your robot instead.</block>",
   "calibration_health_check": "Calibration Health Check",
   "calibration_health_check_intro_body": "<block>Calibration Health Check diagnoses problems with Deck, Tip Length, and Pipette Offset Calibration.</block><block>You will move the pipettes to various positions, which will be compared against your existing calibration data.</block><block>If there is a large difference, you will be prompted to redo some or all of your calibrations.</block>",
   "calibrate_tip_length": "Calibrate the length of a tip on this pipette.",

--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -13,7 +13,7 @@
   "calibrate_z_axis_on_trash": "Calibrate z-axis on trash bin",
   "calibrate_tip_on_block": "Calibrate tip on block",
   "calibrate_tip_on_trash": "Calibrate tip on trash bin",
-  "calibration_block_description": "<block>This block is a specially made tool that fits perfectly on your deck and helps with calibration. If you do not have a Calibration Block, please <supportLink>contact us</supportLink> so we can send you one.</block><block>While you wait for the block to arrive,  you can use the flat surface on the trash bin of your robot instead.</block>",
+  "calibration_block_description": "<block>This block is a specially made tool that fits perfectly on your deck and helps with calibration.</block><block>If you do not have a Calibration Block, please <supportLink>email support</supportLink> so we can send you one. In your message, be sure to include your name, company or institution name, and shipping address. While you wait for the block to arrive, you can use the flat surface on the trash bin of your robot instead.</block>",
   "calibration_health_check": "Calibration Health Check",
   "calibration_health_check_intro_body": "<block>Calibration Health Check diagnoses problems with Deck, Tip Length, and Pipette Offset Calibration.</block><block>You will move the pipettes to various positions, which will be compared against your existing calibration data.</block><block>If there is a large difference, you will be prompted to redo some or all of your calibrations.</block>",
   "calibrate_tip_length": "Calibrate the length of a tip on this pipette.",

--- a/app/src/organisms/CalibrateTipLength/AskForCalibrationBlockModal.tsx
+++ b/app/src/organisms/CalibrateTipLength/AskForCalibrationBlockModal.tsx
@@ -24,7 +24,11 @@ import { StyledText } from '../../atoms/text'
 
 import type { Dispatch } from '../../redux/types'
 
-const BLOCK_REQUEST_URL = 'https://opentrons-ux.typeform.com/to/DgvBE9Ir'
+const BLOCK_REQUEST_EMAIL_BODY =
+  '• Full name\n• Company or institution name\n• Shipping address\n• VAT ID (if outside the US)'
+const BLOCK_REQUEST_URL = `mailto:support@opentrons.com?subject=Calibration%20Block%20Request&body=${encodeURIComponent(
+  BLOCK_REQUEST_EMAIL_BODY
+)}`
 const CAL_BLOCK_LOAD_NAME = 'opentrons_calibrationblock_short_side_right'
 
 interface Props {


### PR DESCRIPTION
# Overview

Remove the link to the legacy calibration block request form from the "do you have a calibration block" modal. Replace with a mailto link to the support team with a prefilled message and subject

Closes RAUT-328

https://user-images.githubusercontent.com/4731953/221275960-65d53dae-54dd-4250-b5c8-71cba0794cde.mov


# Review requests

- Launch Tip Length Calibration from the Calibration Dashboard with the advanced setting for the calibration block modal set to "Always show the prompt to choose calibration block or trash bin". Confirm that the modal copy is correct and that the email support link opens the user's default mail client with the correct subject and body prepopulated.

# Risk assessment
low