### PR TITLE
fix(app): add border to default states and adjust spacing

### DIFF
--- a/app/src/molecules/JogControls/ControlContainer.tsx
+++ b/app/src/molecules/JogControls/ControlContainer.tsx
@@ -20,7 +20,6 @@ const CONTROL_CHILDREN_STYLES = css`
   background-color: ${COLORS.fundamentalsBackground};
   border-radius: ${BORDERS.radiusSoftCorners};
   padding: ${SPACING.spacing4};
-  margin: ${SPACING.spacing1};
   width: 100%;
   height: 9.75rem;
 

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -127,7 +127,7 @@ const PLANE_BUTTONS_STYLE = css`
   flex-direction: ${DIRECTION_COLUMN};
   justify-content: ${JUSTIFY_CENTER};
   grid-gap: ${SPACING.spacing3};
-  width: 9.75rem;
+  width: 9.25rem;
 
   @media (max-width: 750px) {
     flex-direction: ${DIRECTION_ROW};
@@ -146,13 +146,13 @@ const DEFAULT_BUTTON_STYLE = css`
     background-color: ${COLORS.white};
     color: ${COLORS.black};
     box-shadow: 0 0 0;
-    border: 1px ${COLORS.lightGreyHover} solid;
+    outline: 1px ${COLORS.lightGreyHover} solid;
   }
 
   &:active {
     background-color: ${COLORS.white};
     color: ${COLORS.blueEnabled};
-    border: 1px ${COLORS.blueEnabled} solid;
+    outline: 1px ${COLORS.blueEnabled} solid;
   }
 
   &:disabled {
@@ -164,7 +164,7 @@ const DEFAULT_BUTTON_STYLE = css`
 const ACTIVE_BUTTON_STYLE = css`
   ${DEFAULT_BUTTON_STYLE}
   color: ${COLORS.blueEnabled};
-  border: 1px ${COLORS.blueEnabled} solid;
+  outline: 1px ${COLORS.blueEnabled} solid;
 `
 
 interface DirectionControlProps {

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -131,7 +131,7 @@ const PLANE_BUTTONS_STYLE = css`
   flex-direction: ${DIRECTION_COLUMN};
   justify-content: ${JUSTIFY_CENTER};
   grid-gap: ${SPACING.spacing3};
-  width: 9.25rem;
+  min-width: 9.8125rem;
 
   @media (max-width: 750px) {
     flex-direction: ${DIRECTION_ROW};
@@ -140,7 +140,6 @@ const PLANE_BUTTONS_STYLE = css`
 `
 
 const DEFAULT_BUTTON_STYLE = css`
-  min-width: 10rem;
   display: flex;
   border: 1px ${COLORS.white} solid;
   justify-content: ${JUSTIFY_FLEX_START};
@@ -148,6 +147,7 @@ const DEFAULT_BUTTON_STYLE = css`
   background-color: ${COLORS.white};
   color: ${COLORS.black};
   grid-gap: ${SPACING.spacing3};
+  padding: ${SPACING.spacing3};
 
   &:focus {
     background-color: ${COLORS.white};
@@ -225,7 +225,7 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
                   name={
                     plane === 'vertical' ? 'vertical-plane' : 'horizontal-plane'
                   }
-                  width="1.5rem"
+                  height="1.375rem"
                   flex="1 0 auto"
                 />
                 <Flex

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -165,6 +165,11 @@ const ACTIVE_BUTTON_STYLE = css`
   ${DEFAULT_BUTTON_STYLE}
   color: ${COLORS.blueEnabled};
   outline: 1px ${COLORS.blueEnabled} solid;
+
+  &:hover {
+    color: ${COLORS.blueHover};
+    outline: 1px ${COLORS.blueHover} solid;
+  }
 `
 
 interface DirectionControlProps {

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -137,6 +137,7 @@ const PLANE_BUTTONS_STYLE = css`
 
 const DEFAULT_BUTTON_STYLE = css`
   display: flex;
+  border: 1px ${COLORS.white} solid;
   justify-content: ${JUSTIFY_CENTER};
   align-items: ${ALIGN_CENTER};
   background-color: ${COLORS.white};
@@ -146,13 +147,13 @@ const DEFAULT_BUTTON_STYLE = css`
     background-color: ${COLORS.white};
     color: ${COLORS.black};
     box-shadow: 0 0 0;
-    outline: 1px ${COLORS.lightGreyHover} solid;
+    border: 1px ${COLORS.lightGreyHover} solid;
   }
 
   &:active {
     background-color: ${COLORS.white};
     color: ${COLORS.blueEnabled};
-    outline: 1px ${COLORS.blueEnabled} solid;
+    border: 1px ${COLORS.blueEnabled} solid;
   }
 
   &:disabled {
@@ -164,11 +165,11 @@ const DEFAULT_BUTTON_STYLE = css`
 const ACTIVE_BUTTON_STYLE = css`
   ${DEFAULT_BUTTON_STYLE}
   color: ${COLORS.blueEnabled};
-  outline: 1px ${COLORS.blueEnabled} solid;
+  border: 1px ${COLORS.blueEnabled} solid;
 
   &:hover {
     color: ${COLORS.blueHover};
-    outline: 1px ${COLORS.blueHover} solid;
+    border: 1px ${COLORS.blueHover} solid;
   }
 `
 

--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -19,6 +19,9 @@ import {
   DIRECTION_ROW,
   ALIGN_FLEX_START,
   ALIGN_FLEX_END,
+  TEXT_ALIGN_LEFT,
+  JUSTIFY_FLEX_START,
+  ALIGN_STRETCH,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
@@ -67,7 +70,7 @@ const CONTROLS_CONTENTS_BY_PLANE: Record<Plane, ControlsContents> = {
       },
     ],
     title: 'Z-axis',
-    subtitle: 'Shift + Arrow keys',
+    subtitle: 'Shift + Arrow Keys',
   },
   [HORIZONTAL_PLANE]: {
     controls: [
@@ -114,6 +117,7 @@ const CONTROLS_CONTENTS_BY_PLANE: Record<Plane, ControlsContents> = {
 }
 
 const DIRECTION_CONTROL_LAYOUT = css`
+  flex: 1;
   flex-direction: ${DIRECTION_ROW};
   justify-content: ${JUSTIFY_SPACE_BETWEEN};
   grid-gap: ${SPACING.spacing4};
@@ -136,12 +140,18 @@ const PLANE_BUTTONS_STYLE = css`
 `
 
 const DEFAULT_BUTTON_STYLE = css`
+  min-width: 10rem;
   display: flex;
   border: 1px ${COLORS.white} solid;
-  justify-content: ${JUSTIFY_CENTER};
+  justify-content: ${JUSTIFY_FLEX_START};
   align-items: ${ALIGN_CENTER};
   background-color: ${COLORS.white};
   color: ${COLORS.black};
+  grid-gap: ${SPACING.spacing3};
+
+  &:focus {
+    background-color: ${COLORS.white};
+  }
 
   &:hover {
     background-color: ${COLORS.white};
@@ -157,7 +167,7 @@ const DEFAULT_BUTTON_STYLE = css`
   }
 
   &:disabled {
-    background-color: inherit;
+    background-color: ${COLORS.white};
     color: ${COLORS.errorDisabled};
   }
 `
@@ -215,12 +225,18 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
                   name={
                     plane === 'vertical' ? 'vertical-plane' : 'horizontal-plane'
                   }
-                  width="1.2rem"
-                  marginRight={SPACING.spacing3}
+                  width="1.5rem"
+                  flex="1 0 auto"
                 />
-                <Flex flexDirection={DIRECTION_COLUMN}>
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  alignItems={ALIGN_FLEX_START}
+                  flex="1 1 auto"
+                >
                   {title}
                   <StyledText
+                    textAlign={TEXT_ALIGN_LEFT}
+                    alignSelf={ALIGN_STRETCH}
                     color={COLORS.darkGreyEnabled}
                     css={TYPOGRAPHY.labelRegular}
                   >
@@ -302,7 +318,7 @@ const ARROW_BUTTON_STYLES = css`
   }
 
   &:disabled {
-    background-color: inherit;
+    background-color: ${COLORS.white};
     color: ${COLORS.darkGreyDisabled};
   }
 

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -77,6 +77,10 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
     height: 3.62rem;
     color: ${COLORS.black};
 
