### PR TITLE
test(robot-server): Port some tests to the the session-scoped dev server

### DIFF
--- a/robot-server/tests/integration/common.yaml
+++ b/robot-server/tests/integration/common.yaml
@@ -3,5 +3,6 @@ name: Common test information
 description: Variables and other info used across tests
 
 variables:
+  # These must match the session_server_host and session_server_port fixtures in conftest.py.
   host: http://localhost
   port: 31950

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -1,14 +1,14 @@
 import json
-import subprocess
-import sys
 import time
-import signal
+from pathlib import Path
 from typing import Any, Dict, Iterator
 
 import pytest
 import requests
 
 from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
+
+from .dev_server import DevServer
 
 
 def pytest_tavern_beta_before_every_test_run(
@@ -39,38 +39,14 @@ def request_session() -> requests.Session:
 @pytest.fixture(scope="session")
 def run_server(
     request_session: requests.Session, server_temp_directory: str
-) -> Iterator["subprocess.Popen[Any]"]:
+) -> Iterator[None]:
     """Run the robot server in a background process."""
-    # In order to collect coverage we run using `coverage`.
-    # `-a` is to append to existing `.coverage` file.
-    # `--source` is the source code folder to collect coverage stats on.
-    with subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "coverage",
-            "run",
-            "-a",
-            "--source",
-            "robot_server",
-            "-m",
-            "uvicorn",
-            "robot_server:app",
-            "--host",
-            "localhost",
-            "--port",
-            "31950",
-        ],
-        env={
-            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
-            "OT_API_CONFIG_DIR": server_temp_directory,
-        },
-        stdin=subprocess.DEVNULL,
-        # The server will log to its stdout or stderr.
-        # Let it inherit our stdout and stderr so pytest captures its logs.
-        stdout=None,
-        stderr=None,
-    ) as proc:
+    with DevServer(
+        port="31950",
+        ot_api_config_dir=Path(server_temp_directory),
+    ) as dev_server:
+        dev_server.start()
+
         # Wait for a bit to get started by polling /hcpealth
         from requests.exceptions import ConnectionError
 
