### PR TITLE
fix(api): use core to access working volume in transfer

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -450,6 +450,9 @@ class InstrumentCore(AbstractInstrument[WellCore]):
     def get_max_volume(self) -> float:
         return self._engine_client.state.pipettes.get_maximum_volume(self._pipette_id)
 
+    def get_working_volume(self) -> float:
+        return self._engine_client.state.pipettes.get_working_volume(self._pipette_id)
+
     def get_current_volume(self) -> float:
         try:
             current_volume = self._engine_client.state.pipettes.get_aspirated_volume(

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -171,6 +171,10 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
+    def get_working_volume(self) -> float:
+        ...
+
+    @abstractmethod
     def get_current_volume(self) -> float:
         ...
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -390,6 +390,10 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         """Get the max volume."""
         return self.get_hardware_state()["max_volume"]
 
+    def get_working_volume(self) -> float:
+        """Get the max volume."""
+        return self.get_hardware_state()["working_volume"]
+
     def get_current_volume(self) -> float:
         """Get the current volume."""
         return self.get_hardware_state()["current_volume"]

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -391,7 +391,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         return self.get_hardware_state()["max_volume"]
 
     def get_working_volume(self) -> float:
-        """Get the max volume."""
+        """Get the working volume."""
         return self.get_hardware_state()["working_volume"]
 
     def get_current_volume(self) -> float:

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -293,6 +293,10 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
     def get_max_volume(self) -> float:
         return self._pipette_dict["max_volume"]
 
+    def get_working_volume(self) -> float:
+        """Get the max volume."""
+        return self._pipette_dict["working_volume"]
+
     def get_current_volume(self) -> float:
         return self._pipette_dict["current_volume"]
 

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -294,7 +294,6 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
         return self._pipette_dict["max_volume"]
 
     def get_working_volume(self) -> float:
-        """Get the max volume."""
         return self._pipette_dict["working_volume"]
 
     def get_current_volume(self) -> float:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1179,7 +1179,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
             max_volume = min(next_tip.max_volume, self.max_volume)
         else:
-            max_volume = self.hw_pipette["working_volume"]
+            max_volume = self._core.get_working_volume()
 
         touch_tip = None
         if kwargs.get("touch_tip"):

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -702,6 +702,20 @@ def test_get_max_volume(
     assert subject.get_max_volume() == 4.56
 
 
+def test_get_working_volume(
+    decoy: Decoy,
+    subject: InstrumentCore,
+    mock_engine_client: EngineClient,
+) -> None:
+    """It should get the pipette's working volume."""
+    decoy.when(
+        mock_engine_client.state.pipettes.get_working_volume(
+            pipette_id=subject.pipette_id
+        )
+    ).then_return(7.89)
+    assert subject.get_working_volume() == 7.89
+
+
 def test_get_channels(
     decoy: Decoy,
     subject: InstrumentCore,


### PR DESCRIPTION
# Overview

Closes RQA-565.

Fixes a direct `PipetteDict` access in `InstrumentContext.transfer`. It has been replaced with a new instrument core method `get_working_volume`, which maintains the same behavior for the legacy core, and uses the Protocol Engine for the engine-based core.

# Test Plan

Tested analysis on the following protocol taken from the ticket. It passes on both 2.13 and 2.14, with the `disableFastProtocolUpload` on and off.

```
"""Smoke Test v3.0 """
# https://opentrons.atlassian.net/projects/RQA?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/QB-T497
from opentrons import protocol_api

metadata = {
    "protocolName": "2.14 distribute bug",
    "author": "Opentrons Engineering <engineering@opentrons.com>",
    "source": "Software Testing Team",
    "description": ("Description of the protocol that is longish \n has \n returns and \n emoji 😊 ⬆️ "),
    "apiLevel": "2.14",
}


def run(ctx: protocol_api.ProtocolContext) -> None:
    """This method is run by the protocol engine."""


    tips_20ul_position = "4"
    dye_source_position = "3"
    logo_position = "2"

    # 20ul tips
    tips_20ul = [
        ctx.load_labware(
            load_name="opentrons_96_tiprack_20ul",
            location=tips_20ul_position,
            label="20ul tips",
        )
    ]

    pipette_right = ctx.load_instrument(instrument_name="p20_single_gen2", mount="right", tip_racks=tips_20ul)


    # create plates and pattern list
    logo_destination_plate = ctx.load_labware(
        load_name="nest_96_wellplate_100ul_pcr_full_skirt",
        location=logo_position,
        label="logo destination",
    )

    dye_container = ctx.load_labware(
        load_name="nest_12_reservoir_15ml",
        location=dye_source_position,
        label="dye container",
    )

    dye_source = dye_container.wells_by_name()["A2"]

    # Well Location set-up
    dye_destination_wells = [
        logo_destination_plate.wells_by_name()["C7"],
        logo_destination_plate.wells_by_name()["D6"],
        logo_destination_plate.wells_by_name()["D7"],
        logo_destination_plate.wells_by_name()["D8"],
        logo_destination_plate.wells_by_name()["E5"],
    ]

    # Distribute dye
    pipette_right.pick_up_tip()
    pipette_right.distribute(
        volume=18,
        source=dye_source,
        dest=dye_destination_wells,
        new_tip="never",
    )
    pipette_right.drop_tip()
```

# Changelog

- Added `get_working_volume` method to cores
- Replaced `PipetteDict` access in `InstrumentContext.transfer` with the `get_working_volume` method

# Review requests

# Risk assessment

Low, maintains same legacy behavior and uses correct engine access for 2.14.