### PR TITLE
refactor(api): increase calibration threshold value

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -38,7 +38,7 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
             prep_distance_mm=3,
             max_overrun_distance_mm=2,
             speed_mm_per_s=1.0,
-            sensor_threshold_pf=0.5,
+            sensor_threshold_pf=1.0,
         ),
     ),
     edge_sense=EdgeSenseSettings(
@@ -48,7 +48,7 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
             prep_distance_mm=0.2,
             max_overrun_distance_mm=0.5,
             speed_mm_per_s=0.5,
-            sensor_threshold_pf=0.5,
+            sensor_threshold_pf=1.0,
         ),
         search_initial_tolerance_mm=5.0,
         search_iteration_limit=10,


### PR DESCRIPTION
## Overview

Hardware testing found that the sensor threshold value actually needs to increase in order for the robot to accurately detect edges.