### PR TITLE
feat(app-shell-odd): Use sd-notify

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -181,6 +181,7 @@ jobs:
         name: 'build ODD app for linux'
         timeout-minutes: 60
         run: |
+          sudo apt-get install libsystemd-dev
           make -C app-shell-odd dist-ot3
 
   build-app-ot3:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -114,7 +114,7 @@ jobs:
         run: npm install -g npm@6
       - name: check make version
         run: make --version
-      - name: 'install libudev'
+      - name: 'install libudev and libsystemd'
         if: startsWith(matrix.os, 'ubuntu')
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
@@ -181,7 +181,6 @@ jobs:
         name: 'build ODD app for linux'
         timeout-minutes: 60
         run: |
-          sudo apt-get install libsystemd-dev
           make -C app-shell-odd dist-ot3
 
   build-app-ot3:
@@ -206,7 +205,7 @@ jobs:
         run: make --version
       - name: 'install libudev'
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+        run: sudo apt-get update && sudo apt-get install libudev-dev libsystemd-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
         uses: actions/github-script@v6.1.1

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -42,9 +42,6 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 20
     steps:
-      - name: 'install systemd-dev'
-        run: |
-          sudo apt-get  install libsystemd-dev
       - uses: 'actions/checkout@v3'
       - uses: 'actions/setup-node@v3'
         with:

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -42,6 +42,9 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 20
     steps:
+      - name: 'install systemd-dev'
+      - run: |
+          sudo apt-get  install libsystemd-dev
       - uses: 'actions/checkout@v3'
       - uses: 'actions/setup-node@v3'
         with:

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: 'install systemd-dev'
-      - run: |
+        run: |
           sudo apt-get  install libsystemd-dev
       - uses: 'actions/checkout@v3'
       - uses: 'actions/setup-node@v3'

--- a/app-shell-odd/package.json
+++ b/app-shell-odd/package.json
@@ -55,11 +55,13 @@
     "node-fetch": "2.6.0",
     "node-stream-zip": "1.8.2",
     "pump": "3.0.0",
-    "sd-notify": "2.8.0",
     "semver": "5.5.0",
     "tempy": "1.0.1",
     "uuid": "3.2.1",
     "winston": "3.1.0",
     "yargs-parser": "13.1.2"
+  },
+  "optionalDependencies": {
+    "sd-notify": "2.8.0"
   }
 }

--- a/app-shell-odd/package.json
+++ b/app-shell-odd/package.json
@@ -55,6 +55,7 @@
     "node-fetch": "2.6.0",
     "node-stream-zip": "1.8.2",
     "pump": "3.0.0",
+    "sd-notify": "2.8.0",
     "semver": "5.5.0",
     "tempy": "1.0.1",
     "uuid": "3.2.1",

--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -7,10 +7,12 @@ import { registerRobotLogs } from './robot-logs'
 import { registerUpdate, updateLatestVersion } from './update'
 import { registerRobotSystemUpdate } from './system-update'
 import { getConfig, getStore, getOverrides, registerConfig } from './config'
+import sdNotify from 'sd-notify'
 
 import type { BrowserWindow } from 'electron'
 import type { Dispatch, Logger } from './types'
 
+sdNotify.sendStatus('starting app')
 const config = getConfig()
 const log = createLogger('main')
 
