### PR TITLE
feat(api): enable the auto update process for the rear-panel board

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -116,6 +116,7 @@ async def _create_thread_manager() -> ThreadManagedHardware:
 
         thread_manager = ThreadManager(
             OT3API.build_hardware_controller,
+            use_usb_bus=ff.rear_panel_integration(),
             threadmanager_nonblocking=True,
         )
     else:
@@ -158,9 +159,6 @@ async def initialize() -> ThreadManagedHardware:
     # front button light. But that blinking stops when the completed hardware object
     # is returned. Do our own blinking here to keep it going while we home the robot.
     blink_task = asyncio.create_task(_blink())
-
-    if should_use_ot3() and ff.rear_panel_integration():
-        hardware.connect_usb_to_rear_panel()
 
     try:
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1128,3 +1128,5 @@ class OT3Controller:
             raise e
         self._usb_messenger = BinaryMessenger(usb_driver)
         self._usb_messenger.start()
+        self._network_info = NetworkInfo(self._messenger, self._usb_messenger)
+        await self.probe_network()

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -33,7 +33,11 @@ from .ot3utils import (
     PipetteAction,
 )
 
-from opentrons_hardware.firmware_bindings.constants import NodeId, SensorId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    SensorId,
+    FirmwareTarget,
+)
 from opentrons_hardware.hardware_control.motion_planning import (
     Move,
     Coordinates,
@@ -509,7 +513,7 @@ class OT3Simulator:
     async def update_firmware(
         self,
         attached_pipettes: Dict[OT3Mount, PipetteSubType],
-        nodes: Optional[Set[NodeId]] = None,
+        nodes: Optional[Set[FirmwareTarget]] = None,
         force: bool = False,
     ) -> AsyncIterator[Set[UpdateStatus]]:
         """Updates the firmware on the OT3."""

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -397,7 +397,7 @@ class UpdateProgress:
     @property
     def targets(self) -> Set[FirmwareTarget]:
         """Gets the set of update Targets queued or updating."""
-        return {target for target in set(self._tracker)}
+        return set(self._tracker)
 
     def get_progress(self) -> Set[UpdateStatus]:
         """Gets the update status and total progress"""

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -395,10 +395,9 @@ class UpdateProgress:
             self._tracker[target] = UpdateStatus(subsystem, UpdateState.queued, 0)
 
     @property
-    def nodes(self) -> Set[NodeId]:
+    def targets(self) -> Set[FirmwareTarget]:
         """Gets the set of update Targets queued or updating."""
-        # NOTE: (ba, 2023-03-08) ignore rear panel for now
-        return {target for target in set(self._tracker) if isinstance(target, NodeId)}
+        return {target for target in set(self._tracker)}
 
     def get_progress(self) -> Set[UpdateStatus]:
         """Gets the update status and total progress"""

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -271,10 +271,7 @@ class OT3API(
             checked_config = robot_configs.load_ot3()
         else:
             checked_config = config
-        backend = await OT3Controller.build(checked_config)
-
-        if use_usb_bus:
-            await backend.connect_usb_to_rear_panel()
+        backend = await OT3Controller.build(checked_config, use_usb_bus)
 
         api_instance = cls(backend, loop=checked_loop, config=checked_config)
         await api_instance._cache_instruments()
@@ -502,9 +499,6 @@ class OT3API(
             type=modules.ModuleType.from_model(model),
             sim_model=model.value,
         )
-
-    async def connect_usb_to_rear_panel(self) -> None:
-        await self._backend.connect_usb_to_rear_panel()
 
     def _gantry_load_from_instruments(self) -> GantryLoad:
         """Compute the gantry load based on attached instruments."""

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -263,6 +263,7 @@ class OT3API(
         config: Union[OT3Config, RobotConfig, None] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         strict_attached_instruments: bool = True,
+        use_usb_bus: bool = False,
     ) -> "OT3API":
         """Build an ot3 hardware controller."""
         checked_loop = use_or_initialize_loop(loop)
@@ -271,6 +272,10 @@ class OT3API(
         else:
             checked_config = config
         backend = await OT3Controller.build(checked_config)
+
+        if use_usb_bus:
+            await backend.connect_usb_to_rear_panel()
+
         api_instance = cls(backend, loop=checked_loop, config=checked_config)
         await api_instance._cache_instruments()
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1021,11 +1021,11 @@ async def test_update_firmware_specified_nodes(
         controller._network_info, "probe"
     ) as probe:
         async for status_element in controller.update_firmware(
-            {}, nodes={NodeId.head, NodeId.gantry_x}
+            {}, targets={NodeId.head, NodeId.gantry_x}
         ):
             pass
         check_updates.assert_called_with(
-            fw_node_info, {}, nodes={NodeId.head, NodeId.gantry_x}, force=False
+            fw_node_info, {}, targets={NodeId.head, NodeId.gantry_x}, force=False
         )
         run_updates.assert_called_with(
             can_messenger=controller._messenger,
@@ -1059,7 +1059,7 @@ async def test_update_firmware_invalid_specified_node(
     ) as run_updates, mock.patch.object(
         controller._network_info, "probe"
     ) as probe:
-        async for status_element in controller.update_firmware({}, nodes={NodeId.head}):
+        async for status_element in controller.update_firmware({}, targets={NodeId.head}):
             pass
         run_updates.assert_called_with(
             can_messenger=controller._messenger,

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -22,6 +22,7 @@ from opentrons.config.robot_configs import build_config_ot3
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
+    USBTarget,
     PipetteName as FirmwarePipetteName,
 )
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
@@ -155,23 +156,23 @@ def mock_move_group_run():
 
 
 @pytest.fixture
-def mock_present_nodes(controller: OT3Controller) -> OT3Controller:
-    old_pn = controller._present_nodes
-    controller._present_nodes = set(
+def mock_present_devices(controller: OT3Controller) -> OT3Controller:
+    old_pd = controller._present_devices
+    controller._present_devices = set(
         (
             NodeId.pipette_left,
             NodeId.gantry_x,
             NodeId.gantry_y,
-            NodeId.head_l,
-            NodeId.head_r,
+            NodeId.head,
             NodeId.pipette_right,
-            NodeId.gripper_z,
+            NodeId.gripper,
+            USBTarget.rear_panel,
         )
     )
     try:
         yield controller
     finally:
-        controller._present_nodes = old_pn
+        controller._present_devices = old_pd
 
 
 @pytest.fixture
@@ -225,7 +226,7 @@ def move_group_run_side_effect(controller, axes_to_home):
     gantry_homes = {
         axis_to_node(ax): (0.0, 0.0, True, True)
         for ax in OT3Axis.gantry_axes()
-        if ax in axes_to_home and axis_to_node(ax) in controller._present_nodes
+        if ax in axes_to_home and axis_to_node(ax) in controller._present_devices
     }
     if gantry_homes:
         yield gantry_homes
@@ -233,14 +234,14 @@ def move_group_run_side_effect(controller, axes_to_home):
     pipette_homes = {
         axis_to_node(ax): (0.0, 0.0, True, True)
         for ax in OT3Axis.pipette_axes()
-        if ax in axes_to_home and axis_to_node(ax) in controller._present_nodes
+        if ax in axes_to_home and axis_to_node(ax) in controller._present_devices
     }
     yield pipette_homes
 
 
 @pytest.mark.parametrize("axes", home_test_params)
 async def test_home_execute(
-    controller: OT3Controller, mock_move_group_run, axes, mock_present_nodes
+    controller: OT3Controller, mock_move_group_run, axes, mock_present_devices
 ):
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
     # nothing has been homed
@@ -265,7 +266,7 @@ async def test_home_execute(
 
 @pytest.mark.parametrize("axes", home_test_params)
 async def test_home_prioritize_mount(
-    controller: OT3Controller, mock_move_group_run, axes, mock_present_nodes
+    controller: OT3Controller, mock_move_group_run, axes, mock_present_devices
 ):
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
     # nothing has been homed
@@ -291,7 +292,7 @@ async def test_home_prioritize_mount(
 
 @pytest.mark.parametrize("axes", home_test_params)
 async def test_home_build_runners(
-    controller: OT3Controller, mock_move_group_run, axes, mock_present_nodes
+    controller: OT3Controller, mock_move_group_run, axes, mock_present_devices
 ):
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
     assert not controller._motor_status
@@ -320,7 +321,7 @@ async def test_home_build_runners(
 
 
 @pytest.mark.parametrize("axes", home_test_params)
-async def test_home_only_present_nodes(
+async def test_home_only_present_devices(
     controller: OT3Controller, mock_move_group_run, axes
 ):
     starting_position = {
@@ -333,7 +334,7 @@ async def test_home_only_present_nodes(
     }
     homed_position = {}
 
-    controller._present_nodes = set(
+    controller._present_devices = set(
         (NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l, NodeId.head_r)
     )
     controller._position = starting_position
@@ -354,7 +355,7 @@ async def test_home_only_present_nodes(
             for move_group_step in move_group:
                 assert move_group_step  # don't pass in empty moves
                 for node, step in move_group_step.items():
-                    assert node in controller._present_nodes
+                    assert node in controller._present_devices
                     assert step  # don't pass in empty steps
                     homed_position[node] = 0.0  # track homed position for node
 
@@ -369,7 +370,7 @@ async def test_home_only_present_nodes(
 async def test_probing(
     controller: OT3Controller, mock_tool_detector: AsyncMock
 ) -> None:
-    assert controller._present_nodes == set()
+    assert controller._present_devices == set()
 
     call_count = 0
     fake_nodes = set(
@@ -405,14 +406,12 @@ async def test_probing(
                 NodeId.gripper,
             )
         )
-    assert controller._present_nodes == set(
+    assert controller._present_devices == set(
         (
             NodeId.gantry_x,
-            NodeId.head_l,
-            NodeId.head_r,
+            NodeId.head,
             NodeId.pipette_left,
-            NodeId.gripper_g,
-            NodeId.gripper_z,
+            NodeId.gripper,
         )
     )
 
@@ -582,8 +581,8 @@ async def test_gripper_jaw_width(controller: OT3Controller, mock_move_group_run)
 
 
 async def test_get_limit_switches(controller: OT3Controller) -> None:
-    assert controller._present_nodes == set()
-    fake_present_nodes = {NodeId.gantry_x, NodeId.gantry_y}
+    assert controller._present_devices == set()
+    fake_present_devices = {NodeId.gantry_x, NodeId.gantry_y}
     call_count = 0
     fake_response = {
         NodeId.gantry_x: UInt8Field(0),
@@ -601,7 +600,7 @@ async def test_get_limit_switches(controller: OT3Controller) -> None:
 
     with patch(
         "opentrons.hardware_control.backends.ot3controller.get_limit_switches", fake_gls
-    ), patch.object(controller, "_present_nodes", fake_present_nodes):
+    ), patch.object(controller, "_present_devices", fake_present_devices):
         res = await controller.get_limit_switches()
         assert call_count == 1
         assert passed_nodes == {NodeId.gantry_x, NodeId.gantry_y}
@@ -705,7 +704,7 @@ async def test_update_motor_status(
         "opentrons.hardware_control.backends.ot3controller.get_motor_position", fake_gmp
     ):
         nodes = set([NodeId.gantry_x, NodeId.gantry_y, NodeId.head])
-        controller._present_nodes = nodes
+        controller._present_devices = nodes
         await controller.update_motor_status()
         for node in nodes:
             assert controller._position.get(node) == 0.223
@@ -749,27 +748,26 @@ async def test_update_motor_estimation(
     ],
 )
 async def test_set_default_currents(
-    mock_present_nodes: OT3Controller, gantry_load: GantryLoad, expected_call: bool
+    mock_present_devices: OT3Controller, gantry_load: GantryLoad, expected_call: bool
 ):
-    mock_present_nodes._present_nodes.add(NodeId.gripper_g)
+    mock_present_devices._present_devices.add(NodeId.gripper)
     with patch(
         "opentrons.hardware_control.backends.ot3controller.set_currents",
         spec=current_settings.set_currents,
     ) as mocked_currents:
-        await mock_present_nodes.update_to_default_current_settings(gantry_load)
+        await mock_present_devices.update_to_default_current_settings(gantry_load)
         mocked_currents.assert_called_once_with(
             mocked_currents.call_args_list[0][0][0],
             mocked_currents.call_args_list[0][0][1],
             use_tip_motor_message_for=expected_call,
         )
-
-        for k, v in mock_present_nodes._current_settings.items():
+        for k, v in mock_present_devices._current_settings.items():
             if k == OT3Axis.P_L and (
                 gantry_load == GantryLoad.HIGH_THROUGHPUT
                 and expected_call[0] == NodeId.pipette_left
             ):
                 # q motor config
-                v = mock_present_nodes._current_settings[OT3Axis.Q]
+                v = mock_present_devices._current_settings[OT3Axis.Q]
                 assert (
                     mocked_currents.call_args_list[0][0][1][axis_to_node(k)]
                     == v.as_tuple()
@@ -797,7 +795,7 @@ async def test_set_default_currents(
     ],
 )
 async def test_set_run_current(
-    mock_present_nodes: OT3Controller,
+    mock_present_devices: OT3Controller,
     active_current: OT3AxisMap[float],
     gantry_load: GantryLoad,
     expected_call: List[Any],
@@ -810,8 +808,8 @@ async def test_set_run_current(
             "opentrons.hardware_control.backends.ot3controller.set_run_current",
             spec=current_settings.set_run_current,
         ) as mocked_currents:
-            await mock_present_nodes.update_to_default_current_settings(gantry_load)
-            await mock_present_nodes.set_active_current(active_current)
+            await mock_present_devices.update_to_default_current_settings(gantry_load)
+            await mock_present_devices.set_active_current(active_current)
             mocked_currents.assert_called_once_with(
                 mocked_currents.call_args_list[0][0][0],
                 expected_call[0],
@@ -835,7 +833,7 @@ async def test_set_run_current(
     ],
 )
 async def test_set_hold_current(
-    mock_present_nodes: OT3Controller,
+    mock_present_devices: OT3Controller,
     hold_current: OT3AxisMap[float],
     gantry_load: GantryLoad,
     expected_call: List[Any],
@@ -848,8 +846,8 @@ async def test_set_hold_current(
             "opentrons.hardware_control.backends.ot3controller.set_hold_current",
             spec=current_settings.set_hold_current,
         ) as mocked_currents:
-            await mock_present_nodes.update_to_default_current_settings(gantry_load)
-            await mock_present_nodes.set_hold_current(hold_current)
+            await mock_present_devices.update_to_default_current_settings(gantry_load)
+            await mock_present_devices.set_hold_current(hold_current)
             mocked_currents.assert_called_once_with(
                 mocked_currents.call_args_list[0][0][0],
                 expected_call[0],
@@ -862,7 +860,7 @@ async def test_update_required_flag(
 ) -> None:
     """Test that FirmwareUpdateRequired is raised when update_required flag is set."""
     axes = [OT3Axis.X, OT3Axis.Y]
-    controller._present_nodes = {NodeId.gantry_x, NodeId.gantry_y}
+    controller._present_devices = {NodeId.gantry_x, NodeId.gantry_y}
 
     with patch("builtins.open", mock_open()):
         # raise FirmwareUpdateRequired if the _update_required flag is set
@@ -888,8 +886,8 @@ async def test_update_required_bypass_firmware_update(controller: OT3Controller)
 
 async def test_update_required_flag_false(controller: OT3Controller):
     """Do not raise FirmwareUpdateRequired if update_required is False."""
-    controller._present_nodes = {NodeId.gantry_x, NodeId.gantry_y}
-    for node in controller._present_nodes:
+    controller._present_devices = {NodeId.gantry_x, NodeId.gantry_y}
+    for node in controller._present_devices:
         controller._motor_status.update(
             {node: MotorStatus(motor_ok=False, encoder_ok=True)}
         )
@@ -915,8 +913,8 @@ async def test_update_required_flag_false(controller: OT3Controller):
 
 async def test_update_required_flag_initialized(controller: OT3Controller):
     """Do not raise FirmwareUpdateRequired if initialized is False."""
-    controller._present_nodes = {NodeId.gantry_x, NodeId.gantry_y}
-    for node in controller._present_nodes:
+    controller._present_devices = {NodeId.gantry_x, NodeId.gantry_y}
+    for node in controller._present_devices:
         controller._motor_status.update(
             {node: MotorStatus(motor_ok=False, encoder_ok=True)}
         )

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1059,7 +1059,9 @@ async def test_update_firmware_invalid_specified_node(
     ) as run_updates, mock.patch.object(
         controller._network_info, "probe"
     ) as probe:
-        async for status_element in controller.update_firmware({}, targets={NodeId.head}):
+        async for status_element in controller.update_firmware(
+            {}, targets={NodeId.head}
+        ):
             pass
         run_updates.assert_called_with(
             can_messenger=controller._messenger,

--- a/hardware/opentrons_hardware/drivers/binary_usb/binary_messenger.py
+++ b/hardware/opentrons_hardware/drivers/binary_usb/binary_messenger.py
@@ -125,7 +125,7 @@ class BinaryMessenger:
                 except BinarySerializableException:
                     log.exception("Failed to build message")
             else:
-                log.error(f"Message {message_definition} is not recognized.")
+                log.debug("read timed out, calling read again")
 
     async def _handle_error(self, message_definition: BinaryMessageDefinition) -> None:
         log.error("Got a error message.")

--- a/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
@@ -1,4 +1,5 @@
 """Can bus message definitions."""
 from .messages import MessageDefinition, get_definition
+from .binary_message_definitions import BinaryMessageDefinition, get_binary_definition
 
-__all__ = ["MessageDefinition", "get_definition"]
+__all__ = ["MessageDefinition", "get_definition", "BinaryMessageDefinitions", "get_binary_definition"]

--- a/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/__init__.py
@@ -2,4 +2,9 @@
 from .messages import MessageDefinition, get_definition
 from .binary_message_definitions import BinaryMessageDefinition, get_binary_definition
 
-__all__ = ["MessageDefinition", "get_definition", "BinaryMessageDefinitions", "get_binary_definition"]
+__all__ = [
+    "MessageDefinition",
+    "get_definition",
+    "BinaryMessageDefinition",
+    "get_binary_definition",
+]

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -91,6 +91,8 @@ class NetworkInfo:
             expected: Set of FirmwareTargets to expect
             timeout: time in seconds to wait for responses
         """
+        expected_can: Set[NodeId] = {}
+        expected_usb: Set[USBTarget] = {}
         if expected is not None:
             expected_can = {NodeId(target) for target in expected if target in NodeId}
             expected_usb = {

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -106,6 +106,7 @@ class NetworkInfo:
         device_info.update(
             {target: cache for (target, cache) in usb_device_info.items()}
         )
+        self._device_info_cache = device_info
         return device_info
 
 

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -91,8 +91,8 @@ class NetworkInfo:
             expected: Set of FirmwareTargets to expect
             timeout: time in seconds to wait for responses
         """
-        expected_can: Set[NodeId] = {}
-        expected_usb: Set[USBTarget] = {}
+        expected_can: Optional[Set[NodeId]] = None
+        expected_usb: Optional[Set[USBTarget]] = None
         if expected is not None:
             expected_can = {NodeId(target) for target in expected if target in NodeId}
             expected_usb = {

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -5,13 +5,29 @@ import logging
 from typing import Any, Dict, Set, Optional, Union
 from .types import PCBARevision
 from opentrons_hardware.firmware_bindings import ArbitrationId
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    FirmwareTarget,
+    USBTarget,
+)
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     CanMessenger,
 )
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
-    DeviceInfoRequest,
-    DeviceInfoResponse,
+    DeviceInfoRequest as CanDeviceInfoRequest,
+)
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    DeviceInfoResponse as CanDeviceInfoResponse,
+)
+from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
+    DeviceInfoRequest as USBDeviceInfoRequest,
+)
+from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
+    DeviceInfoResponse as USBDeviceInfoResponse,
+)
+from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
+    BinaryMessageDefinition,
 )
 from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
 
@@ -22,7 +38,7 @@ log = logging.getLogger(__name__)
 class DeviceInfoCache:
     """Holds version information for a device on the network."""
 
-    node_id: NodeId
+    target: FirmwareTarget
     version: int
     shortsha: str
     flags: Any
@@ -30,10 +46,144 @@ class DeviceInfoCache:
 
     def __repr__(self) -> str:
         """Readable representation of the device info."""
-        return f"<{self.__class__.__name__}: node={self.node_id}, version={self.version}, sha={self.shortsha}>"
+        return f"<{self.__class__.__name__}: node={self.target}, version={self.version}, sha={self.shortsha}>"
 
 
 class NetworkInfo:
+    """This class is responsible for keeping track of all devices."""
+
+    def __init__(
+        self,
+        can_messenger: CanMessenger,
+        usb_messenger: Optional[BinaryMessenger] = None,
+    ) -> None:
+        """Construct.
+
+        Args:
+            can_messenger: The Can messenger
+            usb_messenger: The usb messenger
+        """
+        self._can_network_info = CanNetworkInfo(can_messenger)
+        self._usb_network_info = UsbNetworkInfo(usb_messenger)
+        self._device_info_cache: Dict[FirmwareTarget, DeviceInfoCache] = dict()
+
+    @property
+    def device_info(self) -> Dict[FirmwareTarget, DeviceInfoCache]:
+        """Dictionary containing known devices and their device info."""
+        return self._device_info_cache
+
+    @property
+    def targets(self) -> Set[FirmwareTarget]:
+        """Set of usb devices on the network."""
+        return set(self._device_info_cache)
+
+    async def probe(
+        self, expected: Optional[Set[FirmwareTarget]] = None, timeout: float = 1.0
+    ) -> Dict[FirmwareTarget, DeviceInfoCache]:
+        """Probe for all connected devices.
+
+        calls probe with both CanNetworkInfo and USBNetworkInfo and collects all devices
+
+        The ideal call pattern is to build an expectation for targets and use this to verify that
+        assumption
+
+        Args:
+            expected: Set of FirmwareTargets to expect
+            timeout: time in seconds to wait for responses
+        """
+        if expected is not None:
+            expected_can = {NodeId(target) for target in expected if target in NodeId}
+            expected_usb = {
+                USBTarget(target) for target in expected if target in USBTarget
+            }
+        can_device_info, usb_device_info = await asyncio.gather(
+            self._can_network_info.probe(expected_can, timeout),
+            self._usb_network_info.probe(expected_usb, timeout),
+        )
+        device_info: Dict[FirmwareTarget, DeviceInfoCache] = {
+            node: cache for (node, cache) in can_device_info.items()
+        }
+        device_info.update(
+            {target: cache for (target, cache) in usb_device_info.items()}
+        )
+        return device_info
+
+
+class UsbNetworkInfo:
+    """This class is responsible for keeping track of usb devices."""
+
+    def __init__(self, usb_messenger: Optional[BinaryMessenger]) -> None:
+        """Construct.
+
+        Args:
+            usb_messenger: The usb messenger
+        """
+        self._usb_messenger = usb_messenger
+        self._device_info_cache: Dict[USBTarget, DeviceInfoCache] = dict()
+
+    @property
+    def device_info(self) -> Dict[USBTarget, DeviceInfoCache]:
+        """Dictionary containing known usb devices and their device info."""
+        return self._device_info_cache
+
+    @property
+    def targets(self) -> Set[USBTarget]:
+        """Set of usb devices on the network."""
+        return set(self._device_info_cache)
+
+    async def probe(
+        self, expected: Optional[Set[USBTarget]] = None, timeout: float = 1.0
+    ) -> Dict[USBTarget, DeviceInfoCache]:
+        """Probe for usb connected devices.
+
+        Sends a status request to the usb messenger and waits for responses. Ends either
+        when all devices in expected respond or when a timeout happens, whichever is first. A
+        None timeout is infinite and is not recommended, but could be useful if this is
+        wrapped in a task and cancelled externally.
+
+        The ideal call pattern is to build an expectation for targets on the bus (i.e., fixed
+        targets such as the rear panel) and use this method to verify the assumption.
+
+        Args:
+            expected: Set of USBTargets to expect
+            timeout: time in seconds to wait for usb message responses
+        """
+        expected_targets = expected or set()
+        event = asyncio.Event()
+        targets: Dict[USBTarget, DeviceInfoCache] = dict()
+
+        if self._usb_messenger is None:
+            return targets
+
+        def listener(message: BinaryMessageDefinition) -> None:
+            if isinstance(message, USBDeviceInfoResponse):
+                device_info_cache = _parse_usb_device_info_response(message)
+                if device_info_cache:
+                    targets[USBTarget(device_info_cache.target)] = device_info_cache
+            if expected_targets and expected_targets.issubset(targets):
+                event.set()
+
+        self._usb_messenger.add_listener(listener)
+        await self._usb_messenger.send(
+            message=USBDeviceInfoRequest(),
+        )
+        try:
+            await asyncio.wait_for(event.wait(), timeout)
+        except asyncio.TimeoutError:
+            if expected_targets:
+                log.warning(
+                    "probe timed out before expected targets found, missing "
+                    f"{expected_targets.difference(targets)}"
+                )
+            else:
+                log.debug("probe terminated (no expected set)")
+        finally:
+            self._usb_messenger.remove_listener(listener)
+            self._device_info_cache = targets
+        return targets
+
+
+class CanNetworkInfo:
     """This class is responsible for keeping track of nodes on the can bus."""
 
     def __init__(self, can_messenger: CanMessenger) -> None:
@@ -78,17 +228,19 @@ class NetworkInfo:
         nodes: Dict[NodeId, DeviceInfoCache] = dict()
 
         def listener(message: MessageDefinition, arbitration_id: ArbitrationId) -> None:
-            if isinstance(message, DeviceInfoResponse):
-                device_info_cache = _parse_device_info_response(message, arbitration_id)
+            if isinstance(message, CanDeviceInfoResponse):
+                device_info_cache = _parse_can_device_info_response(
+                    message, arbitration_id
+                )
                 if device_info_cache:
-                    nodes[device_info_cache.node_id] = device_info_cache
+                    nodes[NodeId(device_info_cache.target)] = device_info_cache
             if expected_nodes and expected_nodes.issubset(nodes):
                 event.set()
 
         self._can_messenger.add_listener(listener)
         await self._can_messenger.send(
             node_id=NodeId.broadcast,
-            message=DeviceInfoRequest(),
+            message=CanDeviceInfoRequest(),
         )
         try:
             await asyncio.wait_for(event.wait(), timeout)
@@ -106,11 +258,32 @@ class NetworkInfo:
         return nodes
 
 
-def _parse_device_info_response(
+def _parse_usb_device_info_response(
+    message: BinaryMessageDefinition,
+) -> Union[DeviceInfoCache, None]:
+    """Parses the DeviceInfoRequest message and returns DeviceInfoCache."""
+    if isinstance(message, USBDeviceInfoResponse):
+        target = USBTarget.rear_panel
+        try:
+            return DeviceInfoCache(
+                target=target,
+                version=int(message.version.value),
+                shortsha=message.shortsha.value.decode(),
+                flags=message.flags.value,
+                revision=PCBARevision(
+                    message.revision.revision, message.revision.tertiary
+                ),
+            )
+        except (ValueError, UnicodeDecodeError) as e:
+            log.error(f"Could not parse DeviceInfoResponse {e}")
+    return None
+
+
+def _parse_can_device_info_response(
     message: MessageDefinition, arbitration_id: ArbitrationId
 ) -> Union[DeviceInfoCache, None]:
     """Parses the DeviceInfoRequest message and returns DeviceInfoCache."""
-    if isinstance(message, DeviceInfoResponse):
+    if isinstance(message, CanDeviceInfoResponse):
         try:
             node = NodeId(arbitration_id.parts.originating_node_id)
         except ValueError:
@@ -121,7 +294,7 @@ def _parse_device_info_response(
             return None
         try:
             return DeviceInfoCache(
-                node_id=node,
+                target=node,
                 version=int(message.payload.version.value),
                 shortsha=message.payload.shortsha.value.decode(),
                 flags=message.payload.flags.value,

--- a/hardware/opentrons_hardware/scripts/network_test.py
+++ b/hardware/opentrons_hardware/scripts/network_test.py
@@ -254,7 +254,9 @@ async def _do_test(
             "one responder"
         )
 
-    target, message, response_size = _test_details_for_mode(mode, present)
+    target, message, response_size = _test_details_for_mode(
+        mode, {NodeId(node) for node in present if node in NodeId}
+    )
 
     message_size = _canbus_message_length_bits(message)
     transaction_size = message_size + response_size

--- a/hardware/tests/opentrons_hardware/firmware_update/test_utils.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_utils.py
@@ -7,7 +7,12 @@ import secrets
 from typing import Any, Dict, Optional
 import mock
 import pytest
-from opentrons_hardware.firmware_bindings.constants import NodeId, PipetteType
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    PipetteType,
+    FirmwareTarget,
+    USBTarget,
+)
 from opentrons_hardware.hardware_control.types import PCBARevision
 
 from opentrons_hardware.firmware_update.utils import (
@@ -38,6 +43,13 @@ def mock_manifest() -> Dict[str, Any]:
                 "files_by_revision": {"c1": "head-c1.hex"},
             }
         },
+        "usb_subsystems": {
+            "rear-panel": {
+                "version": 2,
+                "shortsha": "9d6b5248",
+                "files_by_revision": {"c1": "rear-panel-b1.bin"},
+            }
+        },
     }
 
 
@@ -45,9 +57,9 @@ def generate_device_info(
     manifest: Dict[str, Any],
     random_sha: Optional[bool] = False,
     revision: Optional[str] = "c1",
-) -> Dict[NodeId, DeviceInfoCache]:
+) -> Dict[FirmwareTarget, DeviceInfoCache]:
     """Helper function to generate device info."""
-    device_info_cache: Dict[NodeId, DeviceInfoCache] = {}
+    device_info_cache: Dict[FirmwareTarget, DeviceInfoCache] = {}
     for subsystem, info in manifest["subsystems"].items():
         node_id = NodeId.__members__[subsystem.replace("-", "_")]
         version = info["version"]
@@ -56,6 +68,17 @@ def generate_device_info(
             {
                 node_id: DeviceInfoCache(
                     node_id, version, shortsha, None, PCBARevision(revision, None)
+                )
+            }
+        )
+    for subsystem, info in manifest.get("usb_subsystems", {}).items():
+        target = USBTarget.__members__[subsystem.replace("-", "_")]
+        version = info["version"]
+        shortsha = secrets.token_hex(4) if random_sha else info["shortsha"]
+        device_info_cache.update(
+            {
+                target: DeviceInfoCache(
+                    target, version, shortsha, None, PCBARevision(revision, None)
                 )
             }
         )
@@ -69,6 +92,14 @@ def generate_update_info(
     update_info: Dict[FirmwareUpdateType, UpdateInfo] = {}
     for subsystem, info in manifest["subsystems"].items():
         update_type = FirmwareUpdateType.from_name(subsystem)
+        version = info["version"]
+        shortsha = secrets.token_hex(4) if random_sha else info["shortsha"]
+        files_by_revision = info["files_by_revision"]
+        update_info.update(
+            {update_type: UpdateInfo(update_type, version, shortsha, files_by_revision)}
+        )
+    for usbsubsystem, info in manifest.get("usb_subsystems", {}).items():
+        update_type = FirmwareUpdateType.from_name(usbsubsystem)
         version = info["version"]
         shortsha = secrets.token_hex(4) if random_sha else info["shortsha"]
         files_by_revision = info["files_by_revision"]
@@ -209,9 +240,9 @@ def test_load_firmware_manifest_unknown_update_type(
         json.dump(manifest, fp)
     with mock.patch("os.path.exists"):
         updates = load_firmware_manifest(manifest_filename)
-        # only one update is valid 'head', invalid update types are ignored
+        # only two updates are valid 'head' and 'rear-panel', invalid update types are ignored
         assert FirmwareUpdateType.head in updates
-        assert len(updates) == 1
+        assert len(updates) == 2
         os.unlink(manifest_filename)
 
 
@@ -239,9 +270,9 @@ def test_load_firmware_manifest_invalid_update_info(
         json.dump(manifest, fp)
     with mock.patch("os.path.exists"):
         updates = load_firmware_manifest(manifest_filename)
-        # only one update is valid 'head', invalid update types are ignored
+        # only two updates are valid 'head' and 'rear-panel', invalid update types are ignored
         assert FirmwareUpdateType.head in updates
-        assert len(updates) == 1
+        assert len(updates) == 2
         os.unlink(manifest_filename)
 
 
@@ -328,7 +359,7 @@ def test_check_firmware_updates_available_nodes_specified(
         mock.Mock(return_value=known_firmware_updates),
     ):
         firmware_updates = check_firmware_updates(
-            device_info_cache, attached_pipettes={}, nodes={NodeId.gripper}
+            device_info_cache, attached_pipettes={}, targets={NodeId.gripper}
         )
         # only the gripper needs an update
         assert len(firmware_updates) == 1
@@ -367,7 +398,7 @@ def test_load_firmware_manifest_is_empty(mock_manifest: Dict[str, Any]) -> None:
 
 def test_unknown_firmware_update_type(mock_manifest: Dict[str, Any]) -> None:
     """Don't do updates if the FirmwareUpdateType is unknown."""
-    device_info = {
+    device_info: Dict[FirmwareTarget, DeviceInfoCache] = {
         NodeId.head: DeviceInfoCache(
             NodeId.head, 2, "12345678", None, PCBARevision(None)
         )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -5,6 +5,7 @@ import datetime
 from typing import List, Callable
 from mock import AsyncMock
 
+from opentrons_hardware.drivers.binary_usb.binary_messenger import BinaryMessenger
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings import (
     ArbitrationId,
@@ -16,8 +17,10 @@ from opentrons_hardware.firmware_bindings.messages import (
     message_definitions,
     payloads,
     fields,
+    BinaryMessageDefinition,
+    binary_message_definitions,
 )
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId, USBTarget
 
 from opentrons_hardware.hardware_control.network import NetworkInfo
 
@@ -27,8 +30,13 @@ def mock_can_messenger() -> AsyncMock:
     """Mock communication."""
     return AsyncMock(spec=CanMessenger)
 
+@pytest.fixture
+def mock_usb_messenger() -> AsyncMock:
+    """Mock communication."""
+    return AsyncMock(spec=BinaryMessenger)
 
-class MockStatusResponder:
+
+class MockCanStatusResponder:
     """A harness that will automatically send status responses."""
 
     def __init__(
@@ -73,6 +81,41 @@ class MockStatusResponder:
                     ),
                 )
 
+class MockUSBStatusResponder:
+    """A harness that will automatically send status responses."""
+
+    def __init__(
+        self, mock_messenger: AsyncMock, respond_with_nodes: List[int]
+    ) -> None:
+        """Build the status responder."""
+        self._mock_messenger = mock_messenger
+        self._callbacks: List[Callable[[BinaryMessageDefinition], None]] = []
+        self._mock_messenger.add_listener.side_effect = self.add_callback
+        self._mock_messenger.send.side_effect = self.send
+        self._respond_with_nodes = respond_with_nodes
+
+    def add_callback(
+        self, callback: Callable[[BinaryMessageDefinition], None]
+    ) -> None:
+        """Wrap the add_callback mock method."""
+        self._callbacks.append(callback)
+
+    def send(self, message: BinaryMessageDefinition) -> None:
+        """Wrap the send method to send predefined callbacks."""
+        assert self._callbacks
+        for callback in self._callbacks:
+            for node in self._respond_with_nodes:
+                response = binary_message_definitions.DeviceInfoResponse(
+                        version=utils.UInt32Field(0),
+                        flags=fields.VersionFlagsField(0),
+                        shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
+                        revision=fields.OptionalRevisionField.build(b""),
+                )
+                asyncio.get_running_loop().call_soon(
+                    callback,
+                    response,
+                )
+
 
 async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
     """Test that the timeout functionality works."""
@@ -108,7 +151,7 @@ async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
 
 async def test_completes_exact_equality(mock_can_messenger: AsyncMock) -> None:
     """Test that if the exact specified nodes exist the probe works."""
-    _ = MockStatusResponder(mock_can_messenger, [NodeId.gantry_x.value])
+    _ = MockCanStatusResponder(mock_can_messenger, [NodeId.gantry_x.value])
     # we should not get to the timeout, but if we did we wouldn't know because it
     # doesn't raise, so wrap it in a smaller timeout so it will raise (it should
     # complete basically instantly)
@@ -119,7 +162,7 @@ async def test_completes_exact_equality(mock_can_messenger: AsyncMock) -> None:
 
 async def test_completes_more_than_expected(mock_can_messenger: AsyncMock) -> None:
     """Test that if more than specified node exists, the probe works."""
-    _ = MockStatusResponder(
+    _ = MockCanStatusResponder(
         mock_can_messenger, [NodeId.gantry_y.value, NodeId.gantry_x.value]
     )
     # same deal with the timeout
@@ -131,9 +174,16 @@ async def test_completes_more_than_expected(mock_can_messenger: AsyncMock) -> No
 
 async def test_handles_bad_node_ids(mock_can_messenger: AsyncMock) -> None:
     """Test that invalid node ids are swalloed silently."""
-    _ = MockStatusResponder(mock_can_messenger, [0x01, NodeId.gantry_x.value])
+    _ = MockCanStatusResponder(mock_can_messenger, [0x01, NodeId.gantry_x.value])
     # same deal with the timeout
     network_info = NetworkInfo(mock_can_messenger)
     probed = set(await asyncio.wait_for(network_info.probe({NodeId.gantry_x}), 2.0))
     # we should get everything we prepped the network with and ignore the bad values
     assert probed == {NodeId.gantry_x}
+
+async def test_handles_usb_target(mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock) -> None:
+    """Test that network probe handles rear-panel usb target."""
+    _ = MockUSBStatusResponder(mock_usb_messenger, [USBTarget.rear_panel])
+    network_info = NetworkInfo(mock_can_messenger, mock_usb_messenger)
+    probed = set(await asyncio.wait_for(network_info.probe({USBTarget.rear_panel}), 2.0))
+    assert probed == {USBTarget.rear_panel}

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -30,6 +30,7 @@ def mock_can_messenger() -> AsyncMock:
     """Mock communication."""
     return AsyncMock(spec=CanMessenger)
 
+
 @pytest.fixture
 def mock_usb_messenger() -> AsyncMock:
     """Mock communication."""
@@ -81,6 +82,7 @@ class MockCanStatusResponder:
                     ),
                 )
 
+
 class MockUSBStatusResponder:
     """A harness that will automatically send status responses."""
 
@@ -94,9 +96,7 @@ class MockUSBStatusResponder:
         self._mock_messenger.send.side_effect = self.send
         self._respond_with_nodes = respond_with_nodes
 
-    def add_callback(
-        self, callback: Callable[[BinaryMessageDefinition], None]
-    ) -> None:
+    def add_callback(self, callback: Callable[[BinaryMessageDefinition], None]) -> None:
         """Wrap the add_callback mock method."""
         self._callbacks.append(callback)
 
@@ -106,10 +106,10 @@ class MockUSBStatusResponder:
         for callback in self._callbacks:
             for node in self._respond_with_nodes:
                 response = binary_message_definitions.DeviceInfoResponse(
-                        version=utils.UInt32Field(0),
-                        flags=fields.VersionFlagsField(0),
-                        shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
-                        revision=fields.OptionalRevisionField.build(b""),
+                    version=utils.UInt32Field(0),
+                    flags=fields.VersionFlagsField(0),
+                    shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
+                    revision=fields.OptionalRevisionField.build(b""),
                 )
                 asyncio.get_running_loop().call_soon(
                     callback,
@@ -181,9 +181,14 @@ async def test_handles_bad_node_ids(mock_can_messenger: AsyncMock) -> None:
     # we should get everything we prepped the network with and ignore the bad values
     assert probed == {NodeId.gantry_x}
 
-async def test_handles_usb_target(mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock) -> None:
+
+async def test_handles_usb_target(
+    mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock
+) -> None:
     """Test that network probe handles rear-panel usb target."""
     _ = MockUSBStatusResponder(mock_usb_messenger, [USBTarget.rear_panel])
     network_info = NetworkInfo(mock_can_messenger, mock_usb_messenger)
-    probed = set(await asyncio.wait_for(network_info.probe({USBTarget.rear_panel}), 2.0))
+    probed = set(
+        await asyncio.wait_for(network_info.probe({USBTarget.rear_panel}), 2.0)
+    )
     assert probed == {USBTarget.rear_panel}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Tested on EVT and DVT bots, this PR lets will automatically try to update the rear-panel board if the rearPanelIntegration flag is set in the feature flags
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
