### PR TITLE
fix(app): calibration dashboard with all tasks complete shouldn't show complete screen when visited

### DIFF
--- a/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
+++ b/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
@@ -12,6 +12,7 @@ import {
   expectedBadTipLengthAndOffsetTaskList,
   expectedTaskList,
   expectedIncompleteDeckCalTaskList,
+  expectedIncompleteRightMountTaskList,
 } from '../../Devices/hooks/__fixtures__/taskListFixtures'
 import { useCalibrationTaskList } from '../../Devices/hooks'
 
@@ -65,6 +66,8 @@ describe('CalibrationTaskList', () => {
     )
     const [{ getByText, rerender }] = render()
     expect(getByText('Calibrate')).toBeTruthy()
+    // Complete screen will only render if a wizard has been launched
+    getByText('Calibrate').click()
     rerender(
       <StaticRouter>
         <CalibrationTaskList
@@ -89,6 +92,7 @@ describe('CalibrationTaskList', () => {
     expect(getAllByText('Calibration recommended')).toHaveLength(3)
     expect(getByRole('button', { name: 'Calibrate' })).toBeTruthy()
     getByText('Right Mount')
+    getByText('Calibrate').click()
     rerender(
       <StaticRouter>
         <CalibrationTaskList
@@ -112,6 +116,7 @@ describe('CalibrationTaskList', () => {
     expect(getByRole('button', { name: 'Calibrate' })).toBeTruthy()
     getByText('Left Mount')
     getByText('Right Mount')
+    getByText('Calibrate').click()
     rerender(
       <StaticRouter>
         <CalibrationTaskList
@@ -135,6 +140,53 @@ describe('CalibrationTaskList', () => {
     expect(getByRole('button', { name: 'Calibrate' })).toBeTruthy()
     getByText('Left Mount')
     getByText('Right Mount')
+    getByText('Calibrate').click()
+    rerender(
+      <StaticRouter>
+        <CalibrationTaskList
+          robotName={'otie'}
+          pipOffsetCalLauncher={mockPipOffsetCalLauncher}
+          tipLengthCalLauncher={mockTipLengthCalLauncher}
+          deckCalLauncher={mockDeckCalLauncher}
+        />
+      </StaticRouter>
+    )
+    expect(getByText('Calibrations complete!')).toBeTruthy()
+  })
+
+  it('launching a recalibrate wizard from a subtask will allow the calibration complete screen to show', () => {
+    mockUseCalibrationTaskList.mockReturnValueOnce(
+      expectedIncompleteRightMountTaskList
+    )
+
+    const [{ getAllByText, getByText, rerender }] = render()
+    getByText('Left Mount').click()
+    const recalibrateLinks = getAllByText('Recalibrate') // this includes the deck and Left Mount subtasks CTAs
+    expect(recalibrateLinks).toHaveLength(3)
+    recalibrateLinks[2].click()
+    rerender(
+      <StaticRouter>
+        <CalibrationTaskList
+          robotName={'otie'}
+          pipOffsetCalLauncher={mockPipOffsetCalLauncher}
+          tipLengthCalLauncher={mockTipLengthCalLauncher}
+          deckCalLauncher={mockDeckCalLauncher}
+        />
+      </StaticRouter>
+    )
+    expect(getByText('Calibrations complete!')).toBeTruthy()
+  })
+
+  it('launching a recalibrate wizard from a task will allow the calibration complete screen to show', () => {
+    mockUseCalibrationTaskList.mockReturnValueOnce(
+      expectedIncompleteRightMountTaskList
+    )
+
+    const [{ getAllByText, getByText, rerender }] = render()
+    getByText('Left Mount').click()
+    const recalibrateLinks = getAllByText('Recalibrate')
+    expect(recalibrateLinks).toHaveLength(3)
+    recalibrateLinks[0].click()
     rerender(
       <StaticRouter>
         <CalibrationTaskList

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -39,6 +39,9 @@ export function CalibrationTaskList({
   deckCalLauncher,
 }: CalibrationTaskListProps): JSX.Element {
   const prevActiveIndex = React.useRef<[number, number] | null>(null)
+  const [hasLaunchedWizard, setHasLaunchedWizard] = React.useState<boolean>(
+    false
+  )
   const [
     showCompletionScreen,
     setShowCompletionScreen,
@@ -53,11 +56,15 @@ export function CalibrationTaskList({
   )
 
   React.useEffect(() => {
-    if (prevActiveIndex.current !== null && activeIndex === null) {
+    if (
+      prevActiveIndex.current !== null &&
+      activeIndex === null &&
+      hasLaunchedWizard
+    ) {
       setShowCompletionScreen(true)
     }
     prevActiveIndex.current = activeIndex
-  }, [activeIndex])
+  }, [activeIndex, hasLaunchedWizard])
 
   // start off assuming we are missing calibrations
   let statusLabelBackgroundColor = COLORS.errorEnabled
@@ -138,6 +145,7 @@ export function CalibrationTaskList({
             activeIndex={activeIndex}
             taskList={taskList}
             taskListStatus={taskListStatus}
+            generalTaskClickHandler={() => setHasLaunchedWizard(true)}
           />
         </>
       )}

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -199,6 +199,7 @@ function SubTask({
   cta,
   footer,
   markedBad,
+  generalClickHandler,
 }: SubTaskProps): JSX.Element {
   const [activeTaskIndex, activeSubTaskIndex] = activeIndex ?? []
 
@@ -259,12 +260,29 @@ function SubTask({
         ) : null}
       </Flex>
       {(isTaskListComplete || isPastSubTask) && cta != null ? (
-        <Link css={TYPOGRAPHY.darkLinkLabelSemiBold} onClick={cta.onClick}>
+        <Link
+          css={TYPOGRAPHY.darkLinkLabelSemiBold}
+          onClick={() => {
+            if (generalClickHandler != null) {
+              generalClickHandler()
+            }
+            cta.onClick()
+          }}
+        >
           {cta.label}
         </Link>
       ) : null}
       {isActiveSubTask && cta != null ? (
-        <TertiaryButton onClick={cta.onClick}>{cta.label}</TertiaryButton>
+        <TertiaryButton
+          onClick={() => {
+            if (generalClickHandler != null) {
+              generalClickHandler()
+            }
+            cta.onClick()
+          }}
+        >
+          {cta.label}
+        </TertiaryButton>
       ) : null}
     </Flex>
   )
@@ -281,6 +299,7 @@ function Task({
   taskListLength,
   isComplete,
   markedBad,
+  generalClickHandler,
 }: TaskProps): JSX.Element {
   const [activeTaskIndex] = activeIndex ?? []
 
@@ -372,12 +391,29 @@ function Task({
               height="15px"
             />
           ) : (isTaskListComplete || isPastTask) && cta != null ? (
-            <Link css={TYPOGRAPHY.darkLinkLabelSemiBold} onClick={cta.onClick}>
+            <Link
+              css={TYPOGRAPHY.darkLinkLabelSemiBold}
+              onClick={() => {
+                if (generalClickHandler != null) {
+                  generalClickHandler()
+                }
+                cta.onClick()
+              }}
+            >
               {cta.label}
             </Link>
           ) : null}
           {isActiveTask && cta != null ? (
-            <TertiaryButton onClick={cta.onClick}>{cta.label}</TertiaryButton>
+            <TertiaryButton
+              onClick={() => {
+                if (generalClickHandler != null) {
+                  generalClickHandler()
+                }
+                cta.onClick()
+              }}
+            >
+              {cta.label}
+            </TertiaryButton>
           ) : null}
         </Flex>
         {isTaskOpen ? (
@@ -401,6 +437,7 @@ function Task({
                   subTaskIndex={subTaskIndex}
                   taskIndex={taskIndex}
                   markedBad={markedBad}
+                  generalClickHandler={generalClickHandler}
                 />
               )
             )}
@@ -414,6 +451,7 @@ function Task({
 export function TaskList({
   activeIndex,
   taskList,
+  generalTaskClickHandler,
 }: TaskListProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
@@ -434,6 +472,7 @@ export function TaskList({
             taskListLength={taskList.length}
             isComplete={isComplete}
             markedBad={markedBad}
+            generalClickHandler={generalTaskClickHandler}
           />
         )
       )}

--- a/app/src/organisms/TaskList/types.ts
+++ b/app/src/organisms/TaskList/types.ts
@@ -13,6 +13,7 @@ export interface SubTaskProps {
   footer?: string
   isComplete?: boolean
   markedBad?: boolean
+  generalClickHandler?: () => void
 }
 
 export interface TaskProps extends Omit<SubTaskProps, 'subTaskIndex'> {
@@ -26,4 +27,5 @@ export interface TaskListProps {
   activeIndex: [number, number] | null
   taskList: TaskProps[]
   taskListStatus: string | null
+  generalTaskClickHandler?: () => void
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The calibration dashboard has a "Calibrations Complete!" screen that should show when a user finishes performing some number of calibrations. This screen should not be shown when the user visits the calibration dashboard if all the calibrations are already complete, however. This adds a `hasLaunchedWizard` flag that ensures that the calibrations complete screen only shows after a user has launched one of the calibration wizards first, preventing the case where it would show upon initial visit to the page.

closes RAUT-365

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

I wasn't able to reproduce the reported bug when running the app via simulator, however, I did run through dashboard calibrations and recalibrations to ensure that the expected behavior of the "Calibrations Complete!" screen showing up after completing calibrations was still intact after these changes.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- adds `hasLaunchedWizard` state to the `CalibrationTaskList` which is used as an additional condition to displaying the "Calibrations Complete!" screen
- adds optional onClick behavior and props to the `TaskList`, `Task`, and `Subtask` components

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

1. I was not able to reproduce the bug without a robot. Please check that the [initially reported bug](https://opentrons.atlassian.net/browse/RAUT-365) is still present on the most recent version of the `release_6.3.0` branch (several changes made recently have a small chance of potentially fixing this issue already).
2. Ensure that if the bug still exists, it no longer happens on this branch, and completing calibrations/recalibrations still shows the "Calibrations Complete!" screen when finished.

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low risk of doing any damage, but should fix a potentially blocking bug on the calibration dashboard

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
