### PR TITLE
 fix(robot-server): Resolve DropTipWellOrigin pickle warnings

### DIFF
--- a/robot-server/robot_server/persistence/legacy_pickle.py
+++ b/robot-server/robot_server/persistence/legacy_pickle.py
@@ -143,6 +143,11 @@ def _get_legacy_ot_types() -> List[_LegacyTypeInfo]:
         _LegacyTypeInfo(original_name="DisplayCategory", current_type=DisplayCategory)
     )
 
+    from opentrons.protocol_engine import DropTipWellOrigin
+    _legacy_ot_types.append(
+        _LegacyTypeInfo(original_name="DropTipWellOrigin", current_type=DropTipWellOrigin)
+    )
+
     from opentrons.protocol_engine import EngineStatus
     _legacy_ot_types.append(
         _LegacyTypeInfo(original_name="EngineStatus", current_type=EngineStatus)


### PR DESCRIPTION
# Overview

Resolves this robot server warning:

> Unpickling unknown type "DropTipWellOrigin" from module "opentrons.protocol_engine.types". This may cause problems with reading records created by older versions of this robot software. This should be reported to Opentrons and investigated.

Closes RSS-198.

# Test Plan

I've tested this by doing this:

1. `make -C robot-server dev OT_ROBOT_SERVER_persistence_directory=droptipwellorigin_persistence`
2. Upload a protocol containing a `dropTip` command and wait for its analysis to finish
3. Restart the server
4. Fetch the protocol's analysis
    * A warning is logged before this PR, and not logged with this PR.

# Changelog

* Register `DropTipWellOrigin` as a known type that we pickle.

# Review requests

None in particular.

# Risk assessment

Low. The pattern here is well-established at this point.