### PR TITLE
fix(protocol-engine): Tolerate labware definitions with bad zDimension

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -195,13 +195,15 @@ class GeometryView:
 
     def _get_highest_z_from_labware_data(self, lw_data: LoadedLabware) -> float:
         labware_pos = self.get_labware_position(lw_data.id)
-        definition = self._labware.get_definition(lw_data.id)
-        z_dim = definition.dimensions.zDimension
+
+        dimensions = self._labware.get_dimensions(lw_data.id)
+
         height_over_labware: float = 0
         if isinstance(lw_data.location, ModuleLocation):
             module_id = lw_data.location.moduleId
             height_over_labware = self._modules.get_height_over_labware(module_id)
-        return labware_pos.z + z_dim + height_over_labware
+
+        return labware_pos.z + dimensions.z + height_over_labware
 
     def get_nominal_effective_tip_length(
         self,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -125,7 +125,7 @@ class GeometryView:
     def get_labware_origin_position(self, labware_id: str) -> Point:
         """Get the position of the labware's origin, without calibration."""
         slot_pos = self.get_labware_parent_position(labware_id)
-        origin_offset = self._labware.get_definition(labware_id).cornerOffsetFromSlot
+        origin_offset = self._labware.get_corner_offset_from_slot(labware_id)
 
         return Point(
             x=slot_pos.x + origin_offset.x,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -15,6 +15,7 @@ from typing import (
     NamedTuple,
     cast,
 )
+from functools import lru_cache
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3, SlotDefV3
 from opentrons_shared_data.labware.labware_definition import CornerOffsetFromSlot
@@ -482,6 +483,12 @@ class LabwareView(HasState[LabwareState]):
         definition = self.get_definition(labware_id)
         return definition.cornerOffsetFromSlot
 
+    @lru_cache(
+        # Let the cache per LabwareView grow without bound.
+        # This is okay because the set of loaded labware already grows without bound,
+        # so this only makes that worse by a small constant factor.
+        maxsize=None
+    )
     def get_dimensions(self, labware_id: str) -> Dimensions:
         """Get the labware's dimensions."""
         definition = self.get_definition(labware_id)

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3, SlotDefV3
+from opentrons_shared_data.labware.labware_definition import CornerOffsetFromSlot
 from opentrons_shared_data.pipette.dev_types import LabwareUri
 
 from opentrons.types import DeckSlotName, Point, MountType
@@ -472,6 +473,14 @@ class LabwareView(HasState[LabwareState]):
         """Get the labware's load name."""
         definition = self.get_definition(labware_id)
         return definition.parameters.loadName
+
+    def get_corner_offset_from_slot(self, labware_id: str) -> CornerOffsetFromSlot:
+        """Return the labware's cornerOffsetFromSlot.
+
+        See the labware definition schema for details.
+        """
+        definition = self.get_definition(labware_id)
+        return definition.cornerOffsetFromSlot
 
     def get_dimensions(self, labware_id: str) -> Dimensions:
         """Get the labware's dimensions."""

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -487,10 +487,14 @@ class LabwareView(HasState[LabwareState]):
         definition = self.get_definition(labware_id)
         dims = definition.dimensions
 
+        well_tops = (well.z + well.depth for well in definition.wells.values())
+
         return Dimensions(
             x=dims.xDimension,
             y=dims.yDimension,
-            z=dims.zDimension,
+            # Work around buggy labware definitions where the labware's zDimension is
+            # lower than the tops of the wells. See Jira RSS-197.
+            z=max(dims.zDimension, max(well_tops)),
         )
 
     def get_default_magnet_height(self, module_id: str, offset: float) -> float:


### PR DESCRIPTION
This is a backup workaround to solve issue RSS-197, in case the proper solution, PR #12293, doesn't work out.

