### PR TITLE
chore(system-server): prefix documentation endpoints with /system/

### DIFF
--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -17,6 +17,9 @@ app = FastAPI(
         "This OpenAPI spec describes the HTTP API of the Opentrons System Server."
     ),
     version=version,
+    openapi_url="/system/openapi.json",
+    docs_url="/system/docs",
+    redoc_url="/system/redoc",
 )
 
 # cors


### PR DESCRIPTION

# Overview

In order to make the system server accessible outside of the robot, we need to add it to the `nginx.conf` file on the robot(s). Adding a carveout for `/system/` prefixes (with an exception for `/system/time` works fine, except that the autogenerated docs become unreachable. To fix this, this PR prefixes all of the documentation with `/system/` so that it will appear at the robot's normal interface port (31950).

# Test Plan

Tested with a `make dev` server, and on an OT-3 with https://github.com/Opentrons/oe-core/pull/65:
* Go to `{robot_url}/system/docs`, `{robot_url}/system/redoc` , `{robot_url}/system/openapi.json`  --> see the autogen docs as expected
* Interact with the system server endpoints from the autogen docs page --> able to interact as normal

# Changelog

* Added `/system/` prefix to system server autogenerated documentation

# Review requests

Any other implicit endpoints that should get the same treatment?

# Risk assessment

Low, dev only right now.
