### PR TITLE
fix(app-shell): ot3 update manifests for ot3 spin

### DIFF
--- a/app-shell-odd/webpack.config.js
+++ b/app-shell-odd/webpack.config.js
@@ -13,9 +13,6 @@ const OUTPUT_PATH = path.join(__dirname, 'lib')
 
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
 
-const OT3_UPDATE_MANIFEST_URL =
-  'https://ot3-development.builds.opentrons.com/ot3-oe/releases.json'
-
 module.exports = async () => {
   const version = await versionForProject(project)
 
@@ -26,9 +23,6 @@ module.exports = async () => {
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
         _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
-        _DEFAULT_ROBOT_UPDATE_MANIFEST_URL_: JSON.stringify(
-          OT3_UPDATE_MANIFEST_URL
-        ),
       }),
     ],
   }

--- a/app-shell/src/buildroot/index.ts
+++ b/app-shell/src/buildroot/index.ts
@@ -127,7 +127,9 @@ export function registerBuildrootUpdate(dispatch: Dispatch): Dispatch {
 }
 
 export function getBuildrootUpdateUrls(): Promise<ReleaseSetUrls | null> {
-  const manifestUrl: string = getConfig('robotSystemUpdate').manifestUrls.OT2
+  const manifestUrl: string = getConfig('robotSystemUpdate').manifestUrls[
+    _DEFAULT_ROBOT_UPDATE_SOURCE_CONFIG_SELECTION_
+  ]
 
   return downloadManifest(manifestUrl, MANIFEST_CACHE)
     .then(manifest => {

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -42,7 +42,7 @@ export const DEFAULTS_V0: ConfigV0 = {
   },
 
   buildroot: {
-    manifestUrl: _DEFAULT_ROBOT_UPDATE_MANIFEST_URL_,
+    manifestUrl: OT2_MANIFEST_URL,
   },
 
   // logging config

--- a/app-shell/typings/global.d.ts
+++ b/app-shell/typings/global.d.ts
@@ -4,7 +4,7 @@ declare global {
   const _PKG_VERSION_: string
   const _PKG_PRODUCT_NAME_: string
   const _PKG_BUGS_URL_: string
-  const _DEFAULT_ROBOT_UPDATE_MANIFEST_URL_: string
+  const _DEFAULT_ROBOT_UPDATE_SOURCE_CONFIG_SELECTION_: 'OT3' | 'OT2'
 
   namespace NodeJS {
     export interface Global {

--- a/app-shell/webpack.config.js
+++ b/app-shell/webpack.config.js
@@ -13,12 +13,8 @@ const OUTPUT_PATH = path.join(__dirname, 'lib')
 
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
 
-const OT2_UPDATE_MANIFEST_URL =
-  'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json'
-const OT3_UPDATE_MANIFEST_URL =
-  'https://ot3-development.builds.opentrons.com/ot3-oe/releases.json'
-const manifestUrl = () =>
-  project === 'robot-stack' ? OT2_UPDATE_MANIFEST_URL : OT3_UPDATE_MANIFEST_URL
+const robotUpdateConfigElement = () =>
+  project === 'robot-stack' ? 'OT2' : 'OT3'
 
 module.exports = async () => {
   const version = await versionForProject(project)
@@ -30,7 +26,9 @@ module.exports = async () => {
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
         _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
-        _DEFAULT_ROBOT_UPDATE_MANIFEST_URL_: JSON.stringify(manifestUrl()),
+        _DEFAULT_ROBOT_UPDATE_SOURCE_CONFIG_SELECTION_: JSON.stringify(
+          robotUpdateConfigElement()
+        ),
       }),
     ],
   }

--- a/scripts/setup-global-mocks.js
+++ b/scripts/setup-global-mocks.js
@@ -2,8 +2,7 @@
 
 global._PKG_VERSION_ = '0.0.0-test'
 global._OPENTRONS_PROJECT_ = 'robot-stack'
-global._DEFAULT_ROBOT_UPDATE_MANIFEST_URL_ =
-  'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json'
+global._DEFAULT_ROBOT_UPDATE_SOURCE_CONFIG_SELECTION_ = 'OT2'
 
 // electron and native stuff that will break in unit tests
 jest.mock('electron')


### PR DESCRIPTION
Since aadcb1c6cfdedcfcab1c36b7d19c4532c7daef75, we had been setting the appropriate system update manifest for a spin of the desktop app (i.e. the production variant that only knows about OT-2s or the special variant that is versioned differently for internal releases that knows about OT-3s) via a webpack injection that set config default values for the pre-existing config element for the manifest.

Then, 4de19cfa276b892f2df74c2e71126b6a3ba4b010 refactored this to have both manifest URLs side-by-side in config. However, it didn't reestablish a similar mechanism to aadcb1c6, and so all desktop app spins were hardcoded in logic to just check for OT2 updates.

This commit alters the webpack config to inject the appropriate config element to look up depending on spin, which gets back to previous behavior but definitely does not solve the underlying issue.

## Review requests
- is this an ok approach or do we want to fix it more systematically now?

## Risks
Medium, it's about downloading updates but it's also about the absolute first stage of the process so it's easy to see problems

## Testing
- [x] Run the OT-3 spin and test that it downloads an OT-3 system build
- [x] Run the OT-2 spin and test that it downloads an OT-2 system build