### PR TITLE
feat(hardware): add rear-panel messages for door switch state

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
@@ -25,4 +25,4 @@ class BinaryMessageId(int, Enum):
     estop_state_change = 0x0B
     estop_button_detection_change = 0x0C
     door_switch_state_request = 0x0D
-    door_switch_state_response = 0x0E
+    door_switch_state_info = 0x0E

--- a/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
@@ -24,3 +24,5 @@ class BinaryMessageId(int, Enum):
     release_nsync_out = 0x0A
     estop_state_change = 0x0B
     estop_button_detection_change = 0x0C
+    door_switch_state_request = 0x0D
+    door_switch_state_response = 0x0E

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -192,11 +192,11 @@ class DoorSwitchStateRequest(utils.BinarySerializable):
 
 
 @dataclass
-class DoorSwitchStateResponse(utils.BinarySerializable):
+class DoorSwitchStateInfo(utils.BinarySerializable):
     """Request the version information from the device."""
 
     message_id: utils.UInt16Field = utils.UInt16Field(
-        BinaryMessageId.door_switch_state_response
+        BinaryMessageId.door_switch_state_info
     )
     length: utils.UInt16Field = utils.UInt16Field(1)
     door_open: utils.UInt8Field = utils.UInt8Field(0)
@@ -217,7 +217,7 @@ BinaryMessageDefinition = Union[
     EstopStateChange,
     EstopButtonDetectionChange,
     DoorSwitchStateRequest,
-    DoorSwitchStateResponse,
+    DoorSwitchStateInfo,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -181,6 +181,27 @@ class EstopButtonDetectionChange(utils.BinarySerializable):
     aux2_detected: utils.UInt8Field = utils.UInt8Field(0)
 
 
+@dataclass
+class DoorSwitchStateRequest(utils.BinarySerializable):
+    """Request the version information from the device."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.door_switch_state_request
+    )
+    length: utils.UInt16Field = utils.UInt16Field(0)
+
+
+@dataclass
+class DoorSwitchStateResponse(utils.BinarySerializable):
+    """Request the version information from the device."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.door_switch_state_response
+    )
+    length: utils.UInt16Field = utils.UInt16Field(1)
+    door_open: utils.UInt8Field = utils.UInt8Field(0)
+
+
 BinaryMessageDefinition = Union[
     Echo,
     Ack,
@@ -195,6 +216,8 @@ BinaryMessageDefinition = Union[
     ReleaseSyncOut,
     EstopStateChange,
     EstopButtonDetectionChange,
+    DoorSwitchStateRequest,
+    DoorSwitchStateResponse,
 ]
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
 
If the firmware detects a door switch state change or if the hardware controller requests the firmware will send a DoorSwitchStateResponse message with a bool indicating whether the door is open or not
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
