### PR TITLE
feat(hardware): support tip presence CAN message

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -129,6 +129,7 @@ class MessageId(int, Enum):
 
     attached_tools_request = 0x700
     tools_detected_notification = 0x701
+    tip_presence_notification = 0x702
 
     fw_update_initiate = 0x60
     fw_update_data = 0x61

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -789,3 +789,20 @@ class SetGripperErrorTolerance(BaseMessage):  # noqa: D101
     message_id: Literal[
         MessageId.set_gripper_error_tolerance
     ] = MessageId.set_gripper_error_tolerance
+
+
+@dataclass
+class PushTipPresenceNotification(BaseMessage):
+    """Hardware triggered notification of ejector flag status.
+
+    The response should be a boolean of the ejector flag
+    either being occluded or not.
+    """
+
+    payload: payloads.PushTipPresenceNotificationPayload
+    payload_type: Type[
+        payloads.PushTipPresenceNotificationPayload
+    ] = payloads.PushTipPresenceNotificationPayload
+    message_id: Literal[
+        MessageId.tip_presence_notification
+    ] = MessageId.tip_presence_notification

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -89,6 +89,7 @@ MessageDefinition = Union[
     defs.BrushedMotorConfRequest,
     defs.BrushedMotorConfResponse,
     defs.SetGripperErrorTolerance,
+    defs.PushTipPresenceNotification,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -511,6 +511,13 @@ class GripperErrorTolerancePayload(EmptyPayload):
 
 
 @dataclass(eq=False)
+class PushTipPresenceNotificationPayload(EmptyPayload):
+    """A notification that the ejector flag status has changed."""
+
+    ejector_flag_status: utils.UInt8Field
+
+
+@dataclass(eq=False)
 class TipActionRequestPayload(AddToMoveGroupRequestPayload):
     """A request to perform a tip action."""
 


### PR DESCRIPTION
## Overview

We want to handle notifications from firmware of changes to the ejector flag on pipettes which tells us (roughly) that tips are present or not.

Relates to https://github.com/Opentrons/ot3-firmware/pull/602