### PR TITLE
fix(app): clarify that modules remain on deck during lpc checks

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -74,7 +74,7 @@
   "return_tip_rack_to_location": "Return tip rack to {{location}}",
   "slot_name": "slot {{slotName}}",
   "place_modules": "Place modules on deck",
-  "clear_all_slots": "Clear all deck slots of labware",
+  "clear_all_slots": "Clear all deck slots of labware, leaving modules in place",
   "place_a_full_tip_rack_in_location": "Place <bold>a full {{tip_rack}}</bold> into <bold>{{location}}</bold>",
   "place_previous_tip_rack_in_location": "Place the <bold>{{tip_rack}}</bold> that you used before back into <bold>{{location}}</bold>. The pipette will return tips to their original location in the rack.",
   "place_labware_in_location": "Place a <bold>{{labware}}</bold> into <bold>{{location}}</bold>",

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -62,7 +62,7 @@ describe('CheckItem', () => {
   it('renders correct copy when preparing space with tip rack', () => {
     const { getByText, getByRole } = render(props)
     getByRole('heading', { name: 'Prepare tip rack in slot 1' })
-    getByText('Clear all deck slots of labware')
+    getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
       matchTextWithSpans('Place a full Mock TipRack Definition into slot 1')
     )
@@ -78,7 +78,7 @@ describe('CheckItem', () => {
 
     const { getByText, getByRole } = render(props)
     getByRole('heading', { name: 'Prepare labware in slot 2' })
-    getByText('Clear all deck slots of labware')
+    getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(matchTextWithSpans('Place a Mock Labware Definition into slot 2'))
     getByRole('link', { name: 'Need help?' })
     getByRole('button', { name: 'Confirm placement' })

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -58,7 +58,7 @@ describe('PickUpTip', () => {
   it('renders correct copy when preparing space', () => {
     const { getByText, getByRole } = render(props)
     getByRole('heading', { name: 'Prepare tip rack in slot 1' })
-    getByText('Clear all deck slots of labware')
+    getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
       matchTextWithSpans('Place a full Mock TipRack Definition into slot 1')
     )

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
@@ -49,7 +49,7 @@ describe('ReturnTip', () => {
   it('renders correct copy', () => {
     const { getByText, getByRole } = render(props)
     getByRole('heading', { name: 'Return tip rack to slot 1' })
-    getByText('Clear all deck slots of labware')
+    getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
       matchTextWithSpans(
         'Place the Mock TipRack Definition that you used before back into slot 1. The pipette will return tips to their original location in the rack.'


### PR DESCRIPTION
# Overview

Closes [RQA-575](https://opentrons.atlassian.net/browse/RQA-575)

# Risk assessment
low


[RQA-575]: https://opentrons.atlassian.net/browse/RQA-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