### PR TITLE
fix(engine): subtract nominal overlap when calculating nominal tip length

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -439,7 +439,7 @@ class LabwareView(HasState[LabwareState]):
                 f"Labware {labware_id} has no tip length defined."
             )
 
-        return definition.parameters.tipLength
+        return definition.parameters.tipLength - overlap
 
     def get_tip_drop_z_offset(
         self, labware_id: str, length_scale: float, additional_offset: float

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -373,7 +373,7 @@ def test_get_tip_length_gets_length_from_definition(
     )
 
     length = subject.get_tip_length("tip-rack-id", 12.3)
-    assert length == tip_rack_def.parameters.tipLength - 12.3
+    assert length == tip_rack_def.parameters.tipLength - 12.3  # type: ignore[operator]
 
 
 def test_get_tip_drop_z_offset() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -372,8 +372,8 @@ def test_get_tip_length_gets_length_from_definition(
         definitions_by_uri={"some-tip-rack-uri": tip_rack_def},
     )
 
-    length = subject.get_tip_length("tip-rack-id")
-    assert length == tip_rack_def.parameters.tipLength
+    length = subject.get_tip_length("tip-rack-id", 12.3)
+    assert length == tip_rack_def.parameters.tipLength - 12.3
 
 
 def test_get_tip_drop_z_offset() -> None:

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -153,7 +153,7 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
         ),
         result=commands.PickUpTipResult(
             tipVolume=300.0,
-            tipLength=59.3,
+            tipLength=51.83,
             tipDiameter=5.23,
             position=DeckPoint(x=14.38, y=74.24, z=64.69),
         ),

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -283,7 +283,7 @@ stages:
                 result:
                   position: { 'x': 146.88, 'y': 246.24, 'z': 64.69 }
                   tipVolume: 10.0
-                  tipLength: 39.2
+                  tipLength: 35.910000000000004
                   tipDiameter: 3.27
                 startedAt: !anystr
                 completedAt: !anystr


### PR DESCRIPTION
# Overview

Addresses RSS-196

This PR fixes a regression where, when calculating the nominal tip length for a tip length operation in PAPI 2.14/Protocol Engine, the overlap would not be subtracted from the calculated value. This meant that if calibrated tip length could not be found, the incorrectly calculated nominal value would be used, introducing inaccuracy to pipette movement.

# Test Plan

The full test plan can be found in the ticket description. Previous tip handling protocols were used to ensure no regressions were introduced, and protocols without calibrated tip data were tested on both the OT-2 and OT-3.

# Changelog

- Fixed calculating nominal tip length in protocol engine.

# Risk assessment
Low, fixes a regression and code will not be run into with normal user flow through the app.