### PR TITLE
fix(app, odd): check that isOnDevice true instead of null

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -319,7 +319,7 @@ export const PipetteWizardFlows = (
     exitWizardButton = handleCleanUpAndClose
   }
 
-  return isOnDevice != null ? (
+  return isOnDevice ? (
     <Flex
       flexDirection={DIRECTION_COLUMN}
       width="100%"


### PR DESCRIPTION
# Overview

fixes bug where code thought the pipette flow was being accessed from the ODD instead of the desktop app

# Test Plan

- on deskop app on an Opentrons Flex, access a pipette flow via pipette card. The `BeforeBeginning` and subsequent modals in the flow should render normally with the `Portal`


# Changelog

- fix `isOnDevice` boolean logic in `PipetteWizardFlows`

# Review requests

- see details in `Test Plan`

# Risk assessment

low