### PR TITLE
fix(app): use react query to grab pipette and tip length cal on dash

### DIFF
--- a/app/src/organisms/RobotSettingsCalibration/RobotSettingsTipLengthCalibration.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/RobotSettingsTipLengthCalibration.tsx
@@ -7,13 +7,10 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
 
 import { StyledText } from '../../atoms/text'
-import {
-  useAttachedPipettes,
-  useRobot,
-  useTipLengthCalibrations,
-} from '../../organisms/Devices/hooks'
+import { useAttachedPipettes } from '../../organisms/Devices/hooks'
 import { TipLengthCalibrationItems } from './CalibrationDetails/TipLengthCalibrationItems'
 
 import type { FormattedPipetteOffsetCalibration } from '.'
@@ -42,11 +39,8 @@ export function RobotSettingsTipLengthCalibration({
 }: RobotSettingsTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
-  const robot = useRobot(robotName)
-
   const attachedPipettes = useAttachedPipettes()
-  // wait for robot request to resolve instead of using name directly from params
-  const tipLengthCalibrations = useTipLengthCalibrations(robot?.name)
+  const tipLengthCalibrations = useAllTipLengthCalibrationsQuery().data?.data
   const tipLengthCalsForPipettesAndDefaultRacks: Array<
     Partial<Omit<TipLengthCalibration, 'pipette' | 'uri'>> &
       Pick<TipLengthCalibration, 'pipette' | 'uri'>

--- a/app/src/organisms/RobotSettingsCalibration/index.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/index.tsx
@@ -2,6 +2,11 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { SpinnerModalPage, AlertModal } from '@opentrons/components'
+import {
+  useAllPipetteOffsetCalibrationsQuery,
+  useAllTipLengthCalibrationsQuery,
+  useCalibrationStatusQuery,
+} from '@opentrons/react-api-client'
 
 import { Portal } from '../../App/portal'
 import { Line } from '../../atoms/structure'
@@ -10,7 +15,6 @@ import { CalibrateDeck } from '../../organisms/CalibrateDeck'
 import { CalibrationStatusCard } from '../../organisms/CalibrationStatusCard'
 import { CheckCalibration } from '../../organisms/CheckCalibration'
 import {
-  usePipetteOffsetCalibrations,
   useRobot,
   useAttachedPipettes,
   useRunStatuses,
@@ -35,11 +39,6 @@ import type {
   DeckCalibrationSession,
 } from '../../redux/sessions/types'
 import type { State, Dispatch } from '../../redux/types'
-import {
-  useAllPipetteOffsetCalibrationsQuery,
-  useAllTipLengthCalibrationsQuery,
-  useCalibrationStatusQuery,
-} from '@opentrons/react-api-client'
 
 const CALS_FETCH_MS = 5000
 
@@ -118,8 +117,8 @@ export function RobotSettingsCalibration({
     }
   )
 
-  // wait for robot request to resolve instead of using name directly from params
-  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
+  const pipetteOffsetCalibrations = useAllPipetteOffsetCalibrationsQuery().data
+    ?.data
   const attachedPipettes = useAttachedPipettes()
   const { isRunRunning: isRunning } = useRunStatuses()
 


### PR DESCRIPTION
fix RQA-517

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
The calibration dashboard was grabbing pipette and tip length calibrations from react-query for the calibration status but from redux for the Pipette Offset Calibrations and Tip Length Calibrations sections. I switched these to use our react queries so the calibration breakdown sections benefit from the 5second refetch that is already in place on the calibration dashboard main page.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
On the robot settings page, delete both pipette and tip length calibrations and see the calibration value removed from the UI within 5 seconds

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
1. Use `useAllPipetteOffsetCalibrationsQuery` instead of `usePipetteOffsetCalibrations`
2. Use `useAllTipLengthCalibrationsQuery` instead of `useTipLengthCalibrations`
3. Make these same changes in the Overflow Menu for these calibration items
4. Disable overflow menu buttons if calibration is missing/deleted
5. Update tests

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Delete calibrations and visually verify that the UI reflects this deletion
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low