### PR TITLE
fix(api): Access channels property when analyzing a transfer command on an OT-2

### DIFF
--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -408,7 +408,7 @@ class TransferPlan:
         # then avoid iterating through its Wells.
         # ii. if using single channel pipettes, flatten a multi-dimensional
         # list of Wells into a 1 dimensional list of Wells
-        if self._instr.hw_pipette["channels"] > 1:
+        if self._instr.channels > 1:
             sources, dests = self._multichannel_transfer(sources, dests)
         else:
             if isinstance(sources, List) and isinstance(sources[0], List):


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-540.

# Test Plan

upload the following protocol to an OT-2. make sure it passes analysis and runs as expected. 

```
from opentrons import protocol_api

metadata = {
    'protocolName': 'Serial Dilution Tutorial',
    'description': '''This protocol is the outcome of following the
                   Python Protocol API Tutorial located at
                   https://docs.opentrons.com/v2/tutorial.html. It takes a
                   solution and progressively dilutes it by transferring it
                   stepwise across a plate.''',
    'author': 'New API User'
    }

requirements = {
    "robotType": "OT-2",
    'apiLevel': '2.14',
}

def run(protocol: protocol_api.ProtocolContext):
	tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', 1)
	reservoir = protocol.load_labware('nest_12_reservoir_15ml', 2)
	plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 3)
	p300 = protocol.load_instrument('p300_single_gen2', 'left', tip_racks=[tiprack])

	# distribute diluent
	p300.transfer(100, reservoir['A1'], plate.wells())
```

# Changelog

access InstrumentContext.channels prop instead of retrieving from hardware_state.

# Risk assessment

low. fixed a bug related to analysis on an OT2. 