### PR TITLE
fix(step-generation): specify intermediate temperature for heater shakers

### DIFF
--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -101,6 +101,7 @@ describe('heaterShaker compound command creator', () => {
         key: expect.any(String),
         params: {
           moduleId: 'heaterShakerId',
+          celsius: 80,
         },
       },
       {
@@ -165,6 +166,7 @@ describe('heaterShaker compound command creator', () => {
         key: expect.any(String),
         params: {
           moduleId: 'heaterShakerId',
+          celsius: 80,
         },
       },
       {

--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -97,14 +97,6 @@ describe('heaterShaker compound command creator', () => {
         },
       },
       {
-        commandType: 'heaterShaker/waitForTemperature',
-        key: expect.any(String),
-        params: {
-          moduleId: 'heaterShakerId',
-          celsius: 80,
-        },
-      },
-      {
         commandType: 'heaterShaker/setAndWaitForShakeSpeed',
         key: expect.any(String),
         params: {
@@ -159,14 +151,6 @@ describe('heaterShaker compound command creator', () => {
         params: {
           celsius: 80,
           moduleId: 'heaterShakerId',
-        },
-      },
-      {
-        commandType: 'heaterShaker/waitForTemperature',
-        key: expect.any(String),
-        params: {
-          moduleId: 'heaterShakerId',
-          celsius: 80,
         },
       },
       {

--- a/step-generation/src/commandCreators/atomic/waitForTemperature.ts
+++ b/step-generation/src/commandCreators/atomic/waitForTemperature.ts
@@ -77,6 +77,7 @@ export const waitForTemperature: CommandCreator<WaitForTemperatureArgs> = (
             key: uuid(),
             params: {
               moduleId: module,
+              celsius: temperature,
             },
           },
         ],

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -11,7 +11,6 @@ import { heaterShakerOpenLatch } from '../atomic/heaterShakerOpenLatch'
 import { heaterShakerCloseLatch } from '../atomic/heaterShakerCloseLatch'
 import { heaterShakerDeactivateHeater } from '../atomic/heaterShakerDeactivateHeater'
 import { setTemperature } from '../atomic/setTemperature'
-import { waitForTemperature } from '../atomic'
 import { heaterShakerStopShake } from '../atomic/heaterShakerStopShake'
 import { heaterShakerSetTargetShakeSpeed } from '../atomic/heaterShakerSetTargetShakeSpeed'
 
@@ -61,14 +60,6 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
         module: args.module,
         targetTemperature: args.targetTemperature,
         commandCreatorFnName: 'setTemperature',
-      })
-    )
-
-    commandCreators.push(
-      curryCommandCreator(waitForTemperature, {
-        module: args.module,
-        temperature: args.targetTemperature,
-        commandCreatorFnName: 'waitForTemperature',
       })
     )
   }


### PR DESCRIPTION
# Overview

This PR enables users to specify an intermediate temperature to await with a Heater-Shaker

**IMPORTANT**:
This means that we are no longer immediately awaiting a HS temperature after setting it.

Ex, this is what happened before if you were to use the HS temp form to set a HS to 77 degrees:
- set HS temp to 77 degrees
- await 77 degrees

Now it is up to the user to explicitly await a temperature, which is why we offer to auto create a pause step for users after a user submits a HS form.

This also means that users who previously never specified a pause step will now need to in order for protocols to work they way they expect. 

closes RAUT-330


# Test Plan

- Added a HS step going to a temp
- Added a pause step waiting till a HS reaches an intermediate temp
- Exported the protocol
- Validated that the correct commands were generated


# Changelog

- Allows users to await intermediate temperatures on a heater shaker

# Review requests

See test plan above

# Risk assessment

Low/med
