### PR TITLE
refactor(hardware): add BaselineSensorResponse for polling

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -165,6 +165,7 @@ class MessageId(int, Enum):
     bind_sensor_output_response = 0x8B
     peripheral_status_request = 0x8C
     peripheral_status_response = 0x8D
+    baseline_sensor_response = 0x8E
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -508,6 +508,17 @@ class BaselineSensorRequest(BaseMessage):  # noqa: D101
 
 
 @dataclass
+class BaselineSensorResponse(BaseMessage):  # noqa: D101
+    payload: payloads.BaselineSensorResponsePayload
+    payload_type: Type[
+        payloads.BaselineSensorResponsePayload
+    ] = payloads.BaselineSensorResponsePayload
+    message_id: Literal[
+        MessageId.baseline_sensor_response
+    ] = MessageId.baseline_sensor_response
+
+
+@dataclass
 class ReadFromSensorResponse(BaseMessage):  # noqa: D101
     payload: payloads.ReadFromSensorResponsePayload
     payload_type: Type[

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -66,6 +66,7 @@ MessageDefinition = Union[
     defs.ReadFromSensorRequest,
     defs.WriteToSensorRequest,
     defs.BaselineSensorRequest,
+    defs.BaselineSensorResponse,
     defs.SetSensorThresholdRequest,
     defs.ReadFromSensorResponse,
     defs.SensorThresholdResponse,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -400,7 +400,8 @@ class WriteToSensorRequestPayload(SensorPayload):
 class BaselineSensorRequestPayload(SensorPayload):
     """Take a specified amount of readings from a sensor request payload."""
 
-    sample_rate: utils.UInt16Field
+    number_of_reads: utils.UInt16Field
+    report: utils.UInt8Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -403,7 +403,7 @@ class BaselineSensorRequestPayload(SensorPayload):
     sample_rate: utils.UInt16Field
 
 
-@dataclass
+@dataclass(eq=False)
 class BaselineSensorResponsePayload(SensorPayload):
     """A response containing an averaged offset reading from a sensor."""
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -403,6 +403,13 @@ class BaselineSensorRequestPayload(SensorPayload):
     sample_rate: utils.UInt16Field
 
 
+@dataclass
+class BaselineSensorResponsePayload(SensorPayload):
+    """A response containing an averaged offset reading from a sensor."""
+
+    offset_average: utils.Int32Field
+
+
 @dataclass(eq=False)
 class ReadFromSensorResponsePayload(SensorPayload):
     """A response for either a single reading or an averaged reading of a sensor."""

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -398,10 +398,9 @@ class WriteToSensorRequestPayload(SensorPayload):
 
 @dataclass(eq=False)
 class BaselineSensorRequestPayload(SensorPayload):
-    """Take a specified amount of readings from a sensor request payload."""
+    """Provide a specified amount of readings to take the average of the current sensor."""
 
     number_of_reads: utils.UInt16Field
-    report: utils.UInt8Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -110,6 +110,7 @@ class SensorScheduler:
         can_messenger: CanMessenger,
         timeout: int,
         expected_num_messages: int = 1,
+        report: bool = True,
     ) -> List[SensorDataType]:
         """Send poll message."""
         sensor_info = sensor.sensor
@@ -125,7 +126,8 @@ class SensorScheduler:
                     payload=BaselineSensorRequestPayload(
                         sensor=SensorTypeField(sensor_info.sensor_type),
                         sensor_id=SensorIdField(sensor_info.sensor_id),
-                        sample_rate=UInt16Field(sensor.poll_for),
+                        number_of_reads=UInt16Field(sensor.poll_for),
+                        report=UInt8Field(report),
                     )
                 ),
             )

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -73,11 +73,11 @@ def _format_sensor_response(response: MessageDefinition) -> SensorDataType:
         return SensorDataType.build(
             response.payload.offset_average, response.payload.sensor
         )
-    elif isinstance(response, ReadFromSensorResponse):
+    else:
+        assert isinstance(response, ReadFromSensorResponse)
         return SensorDataType.build(
             response.payload.sensor_data, response.payload.sensor
         )
-    return None
 
 
 class SensorScheduler:
