### PR TITLE
fix(app): decouple checking pipette from state of background fetch

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -6,29 +6,29 @@ import { SmallButton } from '../../atoms/buttons/OnDeviceDisplay'
 interface CheckPipetteButtonProps {
   proceedButtonText: string
   setFetching: React.Dispatch<React.SetStateAction<boolean>>
+  isFetching: boolean
   proceed: () => void
   isOnDevice: boolean | null
 }
 export const CheckPipetteButton = (
   props: CheckPipetteButtonProps
 ): JSX.Element => {
-  const { proceedButtonText, proceed, setFetching, isOnDevice } = props
-  const { refetch, isFetching } = usePipettesQuery(
+  const {
+    proceedButtonText,
+    proceed,
+    setFetching,
+    isFetching,
+    isOnDevice,
+  } = props
+  const { refetch } = usePipettesQuery(
     { refresh: true },
     {
       enabled: false,
-      onSuccess: () => {
-        proceed()
-      },
       onSettled: () => {
         setFetching(false)
       },
     }
   )
-
-  React.useEffect(() => {
-    setFetching(isFetching)
-  }, [isFetching, setFetching])
 
   return isOnDevice ? (
     <SmallButton
@@ -36,8 +36,11 @@ export const CheckPipetteButton = (
       buttonText={proceedButtonText}
       buttonType="default"
       onClick={() => {
+        setFetching(true)
         refetch()
-          .then(() => {})
+          .then(() => {
+            proceed()
+          })
           .catch(() => {})
       }}
     />

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -110,6 +110,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           proceedButtonText={capitalize(t('shared:continue'))}
           proceed={proceed}
           setFetching={setFetching}
+          isFetching={isFetching}
         />
       }
     />

--- a/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
@@ -100,6 +100,7 @@ export const MountPipette = (props: MountPipetteProps): JSX.Element => {
           proceed={proceed}
           proceedButtonText={t('continue')}
           setFetching={setFetching}
+          isFetching={isFetching}
         />
       }
     />

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -123,6 +123,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
             flowType === FLOWS.ATTACH ? 'try_again' : 'attach_and_retry'
           )}
           setFetching={setFetching}
+          isFetching={isFetching}
           isOnDevice={isOnDevice}
         />
       </>

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
@@ -22,6 +22,7 @@ describe('CheckPipetteButton', () => {
       proceedButtonText: 'continue',
       setFetching: jest.fn(),
       isOnDevice: false,
+      isFetching: false,
     }
     mockUsePipettesQuery.mockReturnValue({
       refetch,
@@ -34,7 +35,6 @@ describe('CheckPipetteButton', () => {
     const { getByRole } = render(props)
     getByRole('button', { name: 'continue' }).click()
     expect(refetch).toHaveBeenCalled()
-    expect(props.setFetching).toHaveBeenCalled()
   })
   it('renders button for on device display', () => {
     props = {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
@@ -36,6 +36,10 @@ describe('CheckPipetteButton', () => {
     getByRole('button', { name: 'continue' }).click()
     expect(refetch).toHaveBeenCalled()
   })
+  it('button is disabled when fetching is true', () => {
+    const { getByRole } = render({ ...props, isFetching: true })
+    expect(getByRole('button', { name: 'continue' })).toBeDisabled()
+  })
   it('renders button for on device display', () => {
     props = {
       ...props,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -159,7 +159,7 @@ describe('PipetteWizardFlows', () => {
     mockGetIsOnDevice.mockReturnValue(false)
   })
   it('renders the correct information, calling the correct commands for the calibration flow', async () => {
-    const { getByText, getByRole, getByLabelText } = render(props)
+    const { getByText, getByRole } = render(props)
     //  first page
     getByText('Recalibrate Left Pipette')
     getByText('Before you begin')

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   useCreateRunMutation,
   useStopRunMutation,
+  useDeleteRunMutation,
   usePipettesQuery,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
@@ -21,6 +22,7 @@ import {
 import * as RobotApi from '../../../redux/robot-api'
 import { getIsOnDevice } from '../../../redux/config'
 import { useCloseCurrentRun } from '../../ProtocolUpload/hooks'
+import { useRunStatus } from '../../RunTimeControl/hooks'
 import { getPipetteWizardSteps } from '../getPipetteWizardSteps'
 import { ExitModal } from '../ExitModal'
 import { FLOWS, SECTIONS } from '../constants'
@@ -35,6 +37,7 @@ jest.mock('../../../resources/runs/hooks')
 jest.mock('@opentrons/react-api-client')
 jest.mock('../ExitModal')
 jest.mock('../../ProtocolUpload/hooks')
+jest.mock('../../RunTimeControl/hooks')
 jest.mock('../../../redux/robot-api')
 jest.mock('../UnskippableModal')
 jest.mock('../../../redux/config')
@@ -54,11 +57,17 @@ const mockUseChainRunCommands = useChainRunCommands as jest.MockedFunction<
 const mockUseCreateRunMutation = useCreateRunMutation as jest.MockedFunction<
   typeof useCreateRunMutation
 >
+const mockUseDeleteRunMutation = useDeleteRunMutation as jest.MockedFunction<
+  typeof useDeleteRunMutation
+>
 const mockUseStopRunMutation = useStopRunMutation as jest.MockedFunction<
   typeof useStopRunMutation
 >
 const mockUseCloseCurrentRun = useCloseCurrentRun as jest.MockedFunction<
   typeof useCloseCurrentRun
+>
+const mockUseRunStatus = useRunStatus as jest.MockedFunction<
+  typeof useRunStatus
 >
 const mockExitModal = ExitModal as jest.MockedFunction<typeof ExitModal>
 const mockUnskippableModal = UnskippableModal as jest.MockedFunction<
@@ -84,6 +93,7 @@ describe('PipetteWizardFlows', () => {
   let mockCreateRun: jest.Mock
   let mockStopRun: jest.Mock
   let mockCloseCurrentRun: jest.Mock
+  let mockDeleteRun: jest.Mock
   let refetchPromise: Promise<void>
   let mockRefetch: jest.Mock
   let mockChainRunCommands: jest.Mock
@@ -98,6 +108,7 @@ describe('PipetteWizardFlows', () => {
     mockCreateRun = jest.fn()
     mockStopRun = jest.fn()
     mockCloseCurrentRun = jest.fn()
+    mockDeleteRun = jest.fn()
     refetchPromise = Promise.resolve()
     mockRefetch = jest.fn(() => refetchPromise)
     mockChainRunCommands = jest.fn().mockImplementation(() => Promise.resolve())
@@ -106,6 +117,9 @@ describe('PipetteWizardFlows', () => {
       refetch: mockRefetch,
     } as any)
     mockUseStopRunMutation.mockReturnValue({ stopRun: mockStopRun } as any)
+    mockUseDeleteRunMutation.mockReturnValue({
+      deleteRun: mockDeleteRun,
+    } as any)
     mockExitModal.mockReturnValue(<div>mock exit modal</div>)
     mockUseCreateRunMutation.mockReturnValue({
       createRun: mockCreateRun,
@@ -117,6 +131,7 @@ describe('PipetteWizardFlows', () => {
     mockUseCloseCurrentRun.mockReturnValue({
       closeCurrenRun: mockCloseCurrentRun,
     } as any)
+    mockUseRunStatus.mockReturnValue('idle')
     mockGetPipetteWizardSteps.mockReturnValue([
       {
         section: SECTIONS.BEFORE_BEGINNING,
@@ -144,7 +159,7 @@ describe('PipetteWizardFlows', () => {
     mockGetIsOnDevice.mockReturnValue(false)
   })
   it('renders the correct information, calling the correct commands for the calibration flow', async () => {
-    const { getByText, getByRole } = render(props)
+    const { getByText, getByRole, getByLabelText } = render(props)
     //  first page
     getByText('Recalibrate Left Pipette')
     getByText('Before you begin')
@@ -208,17 +223,18 @@ describe('PipetteWizardFlows', () => {
     const complete = getByRole('button', { name: 'Complete calibration' })
     fireEvent.click(complete)
     await waitFor(() => {
-      expect(mockChainRunCommands).toHaveBeenCalledWith(
-        [
-          {
-            commandType: 'home',
-            params: {},
-          },
-        ],
-        false
-      )
+      //  TODO(sb, 3/21/23): rewire this when home issue is sorted
+      // expect(mockChainRunCommands).toHaveBeenCalledWith(
+      //   [
+      //     {
+      //       commandType: 'home',
+      //       params: {},
+      //     },
+      //   ],
+      //   false
+      // )
       //  TODO(jr, 11/2/22): wire this up when stop run logic is figured out
-      // expect(mockStopRun).toHaveBeenCalled()
+      expect(mockStopRun).toHaveBeenCalled()
     })
     //  last page
     //  TODO(jr, 11/2/22): wire this up when stop run logic is figured out
@@ -628,17 +644,18 @@ describe('PipetteWizardFlows', () => {
       'Unlatch the calibration probe, remove it from the pipette nozzle, and return it to its storage location.'
     )
     getByRole('button', { name: 'Complete calibration' }).click()
-    await waitFor(() => {
-      expect(mockChainRunCommands).toHaveBeenCalledWith(
-        [
-          {
-            commandType: 'home',
-            params: {},
-          },
-        ],
-        false
-      )
-    })
+    //  TODO(sb, 3/21/23): rewire this when home issue is sorted
+    // await waitFor(() => {
+    //   expect(mockChainRunCommands).toHaveBeenCalledWith(
+    //     [
+    //       {
+    //         commandType: 'home',
+    //         params: {},
+    //       },
+    //     ],
+    //     false
+    //   )
+    // })
   })
   it('renders the unskippable modal when you try to exit out of a 96 channel detach flow from a the detach pipette unskippable page', async () => {
     mockUsePipettesQuery.mockReturnValue({


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
We can't rely on the `react-query` `isFetching` state to tell us when this specific instance of a refetch is happening. This was causing a loading state to flash on the attach and detach pages and the `proceed` function to happen unexpectedly.
# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
Run through the attach or detach flows on OT-3, verify that the attach/detach screen does not move in and out of a loading state intermittently. It should have a loading state only when you press the button and wait for a result.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Move `proceed` to `onClick` handler. Decouple local pending state from query pending state since it refetches frequently.

This PR also temporarily removes the `home` command when closing a pipette flow. This is to unblock ABR testers while RSS looks into an issue that is causing these commands to hang.

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