@@ -42,6 +44,7 @@ app.once('window-all-closed', () => {
 
 function startUp(): void {
   log.info('Starting App')
+  sdNotify.sendStatus('loading app')
   process.on('uncaughtException', error => log.error('Uncaught: ', { error }))
   process.on('unhandledRejection', reason =>
     log.error('Uncaught Promise rejection: ', { reason })
@@ -80,6 +83,11 @@ function startUp(): void {
   })
 
   log.silly('Global references', { mainWindow, rendererLogger })
+
+  ipcMain.once('dispatch', () => {
+    sdNotify.sendStatus('started')
+    sdNotify.ready()
+  })
 }
 
 function createRendererLogger(): Logger {

--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -7,7 +7,7 @@ import { registerRobotLogs } from './robot-logs'
 import { registerUpdate, updateLatestVersion } from './update'
 import { registerRobotSystemUpdate } from './system-update'
 import { getConfig, getStore, getOverrides, registerConfig } from './config'
-import sdNotify from 'sd-notify'
+import sdNotify from './systemd'
 
 import type { BrowserWindow } from 'electron'
 import type { Dispatch, Logger } from './types'

--- a/app-shell-odd/src/systemd.ts
+++ b/app-shell-odd/src/systemd.ts
@@ -1,24 +1,36 @@
 import { platform } from 'process'
+// Provide systemd when possible and a default mocked instance, used only during
+// dev workflows, when not.
 
-async function provideLinuxExports() {
-  const sdNotify = await import('sd-notify')
-  return { ready: sdNotify.ready, sendStatus: sdNotify.sendStatus }
+interface SDNotify {
+  ready: () => void
+  sendStatus: (text: string) => void
 }
 
-async function provideMockExports() {
-  return {
-    ready: () => console.log('would send sd-notify ready'),
-    sendStatus: (text: string) =>
-      console.log(`would send sd-notify status ${text}`),
+const provideExports = (): SDNotify => {
+  try {
+    // This has to be a require because import is async when used functionally,
+    // and to catch import errors you have to use it functionally, so it can't be
+    // at top level, and we're doing this to put stuff in exports, so let's
+    // refactor this whenever we turn on top-level async
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const systemdNotify = require('sd-notify')
+    return { ready: systemdNotify.ready, sendStatus: systemdNotify.sendStatus }
+  } catch (err) {
+    if (platform === 'linux') {
+      console.error(
+        'Could not import systemd on linux, where it should be present. This is most likely because libsystemd bindings are not available, which hopefully means this is a dev setup.'
+      )
+    }
+    return {
+      ready: () => console.log('would send sd-notify ready'),
+      sendStatus: (text: string) =>
+        console.log(`would send sd-notify status ${text}`),
+    }
   }
 }
 
-async function provideExportsForPlatform(forPlatform: 'linux' | string) {
-  if (forPlatform === 'linux') {
-    return await provideLinuxExports()
-  } else {
-    return await provideMockExports()
-  }
-}
-
-export default await provideExportsForPlatform(platform)
+// Finally, we want this to work just like the actual sd-notify imports, so a default
+// export it is
+// eslint-disable-next-line import/no-default-export
+export default provideExports()

--- a/app-shell-odd/src/systemd.ts
+++ b/app-shell-odd/src/systemd.ts
@@ -1,0 +1,24 @@
+import { platform } from 'process'
+
+async function provideLinuxExports() {
+  const sdNotify = await import('sd-notify')
+  return { ready: sdNotify.ready, sendStatus: sdNotify.sendStatus }
+}
+
+async function provideMockExports() {
+  return {
+    ready: () => console.log('would send sd-notify ready'),
+    sendStatus: (text: string) =>
+      console.log(`would send sd-notify status ${text}`),
+  }
+}
+
+async function provideExportsForPlatform(forPlatform: 'linux' | string) {
+  if (forPlatform === 'linux') {
+    return await provideLinuxExports()
+  } else {
+    return await provideMockExports()
+  }
+}
+
+export default await provideExportsForPlatform(platform)

--- a/app-shell-odd/typings/sd-notify.d.ts
+++ b/app-shell-odd/typings/sd-notify.d.ts
@@ -1,9 +1,12 @@
 declare module 'sd-notify' {
-    function ready(): void
-    function sendStatus(text: string): void
-    function startWatchdogMode(interval: number): void
-    function stopWatchdogMode(): void
-    export = {
-        ready, sendStatus, startWatchdogMode, stopWatchdogMode
-    }
+  function ready(): void
+  function sendStatus(text: string): void
+  function startWatchdogMode(interval: number): void
+  function stopWatchdogMode(): void
+  export = {
+    ready,
+    sendStatus,
+    startWatchdogMode,
+    stopWatchdogMode,
+  }
 }

--- a/app-shell-odd/typings/sd-notify.d.ts
+++ b/app-shell-odd/typings/sd-notify.d.ts
@@ -1,0 +1,9 @@
+declare module 'sd-notify' {
+    function ready(): void
+    function sendStatus(text: string): void
+    function startWatchdogMode(interval: number): void
+    function stopWatchdogMode(): void
+    export = {
+        ready, sendStatus, startWatchdogMode, stopWatchdogMode
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5434,7 +5434,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bindings@^1.5.0:
+bindings@1.5.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -18736,6 +18736,13 @@ scrollbar-width@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/scrollbar-width/-/scrollbar-width-3.1.1.tgz#c62e63efa5934dac37b43da34f7550caca8444a2"
   integrity sha1-xi5j76WTTaw3tD2jT3VQysqERKI=
+
+sd-notify@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/sd-notify/-/sd-notify-2.8.0.tgz#a8e4477efac8426084e235d5d6a89f2af75571fd"
+  integrity sha512-e+D1v0Y6UzmqXcPlaTkHk1QMdqk36mF/jIYv5gwry/N2Tb8/UNnpfG6ktGLpeBOR6TCC5hPKgqA+0hTl9sm2tA==
+  dependencies:
+    bindings "1.5.0"
 
 seek-bzip@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
# Overview

[sd-notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html#) is a utility for a program to communicate back to the systemd process manager that started it. It can be used in a variety of ways; the one that is most critical is to positively assert that it has started OK. Since this is a function call you can make any time you want to, this lets your program define when it has "started" on its own terms. 

The app, especially on the ODD, takes a long time to start - chrome takes a long time to start, and then we load up all our stuff. Currently, systemd considers us "started" as soon as the shell script that invokes chrome exits, which is long before anything useful is rendered. By making ourselves a `notify` service (in https://github.com/Opentrons/oe-core/pull/63) and putting the notify at the time we receive the first ipc message, which indicates that the frontend is up, we can delay that "ready" status until we're actually rendering.

This can then be used as a criterion in systemd to take down a loading screen.

## TBD
- Whether this is actually the right place to put the notify
- Whether it's pointless (or rather there's more work to do) because the app takes over the screen before the notify anyway
- Whether this catastrophically breaks dev flows on non-linux machines

# Test Plan

- [ ] Run normal dev workflows on not-linux and see if it breaks
- [x] Run on a flex and see if the time that systemd says we're up now matches better with when we start rendering