@@ -125,7 +125,7 @@ class SensorScheduler:
                     payload=BaselineSensorRequestPayload(
                         sensor=SensorTypeField(sensor_info.sensor_type),
                         sensor_id=SensorIdField(sensor_info.sensor_id),
-                        number_of_reads=UInt16Field(sensor.number_of_reads)
+                        number_of_reads=UInt16Field(sensor.number_of_reads),
                     )
                 ),
             )

--- a/hardware/opentrons_hardware/sensors/sensor_abc.py
+++ b/hardware/opentrons_hardware/sensors/sensor_abc.py
@@ -52,7 +52,7 @@ class AbstractSensorDriver(ABC):
         self,
         can_messenger: CanMessenger,
         sensor: BaseSensorType,
-        poll_for_ms: int,
+        number_of_reads: int,
         timeout: int = 1,
     ) -> Optional[SensorReturnType]:
         """Poll the sensor for data."""

--- a/hardware/opentrons_hardware/sensors/sensor_driver.py
+++ b/hardware/opentrons_hardware/sensors/sensor_driver.py
@@ -90,7 +90,9 @@ class SensorDriver(AbstractSensorDriver):
     ) -> Optional[SensorReturnType]:
         """Poll the given sensor."""
         poll = PollSensorInformation(sensor.sensor, poll_for_ms)
-        sensor_data = await self._scheduler.run_poll(poll, can_messenger, timeout)
+        sensor_data = await self._scheduler.run_poll(
+            poll, can_messenger, timeout, sensor.expected_responses
+        )
         if not sensor_data:
             return None
         return sensor.set_sensor_data(sensor_data)

--- a/hardware/opentrons_hardware/sensors/sensor_driver.py
+++ b/hardware/opentrons_hardware/sensors/sensor_driver.py
@@ -85,13 +85,14 @@ class SensorDriver(AbstractSensorDriver):
         self,
         can_messenger: CanMessenger,
         sensor: BaseSensorType,
-        poll_for_ms: int,
+        number_of_reads: int,
         timeout: int = 1,
+        report: bool = True,
     ) -> Optional[SensorReturnType]:
         """Poll the given sensor."""
-        poll = PollSensorInformation(sensor.sensor, poll_for_ms)
+        poll = PollSensorInformation(sensor.sensor, number_of_reads)
         sensor_data = await self._scheduler.run_poll(
-            poll, can_messenger, timeout, sensor.expected_responses
+            poll, can_messenger, timeout, sensor.expected_responses, report
         )
         if not sensor_data:
             return None

--- a/hardware/opentrons_hardware/sensors/sensor_driver.py
+++ b/hardware/opentrons_hardware/sensors/sensor_driver.py
@@ -90,9 +90,7 @@ class SensorDriver(AbstractSensorDriver):
     ) -> Optional[SensorReturnType]:
         """Poll the given sensor."""
         poll = PollSensorInformation(sensor.sensor, poll_for_ms)
-        sensor_data = await self._scheduler.run_poll(
-            poll, can_messenger, timeout, sensor.expected_responses
-        )
+        sensor_data = await self._scheduler.run_poll(poll, can_messenger, timeout)
         if not sensor_data:
             return None
         return sensor.set_sensor_data(sensor_data)
@@ -260,4 +258,4 @@ class LogListener:
             ).to_float()
             self.response_queue.put_nowait(data)
             current_time = round((time.time() - self.start_time), 3)
-            self.csv_writer.writerow([data, current_time])  # type: ignore
+            self.csv_writer.writerow([current_time, data])  # type: ignore

--- a/hardware/opentrons_hardware/sensors/sensor_driver.py
+++ b/hardware/opentrons_hardware/sensors/sensor_driver.py
@@ -87,12 +87,11 @@ class SensorDriver(AbstractSensorDriver):
         sensor: BaseSensorType,
         number_of_reads: int,
         timeout: int = 1,
-        report: bool = True,
     ) -> Optional[SensorReturnType]:
         """Poll the given sensor."""
         poll = PollSensorInformation(sensor.sensor, number_of_reads)
