### PR TITLE
refactor(app): scroll to current split from jump to tick, qol tweaks to run preview

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -85,7 +85,7 @@
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "download_run_log": "Download run log",
   "downloading_run_log": "Downloading run log",
-  "jump_to_current_step": "Jump to current step",
+  "view_current_step": "View current step",
   "run_has_diverged_from_predicted": "Run has diverged from predicted state. Cannot anticipate new steps.",
   "unable_to_determine_steps": "Unable to determine steps",
   "robot_has_previous_offsets": "This robot has stored Labware Offset data from previous protocol runs. Do you want to apply that data to this protocol run? You can still adjust any offsets with Labware Position Check.",

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -43,9 +43,9 @@ export const RunPreviewComponent = (
     setIsCurrentCommandVisible,
   ] = React.useState<boolean>(true)
   if (robotSideAnalysis == null) return null
-  const currentRunCommandIndex =
-    robotSideAnalysis.commands.findIndex(c => c.key === currentRunCommandKey) ??
-    0
+  const currentRunCommandIndex = robotSideAnalysis.commands.findIndex(
+    c => c.key === currentRunCommandKey
+  )
 
   return (
     <Flex

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -80,7 +80,7 @@ export const RunPreviewComponent = (
           if (currentRunCommandIndex >= 0) {
             setIsCurrentCommandVisible(
               currentRunCommandIndex >= lowestVisibleIndex &&
-              currentRunCommandIndex <= highestVisibleIndex
+                currentRunCommandIndex <= highestVisibleIndex
             )
           }
         }}
