### PR TITLE
fix(api): ot3 motor status cannot be trusted, yet

### DIFF
--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1139,15 +1139,17 @@ async def test_home_axis(
 
         await ot3_hardware._home_axis(axis)
 
-        if stepper_ok:
-            """Move to home position"""
-            # move is called
-            mock_backend_move.assert_awaited_once()
-            move = mock_backend_move.call_args_list[0][0][1][0]
-            assert move.distance == 100.0
-            # home is NOT called
-            mock_backend_home.assert_not_awaited()
-        elif encoder_ok:
+        # FIXME: uncomment the following when stall detection
+        # is fully re-enable
+        # if stepper_ok:
+        #     """Move to home position"""
+        #     # move is called
+        #     mock_backend_move.assert_awaited_once()
+        #     move = mock_backend_move.call_args_list[0][0][1][0]
+        #     assert move.distance == 100.0
+        #     # home is NOT called
+        #     mock_backend_home.assert_not_awaited()
+        if encoder_ok:
             """Copy encoder position to stepper pos"""
             mock_estimate.assert_awaited_once()
             # for accurate axis, we just move to home pos:


### PR DESCRIPTION
# Overview
We added a workaround in #11978 to enable hardware testing by forcing the motor status of an axis to report OK if the axis has homed once. This means that after a stall, the motor status will be falsely reporting ok. This leads the hardware controller to trust the motor position when issuing a subsequent move command – even though the motor position has diverged from the actual/encoder position.

Together with the changes added in #12142, the motor can crash into the limit switch during a home command if a stall has occurred beforehand. This PR comments out the `if` block that checks the motor status. Until we can trust the motor status flag, we should instead only check the encoder position and update motor position before homing any axis.