-        sensor_data = await self._scheduler.run_poll(
-            poll, can_messenger, timeout, sensor.expected_responses, report
+        sensor_data = await self._scheduler.run_baseline(
+            poll, can_messenger, timeout, sensor.expected_responses
         )
         if not sensor_data:
             return None

--- a/hardware/opentrons_hardware/sensors/sensor_driver.py
+++ b/hardware/opentrons_hardware/sensors/sensor_driver.py
@@ -26,7 +26,7 @@ from opentrons_hardware.sensors.types import (
 )
 from opentrons_hardware.sensors.utils import (
     ReadSensorInformation,
-    PollSensorInformation,
+    BaselineSensorInformation,
     WriteSensorInformation,
     SensorThresholdInformation,
 )
@@ -89,7 +89,7 @@ class SensorDriver(AbstractSensorDriver):
         timeout: int = 1,
     ) -> Optional[SensorReturnType]:
         """Poll the given sensor."""
-        poll = PollSensorInformation(sensor.sensor, number_of_reads)
+        poll = BaselineSensorInformation(sensor.sensor, number_of_reads)
         sensor_data = await self._scheduler.run_baseline(
             poll, can_messenger, timeout, sensor.expected_responses
         )

--- a/hardware/opentrons_hardware/sensors/utils.py
+++ b/hardware/opentrons_hardware/sensors/utils.py
@@ -35,9 +35,9 @@ class ReadSensorInformation:
 
 
 @dataclass
-class PollSensorInformation:
+class BaselineSensorInformation:
     """Poll sensor information."""
 
     sensor: SensorInformation
-    poll_for: int
+    number_of_reads: int
     offset: bool = False

--- a/hardware/tests/firmware_integration/test_sensors.py
+++ b/hardware/tests/firmware_integration/test_sensors.py
@@ -147,7 +147,8 @@ async def test_baseline_poll_environment(
         payload=BaselineSensorRequestPayload(
             sensor=SensorTypeField(sensor_type),
             sensor_id=SensorIdField(SensorId.S0),
-            sample_rate=UInt16Field(5),
+            number_of_reads=UInt16Field(5),
+            report=UInt8Field(1),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=poll_sensor)
@@ -204,7 +205,8 @@ async def test_baseline_poll_capacitance(
         payload=BaselineSensorRequestPayload(
             sensor=SensorTypeField(sensor_type),
             sensor_id=SensorIdField(SensorId.S0),
-            sample_rate=UInt16Field(5),
+            number_of_reads=UInt16Field(5),
+            report=UInt8Field(1),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=poll_sensor)
@@ -241,7 +243,8 @@ async def test_baseline_poll_pressure(
         payload=BaselineSensorRequestPayload(
             sensor=SensorTypeField(sensor_type),
             sensor_id=SensorIdField(SensorId.S0),
-            sample_rate=UInt16Field(5),
+            number_of_reads=UInt16Field(5),
+            report=UInt8Field(1),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=poll_sensor)

--- a/hardware/tests/firmware_integration/test_sensors.py
+++ b/hardware/tests/firmware_integration/test_sensors.py
@@ -148,7 +148,6 @@ async def test_baseline_poll_environment(
             sensor=SensorTypeField(sensor_type),
             sensor_id=SensorIdField(SensorId.S0),
             number_of_reads=UInt16Field(5),
-            report=UInt8Field(1),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=poll_sensor)
@@ -206,7 +205,6 @@ async def test_baseline_poll_capacitance(
             sensor=SensorTypeField(sensor_type),
             sensor_id=SensorIdField(SensorId.S0),
             number_of_reads=UInt16Field(5),
-            report=UInt8Field(1),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=poll_sensor)
@@ -244,7 +242,6 @@ async def test_baseline_poll_pressure(
             sensor=SensorTypeField(sensor_type),
             sensor_id=SensorIdField(SensorId.S0),
             number_of_reads=UInt16Field(5),
-            report=UInt8Field(1),
         )
     )
     await can_messenger.send(node_id=NodeId.pipette_left, message=poll_sensor)

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -94,7 +94,8 @@ def sensor_driver() -> SensorDriver:
                 payload=BaselineSensorRequestPayload(
                     sensor=SensorTypeField(SensorType.pressure),
                     sensor_id=SensorIdField(SensorId.S0),
-                    sample_rate=UInt16Field(10),
+                    number_of_reads=UInt16Field(10),
+                    report=UInt8Field(1),
                 )
             ),
         ],
