### PR TITLE
fix(app): update protocol setup ui when TLC completed

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
@@ -14,10 +14,6 @@ import * as PipetteConstants from '../../../redux/pipettes/constants'
 import { useRunPipetteInfoByMount } from '../hooks'
 import { SetupCalibrationItem } from './SetupCalibrationItem'
 import { SetupTipLengthCalibrationButton } from './SetupTipLengthCalibrationButton'
-
-import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
-
-const CALIBRATIONS_FETCH_MS = 5000
 interface SetupTipLengthCalibrationProps {
   robotName: string
   runId: string
@@ -29,8 +25,7 @@ export function SetupTipLengthCalibration({
 }: SetupTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
   const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
-
-  useAllTipLengthCalibrationsQuery({ refetchInterval: CALIBRATIONS_FETCH_MS })
+  console.log({ runPipetteInfoByMount })
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
@@ -43,6 +38,7 @@ export function SetupTipLengthCalibration({
       </StyledText>
       {PipetteConstants.PIPETTE_MOUNTS.map(mount => {
         const pipetteInfo = runPipetteInfoByMount[mount]
+        console.log({ pipetteInfo })
         if (pipetteInfo == null) {
           return null
         } else {

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
@@ -25,7 +25,6 @@ export function SetupTipLengthCalibration({
 }: SetupTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
   const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
-  console.log({ runPipetteInfoByMount })
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
@@ -38,7 +37,6 @@ export function SetupTipLengthCalibration({
       </StyledText>
       {PipetteConstants.PIPETTE_MOUNTS.map(mount => {
         const pipetteInfo = runPipetteInfoByMount[mount]
-        console.log({ pipetteInfo })
         if (pipetteInfo == null) {
           return null
         } else {

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
@@ -66,7 +66,7 @@ export function FactoryResetSlideout({
   // Calibration data
   const deckCalibrationData = useDeckCalibrationData(robotName)
   const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robotName)
-  const tipLengthCalibrations = useTipLengthCalibrations(robotName)
+  const tipLengthCalibrations = useTipLengthCalibrations()
   const options = useSelector((state: State) =>
     getResetConfigOptions(state, robotName)
   )

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -148,7 +148,7 @@ describe('useRunPipetteInfoByMount hook', () => {
       .calledWith()
       .mockReturnValue(ATTACHED_PIPETTES)
     when(mockUseTipLengthCalibrations)
-      .calledWith('otie')
+      .calledWith()
       .mockReturnValue(TIP_LENGTH_CALIBRATIONS)
     when(mockUseMostRecentCompletedAnalysis)
       .calledWith('1')

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -49,7 +49,7 @@ export function useRunPipetteInfoByMount(
   const attachedPipettes = useAttachedPipettes()
   const attachedPipetteCalibrations =
     useAttachedPipetteCalibrations() ?? EMPTY_MOUNTS
-  const tipLengthCalibrations = useTipLengthCalibrations(robotName) ?? []
+  const tipLengthCalibrations = useTipLengthCalibrations() ?? []
 
   if (protocolData == null) {
     return EMPTY_MOUNTS

--- a/app/src/organisms/Devices/hooks/useTipLengthCalibrations.ts
+++ b/app/src/organisms/Devices/hooks/useTipLengthCalibrations.ts
@@ -1,32 +1,13 @@
-import React from 'react'
-import { useSelector } from 'react-redux'
-
-import {
-  fetchTipLengthCalibrations,
-  getTipLengthCalibrations,
-} from '../../../redux/calibration'
-import { useDispatchApiRequest } from '../../../redux/robot-api'
-import { useRobot } from '.'
+import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
 
 import type { TipLengthCalibration } from '../../../redux/calibration/types'
-import type { State } from '../../../redux/types'
 
-export function useTipLengthCalibrations(
-  robotName: string | null = null
-): TipLengthCalibration[] | null {
-  const [dispatchRequest] = useDispatchApiRequest()
+const CALIBRATIONS_FETCH_MS = 5000
 
-  const robot = useRobot(robotName)
-
-  const tipLengthCalibrations = useSelector((state: State) =>
-    getTipLengthCalibrations(state, robotName)
-  )
-
-  React.useEffect(() => {
-    if (robotName != null) {
-      dispatchRequest(fetchTipLengthCalibrations(robotName))
-    }
-  }, [dispatchRequest, robotName, robot?.status])
-
+export function useTipLengthCalibrations(): TipLengthCalibration[] | null {
+  const tipLengthCalibrations =
+    useAllTipLengthCalibrationsQuery({
+      refetchInterval: CALIBRATIONS_FETCH_MS,
+    })?.data?.data ?? []
   return tipLengthCalibrations
 }

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
@@ -51,7 +51,7 @@ export function CalibrationDataDownload({
   // wait for robot request to resolve instead of using name directly from params
   const deckCalibrationData = useDeckCalibrationData(robot?.name)
   const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
-  const tipLengthCalibrations = useTipLengthCalibrations(robot?.name)
+  const tipLengthCalibrations = useTipLengthCalibrations()
 
   const downloadIsPossible =
     deckCalibrationData.isDeckCalibrated &&

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -95,7 +95,7 @@ describe('CalibrationDataDownload', () => {
       ])
     when(mockUseRobot).calledWith('otie').mockReturnValue(mockConnectableRobot)
     when(mockUseTipLengthCalibrations)
-      .calledWith(mockConnectableRobot.name)
+      .calledWith()
       .mockReturnValue([
         mockTipLengthCalibration1,
         mockTipLengthCalibration2,
@@ -207,9 +207,7 @@ describe('CalibrationDataDownload', () => {
   })
 
   it('renders disabled button when tip lengths are not calibrated', () => {
-    when(mockUseTipLengthCalibrations)
-      .calledWith(mockConnectableRobot.name)
-      .mockReturnValue([])
+    when(mockUseTipLengthCalibrations).calledWith().mockReturnValue([])
     const [{ getByRole, getByText }] = render()
     getByText('No calibration data available.')
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

replaces an old redux function with the newer react-query version for getting tip length calibrations within the `useTipLengthCalibrations` hook. This results in the UI updating as expected

closes RAUT-341

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Deleted TLCs then started a protocol that required calibrations. After completing the TLCs, verified the UI updated as expected. 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- use `useAllTipLengthCalibrationsQuery` in the `useTipLengthCalibrations` hook instead of the old Redux setup
- update usage of `useTipLengthCalibrations` across the app now that it no longer requires a robot name argument

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure behavior matches what is described in the Test Plan section

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low - mid, touched several parts of the app, but should be good if tests pass

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
