### PR TITLE
feat(hardware): add state messages that come from rear-panel

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
@@ -22,3 +22,5 @@ class BinaryMessageId(int, Enum):
     release_estop = 0x08
     engage_nsync_out = 0x09
     release_nsync_out = 0x0A
+    estop_state_change = 0x0B
+    estop_button_detection_change = 0x0C

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -122,8 +122,8 @@ class EnterBootloaderResponse(utils.BinarySerializable):
     message_id: utils.UInt16Field = utils.UInt16Field(
         BinaryMessageId.enter_bootloader_response
     )
-    success: utils.UInt8Field = utils.UInt8Field(0)
     length: utils.UInt16Field = utils.UInt16Field(1)
+    success: utils.UInt8Field = utils.UInt8Field(0)
 
 
 @dataclass
@@ -158,6 +158,29 @@ class ReleaseSyncOut(utils.BinarySerializable):
     lenght: utils.UInt16Field = utils.UInt16Field(0)
 
 
+@dataclass
+class EstopStateChange(utils.BinarySerializable):
+    """Request the version information from the device."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.estop_state_change
+    )
+    length: utils.UInt16Field = utils.UInt16Field(1)
+    engaged: utils.UInt8Field = utils.UInt8Field(0)
+
+
+@dataclass
+class EstopButtonDetectionChange(utils.BinarySerializable):
+    """Request the version information from the device."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.estop_button_detection_change
+    )
+    length: utils.UInt16Field = utils.UInt16Field(2)
+    aux1_detected: utils.UInt8Field = utils.UInt8Field(0)
+    aux2_detected: utils.UInt8Field = utils.UInt8Field(0)
+
+
 BinaryMessageDefinition = Union[
     Echo,
     Ack,
@@ -170,6 +193,8 @@ BinaryMessageDefinition = Union[
     ReleaseEstop,
     EngageSyncOut,
     ReleaseSyncOut,
+    EstopStateChange,
+    EstopButtonDetectionChange,
 ]
 
 

--- a/hardware/opentrons_hardware/scripts/usb_mon.py
+++ b/hardware/opentrons_hardware/scripts/usb_mon.py
@@ -1,0 +1,98 @@
+"""A script for sending CAN messages."""
+import asyncio
+import logging
+import argparse
+from logging.config import dictConfig
+from typing import Callable
+
+from opentrons_hardware.drivers.binary_usb import build
+
+from opentrons_hardware.drivers.binary_usb.bin_serial import SerialUsbDriver
+
+log = logging.getLogger(__name__)
+
+
+GetInputFunc = Callable[[str], str]
+OutputFunc = Callable[[str], None]
+
+
+class InvalidInput(Exception):
+    """Invalid input exception."""
+
+    pass
+
+
+async def listen_task(usb_driver: SerialUsbDriver) -> None:
+    """A task that listens for can messages.
+
+    Args:
+        usb_driver: Driver
+    Returns: Nothing.
+    """
+    async for message in usb_driver:
+        if message is not None:
+            log.info(f"Received <-- \traw: {message}")
+            print(f"Received <-- \traw: {message}")
+
+
+async def run_ui(driver: SerialUsbDriver) -> None:
+    """Run the UI."""
+    loop = asyncio.get_event_loop()
+    fut = asyncio.gather(loop.create_task(listen_task(driver)))
+    try:
+        await fut
+    except KeyboardInterrupt:
+        fut.cancel()
+    except asyncio.CancelledError:
+        pass
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Entry point for script."""
+    async with build.usb_driver() as driver:
+        await (run_ui(driver))
+
+
+def in_red(s: str) -> str:
+    """Return string formatted in red."""
+    return f"\033[1;31;40m{str(s)}\033[0m"
+
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "basic",
+            "filename": "/var/log/usb_mon.log",
+            "maxBytes": 5000000,
+            "level": logging.INFO,
+            "backupCount": 3,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["file_handler"],
+            "level": logging.INFO,
+        },
+    },
+}
+
+
+def main() -> None:
+    """Entry point."""
+    dictConfig(LOG_CONFIG)
+
+    parser = argparse.ArgumentParser(description="USB bus testing.")
+
+    args = parser.parse_args()
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The rear panel now sends messages when it detects a state change on its gpio pins so this PR adds some messages for the different states that could change now.

The first is a message that gets sent when estop line activation changes

The second message is sent when an estop button is added/removed from the system and which of the Aux ports it is attached to if it is attached.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
