### PR TITLE
docs: remove references to make bump in releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,8 +252,3 @@ circular-dependencies-js:
 	yarn madge $(and $(CI),--no-spinner --no-color) --circular step-generation/src/index.ts
 	yarn madge $(and $(CI),--no-spinner --no-color) --circular labware-library/src/index.tsx
 	yarn madge $(and $(CI),--no-spinner --no-color) --circular app/src/index.tsx
-
-.PHONY: bump
-bump:
-	@echo "Bumping versions"
-	yarn lerna version $(or $(version),prerelease)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -129,6 +129,7 @@ git merge --no-ff release
 ### tag usage
 
 We specify the version of a release artifact through a specifically-formatted git tag. We consider our monorepo to support several projects: robot stack, ot3, protocol-designer, etc. Tags look like this:
+
 ```shell
 ${projectPrefix}${projectVersion}
 ```


### PR DESCRIPTION
We changed to a direct tag-based version process and don't use `make bump` anymore (we don't even have `lerna` installed) so let's remove the actual `make bump` target that doesn't work anymore and update RELEASING.md to contain the new information.