### PR TITLE
fix(api,shared-data): Correct zDimension in certain aluminum block labware

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -1,7 +1,21 @@
-from typing import Tuple, List, Optional
+from typing import Dict, Tuple, List, Optional
 
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.protocol_engine.state.labware import LabwareLoadParams
+
+
+# Default versions of Opentrons standard labware definitions in Python Protocol API
+# v2.14 and above. Labware not explicitly listed here default to 1.
+#
+# This will need to be extended t
+_APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
+    # v1 of many labware definitions have wrong `zDimension`s. (Jira RSS-202.)
+    # For "opentrons_96_aluminumblock_generic_pcr_strip_200ul" and
+    # "opentrons_24_aluminumblock_generic_2ml_screwcap", they're wrong enough to
+    # easily cause collisions. (Jira RSS-197.)
+    "opentrons_24_aluminumblock_generic_2ml_screwcap": 2,
+    "opentrons_96_aluminumblock_generic_pcr_strip_200ul": 2,
+}
 
 
 class AmbiguousLoadLabwareParamsError(RuntimeError):
@@ -69,16 +83,6 @@ def resolve(
 
 
 def _get_default_version_for_standard_labware(load_name: str) -> int:
-    # v1 of many labware definitions have wrong `zDimension`s. (Jira RSS-202.)
-    #
-    # For "opentrons_96_aluminumblock_generic_pcr_strip_200ul" and
-    # "opentrons_24_aluminumblock_generic_2ml_screwcap", they're wrong enough to
-    # easily cause collisions. (Jira RSS-197.)
-    if load_name in {
-        "opentrons_24_aluminumblock_generic_2ml_screwcap",
-        "opentrons_96_aluminumblock_generic_pcr_strip_200ul",
-    }:
-        return 2
-
-    else:
-        return 1
+    # We know the protocol is running at least apiLevel 2.14 by this point because
+    # apiLevel 2.13 and below has its own separate code path for resolving labware.
+    return _APILEVEL_2_14_OT_DEFAULT_VERSIONS.get(load_name, 1)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -124,14 +124,17 @@ class ModuleContext(CommandPublisher):
     ) -> Labware:
         """Load a labware onto the module using its load parameters.
 
-        :param name: The name of the labware object.
-        :param str label: An optional display name to give the labware.
-                          If specified, this is the name the labware will use
-                          in the run log and the calibration view in the Opentrons App.
-        :param str namespace: The namespace the labware definition belongs to.
-                              If unspecified, will search 'opentrons' then 'custom_beta'
-        :param int version: The version of the labware definition.
-                            If unspecified, will use version 1.
+        :param str name: See the ``load_name`` parameter of
+            :py:obj:`ProtocolContext.load_labware`.
+
+        :param str label: See the ``label`` parameter of
+            :py:obj:`ProtocolContext.load_labware`.
+
+        :param str namespace: See the ``namespace`` parameter  of
+            :py:obj:`ProtocolContext.load_labware`.
+
+        :param int version: See the ``version`` parameter  of
+            :py:obj:`ProtocolContext.load_labware`.
 
         :returns: The initialized and loaded labware object.
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -124,17 +124,10 @@ class ModuleContext(CommandPublisher):
     ) -> Labware:
         """Load a labware onto the module using its load parameters.
 
-        :param str name: See the ``load_name`` parameter of
-            :py:obj:`ProtocolContext.load_labware`.
-
-        :param str label: See the ``label`` parameter of
-            :py:obj:`ProtocolContext.load_labware`.
-
-        :param str namespace: See the ``namespace`` parameter  of
-            :py:obj:`ProtocolContext.load_labware`.
-
-        :param int version: See the ``version`` parameter  of
-            :py:obj:`ProtocolContext.load_labware`.
+        The parameters of this function behave like those of
+        :py:obj:`ProtocolContext.load_labware` (which loads labware directly
+        onto the deck). Note that the parameter ``name`` here corresponds to
+        ``load_name`` on the ``ProtocolContext`` function.
 
         :returns: The initialized and loaded labware object.
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -299,7 +299,7 @@ class ProtocolContext(CommandPublisher):
         later in the protocol.
 
         :param str load_name: A string to use for looking up a labware definition.
-            You can find the ``load_name``\\s for standard labware on the Opentrons
+            You can find the ``load_name`` for any standard labware on the Opentrons
             `Labware Library <https://labware.opentrons.com>`_.
 
         :param location: The slot into which to load the labware,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -298,18 +298,32 @@ class ProtocolContext(CommandPublisher):
         This function returns the created and initialized labware for use
         later in the protocol.
 