@@ -104,7 +105,8 @@ def sensor_driver() -> SensorDriver:
                 payload=BaselineSensorRequestPayload(
                     sensor=SensorTypeField(SensorType.capacitive),
                     sensor_id=SensorIdField(SensorId.S0),
-                    sample_rate=UInt16Field(10),
+                    number_of_reads=UInt16Field(10),
+                    report=UInt8Field(1),
                 )
             ),
         ],

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -31,6 +31,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     BindSensorOutputRequest,
     PeripheralStatusRequest,
     PeripheralStatusResponse,
+    BaselineSensorResponse,
 )
 from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.payloads import (
@@ -41,6 +42,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
     SensorThresholdResponsePayload,
     BindSensorOutputRequestPayload,
     PeripheralStatusResponsePayload,
+    BaselineSensorResponsePayload,
 )
 from opentrons_hardware.firmware_bindings.messages.fields import (
     SensorTypeField,
@@ -505,7 +507,7 @@ async def test_get_baseline(
     """Test for get_baseline.
 
     Tests that a BaselineSensorRequest gets sent,
-    and reads ReadFromSensorResponse message containing the
+    and reads BaselineSensorResponse message containing the
     correct information.
     """
 
@@ -514,16 +516,16 @@ async def test_get_baseline(
         if isinstance(message, BaselineSensorRequest):
             if sensor_type.sensor.sensor_type == SensorType.environment:
                 can_message_notifier.notify(
-                    ReadFromSensorResponse(
-                        payload=ReadFromSensorResponsePayload(
-                            sensor_data=Int32Field(50),
+                    BaselineSensorResponse(
+                        payload=BaselineSensorResponsePayload(
+                            offset_average=Int32Field(50),
                             sensor_id=SensorIdField(SensorId.S0),
                             sensor=SensorTypeField(SensorType.humidity),
                         )
                     ),
                     ArbitrationId(
                         parts=ArbitrationIdParts(
-                            message_id=ReadFromSensorResponse.message_id,
+                            message_id=BaselineSensorResponse.message_id,
                             node_id=NodeId.host,
                             function_code=0,
                             originating_node_id=node_id,
@@ -531,16 +533,16 @@ async def test_get_baseline(
                     ),
                 )
                 can_message_notifier.notify(
-                    ReadFromSensorResponse(
-                        payload=ReadFromSensorResponsePayload(
-                            sensor_data=Int32Field(50),
+                    BaselineSensorResponse(
+                        payload=BaselineSensorResponsePayload(
+                            offset_average=Int32Field(50),
                             sensor_id=SensorIdField(SensorId.S0),
                             sensor=SensorTypeField(SensorType.temperature),
                         )
                     ),
                     ArbitrationId(
                         parts=ArbitrationIdParts(
-                            message_id=ReadFromSensorResponse.message_id,
+                            message_id=BaselineSensorResponse.message_id,
                             node_id=NodeId.host,
                             function_code=0,
                             originating_node_id=node_id,
@@ -549,16 +551,16 @@ async def test_get_baseline(
                 )
             else:
                 can_message_notifier.notify(
-                    ReadFromSensorResponse(
-                        payload=ReadFromSensorResponsePayload(
+                    BaselineSensorResponse(
+                        payload=BaselineSensorResponsePayload(
                             sensor=SensorTypeField(sensor_type.sensor.sensor_type),
                             sensor_id=SensorIdField(SensorId.S0),
-                            sensor_data=Int32Field(50),
+                            offset_average=Int32Field(50),
                         )
                     ),
                     ArbitrationId(
                         parts=ArbitrationIdParts(
-                            message_id=ReadFromSensorResponse.message_id,
+                            message_id=BaselineSensorResponse.message_id,
                             node_id=node_id,
                             function_code=0,
                             originating_node_id=node_id,

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -23,6 +23,7 @@ from opentrons_hardware.firmware_bindings.utils import (
 
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     BaselineSensorRequest,
+    BaselineSensorResponse,
     ReadFromSensorRequest,
     SetSensorThresholdRequest,
     WriteToSensorRequest,
@@ -31,7 +32,6 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     BindSensorOutputRequest,
     PeripheralStatusRequest,
     PeripheralStatusResponse,
-    BaselineSensorResponse,
 )
 from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
 from opentrons_hardware.firmware_bindings.messages.payloads import (

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -141,16 +141,16 @@ async def test_receive_data_polling(
         """Message responder."""
         if sensor_type.sensor.sensor_type == SensorType.environment:
             can_message_notifier.notify(
-                ReadFromSensorResponse(
-                    payload=ReadFromSensorResponsePayload(
-                        sensor_data=Int32Field(256),
+                BaselineSensorResponse(
+                    payload=BaselineSensorResponsePayload(
+                        offset_average=Int32Field(256),
                         sensor_id=SensorIdField(SensorId.S0),
                         sensor=SensorTypeField(SensorType.humidity),
                     )
                 ),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
-                        message_id=ReadFromSensorResponse.message_id,
+                        message_id=BaselineSensorResponse.message_id,
                         node_id=NodeId.host,
                         function_code=0,
                         originating_node_id=node_id,
@@ -158,16 +158,16 @@ async def test_receive_data_polling(
                 ),
             )
             can_message_notifier.notify(
-                ReadFromSensorResponse(
-                    payload=ReadFromSensorResponsePayload(
-                        sensor_data=Int32Field(256),
+                BaselineSensorResponse(
+                    payload=BaselineSensorResponsePayload(
+                        offset_average=Int32Field(256),
                         sensor_id=SensorIdField(SensorId.S0),
                         sensor=SensorTypeField(SensorType.temperature),
                     )
                 ),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
-                        message_id=ReadFromSensorResponse.message_id,
+                        message_id=BaselineSensorResponse.message_id,
                         node_id=NodeId.host,
                         function_code=0,
                         originating_node_id=node_id,
@@ -176,16 +176,16 @@ async def test_receive_data_polling(
             )
         else:
             can_message_notifier.notify(
-                ReadFromSensorResponse(
-                    payload=ReadFromSensorResponsePayload(
-                        sensor_data=Int32Field(256),
+                BaselineSensorResponse(
+                    payload=BaselineSensorResponsePayload(
+                        offset_average=Int32Field(256),
                         sensor_id=SensorIdField(SensorId.S0),
                         sensor=SensorTypeField(sensor_type.sensor.sensor_type),
                     )
                 ),
                 ArbitrationId(
                     parts=ArbitrationIdParts(
-                        message_id=ReadFromSensorResponse.message_id,
+                        message_id=BaselineSensorResponse.message_id,
                         node_id=NodeId.host,
                         function_code=0,
                         originating_node_id=node_id,

--- a/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_sensor_drivers.py
@@ -95,7 +95,6 @@ def sensor_driver() -> SensorDriver:
                     sensor=SensorTypeField(SensorType.pressure),
                     sensor_id=SensorIdField(SensorId.S0),
                     number_of_reads=UInt16Field(10),
-                    report=UInt8Field(1),
                 )
             ),
         ],
@@ -106,7 +105,6 @@ def sensor_driver() -> SensorDriver:
                     sensor=SensorTypeField(SensorType.capacitive),
                     sensor_id=SensorIdField(SensorId.S0),
                     number_of_reads=UInt16Field(10),
-                    report=UInt8Field(1),
                 )
             ),
         ],
@@ -131,7 +129,7 @@ async def test_polling(
         [lazy_fixture("environment_sensor")],
     ],
 )
-async def test_receive_data_polling(
+async def test_baseline_averaging(
     sensor_driver: SensorDriver,
     sensor_type: BaseSensorType,
     mock_messenger: mock.AsyncMock,


### PR DESCRIPTION
Currently, after a `BaselineSensorRequest` is sent from Python, the CAN bus is populated with as many `ReadFromSensorResponse` messages as readings requested in the `sample_rate` parameter. 

This pr adds a `BaselineSensorResponse` to replace the `ReadFromSensorResponse` feed with a single message.