### PR TITLE
refactor(api): load pipette config into engine from PipetteDict

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -34,7 +34,7 @@ class PipetteConfig:
     pick_up_speed: float
     aspirate_flow_rate: float
     dispense_flow_rate: float
-    channels: float
+    channels: int
     nozzle_offset: Tuple[float, float, float]
     plunger_current: float
     drop_tip_current: float

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -316,8 +316,7 @@ class LegacyProtocolCore(
             InstrumentLoadInfo(
                 instrument_load_name=instrument_name.value,
                 mount=mount,
-                model=pipette_dict["model"],
-                serial_number=pipette_dict["pipette_id"],
+                pipette_dict=pipette_dict,
             )
         )
 

--- a/api/src/opentrons/protocol_api/core/legacy/load_info.py
+++ b/api/src/opentrons/protocol_api/core/legacy/load_info.py
@@ -8,8 +8,8 @@ It's only for internal Opentrons use.
 from dataclasses import dataclass
 from typing import Optional, Union
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import PipetteModel
 
+from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules.types import ModuleModel
 from opentrons.types import Mount, DeckSlotName
 
@@ -54,8 +54,7 @@ class InstrumentLoadInfo:
 
     instrument_load_name: str
     mount: Mount
-    serial_number: str
-    model: PipetteModel
+    pipette_dict: PipetteDict
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_protocol_core.py
@@ -60,8 +60,7 @@ class LegacyProtocolCoreSimulator(
             InstrumentLoadInfo(
                 instrument_load_name=instrument_name.value,
                 mount=mount,
-                model=pipette_dict["model"],
-                serial_number=pipette_dict["pipette_id"],
+                pipette_dict=pipette_dict,
             )
         )
 

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -206,11 +206,11 @@ class EquipmentHandler:
                 mount.to_hw_mount()
             )
 
-            model = pipette_dict["model"]
             serial_number = pipette_dict["pipette_id"]
             static_pipette_config = pipette_data_provider.get_pipette_static_config(
-                model, serial_number
+                pipette_dict
             )
