### PR TITLE
ci(components): rebuild storybook components when app stories are added/modifed

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -7,12 +7,14 @@ on:
     paths:
       - 'Makefile'
       - 'components/**'
+      - 'app/**/*.stories.@(js|jsx|ts|tsx)'
       - 'webpack-config/**'
       - 'package.json'
       - '.github/workflows/components-test-build-deploy.yaml'
   push:
     paths:
       - 'components/**'
+      - 'app/**/*.stories.@(js|jsx|ts|tsx)'
       - 'webpack-config/**'
       - 'package.json'
       - '.github/workflows/components-test-build-deploy.yaml'


### PR DESCRIPTION
# Overview

When trying to look at ODD components in storybook I realized that we're not rebuilding our storybook components when we add app stories. This PR will trigger our storybook components to get rebuilt whenever we make changes to/add new app stories. 

# Risk assessment

Low