### PR TITLE
refactor(app): switch hardcode border-radius to constants

### DIFF
--- a/app/src/atoms/buttons/ODD/SmallButton.tsx
+++ b/app/src/atoms/buttons/ODD/SmallButton.tsx
@@ -3,13 +3,14 @@ import {
   TYPOGRAPHY,
   COLORS,
   SPACING,
+  BORDERS,
   NewPrimaryBtn,
   styleProps,
 } from '@opentrons/components'
 
 export const SmallButton = styled(NewPrimaryBtn)`
   background-color: ${COLORS.blueEnabled};
-  border-radius: 12px;
+  border-radius: ${BORDERS.size_three};
   box-shadow: none;
   padding-left: ${SPACING.spacing4};
   padding-right: ${SPACING.spacing4};

--- a/app/src/molecules/CardButton/index.tsx
+++ b/app/src/molecules/CardButton/index.tsx
@@ -10,6 +10,7 @@ import {
   TYPOGRAPHY,
   Icon,
   Btn,
+  BORDERS,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 
@@ -48,7 +49,7 @@ export function CardButton(props: CardButtonProps): JSX.Element {
       width={cardWidth}
       height={cardHeight}
       backgroundColor={COLORS.medBlue}
-      borderRadius="16px"
+      borderRadius={BORDERS.size_four}
     >
       <Icon
         name={iconName}

--- a/app/src/molecules/MiniCardButton/index.tsx
+++ b/app/src/molecules/MiniCardButton/index.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   DIRECTION_COLUMN,
   ALIGN_FLEX_START,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../atoms/text'
@@ -37,7 +38,7 @@ export function MiniCardButton({
       flexDirection={DIRECTION_COLUMN}
       alignItems={ALIGN_FLEX_START}
       padding={SPACING.spacing5}
-      borderRadius="12px"
+      borderRadius={BORDERS.size_three}
       onClick={() => history.push(`${destinationPath}`)}
       backgroundColor={COLORS.lightGreyPressed}
       width={width}

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -13,6 +13,7 @@ import {
   JUSTIFY_SPACE_AROUND,
   TYPOGRAPHY,
   Box,
+  BORDERS,
 } from '@opentrons/components'
 
 import { getIsOnDevice } from '../../redux/config'
@@ -52,7 +53,7 @@ export function WizardRequiredEquipmentList(
           <Flex
             backgroundColor="#16212D33"
             flexDirection={DIRECTION_COLUMN}
-            borderRadius="0.75rem"
+            borderRadius={BORDERS.size_three}
           >
             {equipmentList.map((requiredEquipmentProps, index) => (
               <Box

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DeviceReset.tsx
@@ -14,6 +14,7 @@ import {
   COLORS,
   SPACING,
   JUSTIFY_SPACE_BETWEEN,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -115,7 +116,7 @@ export function DeviceReset({
           alignItems={ALIGN_CENTER}
           gridGap="0.75rem"
           padding={`${SPACING.spacing4} ${SPACING.spacing5}`}
-          borderRadius="12px"
+          borderRadius={BORDERS.size_three}
         >
           <Icon name="ot-alert" size="1.5rem" color={COLORS.warningEnabled} />
           <StyledText

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DeviceReset.tsx
@@ -43,7 +43,7 @@ const OptionLabel = styled.label<LabelProps>`
   border: 2px solid
     ${({ isSelected }) =>
       isSelected === true ? COLORS.blueEnabled : COLORS.light_two};
-  border-radius: 16px;
+  border-radius: ${BORDERS.size_four};
   background: ${({ isSelected }) =>
     isSelected === true ? COLORS.medBlue : COLORS.white};
 `

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DisplayBrightness.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DisplayBrightness.tsx
@@ -14,6 +14,7 @@ import {
   DIRECTION_ROW,
   Box,
   JUSTIFY_CENTER,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -32,7 +33,7 @@ interface RectProps {
 const BrightnessTile = styled(Box)`
   width: 5.875rem;
   height: 8.75rem;