+
         else:
             serial_number = self._model_utils.generate_id(prefix="fake-serial-number-")
             static_pipette_config = (

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -3,9 +3,10 @@ from dataclasses import dataclass
 from typing import Dict
 
 from opentrons_shared_data.pipette import dummy_model_for_name
-from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from opentrons_shared_data.pipette.dev_types import PipetteName
 
-from opentrons.config.pipette_config import load as load_pipette_config, PipetteConfig
+from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.config.pipette_config import load as load_pipette_config
 
 from ..types import FlowRates
 
@@ -26,14 +27,19 @@ class LoadedStaticPipetteData:
     nominal_tip_overlap: Dict[str, float]
 
 
-def _return_static_pipette_data(config: PipetteConfig) -> LoadedStaticPipetteData:
-    """Get the needed info from PipetteConfig and return it as a LoadedStaticPipetteData object."""
+def get_virtual_pipette_static_config(
+    pipette_name: PipetteName,
+) -> LoadedStaticPipetteData:
+    """Get the config for a virtual pipette, given only the pipette name."""
+    pipette_model = dummy_model_for_name(pipette_name)
+    config = load_pipette_config(pipette_model)
+
     return LoadedStaticPipetteData(
         model=config.model,
         display_name=config.display_name,
         min_volume=config.min_volume,
         max_volume=config.max_volume,
-        channels=int(config.channels),
+        channels=config.channels,
         home_position=config.home_position,
         nozzle_offset_z=config.nozzle_offset[2],
         flow_rates=FlowRates(
@@ -46,18 +52,23 @@ def _return_static_pipette_data(config: PipetteConfig) -> LoadedStaticPipetteDat
     )
 
 
-def get_virtual_pipette_static_config(
-    pipette_name: PipetteName,
-) -> LoadedStaticPipetteData:
-    """Get the config for a virtual pipette, given only the pipette name."""
-    pipette_model = dummy_model_for_name(pipette_name)
-    config = load_pipette_config(pipette_model)
-    return _return_static_pipette_data(config)
-
-
-def get_pipette_static_config(
-    model: PipetteModel, serial_number: str
-) -> LoadedStaticPipetteData:
-    """Get the config for a pipette, given the actual model and pipette id."""
-    config = load_pipette_config(model, serial_number)
-    return _return_static_pipette_data(config)
+def get_pipette_static_config(pipette_dict: PipetteDict) -> LoadedStaticPipetteData:
+    """Get the config for a pipette, given the state/config object from the HW API."""
+    return LoadedStaticPipetteData(
+        model=pipette_dict["model"],
+        display_name=pipette_dict["display_name"],
+        min_volume=pipette_dict["min_volume"],
+        max_volume=pipette_dict["max_volume"],
+        channels=pipette_dict["channels"],
+        flow_rates=FlowRates(
+            default_blow_out=pipette_dict["default_blow_out_flow_rates"],
+            default_aspirate=pipette_dict["default_aspirate_flow_rates"],
+            default_dispense=pipette_dict["default_dispense_flow_rates"],
+        ),
+        return_tip_scale=pipette_dict["return_tip_height"],
+        nominal_tip_overlap=pipette_dict["tip_overlap"],
+        # TODO(mc, 2023-02-28): these two values are not present in PipetteDict
+        # https://opentrons.atlassian.net/browse/RCORE-655
+        home_position=0,
+        nozzle_offset_z=0,
+    )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -572,10 +572,9 @@ class LegacyCommandMapper:
         )
         pipette_config_action = pe_actions.AddPipetteConfigAction(
             pipette_id=pipette_id,
-            serial_number=instrument_load_info.serial_number,
+            serial_number=instrument_load_info.pipette_dict["pipette_id"],
             config=pipette_data_provider.get_pipette_static_config(
-                model=instrument_load_info.model,
-                serial_number=instrument_load_info.serial_number,
+                instrument_load_info.pipette_dict
             ),
         )
 

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -6,7 +6,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
-from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
+from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
 
 from opentrons.types import DeckSlotName, Location, Mount, Point
@@ -157,8 +157,7 @@ def test_load_instrument(
             InstrumentLoadInfo(
                 instrument_load_name="p300_single",
                 mount=Mount.RIGHT,
-                model=PipetteModel("cool-model"),
-                serial_number="cool-serial-number",
+                pipette_dict=pipette_dict,
             )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -496,17 +496,19 @@ async def test_load_pipette(
     subject: EquipmentHandler,
 ) -> None:
     """It should load pipette data, check attachment, and generate an ID."""
+    pipette_dict = cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+
     decoy.when(state_store.config.use_virtual_pipettes).then_return(False)
     decoy.when(model_utils.generate_id()).then_return("unique-id")
     decoy.when(state_store.pipettes.get_by_mount(MountType.RIGHT)).then_return(
         LoadedPipette.construct(pipetteName=PipetteNameType.P300_MULTI)  # type: ignore[call-arg]
     )
     decoy.when(hardware_api.get_attached_instrument(mount=HwMount.LEFT)).then_return(
-        cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+        pipette_dict
     )
 
     decoy.when(
-        pipette_data_provider.get_pipette_static_config(model="hello", serial_number="world")  # type: ignore[arg-type]
+        pipette_data_provider.get_pipette_static_config(pipette_dict)
     ).then_return(loaded_static_pipette_data)
 
     decoy.when(hardware_api.get_instrument_max_height(mount=HwMount.LEFT)).then_return(
@@ -548,15 +550,15 @@ async def test_load_pipette_96_channels(
     subject: EquipmentHandler,
 ) -> None:
     """It should load pipette data, check attachment, and generate an ID."""
+    pipette_dict = cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+
     decoy.when(state_store.config.use_virtual_pipettes).then_return(False)
     decoy.when(model_utils.generate_id()).then_return("unique-id")
-
     decoy.when(hardware_api.get_attached_instrument(mount=HwMount.LEFT)).then_return(
-        cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+        pipette_dict
     )
-
     decoy.when(
-        pipette_data_provider.get_pipette_static_config("hello", "world")  # type: ignore[arg-type]
+        pipette_data_provider.get_pipette_static_config(pipette_dict)
     ).then_return(loaded_static_pipette_data)
 
     decoy.when(hardware_api.get_instrument_max_height(mount=HwMount.LEFT)).then_return(
@@ -592,13 +594,14 @@ async def test_load_pipette_uses_provided_id(
     subject: EquipmentHandler,
 ) -> None:
     """It should use the provided ID rather than generating an ID for the pipette."""
+    pipette_dict = cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+
     decoy.when(state_store.config.use_virtual_pipettes).then_return(False)
     decoy.when(hardware_api.get_attached_instrument(mount=HwMount.LEFT)).then_return(
-        cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+        pipette_dict
     )
-
     decoy.when(
-        pipette_data_provider.get_pipette_static_config("hello", "world")  # type: ignore[arg-type]
+        pipette_data_provider.get_pipette_static_config(pipette_dict)
     ).then_return(loaded_static_pipette_data)
 
     result = await subject.load_pipette(

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -1,6 +1,7 @@
 """Test pipette data provider."""
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
 
+from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_engine.types import FlowRates
 from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
@@ -42,26 +43,63 @@ def test_get_virtual_pipette_static_config() -> None:
 
 
 def test_get_pipette_static_config() -> None:
-    """It should return config data given a pipette model and serial."""
-    result = subject.get_pipette_static_config("p1000_multi_v3.1", "abc-123")  # type: ignore[arg-type]
+    """It should return config data given a PipetteDict."""
+    pipette_dict: PipetteDict = {
+        "name": "p300_single_gen2",
+        "min_volume": 20,
+        "max_volume": 300,
+        "channels": 1,
+        "aspirate_flow_rate": 46.43,
+        "dispense_flow_rate": 46.43,
+        "pipette_id": "P3HSV202020060308",
+        "current_volume": 0.0,
+        "display_name": "P300 Single-Channel GEN2",
+        "tip_length": 0.0,
+        "model": PipetteModel("p300_single_v2.0"),
+        "blow_out_flow_rate": 46.43,
+        "working_volume": 300,
+        "tip_overlap": {
+            "default": 8.2,
+            "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
+            "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2,
+        },
+        "available_volume": 300.0,
+        "return_tip_height": 0.5,
+        "default_aspirate_flow_rates": {"2.0": 46.43, "2.1": 92.86},
+        "default_blow_out_flow_rates": {"2.0": 46.43, "2.2": 92.86},
+        "default_dispense_flow_rates": {"2.0": 46.43, "2.3": 92.86},
+        "back_compat_names": ["p300_single"],
+        "has_tip": False,
+        "aspirate_speed": 5.021202,
+        "dispense_speed": 5.021202,
+        "blow_out_speed": 5.021202,
+        "ready_to_aspirate": False,
+        "default_blow_out_speeds": {"2.0": 5.021202, "2.6": 10.042404},
+        "default_dispense_speeds": {"2.0": 5.021202, "2.6": 10.042404},
+        "default_aspirate_speeds": {"2.0": 5.021202, "2.6": 10.042404},
+    }
+
+    result = subject.get_pipette_static_config(pipette_dict)
 
     assert result == LoadedStaticPipetteData(
-        model="p1000_multi_v3.1",
-        display_name="P1000 8-Channel GEN3",
-        min_volume=1,
-        max_volume=1000.0,
-        channels=8,
-        nozzle_offset_z=-259.15,
-        home_position=230.15,
+        model="p300_single_v2.0",
+        display_name="P300 Single-Channel GEN2",
+        min_volume=20,
+        max_volume=300,
+        channels=1,
         flow_rates=FlowRates(
-            default_aspirate={"2.0": 159.04, "2.6": 159.04},
-            default_dispense={"2.0": 159.04},
-            default_blow_out={"2.0": 78.52},
+            default_aspirate={"2.0": 46.43, "2.1": 92.86},
+            default_dispense={"2.0": 46.43, "2.3": 92.86},
+            default_blow_out={"2.0": 46.43, "2.2": 92.86},
         ),
-        return_tip_scale=0.83,
+        return_tip_scale=0.5,
         nominal_tip_overlap={
-            "default": 10.5,
-            "opentrons/opentrons_ot3_96_tiprack_1000ul/1": 10.5,
-            "opentrons/opentrons_ot3_96_tiprack_200ul/1": 10.5,
+            "default": 8.2,
+            "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
+            "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2,
         },
+        # TODO(mc, 2023-02-28): these two values are not present in PipetteDict
+        # https://opentrons.atlassian.net/browse/RCORE-655
+        nozzle_offset_z=0,
+        home_position=0,
     )

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -6,6 +6,7 @@ from typing import cast
 import pytest
 from decoy import matchers, Decoy
 
+from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.commands.types import CommentMessage, PauseMessage, CommandMessage
 from opentrons.protocol_engine import (
     DeckSlotLocation,
@@ -35,7 +36,7 @@ from opentrons.protocol_runner.legacy_wrappers import (
 )
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
-from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
+from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import DeckSlotName, Mount, MountType
 
 
@@ -291,19 +292,16 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
 
 def test_map_instrument_load(decoy: Decoy) -> None:
     """It should correctly map an instrument load."""
+    pipette_dict = cast(PipetteDict, {"pipette_id": "fizzbuzz"})
     input = LegacyInstrumentLoadInfo(
         instrument_load_name="p1000_single_gen2",
         mount=Mount.LEFT,
-        model=PipetteModel("foobar"),
-        serial_number="fizzbuzz",
+        pipette_dict=pipette_dict,
     )
     pipette_config = cast(LoadedStaticPipetteData, {"config": True})
 
     decoy.when(
-        pipette_data_provider.get_pipette_static_config(
-            model=PipetteModel("foobar"),
-            serial_number="fizzbuzz",
-        )
+        pipette_data_provider.get_pipette_static_config(pipette_dict)
     ).then_return(pipette_config)
 
     result = LegacyCommandMapper().map_equipment_load(input)


### PR DESCRIPTION
## Overview

Fixes RCORE-662. This implementation avoids double-loading of pipette config when a real or simulating Hardware API is in play.

Two fields necessary for virtual pipette handling are not yet present in PipetteDict. This issue to be resolved in some way by RCORE-655, but due to how this logic works, the lack of proper fields in state when using a Hardware API instance should not matter.

## Test Plan

Ensure protocols using various OT-3 pipettes are able to properly analyze and run on the device, which is currently broken for some pipettes on `edge`.

## Risk assessment

Low, TODOs in PR are important to address for OT-3 but pose limited production risk for the OT-2