### PR TITLE
fix(api): Raise deprecation error when using MagneticModuleContext.calibrate in 2.14 apiLevel

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -348,7 +348,7 @@ class MagneticModuleContext(ModuleContext):
         if self._api_version < ENGINE_CORE_API_VERSION:
             _log.warning(
                 "`MagneticModuleContext.calibrate` doesn't do anything useful"
-                " and will no-op in Protocol API version 2.14 and higher."
+                " and will be deprecated in Protocol API version 2.14 and higher."
             )
             self._core._sync_module_hardware.calibrate()  # type: ignore[attr-defined]
         else:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -348,7 +348,7 @@ class MagneticModuleContext(ModuleContext):
         if self._api_version < ENGINE_CORE_API_VERSION:
             _log.warning(
                 "`MagneticModuleContext.calibrate` doesn't do anything useful"
-                " and will be deprecated in Protocol API version 2.14 and higher."
+                " and will be removed in Protocol API version 2.14 and higher."
             )
             self._core._sync_module_hardware.calibrate()  # type: ignore[attr-defined]
         else:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -345,12 +345,16 @@ class MagneticModuleContext(ModuleContext):
         .. deprecated:: 2.14
             This method is unnecessary; remove any usage.
         """
-        _log.warning(
-            "`MagneticModuleContext.calibrate` doesn't do anything useful"
-            " and will no-op in Protocol API version 2.14 and higher."
-        )
         if self._api_version < ENGINE_CORE_API_VERSION:
+            _log.warning(
+                "`MagneticModuleContext.calibrate` doesn't do anything useful"
+                " and will no-op in Protocol API version 2.14 and higher."
+            )
             self._core._sync_module_hardware.calibrate()  # type: ignore[attr-defined]
+        else:
+            raise APIVersionError(
+                "`MagneticModuleContext.calibrate` has been deprecated."
+            )
 
     @publish(command=cmds.magdeck_engage)
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -352,9 +352,7 @@ class MagneticModuleContext(ModuleContext):
             )
             self._core._sync_module_hardware.calibrate()  # type: ignore[attr-defined]
         else:
-            raise APIVersionError(
-                "`MagneticModuleContext.calibrate` has been removed."
-            )
+            raise APIVersionError("`MagneticModuleContext.calibrate` has been removed.")
 
     @publish(command=cmds.magdeck_engage)
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -353,7 +353,7 @@ class MagneticModuleContext(ModuleContext):
             self._core._sync_module_hardware.calibrate()  # type: ignore[attr-defined]
         else:
             raise APIVersionError(
-                "`MagneticModuleContext.calibrate` has been deprecated."
+                "`MagneticModuleContext.calibrate` has been removed."
             )
 
     @publish(command=cmds.magdeck_engage)

--- a/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_magnetic_module_context.py
@@ -123,6 +123,17 @@ def test_engage_height_from_home_raises_on_high_version(
         subject.engage(42.0)
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
+def test_calibrate_raises_on_high_version(
+    decoy: Decoy,
+    mock_core: MagneticModuleCore,
+    subject: MagneticModuleContext,
+) -> None:
+    """It should raise a deprecation error."""
+    with pytest.raises(APIVersionError):
+        subject.calibrate()
+
+
 def test_engage_height_from_base(
     decoy: Decoy,
     mock_broker: Broker,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-547.
raise a deprecation error when using MagneticModuleContext.calibrate in PAPI 2.14.

# Test Plan

The following protocol should raise a deprecation error for 2.14 and should work for 2.13.

```
from opentrons import protocol_api

metadata = {
    "protocolName": "2.14 test for MagenticModuleContext.calibrate Deprecation",
    "author": "Opentrons Engineering <engineering@opentrons.com>",
    "source": "Software Testing Team",
    "description": "Call to MagenticModuleContext.calibrate to test is deprecated",
    "apiLevel": "2.14",
}


def run(ctx: protocol_api.ProtocolContext) -> None:
    """This method is run by the protocol engine."""
    magdeck = ctx.load_module("magnetic module gen2", "1")
    magdeck.calibrate()
```


# Changelog

- Raise a depreciation error when using apiLevel 2.14.

# Risk assessment

low. raise an error when using deprecated method.