-  border-radius: 8px;
+  border-radius: ${BORDERS.size_two};
   background: ${(props: RectProps) => (props.isActive ? '#9c3ba4' : '#E7C3E9')};
 `
 

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DisplaySleepSettings.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/DisplaySleepSettings.tsx
@@ -12,6 +12,7 @@ import {
   SPACING,
   COLORS,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -34,7 +35,7 @@ const SettingButton = styled.input`
 
 const SettingButtonLabel = styled.label<LabelProps>`
   padding: ${SPACING.spacing5};
-  border-radius: 16px;
+  border-radius: ${BORDERS.size_four};
   cursor: pointer;
   background: ${({ isSelected }) =>
     isSelected === true ? COLORS.blueEnabled : '#e0e0e0'};

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
@@ -13,6 +13,7 @@ import {
   DIRECTION_COLUMN,
   ALIGN_CENTER,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -183,7 +184,7 @@ function NetworkSettingButton({
         width="100%"
         padding={SPACING.spacing5}
         backgroundColor={buttonBackgroundColor}
-        borderRadius="0.75rem"
+        borderRadius={BORDERS.size_three}
         onClick={displayDetailsTab}
       >
         <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing5}>

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/RobotSystemVersion.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/RobotSystemVersion.tsx
@@ -13,6 +13,7 @@ import {
   TYPOGRAPHY,
   DIRECTION_ROW,
   JUSTIFY_SPACE_BETWEEN,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -60,7 +61,7 @@ export function RobotSystemVersion({
               flexDirection={DIRECTION_ROW}
               padding={`${SPACING.spacing5} ${SPACING.spacing4}`}
               gridGap={SPACING.spacing4}
-              borderRadius="12px"
+              borderRadius={BORDERS.size_three}
               alignItems={ALIGN_CENTER}
               backgroundColor={COLORS.warningBackgroundMed}
             >
@@ -87,7 +88,7 @@ export function RobotSystemVersion({
               flexDirection={DIRECTION_ROW}
               padding={SPACING.spacing5}
               justifyContent={JUSTIFY_SPACE_BETWEEN}
-              borderRadius="12px"
+              borderRadius={BORDERS.size_three}
             >
               <StyledText
                 fontSize="1.5rem"

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/DisplayWifiList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/DisplayWifiList.tsx
@@ -15,6 +15,7 @@ import {
   JUSTIFY_CENTER,
   JUSTIFY_END,
   COLORS,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -79,7 +80,7 @@ export function DisplayWifiList({
             key={nw.ssid}
             backgroundColor="#d6d6d6"
             marginBottom={SPACING.spacing3}
-            borderRadius="12px"
+            borderRadius={BORDERS.size_three}
             css={NETWORK_ROW_STYLE}
             onClick={() => handleClick(nw)}
           >
@@ -108,7 +109,7 @@ export function DisplayWifiList({
         marginTop={SPACING.spacing3}
         height="4rem"
         backgroundColor="#d6d6d6"
-        borderRadius="12px"
+        borderRadius={BORDERS.size_three}
         color={COLORS.black}
         css={NETWORK_ROW_STYLE}
       >

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/SearchNetwork.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/SearchNetwork.tsx
@@ -8,6 +8,7 @@ import {
   JUSTIFY_CENTER,
   SPACING,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -19,7 +20,7 @@ export function SearchNetwork(): JSX.Element {
       height="22rem"
       backgroundColor="#D6D6D6"
       justifyContent={JUSTIFY_CENTER}
-      borderRadius="12px"
+      borderRadius={BORDERS.size_three}
       width="100%"
     >
       <Flex

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/SelectAuthenticationType.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/SelectAuthenticationType.tsx
@@ -14,6 +14,7 @@ import {
   Btn,
   Icon,
   JUSTIFY_CENTER,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -186,7 +187,7 @@ export function SelectAuthenticationType({
           padding={SPACING.spacing5}
           width="100%"
           height="6.75rem"
-          borderRadius="12px"
+          borderRadius={BORDERS.size_three}
           flexDirection={DIRECTION_ROW}
           alignItems={ALIGN_CENTER}
         >

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/WifiConnectionDetails.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/WifiConnectionDetails.tsx
@@ -15,6 +15,7 @@ import {
   ALIGN_CENTER,
   ALIGN_FLEX_END,
   JUSTIFY_CENTER,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -118,7 +119,7 @@ const DisplayConnectionStatus = ({
       }
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_CENTER}
-      borderRadius="12px"
+      borderRadius={BORDERS.size_three}
     >
       <Icon
         name="ot-check"
@@ -166,7 +167,7 @@ const DisplayConnectedNetworkInfo = ({
       paddingY={SPACING.spacing5}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       backgroundColor={COLORS.darkGreyDisabled}
-      borderRadius="0.75rem"
+      borderRadius={BORDERS.size_three}
     >
       <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
         <Icon name="wifi" size="2.4rem" />

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -68,7 +68,7 @@ const SELECTED_OPTIONS_STYLE = css`
 `
 const ON_DEVICE_UNSELECTED_OPTIONS_STYLE = css`
   background-color: #cccccc;
