### PR TITLE
feat(api): integrate rear panel door switch control

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -87,6 +87,12 @@ from opentrons_hardware.firmware_bindings.constants import (
     USBTarget,
     FirmwareTarget,
 )
+
+from opentrons_hardware.firmware_bindings.binary_constants import BinaryMessageId
+from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
+    BinaryMessageDefinition,
+    DoorSwitchStateInfo,
+)
 from opentrons_hardware import firmware_update
 
 
@@ -104,6 +110,7 @@ from opentrons.hardware_control.types import (
     PipetteSubType,
     UpdateStatus,
     mount_to_subsystem,
+    DoorState,
 )
 from opentrons.hardware_control.errors import (
     MustHomeError,
@@ -123,6 +130,8 @@ from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_pass,
     liquid_probe,
 )
+from opentrons_hardware.hardware_control.rear_panel_settings import get_door_state
+
 from opentrons_hardware.drivers.gpio import OT3GPIO, RemoteOT3GPIO
 from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons_shared_data.gripper.gripper_definition import GripForceProfile
@@ -1186,3 +1195,24 @@ class OT3Controller:
             await self._gpio_dev.activate_nsync_out()
         else:
             self._gpio_dev.activate_nsync_out()
+
+    async def door_state(self) -> DoorState:
+        door_open = await get_door_state(self._usb_messenger)
+        return DoorState.OPEN if door_open else DoorState.CLOSED
+
+    def add_door_state_listener(self, callback: Callable[[DoorState], None]) -> None:
+        def _door_listener(msg: BinaryMessageDefinition) -> None:
+            door_state = (
+                DoorState.OPEN
+                if cast(DoorSwitchStateInfo, msg).door_open.value
+                else DoorState.CLOSED
+            )
+            callback(door_state)
+
+        if self._usb_messenger is not None:
+            self._usb_messenger.add_listener(
+                _door_listener,
+                lambda message_id: bool(
+                    message_id == BinaryMessageId.door_switch_state_info
+                ),
+            )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -297,6 +297,9 @@ class OT3API(
             api_instance, board_revision=backend.board_revision
         )
         backend.module_controls = module_controls
+        door_state = await backend.door_state()
+        api_instance._update_door_state(door_state)
+        backend.add_door_state_listener(api_instance._update_door_state)
         checked_loop.create_task(backend.watch(loop=checked_loop))
         backend.initialized = True
         return api_instance

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -105,7 +105,9 @@ def stop_server() -> None:
 
 
 def build_api() -> ThreadManager[HardwareControlAPI]:
-    tm = ThreadManager(HCApi.build_hardware_controller)
+    tm = ThreadManager(
+        HCApi.build_hardware_controller, use_usb_bus=ff.rear_panel_integration()
+    )
     tm.managed_thread_ready_blocking()
     return tm
 

--- a/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
@@ -1,0 +1,48 @@
+"""Utilities for updating the rear-panel settings."""
+import logging
+import asyncio
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger
+from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
+    BinaryMessageDefinition,
+    DoorSwitchStateRequest,
+    DoorSwitchStateInfo,
+)
+from opentrons_hardware.firmware_bindings.binary_constants import BinaryMessageId
+from typing import Callable, cast, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+def _create_listener(
+    event: asyncio.Event, responses: List[BinaryMessageDefinition]
+) -> Callable[[BinaryMessageDefinition], None]:
+    def _listener(message: BinaryMessageDefinition) -> None:
+        responses.append(message)
+        event.set()
+
+    return _listener
+
+
+async def get_door_state(messenger: Optional[BinaryMessenger]) -> bool:
+    """Returns true if the door is currently open."""
+    if messenger is None:
+        # the EVT bots don't have switches so just return that the door is closed
+        return False
+    event = asyncio.Event()
+    responses: List[BinaryMessageDefinition] = list()
+    listener = _create_listener(event, responses)
+    messenger.add_listener(
+        listener,
+        lambda message_id: bool(message_id == BinaryMessageId.door_switch_state_info),
+    )
+    await messenger.send(DoorSwitchStateRequest())
+    try:
+        await asyncio.wait_for(event.wait(), 1.0)
+    except asyncio.TimeoutError:
+        log.error("door switch request timed out before response")
+    finally:
+        messenger.remove_listener(listener)
+    if len(responses) > 0:
+        return bool(cast(DoorSwitchStateInfo, responses[0]).door_open.value)
+    # in case of timeout (no messages received) just return closed
+    return False


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR uses the usb connection to the rear panel to set the door_state on startup.
It also adds a listener to the backend so when a new door switch state is sent from the rear-panel it automatically updates the api's door state value using its _update_door_state method.
the update_door_state will also notify any hardware event listeners subscribed to that change.


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Tested using OT3 repl and calling 'api.door_state' while manipulating the door_switch 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
