### PR TITLE
feat(robot-server): remove refresh query param of /instruments endpoint

### DIFF
--- a/robot-server/robot_server/instruments/instrument_models.py
+++ b/robot-server/robot_server/instruments/instrument_models.py
@@ -42,10 +42,6 @@ class MountType(enum.Enum):
         mount_map = {Mount.LEFT: MountType.LEFT, Mount.RIGHT: MountType.RIGHT}
         return mount_map[mount]
 
-    def __str__(self) -> str:
-        """Return the value string."""
-        return self.value
-
 
 class _GenericInstrument(GenericModel, Generic[InstrumentModelT, InstrumentDataT]):
     """Base instrument response."""

--- a/robot-server/robot_server/instruments/instrument_models.py
+++ b/robot-server/robot_server/instruments/instrument_models.py
@@ -32,9 +32,9 @@ InstrumentType = Literal["pipette", "gripper"]
 class MountType(enum.Enum):
     """Available mount types."""
 
-    LEFT = enum.auto()
-    RIGHT = enum.auto()
-    EXTENSION = enum.auto()
+    LEFT = "left"
+    RIGHT = "right"
+    EXTENSION = "extension"
 
     @staticmethod
     def from_hw_mount(mount: Mount) -> MountType:
@@ -42,9 +42,9 @@ class MountType(enum.Enum):
         mount_map = {Mount.LEFT: MountType.LEFT, Mount.RIGHT: MountType.RIGHT}
         return mount_map[mount]
 
-    def as_string(self) -> str:
-        """Get MountType as a string."""
-        return self.name.lower()
+    def __str__(self) -> str:
+        """Return the value string."""
+        return self.value
 
 
 class _GenericInstrument(GenericModel, Generic[InstrumentModelT, InstrumentDataT]):

--- a/robot-server/robot_server/instruments/router.py
+++ b/robot-server/robot_server/instruments/router.py
@@ -1,7 +1,7 @@
 """Instruments routes."""
 from typing import Optional, List, Dict
 
-from fastapi import APIRouter, status, Depends, Query
+from fastapi import APIRouter, status, Depends
 from opentrons.protocol_engine.errors import HardwareNotSupportedError
 
 from robot_server.hardware import get_hardware
