### PR TITLE
refactor(odd): Touchscreen Sleep align with the updated design

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/TouchScreenSleep.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/TouchScreenSleep.tsx
@@ -36,9 +36,10 @@ const SettingButton = styled.input`
 const SettingButtonLabel = styled.label<LabelProps>`
   padding: ${SPACING.spacing5};
   border-radius: ${BORDERS.size_four};
+  height: 5.25rem;
   cursor: pointer;
   background: ${({ isSelected }) =>
-    isSelected === true ? COLORS.blueEnabled : '#e0e0e0'};
+    isSelected === true ? COLORS.blueEnabled : COLORS.foundationalBlue};
   color: ${({ isSelected }) => isSelected === true && COLORS.white};
 `
 
@@ -60,6 +61,8 @@ export function TouchScreenSleep({
   const settingsButtons = [
     { label: t('never'), value: SLEEP_NEVER_MS },
     { label: t('minutes', { minute: 3 }), value: SLEEP_TIME_MS * 3 },
+    { label: t('minutes', { minute: 5 }), value: SLEEP_TIME_MS * 5 },
+    { label: t('minutes', { minute: 10 }), value: SLEEP_TIME_MS * 10 },
     { label: t('minutes', { minute: 15 }), value: SLEEP_TIME_MS * 15 },
     { label: t('minutes', { minute: 30 }), value: SLEEP_TIME_MS * 30 },
     { label: t('one_hour'), value: SLEEP_TIME_MS * 60 },

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/__tests__/TouchScreenSleep.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/__tests__/TouchScreenSleep.test.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react'
+import { fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
+import { updateConfigValue } from '../../../../redux/config'
 import { TouchScreenSleep } from '../TouchScreenSleep'
+
+jest.mock('../../../../redux/config')
+
+const mockUpdateConfigValue = updateConfigValue as jest.MockedFunction<
+  typeof updateConfigValue
+>
 
 const render = (props: React.ComponentProps<typeof TouchScreenSleep>) => {
   return renderWithProviders(<TouchScreenSleep {...props} />, {
@@ -24,10 +32,17 @@ describe('TouchScreenSleep', () => {
     getByText('Touchscreen Sleep')
     getByText('Never')
     getByText('3 minutes')
+    getByText('5 minutes')
+    getByText('10 minutes')
     getByText('15 minutes')
     getByText('30 minutes')
     getByText('1 hour')
   })
 
-  // ToDo (kj:02/06/2023) Additional tests will be added when we implement the update functionality
+  it('should call a mock function when changing the sleep option', () => {
+    const [{ getByText }] = render(props)
+    const button = getByText('10 minutes')
+    fireEvent.click(button)
+    expect(mockUpdateConfigValue).toHaveBeenCalled()
+  })
 })

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/__tests__/TouchscreenBrightness.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/__tests__/TouchscreenBrightness.test.tsx
@@ -41,7 +41,9 @@ describe('TouchscreenBrightness', () => {
     } as any)
   })
 
-  afterEach(() => {})
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
   it('should render text and buttons', () => {
     const [{ getByText, getByTestId }] = render(props)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add 5 min and 10 min and update inactive option's background color. 
Also add a test.

design
https://www.figma.com/file/AoTLAYuWawlaWItB1umOjr/Opentrons-Flex-Touchscreen-Designs?node-id=7808-158040&t=H4iNcGY9MxB3tAYb-0

Close RCORE-702

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
the functionality has been tested already.
 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add 5 min and 10 min
- add a new test case
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Touchscreen sleep shows the updated design
- Touchscreen sleep shows Never, 3 min, 5 min, 10 min, 15 min, 30 min, and 1 hour
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
