### PR TITLE
build: artifacts on gh releases for internal rel

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -302,6 +302,56 @@ jobs:
           mkdir to_upload
           cp ./opentrons-ot3-*/* ./to_upload
           aws --profile=deploy s3 sync --acl=public-read to_upload s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
+      - name: 'create GH release'
+        uses: 'ncipollo/release-action@v1.12.0'
+        if: startsWith(github.ref, 'refs/tags/ot3@')
+        with:
+          replacesArtifacts: true
+          allowUpdates: true
+          generateChangelogs: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+      - name: 'upload windows artifact to GH release'
+        uses: 'ncipollo/release-action@v1.12.0'
+        if: startsWith(github.ref, 'refs/tags/ot3@')
+        with:
+          replacesArtifacts: true
+          allowUpdates: true
+          generateChangelogs: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          artifacts: ./to_upload/*.exe
+          artifactContentType: application/vnd.microsoft.portable-executable
+      - name: 'upload mac artifact to GH release'
+        uses: 'ncipollo/release-action@v1.12.0'
+        if: startsWith(github.ref, 'refs/tags/ot3@')
+        with:
+          replacesArtifacts: true
+          allowUpdates: true
+          generateChangelogs: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          artifacts: ./to_upload/*.dmg
+          artifactContentType: application/octet-stream
+      - name: 'upload linux artifact to GH release'
+        uses: 'ncipollo/release-action@v1.12.0'
+        if: startsWith(github.ref, 'refs/tags/ot3@')
+        with:
+          replacesArtifacts: true
+          allowUpdates: true
+          generateChangelogs: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          artifacts: ./to_upload/*.AppImage
+          artifactContentType: application/octet-stream
       - name: 'detect build data for notification'
         id: names
         run: |

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -306,20 +306,15 @@ jobs:
         uses: 'ncipollo/release-action@v1.12.0'
         if: startsWith(github.ref, 'refs/tags/ot3@')
         with:
-          replacesArtifacts: true
           allowUpdates: true
-          generateChangelogs: true
+          replacesArtifacts: true
           omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
           omitPrereleaseDuringUpdate: true
       - name: 'upload windows artifact to GH release'
         uses: 'ncipollo/release-action@v1.12.0'
         if: startsWith(github.ref, 'refs/tags/ot3@')
         with:
-          replacesArtifacts: true
           allowUpdates: true
-          generateChangelogs: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
@@ -330,9 +325,7 @@ jobs:
         uses: 'ncipollo/release-action@v1.12.0'
         if: startsWith(github.ref, 'refs/tags/ot3@')
         with:
-          replacesArtifacts: true
           allowUpdates: true
-          generateChangelogs: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
@@ -343,9 +336,7 @@ jobs:
         uses: 'ncipollo/release-action@v1.12.0'
         if: startsWith(github.ref, 'refs/tags/ot3@')
         with:
-          replacesArtifacts: true
           allowUpdates: true
-          generateChangelogs: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true


### PR DESCRIPTION
This should add the app build artifacts to the github release pages for internal releases. Once we prove this out with internal release, we can add it for production releases as well.

This will let us tell people to look at the github release page for old releases!