@@ -111,8 +111,9 @@ export const RunPreviewComponent = (
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={SPACING.spacing2}
                 width="100%"
-                border={`solid 1px ${index === jumpedIndex ? COLORS.warningEnabled : borderColor
-                  }`}
+                border={`solid 1px ${
+                  index === jumpedIndex ? COLORS.warningEnabled : borderColor
+                }`}
                 backgroundColor={
                   index === jumpedIndex
                     ? COLORS.warningBackgroundLight

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -11,9 +11,7 @@ import {
   TYPOGRAPHY,
   BORDERS,
   COLORS,
-  Icon,
   POSITION_FIXED,
-  SIZE_1,
 } from '@opentrons/components'
 import { ViewportList, ViewportListRef } from 'react-viewport-list'
 import { PrimaryButton } from '../../atoms/buttons'
@@ -30,22 +28,20 @@ const COLOR_FADE_MS = 500
 interface RunPreviewProps {
   runId: string
   jumpedIndex: number | null
-  makeHandleJumpToStep: (index: number) => () => void
+  makeHandleScrollToStep: (index: number) => () => void
 }
 export const RunPreviewComponent = (
-  { runId, jumpedIndex, makeHandleJumpToStep }: RunPreviewProps,
+  { runId, jumpedIndex, makeHandleScrollToStep }: RunPreviewProps,
   ref: React.ForwardedRef<ViewportListRef>
 ): JSX.Element | null => {
   const { t } = useTranslation('run_details')
   const robotSideAnalysis = useMostRecentCompletedAnalysis(runId)
   const viewPortRef = React.useRef<HTMLDivElement | null>(null)
   const currentRunCommandKey = useLastRunCommandKey(runId)
-  // -1 -> current earlier than visible commands
-  //  0 -> current within visible commands
-  //  1 -> current later than visible commands
-  const [currentCommandDirection, setCurrentCommandDirection] = React.useState<
-    -1 | 0 | 1
-  >(0)
+  const [
+    isCurrentCommandVisible,
+    setIsCurrentCommandVisible,
+  ] = React.useState<boolean>(true)
   if (robotSideAnalysis == null) return null
   const currentRunCommandIndex =
     robotSideAnalysis.commands.findIndex(c => c.key === currentRunCommandKey) ??
@@ -77,61 +73,71 @@ export const RunPreviewComponent = (
         viewportRef={viewPortRef}
         ref={ref}
         items={robotSideAnalysis.commands}
-        onViewportIndexesChange={visibleIndices => {
+        onViewportIndexesChange={([
+          lowestVisibleIndex,
+          highestVisibleIndex,
+        ]) => {
           if (currentRunCommandIndex >= 0) {
-            if (visibleIndices[0] > currentRunCommandIndex) {
-              setCurrentCommandDirection(-1)
-            } else if (visibleIndices[1] > currentRunCommandIndex) {
-              setCurrentCommandDirection(0)
-            } else {
-              setCurrentCommandDirection(1)
-            }
+            setIsCurrentCommandVisible(
+              currentRunCommandIndex >= lowestVisibleIndex &&
+                currentRunCommandIndex <= highestVisibleIndex
+            )
           }
         }}
         initialIndex={currentRunCommandIndex}
       >
-        {(command, index) => (
-          <Flex
-            key={command.id}
-            alignItems={ALIGN_CENTER}
-            gridGap={SPACING.spacing3}
-          >
-            <StyledText
-              minWidth={SPACING.spacing4}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-            >
-              {index + 1}
-            </StyledText>
+        {(command, index) => {
+          const borderColor =
+            index === currentRunCommandIndex
+              ? COLORS.blueEnabled
+              : COLORS.transparent
+          const backgroundColor =
+            index === currentRunCommandIndex
+              ? COLORS.lightBlue
+              : COLORS.fundamentalsBackground
+          return (
             <Flex
-              flexDirection={DIRECTION_COLUMN}
-              gridGap={SPACING.spacing2}
-              width="100%"
-              border={`solid 1px ${
-                index === jumpedIndex ? COLORS.blueEnabled : COLORS.transparent
-              }`}
-              backgroundColor={
-                index === jumpedIndex
-                  ? COLORS.lightBlue
-                  : COLORS.fundamentalsBackground
-              }
-              color={COLORS.darkBlackEnabled}
-              borderRadius={BORDERS.radiusSoftCorners}
-              padding={SPACING.spacing3}
-              css={css`
-                transition: background-color ${COLOR_FADE_MS}ms ease-out,
-                  border-color ${COLOR_FADE_MS}ms ease-out;
-              `}
+              key={command.id}
+              alignItems={ALIGN_CENTER}
+              gridGap={SPACING.spacing3}
             >
-              <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
-                <CommandIcon command={command} />
-                <CommandText
-                  command={command}
-                  robotSideAnalysis={robotSideAnalysis}
-                />
+              <StyledText
+                minWidth={SPACING.spacing4}
+                fontSize={TYPOGRAPHY.fontSizeCaption}
+              >
+                {index + 1}
+              </StyledText>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={SPACING.spacing2}
+                width="100%"
+                border={`solid 1px ${
+                  index === jumpedIndex ? COLORS.warningEnabled : borderColor
+                }`}
+                backgroundColor={
+                  index === jumpedIndex
+                    ? COLORS.warningBackgroundLight
+                    : backgroundColor
+                }
+                color={COLORS.darkBlackEnabled}
+                borderRadius={BORDERS.radiusSoftCorners}
+                padding={SPACING.spacing3}
+                css={css`
+                  transition: background-color ${COLOR_FADE_MS}ms ease-out,
+                    border-color ${COLOR_FADE_MS}ms ease-out;
+                `}
+              >
+                <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing3}>
+                  <CommandIcon command={command} />
+                  <CommandText
+                    command={command}
+                    robotSideAnalysis={robotSideAnalysis}
+                  />
+                </Flex>
               </Flex>
             </Flex>
-          </Flex>
-        )}
+          )
+        }}
       </ViewportList>
       <PrimaryButton
         position={POSITION_FIXED}
@@ -139,16 +145,11 @@ export const RunPreviewComponent = (
         left={`calc(calc(100% + ${NAV_BAR_WIDTH})/2)`} // add width of half of nav bar to center within run tab
         transform="translate(-50%)"
         borderRadius={SPACING.spacing6}
-        display={currentCommandDirection !== 0 ? DISPLAY_FLEX : DISPLAY_NONE}
-        onClick={makeHandleJumpToStep(currentRunCommandIndex)}
+        display={isCurrentCommandVisible ? DISPLAY_NONE : DISPLAY_FLEX}
+        onClick={makeHandleScrollToStep(currentRunCommandIndex)}
         id="RunLog_jumpToCurrentStep"
       >
-        <Icon
-          name={currentCommandDirection > 0 ? 'ot-arrow-down' : 'ot-arrow-up'}
-          size={SIZE_1}
-          marginRight={SPACING.spacing3}
-        />
-        {t('jump_to_current_step')}
+        {t('view_current_step')}
       </PrimaryButton>
     </Flex>
   )

--- a/app/src/organisms/RunProgressMeter/Tick.tsx
+++ b/app/src/organisms/RunProgressMeter/Tick.tsx
@@ -51,9 +51,8 @@ export function Tick(props: TickProps): JSX.Element {
 
   const [targetProps, tooltipProps] = useHoverTooltip()
   const isAggregatedTick = count > 1
-  const percent = (index / (total - 1)) * 100
   const stepNumber = index + 1
-
+  const percent = (stepNumber / total) * 100
   const commandTKey =
     firstCommandType in TRANSLATION_KEY_BY_COMMAND_TYPE &&
     TRANSLATION_KEY_BY_COMMAND_TYPE[firstCommandType] != null

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -75,7 +75,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   ) {
     countOfTotalText = ` ${lastRunCommandIndex + 1}/${analysisCommands.length}`
   } else if (analysis == null) {
-    countOfTotalText = '?/?'
+    countOfTotalText = ''
   }
 
   let currentStepContents: React.ReactNode = null
@@ -158,7 +158,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
           `}
           innerStyles={css`
             height: 0.375rem;
-            background-color: ${COLORS.darkBlackEnabled};
+            background-color: ${COLORS.darkGreyEnabled};
             border-radius: ${BORDERS.radiusSoftCorners};
           `}
         >

--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -86,6 +86,7 @@ const RoundNavLink = styled(NavLink)`
     }
   }
 `
+const JUMP_OFFSET_FROM_TOP_PX = 20
 
 interface RoundTabProps {
   disabled: boolean
@@ -163,7 +164,7 @@ export function ProtocolRunDetails(): JSX.Element | null {
   ) : null
 }
 
-const JUMPED_STEP_HIGHLIGHT_DELAY_MS = 500
+const JUMPED_STEP_HIGHLIGHT_DELAY_MS = 1000
 interface PageContentsProps {
   runId: string
   robotName: string
@@ -180,8 +181,11 @@ function PageContents(props: PageContentsProps): JSX.Element {
     }
   }, [jumpedIndex])
 
+  const makeHandleScrollToStep = (i: number) => () => {
+    listRef.current?.scrollToIndex(i, true, -1 * JUMP_OFFSET_FROM_TOP_PX)
+  }
   const makeHandleJumpToStep = (i: number) => () => {
-    listRef.current?.scrollToIndex(i)
+    makeHandleScrollToStep(i)()
     setJumpedIndex(i)
   }
   const protocolRunDetailsContentByTab: {
@@ -202,7 +206,7 @@ function PageContents(props: PageContentsProps): JSX.Element {
         runId={runId}
         ref={listRef}
         jumpedIndex={jumpedIndex}
-        makeHandleJumpToStep={makeHandleJumpToStep}
+        makeHandleScrollToStep={makeHandleScrollToStep}
       />
     ),
   }


### PR DESCRIPTION
# Overview

Momentarily highlight jumped-to commands with a  new color, maintain the current step highlight without a fade, various small design qa comments addressed.

Closes RLAB-307, RLAB-308

# Changelog

- change highlight color for tick clicks to warning enabled
- change current step highlight to never decay and track with protocol progress
- fix off by one error that placed ticks in slightly wrong location compared to inner progress meter percentage
- remove '?/?' and instead show nothing if analysis and run not present

# Risk assessment
low