### PR TITLE
refactor(app): apply hifi styling to chip component

### DIFF
--- a/app/src/atoms/Chip/Chip.stories.tsx
+++ b/app/src/atoms/Chip/Chip.stories.tsx
@@ -15,7 +15,7 @@ interface ChipStorybookProps extends React.ComponentProps<typeof Chip> {
 // Note: 59rem(944px) is the size of ODD
 const Template: Story<ChipStorybookProps> = ({ ...args }) => (
   <Flex
-    backgroundColor={args.backgroundColor}
+    backgroundColor={COLORS.darkBlack_fourty}
     padding={SPACING.spacing4}
     width="59rem"
   >
@@ -23,34 +23,26 @@ const Template: Story<ChipStorybookProps> = ({ ...args }) => (
   </Flex>
 )
 
+export const Basic = Template.bind({})
+Basic.args = {
+  type: 'basic',
+  text: 'Basic chip text',
+}
+
 export const Success = Template.bind({})
 Success.args = {
   type: 'success',
   text: 'Connected',
-  iconName: 'ot-check',
-  backgroundColor: COLORS.successBackgroundMed,
-}
-
-export const Error = Template.bind({})
-Error.args = {
-  type: 'error',
-  text: 'Error',
-  iconName: 'ot-check',
-  backgroundColor: COLORS.errorBackgroundMed,
 }
 
 export const Warning = Template.bind({})
 Warning.args = {
   type: 'warning',
   text: 'Missing 1 module',
-  iconName: 'ot-alert',
-  backgroundColor: COLORS.warningBackgroundMed,
 }
 
-export const Informing = Template.bind({})
-Informing.args = {
-  type: 'informing',
+export const Neutral = Template.bind({})
+Neutral.args = {
+  type: 'neutral',
   text: 'Not connected',
-  iconName: 'ot-check',
-  backgroundColor: COLORS.medGreyEnabled,
 }

--- a/app/src/atoms/Chip/__tests__/Chip.test.tsx
+++ b/app/src/atoms/Chip/__tests__/Chip.test.tsx
@@ -11,55 +11,94 @@ const render = (props: React.ComponentProps<typeof Chip>) => {
 describe('Chip', () => {
   let props: React.ComponentProps<typeof Chip>
 
-  it('should render text, icon with success colors', () => {
+  it('should render text, no icon with basic colors', () => {
+    props = {
+      type: 'basic',
+      text: 'mockBasic',
+    }
+    const [{ getByText, queryByLabelText }] = render(props)
+    const chip = getByText('mockBasic')
+    expect(chip).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.darkBlack_twenty)}`)
+    expect(queryByLabelText('icon_mockBasic')).not.toBeInTheDocument()
+  })
+
+  it('should render text, icon, bgcolor with success colors', () => {
     props = {
       type: 'success',
       text: 'mockSuccess',
-      iconName: 'ot-check',
     }
     const [{ getByText, getByLabelText }] = render(props)
     const chip = getByText('mockSuccess')
-    expect(chip).toHaveStyle(`color: ${COLORS.successText}`)
+    expect(chip).toHaveStyle(`color: ${String(COLORS.green_one)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.green_three)}`)
     const icon = getByLabelText('icon_mockSuccess')
-    expect(icon).toHaveStyle(`color: ${COLORS.successEnabled}`)
+    expect(icon).toHaveStyle(`color: ${String(COLORS.green_one)}`)
   })
 
-  it('should render text, icon with error colors', () => {
+  it('should render text, icon, no bgcolor with success colors and bg false', () => {
     props = {
-      type: 'error',
-      text: 'mockError',
-      iconName: 'ot-alert',
+      background: false,
+      type: 'success',
+      text: 'mockSuccess',
     }
     const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockError')
-    expect(chip).toHaveStyle(`color: ${COLORS.errorText}`)
-    const icon = getByLabelText('icon_mockError')
-    expect(icon).toHaveStyle(`color: ${COLORS.errorEnabled}`)
+    const chip = getByText('mockSuccess')
+    expect(chip).toHaveStyle(`color: ${String(COLORS.green_one)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    const icon = getByLabelText('icon_mockSuccess')
+    expect(icon).toHaveStyle(`color: ${String(COLORS.green_one)}`)
   })
 
-  it('should render text, icon with warning colors', () => {
+  it('should render text, icon, bgcolor with warning colors', () => {
     props = {
       type: 'warning',
       text: 'mockWarning',
-      iconName: 'ot-alert',
     }
     const [{ getByText, getByLabelText }] = render(props)
     const chip = getByText('mockWarning')
-    expect(chip).toHaveStyle(`color: ${COLORS.warningText}`)
+    expect(chip).toHaveStyle(`color: ${String(COLORS.yellow_one)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.yellow_three)}`)
     const icon = getByLabelText('icon_mockWarning')
-    expect(icon).toHaveStyle(`color: ${COLORS.warningEnabled}`)
+    expect(icon).toHaveStyle(`color: ${String(COLORS.yellow_two)}`)
   })
 
-  it('should render text, icon with informing colors', () => {
+  it('should render text, icon, no bgcolor with warning colors and bg false', () => {
     props = {
-      type: 'informing',
-      text: 'mockInforming',
-      iconName: 'ot-alert',
+      type: 'warning',
+      text: 'mockWarning',
     }
     const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockInforming')
-    expect(chip).toHaveStyle(`color: ${COLORS.darkGreyEnabled}`)
-    const icon = getByLabelText('icon_mockInforming')
-    expect(icon).toHaveStyle(`color: ${COLORS.darkGreyEnabled}`)
+    const chip = getByText('mockWarning')
+    expect(chip).toHaveStyle(`color: ${String(COLORS.yellow_one)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    const icon = getByLabelText('icon_mockWarning')
+    expect(icon).toHaveStyle(`color: ${String(COLORS.yellow_two)}`)
+  })
+
+  it('should render text, icon, bgcolor with neutral colors', () => {
+    props = {
+      type: 'neutral',
+      text: 'mockNeutral',
+    }
+    const [{ getByText, getByLabelText }] = render(props)
+    const chip = getByText('mockNeutral')
+    expect(chip).toHaveStyle(`color: ${String(COLORS.darkBlack_seventy)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.darkBlack_twenty)}`)
+    const icon = getByLabelText('icon_mockNeutral')
+    expect(icon).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
+  })
+
+  it('should render text, icon, no bgcolor with neutral colors and bg false', () => {
+    props = {
+      type: 'neutral',
+      text: 'mockNeutral',
+    }
+    const [{ getByText, getByLabelText }] = render(props)
+    const chip = getByText('mockNeutral')
+    expect(chip).toHaveStyle(`color: ${String(COLORS.darkBlack_seventy)}`)
+    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    const icon = getByLabelText('icon_mockNeutral')
+    expect(icon).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
   })
 })

--- a/app/src/atoms/Chip/__tests__/Chip.test.tsx
+++ b/app/src/atoms/Chip/__tests__/Chip.test.tsx
@@ -13,25 +13,29 @@ describe('Chip', () => {
 
   it('should render text, no icon with basic colors', () => {
     props = {
-      type: 'basic',
       text: 'mockBasic',
+      type: 'basic',
     }
-    const [{ getByText, queryByLabelText }] = render(props)
-    const chip = getByText('mockBasic')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.darkBlack_twenty)}`)
+    const [{ getByTestId, getByText, queryByLabelText }] = render(props)
+    const chip = getByTestId('Chip_basic')
+    const chipText = getByText('mockBasic')
+    expect(chip).toHaveStyle(
+      `background-color: ${String(COLORS.darkBlack_twenty)}`
+    )
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
     expect(queryByLabelText('icon_mockBasic')).not.toBeInTheDocument()
   })
 
   it('should render text, icon, bgcolor with success colors', () => {
     props = {
-      type: 'success',
       text: 'mockSuccess',
+      type: 'success',
     }
-    const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockSuccess')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.green_one)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.green_three)}`)
+    const [{ getByTestId, getByText, getByLabelText }] = render(props)
+    const chip = getByTestId('Chip_success')
+    const chipText = getByText('mockSuccess')
+    expect(chip).toHaveStyle(`background-color: ${String(COLORS.green_three)}`)
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.green_one)}`)
     const icon = getByLabelText('icon_mockSuccess')
     expect(icon).toHaveStyle(`color: ${String(COLORS.green_one)}`)
   })
@@ -39,65 +43,74 @@ describe('Chip', () => {
   it('should render text, icon, no bgcolor with success colors and bg false', () => {
     props = {
       background: false,
-      type: 'success',
       text: 'mockSuccess',
+      type: 'success',
     }
-    const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockSuccess')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.green_one)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    const [{ getByTestId, getByText, getByLabelText }] = render(props)
+    const chip = getByTestId('Chip_success')
+    const chipText = getByText('mockSuccess')
+    expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.green_one)}`)
     const icon = getByLabelText('icon_mockSuccess')
     expect(icon).toHaveStyle(`color: ${String(COLORS.green_one)}`)
   })
 
   it('should render text, icon, bgcolor with warning colors', () => {
     props = {
-      type: 'warning',
       text: 'mockWarning',
+      type: 'warning',
     }
-    const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockWarning')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.yellow_one)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.yellow_three)}`)
+    const [{ getByTestId, getByText, getByLabelText }] = render(props)
+    const chip = getByTestId('Chip_warning')
+    const chipText = getByText('mockWarning')
+    expect(chip).toHaveStyle(`background-color: ${String(COLORS.yellow_three)}`)
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.yellow_one)}`)
     const icon = getByLabelText('icon_mockWarning')
     expect(icon).toHaveStyle(`color: ${String(COLORS.yellow_two)}`)
   })
 
   it('should render text, icon, no bgcolor with warning colors and bg false', () => {
     props = {
-      type: 'warning',
+      background: false,
       text: 'mockWarning',
+      type: 'warning',
     }
-    const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockWarning')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.yellow_one)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    const [{ getByTestId, getByText, getByLabelText }] = render(props)
+    const chip = getByTestId('Chip_warning')
+    const chipText = getByText('mockWarning')
+    expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.yellow_one)}`)
     const icon = getByLabelText('icon_mockWarning')
     expect(icon).toHaveStyle(`color: ${String(COLORS.yellow_two)}`)
   })
 
   it('should render text, icon, bgcolor with neutral colors', () => {
     props = {
-      type: 'neutral',
       text: 'mockNeutral',
+      type: 'neutral',
     }
-    const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockNeutral')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.darkBlack_seventy)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.darkBlack_twenty)}`)
+    const [{ getByTestId, getByText, getByLabelText }] = render(props)
+    const chip = getByTestId('Chip_neutral')
+    const chipText = getByText('mockNeutral')
+    expect(chip).toHaveStyle(
+      `background-color: ${String(COLORS.darkBlack_twenty)}`
+    )
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.darkBlack_seventy)}`)
     const icon = getByLabelText('icon_mockNeutral')
     expect(icon).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
   })
 
   it('should render text, icon, no bgcolor with neutral colors and bg false', () => {
     props = {
-      type: 'neutral',
+      background: false,
       text: 'mockNeutral',
+      type: 'neutral',
     }
-    const [{ getByText, getByLabelText }] = render(props)
-    const chip = getByText('mockNeutral')
-    expect(chip).toHaveStyle(`color: ${String(COLORS.darkBlack_seventy)}`)
-    // expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    const [{ getByTestId, getByText, getByLabelText }] = render(props)
+    const chip = getByTestId('Chip_neutral')
+    const chipText = getByText('mockNeutral')
+    expect(chip).toHaveStyle(`background-color: ${String(COLORS.transparent)}`)
+    expect(chipText).toHaveStyle(`color: ${String(COLORS.darkBlack_seventy)}`)
     const icon = getByLabelText('icon_mockNeutral')
     expect(icon).toHaveStyle(`color: ${String(COLORS.darkBlack_ninety)}`)
   })

--- a/app/src/atoms/Chip/index.tsx
+++ b/app/src/atoms/Chip/index.tsx
@@ -45,20 +45,20 @@ const CHIP_PROPS_BY_TYPE: Record<
   },
   neutral: {
     backgroundColor: COLORS.darkBlack_twenty,
-    borderRadius: BORDERS.radius24,
+    borderRadius: BORDERS.size_six,
     iconColor: COLORS.darkBlack_ninety,
     textColor: COLORS.darkBlack_seventy,
   },
   success: {
     backgroundColor: COLORS.green_three,
-    borderRadius: BORDERS.radius24,
+    borderRadius: BORDERS.size_six,
     iconColor: COLORS.green_one,
     iconName: 'ot-check',
     textColor: COLORS.green_one,
   },
   warning: {
     backgroundColor: COLORS.yellow_three,
-    borderRadius: BORDERS.radius24,
+    borderRadius: BORDERS.size_six,
     iconColor: COLORS.yellow_two,
     textColor: COLORS.yellow_one,
   },

--- a/app/src/atoms/Chip/index.tsx
+++ b/app/src/atoms/Chip/index.tsx
@@ -32,6 +32,7 @@ const CHIP_PROPS_BY_TYPE: Record<
   ChipType,
   {
     backgroundColor: string
+    borderRadius: string
     iconColor?: string
     iconName?: IconName
     textColor: string
@@ -39,21 +40,25 @@ const CHIP_PROPS_BY_TYPE: Record<
 > = {
   basic: {
     backgroundColor: COLORS.darkBlack_twenty,
+    borderRadius: BORDERS.size_one,
     textColor: COLORS.darkBlack_ninety,
   },
   neutral: {
     backgroundColor: COLORS.darkBlack_twenty,
+    borderRadius: BORDERS.radius24,
     iconColor: COLORS.darkBlack_ninety,
     textColor: COLORS.darkBlack_seventy,
   },
   success: {
     backgroundColor: COLORS.green_three,
+    borderRadius: BORDERS.radius24,
     iconColor: COLORS.green_one,
     iconName: 'ot-check',
     textColor: COLORS.green_one,
   },
   warning: {
     backgroundColor: COLORS.yellow_three,
+    borderRadius: BORDERS.radius24,
     iconColor: COLORS.yellow_two,
     textColor: COLORS.yellow_one,
   },
@@ -71,35 +76,17 @@ export function Chip({
       ? COLORS.transparent
       : CHIP_PROPS_BY_TYPE[type].backgroundColor
   const icon = iconName ?? CHIP_PROPS_BY_TYPE[type].iconName ?? 'ot-alert'
-  if (type === 'basic') {
-    return (
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={backgroundColor}
-        borderRadius={BORDERS.size_one}
-        flexDirection={DIRECTION_ROW}
-        padding={`${SPACING.spacing3} 0.75rem`}
-      >
-        <StyledText
-          color={CHIP_PROPS_BY_TYPE[type].textColor}
-          fontSize={TYPOGRAPHY.lineHeight20}
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          lineHeight={TYPOGRAPHY.fontSize28}
-        >
-          {text}
-        </StyledText>
-      </Flex>
-    )
-  } else {
-    return (
-      <Flex
-        flexDirection={DIRECTION_ROW}
-        padding={`${SPACING.spacing3} ${SPACING.spacing4}`}
-        backgroundColor={backgroundColor}
-        borderRadius={BORDERS.radius24}
-        alignItems={ALIGN_CENTER}
-        gridGap={SPACING.spacing3}
-      >
+  return (
+    <Flex
+      alignItems={ALIGN_CENTER}
+      backgroundColor={backgroundColor}
+      borderRadius={CHIP_PROPS_BY_TYPE[type].borderRadius}
+      flexDirection={DIRECTION_ROW}
+      padding={`${SPACING.spacing3} ${SPACING.spacing4}`}
+      gridGap={SPACING.spacing3}
+      data-testid={`Chip_${type}`}
+    >
+      {type !== 'basic' && (
         <Icon
           name={icon}
           color={CHIP_PROPS_BY_TYPE[type].iconColor}
@@ -107,15 +94,15 @@ export function Chip({
           size="1.5rem"
           data-testid="RenderResult_icon"
         />
-        <StyledText
-          fontSize="1.25rem"
-          lineHeight="1.6875rem"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          color={CHIP_PROPS_BY_TYPE[type].textColor}
-        >
-          {text}
-        </StyledText>
-      </Flex>
-    )
-  }
+      )}
+      <StyledText
+        fontSize="1.25rem"
+        lineHeight="1.6875rem"
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+        color={CHIP_PROPS_BY_TYPE[type].textColor}
+      >
+        {text}
+      </StyledText>
+    </Flex>
+  )
 }

--- a/app/src/atoms/Chip/index.tsx
+++ b/app/src/atoms/Chip/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {
+  BORDERS,
   Flex,
   DIRECTION_ROW,
   ALIGN_CENTER,
@@ -14,65 +15,107 @@ import { StyledText } from '../text'
 
 import type { IconName } from '@opentrons/components'
 
-export type ChipType = 'success' | 'warning' | 'error' | 'informing'
+export type ChipType = 'basic' | 'success' | 'warning' | 'neutral'
 
-// Note: When the DS is coming out, we may need to define ChipType like Banner
 interface ChipProps {
-  /** name constant of the text color and the icon color to display */
-  type: ChipType
+  /** Display background color? */
+  background?: boolean
+  /** Chip icon */
+  iconName?: IconName
   /** Chip content */
   text: string
-  /** Chip icon */
-  iconName: IconName
+  /** name constant of the text color and the icon color to display */
+  type: ChipType
 }
 
 const CHIP_PROPS_BY_TYPE: Record<
   ChipType,
-  { textColor: string; iconColor: string }
+  {
+    backgroundColor: string
+    iconColor?: string
+    iconName?: IconName
+    textColor: string
+  }
 > = {
-  success: {
-    textColor: COLORS.successText,
-    iconColor: COLORS.successEnabled,
+  basic: {
+    backgroundColor: COLORS.darkBlack_twenty,
+    textColor: COLORS.darkBlack_ninety,
   },
-  error: {
-    textColor: COLORS.errorText,
-    iconColor: COLORS.errorEnabled,
+  neutral: {
+    backgroundColor: COLORS.darkBlack_twenty,
+    iconColor: COLORS.darkBlack_ninety,
+    textColor: COLORS.darkBlack_seventy,
+  },
+  success: {
+    backgroundColor: COLORS.green_three,
+    iconColor: COLORS.green_one,
+    iconName: 'ot-check',
+    textColor: COLORS.green_one,
   },
   warning: {
-    textColor: COLORS.warningText,
-    iconColor: COLORS.warningEnabled,
-  },
-  informing: {
-    textColor: COLORS.darkGreyEnabled,
-    iconColor: COLORS.darkGreyEnabled,
+    backgroundColor: COLORS.yellow_three,
+    iconColor: COLORS.yellow_two,
+    textColor: COLORS.yellow_one,
   },
 }
 
 // ToDo (kj:02/09/2023) replace hard-coded values when the DS is out
-export function Chip({ type, text, iconName }: ChipProps): JSX.Element {
-  return (
-    <Flex
-      flexDirection={DIRECTION_ROW}
-      padding={`${SPACING.spacing3} ${SPACING.spacing4}`}
-      backgroundColor={COLORS.white}
-      borderRadius="1.9375rem"
-      alignItems={ALIGN_CENTER}
-      gridGap={SPACING.spacing3}
-    >
-      <Icon
-        name={iconName}
-        color={CHIP_PROPS_BY_TYPE[type].iconColor}
-        aria-label={`icon_${text}`}
-        size="1.5rem"
-      />
-      <StyledText
-        fontSize="1.25rem"
-        lineHeight="1.6875rem"
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-        color={CHIP_PROPS_BY_TYPE[type].textColor}
+export function Chip({
+  background,
+  iconName,
+  type,
+  text,
+}: ChipProps): JSX.Element {
+  const backgroundColor =
+    background === false && type !== 'basic'
+      ? COLORS.transparent
+      : CHIP_PROPS_BY_TYPE[type].backgroundColor
+  const icon = iconName ?? CHIP_PROPS_BY_TYPE[type].iconName ?? 'ot-alert'
+  if (type === 'basic') {
+    return (
+      <Flex
+        alignItems={ALIGN_CENTER}
+        backgroundColor={backgroundColor}
+        borderRadius={BORDERS.size_one}
+        flexDirection={DIRECTION_ROW}
+        padding={`${SPACING.spacing3} 0.75rem`}
       >
-        {text}
-      </StyledText>
-    </Flex>
-  )
+        <StyledText
+          color={CHIP_PROPS_BY_TYPE[type].textColor}
+          fontSize={TYPOGRAPHY.lineHeight20}
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          lineHeight={TYPOGRAPHY.fontSize28}
+        >
+          {text}
+        </StyledText>
+      </Flex>
+    )
+  } else {
+    return (
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        padding={`${SPACING.spacing3} ${SPACING.spacing4}`}
+        backgroundColor={backgroundColor}
+        borderRadius={BORDERS.radius24}
+        alignItems={ALIGN_CENTER}
+        gridGap={SPACING.spacing3}
+      >
+        <Icon
+          name={icon}
+          color={CHIP_PROPS_BY_TYPE[type].iconColor}
+          aria-label={`icon_${text}`}
+          size="1.5rem"
+          data-testid="RenderResult_icon"
+        />
+        <StyledText
+          fontSize="1.25rem"
+          lineHeight="1.6875rem"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          color={CHIP_PROPS_BY_TYPE[type].textColor}
+        >
+          {text}
+        </StyledText>
+      </Flex>
+    )
+  }
 }

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
@@ -65,7 +65,7 @@ export function NetworkSettings({
   } // TODO (jb 2-24-2023) implement ethernet and usb details screen titles
 
   const handleChipType = (isConnected: boolean): ChipType => {
-    return isConnected ? 'success' : 'informing'
+    return isConnected ? 'success' : 'neutral'
   }
 
   const handleButtonBackgroundColor = (isConnected: boolean): string =>

--- a/components/src/ui-style-constants/borders.ts
+++ b/components/src/ui-style-constants/borders.ts
@@ -19,15 +19,6 @@ export const size_four = '16px'
 export const size_five = '40px'
 export const size_six = '60px'
 
-// semantic naming
-export const radius60 = '3.75rem' // 60px
-export const radius40 = '2.5rem' // 40px
-export const radius24 = '1.5rem' // 24px
-export const radius16 = '1rem' // 16px
-export const radius12 = '0.75rem' // 12px
-export const radius8 = '0.5rem' // 8px
-export const radius4 = '0.25rem' // 4px
-
 export const tabBorder = css`
   border-bottom-style: ${styleSolid};
   border-bottom-width: ${spacing1};

--- a/components/src/ui-style-constants/borders.ts
+++ b/components/src/ui-style-constants/borders.ts
@@ -19,6 +19,15 @@ export const size_four = '16px'
 export const size_five = '40px'
 export const size_six = '60px'
 
+// semantic naming
+export const radius60 = '3.75rem' // 60px
+export const radius40 = '2.5rem' // 40px
+export const radius24 = '1.5rem' // 24px
+export const radius16 = '1rem' // 16px
+export const radius12 = '0.75rem' // 12px
+export const radius8 = '0.5rem' // 8px
+export const radius4 = '0.25rem' // 4px
+
 export const tabBorder = css`
   border-bottom-style: ${styleSolid};
   border-bottom-width: ${spacing1};


### PR DESCRIPTION
# Overview

This applies HiFi styling rules to the "Chip" component

https://www.figma.com/file/OIdG64Q5cgvEw82ish5Eee/Design-System-(ODD)?node-id=1121%3A61901&t=imrDztvU28AVms4P-0

Closes RAUT-364 and RAUT-349

# Test Plan

Added storybook story and unit tests

# Changelog

- Added new border radius constant
- Made new semantic naming section for border radii
- Applied new styling to Chip
- Added new background boolean parameter to Chip

# Review requests

The storybook story shows it all.

# Risk assessment

None.
