### PR TITLE
refactor(hardware_control): make the gripper back paddle use the primary sensor id

### DIFF
--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -587,9 +587,9 @@ class GripperProbe(enum.Enum):
     @classmethod
     def to_type(cls, gp: "GripperProbe") -> InstrumentProbeType:
         if gp == cls.FRONT:
-            return InstrumentProbeType.PRIMARY
-        else:
             return InstrumentProbeType.SECONDARY
+        else:
+            return InstrumentProbeType.PRIMARY
 
 
 class EarlyLiquidSenseTrigger(RuntimeError):

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -664,8 +664,8 @@ async def test_pipette_capacitive_sweep(
 @pytest.mark.parametrize(
     "probe,intr_probe",
     [
-        (GripperProbe.FRONT, InstrumentProbeType.PRIMARY),
-        (GripperProbe.REAR, InstrumentProbeType.SECONDARY),
+        (GripperProbe.FRONT, InstrumentProbeType.SECONDARY),
+        (GripperProbe.REAR, InstrumentProbeType.PRIMARY),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview
All of the pipettes have their back channel (A1) as the "primary" or "S0" label. To make firmware easier, we decided to switch the gripper ID to match the same. The calibration flow will work the same in practice with the only difference being that the CAN message sensor ids are now flipped.


Should pair with: https://github.com/Opentrons/ot3-firmware/pull/613