### PR TITLE
fix(api): Update liquid setup docstrings

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -10,6 +10,8 @@ class Liquid:
         name: A human-readable name for the liquid.
         description: An optional description.
         display_color: An optional display color for the liquid.
+
+    New in version 2.14.
     """
 
     _id: str

--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -11,7 +11,7 @@ class Liquid:
         description: An optional description.
         display_color: An optional display color for the liquid.
 
-    New in version 2.14.
+    .. versionadded:: 2.14
     """
 
     _id: str

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -216,7 +216,7 @@ class Well:
         Load a liquid into a well.
 
         :param Liquid liquid: The liquid to load into the well.
-        :param str volume: The volume of liquid to load, in µL.
+        :param float volume: The volume of liquid to load, in µL.
         """
         self._core.load_liquid(
             liquid=liquid,

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -215,9 +215,8 @@ class Well:
         """
         Load a liquid into a well.
 
-        :param liquid: a :py:class:`opentrons.types.Liquid`. The return type when defining a liquid in protocol_context.define_liquid.
-            The liquid to load into the well.
-        :param volume: a float that represents the volume of liquid to load, in µL.
+        :param Liquid liquid: The liquid to load into the well.
+        :param str volume: The volume of liquid to load, in µL.
         """
         self._core.load_liquid(
             liquid=liquid,

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -215,8 +215,9 @@ class Well:
         """
         Load a liquid into a well.
 
-        :param liquid: The type of liquid to load into the well.
-        :param volume: The volume of liquid to load, in µL.
+        :param liquid: a :py:class:`opentrons.types.Liquid`. The return type when defining in protocol_context.define_liquid.
+            The type of liquid to load into the well.
+        :param volume: a float that represents the volume of liquid to load, in µL.
         """
         self._core.load_liquid(
             liquid=liquid,

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -215,8 +215,8 @@ class Well:
         """
         Load a liquid into a well.
 
-        :param liquid: a :py:class:`opentrons.types.Liquid`. The return type when defining in protocol_context.define_liquid.
-            The type of liquid to load into the well.
+        :param liquid: a :py:class:`opentrons.types.Liquid`. The return type when defining a liquid in protocol_context.define_liquid.
+            The liquid to load into the well.
         :param volume: a float that represents the volume of liquid to load, in µL.
         """
         self._core.load_liquid(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -796,8 +796,7 @@ class ProtocolContext(CommandPublisher):
         :param str description: An optional description of the liquid.
         :param str display_color: An optional hex color code, with hash included, to represent the specified liquid. Standard three-value, four-value, six-value, and eight-value syntax are all acceptable.
 
-        :return: a :py:class:`opentrons.types.Liquid` representing the specified
-            liquid.
+        :return: A :py:class:`~opentrons.protocol_api.Liquid` object representing the specified liquid.
         """
         return self._core.define_liquid(
             name=name,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -795,6 +795,9 @@ class ProtocolContext(CommandPublisher):
         :param str name: A human-readable name for the liquid.
         :param str description: An optional description of the liquid.
         :param str display_color: An optional hex color code, with hash included, to represent the specified liquid. Standard three-value, four-value, six-value, and eight-value syntax are all acceptable.
+
+        :return: a :py:class:`opentrons.types.Liquid` representing the specified
+            liquid.
         """
         return self._core.define_liquid(
             name=name,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-545.
clarified docstrings for `load_liquid`, `define_liquid` and `Liquid`.

# Changelog

changed docstrings for `load_liquid`, `define_liquid` and `Liquid`.

# Review requests

Any better suggestions? 

# Risk assessment

None. just changed docstrings. 
