### PR TITLE
refactor(api): simplify gantry load configuration

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -83,18 +83,12 @@ DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE: Final = 25
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
-    none={
-        OT3AxisKind.X: 500,
-        OT3AxisKind.Y: 500,
-        OT3AxisKind.Z: 65,
-        OT3AxisKind.P: 45,
-        OT3AxisKind.Z_G: 100,
-    },
     high_throughput={
         OT3AxisKind.X: 500,
         OT3AxisKind.Y: 500,
         OT3AxisKind.Z: 35,
         OT3AxisKind.P: 5,
+        OT3AxisKind.Z_G: 100,
         OT3AxisKind.Q: 5.5,
     },
     low_throughput={
@@ -102,59 +96,37 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
         OT3AxisKind.Y: 500,
         OT3AxisKind.Z: 65,
         OT3AxisKind.P: 45,
+        OT3AxisKind.Z_G: 100,
     },
-    two_low_throughput={
-        OT3AxisKind.X: 500,
-        OT3AxisKind.Y: 500,
-    },
-    gripper={OT3AxisKind.Z: 65},
 )
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
-    none={
+    high_throughput={
+        OT3AxisKind.X: 1000,
+        OT3AxisKind.Y: 1000,
+        OT3AxisKind.Z: 100,
+        OT3AxisKind.P: 10,
+        OT3AxisKind.Z_G: 20,
+        OT3AxisKind.Q: 10,
+    },
+    low_throughput={
         OT3AxisKind.X: 1000,
         OT3AxisKind.Y: 1000,
         OT3AxisKind.Z: 100,
         OT3AxisKind.P: 50,
         OT3AxisKind.Z_G: 20,
     },
-    high_throughput={
-        OT3AxisKind.X: 1000,
-        OT3AxisKind.Y: 1000,
-        OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 10,
-        OT3AxisKind.Q: 10,
-    },
-    low_throughput={
-        OT3AxisKind.X: 1000,
-        OT3AxisKind.Y: 1000,
-        OT3AxisKind.Z: 100,
-        OT3AxisKind.P: 50,
-    },
-    two_low_throughput={
-        OT3AxisKind.X: 1000,
-        OT3AxisKind.Y: 1000,
-    },
-    gripper={
-        OT3AxisKind.Z: 100,
-    },
 )
 
 DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
     ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
-    none={
-        OT3AxisKind.X: 10,
-        OT3AxisKind.Y: 10,
-        OT3AxisKind.Z: 10,
-        OT3AxisKind.Z_G: 10,
-        OT3AxisKind.P: 5,
-    },
     high_throughput={
         OT3AxisKind.X: 10,
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 10,
         OT3AxisKind.P: 10,
+        OT3AxisKind.Z_G: 10,
         OT3AxisKind.Q: 10,
     },
     low_throughput={
@@ -162,61 +134,37 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 10,
         OT3AxisKind.P: 10,
-    },
-    two_low_throughput={
-        OT3AxisKind.X: 10,
-        OT3AxisKind.Y: 10,
-    },
-    gripper={
-        OT3AxisKind.Z: 10,
+        OT3AxisKind.Z_G: 10,
     },
 )
 
 DEFAULT_DIRECTION_CHANGE_SPEED_DISCONTINUITY: Final[
     ByGantryLoad[Dict[OT3AxisKind, float]]
 ] = ByGantryLoad(
-    none={
-        OT3AxisKind.X: 5,
-        OT3AxisKind.Y: 5,
-        OT3AxisKind.Z: 5,
-        OT3AxisKind.P: 5,
-        OT3AxisKind.Z_G: 5,
-    },
     high_throughput={
         OT3AxisKind.X: 5,
         OT3AxisKind.Y: 5,
         OT3AxisKind.Z: 5,
         OT3AxisKind.P: 5,
         OT3AxisKind.Q: 5,
+        OT3AxisKind.Z_G: 5,
     },
     low_throughput={
         OT3AxisKind.X: 5,
         OT3AxisKind.Y: 5,
         OT3AxisKind.Z: 5,
         OT3AxisKind.P: 5,
-    },
-    two_low_throughput={
-        OT3AxisKind.X: 5,
-        OT3AxisKind.Y: 5,
-    },
-    gripper={
-        OT3AxisKind.Z: 5,
+        OT3AxisKind.Z_G: 5,
     },
 )
 
 DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
