### PR TITLE
feat(app): add medium button rounded for odd

### DIFF
--- a/app/src/atoms/buttons/ODD/MediumButtonRounded.tsx
+++ b/app/src/atoms/buttons/ODD/MediumButtonRounded.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+import {
+  TYPOGRAPHY,
+  COLORS,
+  SPACING,
+  BORDERS,
+  NewPrimaryBtn,
+  styleProps,
+} from '@opentrons/components'
+
+export const MediumButtonRounded = styled(NewPrimaryBtn)`
+  background-color: ${COLORS.blueEnabled};
+  border-radius: ${BORDERS.size_six};
+  box-shadow: none;
+  height: '4.25rem';
+  font-size: ${TYPOGRAPHY.fontSize28};
+  font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+  line-height: ${TYPOGRAPHY.lineHeight36};
+  padding: ${SPACING.spacing4} ${SPACING.spacing6};
+  text-transform: ${TYPOGRAPHY.textTransformNone};
+  width: '13.375rem';
+
+  ${styleProps}
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${COLORS.fundamentalsFocus};
+  }
+
+  &:active {
+    background-color: ${COLORS.blueEnabled};
+  }
+
+  &:disabled {
+    background-color: ${COLORS.darkBlack_twenty};
+    color: ${COLORS.darkBlack_sixty};
+  }
+`

--- a/app/src/atoms/buttons/ODD/ODDButtons.stories.tsx
+++ b/app/src/atoms/buttons/ODD/ODDButtons.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { MediumButtonRounded, SmallButton } from '.'
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'ODD/Atoms/Buttons',
+  argTypes: { onClick: { action: 'clicked' } },
+} as Meta
+
+const MediumButtonRoundedTemplate: Story<
+  React.ComponentProps<typeof MediumButtonRounded>
+> = args => <MediumButtonRounded {...args} />
+export const MediumRounded = MediumButtonRoundedTemplate.bind({})
+MediumRounded.args = {
+  children: 'Button text',
+  title: 'medium button rounded',
+}
+
+const SmallButtonTemplate: Story<
+  React.ComponentProps<typeof SmallButton>
+> = args => <SmallButton {...args} />
+export const Small = SmallButtonTemplate.bind({})
+Small.args = {
+  children: 'Button text',
+  title: 'small button',
+}

--- a/app/src/atoms/buttons/ODD/__tests__/MediumButtonRounded.test.tsx
+++ b/app/src/atoms/buttons/ODD/__tests__/MediumButtonRounded.test.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import {
+  renderWithProviders,
+  COLORS,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { MediumButtonRounded } from '..'
+
+const render = (props: React.ComponentProps<typeof MediumButtonRounded>) => {
+  return renderWithProviders(<MediumButtonRounded {...props} />)[0]
+}
+
+describe('MediumButtonRounded', () => {
+  let props: React.ComponentProps<typeof MediumButtonRounded>
+
+  beforeEach(() => {
+    props = {
+      children: 'medium button rounded',
+    }
+  })
+
+  it('renders medium button rounded with text', () => {
+    const { getByText } = render(props)
+    const button = getByText('medium button rounded')
+    expect(button).toHaveStyle(
+      `background-color: ${String(COLORS.blueEnabled)}`
+    )
+    expect(button).toHaveStyle(
+      `padding: ${String(SPACING.spacing4)} ${String(SPACING.spacing6)}`
+    )
+    expect(button).toHaveStyle(`font-size: ${String(TYPOGRAPHY.fontSize28)}`)
+    expect(button).toHaveStyle(
+      `font-weight: ${String(TYPOGRAPHY.fontWeightSemiBold)}`
+    )
+    expect(button).toHaveStyle(
+      `line-height: ${String(TYPOGRAPHY.lineHeight36)}`
+    )
+    expect(button).toHaveStyle(`border-radius: 60px`)
+    expect(button).toHaveStyle(
+      `text-transform: ${String(TYPOGRAPHY.textTransformNone)}`
+    )
+    expect(button).toHaveStyle(`box-shadow: none`)
+    expect(button).toHaveStyle(`color: ${String(COLORS.white)}`)
+  })
+
+  it('renders medium button rounded with text and disabled', () => {
+    props.disabled = true
+    const { getByText } = render(props)
+    const button = getByText('medium button rounded')
+    expect(button).toBeDisabled()
+    expect(button).toHaveStyle(`background-color: #16212d33`)
+    expect(button).toHaveStyle(`color: #16212d99`)
+  })
+
+  it('applies the correct states to the medium button rounded - active', () => {
+    const { getByText } = render(props)
+    const button = getByText('medium button rounded')
+    expect(button).toHaveStyleRule(
+      'background-color',
+      `${COLORS.blueEnabled}`,
+      {
+        modifier: ':active',
+      }
+    )
+  })
+
+  it('applies the correct states to the medium button rounded - focus-visible', () => {
+    const { getByText } = render(props)
+    const button = getByText('medium button rounded')
+    expect(button).toHaveStyleRule(
+      'box-shadow',
+      `0 0 0 3px ${String(COLORS.fundamentalsFocus)}`,
+      {
+        modifier: ':focus-visible',
+      }
+    )
+  })
+})

--- a/app/src/atoms/buttons/ODD/index.ts
+++ b/app/src/atoms/buttons/ODD/index.ts
@@ -1,1 +1,2 @@
+export { MediumButtonRounded } from './MediumButtonRounded'
 export { SmallButton } from './SmallButton'

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -2,6 +2,7 @@ import { css } from 'styled-components'
 import { COLORS } from './'
 
 // Font Sizes
+export const fontSize28 = '1.75rem' // 28px
 export const fontSizeH1 = '1.188rem' // 19px
 export const fontSizeH2 = '0.9375rem' // 15px
 export const fontSizeH3 = '0.875rem' // 14px
@@ -19,6 +20,7 @@ export const fontWeightRegular = 400
 export const fontWeightLight = 300
 
 // Line Heights
+export const lineHeight36 = '2.25rem' // 36px
 export const lineHeight24 = '1.5rem' // 24px
 export const lineHeight20 = '1.25rem' // 20px
 export const lineHeight16 = '1rem' // 16px


### PR DESCRIPTION
# Overview

This adds an atom for the "Medium Button Rounded"

https://www.figma.com/file/OIdG64Q5cgvEw82ish5Eee/Design-System-(ODD)?node-id=531%3A17091&t=y02ADt12lfcYtehV-0

Closes RAUT-361

# Test Plan

Added storybook story and unit tests

# Changelog

- Added new typography sizes
- Created story book story for new button and existing small button
- Add new medium rounded button

# Review requests

I noticed we don't use button states in storybook. Should we?

# Risk assessment

None.