-        :param load_name: A string to use for looking up a labware definition
-        :param location: The slot into which to load the labware such as
-                         1 or '1'
+        :param str load_name: A string to use for looking up a labware definition.
+            You can find the ``load_name``\\s for standard labware on the Opentrons
+            `Labware Library <https://labware.opentrons.com>`_.
+
+        :param location: The slot into which to load the labware,
+            such as ``1`` or ``"1"``.
+
         :type location: int or str
-        :param str label: An optional special name to give the labware. If
-                          specified, this is the name the labware will appear
-                          as in the run log and the calibration view in the
-                          Opentrons app.
-        :param str namespace: The namespace the labware definition belongs to.
-            If unspecified, will search 'opentrons' then 'custom_beta'
-        :param int version: The version of the labware definition. If
-            unspecified, will use version 1.
+
+        :param str label: An optional special name to give the labware. If specified, this
+            is the name the labware will appear as in the run log and the calibration
+            view in the Opentrons app.
+
+        :param str namespace: The namespace that the labware definition belongs to.
+            If unspecified, will search both:
+
+              * ``"opentrons"``, to load standard Opentrons labware definitions.
+              * ``"custom_beta"``, to load custom labware definitions created with the
+                `Custom Labware Creator <https://labware.opentrons.com/create>`_.
+
+            You might need to specify an explicit ``namespace`` if you have a custom
+            definition whose ``load_name`` is the same as an Opentrons standard
+            definition, and you want to explicitly choose one or the other.
+
+        :param version: The version of the labware definition. You should normally
+            leave this unspecified to let the implementation choose a good default.
         """
         load_name = validation.ensure_lowercase_name(load_name)
         deck_slot = validation.ensure_deck_slot(location)

--- a/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
@@ -70,14 +70,47 @@ def test_resolve_load_labware_params(
     assert result == (expected_namespace, expected_version)
 
 
+@pytest.mark.parametrize(
+    "load_name",
+    [
+        "opentrons_24_aluminumblock_generic_2ml_screwcap",
+        "opentrons_96_aluminumblock_generic_pcr_strip_200ul",
+    ],
+)
+@pytest.mark.parametrize("namespace", [OPENTRONS_NAMESPACE, None])
+@pytest.mark.parametrize(
+    ("version", "expected_version"),
+    [
+        (None, 2),
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (123456, 123456),
+    ],
+)
+def test_aluminumblock_bad_zdimension_versioning(
+    load_name: str,
+    namespace: Optional[str],
+    version: Optional[int],
+    expected_version: int,
+) -> None:
+    result = subject.resolve(
+        load_name=load_name,
+        namespace=namespace,
+        version=version,
+        custom_load_labware_params=[],
+    )
+    assert result == (OPENTRONS_NAMESPACE, expected_version)
+
+
 def test_resolve_load_labware_params_raises() -> None:
     """It should raise if multiple custom labware params are provided."""
     with pytest.raises(subject.AmbiguousLoadLabwareParamsError):
         subject.resolve(
-            "hello",
-            "world",
-            None,
-            [
+            load_name="hello",
+            namespace="world",
+            version=None,
+            custom_load_labware_params=[
                 LabwareLoadParams("hello", "world", 123),
                 LabwareLoadParams("hello", "world", 456),
             ],

--- a/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
@@ -88,12 +88,13 @@ def test_resolve_load_labware_params(
         (123456, 123456),
     ],
 )
-def test_aluminumblock_bad_zdimension_versioning(
+def test_aluminumblock_generic_screwcap_or_pcr_strip_versioning(
     load_name: str,
     namespace: Optional[str],
     version: Optional[int],
     expected_version: int,
 ) -> None:
+    """It should default to version 2 for these labware."""
     result = subject.resolve(
         load_name=load_name,
         namespace=namespace,

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_generic_2ml_screwcap/2.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_generic_2ml_screwcap/2.json
@@ -1,0 +1,300 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1"],
+    ["A2", "B2", "C2", "D2"],
+    ["A3", "B3", "C3", "D3"],
+    ["A4", "B4", "C4", "D4"],
+    ["A5", "B5", "C5", "D5"],
+    ["A6", "B6", "C6", "D6"]
+  ],
+  "schemaVersion": 2,
+  "version": 2,
+  "namespace": "opentrons",
+  "metadata": {
+    "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+    "displayVolumeUnits": "mL",
+    "displayCategory": "aluminumBlock",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.75,
+    "yDimension": 85.5,
+    "zDimension": 48.7
+  },
+  "parameters": {
+    "format": "irregular",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap"
+  },
+  "wells": {
+    "D1": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 20.75,
+      "y": 16.88,
+      "z": 6.7
+    },
+    "C1": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 20.75,
+      "y": 34.13,
+      "z": 6.7
+    },
+    "B1": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 20.75,
+      "y": 51.38,
+      "z": 6.7
+    },
+    "A1": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 20.75,
+      "y": 68.63,
+      "z": 6.7
+    },
+    "D2": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 38,
+      "y": 16.88,
+      "z": 6.7
+    },
+    "C2": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 38,
+      "y": 34.13,
+      "z": 6.7
+    },
+    "B2": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 38,
+      "y": 51.38,
+      "z": 6.7
+    },
+    "A2": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 38,
+      "y": 68.63,
+      "z": 6.7
+    },
+    "D3": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 55.25,
+      "y": 16.88,
+      "z": 6.7
+    },
+    "C3": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 55.25,
+      "y": 34.13,
+      "z": 6.7
+    },
+    "B3": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 55.25,
+      "y": 51.38,
+      "z": 6.7
+    },
+    "A3": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 55.25,
+      "y": 68.63,
+      "z": 6.7
+    },
+    "D4": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 72.5,
+      "y": 16.88,
+      "z": 6.7
+    },
+    "C4": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 72.5,
+      "y": 34.13,
+      "z": 6.7
+    },
+    "B4": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 72.5,
+      "y": 51.38,
+      "z": 6.7
+    },
+    "A4": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 72.5,
+      "y": 68.63,
+      "z": 6.7
+    },
+    "D5": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 89.75,
+      "y": 16.88,
+      "z": 6.7
+    },
+    "C5": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 89.75,
+      "y": 34.13,
+      "z": 6.7
+    },
+    "B5": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 89.75,
+      "y": 51.38,
+      "z": 6.7
+    },
+    "A5": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 89.75,
+      "y": 68.63,
+      "z": 6.7
+    },
+    "D6": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 107,
+      "y": 16.88,
+      "z": 6.7
+    },
+    "C6": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 107,
+      "y": 34.13,
+      "z": 6.7
+    },
+    "B6": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 107,
+      "y": 51.38,
+      "z": 6.7
+    },
+    "A6": {
+      "shape": "circular",
+      "depth": 42,
+      "diameter": 8.5,
+      "totalLiquidVolume": 2000,
+      "x": 107,
+      "y": 68.63,
+      "z": 6.7
+    }
+  },
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": [
+      "https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set"
+    ]
+  },
+  "groups": [
+    {
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "A6",
+        "B6",
+        "C6",
+        "D6"
+      ],
+      "metadata": {
+        "displayName": "Generic 2 mL Screwcap",
+        "displayCategory": "tubeRack",
+        "wellBottomShape": "v"
+      },
+      "brand": {
+        "brand": "generic",
+        "brandId": [],
+        "links": []
+      }
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}

--- a/shared-data/labware/definitions/2/opentrons_96_aluminumblock_generic_pcr_strip_200ul/2.json
+++ b/shared-data/labware/definitions/2/opentrons_96_aluminumblock_generic_pcr_strip_200ul/2.json
@@ -1,0 +1,1026 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "schemaVersion": 2,
+  "version": 2,
+  "namespace": "opentrons",
+  "metadata": {
+    "displayName": "Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL",
+    "displayVolumeUnits": "µL",
+    "displayCategory": "aluminumBlock",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.75,
+    "yDimension": 85.5,
+    "zDimension": 25.61
+  },
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_96_aluminumblock_generic_pcr_strip_200ul"
+  },
+  "wells": {
+    "H1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A1": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A2": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A3": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A4": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A5": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A6": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A7": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A8": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A9": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A10": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A11": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 74.25,
+      "z": 5.31
+    },
+    "H12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 11.25,
+      "z": 5.31
+    },
+    "G12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 20.25,
+      "z": 5.31
+    },
+    "F12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 29.25,
+      "z": 5.31
+    },
+    "E12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 38.25,
+      "z": 5.31
+    },
+    "D12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 47.25,
+      "z": 5.31
+    },
+    "C12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 56.25,
+      "z": 5.31
+    },
+    "B12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 65.25,
+      "z": 5.31
+    },
+    "A12": {
+      "shape": "circular",
+      "depth": 20.3,
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 74.25,
+      "z": 5.31
+    }
+  },
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": [
+      "https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set"
+    ]
+  },
+  "groups": [
+    {
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ],
+      "metadata": {
+        "displayName": "Generic 12x8x0.2 mL PCR Strip",
+        "displayCategory": "tubeRack",
+        "wellBottomShape": "v"
+      },
+      "brand": {
+        "brand": "generic",
+        "brandId": [],
+        "links": []
+      }
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}


### PR DESCRIPTION
# Overview

Many of our labware definitions are internally inconsistent: their `zDimension` does not match the tops of their wells. There are legitimate reasons for this to happen, but for several labware, it appears purely accidental. The ticket for these definition errors is RSS-202.

In certain cases, these discrepancies cause motion planning problems where the pipette's z-clearance when moving over the labware is lower than intended. For at least two labware, `opentrons_24_aluminumblock_generic_2ml_screwcap` and `opentrons_96_aluminumblock_generic_pcr_strip_200ul`, the z-clearance is so low that it will actually cause collisions. The ticket for these collisions is RSS-197.

This PR:

* Fixes the underlying discrepancy in the labware definitions, by introducing new versions where `zDimension` is changed to match the well tops.
* Updates Python Protocol API v2.14 to load these new definitions by default when the protocol author doesn't specify an explicit `version`.

Fixes RSS-197 and partially fixes RSS-202.


# Test plan:

I have tested:

* When running the reproduction protocol in RSS-197, the pipette now moves up to clear the PCR strips in the aluminum block.
* This protocol behaves as described:
  
  ```python
  metadata = {
      # "apiLevel": "2.13"
      "apiLevel": "2.14"
  }
  
  
  def run(protocol):
      load_name = "opentrons_24_aluminumblock_generic_2ml_screwcap"
      # load_name = "opentrons_96_aluminumblock_generic_pcr_strip_200ul"
      
      labware_list = [
          # Loads version 1 when apiLevel is 2.13, and version 2 when apiLevel is 2.14, 
          protocol.load_labware(load_name, 1, label="default"),
          # Loads version 1 regardless of apiLevel.
          protocol.load_labware(load_name, 2, label="explicit v1", version=1),
          # Loads version 2 regardless of apiLevel.
          protocol.load_labware(load_name, 3, label="explicit v2", version=2),
      ]
  
      for labware in labware_list:
          protocol.comment(f"{labware.name}: {labware.uri}")
  ```


# Expected effects

Here are the known and intended effects of merging this PR:

* **Python protocols with `apiLevel` <= `2.13`** will continue to load definitions v1 by default.
    * Because of implementation nuances of the legacy back-end, these definitions have always worked well enough in practice in PAPIv<=2.13 even though their `zDimension`s are wrong. We *could* have PAPIv<=2.13 protocols load the updated definitions by default, but I didn't see a need to do that right now.
* **Python protocols with `apiLevel` >= `2.14`** will now load v2 of these definitions by default.
    * This is what fixes RSS-197 for PAPIv2.14 Python protocols.
* **Protocol Designer and Labware Library** [look](https://github.com/Opentrons/opentrons/blob/ca738af97155dedb7be98e1543b90a179a609caa/protocol-designer/src/labware-defs/utils.ts#L39) [like](https://github.com/Opentrons/opentrons/blob/ca738af97155dedb7be98e1543b90a179a609caa/labware-library/src/definitions.tsx#L72) they'll automatically pick up the new definitions the next time they're released. It looks like they'll show the new definition and won't show the old definition.
    * I'm not sure whether Protocol Designer will automatically update the definition for protocols that are imported and re-exported. If not, we should consider introducing some kind of migration to do that, to fix RSS-197 for JSONv6 Protocol Designer protocols.
* **Labware offsets** will *not* be shared across definition versions. Whenever someone runs a protocol that loads the new definitions, it will *not* reuse labware offsets from any prior runs that loaded the old definitions. The offsets will default to (0, 0, 0) until the user adjusts it with Labware Position Check.


# Risks

This would be the first time we're introducing a v2 of a labware definition. We've tried to do this before (in PR #4179 and PR #4240, at least), but it didn't pan out, for a variety of technical and nontechnical reasons. There are probably some unknown unknowns.

Issue #4217 was listed as a blocker when we last tried this in PR #4179 and PR #4240. I don't think it has to be a blocker for this fix.

There are some open questions about how to handle labware versions in the Python Protocol API:

* If you don't specify a `version` in `load_labware`, what should it default to?

  The answer as implemented in this PR is "it depends on the protocol's `apiLevel`". I think this is our best option today. See [this internal proposal](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3625321314/Proposal+Default+labware+versions+in+the+Python+Protocol+API) for my thinking.

* Should you be able to explicitly specify a labware `version` that didn't exist when your protocol's `"apiLevel"` was released? For example, should an `"apiLevel": "2.0"` protocol be able to load these new v2 definitions?

  The answer as implemented in this PR is "yes," mostly just because it was easiest.


# Review requests

Do you agree with all of the above, that this is the correct solution today?