### PR TITLE
refactor(api): do not force home after pickup for OT3

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1646,10 +1646,6 @@ class OT3API(
                     speed=move.speed,
                     home_flagged_axes=False,
                 )
-        # we expect a stall happened here
-        await self._update_position_estimation(
-            [OT3Axis.from_axis(ax) for ax in move.home_axes]
-        )
         if move.home_after:
             await self._home([OT3Axis.from_axis(ax) for ax in move.home_axes])
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -452,7 +452,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 "dispense) must previously have been called so the robot "
                 "knows where it is."
             ) from e
-        print(f"what is target: {target}, {type(target)}")
+
         if isinstance(target, validation.WellTarget):
             if target.well.parent.is_tiprack:
                 _log.warning(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -452,7 +452,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 "dispense) must previously have been called so the robot "
                 "knows where it is."
             ) from e
-
+        print(f"what is target: {target}, {type(target)}")
         if isinstance(target, validation.WellTarget):
             if target.well.parent.is_tiprack:
                 _log.warning(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1022,7 +1022,7 @@ async def test_drop_tip_full_tiprack(
             ),
             _fake_function,
         )
-        await ot3_hardware.drop_tip(Mount.LEFT)
+        await ot3_hardware.drop_tip(Mount.LEFT, home_after=True)
         pipette_handler.plan_check_drop_tip.assert_called_once_with(OT3Mount.LEFT, True)
         tip_action.assert_has_calls(
             calls=[


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We have encoders on the new robot, so we don't have to home the motors as often as we used to on the OT2. 

During pick up tip, we're forcing a motor stall to happen. So we're updating the motor position based on the reported value from the encoder. 