### PR TITLE
fix(app): disallow multiple clicks on HS latch button

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -163,7 +163,5 @@
   "deck_map": "Deck Map",
   "setup_instructions": "Setup Instructions",
   "opening": "Opening...",
-  "open": "Open",
-  "closing": "Closing...",
-  "close": "Close"
+  "closing": "Closing..."
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -163,5 +163,5 @@
   "deck_map": "Deck Map",
   "setup_instructions": "Setup Instructions",
   "opening": "opening...",
-  "securing": "securing..."
+  "closing": "closing..."
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -161,5 +161,7 @@
   "view_current_offsets": "View current offsets",
   "view_module_setup_instructions": "View module setup instructions",
   "deck_map": "Deck Map",
-  "setup_instructions": "Setup Instructions"
+  "setup_instructions": "Setup Instructions",
+  "opening": "opening...",
+  "securing": "securing..."
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -162,6 +162,8 @@
   "view_module_setup_instructions": "View module setup instructions",
   "deck_map": "Deck Map",
   "setup_instructions": "Setup Instructions",
-  "opening": "opening...",
-  "closing": "closing..."
+  "opening": "Opening...",
+  "open": "Open",
+  "closing": "Closing...",
+  "close": "Close"
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -83,6 +83,7 @@ export function LabwareListItem(
   const labwareDisplayName = getLabwareDisplayName(definition)
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const [isLatchLoading, setIsLatchLoading] = React.useState<boolean>(false)
+  const [isLatchClosed, setIsLatchClosed] = React.useState<boolean>(false)
   let slotInfo: JSX.Element | null =
     initialLocation === 'offDeck'
       ? null
@@ -92,7 +93,6 @@ export function LabwareListItem(
   let extraAttentionText: JSX.Element | null = null
   let isCorrectHeaterShakerAttached: boolean = false
   let isHeaterShakerInProtocol: boolean = false
-  let isLatchClosed: boolean = false
   let latchCommand:
     | HeaterShakerOpenLatchCreateCommand
     | HeaterShakerCloseLatchCreateCommand
@@ -169,10 +169,20 @@ export function LabwareListItem(
           matchingHeaterShaker != null &&
           matchingHeaterShaker.moduleType === HEATERSHAKER_MODULE_TYPE
         ) {
-          isLatchClosed =
-            matchingHeaterShaker.data.labwareLatchStatus === 'idle_closed' ||
-            matchingHeaterShaker.data.labwareLatchStatus === 'closing'
-
+          if (
+            (!isLatchClosed &&
+              (matchingHeaterShaker.data.labwareLatchStatus === 'idle_closed' ||
+                matchingHeaterShaker.data.labwareLatchStatus === 'closing')) ||
+            (isLatchClosed &&
+              (matchingHeaterShaker.data.labwareLatchStatus === 'idle_open' ||
+                matchingHeaterShaker.data.labwareLatchStatus === 'opening'))
+          ) {
+            setIsLatchClosed(
+              matchingHeaterShaker.data.labwareLatchStatus === 'idle_closed' ||
+                matchingHeaterShaker.data.labwareLatchStatus === 'closing'
+            )
+            setIsLatchLoading(false)
+          }
           latchCommand = {
             commandType: isLatchClosed
               ? 'heaterShaker/openLabwareLatch'
@@ -187,17 +197,9 @@ export function LabwareListItem(
   }
   const toggleLatch = (): void => {
     setIsLatchLoading(true)
-    createLiveCommand(
-      {
-        command: latchCommand,
-        waitUntilComplete: true,
-      },
-      {
-        onSuccess: () => {
-          setIsLatchLoading(false)
-        },
-      }
-    ).catch((e: Error) => {
+    createLiveCommand({
+      command: latchCommand,
+    }).catch((e: Error) => {
       console.error(
         `error setting module status with command type ${latchCommand.commandType}: ${e.message}`
       )
@@ -206,7 +208,7 @@ export function LabwareListItem(
   const commandType = isLatchClosed
     ? 'heaterShaker/openLabwareLatch'
     : 'heaterShaker/closeLabwareLatch'
-  let hsLatchText: string = t('secure')
+  let hsLatchText: string = isLatchClosed ? t('open') : t('close')
   if (commandType === 'heaterShaker/closeLabwareLatch' && isLatchLoading) {
     hsLatchText = t('closing')
   } else if (

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -208,7 +208,7 @@ export function LabwareListItem(
   const commandType = isLatchClosed
     ? 'heaterShaker/openLabwareLatch'
     : 'heaterShaker/closeLabwareLatch'
-  let hsLatchText: string = isLatchClosed ? t('open') : t('close')
+  let hsLatchText: string = t('secure')
   if (commandType === 'heaterShaker/closeLabwareLatch' && isLatchLoading) {
     hsLatchText = t('closing')
   } else if (

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -208,7 +208,7 @@ export function LabwareListItem(
     : 'heaterShaker/closeLabwareLatch'
   let hsLatchText: string = t('secure')
   if (commandType === 'heaterShaker/closeLabwareLatch' && isLatchLoading) {
-    hsLatchText = t('securing')
+    hsLatchText = t('closing')
   } else if (
     commandType === 'heaterShaker/openLabwareLatch' &&
     isLatchLoading

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -152,7 +152,11 @@ export function LabwareListItem(
       case HEATERSHAKER_MODULE_TYPE:
         isHeaterShakerInProtocol = true
         extraAttentionText = (
-          <StyledText as="p" color={COLORS.darkGreyEnabled} marginRight="1rem">
+          <StyledText
+            as="p"
+            color={COLORS.darkGreyEnabled}
+            marginRight={SPACING.spacing4}
+          >
             {t('heater_shaker_labware_list_view')}
           </StyledText>
         )

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -218,21 +218,17 @@ describe('LabwareListItem', () => {
     getByText('nickName')
     getByText('To add labware, use the toggle to control the latch')
     getByText('Labware Latch')
-    getByText('Secure')
+    getByText('Close')
     const button = getByLabelText('heater_shaker_7_latch_toggle')
     fireEvent.click(button)
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith(
-      {
-        command: {
-          commandType: 'heaterShaker/closeLabwareLatch',
-          params: {
-            moduleId: mockHeaterShaker.id,
-          },
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
+      command: {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        params: {
+          moduleId: mockHeaterShaker.id,
         },
-        waitUntilComplete: true,
       },
-      { onSuccess: expect.any(Function) }
-    )
+    })
   })
 
   it('renders the correct info for an off deck labware', () => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -218,7 +218,7 @@ describe('LabwareListItem', () => {
     getByText('nickName')
     getByText('To add labware, use the toggle to control the latch')
     getByText('Labware Latch')
-    getByText('Close')
+    getByText('Secure')
     const button = getByLabelText('heater_shaker_7_latch_toggle')
     fireEvent.click(button)
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -221,14 +221,18 @@ describe('LabwareListItem', () => {
     getByText('Secure')
     const button = getByLabelText('heater_shaker_7_latch_toggle')
     fireEvent.click(button)
-    expect(mockCreateLiveCommand).toHaveBeenCalledWith({
-      command: {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: {
-          moduleId: mockHeaterShaker.id,
+    expect(mockCreateLiveCommand).toHaveBeenCalledWith(
+      {
+        command: {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: {
+            moduleId: mockHeaterShaker.id,
+          },
         },
+        waitUntilComplete: true,
       },
-    })
+      { onSuccess: expect.any(Function) }
+    )
   })
 
   it('renders the correct info for an off deck labware', () => {


### PR DESCRIPTION
closes RQA-537

# Overview

Disallow multiple clicks on the HS latch button when command is in progress

# Test Plan

- with a protocol with a H/S in the protocol, go to labware setup list. Click on the secure labware latch button. When it is opening, it should be disabled with the text `opening...` and when it is closing it should be disabled with the text `closing...`
- UI should be readable and text for the latch toggle should not move around when it displays different text

# Changelog

- Add `waitUntilComplete`  and `onSuccess` to command in `LabwareListItem`, and add `useState` setter boolean to tell when the command is being executed or not

# Review requests

- see test plan

# Risk assessment

low