### PR TITLE
feat(hardware): add light strip messages

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
@@ -27,6 +27,10 @@ class BinaryMessageId(int, Enum):
     door_switch_state_request = 0x0D
     door_switch_state_info = 0x0E
 
+    # Light messages prefixed by 0x400
+    add_light_action = 0x400
+    clear_light_action_staging_queue = 0x401
+    start_light_action = 0x402
 
 @unique
 class LightTransitionType(int, Enum):

--- a/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
@@ -32,6 +32,7 @@ class BinaryMessageId(int, Enum):
     clear_light_action_staging_queue = 0x401
     start_light_action = 0x402
 
+
 @unique
 class LightTransitionType(int, Enum):
     """The types of transitons that the lights can perform."""

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import Type, Union, Optional
 from typing_extensions import get_args
 
-from ..binary_constants import BinaryMessageId, LightTransitionType, LightActionType
+from ..binary_constants import BinaryMessageId, LightTransitionType, LightAnimationType
 from .. import utils
 import logging
 from .fields import (
@@ -12,7 +12,7 @@ from .fields import (
     VersionFlagsField,
     OptionalRevisionField,
     LightTransitionTypeField,
-    LightActionTypeField,
+    LightAnimationTypeField,
 )
 
 log = logging.getLogger(__name__)
@@ -204,22 +204,27 @@ class DoorSwitchStateInfo(utils.BinarySerializable):
     door_open: utils.UInt8Field = utils.UInt8Field(0)
 
 
-@dataclass 
+@dataclass
 class AddLightActionRequest(utils.BinarySerializable):
-    """Add an action to the staging light queue."""
+    """Add an action to the staging light queue.
 
-    message_id: utils.UInt16Field = utils.UInt16Field(
-        BinaryMessageId.add_light_action
-    )
+    The RGBW values are uint8_t fields and should be specified in the
+    range [0,255], where 0 is fully off and 255 is fully on.
+    """
+
+    message_id: utils.UInt16Field = utils.UInt16Field(BinaryMessageId.add_light_action)
     length: utils.UInt16Field = utils.UInt16Field(7)
     transition_time: utils.UInt16Field = utils.UInt16Field(0)
-    transition_type: LightTransitionTypeField = LightTransitionTypeField(LightTransitionType.linear)
+    transition_type: LightTransitionTypeField = LightTransitionTypeField(
+        LightTransitionType.linear
+    )
     red: utils.UInt8Field = utils.UInt8Field(0)
     green: utils.UInt8Field = utils.UInt8Field(0)
     blue: utils.UInt8Field = utils.UInt8Field(0)
     white: utils.UInt8Field = utils.UInt8Field(0)
-    
-@dataclass 
+
+
+@dataclass
 class ClearLightActionStagingQueue(utils.BinarySerializable):
     """Clear the staging queue for light actions."""
 
@@ -229,7 +234,7 @@ class ClearLightActionStagingQueue(utils.BinarySerializable):
     length: utils.UInt16Field = utils.UInt16Field(0)
 
 
-@dataclass 
+@dataclass
 class StartLightAction(utils.BinarySerializable):
     """Begin the action that is in the staging queue."""
 
@@ -237,7 +242,9 @@ class StartLightAction(utils.BinarySerializable):
         BinaryMessageId.start_light_action
     )
     length: utils.UInt16Field = utils.UInt16Field(1)
