### PR TITLE
test(shared-data): Enforce correct math on well heights

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -18,7 +18,7 @@ const generateStandardWellNames = (rowCount: number, columnCount: number): Set<s
     for (let column = 0; column < columnCount; column++) {
       for (let row = 0; row < rowCount; row++) {
         const columnName = (column + 1).toString()
-        const rowName = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[row]
+        const rowName = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[row]
         yield rowName + columnName
       }
     }
@@ -26,39 +26,79 @@ const generateStandardWellNames = (rowCount: number, columnCount: number): Set<s
   return new Set(generateWelllNames())
 }
 
-const standard24WellNames = generateStandardWellNames(4, 6);
-const standard96WellNames = generateStandardWellNames(8, 12);
-const standard384WellNames = generateStandardWellNames(16, 24);
+const standard24WellNames = generateStandardWellNames(4, 6)
+const standard96WellNames = generateStandardWellNames(8, 12)
+const standard384WellNames = generateStandardWellNames(16, 24)
 
 const definitionsWithWellsNotMatchingZDimension: Record<string, Set<string>> = {
   // TODO: Explain all of these with references to RSS-202.
-  "geb_96_tiprack_10ul/1.json": standard96WellNames,
-  "nest_1_reservoir_195ml/1.json": new Set(["A1"]),
-  "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/1.json": new Set(["A3", "B3", "A4", "B4"]),
-  "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1.json": new Set(["A3", "B3", "A4", "B4"]),
-  "opentrons_10_tuberack_nest_4x50ml_6x15ml_conical/1.json": new Set(["A3", "B3", "A4", "B4"]),
-  "opentrons_24_aluminumblock_generic_2ml_screwcap/1.json": standard24WellNames,
-  "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/1.json": standard24WellNames,
-  "opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/1.json": new Set(
-    ['A3', 'B3', 'C3', 'D3', 'A4', 'B4', 'C4', 'D4', 'A5', 'B5', 'C5', 'D5', 'A6', 'B6', 'C6', 'D6', 'A7', 'B7', 'C7', 'D7', 'A8', 'B8', 'C8', 'D8']
+  'geb_96_tiprack_10ul/1.json': standard96WellNames,
+  'nest_1_reservoir_195ml/1.json': new Set(['A1']),
+  'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/1.json': new Set([
+    'A3',
+    'B3',
+    'A4',
+    'B4',
+  ]),
+  'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1.json': new Set([
+    'A3',
+    'B3',
+    'A4',
+    'B4',
+  ]),
+  'opentrons_10_tuberack_nest_4x50ml_6x15ml_conical/1.json': new Set([
+    'A3',
+    'B3',
+    'A4',
+    'B4',
+  ]),
+  'opentrons_24_aluminumblock_generic_2ml_screwcap/1.json': standard24WellNames,
+  'opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/1.json': standard24WellNames,
+  'opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/1.json': new Set(
+    [
+      'A3',
+      'B3',
+      'C3',
+      'D3',
+      'A4',
+      'B4',
+      'C4',
+      'D4',
+      'A5',
+      'B5',
+      'C5',
+      'D5',
+      'A6',
+      'B6',
+      'C6',
+      'D6',
+      'A7',
+      'B7',
+      'C7',
+      'D7',
+      'A8',
+      'B8',
+      'C8',
+      'D8',
+    ]
   ),
-  "opentrons_96_aluminumblock_generic_pcr_strip_200ul/1.json": standard96WellNames,
-  "opentrons_96_filtertiprack_200ul/1.json": standard96WellNames,
-  "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json": standard96WellNames,
-  "opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json": standard96WellNames,
-  "opentrons_96_tiprack_300ul/1.json": standard96WellNames,
-  "opentrons_calibrationblock_short_side_left/1.json": new Set(["A1"]),
-  "opentrons_calibrationblock_short_side_right/1.json": new Set(["A2"]),
-  "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json": standard384WellNames,
+  'opentrons_96_aluminumblock_generic_pcr_strip_200ul/1.json': standard96WellNames,
+  'opentrons_96_filtertiprack_200ul/1.json': standard96WellNames,
+  'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json': standard96WellNames,
+  'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json': standard96WellNames,
+  'opentrons_96_tiprack_300ul/1.json': standard96WellNames,
+  'opentrons_calibrationblock_short_side_left/1.json': new Set(['A1']),
+  'opentrons_calibrationblock_short_side_right/1.json': new Set(['A2']),
+  'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json': standard384WellNames,
 }
 
 const definitionsWithWellsHigherThanZDimension: Set<string> = new Set([
-  "geb_96_tiprack_10ul/1.json",
-  "opentrons_24_aluminumblock_generic_2ml_screwcap/1.json",
-  "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/1.json",
-  "opentrons_96_aluminumblock_generic_pcr_strip_200ul/1.json",
-  "opentrons_96_tiprack_300ul/1.json",
-  "opentrons_96_filtertiprack_200ul/1.json",
+  'geb_96_tiprack_10ul/1.json',
+  'opentrons_24_aluminumblock_generic_2ml_screwcap/1.json',
+  'opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/1.json',
+  'opentrons_96_aluminumblock_generic_pcr_strip_200ul/1.json',
+  'opentrons_96_tiprack_300ul/1.json',
+  'opentrons_96_filtertiprack_200ul/1.json',
 ])
 
 // JSON Schema defintion & setup
@@ -97,27 +137,26 @@ const expectGroupsFollowConvention = (
 const wellsNotMatchingZDimension = (
   labwareDef: LabwareDefinition2
 ): string[] => {
-  return Object.entries(labwareDef.wells).filter(
-    ([wellName, wellDef]) => {
-      const absDifference = Math.abs(labwareDef.dimensions.zDimension - (wellDef.depth + wellDef.z))
+  return Object.entries(labwareDef.wells)
+    .filter(([wellName, wellDef]) => {
+      const absDifference = Math.abs(
+        labwareDef.dimensions.zDimension - (wellDef.depth + wellDef.z)
+      )
       return absDifference > 0.000001 // Tolerate floating point rounding errors.
-    }
-  ).map(
-    ([wellName, wellDef]) => wellName
-  )
+    })
+    .map(([wellName, wellDef]) => wellName)
 }
 
 const wellsHigherThanZDimension = (
   labwareDef: LabwareDefinition2
 ): string[] => {
-  return Object.entries(labwareDef.wells).filter(
-    ([wellName, wellDef]) => {
-      const difference = (wellDef.depth + wellDef.z) - labwareDef.dimensions.zDimension
+  return Object.entries(labwareDef.wells)
+    .filter(([wellName, wellDef]) => {
+      const difference =
+        wellDef.depth + wellDef.z - labwareDef.dimensions.zDimension
       return difference > 0.000001 // Tolerate floating point rounding errors.
-    }
-  ).map(
-    ([wellName, wellDef]) => wellName
-  )
+    })
+    .map(([wellName, wellDef]) => wellName)
 }
 
 test('fail on bad labware', () => {

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -1,4 +1,3 @@
-import 'regenerator-runtime/runtime'
 import path from 'path'
 import glob from 'glob'
 import Ajv from 'ajv'
@@ -18,16 +17,17 @@ const generateStandardWellNames = (
   rowCount: number,
   columnCount: number
 ): Set<string> => {
-  function* generateWelllNames() {
-    for (let column = 0; column < columnCount; column++) {
-      for (let row = 0; row < rowCount; row++) {
-        const columnName = (column + 1).toString()
-        const rowName = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[row]
-        yield rowName + columnName
-      }
+  const result = new Set<string>()
+
+  for (let column = 0; column < columnCount; column++) {
+    for (let row = 0; row < rowCount; row++) {
+      const columnName = (column + 1).toString()
+      const rowName = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[row]
+      result.add(rowName + columnName)
     }
   }
-  return new Set(generateWelllNames())
+
+  return result
 }
 
 const standard24WellNames = generateStandardWellNames(4, 6)

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -1,4 +1,4 @@
-import 'regenerator-runtime/runtime'
+// import 'regenerator-runtime/runtime'
 import path from 'path'
 import glob from 'glob'
 import Ajv from 'ajv'

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -5,12 +5,52 @@ import Ajv from 'ajv'
 import schema from '../../labware/schemas/2.json'
 import type { LabwareDefinition2 } from '../types'
 
-const definitionsGlobPath = path.join(
-  __dirname,
-  '../../labware/definitions/2/**/*.json'
-)
+import 'regenerator-runtime/runtime'
+
+const definitionsPath = path.join(__dirname, '../../labware/definitions/2')
+
+const definitionsGlobPath = path.join(definitionsPath, '**/*.json')
 
 const fixturesGlobPath = path.join(__dirname, '../../labware/fixtures/2/*.json')
+
+const generateStandardWellNames = (rowCount: number, columnCount: number): Set<string> => {
+  function* generateWelllNames() {
+    for (let column = 0; column < columnCount; column++) {
+      for (let row = 0; row < rowCount; row++) {
+        const columnName = (column + 1).toString()
+        const rowName = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[row]
+        yield rowName + columnName
+      }
+    }
+  }
+  return new Set(generateWelllNames())
+}
+
+const standard24WellNames = generateStandardWellNames(4, 6);
+const standard96WellNames = generateStandardWellNames(8, 12);
+const standard384WellNames = generateStandardWellNames(16, 24);
+
+const definitionsWithWellsNotMatchingZDimension: Record<string, Set<string>> = {
+  // TODO: Explain all of these with references to RSS-202.
+  "geb_96_tiprack_10ul/1.json": standard96WellNames,
+  "nest_1_reservoir_195ml/1.json": new Set(["A1"]),
+  "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/1.json": new Set(["A3", "B3", "A4", "B4"]),
+  "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/1.json": new Set(["A3", "B3", "A4", "B4"]),
+  "opentrons_10_tuberack_nest_4x50ml_6x15ml_conical/1.json": new Set(["A3", "B3", "A4", "B4"]),
+  "opentrons_24_aluminumblock_generic_2ml_screwcap/1.json": standard24WellNames,
+  "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/1.json": standard24WellNames,
+  "opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/1.json": new Set(
+    ['A3', 'B3', 'C3', 'D3', 'A4', 'B4', 'C4', 'D4', 'A5', 'B5', 'C5', 'D5', 'A6', 'B6', 'C6', 'D6', 'A7', 'B7', 'C7', 'D7', 'A8', 'B8', 'C8', 'D8']
+  ),
+  "opentrons_96_aluminumblock_generic_pcr_strip_200ul/1.json": standard96WellNames,
+  "opentrons_96_filtertiprack_200ul/1.json": standard96WellNames,
+  "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json": standard96WellNames,
+  "opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json": standard96WellNames,
+  "opentrons_96_tiprack_300ul/1.json": standard96WellNames,
+  "opentrons_calibrationblock_short_side_left/1.json": new Set(["A1"]),
+  "opentrons_calibrationblock_short_side_right/1.json": new Set(["A2"]),
+  "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json": standard384WellNames,
+}
 
 // JSON Schema defintion & setup
 const ajv = new Ajv({ allErrors: true, jsonPointers: true })
@@ -43,6 +83,29 @@ const expectGroupsFollowConvention = (
       })
     }
   })
+}
+
+const wellsNotMatchingZDimension = (
+  labwareDef: LabwareDefinition2
+): string[] => {
+  return Object.entries(labwareDef.wells).filter(
+    ([wellName, wellDef]) => {
+      const difference = Math.abs(labwareDef.dimensions.zDimension - (wellDef.depth + wellDef.z))
+      return difference > 0.000001 // Tolerate floating point rounding errors.
+    }
+  ).map(
+    ([wellName, wellDef]) => wellName
+  )
+}
+
+const wellsHigherThanZDimension = (
+  labwareDef: LabwareDefinition2
+): string[] => {
+  return Object.entries(labwareDef.wells).filter(
+    ([wellName, wellDef]) => wellDef.z + wellDef.depth > labwareDef.dimensions.zDimension
+  ).map(
+    ([wellName, wellDef]) => wellName
+  )
 }
 
 test('fail on bad labware', () => {
@@ -101,6 +164,30 @@ describe('test schemas of all opentrons definitions', () => {
       expectGroupsFollowConvention(labwareDef, labwarePath)
     }
   })
+})
+
+describe('test dimensional consistency of all opentrons definitions', ()=> {
+  // TODO: "bad" is the wrong word here
+  const knownBadLabware = Object.keys(definitionsWithWellsNotMatchingZDimension)
+
+  knownBadLabware.forEach(labwarePath => {
+    const fullLabwarePath = path.join(definitionsPath, labwarePath)
+    const labwareDef = require(fullLabwarePath) as LabwareDefinition2
+
+    const expectedBadWells = definitionsWithWellsNotMatchingZDimension[labwarePath]
+    test(`${labwarePath} has the expected bad wells`, () => {
+      const actualBadWells = new Set(wellsNotMatchingZDimension(labwareDef))
+      expect(actualBadWells).toEqual(expectedBadWells)
+    })
+  })
+    //   it(`has no wells whose tops are different from its zDimension: ${labwarePath}`, () => {
+    //   if
+    //   expect(wellsNotMatchingZDimension(labwareDef)).toEqual([])
+    // })
+
+    // it(`has no wells whose tops are higher than its zDimension: ${labwarePath}`, () => {
+    //   expect(wellsHigherThanZDimension(labwareDef)).toEqual([])
+    // })
 })
 
 describe('test schemas of all v2 labware fixtures', () => {

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -1,4 +1,4 @@
-// import 'regenerator-runtime/runtime'
+import 'regenerator-runtime/runtime'
 import path from 'path'
 import glob from 'glob'
 import Ajv from 'ajv'

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -155,10 +155,7 @@ const expectGroupsFollowConvention = (
     const topLevelBrand = labwareDef.brand
 
     labwareDef.groups.forEach(group => {
-      if (group.brand != null) {
-        // eslint-disable-next-line jest/no-conditional-expect
-        expect(group.brand.brand).not.toEqual(topLevelBrand)
-      }
+      expect(group.brand?.brand).not.toEqual(topLevelBrand)
     })
   })
 

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -9,7 +9,7 @@ const definitionsDir = path.join(__dirname, '../../labware/definitions/2')
 const fixturesDir = path.join(__dirname, '../../labware/fixtures/2')
 const globPattern = '**/*.json'
 
-// JSON Schema defintion & setup
+// JSON Schema definition & setup
 const ajv = new Ajv({ allErrors: true, jsonPointers: true })
 const validate = ajv.compile(schema)
 

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -115,7 +115,10 @@ const expectedWellsNotMatchingZDimension: Record<string, Set<string>> = {
   'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json': standard384WellNames,
 }
 
-const filterWells = (labwareDef: LabwareDefinition2, predicate: (wellDef: LabwareWell) => boolean): Set<string> => {
+const filterWells = (
+  labwareDef: LabwareDefinition2,
+  predicate: (wellDef: LabwareWell) => boolean
+): Set<string> => {
   return new Set(
     Object.entries(labwareDef.wells)
       .filter(([wellName, wellDef]) => predicate(wellDef))
@@ -123,19 +126,23 @@ const filterWells = (labwareDef: LabwareDefinition2, predicate: (wellDef: Labwar
   )
 }
 
-const getWellsNotMatchingZDimension = (labwareDef: LabwareDefinition2): Set<string> => {
-  return filterWells(labwareDef, (wellDef) => {
+const getWellsNotMatchingZDimension = (
+  labwareDef: LabwareDefinition2
+): Set<string> => {
+  return filterWells(labwareDef, wellDef => {
     const absDifference = Math.abs(
-      (wellDef.depth + wellDef.z) - labwareDef.dimensions.zDimension
+      wellDef.depth + wellDef.z - labwareDef.dimensions.zDimension
     )
     return absDifference > 0.000001 // Tolerate floating point rounding errors.
   })
 }
 
-const getWellsHigherThanZDimension = (labwareDef: LabwareDefinition2): Set<string> => {
-  return filterWells(labwareDef, (wellDef) => {
+const getWellsHigherThanZDimension = (
+  labwareDef: LabwareDefinition2
+): Set<string> => {
+  return filterWells(labwareDef, wellDef => {
     const difference =
-      (wellDef.depth + wellDef.z) - labwareDef.dimensions.zDimension
+      wellDef.depth + wellDef.z - labwareDef.dimensions.zDimension
     return difference > 0.000001 // Tolerate floating point rounding errors.
   })
 }


### PR DESCRIPTION
# Overview

This adds some tests to `shared-data` to prevent us from accidentally creating new labware definitions with the bug described in RSS-202. Closes RSS-203.

The premise is:

* A well top should never be above the labware's `zDimension`.
* A well top should *usually* lie exactly at the labware's `zDimension`. Sometimes, it's legitimate for the well top to be lower, but this is atypical.

For existing labware that break these rules, there's an allow-list.

# Review requests

I'm inexperienced with JavaScript, so style pointers would be appreciated.

# Risk assessment

No risk. Changes are just to `shared-data` tests.
