### PR TITLE
fix(api): Raise an error when trying to load more liquid than the max allowed volume

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -54,12 +54,12 @@ class LoadLiquidImplementation(AbstractCommandImpl[LoadLiquidParams, LoadLiquidR
             labware_id=params.labwareId, wells=params.volumeByWell
         )
 
-        for well in params.volumeByWell:
+        for well_name in params.volumeByWell:
             max_volume = self._state_view.labware.get_well_max_volume(
-                labware_id=params.labwareId, well_name=well
+                labware_id=params.labwareId, well_name=well_name
             )
 
-            if params.volumeByWell[well] > max_volume:
+            if params.volumeByWell[well_name] > max_volume:
                 raise InvalidLoadVolumeError(
                     f"Exceeded maximum volume of well ({max_volume} µL)."
                 )

--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -54,14 +54,15 @@ class LoadLiquidImplementation(AbstractCommandImpl[LoadLiquidParams, LoadLiquidR
             labware_id=params.labwareId, wells=params.volumeByWell
         )
 
-        for well_name in params.volumeByWell:
+        for well_name, volume in params.volumeByWell:
             max_volume = self._state_view.labware.get_well_max_volume(
                 labware_id=params.labwareId, well_name=well_name
             )
 
-            if params.volumeByWell[well_name] > max_volume:
+            if volume > max_volume:
                 raise InvalidLoadVolumeError(
-                    f"Exceeded maximum volume of well ({max_volume} µL)."
+                    f"Well {well_name} allows max volume of {max_volume}µL"
+                    f" but {volume}µL was loaded."
                 )
 
         return LoadLiquidResult()

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -608,6 +608,13 @@ class LabwareView(HasState[LabwareState]):
             z=current_z_position,
         )
 
+    def get_well_max_volume(self, labware_id: str, well_name: str) -> float:
+        """Get well max volume."""
+        well_definition = self.get_well_definition(
+            labware_id=labware_id, well_name=well_name
+        )
+        return well_definition.totalLiquidVolume
+
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:
         """Check whether the labware uri needs to be calculated in half a millimeter."""
         uri = self.get_uri_from_definition(self.get_definition(labware_id))

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -6,7 +6,7 @@ from contextlib import nullcontext as does_not_raise
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.pipette.dev_types import LabwareUri
-from opentrons_shared_data.labware.labware_definition import Parameters
+from opentrons_shared_data.labware.labware_definition import Parameters, WellDefinition
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName, Point, MountType
 
@@ -929,3 +929,31 @@ def test_get_edge_path_type(
     )
 
     assert result == expected_result
+
+
+def test_get_well_max_volume() -> None:
+    """Should get the max volume allowed in a well."""
+    labware = LoadedLabware(
+        id="tip-rack-id",
+        loadName="load-name",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        definitionUri="some-labware-uri",
+        offsetId=None,
+    )
+
+    labware_def = LabwareDefinition.construct(  # type: ignore[call-arg]
+        wells={
+            "A1": WellDefinition.construct(  # type: ignore[call-arg]
+                totalLiquidVolume=30
+            )
+        }
+    )
+
+    subject = get_labware_view(
+        labware_by_id={"labware-id": labware},
+        definitions_by_uri={
+            "some-labware-uri": labware_def,
+        },
+    )
+
+    assert subject.get_well_max_volume("labware-id", "A1") == 30

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -251,8 +251,8 @@ stages:
                   liquidId: 'waterId'
                   labwareId: 'sourcePlateId'
                   volumeByWell:
-                    A1: 100
-                    B1: 100
+                    A1: 33
+                    B1: 33
                 result: {}
                 startedAt: !anystr
                 completedAt: !anystr

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -187,8 +187,8 @@ stages:
               liquidId: 'waterId'
               labwareId: 'sourcePlateId'
               volumeByWell:
-                A1: 100
-                B1: 100
+                A1: 33
+                B1: 33
           - id: !anystr
             key: !anystr
             commandType: pickUpTip
@@ -445,8 +445,8 @@ stages:
               labwareId: sourcePlateId
               liquidId: waterId
               volumeByWell:
-                A1: 100
-                B1: 100
+                A1: 33
+                B1: 33
           - id: !anystr
             key: !anystr
             commandType: pickUpTip

--- a/robot-server/tests/integration/protocols/simple_v6.json
+++ b/robot-server/tests/integration/protocols/simple_v6.json
@@ -1299,8 +1299,8 @@
         "liquidId": "waterId",
         "labwareId": "sourcePlateId",
         "volumeByWell": {
-          "A1": 100,
-          "B1": 100
+          "A1": 33,
+          "B1": 33
         }
       }
     },

--- a/shared-data/protocol/fixtures/6/simpleV6.json
+++ b/shared-data/protocol/fixtures/6/simpleV6.json
@@ -1306,8 +1306,8 @@
         "liquidId": "waterId",
         "labwareId": "sourcePlateId",
         "volumeByWell": {
-          "A1": 100,
-          "B1": 100
+          "A1": 33,
+          "B1": 33
         }
       }
     },


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RLIQ-342.

# Test Plan

upload the following protocol through the app. make sure if fails analysis. 

```
from opentrons import protocol_api, types

metadata = {
    "apiLevel": "2.14",
}

def run(ctx: protocol_api.ProtocolContext) -> None:
    tip_rack = ctx.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", 3)
    liquid = ctx.define_liquid(name="water", description="", display_color="#fff")
    well = tip_rack.wells()[0]
    well.load_liquid(liquid=liquid, volume=200.0)
```

the following protocol should pass analysis. 

```
from opentrons import protocol_api, types

metadata = {
    "apiLevel": "2.14",
}

def run(ctx: protocol_api.ProtocolContext) -> None:
    tip_rack = ctx.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", 3)
    liquid = ctx.define_liquid(name="water", description="", display_color="#fff")
    well = tip_rack.wells()[0]
    well.load_liquid(liquid=liquid, volume=200.0)
```


# Changelog

- Added `get_well_max_volume` to `LabwareView`
- Validate loaded volume against max allowed volume.


# Risk assessment

low. raising an error if trying to load a liquid larger than the max allowed volume. 