-    none={
-        OT3AxisKind.X: 0.5,
-        OT3AxisKind.Y: 0.5,
-        OT3AxisKind.Z: 0.1,
-        OT3AxisKind.P: 0.3,
-        OT3AxisKind.Z_G: 0.2,
-    },
     high_throughput={
         OT3AxisKind.X: 0.5,
         OT3AxisKind.Y: 0.5,
         OT3AxisKind.Z: 0.8,
         OT3AxisKind.P: 0.3,
+        OT3AxisKind.Z_G: 0.2,
         OT3AxisKind.Q: 0.3,
     },
     low_throughput={
@@ -224,44 +172,27 @@ DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLo
         OT3AxisKind.Y: 0.5,
         OT3AxisKind.Z: 0.1,
         OT3AxisKind.P: 0.3,
-    },
-    two_low_throughput={
-        OT3AxisKind.X: 0.5,
-        OT3AxisKind.Y: 0.5,
-    },
-    gripper={
-        OT3AxisKind.Z: 0.1,
+        OT3AxisKind.Z_G: 0.2,
     },
 )
 
 DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
-    none={
-        OT3AxisKind.X: 1.4,
-        OT3AxisKind.Y: 1.4,
-        OT3AxisKind.Z: 1.4,
-        OT3AxisKind.P: 1.0,
-        OT3AxisKind.Z_G: 0.67,
-    },
     high_throughput={
         OT3AxisKind.X: 1.4,
         OT3AxisKind.Y: 1.4,
         OT3AxisKind.Z: 1.4,
+        # TODO: verify this value
         OT3AxisKind.P: 2.0,
-        OT3AxisKind.Q: 2.0,
+        OT3AxisKind.Z_G: 0.67,
+        OT3AxisKind.Q: 1.5,
     },
     low_throughput={
         OT3AxisKind.X: 1.4,
         OT3AxisKind.Y: 1.4,
         OT3AxisKind.Z: 1.4,
+        # TODO: verify this value
         OT3AxisKind.P: 1.0,
-    },
-    two_low_throughput={
-        OT3AxisKind.X: 1.4,
-        OT3AxisKind.Y: 1.4,
-        OT3AxisKind.Z: 1.4,
-    },
-    gripper={
-        OT3AxisKind.Z: 1.4,
+        OT3AxisKind.Z_G: 0.67,
     },
 )
 

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -238,11 +238,6 @@ def _build_default_bpk(
         high_throughput=_build_dict_with_default(
             from_conf.get("high_throughput", {}), default.high_throughput
         ),
-        two_low_throughput=_build_dict_with_default(
-            from_conf.get("two_low_throughput", {}), default.two_low_throughput
-        ),
-        none=_build_dict_with_default(from_conf.get("none", {}), default.none),
-        gripper=_build_dict_with_default(from_conf.get("gripper", {}), default.gripper),
     )
 
 

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -20,18 +20,12 @@ Vt = TypeVar("Vt")
 class GantryLoad(Enum):
     HIGH_THROUGHPUT = "high_throughput"
     LOW_THROUGHPUT = "low_throughput"
-    TWO_LOW_THROUGHPUT = "two_low_throughput"
-    NONE = "none"
-    GRIPPER = "gripper"
 
 
 @dataclass
 class ByGantryLoad(Generic[Vt]):
     high_throughput: Vt
     low_throughput: Vt
-    two_low_throughput: Vt
-    none: Vt
-    gripper: Vt
 
     def __getitem__(self, key: GantryLoad) -> Vt:
         return cast(Vt, asdict(self)[key.value])
