### PR TITLE
refactor(shared-data): remove unused gripper data

### DIFF
--- a/shared-data/gripper/definitions/1/gripperV1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.json
@@ -3,13 +3,6 @@
   "model": "gripperV1",
   "schemaVersion": 1,
   "displayName": "Gripper V1",
-  "zMotorConfigurations": {
-    "idle": 0.2,
-    "run": 0.67
-  },
-  "jawMotorConfigurations": {
-    "vref": 2.0
-  },
   "gripForceProfile": {
     "polynomial": [
       [0, -0.282],

--- a/shared-data/gripper/schemas/1.json
+++ b/shared-data/gripper/schemas/1.json
@@ -20,12 +20,6 @@
     "geometry": {
       "$ref": "#/definitions/Geometry"
     },
-    "zMotorConfigurations": {
-      "$ref": "#/definitions/ZMotorConfigurations"
-    },
-    "jawMotorConfigurations": {
-      "$ref": "#/definitions/JawMotorConfigurations"
-    },
     "gripForceProfile": {
       "$ref": "#/definitions/GripForceProfile"
     }
@@ -35,8 +29,6 @@
     "displayName",
     "model",
     "geometry",
-    "zMotorConfigurations",
-    "jawMotorConfigurations",
     "gripForceProfile"
   ],
   "definitions": {
@@ -126,43 +118,6 @@
         "pinTwoOffsetFromBase",
         "jawWidth"
       ]
-    },
-    "ZMotorConfigurations": {
-      "title": "ZMotorConfigurations",
-      "description": "Gripper z motor configurations.",
-      "type": "object",
-      "properties": {
-        "idle": {
-          "title": "Idle",
-          "description": "Motor idle current in A",
-          "minimum": 0.02,
-          "maximum": 1.0,
-          "type": "number"
-        },
-        "run": {
-          "title": "Run",
-          "description": "Motor active current in A",
-          "minimum": 0.67,
-          "maximum": 2.5,
-          "type": "number"
-        }
-      },
-      "required": ["idle", "run"]
-    },
-    "JawMotorConfigurations": {
-      "title": "JawMotorConfigurations",
-      "description": "Gripper z motor configurations.",
-      "type": "object",
-      "properties": {
-        "vref": {
-          "title": "Vref",
-          "description": "Reference voltage in V",
-          "minimum": 0.5,
-          "maximum": 2.5,
-          "type": "number"
-        }
-      },
-      "required": ["vref"]
     },
     "GripForceProfile": {
       "title": "GripForceProfile",

--- a/shared-data/python/opentrons_shared_data/gripper/__init__.py
+++ b/shared-data/python/opentrons_shared_data/gripper/__init__.py
@@ -10,8 +10,6 @@ from .gripper_definition import (
     GripperSchema,
     GripperSchemaVersion,
     GripForceProfile,
-    JawMotorConfigurations,
-    ZMotorConfigurations,
     GripperModel,
     Geometry,
 )
@@ -59,8 +57,6 @@ __all__ = [
     "GripperSchema",
     "GripperSchemaVersion",
     "GripForceProfile",
-    "JawMotorConfigurations",
-    "ZMotorConfigurations",
     "GripperModel",
     "Geometry",
     "generate_schema",

--- a/shared-data/python/opentrons_shared_data/gripper/gripper_definition.py
+++ b/shared-data/python/opentrons_shared_data/gripper/gripper_definition.py
@@ -65,34 +65,6 @@ class Geometry(GripperBaseModel):
     jaw_width: Dict[str, float]
 
 
-class ZMotorConfigurations(GripperBaseModel):
-    """Gripper z motor configurations."""
-
-    idle: float = Field(
-        ...,
-        description="Motor idle current in A",
-        ge=0.02,
-        le=1.0,
-    )
-    run: float = Field(
-        ...,
-        description="Motor active current in A",
-        ge=0.67,
-        le=2.5,
-    )
-
-
-class JawMotorConfigurations(GripperBaseModel):
-    """Gripper z motor configurations."""
-
-    vref: float = Field(
-        ...,
-        description="Reference voltage in V",
-        ge=0.5,
-        le=2.5,
-    )
-
-
 PolynomialTerm = Tuple[_StrictNonNegativeInt, float]
 
 
@@ -119,6 +91,4 @@ class GripperDefinition(GripperBaseModel):
     display_name: str = Field(..., description="Gripper display name.")
     model: GripperModel
     geometry: Geometry
-    z_motor_configurations: ZMotorConfigurations
-    jaw_motor_configurations: JawMotorConfigurations
     grip_force_profile: GripForceProfile

--- a/shared-data/python/tests/gripper/test_definition.py
+++ b/shared-data/python/tests/gripper/test_definition.py
@@ -20,11 +20,11 @@ def test_gripper_definition_type() -> None:
     assert GripperDefinition.parse_obj(GRIPPER_DEF)
 
     # missing key
-    del GRIPPER_DEF["geometry"]
+    del GRIPPER_DEF["gripForceProfile"]
     with pytest.raises(ValidationError):
         assert GripperDefinition.parse_obj(GRIPPER_DEF)
 
     # no missing key but with incorrect value
-    GRIPPER_DEF["ZMotorConfigurations"] = {"idle": 2.0, "run": "1.0"}
+    GRIPPER_DEF["geometry"]["gripForceProfile"] = {"min": 1.0, "max": "0.0"}
     with pytest.raises(ValidationError):
         assert GripperDefinition.parse_obj(GRIPPER_DEF)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
After discussing with the hardware team, we decided to keep motor current configurations out of shared-data since we already set them in `defaults_ot3.py`. 