### PR TITLE
Refactor(api): Add offset to maintenance position

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -6,7 +6,7 @@ from typing_extensions import Literal
 
 from pydantic import BaseModel, Field
 
-from opentrons.types import MountType
+from opentrons.types import MountType, Point
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     from opentrons.hardware_control import HardwareControlAPI
     from ...state import StateView
 
+
+# These offsets are based on testing attach flows with 8/1 channel pipettes
+_INSTRUMENT_ATTACH_OFFSET = Point(y=10, z=400)
 
 MoveToMaintenancePositionCommandType = Literal["calibration/moveToMaintenancePosition"]
 
@@ -58,7 +61,9 @@ class MoveToMaintenancePositionImplementation(
 
         await self._hardware_api.home()
 
-        calibration_coordinates = self._state_view.labware.get_calibration_coordinates()
+        calibration_coordinates = self._state_view.labware.get_calibration_coordinates(
+            offset=_INSTRUMENT_ATTACH_OFFSET
+        )
 
         await self._hardware_api.move_to(
             mount=hardware_mount,

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -58,13 +58,7 @@ class MoveToMaintenancePositionImplementation(
 
         await self._hardware_api.home()
 
-        mount_current_position = await self._hardware_api.gantry_position(
-            hardware_mount
-        )
-
-        calibration_coordinates = self._state_view.labware.get_calibration_coordinates(
-            current_z_position=mount_current_position.z
-        )
+        calibration_coordinates = self._state_view.labware.get_calibration_coordinates()
 
         await self._hardware_api.move_to(
             mount=hardware_mount,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -60,7 +60,8 @@ _MAGDECK_HALF_MM_LABWARE = {
 }
 
 _INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_1
-_INSTRUMENT_ATTACH_OFFSET = Point(y=10, z=60)
+# These offsets are based on testing attach flows with 8/1 channel pipettes
+_INSTRUMENT_ATTACH_OFFSET = Point(y=10, z=400)
 
 
 class LabwareLoadParams(NamedTuple):

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -60,8 +60,6 @@ _MAGDECK_HALF_MM_LABWARE = {
 }
 
 _INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_1
-# These offsets are based on testing attach flows with 8/1 channel pipettes
-_INSTRUMENT_ATTACH_OFFSET = Point(y=10, z=400)
 
 
 class LabwareLoadParams(NamedTuple):
@@ -598,7 +596,7 @@ class LabwareView(HasState[LabwareState]):
                     f"Labware {labware.loadName} is already present at {location}."
                 )
 
-    def get_calibration_coordinates(self) -> Point:
+    def get_calibration_coordinates(self, offset: Point) -> Point:
         """Get calibration critical point and target position."""
         target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
         # TODO (tz, 11-30-22): These coordinates wont work for OT-2. We will need to apply offsets after
@@ -606,8 +604,8 @@ class LabwareView(HasState[LabwareState]):
 
         return Point(
             x=target_center.x,
-            y=target_center.y + _INSTRUMENT_ATTACH_OFFSET.y,
-            z=_INSTRUMENT_ATTACH_OFFSET.z,
+            y=target_center.y + offset.y,
+            z=offset.z,
         )
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -59,7 +59,8 @@ _MAGDECK_HALF_MM_LABWARE = {
     "opentrons/usascientific_96_wellplate_2.4ml_deep/1",
 }
 
-_INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_2
+_INSTRUMENT_ATTACH_SLOT = DeckSlotName.SLOT_1
+_INSTRUMENT_ATTACH_OFFSET = Point(y=10, z=60)
 
 
 class LabwareLoadParams(NamedTuple):
@@ -604,8 +605,8 @@ class LabwareView(HasState[LabwareState]):
 
         return Point(
             x=target_center.x,
-            y=target_center.y,
-            z=current_z_position,
+            y=target_center.y + _INSTRUMENT_ATTACH_OFFSET.y,
+            z=current_z_position + _INSTRUMENT_ATTACH_OFFSET.z,
         )
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -597,7 +597,7 @@ class LabwareView(HasState[LabwareState]):
                     f"Labware {labware.loadName} is already present at {location}."
                 )
 
-    def get_calibration_coordinates(self, current_z_position: float) -> Point:
+    def get_calibration_coordinates(self) -> Point:
         """Get calibration critical point and target position."""
         target_center = self.get_slot_center_position(_INSTRUMENT_ATTACH_SLOT)
         # TODO (tz, 11-30-22): These coordinates wont work for OT-2. We will need to apply offsets after
@@ -606,7 +606,7 @@ class LabwareView(HasState[LabwareState]):
         return Point(
             x=target_center.x,
             y=target_center.y + _INSTRUMENT_ATTACH_OFFSET.y,
-            z=current_z_position + _INSTRUMENT_ATTACH_OFFSET.z,
+            z=_INSTRUMENT_ATTACH_OFFSET.z,
         )
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -32,9 +32,9 @@ async def test_calibration_move_to_location_implementation(
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(mount=MountType.LEFT)
 
-    decoy.when(state_view.labware.get_calibration_coordinates()).then_return(
-        Point(x=1, y=2, z=3)
-    )
+    decoy.when(
+        state_view.labware.get_calibration_coordinates(offset=Point(y=10, z=400))
+    ).then_return(Point(x=1, y=2, z=3))
 
     result = await subject.execute(params=params)
     assert result == MoveToMaintenancePositionResult()

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -32,13 +32,9 @@ async def test_calibration_move_to_location_implementation(
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(mount=MountType.LEFT)
 
-    decoy.when(await hardware_api.gantry_position(mount=Mount.LEFT)).then_return(
+    decoy.when(state_view.labware.get_calibration_coordinates()).then_return(
         Point(x=1, y=2, z=3)
     )
-
-    decoy.when(
-        state_view.labware.get_calibration_coordinates(current_z_position=3.0)
-    ).then_return(Point(x=1, y=2, z=3))
 
     result = await subject.execute(params=params)
     assert result == MoveToMaintenancePositionResult()

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -828,9 +828,9 @@ def test_get_calibration_coordinates() -> None:
 
     subject = get_labware_view(deck_definition=cast(DeckDefinitionV3, slot_definitions))
 
-    result = subject.get_calibration_coordinates(current_z_position=3.0)
+    result = subject.get_calibration_coordinates()
 
-    assert result == Point(x=4, y=15, z=63)
+    assert result == Point(x=4, y=15, z=60)
 
 
 def test_get_by_slot() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -830,7 +830,7 @@ def test_get_calibration_coordinates() -> None:
 
     result = subject.get_calibration_coordinates()
 
-    assert result == Point(x=4, y=15, z=60)
+    assert result == Point(x=4, y=15, z=400)
 
 
 def test_get_by_slot() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -813,14 +813,14 @@ def test_get_calibration_coordinates() -> None:
         "locations": {
             "orderedSlots": [
                 {
-                    "id": "2",
+                    "id": "1",
                     "position": [2, 2, 0.0],
                     "boundingBox": {
                         "xDimension": 4.0,
                         "yDimension": 6.0,
                         "zDimension": 0,
                     },
-                    "displayName": "Slot 2",
+                    "displayName": "Slot 1",
                 }
             ]
         }
@@ -830,7 +830,7 @@ def test_get_calibration_coordinates() -> None:
 
     result = subject.get_calibration_coordinates(current_z_position=3.0)
 
-    assert result == Point(x=4, y=5, z=3)
+    assert result == Point(x=4, y=15, z=63)
 
 
 def test_get_by_slot() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -828,9 +828,9 @@ def test_get_calibration_coordinates() -> None:
 
     subject = get_labware_view(deck_definition=cast(DeckDefinitionV3, slot_definitions))
 
-    result = subject.get_calibration_coordinates()
+    result = subject.get_calibration_coordinates(offset=Point(y=1, z=2))
 
-    assert result == Point(x=4, y=15, z=400)
+    assert result == Point(x=4, y=6, z=2)
 
 
 def test_get_by_slot() -> None:


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RLIQ-326, https://opentrons.atlassian.net/browse/RLIQ-325, https://opentrons.atlassian.net/browse/RLIQ-324.
Change slot for maintenance position to slot 1 and add offsets for the z and y. 

# Test Plan


# Changelog

- changed slot for attach a pipette to slot_1.
- added offsets from center slot supplied by @Laura-Danielle . still need to test on a robot to make sure its correct. 

# Review requests

Does these changes make sense?

# Risk assessment

low. this effects the attach location. should be tested to make sure the numbers are correct. 
