### PR TITLE
fix(app): use react-api-client in usePipetteOffsetCalibrations

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
@@ -57,7 +57,7 @@ export function SetupTipLengthCalibrationButton({
   ] = useDashboardCalibrateTipLength(robotName)
   const { deleteCalibration } = useDeleteCalibrationMutation()
   const attachedPipettes = useAttachedPipettes()
-  const offsetCalibrations = usePipetteOffsetCalibrations(robotName)
+  const offsetCalibrations = usePipetteOffsetCalibrations()
 
   const offsetCalsToDelete = offsetCalibrations?.filter(
     cal =>

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryResetSlideout.tsx
@@ -65,7 +65,7 @@ export function FactoryResetSlideout({
 
   // Calibration data
   const deckCalibrationData = useDeckCalibrationData(robotName)
-  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robotName)
+  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations()
   const tipLengthCalibrations = useTipLengthCalibrations(robotName)
   const options = useSelector((state: State) =>
     getResetConfigOptions(state, robotName)

--- a/app/src/organisms/Devices/hooks/__tests__/usePipetteOffsetCalibrations.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/usePipetteOffsetCalibrations.test.tsx
@@ -1,104 +1,69 @@
 import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
-import { Provider } from 'react-redux'
-import { createStore, Store } from 'redux'
 import { renderHook } from '@testing-library/react-hooks'
 import { QueryClient, QueryClientProvider } from 'react-query'
-
-import {
-  fetchPipetteOffsetCalibrations,
-  getPipetteOffsetCalibrations,
-} from '../../../../redux/calibration'
+import { useAllPipetteOffsetCalibrationsQuery } from '@opentrons/react-api-client'
 import {
   mockPipetteOffsetCalibration1,
   mockPipetteOffsetCalibration2,
   mockPipetteOffsetCalibration3,
 } from '../../../../redux/calibration/pipette-offset/__fixtures__'
-import { useDispatchApiRequest } from '../../../../redux/robot-api'
-import { useRobot } from '../useRobot'
 import { usePipetteOffsetCalibrations } from '..'
 
-import type { DiscoveredRobot } from '../../../../redux/discovery/types'
-import type { DispatchApiRequestType } from '../../../../redux/robot-api'
+jest.mock('@opentrons/react-api-client')
 
-jest.mock('../../../../redux/calibration')
-jest.mock('../../../../redux/robot-api')
-jest.mock('../useRobot')
-
-const mockFetchPipetteOffsetCalibrations = fetchPipetteOffsetCalibrations as jest.MockedFunction<
-  typeof fetchPipetteOffsetCalibrations
+const mockUseAllPipetteOffsetCalibrationsQuery = useAllPipetteOffsetCalibrationsQuery as jest.MockedFunction<
+  typeof useAllPipetteOffsetCalibrationsQuery
 >
-const mockGetPipetteOffsetCalibrations = getPipetteOffsetCalibrations as jest.MockedFunction<
-  typeof getPipetteOffsetCalibrations
->
-const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
-  typeof useDispatchApiRequest
->
-const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 
-const store: Store<any> = createStore(jest.fn(), {})
-
-const ROBOT_NAME = 'otie'
+const CALIBRATION_DATA_POLL_MS = 5000
 
 describe('usePipetteOffsetCalibrations hook', () => {
-  let dispatchApiRequest: DispatchApiRequestType
   let wrapper: React.FunctionComponent<{}>
   beforeEach(() => {
-    dispatchApiRequest = jest.fn()
     const queryClient = new QueryClient()
     wrapper = ({ children }) => (
-      <Provider store={store}>
-        <QueryClientProvider client={queryClient}>
-          {children}
-        </QueryClientProvider>
-      </Provider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
-    mockUseDispatchApiRequest.mockReturnValue([dispatchApiRequest, []])
-    when(mockUseRobot)
-      .calledWith(ROBOT_NAME)
-      .mockReturnValue(({ status: 'chill' } as unknown) as DiscoveredRobot)
   })
   afterEach(() => {
     resetAllWhenMocks()
     jest.resetAllMocks()
   })
 
-  it('returns no pipette offset calibrations when given a null robot name', () => {
-    when(mockGetPipetteOffsetCalibrations)
-      .calledWith(undefined as any, null)
-      .mockReturnValue([])
+  it('returns empty array when no calibrations found', () => {
+    when(mockUseAllPipetteOffsetCalibrationsQuery)
+      .calledWith({ refetchInterval: CALIBRATION_DATA_POLL_MS })
+      .mockReturnValue(null as any)
 
-    const { result } = renderHook(() => usePipetteOffsetCalibrations(null), {
+    const { result } = renderHook(() => usePipetteOffsetCalibrations(), {
       wrapper,
     })
 
     expect(result.current).toEqual([])
-    expect(dispatchApiRequest).not.toBeCalled()
   })
 
-  it('returns pipette offset calibrations when given a robot name', () => {
-    when(mockGetPipetteOffsetCalibrations)
-      .calledWith(undefined as any, ROBOT_NAME)
-      .mockReturnValue([
-        mockPipetteOffsetCalibration1,
-        mockPipetteOffsetCalibration2,
-        mockPipetteOffsetCalibration3,
-      ])
+  it('returns pipette offset calibrations when calibrations found', () => {
+    when(mockUseAllPipetteOffsetCalibrationsQuery)
+      .calledWith({ refetchInterval: CALIBRATION_DATA_POLL_MS })
+      .mockReturnValue({
+        data: {
+          data: [
+            mockPipetteOffsetCalibration1,
+            mockPipetteOffsetCalibration2,
+            mockPipetteOffsetCalibration3,
+          ],
+        },
+      } as any)
 
-    const { result } = renderHook(
-      () => usePipetteOffsetCalibrations(ROBOT_NAME),
-      {
-        wrapper,
-      }
-    )
+    const { result } = renderHook(() => usePipetteOffsetCalibrations(), {
+      wrapper,
+    })
 
     expect(result.current).toEqual([
       mockPipetteOffsetCalibration1,
       mockPipetteOffsetCalibration2,
       mockPipetteOffsetCalibration3,
     ])
-    expect(dispatchApiRequest).toBeCalledWith(
-      mockFetchPipetteOffsetCalibrations(ROBOT_NAME)
-    )
   })
 })

--- a/app/src/organisms/Devices/hooks/usePipetteOffsetCalibrations.ts
+++ b/app/src/organisms/Devices/hooks/usePipetteOffsetCalibrations.ts
@@ -1,15 +1,16 @@
-
 import { useAllPipetteOffsetCalibrationsQuery } from '@opentrons/react-api-client'
 
 import type { PipetteOffsetCalibration } from '../../../redux/calibration/types'
 
 const CALIBRATION_DATA_POLL_MS = 5000
 
-export function usePipetteOffsetCalibrations(
-): PipetteOffsetCalibration[] | null {
-  const pipetteOffsetCalibrations = useAllPipetteOffsetCalibrationsQuery({
-    refetchInterval: CALIBRATION_DATA_POLL_MS,
-  })?.data?.data ?? []
+export function usePipetteOffsetCalibrations():
+  | PipetteOffsetCalibration[]
+  | null {
+  const pipetteOffsetCalibrations =
+    useAllPipetteOffsetCalibrationsQuery({
+      refetchInterval: CALIBRATION_DATA_POLL_MS,
+    })?.data?.data ?? []
 
   return pipetteOffsetCalibrations
 }

--- a/app/src/organisms/Devices/hooks/usePipetteOffsetCalibrations.ts
+++ b/app/src/organisms/Devices/hooks/usePipetteOffsetCalibrations.ts
@@ -1,32 +1,15 @@
-import React from 'react'
-import { useSelector } from 'react-redux'
 
-import {
-  fetchPipetteOffsetCalibrations,
-  getPipetteOffsetCalibrations,
-} from '../../../redux/calibration'
-import { useDispatchApiRequest } from '../../../redux/robot-api'
-import { useRobot } from '.'
+import { useAllPipetteOffsetCalibrationsQuery } from '@opentrons/react-api-client'
 
 import type { PipetteOffsetCalibration } from '../../../redux/calibration/types'
-import type { State } from '../../../redux/types'
+
+const CALIBRATION_DATA_POLL_MS = 5000
 
 export function usePipetteOffsetCalibrations(
-  robotName: string | null = null
 ): PipetteOffsetCalibration[] | null {
-  const [dispatchRequest] = useDispatchApiRequest()
-
-  const robot = useRobot(robotName)
-
-  const pipetteOffsetCalibrations = useSelector((state: State) =>
-    getPipetteOffsetCalibrations(state, robotName)
-  )
-
-  React.useEffect(() => {
-    if (robotName != null) {
-      dispatchRequest(fetchPipetteOffsetCalibrations(robotName))
-    }
-  }, [dispatchRequest, robotName, robot?.status])
+  const pipetteOffsetCalibrations = useAllPipetteOffsetCalibrationsQuery({
+    refetchInterval: CALIBRATION_DATA_POLL_MS,
+  })?.data?.data ?? []
 
   return pipetteOffsetCalibrations
 }

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
@@ -50,7 +50,7 @@ export function CalibrationDataDownload({
   const isOT3 = useIsOT3(robotName)
   // wait for robot request to resolve instead of using name directly from params
   const deckCalibrationData = useDeckCalibrationData(robot?.name)
-  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
+  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations()
   const tipLengthCalibrations = useTipLengthCalibrations(robot?.name)
 
   const downloadIsPossible =

--- a/app/src/organisms/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
@@ -12,7 +12,6 @@ import { StyledText } from '../../atoms/text'
 import {
   useIsOT3,
   usePipetteOffsetCalibrations,
-  useRobot,
 } from '../../organisms/Devices/hooks'
 import { PipetteOffsetCalibrationItems } from './CalibrationDetails/PipetteOffsetCalibrationItems'
 
@@ -31,11 +30,9 @@ export function RobotSettingsPipetteOffsetCalibration({
 }: RobotSettingsPipetteOffsetCalibrationProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
-  const robot = useRobot(robotName)
   const isOT3 = useIsOT3(robotName)
 
-  // wait for robot request to resolve instead of using name directly from params
-  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations(robot?.name)
+  const pipetteOffsetCalibrations = usePipetteOffsetCalibrations()
 
   return (
     <Flex

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -175,9 +175,7 @@ describe('CalibrationDataDownload', () => {
   })
 
   it('renders disabled button when pipettes are not calibrated', () => {
-    when(mockUsePipetteOffsetCalibrations)
-      .calledWith()
-      .mockReturnValue([])
+    when(mockUsePipetteOffsetCalibrations).calledWith().mockReturnValue([])
     const [{ getByRole, getByText }] = render()
     getByText('No calibration data available.')
 
@@ -189,9 +187,7 @@ describe('CalibrationDataDownload', () => {
 
   it('renders disabled button for OT-3 when pipettes are not calibrated', () => {
     when(mockUseIsOT3).calledWith('otie').mockReturnValue(true)
-    when(mockUsePipetteOffsetCalibrations)
-      .calledWith()
-      .mockReturnValue([])
+    when(mockUsePipetteOffsetCalibrations).calledWith().mockReturnValue([])
     const [{ getByRole, queryByText }] = render()
     queryByText(
       `For the robot to move accurately and precisely, you need to calibrate it. Pipette and gripper calibration is an automated process that uses a calibration probe or pin.`

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -87,7 +87,7 @@ describe('CalibrationDataDownload', () => {
       })
     when(mockUseIsOT3).calledWith('otie').mockReturnValue(false)
     when(mockUsePipetteOffsetCalibrations)
-      .calledWith(mockConnectableRobot.name)
+      .calledWith()
       .mockReturnValue([
         mockPipetteOffsetCalibration1,
         mockPipetteOffsetCalibration2,
@@ -176,7 +176,7 @@ describe('CalibrationDataDownload', () => {
 
   it('renders disabled button when pipettes are not calibrated', () => {
     when(mockUsePipetteOffsetCalibrations)
-      .calledWith(mockConnectableRobot.name)
+      .calledWith()
       .mockReturnValue([])
     const [{ getByRole, getByText }] = render()
     getByText('No calibration data available.')
@@ -190,7 +190,7 @@ describe('CalibrationDataDownload', () => {
   it('renders disabled button for OT-3 when pipettes are not calibrated', () => {
     when(mockUseIsOT3).calledWith('otie').mockReturnValue(true)
     when(mockUsePipetteOffsetCalibrations)
-      .calledWith(mockConnectableRobot.name)
+      .calledWith()
       .mockReturnValue([])
     const [{ getByRole, queryByText }] = render()
     queryByText(

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
@@ -9,11 +9,9 @@ import {
   mockPipetteOffsetCalibration2,
   mockPipetteOffsetCalibration3,
 } from '../../../redux/calibration/pipette-offset/__fixtures__'
-import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import {
   useIsOT3,
   usePipetteOffsetCalibrations,
-  useRobot,
 } from '../../../organisms/Devices/hooks'
 
 import { RobotSettingsPipetteOffsetCalibration } from '../RobotSettingsPipetteOffsetCalibration'
@@ -28,7 +26,6 @@ const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUsePipetteOffsetCalibrations = usePipetteOffsetCalibrations as jest.MockedFunction<
   typeof usePipetteOffsetCalibrations
 >
-const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 const mockPipetteOffsetCalibrationItems = PipetteOffsetCalibrationItems as jest.MockedFunction<
   typeof PipetteOffsetCalibrationItems
 >
@@ -64,7 +61,6 @@ describe('RobotSettingsPipetteOffsetCalibration', () => {
       mockPipetteOffsetCalibration2,
       mockPipetteOffsetCalibration3,
     ])
-    mockUseRobot.mockReturnValue(mockConnectableRobot)
     mockPipetteOffsetCalibrationItems.mockReturnValue(
       <div>PipetteOffsetCalibrationItems</div>
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

removes the old redux logic and replaces it all with the useAllPipetteOffsetCalibrationsQuery hook from the react-api-client package

closes RAUT-369

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- replaces old redux logic with the `useAllPipetteOffsetCalibrationsQuery` in the `usePipetteOffsetCalibrations` hook
- updates all usages of `usePipetteOffsetCalibrations` to remove the now unnecessary robot name argument

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the code looks good and maybe give some of the touched components a once over to ensure the changes didn't break anything. As long as all CI tests are passing things should be good though

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

low - mid, simple change that touches a lot of files. Should be pretty safe as long as tests are passing though

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
