### PR TITLE
test(protocol-designer): do not make assertions on application version

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -1,7 +1,6 @@
 import 'cypress-file-upload'
 import cloneDeep from 'lodash/cloneDeep'
 import { expectDeepEqual } from '@opentrons/shared-data/js/cypressUtils'
-const semver = require('semver')
 
 // TODO: (sa 2022-03-31: change these migration fixtures to v6 protocols once the liquids key is added to PD protocols
 // https://github.com/Opentrons/opentrons/issues/9852
@@ -14,7 +13,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
   const testCases = [
     {
       title:
-        'preFlexGrandfatheredProtocol 1.0.0 (schema 1, PD version pre-1) -> PD 6.1.x, schema 6',
+        'preFlexGrandfatheredProtocol 1.0.0 (schema 1, PD version pre-1) -> PD 6.2.x, schema 6',
       importFixture:
         '../../fixtures/protocol/1/preFlexGrandfatheredProtocol.json',
       expectedExportFixture:
@@ -23,7 +22,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'newLabwareDefs',
     },
     {
-      title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 6.1.x, schema 6',
+      title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 6.2.x, schema 6',
       importFixture: '../../fixtures/protocol/1/example_1_1_0.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/example_1_1_0MigratedFromV1_0_0.json',
@@ -31,7 +30,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'newLabwareDefs',
     },
     {
-      title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 6.1.x, schema 6',
+      title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 6.2.x, schema 6',
       importFixture: '../../fixtures/protocol/4/doItAllV3.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/doItAllV3MigratedToV6.json',
@@ -39,7 +38,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'noBehaviorChange',
     },
     {
-      title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 6.1.x, schema 6',
+      title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 6.2.x, schema 6',
       importFixture: '../../fixtures/protocol/4/doItAllV4.json',
       expectedExportFixture:
         '../../fixtures/protocol/6/doItAllV4MigratedToV6.json',
@@ -57,7 +56,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
     },
     {
       title:
-        'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 6.1.x, schema v6',
+        'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 6.2.x, schema v6',
       importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
       expectedExportFixture: '../../fixtures/protocol/6/mix_6_0_0.json',
       migrationModal: 'noBehaviorChange',
@@ -142,19 +141,6 @@ describe('Protocol fixtures migrate and match snapshots', () => {
               const blobText = await blob.text()
               const savedFile = JSON.parse(blobText)
               const expectedFile = cloneDeep(expectedExportProtocol)
-              const version = semver.parse(
-                savedFile.designerApplication.version
-              )
-              assert.ok(
-                version,
-                'Could not parse designer application version from saved file'
-              )
-              assert.ok(
-                [null, 'prerelease', 'patch', 'prepatch'].includes(
-                  semver.diff(version, '6.1.0')
-                ),
-                `Saved designer application version ${version} too different from 6.1.0`
-              )
               ;[savedFile, expectedFile].forEach(f => {
                 // Homogenize fields we don't want to compare
                 f.metadata.lastModified = 123

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -1,6 +1,7 @@
 import 'cypress-file-upload'
 import cloneDeep from 'lodash/cloneDeep'
 import { expectDeepEqual } from '@opentrons/shared-data/js/cypressUtils'
+const semver = require('semver')
 
 // TODO: (sa 2022-03-31: change these migration fixtures to v6 protocols once the liquids key is added to PD protocols
 // https://github.com/Opentrons/opentrons/issues/9852
@@ -141,6 +142,13 @@ describe('Protocol fixtures migrate and match snapshots', () => {
               const blobText = await blob.text()
               const savedFile = JSON.parse(blobText)
               const expectedFile = cloneDeep(expectedExportProtocol)
+              const version = semver.parse(
+                savedFile.designerApplication.version
+              )
+              assert(
+                version != null,
+                `PD version ${version} is not valid semver`
+              )
               ;[savedFile, expectedFile].forEach(f => {
                 // Homogenize fields we don't want to compare
                 f.metadata.lastModified = 123


### PR DESCRIPTION
# Overview

Now that the PD version is dictated by git tags and injected at build time, there is no need to have cypress make assertions on what the PD version is.

# Changelog

- Do not make test assertions on application version

# Risk assessment

Low
