### PR TITLE
feat(odd): liquids to Protocol Setup

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -163,5 +163,7 @@
   "view_module_setup_instructions": "View module setup instructions",
   "deck_map": "Deck Map",
   "setup_instructions": "Setup Instructions",
-  "labware_latch_instructions": "To add labware to the Heater-Shaker Module, use the labware latch in the controls to the right."
+  "labware_latch_instructions": "To add labware to the Heater-Shaker Module, use the labware latch in the controls to the right.",
+  "liquids_not_in_setup": "Liquids not in setup",
+  "initial_liquids_num": "{{num}} initial liquids"
 }

--- a/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
@@ -87,7 +87,7 @@ export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
           </tr>
         </thead>
         <tbody>
-          {labwareByLiquidId[liquid.id].map((labware, index) => {
+          {labwareByLiquidId[liquid.id].map(labware => {
             const { slotName, labwareName } = getSlotLabwareName(
               labware.labwareId,
               commands

--- a/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
+import {
+  COLORS,
+  Flex,
+  SPACING,
+  TYPOGRAPHY,
+  BORDERS,
+  WRAP,
+  Icon,
+  DIRECTION_ROW,
+} from '@opentrons/components'
+import { MICRO_LITERS } from '@opentrons/shared-data'
+import { StyledText } from '../../atoms/text'
+import { LiquidsLabwareDetailsModal } from '../Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal'
+import { getSlotLabwareName } from '../Devices/ProtocolRun/utils/getSlotLabwareName'
+import { getTotalVolumePerLiquidId } from '../Devices/ProtocolRun/SetupLiquids/utils'
+import type { RunTimeCommand } from '@opentrons/shared-data'
+import type { LabwareByLiquidId, ParsedLiquid } from '@opentrons/api-client'
+
+const Table = styled('table')`
+  table-layout: ${SPACING.spacingAuto};
+  width: 100%;
+  border-spacing: 0 ${BORDERS.size_two};
+  text-align: ${TYPOGRAPHY.textAlignLeft};
+  color: ${COLORS.darkBlack_ninety};
+`
+const TableHeader = styled('th')`
+  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
+  font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+  font-size: ${TYPOGRAPHY.fontSize22};
+  line-height: ${TYPOGRAPHY.lineHeight28};
+  padding: 0 ${SPACING.spacing5} ${SPACING.spacing3} ${SPACING.spacing5};
+`
+const TableRow = styled('tr')`
+  height: 5.75rem;
+  opacity: 90%;
+`
+const TableDatum = styled('td')`
+  z-index: 2;
+  padding: ${SPACING.spacing3} ${SPACING.spacingM};
+  background-color: ${COLORS.light_two};
+  font-size: ${TYPOGRAPHY.fontSize22};
+  white-space: break-spaces;
+  text-overflow: ${WRAP};
+  &:first-child {
+    border-top-left-radius: ${BORDERS.size_three};
+    border-bottom-left-radius: ${BORDERS.size_three};
+    width: 20%;
+  }
+  &:last-child {
+    border-top-right-radius: ${BORDERS.size_three};
+    border-bottom-right-radius: ${BORDERS.size_three};
+  }
+`
+
+interface LiquidDetailsProps {
+  liquid: ParsedLiquid
+  labwareByLiquidId: LabwareByLiquidId
+  runId: string
+  commands?: RunTimeCommand[]
+}
+
+export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
+  const { liquid, labwareByLiquidId, runId, commands } = props
+  const { t } = useTranslation('protocol_setup')
+  const [labwareIdModal, setLabwareId] = React.useState<string | null>(null)
+  return (
+    <Flex marginTop={SPACING.spacing5}>
+      {labwareIdModal != null && (
+        <LiquidsLabwareDetailsModal
+          labwareId={labwareIdModal}
+          liquidId={liquid.id}
+          runId={runId}
+          closeModal={() => setLabwareId(null)}
+        />
+      )}
+      <Table>
+        <thead>
+          <tr>
+            <TableHeader>{t('location')}</TableHeader>
+            <TableHeader>{t('labware_name')}</TableHeader>
+            <TableHeader>{t('volume')}</TableHeader>
+          </tr>
+        </thead>
+        <tbody>
+          {labwareByLiquidId[liquid.id].map((labware, index) => {
+            const { slotName, labwareName } = getSlotLabwareName(
+              labware.labwareId,
+              commands
+            )
+            return (
+              <TableRow
+                key={index}
+                aria-label={`LiquidDetails_${liquid.id}`}
+                onClick={() => setLabwareId(labware.labwareId)}
+              >
+                <TableDatum>
+                  <Flex>
+                    <Flex
+                      padding="0.375rem"
+                      textAlign={TYPOGRAPHY.textAlignLeft}
+                      borderRadius={BORDERS.size_three}
+                      border={`3px solid ${COLORS.darkBlackEnabled}`}
+                      fontSize={TYPOGRAPHY.fontSize20}
+                      fontWeight={700}
+                    >
+                      {slotName}
+                    </Flex>
+                  </Flex>
+                </TableDatum>
+                <TableDatum>
+                  <StyledText lineHeight={TYPOGRAPHY.lineHeight28}>
+                    {labwareName}
+                  </StyledText>
+                </TableDatum>
+
+                <TableDatum>
+                  <Flex flexDirection={DIRECTION_ROW}>
+                    <Flex
+                      height="2.75rem"
+                      padding={`${SPACING.spacing3} 0.75rem`}
+                      width="max-content"
+                      alignItems={TYPOGRAPHY.textAlignCenter}
+                      marginRight={SPACING.spacingAuto}
+                    >
+                      {getTotalVolumePerLiquidId(liquid.id, labwareByLiquidId)}{' '}
+                      {MICRO_LITERS}
+                    </Flex>
+                    <Icon name="chevron-right" height="3rem" />
+                  </Flex>
+                </TableDatum>
+              </TableRow>
+            )
+          })}
+        </tbody>
+      </Table>
+    </Flex>
+  )
+}

--- a/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
@@ -31,7 +31,7 @@ const TableHeader = styled('th')`
   font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
   font-size: ${TYPOGRAPHY.fontSize22};
   line-height: ${TYPOGRAPHY.lineHeight28};
-  padding: 0 ${SPACING.spacing5} ${SPACING.spacing3} ${SPACING.spacing5};
+  padding: 0 ${SPACING.spacing5} ${SPACING.spacing3};
 `
 const TableRow = styled('tr')`
   height: 5.75rem;
@@ -65,7 +65,9 @@ interface LiquidDetailsProps {
 export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
   const { liquid, labwareByLiquidId, runId, commands } = props
   const { t } = useTranslation('protocol_setup')
-  const [labwareIdModal, setLabwareId] = React.useState<string | null>(null)
+  const [labwareIdModal, setLabwareIdModal] = React.useState<string | null>(
+    null
+  )
   return (
     <Flex marginTop={SPACING.spacing5}>
       {labwareIdModal != null && (
@@ -73,7 +75,7 @@ export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
           labwareId={labwareIdModal}
           liquidId={liquid.id}
           runId={runId}
-          closeModal={() => setLabwareId(null)}
+          closeModal={() => setLabwareIdModal(null)}
         />
       )}
       <Table>
@@ -92,9 +94,9 @@ export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
             )
             return (
               <TableRow
-                key={index}
+                key={labware.labwareId}
                 aria-label={`LiquidDetails_${liquid.id}`}
-                onClick={() => setLabwareId(labware.labwareId)}
+                onClick={() => setLabwareIdModal(labware.labwareId)}
               >
                 <TableDatum>
                   <Flex>
@@ -104,14 +106,18 @@ export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
                       borderRadius={BORDERS.size_three}
                       border={`3px solid ${COLORS.darkBlackEnabled}`}
                       fontSize={TYPOGRAPHY.fontSize20}
-                      fontWeight={700}
+                      fontWeight="700"
                     >
                       {slotName}
                     </Flex>
                   </Flex>
                 </TableDatum>
                 <TableDatum>
-                  <StyledText lineHeight={TYPOGRAPHY.lineHeight28}>
+                  <StyledText
+                    lineHeight={TYPOGRAPHY.lineHeight28}
+                    fontSize="1.375rem"
+                    fontWeight={TYPOGRAPHY.fontWeightRegular}
+                  >
                     {labwareName}
                   </StyledText>
                 </TableDatum>

--- a/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/LiquidDetails.tsx
@@ -134,7 +134,7 @@ export function LiquidDetails(props: LiquidDetailsProps): JSX.Element {
                       {getTotalVolumePerLiquidId(liquid.id, labwareByLiquidId)}{' '}
                       {MICRO_LITERS}
                     </Flex>
-                    <Icon name="chevron-right" height="3rem" />
+                    <Icon name="chevron-right" size="3rem" />
                   </Flex>
                 </TableDatum>
               </TableRow>

--- a/app/src/organisms/ProtocolSetupLiquids/__tests__/LiquidDetails.test.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/__tests__/LiquidDetails.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
+import { getSlotLabwareName } from '../../Devices/ProtocolRun/utils/getSlotLabwareName'
+import { getTotalVolumePerLiquidId } from '../../Devices/ProtocolRun/SetupLiquids/utils'
+import { LiquidDetails } from '../LiquidDetails'
+import { LiquidsLabwareDetailsModal } from '../../Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal'
+import {
+  MOCK_LABWARE_INFO_BY_LIQUID_ID,
+  MOCK_PROTOCOL_ANALYSIS,
+} from '../fixtures'
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+
+jest.mock('../../Devices/ProtocolRun/SetupLiquids/utils')
+jest.mock('../../Devices/ProtocolRun/utils/getSlotLabwareName')
+jest.mock('../../Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal')
+
+const mockGetSlotLabwareNames = getSlotLabwareName as jest.MockedFunction<
+  typeof getSlotLabwareName
+>
+const mockgetTotalVolumePerLiquidId = getTotalVolumePerLiquidId as jest.MockedFunction<
+  typeof getTotalVolumePerLiquidId
+>
+const mockLiquidsLabwareDetailsModal = LiquidsLabwareDetailsModal as jest.MockedFunction<
+  typeof LiquidsLabwareDetailsModal
+>
+const render = (props: React.ComponentProps<typeof LiquidDetails>) => {
+  return renderWithProviders(<LiquidDetails {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('LiquidDetails', () => {
+  let props: React.ComponentProps<typeof LiquidDetails>
+  beforeEach(() => {
+    props = {
+      commands: (MOCK_PROTOCOL_ANALYSIS as CompletedProtocolAnalysis).commands,
+      labwareByLiquidId: MOCK_LABWARE_INFO_BY_LIQUID_ID,
+      runId: RUN_ID_1,
+      liquid: {
+        id: '0',
+        displayName: 'mock liquid 1',
+        description: 'mock sample',
+        displayColor: '#ff4888',
+      },
+    }
+    mockgetTotalVolumePerLiquidId.mockReturnValue(50)
+    mockGetSlotLabwareNames.mockReturnValue({
+      slotName: '4',
+      labwareName: 'mock labware name',
+    })
+    mockLiquidsLabwareDetailsModal.mockReturnValue(<div>mock modal</div>)
+  })
+
+  it('renders the total volume of the liquid, sample display name, clicking on arrow renders the modal', () => {
+    const [{ getByText, getByLabelText }] = render(props)
+    getByText('4')
+    getByText('mock labware name')
+    getByText('Location')
+    getByText('Labware Name')
+    getByText('Volume')
+    getByText('50 µL')
+    getByLabelText('LiquidDetails_0').click()
+    getByText('mock modal')
+  })
+})

--- a/app/src/organisms/ProtocolSetupLiquids/__tests__/ProtocolSetupLiquids.test.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/__tests__/ProtocolSetupLiquids.test.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import {
+  parseLiquidsInLoadOrder,
+  parseLabwareInfoByLiquidId,
+} from '@opentrons/api-client'
+import { i18n } from '../../../i18n'
+import { BackButton } from '../../../atoms/buttons'
+import { ContinueButton } from '../../ProtocolSetupModules'
+import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
+import { getTotalVolumePerLiquidId } from '../../Devices/ProtocolRun/SetupLiquids/utils'
+import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { LiquidDetails } from '../LiquidDetails'
+import {
+  MOCK_LABWARE_INFO_BY_LIQUID_ID,
+  MOCK_LIQUIDS_IN_LOAD_ORDER,
+  MOCK_PROTOCOL_ANALYSIS,
+} from '../fixtures'
+import { ProtocolSetupLiquids } from '..'
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+
+jest.mock('../../Devices/ProtocolRun/SetupLiquids/utils')
+jest.mock('../../ProtocolSetupModules')
+jest.mock('../../../atoms/buttons')
+jest.mock('../LiquidDetails')
+jest.mock('../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
+jest.mock('@opentrons/api-client')
+
+const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
+  typeof useMostRecentCompletedAnalysis
+>
+const mockParseLiquidsInLoadOrder = parseLiquidsInLoadOrder as jest.MockedFunction<
+  typeof parseLiquidsInLoadOrder
+>
+const mockParseLabwareInfoByLiquidId = parseLabwareInfoByLiquidId as jest.MockedFunction<
+  typeof parseLabwareInfoByLiquidId
+>
+const mockLiquidDetails = LiquidDetails as jest.MockedFunction<
+  typeof LiquidDetails
+>
+const mockBackButton = BackButton as jest.MockedFunction<typeof BackButton>
+const mockContinueButton = ContinueButton as jest.MockedFunction<
+  typeof ContinueButton
+>
+const mockgetTotalVolumePerLiquidId = getTotalVolumePerLiquidId as jest.MockedFunction<
+  typeof getTotalVolumePerLiquidId
+>
+const render = (props: React.ComponentProps<typeof ProtocolSetupLiquids>) => {
+  return renderWithProviders(<ProtocolSetupLiquids {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('ProtocolSetupLiquids', () => {
+  let props: React.ComponentProps<typeof ProtocolSetupLiquids>
+  beforeEach(() => {
+    props = { runId: RUN_ID_1, setSetupScreen: jest.fn() }
+    mockParseLiquidsInLoadOrder.mockReturnValue(MOCK_LIQUIDS_IN_LOAD_ORDER)
+    mockParseLabwareInfoByLiquidId.mockReturnValue(
+      MOCK_LABWARE_INFO_BY_LIQUID_ID as any
+    )
+    mockUseMostRecentCompletedAnalysis.mockReturnValue(
+      MOCK_PROTOCOL_ANALYSIS as CompletedProtocolAnalysis
+    )
+    mockLiquidDetails.mockReturnValue(<div>mock liquid details</div>)
+    mockBackButton.mockReturnValue(<div>mock back button</div>)
+    mockContinueButton.mockReturnValue(<div>mock continue button</div>)
+    mockgetTotalVolumePerLiquidId.mockReturnValue(50)
+  })
+
+  it('renders the total volume of the liquid, sample display name, clicking on arrow renders the modal', () => {
+    const [{ getByText, getAllByText, getByLabelText }] = render(props)
+    getByText('mock liquid 1')
+    getByText('mock liquid 2')
+    getAllByText('50 µL')
+    getByText('mock back button')
+    getByText('mock continue button')
+    getByLabelText('Liquids_1').click()
+    getByText('mock liquid details')
+  })
+})

--- a/app/src/organisms/ProtocolSetupLiquids/fixtures.ts
+++ b/app/src/organisms/ProtocolSetupLiquids/fixtures.ts
@@ -1,0 +1,147 @@
+export const MOCK_LIQUIDS_IN_LOAD_ORDER = [
+  {
+    id: '0',
+    displayName: 'mock liquid 1',
+    description: 'mock sample',
+    displayColor: '#ff4888',
+  },
+  {
+    id: '1',
+    displayName: 'mock liquid 2',
+    description: 'another mock sample',
+    displayColor: '#ff8999',
+  },
+]
+export const MOCK_LABWARE_INFO_BY_LIQUID_ID = {
+  '0': [
+    {
+      labwareId: '123',
+      volumeByWell: { A1: 50 },
+    },
+  ],
+  '1': [
+    {
+      labwareId: '234',
+      volumeByWell: { B1: 20 },
+    },
+  ],
+}
+export const MOCK_PROTOCOL_ANALYSIS = {
+  commands: [
+    {
+      id: '97ba49a5-04f6-4f91-986a-04a0eb632882',
+      createdAt: '2022-09-07T19:47:42.781065+00:00',
+      commandType: 'loadPipette',
+      key: '0feeecaf-3895-46d7-ab71-564601265e35',
+      status: 'succeeded',
+      params: {
+        pipetteName: 'p20_single_gen2',
+        mount: 'left',
+        pipetteId: '90183a18-a1df-4fd6-9636-be3bcec63fe4',
+      },
+      result: {
+        pipetteId: '90183a18-a1df-4fd6-9636-be3bcec63fe4',
+      },
+      startedAt: '2022-09-07T19:47:42.782665+00:00',
+      completedAt: '2022-09-07T19:47:42.785061+00:00',
+    },
+    {
+      id: '846e0b7b-1e54-4f42-9ab1-964ebda45da5',
+      createdAt: '2022-09-07T19:47:42.781281+00:00',
+      commandType: 'loadLiquid',
+      key: '1870d1a2-8dcd-46f2-9e27-16578365913b',
+      status: 'succeeded',
+      params: {
+        liquidId: '1',
+        labwareId: 'mockLabwareId1',
+        volumeByWell: {
+          A2: 20,
+          B2: 20,
+          C2: 20,
+          D2: 20,
+          E2: 20,
+          F2: 20,
+          G2: 20,
+          H2: 20,
+        },
+      },
+      result: {},
+      startedAt: '2022-09-07T19:47:42.785987+00:00',
+      completedAt: '2022-09-07T19:47:42.786087+00:00',
+    },
+    {
+      id: '1e03ae10-7e9b-465c-bc72-21ab5706bfb0',
+      createdAt: '2022-09-07T19:47:42.781323+00:00',
+      commandType: 'loadLiquid',
+      key: '48df9766-04ff-4927-9f2d-4efdcf0b3df8',
+      status: 'succeeded',
+      params: {
+        liquidId: '1',
+        labwareId: 'mockLabwareId2',
+        volumeByWell: {
+          D3: 40,
+        },
+      },
+      result: {},
+      startedAt: '2022-09-07T19:47:42.786212+00:00',
+      completedAt: '2022-09-07T19:47:42.786285+00:00',
+    },
+    {
+      id: '1e03ae10-7e9b-465c-bc72-21ab5706bfb0',
+      createdAt: '2022-09-07T19:47:42.781323+00:00',
+      commandType: 'loadLiquid',
+      key: '48df9766-04ff-4927-9f2d-4efdcf0b3df8',
+      status: 'succeeded',
+      params: {
+        liquidId: '1',
+        labwareId: 'mockLabwareId2',
+        volumeByWell: {
+          A3: 33,
+          B3: 33,
+          C3: 33,
+        },
+      },
+      result: {},
+      startedAt: '2022-09-07T19:47:42.786212+00:00',
+      completedAt: '2022-09-07T19:47:42.786285+00:00',
+    },
+    {
+      id: 'e8596bb3-b650-4d62-9bb5-dfc6e9e63249',
+      createdAt: '2022-09-07T19:47:42.781363+00:00',
+      commandType: 'loadLiquid',
+      key: '69d19b03-fdcc-4964-a2f8-3cbb30f4ddf3',
+      status: 'succeeded',
+      params: {
+        liquidId: '0',
+        labwareId: 'mockLabwareId1',
+        volumeByWell: {
+          A1: 33,
+          B1: 33,
+          C1: 33,
+          D1: 33,
+          E1: 33,
+          F1: 33,
+          G1: 33,
+          H1: 33,
+        },
+      },
+      result: {},
+      startedAt: '2022-09-07T19:47:42.786347+00:00',
+      completedAt: '2022-09-07T19:47:42.786412+00:00',
+    },
+  ],
+  liquids: [
+    {
+      id: '1',
+      displayName: 'Saline',
+      description: 'mock liquid 2',
+      displayColor: '#b925ff',
+    },
+    {
+      id: '0',
+      displayName: 'Water',
+      description: 'mock liquid 1',
+      displayColor: '#50d5ff',
+    },
+  ],
+}

--- a/app/src/organisms/ProtocolSetupLiquids/index.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/index.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  TYPOGRAPHY,
+  JUSTIFY_FLEX_END,
+} from '@opentrons/components'
+import {
+  parseLiquidsInLoadOrder,
+  parseLabwareInfoByLiquidId,
+} from '@opentrons/api-client'
+import { MICRO_LITERS, RunTimeCommand } from '@opentrons/shared-data'
+import { BackButton } from '../../atoms/buttons'
+import { StyledText } from '../../atoms/text'
+import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { ContinueButton } from '../ProtocolSetupModules'
+import { getTotalVolumePerLiquidId } from '../Devices/ProtocolRun/SetupLiquids/utils'
+import { LiquidDetails } from './LiquidDetails'
+import type { ParsedLiquid } from '@opentrons/api-client'
+import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
+
+export interface ProtocolSetupLiquidsProps {
+  runId: string
+  setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
+}
+
+export function ProtocolSetupLiquids({
+  runId,
+  setSetupScreen,
+}: ProtocolSetupLiquidsProps): JSX.Element {
+  const { t } = useTranslation('protocol_setup')
+  const protocolData = useMostRecentCompletedAnalysis(runId)
+  const liquidsInLoadOrder = parseLiquidsInLoadOrder(
+    protocolData?.liquids ?? [],
+    protocolData?.commands ?? []
+  )
+  return (
+    <>
+      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <BackButton onClick={() => setSetupScreen('prepare to run')}>
+          {t('liquids')}
+        </BackButton>
+        <Flex gridGap={SPACING.spacingXXL}>
+          {/* TODO(jr, 3/21/23):  wire up this */}
+          <ContinueButton onClick={() => console.log('run!')} />
+        </Flex>
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing3}
+        marginTop="2.375rem"
+      >
+        {liquidsInLoadOrder?.map(liquid => (
+          <React.Fragment key={liquid.id}>
+            <LiquidsList
+              liquid={liquid}
+              commands={protocolData?.commands}
+              runId={runId}
+            />
+          </React.Fragment>
+        ))}
+      </Flex>
+    </>
+  )
+}
+
+interface LiquidsListProps {
+  liquid: ParsedLiquid
+  runId: string
+  commands?: RunTimeCommand[]
+}
+
+export function LiquidsList(props: LiquidsListProps): JSX.Element {
+  const { liquid, runId, commands } = props
+  const [openItem, setOpenItem] = React.useState(false)
+  const labwareByLiquidId = parseLabwareInfoByLiquidId(commands ?? [])
+
+  return (
+    <Flex
+      backgroundColor={COLORS.light_one}
+      borderRadius={BORDERS.size_four}
+      fontSize={TYPOGRAPHY.fontSize22}
+      flexDirection={DIRECTION_COLUMN}
+      padding={SPACING.spacing5}
+      width="100%"
+    >
+      <Flex
+        alignItems={ALIGN_CENTER}
+        width="100%"
+        gridGap={SPACING.spacing4}
+        onClick={() => setOpenItem(!openItem)}
+        aria-label={`Liquids_${liquid.id}`}
+      >
+        <Flex
+          borderRadius={BORDERS.size_two}
+          padding={SPACING.spacing4}
+          backgroundColor={COLORS.white}
+          height="3.75rem"
+          width="3.75rem"
+          marginRight={SPACING.spacing4}
+        >
+          <Icon
+            name="circle"
+            color={liquid.displayColor}
+            aria-label={`Liquids_${liquid.displayColor}`}
+          />
+        </Flex>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          alignItems={TYPOGRAPHY.textAlignCenter}
+        >
+          <StyledText lineHeight={TYPOGRAPHY.lineHeight28}>
+            {liquid.displayName}
+          </StyledText>
+        </Flex>
+        <Flex justifyContent={JUSTIFY_FLEX_END} flex="1">
+          <Flex
+            backgroundColor={COLORS.darkBlack_twenty}
+            borderRadius={BORDERS.radiusSoftCorners}
+            height="2.75rem"
+            padding={`${SPACING.spacing3} 0.75rem`}
+            alignItems={TYPOGRAPHY.textAlignCenter}
+            marginRight={SPACING.spacing3}
+          >
+            {getTotalVolumePerLiquidId(liquid.id, labwareByLiquidId)}{' '}
+            {MICRO_LITERS}
+          </Flex>
+        </Flex>
+        <Icon name={openItem ? 'chevron-up' : 'chevron-right'} size="3rem" />
+      </Flex>
+      {openItem ? (
+        <LiquidDetails
+          runId={runId}
+          liquid={liquid}
+          commands={commands}
+          labwareByLiquidId={labwareByLiquidId}
+        />
+      ) : null}
+    </Flex>
+  )
+}

--- a/app/src/organisms/ProtocolSetupLiquids/index.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/index.tsx
@@ -95,7 +95,7 @@ export function LiquidsList(props: LiquidsListProps): JSX.Element {
         alignItems={ALIGN_CENTER}
         width="100%"
         gridGap={SPACING.spacing4}
-        onClick={() => setOpenItem(!openItem)}
+        onClick={() => setOpenItem(prevOpenItem => !prevOpenItem)}
         aria-label={`Liquids_${liquid.id}`}
       >
         <Flex
@@ -110,13 +110,18 @@ export function LiquidsList(props: LiquidsListProps): JSX.Element {
             name="circle"
             color={liquid.displayColor}
             aria-label={`Liquids_${liquid.displayColor}`}
+            size="1.75rem"
           />
         </Flex>
         <Flex
           flexDirection={DIRECTION_COLUMN}
           alignItems={TYPOGRAPHY.textAlignCenter}
         >
-          <StyledText lineHeight={TYPOGRAPHY.lineHeight28}>
+          <StyledText
+            lineHeight={TYPOGRAPHY.lineHeight28}
+            fontSize="1.375rem"
+            fontWeight={TYPOGRAPHY.fontWeightRegular}
+          >
             {liquid.displayName}
           </StyledText>
         </Flex>

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
@@ -34,6 +34,7 @@ import { useMostRecentCompletedAnalysis } from '../../organisms/LabwarePositionC
 import { getProtocolModulesInfo } from '../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
 import { ProtocolSetupLabware } from '../../organisms/ProtocolSetupLabware'
 import { ProtocolSetupModules } from '../../organisms/ProtocolSetupModules'
+import { ProtocolSetupLiquids } from '../../organisms/ProtocolSetupLiquids'
 import { getUnmatchedModulesForProtocol } from '../../organisms/ProtocolSetupModules/utils'
 import { ConfirmCancelModal } from '../../organisms/RunDetails/ConfirmCancelModal'
 import {
@@ -264,6 +265,9 @@ function PrepareToRun({
       ? t('additional_labware', { count: additionalLabwareCount })
       : null
 
+  // Liquids information
+  const liquidsInProtocol = mostRecentAnalysis?.liquids ?? []
+
   return (
     <>
       {/* Protocol Setup Header */}
@@ -337,6 +341,13 @@ function PrepareToRun({
           onClickSetupStep={() => setSetupScreen('liquids')}
           title={t('liquids')}
           status="general"
+          detail={
+            liquidsInProtocol !== []
+              ? t('initial_liquids_num', {
+                  num: liquidsInProtocol.length,
+                })
+              : t('liquids_not_in_setup')
+          }
         />
       </Flex>
       {showConfirmCancelModal ? (
@@ -386,10 +397,7 @@ export function ProtocolSetup(): JSX.Element {
       </>
     ),
     liquids: (
-      <>
-        <BackButton onClick={() => setSetupScreen('prepare to run')} />
-        Liquids
-      </>
+      <ProtocolSetupLiquids runId={runId} setSetupScreen={setSetupScreen} />
     ),
   }
 

--- a/app/src/pages/OnDeviceDisplay/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/ProtocolSetup.test.tsx
@@ -15,6 +15,7 @@ import {
   useRunCreatedAtTimestamp,
 } from '../../../organisms/Devices/hooks'
 import { useMostRecentCompletedAnalysis } from '../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { ProtocolSetupLiquids } from '../../../organisms/ProtocolSetupLiquids'
 import { getProtocolModulesInfo } from '../../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
 import { ProtocolSetupModules } from '../../../organisms/ProtocolSetupModules'
 import { getUnmatchedModulesForProtocol } from '../../../organisms/ProtocolSetupModules/utils'
@@ -37,6 +38,7 @@ jest.mock('../../../organisms/ProtocolSetupModules')
 jest.mock('../../../organisms/ProtocolSetupModules/utils')
 jest.mock('../../../organisms/RunDetails/ConfirmCancelModal')
 jest.mock('../../../organisms/RunTimeControl/hooks')
+jest.mock('../../../organisms/ProtocolSetupLiquids')
 
 const mockGetDeckDefFromRobotType = getDeckDefFromRobotType as jest.MockedFunction<
   typeof getDeckDefFromRobotType
@@ -68,7 +70,9 @@ const mockUseRunStatus = useRunStatus as jest.MockedFunction<
 const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
   typeof useMostRecentCompletedAnalysis
 >
-
+const mockProtocolSetupLiquids = ProtocolSetupLiquids as jest.MockedFunction<
+  typeof ProtocolSetupLiquids
+>
 const render = (path = '/') => {
   return renderWithProviders(
     <MemoryRouter initialEntries={[path]} initialIndex={0}>
@@ -92,6 +96,9 @@ describe('ProtocolSetup', () => {
     when(mockUseAttachedModules).calledWith().mockReturnValue([])
     mockProtocolSetupModules.mockReturnValue(
       <div>Mock ProtocolSetupModules</div>
+    )
+    mockProtocolSetupLiquids.mockReturnValue(
+      <div>Mock ProtocolSetupLiquids</div>
     )
     mockConfirmCancelModal.mockReturnValue(<div>Mock ConfirmCancelModal</div>)
     when(mockUseRunControls)
@@ -177,5 +184,12 @@ describe('ProtocolSetup', () => {
     expect(queryByText('Mock ProtocolSetupModules')).toBeNull()
     queryByText('Modules')?.click()
     getByText('Mock ProtocolSetupModules')
+  })
+
+  it('should launch protocol setup liquids screen when click liquids', () => {
+    const [{ getByText, queryByText }] = render(`/protocols/${RUN_ID}/setup/`)
+    expect(queryByText('Mock ProtocolSetupLiquids')).toBeNull()
+    queryByText('Liquids')?.click()
+    getByText('Mock ProtocolSetupLiquids')
   })
 })


### PR DESCRIPTION
closes RLIQ-351

# Overview

Add liquids to Protocol Setup - the only thing that is not added is modifying the `LiquidsLabwareDetailsModal` to work with ODD. It will be addressed in a follow up [ticket](https://opentrons.atlassian.net/browse/RLIQ-353)

<img width="991" alt="Screen Shot 2023-03-21 at 3 13 15 PM" src="https://user-images.githubusercontent.com/66035149/226716582-d0d1b38b-a831-4fba-ac65-bdbcdf4215e4.png">

<img width="1020" alt="Screen Shot 2023-03-21 at 3 13 42 PM" src="https://user-images.githubusercontent.com/66035149/226716686-6a82a6be-bb00-4416-87cf-79e2fdd0cab9.png">

# Test Plan

- with a protocol with liquids on ODD, examine the protocol setup page. The liquids button should have info on how many liquids are in the protocol, if any. Clicking on it goes to the liquids protocol setup page. Should see a row for each liquid and clicking on them should expand to show details about the liquid (location, labware name, volume). Clicking on that should open up a modal (this modal is not complete yet!)

# Changelog

- create `ProtocolSetupLiquids` organism folder with an index file and `LiquidsDetails` for more information on the liquids. 
- create fixtures for tests
- create tests

# Review requests

- see test plan

# Risk assessment

low