### PR TITLE
feat(robot-server): add referenced runs to protocol endpoint

### DIFF
--- a/api/src/opentrons/protocol_reader/protocol_reader.py
+++ b/api/src/opentrons/protocol_reader/protocol_reader.py
@@ -142,8 +142,6 @@ class ProtocolReader:
             for f in role_analysis.all_files
         ]
 
-        metadata = {**role_analysis.main_file.metadata, "referenced_run_ids": []}
-
         return ProtocolSource(
             directory=directory,
             main_file=main_file,

--- a/api/src/opentrons/protocol_reader/protocol_reader.py
+++ b/api/src/opentrons/protocol_reader/protocol_reader.py
@@ -142,6 +142,8 @@ class ProtocolReader:
             for f in role_analysis.all_files
         ]
 
+        metadata = {**role_analysis.main_file.metadata, "referenced_run_ids": []}
+
         return ProtocolSource(
             directory=directory,
             main_file=main_file,

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -276,10 +276,12 @@ class ProtocolStore:
 
         return usage_info
 
-    def get_linked_run_ids(self, protocol_id: str) -> List[str]:
+    def get_referenced_run_ids(self, protocol_id: str) -> List[str]:
         """Return a list of run ids that reference a particular protocol.
 
         See the `runs` module for information about runs.
+
+        Results are ordered with the oldest-added (NOT created) run first.
         """
         select_referenced_run_ids = sqlalchemy.select(run_table.c.id).where(
             run_table.c.protocol_id == protocol_id

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -286,6 +286,7 @@ class ProtocolStore:
         select_referenced_run_ids = sqlalchemy.select(run_table.c.id).where(
             run_table.c.protocol_id == protocol_id
         )
+        referenced_run_ids = []
 
         with self._sql_engine.begin() as transaction:
             referenced_run_ids = (

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -276,6 +276,21 @@ class ProtocolStore:
 
         return usage_info
 
+    def get_linked_run_ids(self, protocol_id: str) -> List[str]:
+        """Return a list of run ids that reference a particular protocol.
+
+        See the `runs` module for information about runs.
+        """
+        select_referenced_run_ids = sqlalchemy.select(run_table.c.id).where(
+            run_table.c.protocol_id == protocol_id
+        )
+
+        with self._sql_engine.begin() as transaction:
+            referenced_run_ids = (
+                transaction.execute(select_referenced_run_ids).scalars().all()
+            )
+        return referenced_run_ids
+
     def _sql_insert(self, resource: _DBProtocolResource) -> None:
         statement = sqlalchemy.insert(protocol_table).values(
             _convert_dataclass_to_sql_values(resource=resource)

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -187,12 +187,18 @@ async def create_protocol(
         analysis_id=analysis_id,
     )
 
+    referenced_run_ids = protocol_store.get_linked_run_ids(protocol_id)
+
+    metadata = Metadata.parse_obj(
+        {**source.metadata, "referenced_run_ids": referenced_run_ids}
+    )
+
     data = Protocol(
         id=protocol_id,
         createdAt=created_at,
         protocolType=source.config.protocol_type,
         robotType=source.robot_type,
-        metadata=Metadata.parse_obj(source.metadata),
+        metadata=metadata,
         analysisSummaries=[pending_analysis],
         key=key,
         files=[ProtocolFile(name=f.path.name, role=f.role) for f in source.files],

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -63,6 +63,7 @@ stages:
             created: !anyint
             description: A short test protocol
             author: engineering <engineering@opentrons.com>
+            referencedRunIds: []
             protocolName: Simple test protocol
           analyses: []
           analysisSummaries:

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -344,8 +344,6 @@ def test_get_referenced_run_ids(
     # Still no runs, so we should still get back an empty list
     assert subject.get_referenced_run_ids("protocol-id-1") == []
 
-    # When a run is added that uses a protocol,
-    # that protocol's is_used_by_run should become True.
     run_store.insert(
         run_id="run-id-1",
         protocol_id="protocol-id-1",

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -318,3 +318,49 @@ def test_get_usage_info(
             is_used_by_run=False,
         ),
     ]
+
+
+def test_get_referenced_run_ids(
+    subject: ProtocolStore,
+    run_store: RunStore,
+) -> None:
+    """It should return a list of run ids that reference a given protocol."""
+
+    protocol_resource_1 = ProtocolResource(
+        protocol_id="protocol-id-1",
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        source=ProtocolSource(
+            directory=None,
+            main_file=Path("/dev/null"),
+            config=JsonProtocolConfig(schema_version=123),
+            files=[],
+            metadata={},
+            robot_type="OT-2 Standard",
+        ),
+        protocol_key=None,
+    )
+
+    subject.insert(protocol_resource_1)
+    # Still no runs, so we should still get back an empty list
+    assert subject.get_referenced_run_ids("protocol-id-1") == []
+
+    # When a run is added that uses a protocol,
+    # that protocol's is_used_by_run should become True.
+    run_store.insert(
+        run_id="run-id-1",
+        protocol_id="protocol-id-1",
+        created_at=datetime(year=2022, month=1, day=1, tzinfo=timezone.utc),
+    )
+    assert subject.get_referenced_run_ids("protocol-id-1") == ["run-id-1"]
+
+    run_store.insert(
+        run_id="run-id-2",
+        protocol_id="protocol-id-1",
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+    assert subject.get_referenced_run_ids("protocol-id-1") == ["run-id-1", "run-id-2"]
+
+    run_store.remove(run_id="run-id-1")
+    run_store.remove(run_id="run-id-2")
+
+    assert subject.get_referenced_run_ids("protocol-id-1") == []

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -325,7 +325,6 @@ def test_get_referenced_run_ids(
     run_store: RunStore,
 ) -> None:
     """It should return a list of run ids that reference a given protocol."""
-
     protocol_resource_1 = ProtocolResource(
         protocol_id="protocol-id-1",
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -211,6 +211,9 @@ async def test_get_protocol_by_id(
     decoy.when(
         analysis_store.get_summaries_by_protocol(protocol_id="protocol-id")
     ).then_return([analysis_summary])
+    decoy.when(
+        protocol_store.get_referenced_run_ids(protocol_id="protocol-id")
+    ).then_return([])
 
     result = await get_protocol_by_id(
         "protocol-id",
@@ -222,7 +225,7 @@ async def test_get_protocol_by_id(
         id="protocol-id",
         createdAt=datetime(year=2021, month=1, day=1),
         protocolType=ProtocolType.PYTHON,
-        metadata=Metadata(),
+        metadata=Metadata().parse_obj({"referencedRunIds": []}),
         robotType="OT-2 Standard",
         analysisSummaries=[analysis_summary],
         files=[],


### PR DESCRIPTION
# Overview
This PR exposes a `referencedRunIds` key in the `GET` `/protocols/${protocolId}` endpoint so that clients may use this information to delete a protocol's runs. For now, this will only be used by the ODD (not the desktop app).

closes RCORE-686

# Test Plan

- Verified correct API response in postman

# Changelog

- Add linked runs to protocol endpoint

# Review requests

Verify you get a list of referenced run ids from the  `GET` `/protocols/${protocolId}` endpoint

# Risk assessment

Med — touching an endpoint that is important
