### PR TITLE
fix(app): update ui when deck calibration completed

### DIFF
--- a/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
@@ -6,7 +6,6 @@ import type {
 } from '../../../../redux/calibration/api-types'
 import type { AttachedPipettesByMount } from '../../../../redux/pipettes/types'
 import type { TaskListProps } from '../../../TaskList/types'
-import type { DeckCalibrationData } from '@opentrons/api-client'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 export const TASK_COUNT = 3
@@ -52,23 +51,33 @@ export const mockSingleAttachedPipetteResponse: AttachedPipettesByMount = {
 }
 
 export const mockBadDeckCalibration = {
-  isDeckCalibrated: false,
-  deckCalibrationData: {
-    lastModified: '2022-01-01T12:00:00.000000+00:00',
-  } as DeckCalibrationData,
-  markedBad: true,
+  deckCalibration: {
+    status: 'BAD_CALIBRATION',
+    data: {
+      lastModified: '2022-01-01T12:00:00.000000+00:00',
+      status: { markedBad: true },
+    },
+  },
 }
 
 export const mockCompleteDeckCalibration = {
-  isDeckCalibrated: true,
-  deckCalibrationData: {
-    lastModified: '2022-01-01T12:00:00.000000+00:00',
-  } as DeckCalibrationData,
+  deckCalibration: {
+    status: 'OK',
+    data: {
+      lastModified: '2022-01-01T12:00:00.000000+00:00',
+      status: { markedBad: false },
+    },
+  },
 }
 
 export const mockIncompleteDeckCalibration = {
-  isDeckCalibrated: false,
-  deckCalibrationData: null,
+  status: 'IDENTITY',
+  data: {
+    lastModified: null,
+    status: {
+      markedBad: false,
+    },
+  },
 }
 
 export const mockBadTipLengthCalibrations: TipLengthCalibration[] = [
@@ -216,7 +225,7 @@ export const expectedTaskList: TaskListProps = {
       title: 'Deck Calibration',
       footer: `Last completed ${formatTimestamp(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        mockCompleteDeckCalibration.deckCalibrationData.lastModified!
+        mockCompleteDeckCalibration.deckCalibration.data.lastModified!
       )}`,
       cta: { label: 'Recalibrate', onClick: mockDeckCalLauncher },
       isComplete: true,
@@ -668,7 +677,7 @@ export const expectedBadTipLengthTaskList: TaskListProps = {
       title: 'Deck Calibration',
       footer: `Last completed ${formatTimestamp(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        mockCompleteDeckCalibration.deckCalibrationData.lastModified!
+        mockCompleteDeckCalibration.deckCalibration.data.lastModified!
       )}`,
       cta: { label: 'Recalibrate', onClick: () => {} },
       isComplete: true,
@@ -760,7 +769,7 @@ export const expectedBadTipLengthAndOffsetTaskList: TaskListProps = {
       title: 'Deck Calibration',
       footer: `Last completed ${formatTimestamp(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        mockCompleteDeckCalibration.deckCalibrationData.lastModified!
+        mockCompleteDeckCalibration.deckCalibration.data.lastModified!
       )}`,
       cta: { label: 'Recalibrate', onClick: () => {} },
       isComplete: true,
@@ -940,7 +949,7 @@ export const expectedIncompleteLeftMountTaskList: TaskListProps = {
       title: 'Deck Calibration',
       footer: `Last completed ${formatTimestamp(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        mockCompleteDeckCalibration.deckCalibrationData.lastModified!
+        mockCompleteDeckCalibration.deckCalibration.data.lastModified!
       )}`,
       cta: { label: 'Recalibrate', onClick: mockDeckCalLauncher },
       isComplete: true,
@@ -1028,7 +1037,7 @@ export const expectedIncompleteRightMountTaskList: TaskListProps = {
       title: 'Deck Calibration',
       footer: `Last completed ${formatTimestamp(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        mockCompleteDeckCalibration.deckCalibrationData.lastModified!
+        mockCompleteDeckCalibration.deckCalibration.data.lastModified!
       )}`,
       cta: { label: 'Recalibrate', onClick: mockDeckCalLauncher },
       isComplete: true,

--- a/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
@@ -71,11 +71,13 @@ export const mockCompleteDeckCalibration = {
 }
 
 export const mockIncompleteDeckCalibration = {
-  status: 'IDENTITY',
-  data: {
-    lastModified: null,
-    status: {
-      markedBad: false,
+  deckCalibration: {
+    status: 'IDENTITY',
+    data: {
+      lastModified: null,
+      status: {
+        markedBad: false,
+      },
     },
   },
 }

--- a/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
@@ -8,9 +8,10 @@ import {
   useDeleteCalibrationMutation,
   useAllPipetteOffsetCalibrationsQuery,
   useAllTipLengthCalibrationsQuery,
+  useCalibrationStatusQuery,
 } from '@opentrons/react-api-client'
 import { useCalibrationTaskList } from '../useCalibrationTaskList'
-import { useAttachedPipettes, useDeckCalibrationData } from '..'
+import { useAttachedPipettes } from '..'
 import {
   TASK_COUNT,
   mockAttachedPipettesResponse,
@@ -43,8 +44,8 @@ const mockUseAllTipLengthCalibrationsQuery = useAllTipLengthCalibrationsQuery as
 const mockUseAllPipetteOffsetCalibrationsQuery = useAllPipetteOffsetCalibrationsQuery as jest.MockedFunction<
   typeof useAllPipetteOffsetCalibrationsQuery
 >
-const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
-  typeof useDeckCalibrationData
+const mockUseCalibrationStatusQuery = useCalibrationStatusQuery as jest.MockedFunction<
+  typeof useCalibrationStatusQuery
 >
 const mockUseDeleteCalibrationMutation = useDeleteCalibrationMutation as jest.MockedFunction<
   typeof useDeleteCalibrationMutation
@@ -81,9 +82,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -118,9 +119,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -152,9 +153,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockSingleAttachedPipetteResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -185,9 +186,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockIncompleteDeckCalibration) // isDeckCalibrated === false
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockIncompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -218,9 +219,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockBadDeckCalibration) // markedBad === true
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockBadDeckCalibration } as any) // markedBad === true
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -251,9 +252,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -284,9 +285,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -317,9 +318,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -350,9 +351,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({ data: { data: mockBadTipLengthCalibrations } } as any)
@@ -381,9 +382,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({ data: { data: mockBadTipLengthCalibrations } } as any)
@@ -412,9 +413,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockBadDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockBadDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -445,9 +446,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockBadDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockBadDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({ data: { data: mockBadTipLengthCalibrations } } as any)
@@ -476,9 +477,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockIncompleteDeckCalibration) // isDeckCalibrated === false
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockIncompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -509,9 +510,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockIncompleteDeckCalibration) // isDeckCalibrated === false
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockIncompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -550,9 +551,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -591,9 +592,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockCompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockCompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({
@@ -634,9 +635,9 @@ describe('useCalibrationTaskList hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(mockAttachedPipettesResponse)
-    when(mockUseDeckCalibrationData)
-      .calledWith('otie')
-      .mockReturnValue(mockIncompleteDeckCalibration)
+    when(mockUseCalibrationStatusQuery)
+      .calledWith({ refetchInterval: 5000 })
+      .mockReturnValue({ data: mockIncompleteDeckCalibration } as any)
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({

--- a/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
@@ -512,7 +512,7 @@ describe('useCalibrationTaskList hook', () => {
       .mockReturnValue(mockAttachedPipettesResponse)
     when(mockUseCalibrationStatusQuery)
       .calledWith({ refetchInterval: 5000 })
-      .mockReturnValue({ data: mockIncompleteDeckCalibration } as any)
+      .mockReturnValue({ data: null } as any) // null deck response
     when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith({ refetchInterval: 5000 })
       .mockReturnValue({


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Previously the UI would not update and show the new last completion date once the deck calibration was complete. We were using `useDeckCalibrationData` to get the data and attempting to refresh data using a polling `useCalibrationStatusQuery` call. This wasn't working as expected, so pulling the necessary data from the result of the `useCalibrationStatusQuery` result for the deck calibrations instead of the deck calibration data hook resolves the issue of the UI not updating like it does for other calibrations

closes RAUT-368

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Performed a calibration and recalibration of the deck and verified that the UI updated correctly and displayed the updated latest completion date

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- removed usage of `useDeckCalibrationData` in favor of the already used `useCalibrationStatusQuery` call
- updated tests and fixtures

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the code looks good and the app behaves as described in the Test Plan section

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
