### PR TITLE
build: fix py versions in buildroot builds

### DIFF
--- a/api/buildroot.mk
+++ b/api/buildroot.mk
@@ -26,6 +26,7 @@ ot_api_name := python-opentrons-api
 define PYTHON_OPENTRONS_API_INSTALL_RELEASE_NOTES
 	$(INSTALL) -D -m 0644 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/api/release-notes.md $(BINARIES_DIR)/release-notes.md
 endef
+export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of

--- a/api/setup.py
+++ b/api/setup.py
@@ -23,11 +23,12 @@ if os.name == "posix":
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
+    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("api", project, **normalize_opts)
+    return normalize_version("api", project, git_dir=git_dir, **normalize_opts)
 
 
 VERSION = get_version()

--- a/api/setup.py
+++ b/api/setup.py
@@ -23,7 +23,7 @@ if os.name == "posix":
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
-    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
+    git_dir = os.getenv("OPENTRONS_GIT_DIR", None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:

--- a/notify-server/buildroot.mk
+++ b/notify-server/buildroot.mk
@@ -34,6 +34,7 @@ define PYTHON_OPENTRONS_NOTIFY_SERVER_INSTALL_INIT_SYSTEMD
   ln -sf ../$(PYTHON_OPENTRONS_NOTIFY_SERVER_SERVICE_FILE_NAME) \
     $(TARGET_DIR)/etc/systemd/system/opentrons.target.wants/$(PYTHON_OPENTRONS_NOTIFY_SERVER_SERVICE_FILE_NAME)
 endef
+export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of

--- a/notify-server/setup.py
+++ b/notify-server/setup.py
@@ -15,12 +15,14 @@ from python_build_utils import normalize_version
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
-    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
+    git_dir = os.getenv("OPENTRONS_GIT_DIR", None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("notify-server", project, git_dir=git_dir, **normalize_opts)
+    return normalize_version(
+        "notify-server", project, git_dir=git_dir, **normalize_opts
+    )
 
 
 VERSION = get_version()

--- a/notify-server/setup.py
+++ b/notify-server/setup.py
@@ -15,11 +15,12 @@ from python_build_utils import normalize_version
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
+    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("notify-server", project, **normalize_opts)
+    return normalize_version("notify-server", project, git_dir=git_dir, **normalize_opts)
 
 
 VERSION = get_version()

--- a/robot-server/buildroot.mk
+++ b/robot-server/buildroot.mk
@@ -33,6 +33,7 @@ define PYTHON_OPENTRONS_ROBOT_SERVER_INSTALL_INIT_SYSTEMD
   ln -sf ../$(PYTHON_OPENTRONS_ROBOT_SERVER_SERVICE_FILE_NAME) \
     $(TARGET_DIR)/etc/systemd/system/opentrons.target.wants/$(PYTHON_OPENTRONS_ROBOT_SERVER_SERVICE_FILE_NAME)
 endef
+export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of

--- a/robot-server/setup.py
+++ b/robot-server/setup.py
@@ -22,7 +22,7 @@ from python_build_utils import normalize_version  # noqa: E402
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
-    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
+    git_dir = os.getenv("OPENTRONS_GIT_DIR", None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:

--- a/robot-server/setup.py
+++ b/robot-server/setup.py
@@ -22,11 +22,12 @@ from python_build_utils import normalize_version  # noqa: E402
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
+    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("robot-server", project, **normalize_opts)
+    return normalize_version("robot-server", project, git_dir=git_dir, **normalize_opts)
 
 
 VERSION = get_version()

--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -22,7 +22,6 @@ HERE = os.path.dirname(__file__)
 # from script directory.
 CWD = HERE or '.'
 
-
 package_entries = {
     'api': PackageEntry('opentrons_api'),
     'update-server': PackageEntry('update_server'),
@@ -41,15 +40,15 @@ project_entries = {
 }
 
 
-def get_version(package, project, extra_tag=''):
-    builtin_ver = _latest_version_for_project(project)
+def get_version(package, project, extra_tag='', git_dir=None):
+    builtin_ver = _latest_version_for_project(project, git_dir)
     if extra_tag:
         version = builtin_ver + '.dev{}'.format(extra_tag)
     else:
         version = builtin_ver
     return version
 
-def normalize_version(package, project, extra_tag=''):
+def normalize_version(package, project, extra_tag='', git_dir=None):
     # Pipenv requires setuptools >= 36.2.1. Since 36.2.1, setuptools changed
     # the way they vendor dependencies, like the packaging module that
     # provides the way to normalize version numbers for wheel file names. So
@@ -60,14 +59,15 @@ def normalize_version(package, project, extra_tag=''):
     except ImportError:
         # old way
         from pkg_resources.extern import packaging
-    vers_obj = packaging.version.Version(get_version(package, project, extra_tag))
+    vers_obj = packaging.version.Version(get_version(package, project, extra_tag, git_dir))
     return str(vers_obj)
 
-def _latest_tag_for_prefix(prefix):
+def _latest_tag_for_prefix(prefix, git_dir):
+    check_dir = git_dir or CWD
     try:
         tags_result = subprocess.check_output(
             ['git', 'describe', '--tags', '--abbrev=0', '--match=' + prefix + '*'],
-            cwd=CWD)
+            cwd=check_dir)
     except subprocess.CalledProcessError:
         # This happens if a tag for the project didn't exist. This might be because
         # this is a new project that hasn't been tagged yet; it also might be because
@@ -75,15 +75,16 @@ def _latest_tag_for_prefix(prefix):
         # without its tags. We'll print an error (to stderr, since this is called as
         # a shell program by make and printing it to stdout would get captured).
         sys.stderr.write(
-            'Could not find tag matching {prefix} '.format(prefix=prefix)
+            'Could not find tag in {check_dir} matching {prefix} '.format(
+                check_dir=check_dir, prefix=prefix)
             + '- build before release or no tags. Using 0.0.0-dev\n')
         tags_result = prefix.encode() + b'0.0.0-dev'
     tags_matching = tags_result.strip().split(b'\n')
     return tags_matching[-1].decode()
 
-def _latest_version_for_project(project):
+def _latest_version_for_project(project, git_dir):
     prefix = project_entries[project].tag_prefix
-    tag = _latest_tag_for_prefix(prefix)
+    tag = _latest_tag_for_prefix(prefix, git_dir)
     return prefix.join(tag.split(prefix)[1:])
 
 def _ref_from_sha(sha):
@@ -118,13 +119,13 @@ def _ref_from_sha(sha):
     return sha[:12]
 
 
-def dump_br_version(package, project, extra_tag=''):
+def dump_br_version(package, project, extra_tag='', git_dir=None):
     """ Dump an enhanced version json including
     - The version from the latest git tag
     - The current branch (if it can be found)
     - The current sha
     """
-    normalized = get_version(package, project, extra_tag)
+    normalized = get_version(package, project, extra_tag, git_dir)
     sha = subprocess.check_output(
         ['git', 'rev-parse', 'HEAD'], cwd=CWD).strip().decode()
     branch = _ref_from_sha(sha)

--- a/shared-data/python/buildroot.mk
+++ b/shared-data/python/buildroot.mk
@@ -22,6 +22,8 @@ endef
 
 ot_sd_name := python-opentrons-shared-data
 
+export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
+
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -95,7 +95,7 @@ class BuildWithData(build_py.build_py):
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
-    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
+    git_dir = os.getenv("OPENTRONS_GIT_DIR", None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -95,11 +95,12 @@ class BuildWithData(build_py.build_py):
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "robot-stack")
+    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("shared-data", project, **normalize_opts)
+    return normalize_version("shared-data", project, git_dir=git_dir, **normalize_opts)
 
 
 VERSION = get_version()

--- a/system-server/buildroot.mk
+++ b/system-server/buildroot.mk
@@ -33,6 +33,7 @@ define PYTHON_OPENTRONS_SYSTEM_SERVER_INSTALL_INIT_SYSTEMD
   ln -sf ../$(PYTHON_OPENTRONS_SYSTEM_SERVER_SERVICE_FILE_NAME) \
     $(TARGET_DIR)/etc/systemd/system/opentrons.target.wants/$(PYTHON_OPENTRONS_SYSTEM_SERVER_SERVICE_FILE_NAME)
 endef
+export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of

--- a/system-server/setup.py
+++ b/system-server/setup.py
@@ -15,11 +15,12 @@ from python_build_utils import normalize_version  # noqa: E402
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv('OPENTRONS_PROJECT', 'robot-stack')
+    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version('system-server', project, **normalize_opts)
+    return normalize_version('system-server', project, git_dir=git_dir, **normalize_opts)
 
 
 VERSION = get_version()

--- a/update-server/buildroot.mk
+++ b/update-server/buildroot.mk
@@ -36,6 +36,7 @@ define PYTHON_OPENTRONS_UPDATE_SERVER_INSTALL_INIT_SYSTEMD
   ln -sf ../opentrons-update-server.service \
     $(TARGET_DIR)/etc/systemd/system/opentrons.target.wants/opentrons-update-server.service
 endef
+export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of

--- a/update-server/setup.py
+++ b/update-server/setup.py
@@ -15,11 +15,12 @@ from python_build_utils import normalize_version  # noqa: E402
 def get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv('OPENTRONS_PROJECT', 'robot-stack')
+    git_dir = os.getenv('OPENTRONS_GIT_DIR', None)
     if buildno:
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("update-server", project, **normalize_opts)
+    return normalize_version("update-server", project, git_dir=git_dir, **normalize_opts)
 
 
 VERSION = get_version()


### PR DESCRIPTION
The python version numbers are now generated from git tags. That means you have to run git commands with a cwd inside the git directory. While building on buildroot, this was not happening because when buildroot builds out-of-tree projects it does so after first rsync'ing their contents (i.e. _not_ the .git directory) into the build directory.

That means that when we called the version machinery in the buildroot make scripts to do things like create /etc/VERSION.json everything worked, because those makefiles explicitly ran the script in the external tree; but when buildroot called setup.py build, that happened in the build directory which is inside the buildroot directory and therefore the scripts would pick up the latest tag _from buildroot_, since that tag scheme matches the robot-stack tag scheme.

The way to fix this is to make sure the version runs inside the source directory when building on buildroot. This could be done a couple ways; in my opinion, this is a nice combination of minimally altering the python code that is reused outside of buildroot while still keeping things obvious: adding an optional environment variable respected by the setup.pys (rather than the build script, which would make the environment variable hard to find) that can change the location of the git calls.

# Testing
This PR will be built by buildroot. We need to make sure that the output of that build has the correct wheel versions. 
- [x] Locally build and check the wheel versions in a mount of the system partition
- [x] Download the CI build and check the wheel versions in a mount of the system partition
- [x] Install the CI build on a robot and check that it works in practice

## Risks
Minimal if the above all works. Flex doesn't use the same processes so it should be unaffected.