+    &:focus {
+      background-color: ${COLORS.white};
+    }
+
     &:hover {
       background-color: ${COLORS.white};
       color: ${COLORS.black};

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -80,13 +80,13 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
       background-color: ${COLORS.white};
       color: ${COLORS.black};
       box-shadow: 0 0 0;
-      border: 1px ${COLORS.lightGreyHover} solid;
+      outline: 1px ${COLORS.lightGreyHover} solid;
     }
 
     &:active {
       background-color: ${COLORS.white};
       color: ${COLORS.blueEnabled};
-      border: 1px ${COLORS.blueEnabled} solid;
+      outline: 1px ${COLORS.blueEnabled} solid;
     }
 
     &:disabled {
@@ -97,7 +97,7 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
   const ACTIVE_BUTTON_STYLE = css`
     ${DEFAULT_BUTTON_STYLE}
     color: ${COLORS.blueEnabled};
-    border: 1px ${COLORS.blueEnabled} solid;
+    outline: 1px ${COLORS.blueEnabled} solid;
   `
   return (
     <ControlContainer title={STEP_SIZE_TITLE}>

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -98,6 +98,11 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
     ${DEFAULT_BUTTON_STYLE}
     color: ${COLORS.blueEnabled};
     outline: 1px ${COLORS.blueEnabled} solid;
+
+    &:hover {
+      color: ${COLORS.blueHover};
+      outline: 1px ${COLORS.blueHover} solid;
+    }
   `
   return (
     <ControlContainer title={STEP_SIZE_TITLE}>

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -73,6 +73,7 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
 
   const DEFAULT_BUTTON_STYLE = css`
     background-color: ${COLORS.white};
+    border: 1px ${COLORS.white} solid;
     height: 3.62rem;
     color: ${COLORS.black};
 
@@ -80,13 +81,13 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
       background-color: ${COLORS.white};
       color: ${COLORS.black};
       box-shadow: 0 0 0;
-      outline: 1px ${COLORS.lightGreyHover} solid;
+      border: 1px ${COLORS.lightGreyHover} solid;
     }
 
     &:active {
       background-color: ${COLORS.white};
       color: ${COLORS.blueEnabled};
-      outline: 1px ${COLORS.blueEnabled} solid;
+      border: 1px ${COLORS.blueEnabled} solid;
     }
 
     &:disabled {
@@ -97,11 +98,11 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
   const ACTIVE_BUTTON_STYLE = css`
     ${DEFAULT_BUTTON_STYLE}
     color: ${COLORS.blueEnabled};
-    outline: 1px ${COLORS.blueEnabled} solid;
+    border: 1px ${COLORS.blueEnabled} solid;
 
     &:hover {
       color: ${COLORS.blueHover};
-      outline: 1px ${COLORS.blueHover} solid;
+      border: 1px ${COLORS.blueHover} solid;
     }
   `
   return (

--- a/app/src/organisms/CalibrationPanels/TipConfirmation.tsx
+++ b/app/src/organisms/CalibrationPanels/TipConfirmation.tsx
@@ -54,7 +54,7 @@ export function TipConfirmation(props: CalibrationPanelProps): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       padding={SPACING.spacing6}
-      minHeight="32rem"
+      minHeight="25rem"
     >
       <StyledText as="h1" marginBottom={SPACING.spacing4}>
         {t('did_pipette_pick_up_tip')}


### PR DESCRIPTION
closes RAUT-339 and RAUT-340

# Overview

Adjust the jog controls and `is pipette successfully attached?` modal size as outlined in tickets

# Test Plan

- in LPC, click through and when you reach the `jog control` pages, hover over and click the buttons. When you hover over the button, the surrounding buttons should not move. When you click to reveal the different jog arrow buttons, the surrounding buttons should not move around. 
- in LPC, click through and when you run into the `Did pipette pick up tip successfully?`, the model size should match figma.

# Changelog

- change rem size of the `Did pipette pick up tip successfully?` modal
- add `border` to default states to stop the buttons from moving when you hover over

# Review requests

- review test plan

# Risk assessment

low