### PR TITLE
fix(app): offset data model says correct info when theres no offset data

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -62,7 +62,7 @@
   "robot_has_offsets_from_previous_runs": "This robot has offsets for labware used in this protocol. If you apply these offsets, you can still adjust them with Labware Position Check.",
   "no_offset_data_on_robot": "This robot has no useable labware offset data for this run.",
   "what_labware_offset": "What is labware offset?",
-  "robot_has_no_offsets_from_previous_runs": "<block>Labware offsets data references pervious protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.</block> <block>You can add new offsets with Labware Position Check in later steps if you desire.</block>",
+  "robot_has_no_offsets_from_previous_runs": "<block>Labware offsets data references previous protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.</block> <block>You can add new offsets with Labware Position Check in later steps if you desire.</block>",
   "see_how_offsets_work": "See how labware offsets work",
   "stored_offset_data": "Stored Labware Offset data",
   "applied_offset_data": "Applied Labware Offset data",
@@ -91,5 +91,5 @@
   "jupyter_notebook": "Jupyter Notebook",
   "cli_ssh": "Command Line Interface (SSH)",
   "learn_more": "Learn more",
-  "no_offset_data_available": "No labware offset data avaliable"
+  "no_offset_data_available": "No labware offset data available"
 }

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -1,5 +1,6 @@
 {
   "apply_offset_data": "Apply Labware Offset data",
+  "no_offset_data": "No offset data avaliable",
   "labware_position_check_title": "Labware Position Check",
   "labware_position_check_overview": "Labware Position Check Overview",
   "position_check_description": "<block>Labware Position Check is a guided workflow that checks every labware on the deck for an added degree of precision in your protocol.</block><block>When you check a labware, the OT-2’s pipette nozzle or attached tip will stop at the center of the A1 well. If the pipette nozzle or tip is not centered, you can reveal the OT-2’s jog controls to make an adjustment. This Labware Offset will be applied to the entire labware. Offset data is measured to the nearest 1/10th mm and can be made in the X, Y and/or Z directions.</block>",
@@ -59,7 +60,9 @@
   "run": "Run",
   "slot": "Slot {{slotName}}",
   "robot_has_offsets_from_previous_runs": "This robot has offsets for labware used in this protocol. If you apply these offsets, you can still adjust them with Labware Position Check.",
-  "robot_has_no_offsets_from_previous_runs": "This robot has no useable offsets for labware used in this protocol. You can still add new offsets with Labware Position Check.",
+  "no_offset_data_on_robot": "This robot has no useable labware offset data for this run.",
+  "what_labware_offset": "What is labware offset?",
+  "robot_has_no_offsets_from_previous_runs": "<block>Labware offsets data references pervious protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.</block> <block>You can add new offsets with Labware Position Check in later steps if you desire.</block>",
   "see_how_offsets_work": "See how labware offsets work",
   "stored_offset_data": "Stored Labware Offset data",
   "applied_offset_data": "Applied Labware Offset data",
@@ -86,5 +89,7 @@
   "get_labware_offset_data": "Get Labware Offset Data",
   "table_view": "Table View",
   "jupyter_notebook": "Jupyter Notebook",
-  "cli_ssh": "Command Line Interface (SSH)"
+  "cli_ssh": "Command Line Interface (SSH)",
+  "learn_more": "Learn more",
+  "no_offset_data_available": "No labware offset data avaliable"
 }

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -1,6 +1,6 @@
 {
   "apply_offset_data": "Apply Labware Offset data",
-  "no_offset_data": "No offset data avaliable",
+  "no_offset_data": "No offset data available",
   "labware_position_check_title": "Labware Position Check",
   "labware_position_check_overview": "Labware Position Check Overview",
   "position_check_description": "<block>Labware Position Check is a guided workflow that checks every labware on the deck for an added degree of precision in your protocol.</block><block>When you check a labware, the OT-2’s pipette nozzle or attached tip will stop at the center of the A1 well. If the pipette nozzle or tip is not centered, you can reveal the OT-2’s jog controls to make an adjustment. This Labware Offset will be applied to the entire labware. Offset data is measured to the nearest 1/10th mm and can be made in the X, Y and/or Z directions.</block>",
@@ -62,7 +62,7 @@
   "robot_has_offsets_from_previous_runs": "This robot has offsets for labware used in this protocol. If you apply these offsets, you can still adjust them with Labware Position Check.",
   "no_offset_data_on_robot": "This robot has no useable labware offset data for this run.",
   "what_labware_offset": "What is labware offset?",
-  "robot_has_no_offsets_from_previous_runs": "<block>Labware offsets data references previous protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.</block> <block>You can add new offsets with Labware Position Check in later steps if you desire.</block>",
+  "robot_has_no_offsets_from_previous_runs": "<block>Labware offset data references previous protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.</block> <block>You can add new offsets with Labware Position Check in later steps if you desire.</block>",
   "see_how_offsets_work": "See how labware offsets work",
   "stored_offset_data": "Stored Labware Offset data",
   "applied_offset_data": "Applied Labware Offset data",

--- a/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
@@ -115,11 +115,11 @@ describe('ApplyHistoricOffsets', () => {
     getByText('No offset data avaliable')
     getByText('Learn more').click()
 
-    getByRole('heading', { name: 'No labware offset data avaliable' })
+    getByRole('heading', { name: 'No labware offset data available' })
     getByText('This robot has no useable labware offset data for this run.')
     getByText('What is labware offset?')
     getByText(
-      'Labware offsets data references pervious protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.'
+      'Labware offsets data references previous protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.'
     )
     getByText(
       'You can add new offsets with Labware Position Check in later steps if you desire.'

--- a/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
@@ -112,11 +112,17 @@ describe('ApplyHistoricOffsets', () => {
     const [{ getByText, getByRole, queryByText }] = render({
       offsetCandidates: [],
     })
-    getByText('View data').click()
+    getByText('No offset data avaliable')
+    getByText('Learn more').click()
 
-    getByRole('heading', { name: 'Stored Labware Offset data' })
+    getByRole('heading', { name: 'No labware offset data avaliable' })
+    getByText('This robot has no useable labware offset data for this run.')
+    getByText('What is labware offset?')
     getByText(
-      'This robot has no useable offsets for labware used in this protocol. You can still add new offsets with Labware Position Check.'
+      'Labware offsets data references pervious protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.'
+    )
+    getByText(
+      'You can add new offsets with Labware Position Check in later steps if you desire.'
     )
     expect(
       getByRole('link', { name: 'See how labware offsets work' })

--- a/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
@@ -112,14 +112,14 @@ describe('ApplyHistoricOffsets', () => {
     const [{ getByText, getByRole, queryByText }] = render({
       offsetCandidates: [],
     })
-    getByText('No offset data avaliable')
+    getByText('No offset data available')
     getByText('Learn more').click()
 
     getByRole('heading', { name: 'No labware offset data available' })
     getByText('This robot has no useable labware offset data for this run.')
     getByText('What is labware offset?')
     getByText(
-      'Labware offsets data references previous protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.'
+      'Labware offset data references previous protocol run labware locations to save you time. Labware that has been used in the same slot as a protocol you are running will not need additional calibration. If all the labware in a new protocol have been checked in previous runs, you do not have to run Labware Position Check.'
     )
     getByText(
       'You can add new offsets with Labware Position Check in later steps if you desire.'

--- a/app/src/organisms/ApplyHistoricOffsets/index.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import pick from 'lodash/pick'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import {
   Flex,
   Link,
@@ -77,6 +77,7 @@ export function ApplyHistoricOffsets(
       {...{ labware, modules, commands }}
     />
   )
+  const noOffsetData = offsetCandidates.length < 1
   return (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
       <CheckboxField
@@ -84,12 +85,14 @@ export function ApplyHistoricOffsets(
           setShouldApplyOffsets(e.currentTarget.checked)
         }}
         value={shouldApplyOffsets}
-        disabled={offsetCandidates.length < 1}
-        isIndeterminate={offsetCandidates.length < 1}
+        disabled={noOffsetData}
+        isIndeterminate={noOffsetData}
         label={
           <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing2}>
             <Icon size={SIZE_1} name="reticle" />
-            <StyledText as="p">{t('apply_offset_data')}</StyledText>
+            <StyledText as="p">
+              {t(noOffsetData ? 'no_offset_data' : 'apply_offset_data')}
+            </StyledText>
           </Flex>
         }
       />
@@ -97,7 +100,7 @@ export function ApplyHistoricOffsets(
         onClick={() => setShowOffsetDataModal(true)}
         css={TYPOGRAPHY.linkPSemiBold}
       >
-        {t('view_data')}
+        {t(noOffsetData ? 'learn_more' : 'view_data')}
       </Link>
       {showOffsetDataModal ? (
         <Portal level="top">
@@ -105,26 +108,55 @@ export function ApplyHistoricOffsets(
             maxWidth="40rem"
             header={
               <ModalHeader
-                title={t('stored_offset_data')}
+                title={t(
+                  noOffsetData
+                    ? 'no_offset_data_available'
+                    : 'stored_offset_data'
+                )}
                 onClose={() => setShowOffsetDataModal(false)}
               />
             }
           >
-            <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing6}>
-              <StyledText as="p">
-                {offsetCandidates.length > 0
-                  ? t('robot_has_offsets_from_previous_runs')
-                  : t('robot_has_no_offsets_from_previous_runs')}
-              </StyledText>
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              padding={
+                noOffsetData
+                  ? `${SPACING.spacing4} ${SPACING.spacing6} ${SPACING.spacing6} ${SPACING.spacing6}`
+                  : SPACING.spacing6
+              }
+            >
+              {noOffsetData ? (
+                <>
+                  <StyledText as="p" marginBottom={SPACING.spacing3}>
+                    {t('no_offset_data_on_robot')}
+                  </StyledText>
+                  <StyledText css={TYPOGRAPHY.pSemiBold}>
+                    {t('what_labware_offset')}
+                  </StyledText>
+                  <Trans
+                    t={t}
+                    i18nKey={'robot_has_no_offsets_from_previous_runs'}
+                    components={{
+                      block: (
+                        <StyledText as="p" marginBottom={SPACING.spacing3} />
+                      ),
+                    }}
+                  />
+                </>
+              ) : (
+                <StyledText as="p">
+                  {t('robot_has_offsets_from_previous_runs')}
+                </StyledText>
+              )}
               <Link
                 external
                 css={TYPOGRAPHY.linkPSemiBold}
-                marginTop={SPACING.spacing3}
+                marginTop={noOffsetData ? '0px' : SPACING.spacing3}
                 href={HOW_OFFSETS_WORK_SUPPORT_URL}
               >
                 {t('see_how_offsets_work')}
               </Link>
-              {offsetCandidates.length > 0 ? (
+              {!noOffsetData ? (
                 isLabwareOffsetCodeSnippetsOn ? (
                   <LabwareOffsetTabs
                     TableComponent={

--- a/app/src/organisms/ApplyHistoricOffsets/index.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/index.tsx
@@ -121,7 +121,7 @@ export function ApplyHistoricOffsets(
               flexDirection={DIRECTION_COLUMN}
               padding={
                 noOffsetData
-                  ? `${SPACING.spacing4} ${SPACING.spacing6} ${SPACING.spacing6} ${SPACING.spacing6}`
+                  ? `${SPACING.spacing4} ${SPACING.spacing6} ${SPACING.spacing6}`
                   : SPACING.spacing6
               }
             >


### PR DESCRIPTION
closes RAUT-336 and RAUT-337

# Overview

 ✅  Already got design approval from Emily ✅ 

Offset model copy should match figma, saying the correct info for when no offset data is available

<img width="660" alt="Screen Shot 2023-03-07 at 2 15 47 PM" src="https://user-images.githubusercontent.com/66035149/223528112-dd5dd1ca-09c0-47a9-aa2c-00b9454c9693.png">

<img width="316" alt="Screen Shot 2023-03-07 at 1 52 53 PM" src="https://user-images.githubusercontent.com/66035149/223523325-a3f6ce3e-cff0-4e4f-9920-d1742ea19392.png">

# Test Plan

- in the desktop app, click on `Run now` from the overflow menu of a protocol card. The bottom of the Choose robot slideout should say `No offset data available, learn more`. Click on `Learn more`, the modal should give correct info for when there is no offset data available.

# Changelog

- add keys to i18n
- add no offset data logic to `ApplyHistoricalOffsets` and update test

# Review requests

- should match figma

# Risk assessment

low