### PR TITLE
fix(api): allow errors in initial home z

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -166,7 +166,15 @@ async def initialize() -> ThreadManagedHardware:
 
         if not ff.disable_home_on_boot():
             log.info("Homing Z axes")
-            await hardware.home_z()
+            try:
+                await hardware.home_z()
+            except Exception:
+                # If this is a flex, and the estop is asserted, we'll get an error
+                # here; make sure that it doesn't prevent things from actually
+                # starting.
+                log.error(
+                    "Exception homing z on startup, ignoring to allow server to start"
+                )
 
         await hardware.set_lights(button=True)
         return hardware


### PR DESCRIPTION
We saw an issue on the flex where if the estop was asserted during startup, the axis controllers would swallow move messages instead of sending errors - and if those move messages were homing commands with very long timeouts, it could delay server startup indefinitely.

After https://github.com/Opentrons/ot3-firmware/pull/599 we will instead get an error message when we send a command while estop is enabled. This is better because we can now detect the problem, but an error occuring at this point in initialization would prevent the robot server from starting up, which is also bad. So let's swallow exceptions from motion here so that the robot server doesn't stop working.

# Test Plan

- Put this and https://github.com/Opentrons/ot3-firmware/pull/599 on a robot
- [ ] stop the server; engage estop; start the server; and check that the error is logged but the server starts and nothing is homed