### PR TITLE
fix(protocol-designer): disallow 2 modules in same slot & allow easier color picker

### DIFF
--- a/protocol-designer/src/components/ColorPicker/index.tsx
+++ b/protocol-designer/src/components/ColorPicker/index.tsx
@@ -29,10 +29,7 @@ export function ColorPicker(props: ColorPickerProps): JSX.Element {
         />
       </div>
       {showColorPicker ? (
-        <div
-          className={styles.popover}
-          onBlur={() => setShowColorPicker(false)}
-        >
+        <div className={styles.popover}>
           <div
             className={styles.cover}
             onClick={() => setShowColorPicker(false)}

--- a/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
@@ -149,7 +149,10 @@ export function LiquidEditForm(props: Props): JSX.Element {
               <PrimaryButton onClick={cancelForm}>
                 {i18n.t('button.cancel')}
               </PrimaryButton>
-              <PrimaryButton disabled={!dirty} type="submit">
+              <PrimaryButton
+                disabled={!dirty || errors.name != null}
+                type="submit"
+              >
                 {i18n.t('button.save')}
               </PrimaryButton>
             </div>

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -126,7 +126,10 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
         'alert.module_placement.HEATER_SHAKER_ADJACENT_TO_MODULE.body',
         { selectedSlot }
       )
-    } else if (moduleOnDeck?.type === HEATERSHAKER_MODULE_TYPE) {
+    } else if (
+      moduleOnDeck?.type === HEATERSHAKER_MODULE_TYPE &&
+      !hasSlotIssue(selectedSlot)
+    ) {
       const isHeaterShakerAdjacentToAnotherModule = some(
         initialDeckSetup.modules,
         hwModule =>
@@ -230,7 +233,6 @@ const EditModulesModalComponent = (
       {i18n.t('tooltip.edit_module_modal.slot_selection')}
     </div>
   )
-
   const showSlotOption = moduleType !== THERMOCYCLER_MODULE_TYPE
   // NOTE: selectedSlot error could either be required field (though the field is auto-populated)
   // or occupied slot error. `slotIssue` is only for occupied slot error.

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -233,6 +233,7 @@ const EditModulesModalComponent = (
       {i18n.t('tooltip.edit_module_modal.slot_selection')}
     </div>
   )
+
   const showSlotOption = moduleType !== THERMOCYCLER_MODULE_TYPE
   // NOTE: selectedSlot error could either be required field (though the field is auto-populated)
   // or occupied slot error. `slotIssue` is only for occupied slot error.


### PR DESCRIPTION
closes RQA-523 and RQA-521

# Overview

This fixes 2 PD bugs:

1. color picker bug outlined in ticket 523: now you can select different colors without the color picker modal closing
2. H-S on top of TC bug outlined in ticket 521: now you should not be allowed to place the H-S on top of the TC in the edit modules modal when creating a new protocol.

# Test Plan

H-S on top of TC bug steps:
- create new protocol, in the `Create New Protocol` modal, add a H-S and a Thermocycler
- click save
- click `edit` for H-S placement, selection positions `slot 7` and `slot 10` should now show an error warning

Color picker bug steps:
- add a new liquid
- in the color picker box you should be able to click through the different preselected colors without the box closing after each selection. Adding a color should retain full functionality otherwise.

# Changelog

- remove `onBlur` in `ColorPicker` and add on to the disabled reason in `LiquidEditForm` (this fixes another bug I found where the `save` button was no longer disabled after selecting a different color but not adding a liquid name which is required)
- fix H-S logic in `EditModulesModal`. previously, the H-S module was never hitting the `hasSlotIssue(selectedSlot)` if statement.

# Review requests

- is the way i fixed the H-S logic clean and easy to read?

# Risk assessment

low