### PR TITLE
feat(shared-data): Increase DVT "top" plunger position from 0.5 to 0.0 mm from endstop

### DIFF
--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
@@ -4,7 +4,7 @@
   "model": "p1000",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {
-    "current": 0.5,
+    "current": 0.0,
     "presses": 1,
     "speed": 10,
     "increment": 0.0,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -4,7 +4,7 @@
   "model": "p50",
   "displayCategory": "GEN3",
   "pickUpTipConfigurations": {
-    "current": 0.5,
+    "current": 0.0,
     "presses": 1,
     "speed": 10,
     "increment": 0.0,

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
@@ -19,7 +19,7 @@
     "run": 1.0
   },
   "plungerPositionsConfigurations": {
-    "top": 0.5,
+    "top": 0.0,
     "bottom": 71.5,
     "blowout": 76.5,
     "drop": 90.5

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -19,7 +19,7 @@
     "run": 1.0
   },
   "plungerPositionsConfigurations": {
-    "top": 0.5,
+    "top": 0.0,
     "bottom": 71.5,
     "blowout": 76.5,
     "drop": 90.5


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Having this be `0.5` is a remnant of the mechanical endstops used in the OT2. Now that GEN3 uses photointerrupts, we can set the "top" position to `0.0` without concern.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
