### PR TITLE
fix(api): Fix offsets not applying to labware atop "compatible" Temperature Modules

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -149,7 +149,7 @@ def _map_module(
     engine_state: StateView,
     module_id: str,
 ) -> Optional[Tuple[int, wrapped_deck_conflict.DeckItem]]:
-    module_model = engine_state.modules.get_model(module_id=module_id)
+    module_model = engine_state.modules.get_actual_model(module_id=module_id)
     module_type = module_model.as_type()
     mapped_location = _deck_slot_to_int(
         engine_state.modules.get_location(module_id=module_id)

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -149,7 +149,7 @@ def _map_module(
     engine_state: StateView,
     module_id: str,
 ) -> Optional[Tuple[int, wrapped_deck_conflict.DeckItem]]:
-    module_model = engine_state.modules.get_actual_model(module_id=module_id)
+    module_model = engine_state.modules.get_connected_model(module_id=module_id)
     module_type = module_model.as_type()
     mapped_location = _deck_slot_to_int(
         engine_state.modules.get_location(module_id=module_id)

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -67,7 +67,7 @@ class ModuleCore(AbstractModuleCore):
     def get_model(self) -> ModuleModel:
         """Get the module's model identifier."""
         return module_model_from_string(
-            self._engine_client.state.modules.get_model(self.module_id)
+            self._engine_client.state.modules.get_actual_model(self.module_id)
         )
 
     def get_serial_number(self) -> str:

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -67,7 +67,7 @@ class ModuleCore(AbstractModuleCore):
     def get_model(self) -> ModuleModel:
         """Get the module's model identifier."""
         return module_model_from_string(
-            self._engine_client.state.modules.get_actual_model(self.module_id)
+            self._engine_client.state.modules.get_connected_model(self.module_id)
         )
 
     def get_serial_number(self) -> str:

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -98,6 +98,9 @@ class PipetteNotLoadedError(ProtocolEngineError):
 class ModuleNotLoadedError(ProtocolEngineError):
     """And error raised when referencing a module that has not been loaded."""
 
+    def __init__(self, *, module_id: str) -> None:
+        super().__init__(f"Module {module_id} not found.")
+
 
 class ModuleNotOnDeckError(ProtocolEngineError):
     """And error raised when trying to use a module that is loaded off the deck."""

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -39,6 +39,7 @@ from ..types import (
     LabwareLocation,
     DeckSlotLocation,
     ModuleLocation,
+    LabwareOffset,
     LabwareOffsetLocation,
     ModuleModel,
     ModuleDefinition,
@@ -349,18 +350,57 @@ class EquipmentHandler:
             or None if no labware offset will apply.
         """
         if isinstance(labware_location, DeckSlotLocation):
-            slot_name = labware_location.slotName
-            module_model = None
+            offset = self._state_store.labware.find_applicable_labware_offset(
+                definition_uri=labware_definition_uri,
+                location=LabwareOffsetLocation(
+                    slotName=labware_location.slotName,
+                    moduleModel=None,
+                ),
+            )
+            return self._get_id_from_offset(offset)
+
         elif isinstance(labware_location, ModuleLocation):
             module_id = labware_location.moduleId
             # Allow ModuleNotLoadedError to propagate.
-            module_model = self._state_store.modules.get_actual_model(
+            # Note also that we match based on the module's requested model, not its
+            # actual model, to implement robot-server's documented HTTP API semantics.
+            module_model = self._state_store.modules.get_requested_model(
                 module_id=module_id
             )
+
+            # If `module_model is None`, it probably means that this module was added by
+            # `ProtocolEngine.use_attached_modules()`, instead of an explicit
+            # `loadModule` command.
+            #
+            # This assert should never raise in practice because:
+            #   1. `ProtocolEngine.use_attached_modules()` is only used by
+            #      robot-server's "stateless command" endpoints, under `/commands`.
+            #   2. Those endpoints don't support loading labware, so this code will
+            #      never run.
+            #
+            # Nevertheless, if it does happen somehow, we do NOT want to pass the
+            # `None` value along to `LabwareView.find_applicable_labware_offset()`.
+            # `None` means something different there, which will cause us to return
+            # wrong results.
+            assert module_model is not None, (
+                "Can't find offsets for labware"
+                " that are loaded on modules"
+                " that were loaded with ProtocolEngine.use_attached_modules()."
+            )
+
             module_location = self._state_store.modules.get_location(
                 module_id=module_id
             )
             slot_name = module_location.slotName
+            offset = self._state_store.labware.find_applicable_labware_offset(
+                definition_uri=labware_definition_uri,
+                location=LabwareOffsetLocation(
+                    slotName=slot_name,
+                    moduleModel=module_model,
+                ),
+            )
+            return self._get_id_from_offset(offset)
+
         else:
             # No offset for off-deck location.
             # Returning None instead of raising an exception allows loading a labware
@@ -368,12 +408,6 @@ class EquipmentHandler:
             # Also allows using `moveLabware` with 'offDeck' location.
             return None
 
-        offset = self._state_store.labware.find_applicable_labware_offset(
-            definition_uri=labware_definition_uri,
-            location=LabwareOffsetLocation(
-                slotName=slot_name,
-                moduleModel=module_model,
-            ),
-        )
-
-        return None if offset is None else offset.id
+    @staticmethod
+    def _get_id_from_offset(labware_offset: Optional[LabwareOffset]) -> Optional[str]:
+        return None if labware_offset is None else labware_offset.id

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -354,7 +354,9 @@ class EquipmentHandler:
         elif isinstance(labware_location, ModuleLocation):
             module_id = labware_location.moduleId
             # Allow ModuleNotLoadedError to propagate.
-            module_model = self._state_store.modules.get_model(module_id=module_id)
+            module_model = self._state_store.modules.get_actual_model(
+                module_id=module_id
+            )
             module_location = self._state_store.modules.get_location(
                 module_id=module_id
             )

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_plate_lifter.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_plate_lifter.py
@@ -38,7 +38,7 @@ class ThermocyclerPlateLifter:
         if isinstance(labware_location, ModuleLocation):
             module_id = labware_location.moduleId
             if (
-                self._state_store.modules.get_model(module_id)
+                self._state_store.modules.get_actual_model(module_id)
                 == ModuleModel.THERMOCYCLER_MODULE_V2
             ):
                 # We already verify that TC lid is open before moving labware. So,

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_plate_lifter.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_plate_lifter.py
@@ -38,7 +38,7 @@ class ThermocyclerPlateLifter:
         if isinstance(labware_location, ModuleLocation):
             module_id = labware_location.moduleId
             if (
-                self._state_store.modules.get_actual_model(module_id)
+                self._state_store.modules.get_connected_model(module_id)
                 == ModuleModel.THERMOCYCLER_MODULE_V2
             ):
                 # We already verify that TC lid is open before moving labware. So,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -100,11 +100,20 @@ class HardwareModule:
 
 @dataclass
 class ModuleState:
-    """Basic module data state and getter methods."""
+    """The internal data to keep track of loaded modules."""
 
     slot_by_module_id: Dict[str, Optional[DeckSlotName]]
+    """The deck slot that each module has been loaded into.
+
+    This will be None when a module has been added via
+    ProtocolEngine.use_attached_modules() instead of an explicit loadModule command.
+    """
+
     hardware_by_module_id: Dict[str, HardwareModule]
+    """Information about each module's physical hardware."""
+
     substate_by_module_id: Dict[str, ModuleSubStateType]
+    """Information about each module that's specific to the module type."""
 
 
 class ModuleStore(HasState[ModuleState], HandlesActions):
@@ -128,6 +137,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 module_id=action.module_id,
                 serial_number=action.serial_number,
                 definition=action.definition,
+                slot_name=None,
                 module_live_data=action.module_live_data,
             )
 
@@ -138,6 +148,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 serial_number=command.result.serialNumber,
                 definition=command.result.definition,
                 slot_name=command.params.location.slotName,
+                module_live_data=None,
             )
 
         if isinstance(
@@ -180,8 +191,8 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
         module_id: str,
         serial_number: str,
         definition: ModuleDefinition,
-        slot_name: Optional[DeckSlotName] = None,
-        module_live_data: Optional[LiveData] = None,
+        slot_name: Optional[DeckSlotName],
+        module_live_data: Optional[LiveData],
     ) -> None:
         model = definition.model
         live_data = module_live_data["data"] if module_live_data else None

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -420,7 +420,7 @@ class ModuleView(HasState[ModuleState]):
             attached_module = self._state.hardware_by_module_id[module_id]
 
         except KeyError as e:
-            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
+            raise errors.ModuleNotLoadedError(module_id=module_id) from e
 
         location = (
             DeckSlotLocation(slotName=slot_name) if slot_name is not None else None
@@ -471,7 +471,7 @@ class ModuleView(HasState[ModuleState]):
         try:
             substate = self._state.substate_by_module_id[module_id]
         except KeyError as e:
-            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
+            raise errors.ModuleNotLoadedError(module_id=module_id) from e
 
         if isinstance(substate, expected_type):
             return substate
@@ -560,7 +560,7 @@ class ModuleView(HasState[ModuleState]):
         try:
             return self._state.requested_model_by_id[module_id]
         except KeyError as e:
-            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
+            raise errors.ModuleNotLoadedError(module_id=module_id) from e
 
     def get_actual_model(self, module_id: str) -> ModuleModel:
         """Return the model of the connected module.
@@ -585,7 +585,7 @@ class ModuleView(HasState[ModuleState]):
         try:
             attached_module = self._state.hardware_by_module_id[module_id]
         except KeyError as e:
-            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
+            raise errors.ModuleNotLoadedError(module_id=module_id) from e
 
         return attached_module.definition
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -549,8 +549,27 @@ class ModuleView(HasState[ModuleState]):
             )
         return location
 
+    def get_requested_model(self, module_id: str) -> Optional[ModuleModel]:
+        """Return the model by which this module was requested.
+
+        Or, if this module was not loaded with an explicit ``loadModule`` command,
+        return ``None``.
+
+        See also `get_actual_model()`.
+        """
+        try:
+            return self._state.requested_model_by_id[module_id]
+        except KeyError as e:
+            raise errors.ModuleNotLoadedError(f"Module {module_id} not found.") from e
+
     def get_actual_model(self, module_id: str) -> ModuleModel:
-        """Get the model name of the given module."""
+        """Return the model of the connected module.
+
+        This can differ from `get_requested_model()` because of module compatibility.
+        For example, a ``loadModule`` command might request a ``temperatureModuleV1``
+        but return a ``temperatureModuleV2`` if that's what it finds actually connected
+        at run time.
+        """
         return self.get(module_id).model
 
     def get_serial_number(self, module_id: str) -> str:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -531,7 +531,7 @@ class ModuleView(HasState[ModuleState]):
             )
         return location
 
-    def get_model(self, module_id: str) -> ModuleModel:
+    def get_actual_model(self, module_id: str) -> ModuleModel:
         """Get the model name of the given module."""
         return self.get(module_id).model
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -114,7 +114,7 @@ class ModuleState:
 
     Becuse of module compatibility, this can differ from the model found through
     hardware_module_by_id. See `ModuleView.get_requested_model()` versus
-    `ModuleView.get_actual_model()`.
+    `ModuleView.get_connected_model()`.
 
     This will be None when the module was added via
     ProtocolEngine.use_attached_modules() instead of an explicit loadModule command.
@@ -555,14 +555,14 @@ class ModuleView(HasState[ModuleState]):
         Or, if this module was not loaded with an explicit ``loadModule`` command,
         return ``None``.
 
-        See also `get_actual_model()`.
+        See also `get_connected_model()`.
         """
         try:
             return self._state.requested_model_by_id[module_id]
         except KeyError as e:
             raise errors.ModuleNotLoadedError(module_id=module_id) from e
 
-    def get_actual_model(self, module_id: str) -> ModuleModel:
+    def get_connected_model(self, module_id: str) -> ModuleModel:
         """Return the model of the connected module.
 
         This can differ from `get_requested_model()` because of module compatibility.

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -118,7 +118,7 @@ def test_maps_module_without_labware(decoy: Decoy, mock_state_view: StateView) -
         3.14159
     )
 
-    decoy.when(mock_state_view.modules.get_actual_model("module-id")).then_return(
+    decoy.when(mock_state_view.modules.get_connected_model("module-id")).then_return(
         ModuleModel.HEATER_SHAKER_MODULE_V1
     )
     decoy.when(mock_state_view.modules.get_location("module-id")).then_return(
@@ -164,7 +164,7 @@ def test_maps_module_with_labware(decoy: Decoy, mock_state_view: StateView) -> N
         mock_state_view.geometry.get_labware_highest_z("labware-id")
     ).then_return(3.14159)
 
-    decoy.when(mock_state_view.modules.get_actual_model("module-id")).then_return(
+    decoy.when(mock_state_view.modules.get_connected_model("module-id")).then_return(
         ModuleModel.HEATER_SHAKER_MODULE_V1
     )
     decoy.when(mock_state_view.modules.get_location("module-id")).then_return(
@@ -234,7 +234,7 @@ def test_maps_different_module_models(
         # If a new value is added to ModuleModel, it should cause an error here and
         # force us to think about how it should be mapped.
 
-    decoy.when(mock_state_view.modules.get_actual_model("module-id")).then_return(
+    decoy.when(mock_state_view.modules.get_connected_model("module-id")).then_return(
         module_model
     )
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -118,7 +118,7 @@ def test_maps_module_without_labware(decoy: Decoy, mock_state_view: StateView) -
         3.14159
     )
 
-    decoy.when(mock_state_view.modules.get_model("module-id")).then_return(
+    decoy.when(mock_state_view.modules.get_actual_model("module-id")).then_return(
         ModuleModel.HEATER_SHAKER_MODULE_V1
     )
     decoy.when(mock_state_view.modules.get_location("module-id")).then_return(
@@ -164,7 +164,7 @@ def test_maps_module_with_labware(decoy: Decoy, mock_state_view: StateView) -> N
         mock_state_view.geometry.get_labware_highest_z("labware-id")
     ).then_return(3.14159)
 
-    decoy.when(mock_state_view.modules.get_model("module-id")).then_return(
+    decoy.when(mock_state_view.modules.get_actual_model("module-id")).then_return(
         ModuleModel.HEATER_SHAKER_MODULE_V1
     )
     decoy.when(mock_state_view.modules.get_location("module-id")).then_return(
@@ -234,7 +234,9 @@ def test_maps_different_module_models(
         # If a new value is added to ModuleModel, it should cause an error here and
         # force us to think about how it should be mapped.
 
-    decoy.when(mock_state_view.modules.get_model("module-id")).then_return(module_model)
+    decoy.when(mock_state_view.modules.get_actual_model("module-id")).then_return(
+        module_model
+    )
 
     decoy.when(mock_state_view.labware.get_id_by_module("module-id")).then_raise(
         LabwareNotLoadedOnModuleError()

--- a/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
@@ -69,7 +69,7 @@ def test_engage_from_base(
 ) -> None:
     """Should verify a call to sync client engage method."""
     decoy.when(
-        mock_engine_client.state.modules.get_actual_model(module_id="1234")
+        mock_engine_client.state.modules.get_connected_model(module_id="1234")
     ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
 
     decoy.when(
@@ -90,7 +90,7 @@ def test_engage_to_labware(
 ) -> None:
     """Should verify a call to sync client engage method."""
     decoy.when(
-        mock_engine_client.state.modules.get_actual_model(module_id="1234")
+        mock_engine_client.state.modules.get_connected_model(module_id="1234")
     ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
 
     decoy.when(

--- a/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_magnetic_module_core.py
@@ -69,7 +69,7 @@ def test_engage_from_base(
 ) -> None:
     """Should verify a call to sync client engage method."""
     decoy.when(
-        mock_engine_client.state.modules.get_model(module_id="1234")
+        mock_engine_client.state.modules.get_actual_model(module_id="1234")
     ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
 
     decoy.when(
@@ -90,7 +90,7 @@ def test_engage_to_labware(
 ) -> None:
     """Should verify a call to sync client engage method."""
     decoy.when(
-        mock_engine_client.state.modules.get_model(module_id="1234")
+        mock_engine_client.state.modules.get_actual_model(module_id="1234")
     ).then_return(ModuleModel.MAGNETIC_MODULE_V1)
 
     decoy.when(

--- a/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
@@ -67,7 +67,7 @@ def test_get_model(
     decoy: Decoy, subject: ModuleCore, mock_engine_client: EngineClient
 ) -> None:
     """It should return the module model."""
-    decoy.when(mock_engine_client.state.modules.get_actual_model("1234")).then_return(
+    decoy.when(mock_engine_client.state.modules.get_connected_model("1234")).then_return(
         ModuleModel.HEATER_SHAKER_MODULE_V1
     )
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
@@ -67,9 +67,9 @@ def test_get_model(
     decoy: Decoy, subject: ModuleCore, mock_engine_client: EngineClient
 ) -> None:
     """It should return the module model."""
-    decoy.when(mock_engine_client.state.modules.get_connected_model("1234")).then_return(
-        ModuleModel.HEATER_SHAKER_MODULE_V1
-    )
+    decoy.when(
+        mock_engine_client.state.modules.get_connected_model("1234")
+    ).then_return(ModuleModel.HEATER_SHAKER_MODULE_V1)
 
     result = subject.get_model()
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
@@ -67,7 +67,7 @@ def test_get_model(
     decoy: Decoy, subject: ModuleCore, mock_engine_client: EngineClient
 ) -> None:
     """It should return the module model."""
-    decoy.when(mock_engine_client.state.modules.get_model("1234")).then_return(
+    decoy.when(mock_engine_client.state.modules.get_actual_model("1234")).then_return(
         ModuleModel.HEATER_SHAKER_MODULE_V1
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -209,7 +209,7 @@ async def test_move_labware_raises_for_labware_or_module_not_found(
             labware_definition_uri="opentrons-test/load-name/1",
             labware_location=ModuleLocation(moduleId="imaginary-module-id-2"),
         )
-    ).then_raise(errors.ModuleNotLoadedError("Woops 2.0!"))
+    ).then_raise(errors.ModuleNotLoadedError(module_id="woops-i-dont-exist"))
 
     with pytest.raises(errors.ModuleNotLoadedError):
         await subject.execute(move_labware_from_questionable_module_params)

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -357,7 +357,7 @@ async def test_load_labware_on_module(
         state_store.labware.get_definition_by_uri(matchers.IsA(str))
     ).then_return(minimal_labware_def)
 
-    decoy.when(state_store.modules.get_actual_model("module-id")).then_return(
+    decoy.when(state_store.modules.get_requested_model("module-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
     )
     decoy.when(state_store.modules.get_location("module-id")).then_return(
@@ -441,7 +441,7 @@ def test_find_offset_id_of_labware_on_module(
     subject: EquipmentHandler,
 ) -> None:
     """It should find a new offset by resolving the new location."""
-    decoy.when(state_store.modules.get_actual_model("input-module-id")).then_return(
+    decoy.when(state_store.modules.get_requested_model("input-module-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
     )
     decoy.when(state_store.modules.get_location("input-module-id")).then_return(

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -357,7 +357,7 @@ async def test_load_labware_on_module(
         state_store.labware.get_definition_by_uri(matchers.IsA(str))
     ).then_return(minimal_labware_def)
 
-    decoy.when(state_store.modules.get_model("module-id")).then_return(
+    decoy.when(state_store.modules.get_actual_model("module-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
     )
     decoy.when(state_store.modules.get_location("module-id")).then_return(
@@ -441,7 +441,7 @@ def test_find_offset_id_of_labware_on_module(
     subject: EquipmentHandler,
 ) -> None:
     """It should find a new offset by resolving the new location."""
-    decoy.when(state_store.modules.get_model("input-module-id")).then_return(
+    decoy.when(state_store.modules.get_actual_model("input-module-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
     )
     decoy.when(state_store.modules.get_location("input-module-id")).then_return(

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_plate_lifter.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_plate_lifter.py
@@ -66,7 +66,7 @@ async def test_lift_plate_for_labware_movement_from_tc_gen2(
     labware_location = ModuleLocation(moduleId="thermocycler-id")
     tc_hardware = decoy.mock(cls=Thermocycler)
 
-    decoy.when(state_store.modules.get_actual_model("thermocycler-id")).then_return(
+    decoy.when(state_store.modules.get_connected_model("thermocycler-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V2
     )
     decoy.when(
@@ -99,7 +99,7 @@ async def test_do_not_lift_plate_if_not_in_tc_gen2(
     subject: ThermocyclerPlateLifter,
 ) -> None:
     """It should execute plate lift if moving labware from TC Gen2."""
-    decoy.when(state_store.modules.get_actual_model("thermocycler-id")).then_return(
+    decoy.when(state_store.modules.get_connected_model("thermocycler-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
     )
     await subject.lift_plate_for_labware_movement(
@@ -130,7 +130,7 @@ async def test_do_not_lift_plate_with_lid_closed(
     labware_location = ModuleLocation(moduleId="thermocycler-id")
     tc_hardware = decoy.mock(cls=Thermocycler)
 
-    decoy.when(state_store.modules.get_actual_model("thermocycler-id")).then_return(
+    decoy.when(state_store.modules.get_connected_model("thermocycler-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V2
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_plate_lifter.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_plate_lifter.py
@@ -66,7 +66,7 @@ async def test_lift_plate_for_labware_movement_from_tc_gen2(
     labware_location = ModuleLocation(moduleId="thermocycler-id")
     tc_hardware = decoy.mock(cls=Thermocycler)
 
-    decoy.when(state_store.modules.get_model("thermocycler-id")).then_return(
+    decoy.when(state_store.modules.get_actual_model("thermocycler-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V2
     )
     decoy.when(
@@ -99,7 +99,7 @@ async def test_do_not_lift_plate_if_not_in_tc_gen2(
     subject: ThermocyclerPlateLifter,
 ) -> None:
     """It should execute plate lift if moving labware from TC Gen2."""
-    decoy.when(state_store.modules.get_model("thermocycler-id")).then_return(
+    decoy.when(state_store.modules.get_actual_model("thermocycler-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
     )
     await subject.lift_plate_for_labware_movement(
@@ -130,7 +130,7 @@ async def test_do_not_lift_plate_with_lid_closed(
     labware_location = ModuleLocation(moduleId="thermocycler-id")
     tc_hardware = decoy.mock(cls=Thermocycler)
 
-    decoy.when(state_store.modules.get_model("thermocycler-id")).then_return(
+    decoy.when(state_store.modules.get_actual_model("thermocycler-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V2
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -38,12 +38,14 @@ from opentrons.protocol_engine.state.module_substates import (
 
 def make_module_view(
     slot_by_module_id: Optional[Dict[str, Optional[DeckSlotName]]] = None,
+    requested_model_by_module_id: Optional[Dict[str, Optional[ModuleModel]]] = None,
     hardware_by_module_id: Optional[Dict[str, HardwareModule]] = None,
     substate_by_module_id: Optional[Dict[str, ModuleSubStateType]] = None,
 ) -> ModuleView:
     """Get a module view test subject with the specified state."""
     state = ModuleState(
         slot_by_module_id=slot_by_module_id or {},
+        requested_model_by_id=requested_model_by_module_id or {},
         hardware_by_module_id=hardware_by_module_id or {},
         substate_by_module_id=substate_by_module_id or {},
     )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -207,7 +207,7 @@ def test_get_properties_by_id(
 
     assert subject.get_definition("module-1") == tempdeck_v1_def
     assert subject.get_dimensions("module-1") == tempdeck_v1_def.dimensions
-    assert subject.get_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
+    assert subject.get_actual_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
     assert subject.get_serial_number("module-1") == "serial-1"
     assert subject.get_location("module-1") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_1
@@ -215,7 +215,7 @@ def test_get_properties_by_id(
 
     assert subject.get_definition("module-2") == tempdeck_v2_def
     assert subject.get_dimensions("module-2") == tempdeck_v2_def.dimensions
-    assert subject.get_model("module-2") == ModuleModel.TEMPERATURE_MODULE_V2
+    assert subject.get_actual_model("module-2") == ModuleModel.TEMPERATURE_MODULE_V2
     assert subject.get_serial_number("module-2") == "serial-2"
     assert subject.get_location("module-2") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_2

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -215,7 +215,7 @@ def test_get_properties_by_id(
     assert subject.get_definition("module-1") == tempdeck_v2_def
     assert subject.get_dimensions("module-1") == tempdeck_v2_def.dimensions
     assert subject.get_requested_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
-    assert subject.get_actual_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V2
+    assert subject.get_connected_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V2
     assert subject.get_serial_number("module-1") == "serial-1"
     assert subject.get_location("module-1") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_1
@@ -224,7 +224,7 @@ def test_get_properties_by_id(
     assert subject.get_definition("module-2") == magdeck_v1_def
     assert subject.get_dimensions("module-2") == magdeck_v1_def.dimensions
     assert subject.get_requested_model("module-2") == ModuleModel.MAGNETIC_MODULE_V1
-    assert subject.get_actual_model("module-2") == ModuleModel.MAGNETIC_MODULE_V1
+    assert subject.get_connected_model("module-2") == ModuleModel.MAGNETIC_MODULE_V1
     assert subject.get_serial_number("module-2") == "serial-2"
     assert subject.get_location("module-2") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_2

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -186,8 +186,8 @@ def test_get_all_modules(
 
 
 def test_get_properties_by_id(
-    tempdeck_v1_def: ModuleDefinition,
     tempdeck_v2_def: ModuleDefinition,
+    magdeck_v1_def: ModuleDefinition,
 ) -> None:
     """It should return a loaded module's properties by ID."""
     subject = make_module_view(
@@ -195,29 +195,36 @@ def test_get_properties_by_id(
             "module-1": DeckSlotName.SLOT_1,
             "module-2": DeckSlotName.SLOT_2,
         },
+        requested_model_by_module_id={
+            "module-1": ModuleModel.TEMPERATURE_MODULE_V1,
+            "module-2": ModuleModel.MAGNETIC_MODULE_V1,
+        },
         hardware_by_module_id={
             "module-1": HardwareModule(
                 serial_number="serial-1",
-                definition=tempdeck_v1_def,
+                # Intentionally different from requested model.
+                definition=tempdeck_v2_def,
             ),
             "module-2": HardwareModule(
                 serial_number="serial-2",
-                definition=tempdeck_v2_def,
+                definition=magdeck_v1_def,
             ),
         },
     )
 
-    assert subject.get_definition("module-1") == tempdeck_v1_def
-    assert subject.get_dimensions("module-1") == tempdeck_v1_def.dimensions
-    assert subject.get_actual_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
+    assert subject.get_definition("module-1") == tempdeck_v2_def
+    assert subject.get_dimensions("module-1") == tempdeck_v2_def.dimensions
+    assert subject.get_requested_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V1
+    assert subject.get_actual_model("module-1") == ModuleModel.TEMPERATURE_MODULE_V2
     assert subject.get_serial_number("module-1") == "serial-1"
     assert subject.get_location("module-1") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_1
     )
 
-    assert subject.get_definition("module-2") == tempdeck_v2_def
-    assert subject.get_dimensions("module-2") == tempdeck_v2_def.dimensions
-    assert subject.get_actual_model("module-2") == ModuleModel.TEMPERATURE_MODULE_V2
+    assert subject.get_definition("module-2") == magdeck_v1_def
+    assert subject.get_dimensions("module-2") == magdeck_v1_def.dimensions
+    assert subject.get_requested_model("module-2") == ModuleModel.MAGNETIC_MODULE_V1
+    assert subject.get_actual_model("module-2") == ModuleModel.MAGNETIC_MODULE_V1
     assert subject.get_serial_number("module-2") == "serial-2"
     assert subject.get_location("module-2") == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_2

--- a/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
+++ b/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
@@ -1,0 +1,195 @@
+import asyncio
+from textwrap import dedent
+from typing import Any, Generator, AsyncGenerator
+
+import anyio
+import pytest
+
+from tests.integration.dev_server import DevServer
+from tests.integration.robot_client import RobotClient
+
+
+# An arbitrary choice of labware.
+LABWARE_LOAD_NAME = "opentrons_96_aluminumblock_biorad_wellplate_200ul"
+LABWARE_URI = "opentrons/opentrons_96_aluminumblock_biorad_wellplate_200ul/1"
+SLOT = "1"
+
+RUN_POLL_INTERVAL = 0.01
+RUN_POLL_TIMEOUT = 10
+PORT = "15555"
+
+
+def generate_protocol_contents(
+    use_protocol_engine_backend: bool,
+    python_api_module_load_name: str,
+) -> bytes:
+    api_level = "2.14" if use_protocol_engine_backend else "2.13"
+    return dedent(
+        f"""\
+        metadata = {{"apiLevel": "{api_level}"}}
+        def run(context):
+            module = context.load_module("{python_api_module_load_name}", {SLOT})
+            labware = module.load_labware("{LABWARE_LOAD_NAME}")
+        """
+    ).encode("utf-8")
+
+
+async def poll_until_run_succeeds(robot_client: RobotClient, run_id: str) -> Any:
+    """Wait until a run completes, and then assert that it succeeded.
+
+    Return the completed run response.
+    """
+    completed_run_statuses = {"stopped", "failed", "succeeded"}
+    while True:
+        run = (await robot_client.get_run(run_id=run_id)).json()
+        status = run["data"]["status"]
+        if status in completed_run_statuses:
+            assert status == "succeeded"
+            return run
+        else:
+            # The run is still ongoing. Wait a beat, then poll again.
+            await asyncio.sleep(RUN_POLL_INTERVAL)
+
+
+# TODO(mm, 2023-03-03): This unnecessarily adds 5-10 seconds to the test suite.
+# See RSS-195.
+@pytest.fixture(scope="module")
+def dev_server() -> Generator[DevServer, None, None]:
+    """Return a running dev server."""
+    with DevServer(port=PORT) as dev_server:
+        dev_server.start()
+        yield dev_server
+
+
+@pytest.fixture
+async def robot_client(dev_server: DevServer) -> AsyncGenerator[RobotClient, None]:
+    """Return a client for a running dev server."""
+    async with RobotClient.make(
+        host="http://localhost", port=dev_server.port, version="*"
+    ) as robot_client:
+        assert (
+            await robot_client.wait_until_alive()
+        ), "Dev Robot never became available."
+        yield robot_client
+
+
+@pytest.mark.parametrize("use_protocol_engine_backend", [False, True])
+@pytest.mark.parametrize(
+    (
+        "python_api_module_load_name",
+        "labware_offset_module_model",
+        "labware_offset_should_apply",
+    ),
+    [
+        # The model in the labware offset matches what the protocol requests.
+        # The server should apply the labware offset.
+        ("temperature module", "temperatureModuleV1", True),
+        ("temperature module gen2", "temperatureModuleV2", True),
+        # The model in the labware offset does not match what the protocol requests.
+        # The server should not apply the labware offset.
+        ("temperature module", "temperatureModuleV2", False),
+        ("temperature module gen2", "temperatureModuleV1", False),
+    ],
+)
+async def test_labware_offsets_on_compatible_modules(
+    robot_client: RobotClient,
+    use_protocol_engine_backend: bool,
+    python_api_module_load_name: str,
+    labware_offset_module_model: str,
+    labware_offset_should_apply: bool,
+) -> None:
+    """Test that the server correctly handles "compatible" modules when applying
+    labware offsets.
+
+    When a protocol loads a hardware module, it specifies the specific model that it's
+    requesting. However, at runtime, the model that the robot actually loads can be
+    slightly different, as long as it's still "compatible."
+
+    For example, a protocol can request a Temperature Module GEN2, but actually receive
+    a Temperature Module GEN1 at run time, if that's what's plugged in.
+
+    This causes confusion when an HTTP client wants to apply labware offsets to a run.
+    When the client wants to apply an offset to a labware atop a module, it needs to
+    specify the module's model. But should it use the model that the protocol requests,
+    or the model that's actually plugged in to the robot?
+
+    The HTTP API documents that the client should use the model that the protocol
+    requests. This test makes sure that the server upholds its end of that contract.
+
+    Bug reference: RSS-194
+    """
+    # Create a protocol run.
+    protocol_contents = generate_protocol_contents(
+        use_protocol_engine_backend=use_protocol_engine_backend,
+        python_api_module_load_name=python_api_module_load_name,
+    )
+    protocol = (
+        await robot_client.post_protocol(files=[("protocol.py", protocol_contents)])
+    ).json()
+    protocol_id = protocol["data"]["id"]
+    run = (
+        await robot_client.post_run(req_body={"data": {"protocolId": protocol_id}})
+    ).json()
+    run_id = run["data"]["id"]
+
+    # Apply a labware offset to the run.
+    labware_offset = (
+        await robot_client.post_labware_offset(
+            run_id=run_id,
+            req_body={
+                "data": {
+                    "definitionUri": LABWARE_URI,
+                    "location": {
+                        "slotName": SLOT,
+                        "moduleModel": labware_offset_module_model,
+                    },
+                    "vector": {"x": 11.1, "y": 22.2, "z": 33.3},
+                }
+            },
+        )
+    ).json()
+    labware_offset_id = labware_offset["data"]["id"]
+
+    # Play the run and wait for it to succeed.
+    await robot_client.post_run_action(
+        run_id=run_id, req_body={"data": {"actionType": "play"}}
+    )
+    with anyio.fail_after(RUN_POLL_TIMEOUT):
+        await poll_until_run_succeeds(robot_client=robot_client, run_id=run_id)
+
+    # Retrieve details about the protocol's completed commands.
+    commands = (await robot_client.get_run_commands(run_id=run_id)).json()
+    [load_module_command_summary, load_labware_command_summary] = commands["data"]
+    assert load_module_command_summary["commandType"] == "loadModule"
+    load_module_command = (
+        await robot_client.get_run_command(
+            run_id=run_id, command_id=load_module_command_summary["id"]
+        )
+    ).json()
+    load_module_result = load_module_command["data"]["result"]
+    assert load_labware_command_summary["commandType"] == "loadLabware"
+    load_labware_command = (
+        await robot_client.get_run_command(
+            run_id=run_id, command_id=load_labware_command_summary["id"]
+        )
+    ).json()
+    load_labware_result = load_labware_command["data"]["result"]
+
+    # Make sure the labware offset applied, or didn't apply, as we expect.
+    if labware_offset_should_apply:
+        assert load_labware_result["offsetId"] == labware_offset_id
+    else:
+        assert load_labware_result.get("offsetId", None) is None
+
+    # For this test to catch bugs like RSS-194, there must be at least some cases where
+    # the module model that the protocol requests is different from the one that
+    # the server actually finds.
+    #
+    # This is currently true because:
+    #   1. This test's parametrizations vary the module that the protocol requests
+    #      between temperatureModuleV1 and temperatureModuleV2.
+    #   2. The dev server always has a single model of Temperature Module connected,
+    #      as a constant.
+    #
+    # Make sure that (2) stays true so this test doesn't become useless.
+    assert load_module_result["model"] == "temperatureModuleV1"


### PR DESCRIPTION
# Overview

Fixes RSS-194.

The `moduleModel` that a protocol requests may not be exactly the same as the `moduleModel` that it receives at run time. For example, a protocol can request a `temperatureModuleV1` but receive a `temperatureModuleV2`.

This presents a problem when a client wants to apply an offset to a labware that's loaded atop a module. It needs to send an HTTP `POST` a request like this:

```json
{
 "data": {
    "definitionUri": "string",
    "location": {
      "slotName": "1",
      "moduleModel": "temperatureModuleV1"
    },
    "vector": {
      "x": 1,
      "y": 2,
      "z": 3
    }
  }
}
```

...so should the `moduleModel` in the request be what the protocol is expected to request, or what the protocol is expected to receive? The robot server's documented contract is that **it should be what the protocol is expected to request.**

The robot server implements this contract correctly for old protocols, but not for new protocols that are run through Protocol Engine. Protocol Engine incorrectly matches based on the received model. This PR fixes it to match based on the requested model.

# Test plan

I've tested this on an OT-2, following the steps to reproduce in RSS-194.

This PR also includes an HTTP-level integration test. This isn't enough to ensure that the pipette moves to the correct place, but it is enough to ensure that the server logically identifies the correct offset to apply to the labware. This is good enough to detect the original bug.

# Changelog

* When Protocol Engine loads a module, keep track of the model by which it was requested in addition to the model that we actually found connected.
* When searching for labware offsets, search based on the requested model, not the actual model.

# Review requests

* Does my handling of stateless commands—where, conceptually, there is no requested model—make sense?

# Risk assessment

Low. Although this is a sensitive, error-prone part of our API, I'm satisfied with the integration test that this PR adds.