@@ -89,16 +83,10 @@ class OT3MotionSettings:
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        # create a shallow copy
-        base = dict(
-            (field.name, getattr(self, field.name)[GantryLoad.NONE])
+        return dict(
+            (field.name, getattr(self, field.name)[gantry_load])
             for field in fields(self)
         )
-        if gantry_load is GantryLoad.NONE:
-            return base
-        for key in base.keys():
-            base[key].update(getattr(self, key)[gantry_load])
-        return base
 
 
 @dataclass(frozen=True)
@@ -109,16 +97,10 @@ class OT3CurrentSettings:
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        # create a shallow copy
-        base = dict(
-            (field.name, getattr(self, field.name)[GantryLoad.NONE])
+        return dict(
+            (field.name, getattr(self, field.name)[gantry_load])
             for field in fields(self)
         )
-        if gantry_load is GantryLoad.NONE:
-            return base
-        for key in base.keys():
-            base[key].update(getattr(self, key)[gantry_load])
-        return base
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -405,7 +405,7 @@ class OT3Controller:
         self, axes: Sequence[OT3Axis]
     ) -> Optional[MoveGroupRunner]:
         speed_settings = (
-            self._configuration.motion_settings.max_speed_discontinuity.none
+            self._configuration.motion_settings.max_speed_discontinuity.low_throughput
         )
 
         distances_pipette = {
@@ -434,7 +434,7 @@ class OT3Controller:
         self, axes: Sequence[OT3Axis]
     ) -> Optional[MoveGroupRunner]:
         speed_settings = (
-            self._configuration.motion_settings.max_speed_discontinuity.none
+            self._configuration.motion_settings.max_speed_discontinuity.low_throughput
         )
 
         distances_gantry = {

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -189,7 +189,7 @@ class OT3API(
         self._door_state = DoorState.CLOSED
         self._pause_manager = PauseManager()
         self._transforms = build_ot3_transforms(self._config)
-        self._gantry_load = GantryLoad.NONE
+        self._gantry_load = GantryLoad.LOW_THROUGHPUT
         self._move_manager = MoveManager(
             constraints=get_system_constraints(
                 self._config.motion_settings, self._gantry_load
@@ -442,27 +442,11 @@ class OT3API(
     def _gantry_load_from_instruments(self) -> GantryLoad:
         """Compute the gantry load based on attached instruments."""
         left = self._pipette_handler.has_pipette(OT3Mount.LEFT)
-        right = self._pipette_handler.has_pipette(OT3Mount.RIGHT)
-        gripper = self._gripper_handler.has_gripper()
-        if left and right:
-            # Only low-throughputs can have the two-instrument case
-            return GantryLoad.TWO_LOW_THROUGHPUT
-        if right:
-            # only a low-throughput pipette can be on the right mount
-            return GantryLoad.LOW_THROUGHPUT
         if left:
-            # as good a measure as any to define low vs high throughput, though
-            # we'll want to touch this up as we get pipette definitions for HT
-            # pipettes
-            left_hw_pipette = self._pipette_handler.get_pipette(OT3Mount.LEFT)
-            if left_hw_pipette.config.channels.as_int <= 8:
-                return GantryLoad.LOW_THROUGHPUT
-            else:
+            pip = self._pipette_handler.get_pipette(OT3Mount.LEFT)
+            if pip.config.channels.as_int > 8:
                 return GantryLoad.HIGH_THROUGHPUT
-        if gripper:
-            # only a gripper is attached
-            return GantryLoad.GRIPPER
-        return GantryLoad.NONE
+        return GantryLoad.LOW_THROUGHPUT
 
     async def cache_pipette(
         self,

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -4,18 +4,12 @@ ot3_dummy_settings = {
     "version": 1,
     "motion_settings": {
         "acceleration": {
-            "none": {
-                "X": 3,
-                "Y": 2,
-                "Z": 15,
-                "P": 2,
-                "Z_G": 5,
-            },
             "low_throughput": {
                 "X": 3,
                 "Y": 2,
                 "Z": 15,
                 "P": 15,
+                "Z_G": 5,
             },
             "high_throughput": {
                 "X": 3,
@@ -23,26 +17,16 @@ ot3_dummy_settings = {
                 "Z": 15,
                 "P": 15,
                 "Q": 5,
-            },
-            "two_low_throughput": {"X": 1.1, "Y": 2.2},
-            "gripper": {
-                "Z": 2.8,
-                "Z_G": 6,
+                "Z_G": 5,
             },
         },
         "default_max_speed": {
-            "none": {
-                "X": 1,
-                "Y": 2,
-                "Z": 3,
-                "P": 4,
-                "Z_G": 5,
-            },
             "low_throughput": {
                 "X": 1,
                 "Y": 2,
                 "Z": 3,
                 "P": 4,
+                "Z_G": 5,
             },
             "high_throughput": {
                 "X": 1,
@@ -50,88 +34,52 @@ ot3_dummy_settings = {
                 "Z": 3,
                 "P": 4,
                 "Q": 5,
+                "Z_G": 6,
             },
-            "two_low_throughput": {
-                "X": 4,
-                "Y": 3,
-                "Z": 2,
-                "P": 1,
-            },
-            "gripper": {"Z": 2.8, "Z_G": 5},
         },
         "max_speed_discontinuity": {
-            "none": {
+            "low_throughput": {
                 "X": 10,
                 "Y": 20,
                 "Z": 30,
                 "P": 40,
                 "Z_G": 50,
             },
-            "low_throughput": {
-                "X": 1,
-                "Y": 2,
-                "Z": 3,
-                "P": 6,
-            },
             "high_throughput": {
                 "X": 1,
                 "Y": 2,
                 "Z": 3,
                 "P": 6,
                 "Q": 5,
+                "Z_G": 7,
             },
-            "two_low_throughput": {
-                "X": 1,
-                "Y": 2,
-                "Z": 3,
-                "P": 6,
-            },
-            "gripper": {"Z": 2.8},
         },
         "direction_change_speed_discontinuity": {
-            "none": {
+            "low_throughput": {
                 "X": 5,
                 "Y": 10,
                 "Z": 15,
                 "P": 20,
                 "Z_G": 15,
             },
-            "low_throughput": {
-                "X": 0.8,
-                "Y": 1,
-                "Z": 2,
-                "P": 4,
-            },
             "high_throughput": {
                 "X": 1,
                 "Y": 2,
                 "Z": 3,
                 "P": 6,
                 "Q": 5,
+                "Z_G": 15,
             },
-            "two_low_throughput": {
-                "X": 0.5,
-                "Y": 1,
-                "Z": 1.5,
-                "P": 3,
-            },
-            "gripper": {"Z": 2.8},
         },
     },
     "current_settings": {
         "hold_current": {
-            "none": {
-                "X": 0.7,
-                "Y": 0.7,
-                "Z": 0.7,
-                "P": 0.8,
-                "Z_G": 0.5,
-            },
             "low_throughput": {
                 "X": 0.7,
                 "Y": 0.7,
                 "Z": 0.7,
                 "P": 0.8,
+                "Z_G": 0.5,
             },
             "high_throughput": {
                 "X": 0.7,
@@ -139,25 +87,16 @@ ot3_dummy_settings = {
                 "Z": 0.7,
                 "P": 0.8,
                 "Q": 0.3,
-            },
-            "two_low_throughput": {"X": 0.7, "Y": 0.7, "Z": 0.6},
-            "gripper": {
-                "Z": 0.7,
+                "Z_G": 0.5,
             },
         },
         "run_current": {
-            "none": {
+            "low_throughput": {
                 "X": 7.0,
                 "Y": 7.0,
                 "Z": 7.0,
                 "P": 5.0,
                 "Z_G": 5.0,
-            },
-            "low_throughput": {
-                "X": 1,
-                "Y": 2,
-                "Z": 3,
-                "P": 4.0,
             },
             "high_throughput": {
                 "X": 0.2,
@@ -165,10 +104,7 @@ ot3_dummy_settings = {
                 "Z": 0.4,
                 "P": 2.0,
                 "Q": 0.3,
-            },
-            "two_low_throughput": {"X": 9, "Y": 0.1, "Z": 0.6},
-            "gripper": {
-                "Z": 10,
+                "Z_G": 0.5,
             },
         },
     },

--- a/api/tests/opentrons/config/test_defaults_ot3.py
+++ b/api/tests/opentrons/config/test_defaults_ot3.py
@@ -76,13 +76,13 @@ def test_load_per_pipette_vals() -> None:
 
     # added values are preserved
     altered_default = copy.deepcopy(defaults_ot3.DEFAULT_ACCELERATIONS)
-    altered_default.two_low_throughput.pop(OT3AxisKind.X, None)
+    altered_default.high_throughput.pop(OT3AxisKind.X, None)
 
-    mostly_right["motion_settings"]["acceleration"]["two_low_throughput"]["X"] = -72
+    mostly_right["motion_settings"]["acceleration"]["high_throughput"]["X"] = -72
     assert (
         defaults_ot3._build_default_bpk(
             mostly_right["motion_settings"]["acceleration"], altered_default
-        ).two_low_throughput[OT3AxisKind.X]
+        ).high_throughput[OT3AxisKind.X]
         == -72
     )
 
@@ -166,92 +166,32 @@ def test_motion_settings_dataclass() -> None:
     assert isinstance(built_config, OT3Config)
     motion_settings = built_config.motion_settings
 
-    none_setting = motion_settings.by_gantry_load(GantryLoad.NONE)
-    assert none_setting["acceleration"] == {
+    low_setting = motion_settings.by_gantry_load(GantryLoad.LOW_THROUGHPUT)
+    assert low_setting["acceleration"] == {
         OT3AxisKind.X: 3,
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 15,
-        OT3AxisKind.P: 2,
+        OT3AxisKind.P: 15,
         OT3AxisKind.Z_G: 5,
     }
-    assert none_setting["default_max_speed"] == {
+    assert low_setting["default_max_speed"] == {
         OT3AxisKind.X: 1,
         OT3AxisKind.Y: 2,
         OT3AxisKind.Z: 3,
         OT3AxisKind.P: 4,
         OT3AxisKind.Z_G: 5,
     }
-    assert none_setting["max_speed_discontinuity"] == {
+    assert low_setting["max_speed_discontinuity"] == {
         OT3AxisKind.X: 10,
         OT3AxisKind.Y: 20,
         OT3AxisKind.Z: 30,
         OT3AxisKind.P: 40,
         OT3AxisKind.Z_G: 50,
     }
-    assert none_setting["direction_change_speed_discontinuity"] == {
+    assert low_setting["direction_change_speed_discontinuity"] == {
         OT3AxisKind.X: 5,
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 15,
         OT3AxisKind.P: 20,
-        OT3AxisKind.Z_G: 15,
-    }
-
-    gripper_setting = motion_settings.by_gantry_load(GantryLoad.GRIPPER)
-    assert gripper_setting["acceleration"] == {
-        OT3AxisKind.X: 3,
-        OT3AxisKind.Y: 2,
-        OT3AxisKind.Z: 2.8,
-        OT3AxisKind.P: 2,
-        OT3AxisKind.Z_G: 6,
-    }
-    assert gripper_setting["default_max_speed"] == {
-        OT3AxisKind.X: 1,
-        OT3AxisKind.Y: 2,
-        OT3AxisKind.Z: 2.8,
-        OT3AxisKind.P: 4,
-        OT3AxisKind.Z_G: 5,
-    }
-    assert gripper_setting["max_speed_discontinuity"] == {
-        OT3AxisKind.X: 10,
-        OT3AxisKind.Y: 20,
-        OT3AxisKind.Z: 2.8,
-        OT3AxisKind.P: 40,
-        OT3AxisKind.Z_G: 50,
-    }
-    assert gripper_setting["direction_change_speed_discontinuity"] == {
-        OT3AxisKind.X: 5,
-        OT3AxisKind.Y: 10,
-        OT3AxisKind.Z: 2.8,
-        OT3AxisKind.P: 20,
-        OT3AxisKind.Z_G: 15,
-    }
-
-    two_low_setting = motion_settings.by_gantry_load(GantryLoad.TWO_LOW_THROUGHPUT)
-    assert two_low_setting["acceleration"] == {
-        OT3AxisKind.X: 1.1,
-        OT3AxisKind.Y: 2.2,
-        OT3AxisKind.Z: 15,
-        OT3AxisKind.P: 2,
-        OT3AxisKind.Z_G: 5,
-    }
-    assert two_low_setting["default_max_speed"] == {
-        OT3AxisKind.X: 4,
-        OT3AxisKind.Y: 3,
-        OT3AxisKind.Z: 2,
-        OT3AxisKind.P: 1,
-        OT3AxisKind.Z_G: 5,
-    }
-    assert two_low_setting["max_speed_discontinuity"] == {
-        OT3AxisKind.X: 1,
-        OT3AxisKind.Y: 2,
-        OT3AxisKind.Z: 3,
-        OT3AxisKind.P: 6,
-        OT3AxisKind.Z_G: 50,
-    }
-    assert two_low_setting["direction_change_speed_discontinuity"] == {
-        OT3AxisKind.X: 0.5,
-        OT3AxisKind.Y: 1,
-        OT3AxisKind.Z: 1.5,
-        OT3AxisKind.P: 3,
         OT3AxisKind.Z_G: 15,
     }

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -736,7 +736,7 @@ async def test_update_motor_estimation(
 @pytest.mark.parametrize(
     argnames=["gantry_load", "expected_call"],
     argvalues=[
-        [GantryLoad.HIGH_THROUGHPUT, [NodeId.pipette_left]],  ## this uses the Q motor
+        [GantryLoad.HIGH_THROUGHPUT, [NodeId.pipette_left]],  # this uses the Q motor
         [GantryLoad.LOW_THROUGHPUT, []],
     ],
 )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -202,12 +202,12 @@ async def mock_instrument_handlers(
                 OT3Mount.RIGHT: {"channels": 8, "version": (3, 3), "model": "p50"},
                 OT3Mount.LEFT: {"channels": 1, "version": (3, 3), "model": "p1000"},
             },
-            GantryLoad.TWO_LOW_THROUGHPUT,
+            GantryLoad.LOW_THROUGHPUT,
         ),
-        ({}, GantryLoad.NONE),
+        ({}, GantryLoad.LOW_THROUGHPUT),
         (
             {OT3Mount.GRIPPER: {"model": GripperModel.v1, "id": "g12345"}},
-            GantryLoad.GRIPPER,
+            GantryLoad.LOW_THROUGHPUT,
         ),
         (
             {OT3Mount.LEFT: {"channels": 8, "version": (3, 3), "model": "p1000"}},

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -145,14 +145,8 @@ def set_gantry_per_axis_setting_ot3(
     axis_kind = OT3Axis.to_kind(axis)
     if load == GantryLoad.HIGH_THROUGHPUT:
         settings.high_throughput[axis_kind] = value
-    elif load == GantryLoad.LOW_THROUGHPUT:
+    else:
         settings.low_throughput[axis_kind] = value
-    elif load == GantryLoad.TWO_LOW_THROUGHPUT:
-        settings.two_low_throughput[axis_kind] = value
-    elif load == GantryLoad.NONE:
-        settings.none[axis_kind] = value
-    elif load == GantryLoad.GRIPPER:
-        settings.gripper[axis_kind] = value
 
 
 def get_gantry_per_axis_setting_ot3(
@@ -162,15 +156,7 @@ def get_gantry_per_axis_setting_ot3(
     axis_kind = OT3Axis.to_kind(axis)
     if load == GantryLoad.HIGH_THROUGHPUT:
         return settings.high_throughput[axis_kind]
-    elif load == GantryLoad.LOW_THROUGHPUT:
-        return settings.low_throughput[axis_kind]
-    elif load == GantryLoad.TWO_LOW_THROUGHPUT:
-        return settings.two_low_throughput[axis_kind]
-    elif load == GantryLoad.NONE:
-        return settings.none[axis_kind]
-    elif load == GantryLoad.GRIPPER:
-        return settings.gripper[axis_kind]
-    raise ValueError(f"unexpected gantry load: {load}")
+    return settings.low_throughput[axis_kind]
 
 
 def set_gantry_load_per_axis_current_settings_ot3(
@@ -269,13 +255,13 @@ def get_gantry_load_per_axis_motion_settings_ot3(
         try:
             return getattr(m_cfg, a)[load][ax_kind]
         except KeyError:
-            return getattr(m_cfg, a)[GantryLoad.NONE][ax_kind]
+            return getattr(m_cfg, a)[GantryLoad.LOW_THROUGHPUT][ax_kind]
 
     def _default_current(a: str) -> float:
         try:
             return getattr(c_cfg, a)[load][ax_kind]
         except KeyError:
-            return getattr(c_cfg, a)[GantryLoad.NONE][ax_kind]
+            return getattr(c_cfg, a)[GantryLoad.LOW_THROUGHPUT][ax_kind]
 
     return GantryLoadSettings(
         max_speed=_default_motion("default_max_speed"),


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
After discussing with hardware team, we will only need two gantry load configurations for the Flex: **with** or **without** 96 channel. We'll distinguish the two config by using `GantryLoad.HIGH_THROUGHPUT` and `GantryLoad.LOW_THROUGHPUT`.