### PR TITLE
fix(api): fsync protocol files to keep them consistent with robot-server's database

### DIFF
--- a/api/src/opentrons/protocol_reader/file_reader_writer.py
+++ b/api/src/opentrons/protocol_reader/file_reader_writer.py
@@ -1,17 +1,11 @@
 """Input file reading."""
 
 import os
+import pathlib
 from dataclasses import dataclass
-from pathlib import Path
 from typing import List, Optional, Sequence, Union
 
-from anyio import (
-    create_task_group,
-    to_thread,
-    Path as AsyncPath,
-    wrap_file as wrap_file_async,
-    open_file as open_file_async,
-)
+import anyio
 
 from .input_file import AbstractInputFile
 from .protocol_files_invalid_error import ProtocolFilesInvalidError
@@ -23,7 +17,7 @@ class BufferedFile:
 
     name: str
     contents: bytes
-    path: Optional[Path]
+    path: Optional[pathlib.Path]
 
 
 class FileReadError(ProtocolFilesInvalidError):
@@ -35,15 +29,15 @@ class FileReaderWriter:
 
     @staticmethod
     async def read(
-        files: Sequence[Union[AbstractInputFile, Path]]
+        files: Sequence[Union[AbstractInputFile, pathlib.Path]]
     ) -> List[BufferedFile]:
         """Read a set of input files into memory."""
         return [await _read_file(input_file=file) for file in files]
 
     @staticmethod
-    async def write(directory: Path, files: Sequence[BufferedFile]) -> None:
+    async def write(directory: pathlib.Path, files: Sequence[BufferedFile]) -> None:
         """Write a set of previously buffered files to disk."""
-        await AsyncPath(directory).mkdir(parents=True, exist_ok=True)
+        await anyio.Path(directory).mkdir(parents=True, exist_ok=True)
 
         for file in files:
             path = directory / file.name
@@ -52,17 +46,19 @@ class FileReaderWriter:
         await _fsync_directory(path=directory)
 
 
-async def _read_file(input_file: Union[AbstractInputFile, Path]) -> BufferedFile:
-    if isinstance(input_file, Path):
-        path: Optional[Path] = input_file
+async def _read_file(
+    input_file: Union[AbstractInputFile, pathlib.Path]
+) -> BufferedFile:
+    if isinstance(input_file, pathlib.Path):
+        path: Optional[pathlib.Path] = input_file
         filename = input_file.name
-        contents = await AsyncPath(input_file).read_bytes()
+        contents = await anyio.Path(input_file).read_bytes()
     elif not input_file.filename:
         raise FileReadError("File was missing a name")
     else:
         path = None
         filename = input_file.filename
-        async with wrap_file_async(input_file.file) as f:
+        async with anyio.wrap_file(input_file.file) as f:
             contents = await f.read()
 
     return BufferedFile(
@@ -72,14 +68,14 @@ async def _read_file(input_file: Union[AbstractInputFile, Path]) -> BufferedFile
     )
 
 
-async def _write_and_fsync_file(path: Path, contents: bytes) -> None:
-    async with await open_file_async(path, "wb") as file:
+async def _write_and_fsync_file(path: pathlib.Path, contents: bytes) -> None:
+    async with await anyio.open_file(path, "wb") as file:
         await file.write(contents)
         await file.flush()
-        await to_thread.run_sync(os.fsync, file.wrapped.fileno())
+        await anyio.to_thread.run_sync(os.fsync, file.wrapped.fileno())
 
 
-async def _fsync_directory(path: Path) -> None:
+async def _fsync_directory(path: pathlib.Path) -> None:
     def _fsync_directory_sync() -> None:
         fd = os.open(path, os.O_RDONLY)
         try:
@@ -87,4 +83,4 @@ async def _fsync_directory(path: Path) -> None:
         finally:
             os.close(fd)
 
-    await to_thread.run_sync(_fsync_directory_sync)
+    await anyio.to_thread.run_sync(_fsync_directory_sync)


### PR DESCRIPTION
# Overview

This attempts to fix RSS-147. See my comment in that thread for the theory behind this fix.

# Test plan

To make sure this doesn't break anything, I need to:

* [x] Make sure files are saved and read without errors on an OT-2.
* [x] Make sure files are saved and read without errors on a Flex.
* [x] Make sure files are saved and read without errors in a local dev environment.

Unfortunately, the RSS team has never been able to reproduce the bug, so we don't have a way of confirming that this fixes it. I think the best that we can do is try this out, deploy it widely internally, and see if the problem stops happening.

# Changelog

* After writing each protocol file, `fsync` it.
* Also `fsync` the enclosing directory after writing all files.
* Serialize our writes instead of doing them concurrently. I don't think this had anything to do with the bug—this is just a refactor I'm doing for simplicity. A robot's filesystem is on a single SD card, so I don't think doing the writes concurrently made anything faster.

# Review requests

This is lower-level I/O than we're used to. It's [easy](https://stackoverflow.com/questions/37288453/calling-fsync2-after-close2) to get this kind of thing wrong. Please scrutinize my use of the `os` functions.

# Risk assessment

Medium. Because we're dealing with `os` functions, there's room for platform-dependent behavior to sneak in.
