### PR TITLE
build: add internal release notes

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -1,0 +1,12 @@
+For more details about this release, please see the full [technical change log][]. 
+
+[technical change log]: https://github.com/Opentrons/opentrons/releases
+
+---
+
+## OT Internal Robot Software Changes in 0.0.2
+
+### Bugfixes
+
+### Known Issues
+

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,0 +1,13 @@
+For more details about this release, please see the full [technical change
+log][]. 
+[technical change log]: https://github.com/Opentrons/opentrons/releases
+
+---
+
+## Opentrons App Internal Changes in 0.0.2
+
+### Bug Fixes
+
+### Improved Features
+
+### Known Issues

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,5 +1,4 @@
-For more details about this release, please see the full [technical change
-log][]. 
+For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
 ---

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -32,7 +32,7 @@ module.exports = async () => ({
   npmRebuild: false,
   releaseNotesFile: project === 'robot-stack' ? 'release-notes.md' : 'release-notes-internal.md',
   files: [
-g    '**/*',
+    '**/*',
     'build/br-premigration-wheels',
     '!Makefile',
     '!python',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -30,9 +30,9 @@ module.exports = async () => ({
     project === 'robot-stack' ? 'com.opentrons.app' : 'com.opentrons.appot3',
   electronVersion: '21.3.1',
   npmRebuild: false,
-  releaseNotesFile: project === 'robot-stack' ? 'release-notes.md' : 'release-notes-internal.md'
+  releaseNotesFile: project === 'robot-stack' ? 'release-notes.md' : 'release-notes-internal.md',
   files: [
-    '**/*',
+g    '**/*',
     'build/br-premigration-wheels',
     '!Makefile',
     '!python',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -30,6 +30,7 @@ module.exports = async () => ({
     project === 'robot-stack' ? 'com.opentrons.app' : 'com.opentrons.appot3',
   electronVersion: '21.3.1',
   npmRebuild: false,
+  releaseNotesFile: project === 'robot-stack' ? 'release-notes.md' : 'release-notes-internal.md'
   files: [
     '**/*',
     'build/br-premigration-wheels',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -30,7 +30,10 @@ module.exports = async () => ({
     project === 'robot-stack' ? 'com.opentrons.app' : 'com.opentrons.appot3',
   electronVersion: '21.3.1',
   npmRebuild: false,
-  releaseNotesFile: project === 'robot-stack' ? 'release-notes.md' : 'release-notes-internal.md',
+  releaseNotesFile:
+    project === 'robot-stack'
+      ? 'release-notes.md'
+      : 'release-notes-internal.md',
   files: [
     '**/*',
     'build/br-premigration-wheels',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -30,10 +30,12 @@ module.exports = async () => ({
     project === 'robot-stack' ? 'com.opentrons.app' : 'com.opentrons.appot3',
   electronVersion: '21.3.1',
   npmRebuild: false,
-  releaseNotesFile:
-    project === 'robot-stack'
-      ? 'release-notes.md'
-      : 'release-notes-internal.md',
+  releaseInfo: {
+    releaseNotesFile:
+      project === 'robot-stack'
+        ? 'release-notes.md'
+        : 'release-notes-internal.md',
+  },
   files: [
     '**/*',
     'build/br-premigration-wheels',


### PR DESCRIPTION
Both the desktop app and the robot software need release notes for internal releases. These will work the same as the external releases, but need slightly less editing.

The robot side release notes get picked up by corresponding work in https://github.com/Opentrons/oe-core ; the app ones are built in to electron-updater manifests by configuration in the builder config.

