### PR TITLE
feat(shared-data): change Opentrons Flex pipette displayNames

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -545,7 +545,7 @@ describe('PipetteWizardFlows', () => {
       },
     ])
     const { getByText, getByRole } = render(props)
-    getByText('Detach P1000 Single-Channel GEN3 and Attach 96-Channel Pipette')
+    getByText('Detach Flex 1-Channel 1000 μL and Attach 96-Channel Pipette')
     getByText('Before you begin')
     // page 1
     const getStarted = getByRole('button', { name: 'Move gantry to front' })

--- a/shared-data/pipette/definitions/1/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteNameSpecs.json
@@ -457,7 +457,7 @@
     ]
   },
   "p50_single_gen3": {
-    "displayName": "P50 Single-Channel GEN3",
+    "displayName": "Flex 1-Channel 50 μL",
     "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 7.85,
@@ -497,7 +497,7 @@
     ]
   },
   "p1000_single_gen3": {
-    "displayName": "P1000 Single-Channel GEN3",
+    "displayName": "Flex 1-Channel 1000 μL",
     "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 137.35,
@@ -541,7 +541,7 @@
     ]
   },
   "p1000_multi_gen3": {
-    "displayName": "P1000 8-Channel GEN3",
+    "displayName": "Flex 8-Channel 1000 μL",
     "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 159.04,
@@ -583,7 +583,7 @@
     ]
   },
   "p50_multi_gen3": {
-    "displayName": "P50 8-Channel GEN3",
+    "displayName": "Flex 8-Channel 50 μL",
     "displayCategory": "GEN3",
     "defaultAspirateFlowRate": {
       "value": 7.85,
@@ -623,7 +623,7 @@
     ]
   },
   "p1000_96": {
-    "displayName": "P1000 96-Channel GEN1",
+    "displayName": "Flex 96-Channel 1000 μL",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
       "value": 7.85,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 Eight Channel GEN3",
+  "displayName": "Flex 8-Channel 1000 μL",
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 Eight Channel GEN3",
+  "displayName": "Flex 8-Channel 1000 μL",
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P50 Eight Channel GEN3",
+  "displayName": "Flex 8-Channel 50 μL",
   "model": "p50",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P50 Eight Channel GEN3",
+  "displayName": "Flex 8-Channel 50 μL",
   "model": "p50",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 96 Channel GEN3",
+  "displayName": "Flex 96-Channel 1000 μL",
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 96 Channel GEN3",
+  "displayName": "Flex 96-Channel 1000 μL",
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 One Channel GEN3",
+  "displayName": "Flex 1-Channel 1000 μL",
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 One Channel GEN3",
+  "displayName": "Flex 1-Channel 1000 μL",
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P50 One Channel GEN3",
+  "displayName": "Flex 1-Channel 50 μL",
   "model": "p50",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -1,6 +1,6 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P50 One Channel GEN3",
+  "displayName": "Flex 1-Channel 50 μL",
   "model": "p50",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {


### PR DESCRIPTION
closes RLIQ-228

# Overview

change the Opentrons Flex pipette `displayName`s to match the short alternative names mentioned in the confluence doc in the ticket.

# Test Plan

- just ensure that any broken test as a result from this change is fixed and that everything looks good

# Changelog

- update all Opentrons Flex pipette `displayName`s in `pipetteNameSpecs` and in schema v2 `shared-data/pipette/definitions/2/general/`
- fix affected tests

# Review requests

- review `pipetteNameSpecs` and schema v2 changes

# Risk assessment

low