-    type: LightActionTypeField = LightActionTypeField(LightActionType.single_shot)
+    type: LightAnimationTypeField = LightAnimationTypeField(
+        LightAnimationType.single_shot
+    )
 
 
 BinaryMessageDefinition = Union[

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -4,13 +4,15 @@ from functools import lru_cache
 from typing import Type, Union, Optional
 from typing_extensions import get_args
 
-from ..binary_constants import BinaryMessageId
+from ..binary_constants import BinaryMessageId, LightTransitionType, LightActionType
 from .. import utils
 import logging
 from .fields import (
     FirmwareShortSHADataField,
     VersionFlagsField,
     OptionalRevisionField,
+    LightTransitionTypeField,
+    LightActionTypeField,
 )
 
 log = logging.getLogger(__name__)
@@ -202,6 +204,42 @@ class DoorSwitchStateInfo(utils.BinarySerializable):
     door_open: utils.UInt8Field = utils.UInt8Field(0)
 
 
+@dataclass 
+class AddLightActionRequest(utils.BinarySerializable):
+    """Add an action to the staging light queue."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.add_light_action
+    )
+    length: utils.UInt16Field = utils.UInt16Field(7)
+    transition_time: utils.UInt16Field = utils.UInt16Field(0)
+    transition_type: LightTransitionTypeField = LightTransitionTypeField(LightTransitionType.linear)
+    red: utils.UInt8Field = utils.UInt8Field(0)
+    green: utils.UInt8Field = utils.UInt8Field(0)
+    blue: utils.UInt8Field = utils.UInt8Field(0)
+    white: utils.UInt8Field = utils.UInt8Field(0)
+    
+@dataclass 
+class ClearLightActionStagingQueue(utils.BinarySerializable):
+    """Clear the staging queue for light actions."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.clear_light_action_staging_queue
+    )
+    length: utils.UInt16Field = utils.UInt16Field(0)
+
+
+@dataclass 
+class StartLightAction(utils.BinarySerializable):
+    """Begin the action that is in the staging queue."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.start_light_action
+    )
+    length: utils.UInt16Field = utils.UInt16Field(1)
+    type: LightActionTypeField = LightActionTypeField(LightActionType.single_shot)
+
+
 BinaryMessageDefinition = Union[
     Echo,
     Ack,
@@ -218,6 +256,9 @@ BinaryMessageDefinition = Union[
     EstopButtonDetectionChange,
     DoorSwitchStateRequest,
     DoorSwitchStateInfo,
+    AddLightActionRequest,
+    ClearLightActionStagingQueue,
+    StartLightAction,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -21,6 +21,11 @@ from opentrons_hardware.firmware_bindings.constants import (
     GearMotorId,
 )
 
+from opentrons_hardware.firmware_bindings.binary_constants import (
+    LightTransitionType,
+    LightActionType,
+)
+
 
 class OptionalRevisionField(utils.BinaryFieldBase[bytes]):
     """The revision indicator in a device info.
@@ -390,3 +395,25 @@ class MoveStopConditionField(utils.UInt8Field):
         except ValueError:
             condition = str(self.value)
         return f"{self.__class__.__name__}(value={condition})"
+
+class LightTransitionTypeField(utils.UInt8Field):
+    """Light transition type."""
+
+    def __repr__(self) -> str:
+        """Print light transition type."""
+        try:
+            transition = LightTransitionType(self.value).name
+        except ValueError:
+            transition = str(self.value)
+        return f"{self.__class__.__name__}(value={transition})"
+
+class LightActionTypeField(utils.UInt8Field):
+    """Light action type."""
+
+    def __repr__(self) -> str:
+        """Print light action type."""
+        try:
+            action = LightActionType(self.value).name
+        except ValueError:
+            action = str(self.value)
+        return f"{self.__class__.__name__}(value={action})"

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -23,7 +23,7 @@ from opentrons_hardware.firmware_bindings.constants import (
 
 from opentrons_hardware.firmware_bindings.binary_constants import (
     LightTransitionType,
-    LightActionType,
+    LightAnimationType,
 )
 
 
@@ -396,6 +396,7 @@ class MoveStopConditionField(utils.UInt8Field):
             condition = str(self.value)
         return f"{self.__class__.__name__}(value={condition})"
 
+
 class LightTransitionTypeField(utils.UInt8Field):
     """Light transition type."""
 
@@ -407,13 +408,14 @@ class LightTransitionTypeField(utils.UInt8Field):
             transition = str(self.value)
         return f"{self.__class__.__name__}(value={transition})"
 
-class LightActionTypeField(utils.UInt8Field):
+
+class LightAnimationTypeField(utils.UInt8Field):
     """Light action type."""
 
     def __repr__(self) -> str:
         """Print light action type."""
         try:
-            action = LightActionType(self.value).name
+            action = LightAnimationType(self.value).name
         except ValueError:
             action = str(self.value)
         return f"{self.__class__.__name__}(value={action})"


### PR DESCRIPTION
# Overview

Adds some messages for interacting with the rear panel. See https://github.com/Opentrons/ot3-firmware/pull/619 for a more detailed description.

# Test Plan

Updated the `hardware` package on a DVT robot, uploaded the correct firmware branch, and tested using `usb_comm.py`. I was able to send a series of animation steps and then start an animation, and the steps would actually run on the microcontroller.

# Changelog

- Added commands for controlling the rear panel light strip

# Review requests

I have the power set to be `uint8_t` values because:
   1) the color specs in confluence are defined in terms of 8-bit RGBW values
   2) it is more straightforward to implement than using a fixed-point value ranging from [0,1]
   3) it is less annoying through the `usb_comm.py` script to type in integers than fixed point values

Does anyone strongly disagree with this? 

# Risk assessment

Low