### PR TITLE
fix(app): prevent launching calibrations while active protocol run

### DIFF
--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -19,7 +19,8 @@ import { StyledText } from '../../atoms/text'
 import { Modal } from '../../molecules/Modal'
 import { TaskList } from '../TaskList'
 
-import { useCalibrationTaskList } from '../Devices/hooks'
+import { useCalibrationTaskList, useRunHasStarted } from '../Devices/hooks'
+import { useCurrentRunId } from '../ProtocolUpload/hooks'
 
 import type { DashboardCalOffsetInvoker } from '../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibratePipOffset'
 import type { DashboardCalTipLengthInvoker } from '../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength'
@@ -54,6 +55,8 @@ export function CalibrationTaskList({
     tipLengthCalLauncher,
     deckCalLauncher
   )
+  const runId = useCurrentRunId()
+  const runHasStarted = useRunHasStarted(runId)
 
   React.useEffect(() => {
     if (
@@ -146,6 +149,9 @@ export function CalibrationTaskList({
             taskList={taskList}
             taskListStatus={taskListStatus}
             generalTaskClickHandler={() => setHasLaunchedWizard(true)}
+            generalTaskDisabledReason={
+              runHasStarted ? 'some_robot_controls_are_not_available' : null
+            }
           />
         </>
       )}

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -150,7 +150,9 @@ export function CalibrationTaskList({
             taskListStatus={taskListStatus}
             generalTaskClickHandler={() => setHasLaunchedWizard(true)}
             generalTaskDisabledReason={
-              runHasStarted ? 'some_robot_controls_are_not_available' : null
+              runHasStarted
+                ? t('device_settings:some_robot_controls_are_not_available')
+                : null
             }
           />
         </>

--- a/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
+++ b/app/src/organisms/Devices/hooks/__fixtures__/taskListFixtures.ts
@@ -1114,3 +1114,87 @@ export const expectedIncompleteRightMountTaskList: TaskListProps = {
   ],
   taskListStatus: 'incomplete',
 }
+
+export const expectedIncompleteTaskList: TaskListProps = {
+  activeIndex: [0, 0],
+  taskList: [
+    // deck calibration task
+    {
+      subTasks: [],
+      taskListLength: TASK_COUNT,
+      activeIndex: [0, 0],
+      description:
+        'Start with Deck Calibration, which is the basis for the rest of calibration.',
+      title: 'Deck Calibration',
+      cta: { label: 'Calibrate', onClick: mockDeckCalLauncher },
+      taskIndex: 0,
+    },
+    // left mount calibration task
+    {
+      subTasks: [
+        // tip length calibration subtask
+        {
+          activeIndex: [1, 0],
+          description: 'Calibrate the length of a tip on this pipette.',
+          title: 'Tip Length Calibration',
+          cta: { label: 'Calibrate', onClick: mockTipLengthCalLauncher },
+          taskIndex: 1,
+          subTaskIndex: 0,
+        },
+        // offset calibration subtask
+        {
+          activeIndex: [1, 0],
+          description:
+            "Calibrate this pipette's offset while attached to the robot's left mount.",
+          title: 'Pipette Offset Calibration',
+          cta: { label: 'Calibrate', onClick: mockPipOffsetCalLauncher },
+          taskIndex: 1,
+          subTaskIndex: 1,
+        },
+      ],
+      taskListLength: TASK_COUNT,
+      activeIndex: [1, 0],
+      description: 'Test Left Display Name, test-left',
+      title: 'Left Mount',
+      taskIndex: 1,
+    },
+    // right mount calibration task
+    {
+      subTasks: [
+        // tip length calibration subtask
+        {
+          activeIndex: [0, 0],
+          description: '',
+          title: 'Tip Length Calibration',
+          footer: `Last completed ${formatTimestamp(
+            mockCompleteTipLengthCalibrations[1].lastModified
+          )}`,
+          cta: { label: 'Recalibrate', onClick: mockTipLengthCalLauncher },
+          isComplete: true,
+          taskIndex: 2,
+          subTaskIndex: 0,
+        },
+        // offset calibration subtask
+        {
+          activeIndex: [0, 0],
+          description: '',
+          title: 'Pipette Offset Calibration',
+          footer: `Last completed ${formatTimestamp(
+            mockCompletePipetteOffsetCalibrations[1].lastModified
+          )}`,
+          cta: { label: 'Recalibrate', onClick: mockPipOffsetCalLauncher },
+          isComplete: true,
+          taskIndex: 2,
+          subTaskIndex: 1,
+        },
+      ],
+      isComplete: true,
+      taskListLength: TASK_COUNT,
+      activeIndex: [0, 0],
+      description: 'Test Right Display Name, test-right',
+      title: 'Right Mount',
+      taskIndex: 2,
+    },
+  ],
+  taskListStatus: 'incomplete',
+}

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -15,12 +15,15 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   TYPOGRAPHY,
+  useHoverTooltip,
 } from '@opentrons/components'
 
 import { TertiaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 
 import type { SubTaskProps, TaskListProps, TaskProps } from './types'
+import { useTranslation } from 'react-i18next'
+import { Tooltip } from '../../atoms/Tooltip'
 
 interface ProgressTrackerItemProps {
   activeIndex: [number, number] | null
@@ -200,7 +203,11 @@ function SubTask({
   footer,
   markedBad,
   generalClickHandler,
+  generalTaskDisabledReason,
 }: SubTaskProps): JSX.Element {
+  const { t } = useTranslation('device_settings')
+  const [targetProps, tooltipProps] = useHoverTooltip()
+
   const [activeTaskIndex, activeSubTaskIndex] = activeIndex ?? []
 
   const isTaskListComplete = activeIndex == null
@@ -211,6 +218,7 @@ function SubTask({
     activeSubTaskIndex != null &&
     ((activeSubTaskIndex > subTaskIndex && activeTaskIndex === taskIndex) ||
       activeTaskIndex > taskIndex)
+  const isDisabled = generalTaskDisabledReason != null
 
   return (
     <Flex
@@ -260,29 +268,53 @@ function SubTask({
         ) : null}
       </Flex>
       {(isTaskListComplete || isPastSubTask) && cta != null ? (
-        <Link
-          css={TYPOGRAPHY.darkLinkLabelSemiBold}
-          onClick={() => {
-            if (generalClickHandler != null) {
-              generalClickHandler()
+        <>
+          <Link
+            {...targetProps}
+            css={
+              isDisabled
+                ? TYPOGRAPHY.darkLinkLabelSemiBoldDisabled
+                : TYPOGRAPHY.darkLinkLabelSemiBold
             }
-            cta.onClick()
-          }}
-        >
-          {cta.label}
-        </Link>
+            onClick={() => {
+              if (isDisabled) {
+                return
+              }
+              if (generalClickHandler != null) {
+                generalClickHandler()
+              }
+              cta.onClick()
+            }}
+          >
+            {cta.label}
+          </Link>
+          {isDisabled ? (
+            <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
+              {t(generalTaskDisabledReason)}
+            </Tooltip>
+          ) : null}
+        </>
       ) : null}
       {isActiveSubTask && cta != null ? (
-        <TertiaryButton
-          onClick={() => {
-            if (generalClickHandler != null) {
-              generalClickHandler()
-            }
-            cta.onClick()
-          }}
-        >
-          {cta.label}
-        </TertiaryButton>
+        <>
+          <TertiaryButton
+            {...targetProps}
+            disabled={isDisabled}
+            onClick={() => {
+              if (generalClickHandler != null) {
+                generalClickHandler()
+              }
+              cta.onClick()
+            }}
+          >
+            {cta.label}
+          </TertiaryButton>
+          {isDisabled ? (
+            <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
+              {t(generalTaskDisabledReason)}
+            </Tooltip>
+          ) : null}
+        </>
       ) : null}
     </Flex>
   )
@@ -300,7 +332,10 @@ function Task({
   isComplete,
   markedBad,
   generalClickHandler,
+  generalTaskDisabledReason,
 }: TaskProps): JSX.Element {
+  const { t } = useTranslation('device_settings')
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const [activeTaskIndex] = activeIndex ?? []
 
   // TODO(bh, 2022-10-18): pass booleans to children as props
@@ -308,6 +343,7 @@ function Task({
   const isPastTask = activeTaskIndex != null && taskIndex < activeTaskIndex
   const isActiveTask = activeTaskIndex === taskIndex
   const hasSubTasks = subTasks.length > 0
+  const isDisabled = generalTaskDisabledReason != null
 
   const [isTaskOpen, setIsTaskOpen] = React.useState<boolean>(
     hasSubTasks && isActiveTask
@@ -391,29 +427,53 @@ function Task({
               height="15px"
             />
           ) : (isTaskListComplete || isPastTask) && cta != null ? (
-            <Link
-              css={TYPOGRAPHY.darkLinkLabelSemiBold}
-              onClick={() => {
-                if (generalClickHandler != null) {
-                  generalClickHandler()
+            <>
+              <Link
+                {...targetProps}
+                css={
+                  isDisabled
+                    ? TYPOGRAPHY.darkLinkLabelSemiBoldDisabled
+                    : TYPOGRAPHY.darkLinkLabelSemiBold
                 }
-                cta.onClick()
-              }}
-            >
-              {cta.label}
-            </Link>
+                onClick={() => {
+                  if (isDisabled) {
+                    return
+                  }
+                  if (generalClickHandler != null) {
+                    generalClickHandler()
+                  }
+                  cta.onClick()
+                }}
+              >
+                {cta.label}
+              </Link>
+              {isDisabled ? (
+                <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
+                  {t(generalTaskDisabledReason)}
+                </Tooltip>
+              ) : null}
+            </>
           ) : null}
           {isActiveTask && cta != null ? (
-            <TertiaryButton
-              onClick={() => {
-                if (generalClickHandler != null) {
-                  generalClickHandler()
-                }
-                cta.onClick()
-              }}
-            >
-              {cta.label}
-            </TertiaryButton>
+            <>
+              <TertiaryButton
+                {...targetProps}
+                disabled={isDisabled}
+                onClick={() => {
+                  if (generalClickHandler != null) {
+                    generalClickHandler()
+                  }
+                  cta.onClick()
+                }}
+              >
+                {cta.label}
+              </TertiaryButton>
+              {isDisabled ? (
+                <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
+                  {t(generalTaskDisabledReason)}
+                </Tooltip>
+              ) : null}
+            </>
           ) : null}
         </Flex>
         {isTaskOpen ? (
@@ -438,6 +498,7 @@ function Task({
                   taskIndex={taskIndex}
                   markedBad={markedBad}
                   generalClickHandler={generalClickHandler}
+                  generalTaskDisabledReason={generalTaskDisabledReason}
                 />
               )
             )}
@@ -452,6 +513,7 @@ export function TaskList({
   activeIndex,
   taskList,
   generalTaskClickHandler,
+  generalTaskDisabledReason,
 }: TaskListProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
@@ -473,6 +535,7 @@ export function TaskList({
             isComplete={isComplete}
             markedBad={markedBad}
             generalClickHandler={generalTaskClickHandler}
+            generalTaskDisabledReason={generalTaskDisabledReason}
           />
         )
       )}

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -20,10 +20,9 @@ import {
 
 import { TertiaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
+import { Tooltip } from '../../atoms/Tooltip'
 
 import type { SubTaskProps, TaskListProps, TaskProps } from './types'
-import { useTranslation } from 'react-i18next'
-import { Tooltip } from '../../atoms/Tooltip'
 
 interface ProgressTrackerItemProps {
   activeIndex: [number, number] | null
@@ -205,7 +204,6 @@ function SubTask({
   generalClickHandler,
   generalTaskDisabledReason,
 }: SubTaskProps): JSX.Element {
-  const { t } = useTranslation('device_settings')
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const [activeTaskIndex, activeSubTaskIndex] = activeIndex ?? []
@@ -290,7 +288,7 @@ function SubTask({
           </Link>
           {isDisabled ? (
             <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
-              {t(generalTaskDisabledReason)}
+              {generalTaskDisabledReason}
             </Tooltip>
           ) : null}
         </>
@@ -311,7 +309,7 @@ function SubTask({
           </TertiaryButton>
           {isDisabled ? (
             <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
-              {t(generalTaskDisabledReason)}
+              {generalTaskDisabledReason}
             </Tooltip>
           ) : null}
         </>
@@ -334,7 +332,6 @@ function Task({
   generalClickHandler,
   generalTaskDisabledReason,
 }: TaskProps): JSX.Element {
-  const { t } = useTranslation('device_settings')
   const [targetProps, tooltipProps] = useHoverTooltip()
   const [activeTaskIndex] = activeIndex ?? []
 
@@ -449,7 +446,7 @@ function Task({
               </Link>
               {isDisabled ? (
                 <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
-                  {t(generalTaskDisabledReason)}
+                  {generalTaskDisabledReason}
                 </Tooltip>
               ) : null}
             </>
@@ -470,7 +467,7 @@ function Task({
               </TertiaryButton>
               {isDisabled ? (
                 <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
-                  {t(generalTaskDisabledReason)}
+                  {generalTaskDisabledReason}
                 </Tooltip>
               ) : null}
             </>

--- a/app/src/organisms/TaskList/types.ts
+++ b/app/src/organisms/TaskList/types.ts
@@ -14,6 +14,7 @@ export interface SubTaskProps {
   isComplete?: boolean
   markedBad?: boolean
   generalClickHandler?: () => void
+  generalTaskDisabledReason?: string | null
 }
 
 export interface TaskProps extends Omit<SubTaskProps, 'subTaskIndex'> {
@@ -28,4 +29,5 @@ export interface TaskListProps {
   taskList: TaskProps[]
   taskListStatus: string | null
   generalTaskClickHandler?: () => void
+  generalTaskDisabledReason?: string | null
 }

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -139,3 +139,12 @@ export const darkLinkLabelSemiBold = css`
     color: ${COLORS.darkBlackEnabled};
   }
 `
+
+export const darkLinkLabelSemiBoldDisabled = css`
+font-size: ${fontSizeLabel};
+  font-weight: ${fontWeightSemiBold};
+  line-height: ${lineHeight20};
+  color: ${COLORS.medGreyHover};
+  cursor: not-allowed;
+  }
+`


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Previously there was nothing stopping a user from launching calibrations from the calibration dashboard while a protocol was running. This resulted in wild, unpredictable robot movements. This change adds a check for an active protocol using the `useRunHasStarted` hook and conditionally disables the calibrate and recalibrate ctas with a descriptive tooltip on hover

closes RQA-572


https://user-images.githubusercontent.com/66637570/226990228-1ce1f067-b793-4133-aaea-0e9ed28ca4ac.mov


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Verified that without a protocol running I could launch and complete calibrations as expected. Started a protocol run then visited the dashboard again and verified that all buttons/links were disabled and had a tooltip with and explanation for the disabled reason

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- adds a `generalTaskDisabledReason` prop to the `TaskList` and its children that takes a string or null argument which is used to determine if the task/subtask should have a disabled cta and what the tooltip text should be
- adds a `darkLinkLabelSemiBoldDisabled` typography style to account for "disabling" a `Link` component

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the code looks good and the app behaves as described in the Test Plan section

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low risk, though the bug it fixes is fairly nasty in that it may cause damage to the robot

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
