### PR TITLE
fix(app): move to next screen only when check pipette button ispressed

### DIFF
--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -31,15 +31,15 @@ export function CheckPipettesButton(
     { refresh: true },
     {
       enabled: false,
-      onSuccess: () => {
-        onDone?.()
-      },
+      onSuccess: () => {},
       onSettled: () => {},
     }
   )
   const handleClick = (): void => {
     refetchPipettes()
-      .then(() => {})
+      .then(() => {
+        onDone?.()
+      })
       .catch(() => {})
   }
   const icon = (

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -31,8 +31,6 @@ export function CheckPipettesButton(
     { refresh: true },
     {
       enabled: false,
-      onSuccess: () => {},
-      onSettled: () => {},
     }
   )
   const handleClick = (): void => {

--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -27,13 +27,18 @@ export function CheckPipettesButton(
 ): JSX.Element | null {
   const { onDone, children, actualPipette } = props
   const { t } = useTranslation('change_pipette')
-  const { isFetching: isPending, refetch: refetchPipettes } = usePipettesQuery(
+  const [isPending, setIsPending] = React.useState(false)
+  const { refetch: refetchPipettes } = usePipettesQuery(
     { refresh: true },
     {
       enabled: false,
+      onSettled: () => {
+        setIsPending(false)
+      },
     }
   )
   const handleClick = (): void => {
+    setIsPending(true)
     refetchPipettes()
       .then(() => {
         onDone?.()

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -78,7 +78,6 @@ describe('CheckPipettesButton', () => {
     const refetch = jest.fn(() => Promise.resolve())
     mockUsePipettesQuery.mockReturnValue({
       refetch,
-      isFetching: true,
     } as any)
     props = {
       robotName: 'otie',
@@ -86,6 +85,8 @@ describe('CheckPipettesButton', () => {
       actualPipette: MOCK_ACTUAL_PIPETTE,
     }
     const { getByLabelText } = render(props)
+    const btn = getByLabelText('Confirm')
+    fireEvent.click(btn)
     expect(getByLabelText('Confirm')).toBeDisabled()
   })
 
@@ -104,5 +105,6 @@ describe('CheckPipettesButton', () => {
     getByText('btn text')
     fireEvent.click(btn)
     expect(refetch).toHaveBeenCalled()
+    expect(getByLabelText('Confirm')).toBeDisabled()
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
We can't rely on the `react-query` `isFetching` state to tell us when this specific instance of a refetch is happening. This was causing a loading state to flash on the attach and detach pages and the `onDone` function to happen unexpectedly.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
Run through the attach or detach flows on OT-2, verify that the check pipette button does not move in and out of a loading state intermittently. It should have a loading state only when you press the button and wait for a result.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Move `onDone` to `onClick` handler. Decouple local pending state from query pending state since it refetches frequently.

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

