### PR TITLE
feat(app-shell-odd): control devtools access

### DIFF
--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -7,12 +7,12 @@ import { registerRobotLogs } from './robot-logs'
 import { registerUpdate, updateLatestVersion } from './update'
 import { registerRobotSystemUpdate } from './system-update'
 import { getConfig, getStore, getOverrides, registerConfig } from './config'
-import sdNotify from './systemd'
+import systemd from './systemd'
 
 import type { BrowserWindow } from 'electron'
 import type { Dispatch, Logger } from './types'
 
-sdNotify.sendStatus('starting app')
+systemd.sendStatus('starting app')
 const config = getConfig()
 const log = createLogger('main')
 
@@ -22,10 +22,7 @@ log.debug('App config', {
   overrides: getOverrides(),
 })
 
-if (config.devtools) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  require('electron-debug')({ isEnabled: true, showDevTools: true })
-}
+systemd.setRemoteDevToolsEnabled(config.devtools)
 
 // hold on to references so they don't get garbage collected
 let mainWindow: BrowserWindow | null | undefined
@@ -34,8 +31,6 @@ let rendererLogger: Logger
 // prepended listener is important here to work around Electron issue
 // https://github.com/electron/electron/issues/19468#issuecomment-623529556
 app.prependOnceListener('ready', startUp)
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
-if (config.devtools) app.once('ready', installDevtools)
 
 app.once('window-all-closed', () => {
   log.debug('all windows closed, quitting the app')
@@ -44,7 +39,7 @@ app.once('window-all-closed', () => {
 
 function startUp(): void {
   log.info('Starting App')
-  sdNotify.sendStatus('loading app')
+  systemd.sendStatus('loading app')
   process.on('uncaughtException', error => log.error('Uncaught: ', { error }))
   process.on('unhandledRejection', reason =>
     log.error('Uncaught Promise rejection: ', { reason })
@@ -85,8 +80,8 @@ function startUp(): void {
   log.silly('Global references', { mainWindow, rendererLogger })
 
   ipcMain.once('dispatch', () => {
-    sdNotify.sendStatus('started')
-    sdNotify.ready()
+    systemd.sendStatus('started')
+    systemd.ready()
   })
 }
 
@@ -97,23 +92,4 @@ function createRendererLogger(): Logger {
   ipcMain.on('log', (_, info) => logger.log(info))
 
   return logger
-}
-
-function installDevtools(): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const devtools = require('electron-devtools-installer')
-  const extensions = [devtools.REACT_DEVELOPER_TOOLS, devtools.REDUX_DEVTOOLS]
-  const install = devtools.default
-  const forceReinstall = config.reinstallDevtools
-
-  log.debug('Installing devtools')
-
-  return install(extensions, forceReinstall)
-    .then(() => log.debug('Devtools extensions installed'))
-    .catch((error: unknown) => {
-      log.warn('Failed to install devtools extensions', {
-        forceReinstall,
-        error,
-      })
-    })
 }


### PR DESCRIPTION
We now allow remote devtools access to the robot, but we probably want it to be controlled. This PR links the state of the devtools access (via starting or stopping the tcp socket proxy) to the state of the devtools config element.

## TODO
- [ ] This doesn't actually require a restart to load the devtools into the web content anymore, so we could reasonably listen for the config changing and do the toggle there. I'm not sure how to do that though - @Opentrons/app-and-uis eyes would be welcome!

## Testing
- [ ] we're not loading all those devtools extensions in anymore. is that... okay? do they still work elsewhere? How does this all work anyway?
- [x] make sure it works and devtools are inaccessible when toggled off and accessible when toggled on

Don't merge this until #12286 