### PR TITLE
fix(api): Add set_calibration not implemented to versioning doc

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -319,5 +319,8 @@ If you specify an API version of ``2.13`` or lower, your protocols will continue
   - :py:meth:`.Labware.set_offset` is not yet supported on this API version.
     Run protocols via the Opentrons App, instead.
 
+  - :py:meth:`.Labware.set_calibration` is not supported on this API version.
+    Setting a labware's calibration after it's been loaded is not supported.
+
   - :py:attr:`.ProtocolContext.max_speeds` is not yet supported on the API version.
     Use :py:attr:`.InstrumentContext.default_speed` or the per-method `speed` argument, instead.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -298,6 +298,8 @@ If you specify an API version of ``2.13`` or lower, your protocols will continue
 
   - ``Labware.separate_calibration`` and ``ModuleContext.separate_calibration`` were removed,
     since they were holdovers from a calibration system that no longer exists.
+    :py:meth:`.Labware.set_calibration` was removed.
+    Setting a labware's calibration after it's been loaded is not supported.
 
   - Various methods and setters were removed that could modify tip state outside of
     calls to :py:meth:`.InstrumentContext.pick_up_tip` and :py:meth:`.InstrumentContext.drop_tip`.
@@ -313,9 +315,6 @@ If you specify an API version of ``2.13`` or lower, your protocols will continue
   - The ``configuration`` argument of :py:meth:`.ProtocolContext.load_module` was removed
     because it made unsafe modifications to the protocol's geometry system,
     and the Thermocycler's "semi" configuration is not officially supported.
-
-  - :py:meth:`.Labware.set_calibration` is not supported on this API version.
-    Setting a labware's calibration after it's been loaded is not supported.
 
 - Known limitations
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -296,10 +296,8 @@ If you specify an API version of ``2.13`` or lower, your protocols will continue
   - The ``height`` parameter of :py:meth:`.MagneticModuleContext.engage` was removed.
     Use ``offset`` or ``height_from_base`` instead.
     
-  - ``Labware.separate_calibration`` was removed,
-    since it was a holdover from a calibration system that no longer exists.
-    :py:meth:`.Labware.set_calibration` was removed.
-    Setting a labware's calibration after it's been loaded is not supported.
+  - ``Labware.separate_calibration`` and :py:meth:`.Labware.set_calibration` were removed,
+    since they were holdovers from a calibration system that no longer exists.
 
   - Various methods and setters were removed that could modify tip state outside of
     calls to :py:meth:`.InstrumentContext.pick_up_tip` and :py:meth:`.InstrumentContext.drop_tip`.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -314,13 +314,13 @@ If you specify an API version of ``2.13`` or lower, your protocols will continue
     because it made unsafe modifications to the protocol's geometry system,
     and the Thermocycler's "semi" configuration is not officially supported.
 
+  - :py:meth:`.Labware.set_calibration` is not supported on this API version.
+    Setting a labware's calibration after it's been loaded is not supported.
+
 - Known limitations
 
   - :py:meth:`.Labware.set_offset` is not yet supported on this API version.
     Run protocols via the Opentrons App, instead.
-
-  - :py:meth:`.Labware.set_calibration` is not supported on this API version.
-    Setting a labware's calibration after it's been loaded is not supported.
 
   - :py:attr:`.ProtocolContext.max_speeds` is not yet supported on the API version.
     Use :py:attr:`.InstrumentContext.default_speed` or the per-method `speed` argument, instead.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -432,10 +432,16 @@ class Labware:
 
     def set_calibration(self, delta: Point) -> None:
         """
-        An internal, deprecated method Called by set_offset in order to update the offset on the object.
+        An internal, deprecated method used for updating the offset on the object.
 
         .. deprecated:: 2.14
         """
+        if self._api_version >= ENGINE_CORE_API_VERSION:
+            raise APIVersionError(
+                "Labware.set_calibration() is not supported when apiLevel is 2.14 or higher."
+                " Use a lower apiLevel"
+                " or use the Opentrons App's Labware Position Check."
+            )
         self._core.set_calibration(delta)
 
     @requires_version(2, 12)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -432,7 +432,9 @@ class Labware:
 
     def set_calibration(self, delta: Point) -> None:
         """
-        Called by save calibration in order to update the offset on the object.
+        An internal, deprecated method Called by set_offset in order to update the offset on the object.
+
+        .. deprecated:: 2.14
         """
         self._core.set_calibration(delta)
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-544. 
Added a not implemented explantation to the version doc. 

# Test Plan

Uploading this protocol should raise a not implemented error.

```
# Test protocol
from opentrons import protocol_api
from opentrons.types import Point

metadata = {
    "protocolName": "2.14 test for Labware and Well now adhere to the protocol's API level setting. Prior to this version, they incorrectly ignored the setting.",
    "author": "Opentrons Engineering <engineering@opentrons.com>",
    "source": "Software Testing Team",
    "description": ("Labware and Well"),
    "apiLevel": "2.14",
}


def run(protocol: protocol_api.ProtocolContext) -> None:
    """This method is run by the protocol engine."""
    # Labware
    plate = protocol.load_labware(
        "corning_96_wellplate_360ul_flat", location="2", label="plate_label"
    )
    plate.set_calibration(delta=Point(x=0.10, y=0.01, z=-1.01))
```

# Changelog

Added to the versioning doc under Known limitations.

# Review requests

Do we feel good about this change? 

# Risk assessment

low. just added an explanation to the docs. 
