### PR TITLE
refactor(app): always pick up tip from last check tip rack in LPC

### DIFF
--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -121,6 +121,7 @@ const DIRECTION_CONTROL_LAYOUT = css`
   flex-direction: ${DIRECTION_ROW};
   justify-content: ${JUSTIFY_SPACE_BETWEEN};
   grid-gap: ${SPACING.spacing4};
+  min-width: 313px;
 
   @media (max-width: 750px) {
     flex-direction: ${DIRECTION_COLUMN};
@@ -178,8 +179,8 @@ const ACTIVE_BUTTON_STYLE = css`
   border: 1px ${COLORS.blueEnabled} solid;
 
   &:hover {
-    color: ${COLORS.blueHover};
-    border: 1px ${COLORS.blueHover} solid;
+    color: ${COLORS.bluePressed};
+    border: 1px ${COLORS.bluePressed} solid;
   }
 `
 

--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -95,7 +95,9 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
   React.useEffect(() => {
     chainRunCommands(modulePrepCommands, true)
       .then(() => {})
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }, [moduleId])
 
   if (pipetteName == null || labwareDef == null) return null
@@ -177,9 +179,13 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
               position,
             })
           })
-          .catch(() => {})
+          .catch(e => {
+            console.error('Unexpected command failure: ', e)
+          })
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
 
   const handleConfirmPosition = (): void => {
@@ -230,9 +236,13 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
         }
         chainRunCommands(confirmPositionCommands, true)
           .then(() => proceed())
-          .catch(() => {})
+          .catch(e => {
+            console.error('Unexpected command failure: ', e)
+          })
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
   const handleGoBack = (): void => {
     chainRunCommands(
@@ -247,7 +257,9 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
           position: null,
         })
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
 
   const initialPosition = workingOffsets.find(

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -31,12 +31,14 @@ export const IntroScreen = (props: {
 }): JSX.Element | null => {
   const { proceed, protocolData, chainRunCommands, isRobotMoving } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
-
+  console.error('eouerjfo', { some: 'thing' })
   const handleClickStartLPC = (): void => {
     const prepCommands = getPrepCommands(protocolData)
     chainRunCommands(prepCommands, true)
       .then(() => proceed())
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
 
   if (isRobotMoving) {

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -8,15 +8,15 @@ import {
   TYPOGRAPHY,
   ALIGN_CENTER,
 } from '@opentrons/components'
+import { CompletedProtocolAnalysis } from '@opentrons/shared-data'
 import { NeedHelpLink } from '../../CalibrationPanels'
 import { PrimaryButton } from '../../../atoms/buttons'
 import { StyledText } from '../../../atoms/text'
 import { RobotMotionLoader } from '../RobotMotionLoader'
 import { getPrepCommands } from './getPrepCommands'
-import { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+import { useChainRunCommands } from '../../../resources/runs/hooks'
 import type { CreateRunCommand, RegisterPositionAction } from '../types'
 import type { Jog } from '../../../molecules/JogControls'
-import { chainRunCommands } from '../utils/chainRunCommands'
 
 export const INTERVAL_MS = 3000
 
@@ -25,15 +25,18 @@ export const IntroScreen = (props: {
   protocolData: CompletedProtocolAnalysis
   registerPosition: React.Dispatch<RegisterPositionAction>
   createRunCommand: CreateRunCommand
+  chainRunCommands: ReturnType<typeof useChainRunCommands>['chainRunCommands']
   handleJog: Jog
   isRobotMoving: boolean
 }): JSX.Element | null => {
-  const { proceed, protocolData, createRunCommand, isRobotMoving } = props
+  const { proceed, protocolData, chainRunCommands, isRobotMoving } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
 
   const handleClickStartLPC = (): void => {
     const prepCommands = getPrepCommands(protocolData)
-    chainRunCommands(prepCommands, createRunCommand, proceed)
+    chainRunCommands(prepCommands, true)
+      .then(() => proceed())
+      .catch(() => {})
   }
 
   if (isRobotMoving) {

--- a/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
@@ -66,6 +66,7 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
   const [joggedPosition, setJoggedPosition] = React.useState<VectorOffset>(
     initialPosition
   )
+  console.table({ initialPosition, joggedPosition })
 
   let wellsToHighlight: string[] = []
   if (getPipetteNameSpecs(pipetteName)?.channels === 8) {

--- a/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
@@ -66,7 +66,6 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
   const [joggedPosition, setJoggedPosition] = React.useState<VectorOffset>(
     initialPosition
   )
-  console.table({ initialPosition, joggedPosition })
 
   let wellsToHighlight: string[] = []
   if (getPipetteNameSpecs(pipetteName)?.channels === 8) {

--- a/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
@@ -48,7 +48,6 @@ interface JogToWellProps {
   body: React.ReactNode
   initialPosition: VectorOffset
   existingOffset: VectorOffset
-  showLiveOffset?: boolean
 }
 export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
   const { t } = useTranslation(['labware_position_check', 'shared'])
@@ -62,7 +61,6 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
     handleJog,
     initialPosition,
     existingOffset,
-    showLiveOffset = true,
   } = props
 
   const [joggedPosition, setJoggedPosition] = React.useState<VectorOffset>(
@@ -102,7 +100,7 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
         >
           <StyledText as="h1">{header}</StyledText>
           {body}
-          {showLiveOffset ? <LiveOffsetValue {...liveOffset} /> : null}
+          <LiveOffsetValue {...liveOffset} />
         </Flex>
         <Flex flex="1" alignItems={ALIGN_CENTER} gridGap={SPACING.spacingM}>
           <RobotWorkSpace viewBox={DECK_MAP_VIEWBOX}>

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -120,6 +120,7 @@ export const LabwarePositionCheckInner = (
     },
     { workingOffsets: [], tipPickUpOffset: null }
   )
+  const [isExiting, setIsExiting] = React.useState(false)
   const {
     createCommand,
     isLoading: isCommandMutationLoading,
@@ -135,6 +136,7 @@ export const LabwarePositionCheckInner = (
   const { createLabwareOffset } = useCreateLabwareOffsetMutation()
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
   const handleCleanUpAndClose = (): void => {
+    setIsExiting(true)
     const dropTipToBeSafeCommands: DropTipCreateCommand[] = (
       protocolData?.pipettes ?? []
     ).map(pip => ({
@@ -153,8 +155,10 @@ export const LabwarePositionCheckInner = (
       ],
       true
     )
-      .then(() => props.onCloseClick)
-      .catch(() => {})
+      .then(() => props.onCloseClick())
+      .catch(() => {
+        setIsExiting(false)
+      })
   }
   const {
     confirm: confirmExitLPC,
@@ -269,7 +273,7 @@ export const LabwarePositionCheckInner = (
             title={t('labware_position_check_title')}
             currentStep={currentStepIndex}
             totalSteps={totalStepCount}
-            onExit={showConfirmation ? null : confirmExitLPC}
+            onExit={showConfirmation || isExiting ? null : confirmExitLPC}
           />
         }
       >

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -120,25 +120,12 @@ export const LabwarePositionCheckInner = (
     },
     { workingOffsets: [], tipPickUpOffset: null }
   )
-  const {
-    createCommand,
-    isLoading: isCommandMutationLoading,
-  } = useCreateCommandMutation()
+  const { createCommand, isLoading: isRobotMoving } = useCreateCommandMutation()
   const { createCommand: createSilentCommand } = useCreateCommandMutation()
   const createRunCommand: CreateRunCommand = (variables, ...options) => {
     return createCommand({ ...variables, runId }, ...options)
   }
   const { createLabwareOffset } = useCreateLabwareOffsetMutation()
-  const [isRobotMoving, setIsRobotMoving] = React.useState<boolean>(false)
-  React.useEffect(() => {
-    if (isCommandMutationLoading) {
-      const timer = setTimeout(() => setIsRobotMoving(true), 700)
-      return () => clearTimeout(timer)
-    } else {
-      setIsRobotMoving(false)
-    }
-  }, [isCommandMutationLoading])
-
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
   const handleCleanUpAndClose = (): void => {
     const dropTipToBeSafeCommands: DropTipCreateCommand[] = (
@@ -168,13 +155,11 @@ export const LabwarePositionCheckInner = (
   } = useConditionalConfirm(handleCleanUpAndClose, true)
 
   const proceed = (): void => {
-    if (!isCommandMutationLoading) {
-      setCurrentStepIndex(
-        currentStepIndex !== LPCSteps.length - 1
-          ? currentStepIndex + 1
-          : currentStepIndex
-      )
-    }
+    setCurrentStepIndex(
+      currentStepIndex !== LPCSteps.length - 1
+        ? currentStepIndex + 1
+        : currentStepIndex
+    )
   }
   if (protocolData == null) return null
   const LPCSteps = getLabwarePositionCheckSteps(protocolData)

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -56,7 +56,7 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
     handleJog,
     isRobotMoving,
     existingOffsets,
-    workingOffsets
+    workingOffsets,
   } = props
   const [showTipConfirmation, setShowTipConfirmation] = React.useState(false)
 
@@ -244,7 +244,7 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
       }
     )
   }
-  const handleGoBack  = (): void => {
+  const handleGoBack = (): void => {
     registerPosition({
       type: 'initialPosition',
       labwareId,

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -281,9 +281,8 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
           handleConfirmPosition={handleConfirmPosition}
           handleGoBack={handleGoBack}
           handleJog={handleJog}
-          initialPosition={IDENTITY_VECTOR}
+          initialPosition={initialPosition}
           existingOffset={existingOffset}
-          showLiveOffset={false}
         />
       ) : (
         <PrepareSpace

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -23,7 +23,6 @@ import { getCurrentOffsetForLabwareInLocation } from '../Devices/ProtocolRun/uti
 import { TipConfirmation } from './TipConfirmation'
 import { getLabwareDef } from './utils/labware'
 import { getDisplayLocation } from './utils/getDisplayLocation'
-import { chainRunCommands } from './utils/chainRunCommands'
 
 import type { Jog } from '../../molecules/JogControls/types'
 import type {
@@ -145,7 +144,6 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
               position,
             })
           })
-          .then(() => {})
           .catch(() => {})
       })
       .catch(() => {})

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -144,9 +144,13 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
               position,
             })
           })
-          .catch(() => {})
+          .catch(e => {
+            console.error('Unexpected command failure: ', e)
+          })
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
   const handleConfirmPosition = (): void => {
     createRunCommand({
@@ -179,9 +183,13 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
           waitUntilComplete: true,
         })
           .then(() => setShowTipConfirmation(true))
-          .catch(() => {})
+          .catch(e => {
+            console.error('Unexpected command failure: ', e)
+          })
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
 
   const handleConfirmTipAttached = (): void => {
@@ -208,7 +216,9 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
       true
     )
       .then(() => proceed())
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
   const handleInvalidateTip = (): void => {
     createRunCommand({
@@ -232,7 +242,9 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
         })
         setShowTipConfirmation(false)
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
   const handleGoBack = (): void => {
     registerPosition({

--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
-import isEqual from 'lodash/isEqual'
 import { PrimaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import {
@@ -23,7 +22,6 @@ import {
   ALIGN_CENTER,
   TYPOGRAPHY,
   COLORS,
-  JUSTIFY_FLEX_END,
 } from '@opentrons/components'
 import { getCurrentOffsetForLabwareInLocation } from '../Devices/ProtocolRun/utils/getCurrentOffsetForLabwareInLocation'
 import { getLabwareDefinitionsFromCommands } from './utils/labware'
@@ -223,15 +221,15 @@ const OffsetTable = (props: OffsetTableProps): JSX.Element => {
                 <StyledText as="p">{labwareDisplayName}</StyledText>
               </TableDatum>
               <TableDatum>
-                {isEqual(vector, IDENTITY_VECTOR) ? (
+                {index === 0 ? (
                   <StyledText>{t('no_labware_offsets')}</StyledText>
                 ) : (
-                  <Flex justifyContent={JUSTIFY_FLEX_END}>
+                  <Flex>
                     {[vector.x, vector.y, vector.z].map((axis, index) => (
                       <React.Fragment key={index}>
                         <StyledText
                           as="p"
-                          marginLeft={SPACING.spacing3}
+                          marginLeft={index > 0 ? SPACING.spacing3 : 0}
                           marginRight={SPACING.spacing2}
                           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                         >

--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
+import isEqual from 'lodash/isEqual'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { PrimaryButton } from '../../atoms/buttons'
@@ -221,7 +222,7 @@ const OffsetTable = (props: OffsetTableProps): JSX.Element => {
                 <StyledText as="p">{labwareDisplayName}</StyledText>
               </TableDatum>
               <TableDatum>
-                {index === 0 ? (
+                {isEqual(vector, IDENTITY_VECTOR) ? (
                   <StyledText>{t('no_labware_offsets')}</StyledText>
                 ) : (
                   <Flex>

--- a/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
@@ -13,21 +13,22 @@ import {
 } from '@opentrons/shared-data'
 import { getLabwareDef } from './utils/labware'
 import { UnorderedList } from '../../molecules/UnorderedList'
-
-import type { CreateRunCommand, ReturnTipStep } from './types'
-import { VectorOffset } from '@opentrons/api-client'
+import { useChainRunCommands } from '../../resources/runs/hooks'
 import { getDisplayLocation } from './utils/getDisplayLocation'
-import { chainRunCommands } from './utils/chainRunCommands'
+
+import type { VectorOffset } from '@opentrons/api-client'
+import type { CreateRunCommand, ReturnTipStep } from './types'
 
 interface ReturnTipProps extends ReturnTipStep {
   protocolData: CompletedProtocolAnalysis
   proceed: () => void
   createRunCommand: CreateRunCommand
+  chainRunCommands: ReturnType<typeof useChainRunCommands>['chainRunCommands']
   tipPickUpOffset: VectorOffset | null
   isRobotMoving: boolean
 }
 export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
-  const { t } = useTranslation('labware_position_check')
+  const { t } = useTranslation(['labware_position_check', 'shared'])
   const {
     pipetteId,
     labwareId,
@@ -36,7 +37,7 @@ export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
     proceed,
     tipPickUpOffset,
     isRobotMoving,
-    createRunCommand,
+    chainRunCommands,
   } = props
 
   const labwareDef = getLabwareDef(labwareId, protocolData)
@@ -121,12 +122,18 @@ export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
         },
         { commandType: 'home' as const, params: {} },
       ],
-      createRunCommand,
-      proceed
+      true
     )
+      .then(() => {
+        proceed()
+      })
+      .catch(() => {})
   }
 
-  if (isRobotMoving) return <RobotMotionLoader />
+  if (isRobotMoving)
+    return (
+      <RobotMotionLoader header={t('shared:stand_back_robot_is_in_motion')} />
+    )
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <PrepareSpace

--- a/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
@@ -127,7 +127,9 @@ export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
       .then(() => {
         proceed()
       })
-      .catch(() => {})
+      .catch(e => {
+        console.error('Unexpected command failure: ', e)
+      })
   }
 
   if (isRobotMoving)

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -5,18 +5,11 @@ import { i18n } from '../../../i18n'
 import { PickUpTip } from '../PickUpTip'
 import { SECTIONS } from '../constants'
 import { mockCompletedAnalysis, mockExistingOffsets } from '../__fixtures__'
-import { chainRunCommands } from '../utils/chainRunCommands'
 import { HEATERSHAKER_MODULE_V1 } from '@opentrons/shared-data'
 import { CommandData } from '@opentrons/api-client'
 import { resetAllWhenMocks, when } from 'jest-when'
 
-jest.mock('../utils/chainRunCommands')
-
 const mockStartPosition = { x: 10, y: 20, z: 30 }
-const mockEndPosition = { x: 9, y: 19, z: 29 }
-const mockChainRunCommands = chainRunCommands as jest.Mock<
-  typeof chainRunCommands
->
 
 const matchTextWithSpans: (text: string) => MatcherFunction = (
   text: string
@@ -37,9 +30,11 @@ const render = (props: React.ComponentProps<typeof PickUpTip>) => {
 
 describe('PickUpTip', () => {
   let props: React.ComponentProps<typeof PickUpTip>
+  let mockChainRunCommands
   const mockCreateRunCommand = jest.fn()
 
   beforeEach(() => {
+    mockChainRunCommands = jest.fn().mockImplementation(() => Promise.resolve())
     props = {
       section: SECTIONS.PICK_UP_TIP,
       pipetteId: mockCompletedAnalysis.pipettes[0].id,
@@ -48,23 +43,13 @@ describe('PickUpTip', () => {
       protocolData: mockCompletedAnalysis,
       proceed: jest.fn(),
       createRunCommand: mockCreateRunCommand,
+      chainRunCommands: mockChainRunCommands,
       handleJog: jest.fn(),
       registerPosition: jest.fn(),
       workingOffsets: [],
       existingOffsets: mockExistingOffsets,
       isRobotMoving: false,
     }
-    mockChainRunCommands.mockImplementation(
-      (commands, createRunCommand, onAllSuccess) => {
-        commands.forEach((c: any) => {
-          createRunCommand({
-            command: c,
-            waitUntilComplete: true,
-          })
-        })
-        return onAllSuccess()
-      }
-    )
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -82,25 +67,14 @@ describe('PickUpTip', () => {
   })
   it('renders correct copy when confirming position', () => {
     when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
+      .calledWith({
+        command: {
+          commandType: 'savePosition',
+          params: { pipetteId: 'pipetteId1' },
         },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementation((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockStartPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
+        waitUntilComplete: true,
       })
+      .mockImplementation(() => Promise.resolve({} as CommandData))
     const { getByText, getByRole } = render({
       ...props,
       workingOffsets: [
@@ -118,185 +92,89 @@ describe('PickUpTip', () => {
     )
     getByRole('link', { name: 'Need help?' })
   })
-  it('executes correct chained commands when confirm placement CTA is clicked', () => {
+  it('executes correct chained commands when confirm placement CTA is clicked', async () => {
     when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementation((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockStartPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
-      })
-    const { getByRole } = render(props)
-    getByRole('button', { name: 'Confirm placement' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: { slotName: '1' },
-          strategy: 'manualMoveWithoutPause',
-        },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
-      command: {
-        commandType: 'moveToWell',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'top', offset: undefined },
-        },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(
-      3,
-      {
+      .calledWith({
         command: {
           commandType: 'savePosition',
           params: { pipetteId: 'pipetteId1' },
         },
         waitUntilComplete: true,
-      },
-      { onSuccess: expect.any(Function) }
+      })
+      .mockImplementation(() => Promise.resolve({} as CommandData))
+    const { getByRole } = render(props)
+    await getByRole('button', { name: 'Confirm placement' }).click()
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: { slotName: '1' },
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: undefined },
+          },
+        },
+      ],
+      true
     )
+    await expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
+      command: {
+        commandType: 'savePosition',
+        params: { pipetteId: 'pipetteId1' },
+      },
+      waitUntilComplete: true,
+    })
   })
 
-  it('executes correct chained commands when confirm position CTA is clicked and user tries again', () => {
+  it('executes correct chained commands when confirm position CTA is clicked and user tries again', async () => {
     when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
+      .calledWith({
+        command: {
+          commandType: 'savePosition',
+          params: { pipetteId: 'pipetteId1' },
         },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockStartPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
+        waitUntilComplete: true,
       })
+      .mockImplementation(() =>
+        Promise.resolve({ data: { result: { position: mockStartPosition } } })
+      )
     when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
+      .calledWith({
+        command: {
+          commandType: 'pickUpTip',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: { x: 9, y: 18, z: 27 } },
           },
-          waitUntilComplete: true,
         },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockEndPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
+        waitUntilComplete: true,
       })
+      .mockImplementation(() => Promise.resolve({} as CommandData))
     when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
+      .calledWith({
+        command: {
+          commandType: 'dropTip',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
           },
-          waitUntilComplete: true,
         },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockStartPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
+        waitUntilComplete: true,
       })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockEndPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
-      })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'pickUpTip',
-            params: {
-              pipetteId: 'pipetteId1',
-              labwareId: 'labwareId1',
-              wellName: 'A1',
-              wellLocation: { origin: 'top', offset: { x: 9, y: 18, z: 27 } },
-            },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementation((_c, opts) => {
-        opts != null && (opts?.onSuccess as any)()
-        return Promise.resolve({} as CommandData)
-      })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'dropTip',
-            params: {
-              pipetteId: 'pipetteId1',
-              labwareId: 'labwareId1',
-              wellName: 'A1',
-            },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementation((_c, opts) => {
-        opts != null && (opts?.onSuccess as any)()
-        return Promise.resolve({} as CommandData)
-      })
+      .mockImplementationOnce(() => Promise.resolve({} as CommandData))
     const { getByRole } = render({
       ...props,
       workingOffsets: [
@@ -311,31 +189,68 @@ describe('PickUpTip', () => {
 
     getByRole('button', { name: 'forward' }).click()
     expect(props.handleJog).toHaveBeenCalled()
-    getByRole('button', { name: 'Confirm position' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(
-      1,
-      {
-        command: {
-          commandType: 'savePosition',
-          params: { pipetteId: 'pipetteId1' },
-        },
-        waitUntilComplete: true,
+    await getByRole('button', { name: 'Confirm position' }).click()
+    await expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
+      command: {
+        commandType: 'savePosition',
+        params: { pipetteId: 'pipetteId1' },
       },
-      { onSuccess: expect.any(Function) }
-    )
-    expect(props.registerPosition).toHaveBeenNthCalledWith(1, {
+      waitUntilComplete: true,
+    })
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(1, {
       type: 'finalPosition',
       labwareId: 'labwareId1',
       location: { slotName: '1' },
       position: { x: 10, y: 20, z: 30 },
     })
-    expect(props.registerPosition).toHaveBeenNthCalledWith(2, {
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(2, {
       type: 'tipPickUpOffset',
       offset: { x: 9, y: 18, z: 27 },
     })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(
-      2,
-      {
+    await expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
+      command: {
+        commandType: 'pickUpTip',
+        params: {
+          pipetteId: 'pipetteId1',
+          labwareId: 'labwareId1',
+          wellName: 'A1',
+          wellLocation: { origin: 'top', offset: { x: 9, y: 18, z: 27 } },
+        },
+      },
+      waitUntilComplete: true,
+    })
+    getByRole('heading', { name: 'Did pipette pick up tip successfully?' })
+    getByRole('button', { name: 'try again' }).click()
+    await expect(props.createRunCommand).toHaveBeenNthCalledWith(3, {
+      command: {
+        commandType: 'dropTip',
+        params: {
+          pipetteId: 'pipetteId1',
+          labwareId: 'labwareId1',
+          wellName: 'A1',
+        },
+      },
+      waitUntilComplete: true,
+    })
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(3, {
+      type: 'tipPickUpOffset',
+      offset: null,
+    })
+  })
+  it('proceeds after confirm position and pick up tip', async () => {
+    when(mockCreateRunCommand)
+      .calledWith({
+        command: {
+          commandType: 'savePosition',
+          params: { pipetteId: 'pipetteId1' },
+        },
+        waitUntilComplete: true,
+      })
+      .mockImplementation(() =>
+        Promise.resolve({ data: { result: { position: mockStartPosition } } })
+      )
+    when(mockCreateRunCommand)
+      .calledWith({
         command: {
           commandType: 'pickUpTip',
           params: {
@@ -346,14 +261,10 @@ describe('PickUpTip', () => {
           },
         },
         waitUntilComplete: true,
-      },
-      { onSuccess: expect.any(Function) }
-    )
-    getByRole('heading', { name: 'Did pipette pick up tip successfully?' })
-    getByRole('button', { name: 'try again' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(
-      3,
-      {
+      })
+      .mockImplementation(() => Promise.resolve({} as CommandData))
+    when(mockCreateRunCommand)
+      .calledWith({
         command: {
           commandType: 'dropTip',
           params: {
@@ -363,134 +274,8 @@ describe('PickUpTip', () => {
           },
         },
         waitUntilComplete: true,
-      },
-      { onSuccess: expect.any(Function) }
-    )
-    expect(props.registerPosition).toHaveBeenNthCalledWith(3, {
-      type: 'tipPickUpOffset',
-      offset: null,
-    })
-  })
-  it('proceeds after confirm position and pick up tip', () => {
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockStartPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
       })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockEndPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
-      })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockStartPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
-      })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'savePosition',
-            params: { pipetteId: 'pipetteId1' },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementationOnce((_c, opts) => {
-        opts != null &&
-          (opts?.onSuccess as any)({
-            data: {
-              result: { position: mockEndPosition },
-            },
-          })
-        return Promise.resolve({} as CommandData)
-      })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'pickUpTip',
-            params: {
-              pipetteId: 'pipetteId1',
-              labwareId: 'labwareId1',
-              wellName: 'A1',
-              wellLocation: { origin: 'top', offset: { x: 9, y: 18, z: 27 } },
-            },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementation((_c, opts) => {
-        opts != null && (opts?.onSuccess as any)()
-        return Promise.resolve({} as CommandData)
-      })
-    when(mockCreateRunCommand)
-      .calledWith(
-        {
-          command: {
-            commandType: 'dropTip',
-            params: {
-              pipetteId: 'pipetteId1',
-              labwareId: 'labwareId1',
-              wellName: 'A1',
-            },
-          },
-          waitUntilComplete: true,
-        },
-        { onSuccess: expect.any(Function) }
-      )
-      .mockImplementation((_c, opts) => {
-        opts != null && (opts?.onSuccess as any)()
-        return Promise.resolve({} as CommandData)
-      })
+      .mockImplementation(() => Promise.resolve({} as CommandData))
     const { getByRole } = render({
       ...props,
       workingOffsets: [
@@ -503,72 +288,64 @@ describe('PickUpTip', () => {
       ],
     })
 
-    getByRole('button', { name: 'Confirm position' }).click()
+    await getByRole('button', { name: 'Confirm position' }).click()
 
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(
-      1,
-      {
-        command: {
-          commandType: 'savePosition',
-          params: { pipetteId: 'pipetteId1' },
-        },
-        waitUntilComplete: true,
+    await expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
+      command: {
+        commandType: 'savePosition',
+        params: { pipetteId: 'pipetteId1' },
       },
-      { onSuccess: expect.any(Function) }
-    )
-    expect(props.registerPosition).toHaveBeenNthCalledWith(1, {
+      waitUntilComplete: true,
+    })
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(1, {
       type: 'finalPosition',
       labwareId: 'labwareId1',
       location: { slotName: '1' },
       position: { x: 10, y: 20, z: 30 },
     })
-    expect(props.registerPosition).toHaveBeenNthCalledWith(2, {
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(2, {
       type: 'tipPickUpOffset',
       offset: { x: 9, y: 18, z: 27 },
     })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(
-      2,
-      {
-        command: {
-          commandType: 'pickUpTip',
-          params: {
-            pipetteId: 'pipetteId1',
-            labwareId: 'labwareId1',
-            wellName: 'A1',
-            wellLocation: { origin: 'top', offset: { x: 9, y: 18, z: 27 } },
-          },
-        },
-        waitUntilComplete: true,
-      },
-      { onSuccess: expect.any(Function) }
-    )
-    getByRole('heading', { name: 'Did pipette pick up tip successfully?' })
-    getByRole('button', { name: 'yes' }).click()
-
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(3, {
+    await expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
       command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: 'offDeck',
-          strategy: 'manualMoveWithoutPause',
-        },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(4, {
-      command: {
-        commandType: 'moveToWell',
+        commandType: 'pickUpTip',
         params: {
           pipetteId: 'pipetteId1',
-          labwareId: 'fixedTrash',
+          labwareId: 'labwareId1',
           wellName: 'A1',
-          wellLocation: { origin: 'top' },
+          wellLocation: { origin: 'top', offset: { x: 9, y: 18, z: 27 } },
         },
       },
       waitUntilComplete: true,
     })
-    expect(props.proceed).toHaveBeenCalled()
+    getByRole('heading', { name: 'Did pipette pick up tip successfully?' })
+    await getByRole('button', { name: 'yes' }).click()
+
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'fixedTrash',
+            wellName: 'A1',
+            wellLocation: { origin: 'top' },
+          },
+        },
+      ],
+      true
+    )
+    await expect(props.proceed).toHaveBeenCalled()
   })
   it('executes heater shaker closed latch commands for every hs module before other commands', () => {
     props = {
@@ -593,19 +370,36 @@ describe('PickUpTip', () => {
     }
     const { getByRole } = render(props)
     getByRole('button', { name: 'Confirm placement' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
-      command: {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: { moduleId: 'firstHSId' },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
-      command: {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: { moduleId: 'secondHSId' },
-      },
-      waitUntilComplete: true,
-    })
+    expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: { moduleId: 'firstHSId' },
+        },
+        {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: { moduleId: 'secondHSId' },
+        },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: { slotName: '1' },
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top' },
+          },
+        },
+      ],
+      true
+    )
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
@@ -5,14 +5,7 @@ import { i18n } from '../../../i18n'
 import { ReturnTip } from '../ReturnTip'
 import { SECTIONS } from '../constants'
 import { mockCompletedAnalysis } from '../__fixtures__'
-import { chainRunCommands } from '../utils/chainRunCommands'
 import { HEATERSHAKER_MODULE_V1 } from '@opentrons/shared-data'
-
-jest.mock('../utils/chainRunCommands')
-
-const mockChainRunCommands = chainRunCommands as jest.Mock<
-  typeof chainRunCommands
->
 
 const matchTextWithSpans: (text: string) => MatcherFunction = (
   text: string
@@ -33,8 +26,10 @@ const render = (props: React.ComponentProps<typeof ReturnTip>) => {
 
 describe('ReturnTip', () => {
   let props: React.ComponentProps<typeof ReturnTip>
+  let mockChainRunCommands
 
   beforeEach(() => {
+    mockChainRunCommands = jest.fn().mockImplementation(() => Promise.resolve())
     props = {
       section: SECTIONS.RETURN_TIP,
       pipetteId: mockCompletedAnalysis.pipettes[0].id,
@@ -43,20 +38,10 @@ describe('ReturnTip', () => {
       protocolData: mockCompletedAnalysis,
       proceed: jest.fn(),
       createRunCommand: jest.fn(),
+      chainRunCommands: mockChainRunCommands,
       tipPickUpOffset: null,
       isRobotMoving: false,
     }
-    mockChainRunCommands.mockImplementation(
-      (commands, createRunCommand, onAllSuccess) => {
-        return commands.forEach((c: any) => {
-          createRunCommand({
-            command: c,
-            waitUntilComplete: true,
-          })
-          onAllSuccess()
-        })
-      }
-    )
   })
   afterEach(() => {
     jest.restoreAllMocks()
@@ -72,121 +57,106 @@ describe('ReturnTip', () => {
     )
     getByRole('link', { name: 'Need help?' })
   })
-  it('executes correct chained commands when CTA is clicked', () => {
+  it('executes correct chained commands when CTA is clicked', async () => {
     const { getByRole } = render(props)
-    getByRole('button', { name: 'Confirm placement' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: { slotName: '1' },
-          strategy: 'manualMoveWithoutPause',
+    await getByRole('button', { name: 'Confirm placement' }).click()
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: { slotName: '1' },
+            strategy: 'manualMoveWithoutPause',
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
-      command: {
-        commandType: 'moveToWell',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'top', offset: undefined },
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: undefined },
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(3, {
-      command: {
-        commandType: 'dropTip',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'default', offset: undefined },
+        {
+          commandType: 'dropTip',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'default', offset: undefined },
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(4, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: 'offDeck',
-          strategy: 'manualMoveWithoutPause',
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(5, {
-      command: { commandType: 'home', params: {} },
-      waitUntilComplete: true,
-    })
-    expect(props.proceed).toHaveBeenCalled()
+        { commandType: 'home', params: {} },
+      ],
+      true
+    )
+    await expect(props.proceed).toHaveBeenCalled()
   })
-  it('executes correct chained commands with tip pick up offset when CTA is clicked', () => {
+  it('executes correct chained commands with tip pick up offset when CTA is clicked', async () => {
     props = {
       ...props,
       tipPickUpOffset: { x: 10, y: 11, z: 12 },
     }
     const { getByRole } = render(props)
-    getByRole('button', { name: 'Confirm placement' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: { slotName: '1' },
-          strategy: 'manualMoveWithoutPause',
+    await getByRole('button', { name: 'Confirm placement' }).click()
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: { slotName: '1' },
+            strategy: 'manualMoveWithoutPause',
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
-      command: {
-        commandType: 'moveToWell',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'top', offset: { x: 10, y: 11, z: 12 } },
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: { x: 10, y: 11, z: 12 } },
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(3, {
-      command: {
-        commandType: 'dropTip',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'default', offset: { x: 10, y: 11, z: 12 } },
+        {
+          commandType: 'dropTip',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'default',
+              offset: { x: 10, y: 11, z: 12 },
+            },
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(4, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: 'offDeck',
-          strategy: 'manualMoveWithoutPause',
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(5, {
-      command: { commandType: 'home', params: {} },
-      waitUntilComplete: true,
-    })
-    expect(props.proceed).toHaveBeenCalled()
+        { commandType: 'home', params: {} },
+      ],
+      true
+    )
+    await expect(props.proceed).toHaveBeenCalled()
   })
-  it('executes heater shaker closed latch commands for every hs module before other commands', () => {
+  it('executes heater shaker closed latch commands for every hs module before other commands', async () => {
     props = {
       ...props,
       tipPickUpOffset: { x: 10, y: 11, z: 12 },
@@ -209,71 +179,59 @@ describe('ReturnTip', () => {
       },
     }
     const { getByRole } = render(props)
-    getByRole('button', { name: 'Confirm placement' }).click()
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(1, {
-      command: {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: { moduleId: 'firstHSId' },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(2, {
-      command: {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: { moduleId: 'secondHSId' },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(3, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: { slotName: '1' },
-          strategy: 'manualMoveWithoutPause',
+    await getByRole('button', { name: 'Confirm placement' }).click()
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: { moduleId: 'firstHSId' },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(4, {
-      command: {
-        commandType: 'moveToWell',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'top', offset: { x: 10, y: 11, z: 12 } },
+        {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: { moduleId: 'secondHSId' },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(5, {
-      command: {
-        commandType: 'dropTip',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
-          wellLocation: { origin: 'default', offset: { x: 10, y: 11, z: 12 } },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: { slotName: '1' },
+            strategy: 'manualMoveWithoutPause',
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(6, {
-      command: {
-        commandType: 'moveLabware',
-        params: {
-          labwareId: 'labwareId1',
-          newLocation: 'offDeck',
-          strategy: 'manualMoveWithoutPause',
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: { x: 10, y: 11, z: 12 } },
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
-    expect(props.createRunCommand).toHaveBeenNthCalledWith(7, {
-      command: { commandType: 'home', params: {} },
-      waitUntilComplete: true,
-    })
-    expect(props.proceed).toHaveBeenCalled()
+        {
+          commandType: 'dropTip',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'default',
+              offset: { x: 10, y: 11, z: 12 },
+            },
+          },
+        },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        { commandType: 'home', params: {} },
+      ],
+      true
+    )
+    await expect(props.proceed).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -35,8 +35,12 @@ const OT2_STANDARD_DECK_DEF = standardDeckDef as any
 export const getCheckSteps = (args: LPCArgs): LabwarePositionCheckStep[] => {
   const checkTipRacksSectionSteps = getCheckTipRackSectionSteps(args)
   if (checkTipRacksSectionSteps.length < 1) return []
-  const allButLastTiprackCheckSteps = checkTipRacksSectionSteps.slice(0, checkTipRacksSectionSteps.length - 1)
-  const lastTiprackCheckStep = checkTipRacksSectionSteps[checkTipRacksSectionSteps.length - 1]
+  const allButLastTiprackCheckSteps = checkTipRacksSectionSteps.slice(
+    0,
+    checkTipRacksSectionSteps.length - 1
+  )
+  const lastTiprackCheckStep =
+    checkTipRacksSectionSteps[checkTipRacksSectionSteps.length - 1]
 
   const pickUpTipSectionStep: PickUpTipStep = {
     section: SECTIONS.PICK_UP_TIP,

--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -21,7 +21,6 @@ import type {
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
-import type { LabwareOffsetLocation } from '@opentrons/api-client'
 
 interface LPCArgs {
   primaryPipetteId: string
@@ -33,27 +32,17 @@ interface LPCArgs {
 
 const OT2_STANDARD_DECK_DEF = standardDeckDef as any
 
-const PICK_UP_TIP_LOCATION: LabwareOffsetLocation = { slotName: '2' }
-
 export const getCheckSteps = (args: LPCArgs): LabwarePositionCheckStep[] => {
   const checkTipRacksSectionSteps = getCheckTipRackSectionSteps(args)
   if (checkTipRacksSectionSteps.length < 1) return []
+  const allButLastTiprackCheckSteps = checkTipRacksSectionSteps.slice(0, checkTipRacksSectionSteps.length - 1)
+  const lastTiprackCheckStep = checkTipRacksSectionSteps[checkTipRacksSectionSteps.length - 1]
 
-  const lastTiprackCheckStep =
-    checkTipRacksSectionSteps[checkTipRacksSectionSteps.length - 1]
-  // TODO(BC, 2022-11-30): once robot model is available from analysis output, this should only
-  // be a conflict with heater shaker positioning on OT2's so something like `isOT2Protocol &&`
-  // should be prepended to this boolean
-  const cannotAccessDefaultPickUpTipLocation = args.modules.some(m =>
-    ['1', '3'].includes(m.location.slotName)
-  )
   const pickUpTipSectionStep: PickUpTipStep = {
     section: SECTIONS.PICK_UP_TIP,
     labwareId: lastTiprackCheckStep.labwareId,
     pipetteId: lastTiprackCheckStep.pipetteId,
-    location: cannotAccessDefaultPickUpTipLocation
-      ? lastTiprackCheckStep.location
-      : PICK_UP_TIP_LOCATION,
+    location: lastTiprackCheckStep.location,
   }
   const checkLabwareSectionSteps = getCheckLabwareSectionSteps(args)
 
@@ -61,14 +50,12 @@ export const getCheckSteps = (args: LPCArgs): LabwarePositionCheckStep[] => {
     section: SECTIONS.RETURN_TIP,
     labwareId: lastTiprackCheckStep.labwareId,
     pipetteId: lastTiprackCheckStep.pipetteId,
-    location: cannotAccessDefaultPickUpTipLocation
-      ? lastTiprackCheckStep.location
-      : PICK_UP_TIP_LOCATION,
+    location: lastTiprackCheckStep.location,
   }
 
   return [
     { section: SECTIONS.BEFORE_BEGINNING },
-    ...checkTipRacksSectionSteps,
+    ...allButLastTiprackCheckSteps,
     pickUpTipSectionStep,
     ...checkLabwareSectionSteps,
     returnTipSectionStep,


### PR DESCRIPTION
# Overview

Instead of consistently picking up and dropping tips off in the front-center slot of the robot (Slot 2), pick
up and drop tip from the final checked tip rack location.

Closes [RAUT-345](https://opentrons.atlassian.net/browse/RAUT-345), Closes RQA-551

# Review requests

Please run LPC:
- confirm that tip is picked up after clicking "Confirm position" on the final tip rack check.
- confirm that tip is returned to the same slot that it was picked up from after all labware checks are completed

# Risk assessment
med, this effects the core logic of LPC


[RAUT-345]: https://opentrons.atlassian.net/browse/RAUT-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