-  border-radius: 1rem;
+  border-radius: ${BORDERS.size_four};
   padding: ${SPACING.spacing5};
   margin-bottom: ${SPACING.spacing3};
   height: 5.25rem;

--- a/app/src/organisms/ProtocolSetupModules/index.tsx
+++ b/app/src/organisms/ProtocolSetupModules/index.tsx
@@ -13,6 +13,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 import {
   getDeckDefFromRobotType,
@@ -119,7 +120,7 @@ function SetupInstructionsButton(
     <Btn
       alignItems="center"
       backgroundColor={`${COLORS.darkBlackEnabled}${COLORS.opacity20HexCode}`}
-      borderRadius="40px"
+      borderRadius={BORDERS.size_five}
       display="flex"
       gridGap="0.5rem"
       padding="1rem 2rem"
@@ -141,7 +142,7 @@ function ContinueButton(
   return (
     <Btn
       backgroundColor={COLORS.blueEnabled}
-      borderRadius="40px"
+      borderRadius={BORDERS.size_five}
       color={COLORS.white}
       padding="1rem 2rem"
       onClick={props.onClick}
@@ -165,7 +166,7 @@ function DeckMapButton(props: React.HTMLProps<HTMLButtonElement>): JSX.Element {
       bottom="1.5rem"
       right="1.5rem"
       backgroundColor={COLORS.blueEnabled}
-      borderRadius="40px"
+      borderRadius={BORDERS.size_five}
       color={COLORS.white}
       padding="1rem 2rem"
       onClick={props.onClick}

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
@@ -11,6 +11,7 @@ import {
   JUSTIFY_CENTER,
   SPACING,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 import {
   useCreateRunMutation,
@@ -105,7 +106,7 @@ export function LongPressModal(props: {
         <TooManyPinsModal longpress={longpress} />
       ) : (
         <ModalShell
-          borderRadius="0.75rem"
+          borderRadius={BORDERS.size_three}
           onOutsideClick={handleCloseModal}
           width="15.625rem"
         >

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/TooManyPinsModal.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/TooManyPinsModal.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   SPACING,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
@@ -25,7 +26,7 @@ export function TooManyPinsModal(props: {
 
   return (
     <ModalShell
-      borderRadius="0.75rem"
+      borderRadius={BORDERS.size_three}
       height="26rem"
       onOutsideClick={handleCloseMaxPinsAlert}
       width="32.375rem"
@@ -52,7 +53,7 @@ export function TooManyPinsModal(props: {
         </StyledText>
         <Flex
           backgroundColor={COLORS.blueEnabled}
-          borderRadius="0.75rem"
+          borderRadius={BORDERS.size_three}
           flexDirection={DIRECTION_COLUMN}
           marginTop={SPACING.spacing6}
           onClick={handleCloseMaxPinsAlert}

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
@@ -16,6 +16,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   TEXT_ALIGN_RIGHT,
   TYPOGRAPHY,
+  BORDERS,
 } from '@opentrons/components'
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import {
@@ -70,7 +71,7 @@ function ProtocolSetupStep({
       <Flex
         alignItems={ALIGN_CENTER}
         backgroundColor={backgroundColorByStepStatus[status]}
-        borderRadius="1rem"
+        borderRadius={BORDERS.size_four}
         gridGap="1.5rem"
         padding="1.5rem 1rem"
       >

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard.tsx
@@ -18,6 +18,7 @@ import {
   JUSTIFY_CENTER,
   TYPOGRAPHY,
   ALIGN_FLEX_END,
+  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../atoms/text'
@@ -239,7 +240,7 @@ const RobotSettingButton = ({
             alignItems={ALIGN_CENTER}
             backgroundColor={COLORS.warningBackgroundMed}
             padding={`0.75rem ${SPACING.spacing4}`}
-            borderRadius="16px"
+            borderRadius={BORDERS.size_four}
           >
             <Icon
               name="ot-alert"

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard.tsx
@@ -49,7 +49,7 @@ const SETTING_BUTTON_STYLE = css`
   margin-bottom: ${SPACING.spacing3};
   background-color: ${COLORS.medGreyEnabled};
   padding: 1.5rem;
-  border-radius: 16px;
+  border-radius: ${BORDERS.size_four};
 `
 export type SettingOption =
   | 'RobotName'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update borderRadius/border-radius 8px, 12px, 16px, 40px + rem (ODD related components only) 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
not required since this PR won't change any UIs and functions
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update hardcoded `boderRadius/border-radius` value
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- The size is converted correctly
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
