### PR TITLE
fix(api): Raise a helpful error if you call `.reset()` on a labware that isn't a tip rack

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -271,7 +271,7 @@ If you specify an API version of ``2.13`` or lower, your protocols will continue
   - Motion planning has been improved to avoid certain erroneous downward movements,
     especially when using :py:meth:`.InstrumentContext.aspirate`.
 
-  - :py:attr:`.Labware.tip_length` will raise a useful error if called on labware that is not a tip rack.
+  - :py:meth:`.Labware.reset` and :py:attr:`.Labware.tip_length` will raise useful errors if called on labware that is not a tip rack.
 
 - Removals
 

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -108,7 +108,10 @@ class LabwareCore(AbstractLabware[WellCore]):
         return self._engine_client.state.labware.get_tip_length(self._labware_id)
 
     def reset_tips(self) -> None:
-        self._engine_client.reset_tips(labware_id=self.labware_id)
+        if self.is_tip_rack():
+            self._engine_client.reset_tips(labware_id=self.labware_id)
+        else:
+            raise TypeError(f"{self.get_display_name()} is not a tip rack.")
 
     def get_next_tip(
         self, num_tips: int, starting_tip: Optional[WellCore]

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -874,7 +874,12 @@ class Labware:
 
     @requires_version(2, 0)
     def reset(self) -> None:
-        """Reset all tips in a tiprack."""
+        """Reset all tips in a tiprack.
+
+        .. versionchanged:: 2.14
+            This method will raise an exception if you call it on a labware that isn't
+            a tip rack. Formerly, it would do nothing.
+        """
         self._core.reset_tips()
 
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -874,7 +874,7 @@ class Labware:
 
     @requires_version(2, 0)
     def reset(self) -> None:
-        """Reset all tips in a tiprack.
+        """Reset all tips in a tip rack.
 
         .. versionchanged:: 2.14
             This method will raise an exception if you call it on a labware that isn't

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -319,6 +319,8 @@ class ProtocolEngine:
 
     def reset_tips(self, labware_id: str) -> None:
         """Reset the tip state of a given labware."""
+        # TODO(mm, 2023-03-10): Safely raise an error if the given labware isn't a
+        # tip rack?
         self._action_dispatcher.dispatch(ResetTipsAction(labware_id=labware_id))
 
     # TODO(mm, 2022-11-10): This is a method on ProtocolEngine instead of a command

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -246,6 +246,9 @@ def test_reset_tips(
         LabwareDefinition.construct(  # type: ignore[call-arg]
             ordering=[],
             parameters=LabwareDefinitionParameters.construct(isTiprack=False),  # type: ignore[call-arg]
+            metadata=LabwareDefinitionMetadata.construct(  # type: ignore[call-arg]
+                displayName="Cool Display Name"
+            ),
         )
     ],
 )
@@ -253,7 +256,7 @@ def test_reset_tips_raises_if_not_tip_rack(
     decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
 ) -> None:
     """It should raise an exception if the labware isn't a tip rack."""
-    with pytest.raises(TypeError, match="not a tip rack"):
+    with pytest.raises(TypeError, match="Cool Display Name is not a tip rack"):
         subject.reset_tips()
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -223,12 +223,38 @@ def test_get_next_tip(
     assert result == "A2"
 
 
+@pytest.mark.parametrize(
+    "labware_definition",
+    [
+        LabwareDefinition.construct(  # type: ignore[call-arg]
+            ordering=[],
+            parameters=LabwareDefinitionParameters.construct(isTiprack=True),  # type: ignore[call-arg]
+        )
+    ],
+)
 def test_reset_tips(
     decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
 ) -> None:
     """It should reset the tip state of a labware."""
     subject.reset_tips()
     decoy.verify(mock_engine_client.reset_tips(labware_id="cool-labware"), times=1)
+
+
+@pytest.mark.parametrize(
+    "labware_definition",
+    [
+        LabwareDefinition.construct(  # type: ignore[call-arg]
+            ordering=[],
+            parameters=LabwareDefinitionParameters.construct(isTiprack=False),  # type: ignore[call-arg]
+        )
+    ],
+)
+def test_reset_tips_raises_if_not_tip_rack(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: LabwareCore
+) -> None:
+    """It should raise an exception if the labware isn't a tip rack."""
+    with pytest.raises(TypeError, match="not a tip rack"):
+        subject.reset_tips()
 
 
 def test_get_tip_length(


### PR DESCRIPTION
# Overview

Closes RQA-543.

`Labware.reset()` resets all the tips in a tip rack. In Python Protocol API v2.13, if you call it on a non-tip-rack, like this, it "succeeds" but does nothing:

```python
not_a_tip_rack = protocol.load("nest_12_reservoir_15ml", 1)
not_a_tip_rack.reset()
```

In Python Protocol API v2.14, it currently raises a confusing internal `KeyError`:

> KeyError [line 123]: '596d7d17-b370-4810-a40e-f5121dc0766d'

This PR changes the v2.14 error to be more descriptive:

> TypeError [line 123]: NEST 12 Well Reservoir 15 mL is not a tip rack.

It also documents the error to make it official.


# Test Plan

I've tested this locally with the internal `opentrons.cli analyze` tool. v2.13 protocols are unchanged, and v2.14 protocols now raise the descriptive error.


# Review requests

I kind of weird about where I chose to add this check.

Ideally, `ProtocolEngine.reset_tips()` would raise a well-defined exception when it's given a `labware_id` that isn't a tip rack.

However, `ProtocolEngine.reset_tips()` is implemented with a Protocol Engine action, and the existing Protocol Engine error-handling strategy is that handling an action should never raise. So, to for `ProtocolEngine.reset_tips()` to raise an exception, it would have to do its own check, with a new method like `TipStore.can_be_reset()`.

That all seemed like a bit much, since `LabwareCore` would have to raise its own exception *anyway* to hide Protocol Engine internal details like the labware ID.

So I just added the check to `LabwareCore`. 🤷


# Risk assessment

Low.