@@ -35,7 +35,7 @@ def _pipette_dict_to_pipette_res(pipette_dict: PipetteDict, mount: Mount) -> Pip
     """Convert PipetteDict to Pipette response model."""
     if pipette_dict:
         return Pipette.construct(
-            mount=MountType.from_hw_mount(mount).as_string(),
+            mount=str(MountType.from_hw_mount(mount)),
             instrumentName=pipette_dict["name"],
             instrumentModel=pipette_dict["model"],
             serialNumber=pipette_dict["pipette_id"],
@@ -51,7 +51,7 @@ def _gripper_dict_to_gripper_res(gripper_dict: GripperDict) -> Gripper:
     """Convert GripperDict to Gripper response model."""
     calibration_data = gripper_dict["calibration_offset"]
     return Gripper.construct(
-        mount=MountType.EXTENSION.as_string(),
+        mount=str(MountType.EXTENSION),
         instrumentModel=GripperModelStr(str(gripper_dict["model"])),
         serialNumber=gripper_dict["gripper_id"],
         data=GripperData(
@@ -77,29 +77,18 @@ def _gripper_dict_to_gripper_res(gripper_dict: GripperDict) -> Gripper:
     responses={status.HTTP_200_OK: {"model": SimpleMultiBody[AttachedInstrument]}},
 )
 async def get_attached_instruments(
-    # TODO (spp, 2023-01-06): Active scan restriction is probably not relevant for OT3.
-    #  Furthermore, it might be better to have the server decide whether to do
-    #  an active scan depending on whether a protocol or calibration session is active.
-    refresh: Optional[bool] = Query(
-        False,
-        description="If true, actively scan for attached pipettes. Note:"
-        " this requires  disabling the pipette motors and"
-        " should only be done when no  protocol is running "
-        "and you know it won't cause a problem",
-    ),
     hardware: HardwareControlAPI = Depends(get_hardware),
 ) -> PydanticResponse[SimpleMultiBody[AttachedInstrument]]:
     """Get a list of all attached instruments."""
     pipettes: Dict[Mount, PipetteDict]
     gripper: Optional[GripperDict] = None
 
-    if refresh is True:
-        await hardware.cache_instruments()
     try:
         # TODO (spp, 2023-01-06): revise according to
         #  https://opentrons.atlassian.net/browse/RET-1295
         ot3_hardware = ensure_ot3_hardware(hardware_api=hardware)
         # OT3
+        await hardware.cache_instruments()
         gripper = ot3_hardware.attached_gripper
         pipettes = ot3_hardware.attached_pipettes
     except HardwareNotSupportedError:

--- a/robot-server/robot_server/instruments/router.py
+++ b/robot-server/robot_server/instruments/router.py
@@ -35,7 +35,7 @@ def _pipette_dict_to_pipette_res(pipette_dict: PipetteDict, mount: Mount) -> Pip
     """Convert PipetteDict to Pipette response model."""
     if pipette_dict:
         return Pipette.construct(
-            mount=str(MountType.from_hw_mount(mount)),
+            mount=MountType.from_hw_mount(mount).value,
             instrumentName=pipette_dict["name"],
             instrumentModel=pipette_dict["model"],
             serialNumber=pipette_dict["pipette_id"],
@@ -51,7 +51,7 @@ def _gripper_dict_to_gripper_res(gripper_dict: GripperDict) -> Gripper:
     """Convert GripperDict to Gripper response model."""
     calibration_data = gripper_dict["calibration_offset"]
     return Gripper.construct(
-        mount=str(MountType.EXTENSION),
+        mount=MountType.EXTENSION.value,
         instrumentModel=GripperModelStr(str(gripper_dict["model"])),
         serialNumber=gripper_dict["gripper_id"],
         data=GripperData(

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -94,44 +94,47 @@ async def test_get_all_attached_instruments(
     ot3_hardware_api: OT3API,
 ) -> None:
     """It should get data of all attached instruments."""
-    decoy.when(ot3_hardware_api.attached_gripper).then_return(
-        {
-            "model": GripperModel.v1,
-            "gripper_id": "GripperID321",
-            "display_name": "my-special-gripper",
-            "state": GripperJawState.UNHOMED,
-            "calibration_offset": GripperCalibrationOffset(
-                offset=Point(x=1, y=2, z=3),
-                source=SourceType.default,
-                status=CalibrationStatus(markedBad=False),
-                last_modified=None,
-            ),
-            "fw_update_required": False,
-            "fw_current_version": 1,
-            "fw_next_version": None,
-        }
-    )
-    decoy.when(ot3_hardware_api.attached_pipettes).then_return(
-        {
-            Mount.LEFT: get_sample_pipette_dict(
-                name="p10_multi",
-                model=PipetteModel("abc"),
-                pipette_id="my-pipette-id",
-            ),
-            Mount.RIGHT: get_sample_pipette_dict(
-                name="p20_multi_gen2",
-                model=PipetteModel("xyz"),
-                pipette_id="my-other-pipette-id",
-            ),
-        }
+
+    def rehearse_instrument_retrievals() -> None:
+        decoy.when(ot3_hardware_api.attached_gripper).then_return(
+            {
+                "model": GripperModel.v1,
+                "gripper_id": "GripperID321",
+                "display_name": "my-special-gripper",
+                "state": GripperJawState.UNHOMED,
+                "calibration_offset": GripperCalibrationOffset(
+                    offset=Point(x=1, y=2, z=3),
+                    source=SourceType.default,
+                    status=CalibrationStatus(markedBad=False),
+                    last_modified=None,
+                ),
+                "fw_update_required": False,
+                "fw_current_version": 1,
+                "fw_next_version": None,
+            }
+        )
+        decoy.when(ot3_hardware_api.attached_pipettes).then_return(
+            {
+                Mount.LEFT: get_sample_pipette_dict(
+                    name="p10_multi",
+                    model=PipetteModel("abc"),
+                    pipette_id="my-pipette-id",
+                ),
+                Mount.RIGHT: get_sample_pipette_dict(
+                    name="p20_multi_gen2",
+                    model=PipetteModel("xyz"),
+                    pipette_id="my-other-pipette-id",
+                ),
+            }
+        )
+
+    # We use this convoluted way of testing to verify the important point that
+    # cache_instruments is called before fetching attached pipette and gripper data.
+    decoy.when(await ot3_hardware_api.cache_instruments()).then_do(
+        rehearse_instrument_retrievals
     )
     result = await get_attached_instruments(hardware=ot3_hardware_api)
-    # Ideally we would like to verify that cache_instruments was called before
-    # fetching pipettes and gripper. But decoy doesn't allow verifying getters so,
-    # we will have to rely on manual testing for this.
-    decoy.verify(
-        await ot3_hardware_api.cache_instruments(),
-    )
+
     assert result.content.data == [
         Pipette.construct(
             mount="left",

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -126,6 +126,12 @@ async def test_get_all_attached_instruments(
         }
     )
     result = await get_attached_instruments(hardware=ot3_hardware_api)
+    # Ideally we would like to verify that cache_instruments was called before
+    # fetching pipettes and gripper. But decoy doesn't allow verifying getters so,
+    # we will have to rely on manual testing for this.
+    decoy.verify(
+        await ot3_hardware_api.cache_instruments(),
+    )
     assert result.content.data == [
         Pipette.construct(
             mount="left",
@@ -191,6 +197,7 @@ async def test_get_ot2_instruments(
         }
     )
     result2 = await get_attached_instruments(hardware=hardware_api)
+    decoy.verify(await hardware_api.cache_instruments(), times=0)
     assert result2.status_code == 200
     assert result2.content.data == [
         Pipette.construct(


### PR DESCRIPTION
# Overview

The `?refresh` query param on the instruments endpoint was questionable since the beginning. It has no real use on OT3 while on the OT2 it could cause `GET /instruments` requests to be unsafe if not used with caution. This PR is part 1 of a 2-part change in order to improve the way we handle fetching instruments info.

# Test Plan

Push to both OT2 & OT3. A `GET /instruments` request on the OT2 should always return stale instruments data while it should return up-to-date info on attached instruments on OT3.

# Changelog

- Removed query param, updated caching behaviors for ot2 vs ot3
- made a small change to MountType enum

# Review requests

- code comments
- testing on robots

# Risk assessment

Low
