### PR TITLE
refactor(robot-server): fix linting error after bad merge

### DIFF
--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -344,6 +344,7 @@ def test_get_referenced_run_ids(
             files=[],
             metadata={},
             robot_type="OT-2 Standard",
+            content_hash="abc123",
         ),
         protocol_key=None,
     )


### PR DESCRIPTION
# Overview

[A bad merge](https://github.com/Opentrons/opentrons/actions/runs/4449956722/jobs/7814816603) into edge caused a linting error — this PR adds a small fix up to address it.

# Risk assessment
Low