### PR TITLE
fix(app): show tooltip and not yet started when run is idle

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -116,5 +116,6 @@
   "not_started_yet": "Not started yet",
   "preview_of_protocol_steps": "This is a preview of your protocol's steps",
   "steps_total": "{{count}} steps total",
-  "protocol_completed": "Protocol completed"
+  "protocol_completed": "Protocol completed",
+  "complete_protocol_to_download": "Complete the protocol to download the run log"
 }

--- a/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -5,8 +5,10 @@ import {
   useAllCommandsQuery,
   useCommandQuery,
 } from '@opentrons/react-api-client'
+import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 
 import { i18n } from '../../../i18n'
+import { ProgressBar } from '../../../atoms/ProgressBar'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useLastRunCommandKey } from '../../Devices/hooks/useLastRunCommandKey'
@@ -17,9 +19,7 @@ import {
   NON_DETERMINISTIC_COMMAND_ID,
   NON_DETERMINISTIC_COMMAND_KEY,
 } from '../__fixtures__'
-
 import { RunProgressMeter } from '..'
-import { ProgressBar } from '../../../atoms/ProgressBar'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../RunTimeControl/hooks')
@@ -61,7 +61,7 @@ describe('RunProgressMeter', () => {
   let props: React.ComponentProps<typeof RunProgressMeter>
   beforeEach(() => {
     mockProgressBar.mockReturnValue(<div>MOCK PROGRESS BAR</div>)
-    mockUseRunStatus.mockReturnValue('running')
+    mockUseRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
     when(mockUseMostRecentCompletedAnalysis)
       .calledWith(NON_DETERMINISTIC_RUN_ID)
       .mockReturnValue(null)
@@ -95,5 +95,12 @@ describe('RunProgressMeter', () => {
     const { getByText, queryByText } = render(props)
     expect(getByText('Current Step 42/?')).toBeTruthy()
     expect(queryByText('MOCK PROGRESS BAR')).toBeFalsy()
+  })
+  it('should give the correct info when run status is idle', () => {
+    mockUseRunStatus.mockReturnValue(RUN_STATUS_IDLE)
+    const { getByText } = render(props)
+    getByText('Current Step:')
+    getByText('Not started yet')
+    getByText('Download run log')
   })
 })

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -108,9 +108,8 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
 
   let currentStepContents: React.ReactNode = null
   if (
-    (runStatus === RUN_STATUS_IDLE &&
-      analysisCommands[lastRunCommandIndex] == null) ||
-    runStatus === RUN_STATUS_IDLE
+    runStatus === RUN_STATUS_IDLE ||
+    analysisCommands[lastRunCommandIndex] == null
   ) {
     currentStepContents = (
       <StyledText as="h2">{t('not_started_yet')}</StyledText>
@@ -161,9 +160,8 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
           <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>{`${t(
             'current_step'
           )}${
-            (runStatus === RUN_STATUS_IDLE &&
-              analysisCommands[lastRunCommandIndex] == null) ||
-            runStatus === RUN_STATUS_IDLE
+            runStatus === RUN_STATUS_IDLE ||
+            analysisCommands[lastRunCommandIndex] == null
               ? ':'
               : ` ${countOfTotalText}${currentStepContents != null ? ': ' : ''}`
           }`}</StyledText>

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -105,20 +105,9 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   } else if (analysis == null) {
     countOfTotalText = ''
   }
-  const displayRunNotStarted =
-    (runStatus === RUN_STATUS_IDLE &&
-      analysisCommands[lastRunCommandIndex] == null) ||
-    runStatus === RUN_STATUS_IDLE
 
   let currentStepContents: React.ReactNode = null
-  if (displayRunNotStarted) {
-    currentStepContents = (
-      <StyledText as="h2">{t('not_started_yet')}</StyledText>
-    )
-  } else if (
-    analysis != null &&
-    analysisCommands[lastRunCommandIndex] != null
-  ) {
+  if (analysis != null && analysisCommands[lastRunCommandIndex] != null) {
     currentStepContents = (
       <CommandText
         robotSideAnalysis={analysis}
@@ -135,6 +124,10 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
         robotSideAnalysis={analysis}
         command={runCommandDetails.data}
       />
+    )
+  } else if (runStatus === RUN_STATUS_IDLE) {
+    currentStepContents = (
+      <StyledText as="h2">{t('not_started_yet')}</StyledText>
     )
   } else if (runStatus != null && TERMINAL_RUN_STATUSES.includes(runStatus)) {
     currentStepContents = (
@@ -161,7 +154,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
           <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>{`${t(
             'current_step'
           )}${
-            displayRunNotStarted
+            runStatus === RUN_STATUS_IDLE
               ? ':'
               : ` ${countOfTotalText}${currentStepContents != null ? ': ' : ''}`
           }`}</StyledText>

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -13,6 +13,8 @@ import {
   SIZE_1,
   Link,
   ALIGN_CENTER,
+  useHoverTooltip,
+  TOOLTIP_LEFT,
 } from '@opentrons/components'
 import {
   RUN_STATUS_IDLE,
@@ -28,6 +30,7 @@ import {
 } from '@opentrons/react-api-client'
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { StyledText } from '../../atoms/text'
+import { Tooltip } from '../../atoms/Tooltip'
 import { CommandText } from '../CommandText'
 import { useRunStatus } from '../RunTimeControl/hooks'
 import { ProgressBar } from '../../atoms/ProgressBar'
@@ -53,6 +56,9 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   const { runId, robotName, makeHandleJumpToStep } = props
   const { t } = useTranslation('run_details')
   const runStatus = useRunStatus(runId)
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_LEFT,
+  })
   const analysis = useMostRecentCompletedAnalysis(runId)
   const { data: allCommandsQueryData } = useAllCommandsQuery(runId)
   const analysisCommands = analysis?.commands ?? []
@@ -101,7 +107,18 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   }
 
   let currentStepContents: React.ReactNode = null
-  if (analysis != null && analysisCommands[lastRunCommandIndex] != null) {
+  if (
+    (runStatus === RUN_STATUS_IDLE &&
+      analysisCommands[lastRunCommandIndex] == null) ||
+    runStatus === RUN_STATUS_IDLE
+  ) {
+    currentStepContents = (
+      <StyledText as="h2">{t('not_started_yet')}</StyledText>
+    )
+  } else if (
+    analysis != null &&
+    analysisCommands[lastRunCommandIndex] != null
+  ) {
     currentStepContents = (
       <CommandText
         robotSideAnalysis={analysis}
@@ -119,13 +136,6 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
         command={runCommandDetails.data}
       />
     )
-  } else if (
-    runStatus === RUN_STATUS_IDLE &&
-    analysisCommands[lastRunCommandIndex] == null
-  ) {
-    currentStepContents = (
-      <StyledText as="h2">{t('not_started_yet')}</StyledText>
-    )
   } else if (runStatus != null && TERMINAL_RUN_STATUSES.includes(runStatus)) {
     currentStepContents = (
       <StyledText as="h2">{t('protocol_completed')}</StyledText>
@@ -139,7 +149,10 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     downloadRunLog()
   }
 
-  const downloadIsDisabled = runStatus === RUN_STATUS_RUNNING
+  const downloadIsDisabled =
+    runStatus === RUN_STATUS_RUNNING ||
+    runStatus === RUN_STATUS_IDLE ||
+    runStatus === RUN_STATUS_FINISHING
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
@@ -147,12 +160,18 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
         <Flex gridGap={SPACING.spacing3}>
           <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>{`${t(
             'current_step'
-          )} ${countOfTotalText}${
-            currentStepContents != null ? ': ' : ''
+          )}${
+            (runStatus === RUN_STATUS_IDLE &&
+              analysisCommands[lastRunCommandIndex] == null) ||
+            runStatus === RUN_STATUS_IDLE
+              ? ':'
+              : ` ${countOfTotalText}${currentStepContents != null ? ': ' : ''}`
           }`}</StyledText>
+
           {currentStepContents}
         </Flex>
         <Link
+          {...targetProps}
           role="button"
           css={css`
             ${TYPOGRAPHY.darkLinkH4SemiBold}
@@ -174,6 +193,11 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
             {t('download_run_log')}
           </Flex>
         </Link>
+        {downloadIsDisabled ? (
+          <Tooltip tooltipProps={tooltipProps}>
+            {t('complete_protocol_to_download')}
+          </Tooltip>
+        ) : null}
       </Flex>
       {analysis != null && lastRunCommandIndex >= 0 ? (
         <ProgressBar

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -105,12 +105,13 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   } else if (analysis == null) {
     countOfTotalText = ''
   }
+  const displayRunNotStarted =
+    (runStatus === RUN_STATUS_IDLE &&
+      analysisCommands[lastRunCommandIndex] == null) ||
+    runStatus === RUN_STATUS_IDLE
 
   let currentStepContents: React.ReactNode = null
-  if (
-    runStatus === RUN_STATUS_IDLE ||
-    analysisCommands[lastRunCommandIndex] == null
-  ) {
+  if (displayRunNotStarted) {
     currentStepContents = (
       <StyledText as="h2">{t('not_started_yet')}</StyledText>
     )
@@ -160,8 +161,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
           <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>{`${t(
             'current_step'
           )}${
-            runStatus === RUN_STATUS_IDLE ||
-            analysisCommands[lastRunCommandIndex] == null
+            displayRunNotStarted
               ? ':'
               : ` ${countOfTotalText}${currentStepContents != null ? ': ' : ''}`
           }`}</StyledText>


### PR DESCRIPTION
closes RAUT-343 RAUT-344

# Overview

✅  design qa already completed from Mel & Ed

Now when a run is idle, the current command will say `Not yet started` and when a run is idle or running, the `download run log` button is disabled with a tooltip explaining when the log is downloadable.

<img width="906" alt="Screen Shot 2023-03-09 at 10 23 37 AM" src="https://user-images.githubusercontent.com/66035149/224070692-c16c1eda-323f-41d7-95c9-753969cc796f.png">

<img width="342" alt="Screen Shot 2023-03-09 at 10 23 51 AM" src="https://user-images.githubusercontent.com/66035149/224070769-58f11bf0-8268-4e79-a4d1-d5f673e14d50.png">

# Test Plan

- upload a run to the robot, the run progress bar should display `Not yet started` when the run has not been started yet.
- hover over the `download run log` button, you should see a tooltip. Start the run, the tooltip should still be visible. The button should be disabled as well. when the run is complete, failed, or stopped, the run log button should not be disabled.

# Changelog

- add tooltip to the link button in `RunProgressMeter`
- rearrange if statement logic and add if run status is idle to display the `not yet started` text

# Review requests

- see test plan

# Risk assessment

- low