### PR TITLE
fix(app): prefer newer offsets when proposing candidates from past runs

### DIFF
--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useHistoricRunDetails.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useHistoricRunDetails.test.tsx
@@ -47,14 +47,14 @@ describe('useHistoricRunDetails', () => {
     )
     const { result, waitFor } = renderHook(useHistoricRunDetails, { wrapper })
     await waitFor(() => result.current != null)
-    expect(result.current).toEqual([MOCK_RUN_EARLIER, MOCK_RUN_LATER])
+    expect(result.current).toEqual([MOCK_RUN_LATER, MOCK_RUN_EARLIER])
   })
   it('returns historical run details with newest first to specific host', async () => {
     when(mockUseAllRunsQuery)
       .calledWith({}, { hostname: 'fakeIp' })
       .mockReturnValue(
         mockSuccessQueryResults({
-          data: [MOCK_RUN_LATER, MOCK_RUN_EARLIER, MOCK_RUN_EARLIER],
+          data: [MOCK_RUN_EARLIER, MOCK_RUN_EARLIER, MOCK_RUN_LATER],
           links: {},
         })
       )
@@ -67,9 +67,9 @@ describe('useHistoricRunDetails', () => {
     )
     await waitFor(() => result.current != null)
     expect(result.current).toEqual([
-      MOCK_RUN_EARLIER,
-      MOCK_RUN_EARLIER,
       MOCK_RUN_LATER,
+      MOCK_RUN_EARLIER,
+      MOCK_RUN_EARLIER,
     ])
   })
 })

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
@@ -35,8 +35,8 @@ const mockFirstCandidate: OffsetCandidate = {
   location: { slotName: '1' },
   vector: { x: 1, y: 2, z: 3 },
   definitionUri: 'firstFakeDefURI',
-  createdAt: '2022-07-11T13:34:51.012179+00:00',
-  runCreatedAt: '2022-07-11T13:33:51.012179+00:00',
+  createdAt: '2022-05-11T13:34:51.012179+00:00',
+  runCreatedAt: '2022-05-11T13:33:51.012179+00:00',
 }
 const mockSecondCandidate: OffsetCandidate = {
   id: 'second_offset_id',
@@ -53,13 +53,15 @@ const mockThirdCandidate: OffsetCandidate = {
   location: { slotName: '3', moduleModel: 'heaterShakerModuleV1' },
   vector: { x: 7, y: 8, z: 9 },
   definitionUri: 'thirdFakeDefURI',
-  createdAt: '2022-05-11T13:34:51.012179+00:00',
-  runCreatedAt: '2022-05-11T13:33:51.012179+00:00',
+  createdAt: '2022-07-11T13:34:51.012179+00:00',
+  runCreatedAt: '2022-07-11T13:33:51.012179+00:00',
 }
 
 const mockFirstDupCandidate = {
   ...mockFirstCandidate,
   id: 'laterDuplicateOfFirstOffset',
+  createdAt: '2022-08-11T13:34:51.012179+00:00',
+  runCreatedAt: '2022-08-11T13:33:51.012179+00:00',
 }
 
 const mockRobotIp = 'fakeRobotIp'
@@ -135,7 +137,7 @@ describe('useOffsetCandidatesForAnalysis', () => {
     await waitFor(() => result.current != null)
     expect(result.current).toEqual([])
   })
-  it('returns candidates for each first match', async () => {
+  it('returns candidates for each first match with newest first', async () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <div>{children}</div>
     )
@@ -150,7 +152,7 @@ describe('useOffsetCandidatesForAnalysis', () => {
     await waitFor(() => result.current != null)
     expect(result.current).toEqual([
       {
-        ...mockFirstCandidate,
+        ...mockThirdCandidate,
         labwareDisplayName: getLabwareDisplayName(mockLabwareDef),
       },
       {
@@ -158,7 +160,7 @@ describe('useOffsetCandidatesForAnalysis', () => {
         labwareDisplayName: getLabwareDisplayName(mockLabwareDef),
       },
       {
-        ...mockThirdCandidate,
+        ...mockFirstCandidate,
         labwareDisplayName: getLabwareDisplayName(mockLabwareDef),
       },
     ])

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
@@ -71,10 +71,10 @@ describe('useOffsetCandidatesForAnalysis', () => {
     when(mockUseAllHistoricOffsets)
       .calledWith({ hostname: mockRobotIp })
       .mockReturnValue([
-        mockFirstCandidate,
         mockFirstDupCandidate,
-        mockSecondCandidate,
         mockThirdCandidate,
+        mockSecondCandidate,
+        mockFirstCandidate,
       ])
     when(mockUseAllHistoricOffsets).calledWith(null).mockReturnValue([])
     when(mockGetLabwareLocationCombos)
@@ -152,7 +152,7 @@ describe('useOffsetCandidatesForAnalysis', () => {
     await waitFor(() => result.current != null)
     expect(result.current).toEqual([
       {
-        ...mockThirdCandidate,
+        ...mockFirstDupCandidate,
         labwareDisplayName: getLabwareDisplayName(mockLabwareDef),
       },
       {
@@ -160,7 +160,7 @@ describe('useOffsetCandidatesForAnalysis', () => {
         labwareDisplayName: getLabwareDisplayName(mockLabwareDef),
       },
       {
-        ...mockFirstCandidate,
+        ...mockThirdCandidate,
         labwareDisplayName: getLabwareDisplayName(mockLabwareDef),
       },
     ])

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/useAllHistoricOffsets.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/useAllHistoricOffsets.ts
@@ -19,7 +19,7 @@ export function useAllHistoricOffsets(
           }))
           ?.sort(
             (a, b) =>
-              new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
           ) ?? []
     )
     .flat()

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/useHistoricRunDetails.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/useHistoricRunDetails.ts
@@ -11,6 +11,6 @@ export function useHistoricRunDetails(
     ? []
     : allHistoricRuns.data.sort(
         (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
       )
 }


### PR DESCRIPTION
# Overview

Repair inverse sorting of offset candidates from the apply historic offsets check boxes in the run creation slideouts.  This fix actually went into the old code during the 6.1 release process with PR #11502, but was never ported to the new logic, which had already branched behind a feature flag by that point.

Closes RQA-570

# Review Requests
 - follow repro steps in RQA-570:
   - perform LPC, apply recognizable offsets to all labware (e.g. {x: 1, y: 1, z: 1}), start and finish run
   - create another run of the same protocol from the Protocol List/Detail page (choose a robot slideout), perform LPC, apply new unique recognizable offsets (e.g. {x: 2, y: 2, z: 2}), start and finish run
   - return to the Protocol List/Detail page (choose a robot slideout), confirm that the "view data" link in the footer presents the newer set of offsets (the 2's instead of the 1's).

# Risk assessment
low