@@ -85,9 +61,8 @@ def run_server(
         request_session.post(
             "http://localhost:31950/robot/home", json={"target": "robot"}
         )
-        yield proc
-        proc.send_signal(signal.SIGTERM)
-        proc.wait()
+
+        yield
 
 
 @pytest.fixture

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -1,7 +1,14 @@
 import json
-from typing import Any, Dict
+import subprocess
+import sys
+import time
+import signal
+from typing import Any, Dict, Iterator
 
-from requests import Response
+import pytest
+import requests
+
+from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
 
 
 def pytest_tavern_beta_before_every_test_run(
@@ -15,6 +22,83 @@ def pytest_tavern_beta_before_every_test_run(
         stage["request"].update({"headers": headers})
 
 
-def pytest_tavern_beta_after_every_response(expected: Any, response: Response) -> None:
+def pytest_tavern_beta_after_every_response(
+    expected: Any, response: requests.Response
+) -> None:
     print(response.url)
     print(json.dumps(response.json(), indent=4))
+
+
+@pytest.fixture(scope="session")
+def request_session() -> requests.Session:
+    session = requests.Session()
+    session.headers.update({API_VERSION_HEADER: LATEST_API_VERSION_HEADER_VALUE})
+    return session
+
+
+@pytest.fixture(scope="session")
+def run_server(
+    request_session: requests.Session, server_temp_directory: str
+) -> Iterator["subprocess.Popen[Any]"]:
+    """Run the robot server in a background process."""
+    # In order to collect coverage we run using `coverage`.
+    # `-a` is to append to existing `.coverage` file.
+    # `--source` is the source code folder to collect coverage stats on.
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-a",
+            "--source",
+            "robot_server",
+            "-m",
+            "uvicorn",
+            "robot_server:app",
+            "--host",
+            "localhost",
+            "--port",
+            "31950",
+        ],
+        env={
+            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
+            "OT_API_CONFIG_DIR": server_temp_directory,
+        },
+        stdin=subprocess.DEVNULL,
+        # The server will log to its stdout or stderr.
+        # Let it inherit our stdout and stderr so pytest captures its logs.
+        stdout=None,
+        stderr=None,
+    ) as proc:
+        # Wait for a bit to get started by polling /hcpealth
+        from requests.exceptions import ConnectionError
+
+        while True:
+            try:
+                request_session.get("http://localhost:31950/health")
+            except ConnectionError:
+                pass
+            else:
+                break
+            time.sleep(0.5)
+        request_session.post(
+            "http://localhost:31950/robot/home", json={"target": "robot"}
+        )
+        yield proc
+        proc.send_signal(signal.SIGTERM)
+        proc.wait()
+
+
+@pytest.fixture
+def set_disable_fast_analysis(
+    request_session: requests.Session,
+) -> Iterator[None]:
+    """For integration tests that need to set then clear the
+    enableHttpProtocolSessions feature flag"""
+    url = "http://localhost:31950/settings"
+    data = {"id": "disableFastProtocolUpload", "value": True}
+    request_session.post(url, json=data)
+    yield None
+    data["value"] = None
+    request_session.post(url, json=data)

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -12,6 +12,7 @@ class DevServer:
     def __init__(
         self,
         port: str = "31950",
+        ot_api_config_dir: Optional[Path] = None,
         persistence_directory: Optional[Path] = None,
         maximum_runs: Optional[int] = None,
         maximum_unused_protocols: Optional[int] = None,
@@ -19,7 +20,11 @@ class DevServer:
         """Initialize a dev server."""
         self.port: str = port
 
-        self.server_temp_directory: str = tempfile.mkdtemp()
+        self.ot_api_config_dir: Path = (
+            ot_api_config_dir
+            if ot_api_config_dir is not None
+            else Path(tempfile.mkdtemp())
+        )
         self.persistence_directory: Path = (
             persistence_directory
             if persistence_directory is not None
@@ -46,7 +51,7 @@ class DevServer:
         # not have any side effects.
         env = {
             "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
-            "OT_API_CONFIG_DIR": self.server_temp_directory,
+            "OT_API_CONFIG_DIR": str(self.ot_api_config_dir),
             "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),
         }
         if self.maximum_runs is not None:

--- a/robot-server/tests/integration/http_api/protocols/test_upload_bundled_data.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_bundled_data.py
@@ -3,45 +3,38 @@ import os
 import secrets
 from pathlib import Path
 
-from tests.integration.dev_server import DevServer
 from tests.integration.robot_client import RobotClient
 from tests.integration.protocol_files import get_py_protocol, get_bundled_data
 
 
-async def test_upload_protocols_with_bundled_data() -> None:
+async def test_upload_protocols_with_bundled_data(
+    session_server_host: str, session_server_port: str
+) -> None:
     """Test uploading data files with protocol."""
-    port = "15555"
     async with RobotClient.make(
-        host="http://localhost", port=port, version="*"
+        host=session_server_host, port=session_server_port, version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
-        with DevServer(port=port) as server:
-            server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+        with get_py_protocol(secrets.token_urlsafe(16)) as protocol:
+            with get_bundled_data(".csv") as csv:
+                with get_bundled_data(".txt") as txt:
+                    protocol_name = os.path.basename(protocol.name)
+                    csv_name = os.path.basename(csv.name)
+                    txt_name = os.path.basename(txt.name)
+                    response = await robot_client.post_protocol(
+                        [Path(protocol.name), Path(csv.name), Path(txt.name)]
+                    )
+        assert response.status_code == 201
+        response_data = response.json()["data"]
+        assert response_data["files"] == [
+            {"name": protocol_name, "role": "main"},
+            {"name": csv_name, "role": "data"},
+            {"name": txt_name, "role": "data"},
+        ]
+        protocol_id = response_data["id"]
 
-            with get_py_protocol(secrets.token_urlsafe(16)) as protocol:
-                with get_bundled_data(".csv") as csv:
-                    with get_bundled_data(".txt") as txt:
-                        protocol_name = os.path.basename(protocol.name)
-                        csv_name = os.path.basename(csv.name)
-                        txt_name = os.path.basename(txt.name)
-                        response = await robot_client.post_protocol(
-                            [Path(protocol.name), Path(csv.name), Path(txt.name)]
-                        )
-            assert response.status_code == 201
-            assert response.json()["data"]["files"] == [
-                {"name": protocol_name, "role": "main"},
-                {"name": csv_name, "role": "data"},
-                {"name": txt_name, "role": "data"},
-            ]
-
-            result = await robot_client.get_protocols()
-            assert result.json()["data"][0]["files"] == [
-                {"name": protocol_name, "role": "main"},
-                {"name": csv_name, "role": "data"},
-                {"name": txt_name, "role": "data"},
-            ]
+        result = await robot_client.get_protocol(protocol_id=protocol_id)
+        assert result.json()["data"]["files"] == [
+            {"name": protocol_name, "role": "main"},
+            {"name": csv_name, "role": "data"},
+            {"name": txt_name, "role": "data"},
+        ]

--- a/robot-server/tests/integration/http_api/protocols/test_upload_bundled_data.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_bundled_data.py
@@ -1,3 +1,8 @@
+# TODO(mm, 2023-01-11): Port this to a Tavern test once
+# https://github.com/taverntesting/tavern/issues/833 is resolved. We need to upload
+# multiple files into the `files` field of the `POST /protocols` endpoint.
+
+
 import os
 
 import secrets

--- a/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
@@ -16,12 +16,11 @@ labware.
 import asyncio
 import textwrap
 from pathlib import Path
-from typing import Any, AsyncGenerator, Generator
+from typing import Any, AsyncGenerator
 
 import anyio
 import pytest
 
-from tests.integration.dev_server import DevServer
 from tests.integration.robot_client import RobotClient
 
 
@@ -29,24 +28,18 @@ INTEGRATION_TEST_PROTOCOLS_DIR = Path(__file__).parent / "../../protocols"
 LABWARE_PATH = INTEGRATION_TEST_PROTOCOLS_DIR / "test_1_reservoir_5ul.json"
 EXPECTED_LABWARE_LOAD_NAME = "test_1_reservoir_5ul"
 
-PORT = "15555"
 ANALYSIS_POLL_INTERVAL = 0.1
 ANALYSIS_POLL_TIMEOUT = 10
 
 
-@pytest.fixture(scope="module")
-def dev_server() -> Generator[DevServer, None, None]:
-    """Return a running dev server."""
-    with DevServer(port=PORT) as dev_server:
-        dev_server.start()
-        yield dev_server
-
-
 @pytest.fixture
-async def robot_client(dev_server: DevServer) -> AsyncGenerator[RobotClient, None]:
+async def robot_client(
+    session_server_host: str,
+    session_server_port: str,
+) -> AsyncGenerator[RobotClient, None]:
     """Return a client for a running dev server."""
     async with RobotClient.make(
-        host="http://localhost", port=dev_server.port, version="*"
+        host=session_server_host, port=session_server_port, version="*"
     ) as robot_client:
         assert (
             await robot_client.wait_until_alive()


### PR DESCRIPTION
# Overview

This PR makes `robot-server`'s integration tests faster. Closes RSS-195.

This is merging into `release_6.3.0` instead of `edge`, to undo the damage that I did in #12229.

# Test Plan

Run `make -C robot-server test` locally and make sure it still works properly.

# Changelog

* Port some tests to use the preexisting session-scoped `run_server` instead of spinning up a bespoke isolated `DevServer`. This reduces isolation, but speeds up the tests by ~30 seconds on my machine.

Plus some incidental refactors:

* Move some fixtures that only made sense for integration tests from the top-level `conftest.py` to `tests/integration/conftest.py`.
* Deduplicate the implementations of `run_server` and `DevServer`. `run_server` is now implemented in terms of `DevServer`.


# Review requests

* Are there any other tests that look like they can be ported from an isolated `DevServer` to the session-scoped `run_server` fixture?

# Risk assessment

No risk to production code. This affects tests only.

There's some risk of introducing test flakiness because of the nature of sharing a single server across many tests.
