### PR TITLE
feat(hardware): add Flex deck light integration

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -326,7 +326,7 @@ class API(
         """Control the robot lights."""
         self._backend.set_lights(button, rails)
 
-    def get_lights(self) -> Dict[str, bool]:
+    async def get_lights(self) -> Dict[str, bool]:
         """Return the current status of the robot lights.
 
         :returns: A dict of the lights: `{'button': bool, 'rails': bool}`

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -130,7 +130,11 @@ from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_pass,
     liquid_probe,
 )
-from opentrons_hardware.hardware_control.rear_panel_settings import get_door_state
+from opentrons_hardware.hardware_control.rear_panel_settings import (
+    get_door_state,
+    set_deck_light,
+    get_deck_light_state,
+)
 
 from opentrons_hardware.drivers.gpio import OT3GPIO, RemoteOT3GPIO
 from opentrons_shared_data.pipette.dev_types import PipetteName
@@ -927,13 +931,15 @@ class OT3Controller:
         nodes = {axis_to_node(ax) for ax in axes}
         await set_enable_motor(self._messenger, nodes)
 
-    def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
+    async def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
         """Set the light states."""
-        return None
+        if rails is not None:
+            await set_deck_light(1 if rails else 0, self._usb_messenger)
 
-    def get_lights(self) -> Dict[str, bool]:
+    async def get_lights(self) -> Dict[str, bool]:
         """Get the light state."""
-        return {}
+        return {"rails": await get_deck_light_state(self._usb_messenger),
+        "button": False}
 
     def pause(self) -> None:
         """Pause the controller activity."""

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -938,8 +938,10 @@ class OT3Controller:
 
     async def get_lights(self) -> Dict[str, bool]:
         """Get the light state."""
-        return {"rails": await get_deck_light_state(self._usb_messenger),
-        "button": False}
+        return {
+            "rails": await get_deck_light_state(self._usb_messenger),
+            "button": False,
+        }
 
     def pause(self) -> None:
         """Pause the controller activity."""

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -126,6 +126,7 @@ class OT3Simulator:
         self._stubbed_attached_modules = attached_modules
         self._update_required = False
         self._initialized = False
+        self._lights = {"button": False, "rails": False}
 
         def _sanitize_attached_instrument(
             mount: OT3Mount, passed_ai: Optional[Dict[str, Optional[str]]] = None
@@ -528,12 +529,14 @@ class OT3Simulator:
     @ensure_yield
     async def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
         """Set the light states."""
-        return None
+        # Simulate how the real driver does this - there's no button so it's always false
+        if rails is not None:
+            self._lights["rails"] = rails
 
     @ensure_yield
     async def get_lights(self) -> Dict[str, bool]:
         """Get the light state."""
-        return {}
+        return self._lights
 
     def pause(self) -> None:
         """Pause the controller activity."""

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -525,11 +525,13 @@ class OT3Simulator:
         """Engage axes."""
         return None
 
-    def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
+    @ensure_yield
+    async def set_lights(self, button: Optional[bool], rails: Optional[bool]) -> None:
         """Set the light states."""
         return None
 
-    def get_lights(self) -> Dict[str, bool]:
+    @ensure_yield
+    async def get_lights(self) -> Dict[str, bool]:
         """Get the light state."""
         return {}
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -471,11 +471,11 @@ class OT3API(
         self, button: Optional[bool] = None, rails: Optional[bool] = None
     ) -> None:
         """Control the robot lights."""
-        self._backend.set_lights(button, rails)
+        await self._backend.set_lights(button, rails)
 
-    def get_lights(self) -> Dict[str, bool]:
+    async def get_lights(self) -> Dict[str, bool]:
         """Return the current status of the robot lights."""
-        return self._backend.get_lights()
+        return await self._backend.get_lights()
 
     async def identify(self, duration_s: int = 5) -> None:
         """Blink the button light to identify the robot."""

--- a/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
+++ b/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
@@ -28,7 +28,7 @@ class ChassisAccessoryManager(EventSourcer, Protocol):
         """
         ...
 
-    def get_lights(self) -> Dict[str, bool]:
+    async def get_lights(self) -> Dict[str, bool]:
         """Return the current status of the robot lights.
 
         :returns: A dict of the lights: `{'button': bool, 'rails': bool}`

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1180,3 +1180,24 @@ async def test_home_axis(
     expected_pos = {axis_to_node(ax): v for ax, v in origin_pos.items()}
     expected_pos.update({axis_to_node(axis): 0})
     assert backend._position == expected_pos
+
+
+@pytest.mark.parametrize("setting", [True, False])
+async def test_light_settings(
+    ot3_hardware: ThreadManager[OT3API], setting: bool
+) -> None:
+    await ot3_hardware.set_lights(rails=setting)
+    check = await ot3_hardware.get_lights()
+    assert check["rails"] == setting
+    assert not check["button"]
+
+    await ot3_hardware.set_lights(rails=not setting)
+    check = await ot3_hardware.get_lights()
+    assert check["rails"] != setting
+    assert not check["button"]
+
+    # Make sure setting the button doesn't affect the rails
+    await ot3_hardware.set_lights(button=setting)
+    check = await ot3_hardware.get_lights()
+    assert check["rails"] != setting
+    assert not check["button"]

--- a/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/binary_constants.py
@@ -28,9 +28,14 @@ class BinaryMessageId(int, Enum):
     door_switch_state_info = 0x0E
 
     # Light messages prefixed by 0x400
+    # 0x40x = light strip
     add_light_action = 0x400
     clear_light_action_staging_queue = 0x401
     start_light_action = 0x402
+    # 0x41x = deck light
+    set_deck_light_request = 0x410
+    get_deck_light_request = 0x411
+    get_deck_light_response = 0x412
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -276,7 +276,7 @@ class GetDeckLightResponse(utils.BinarySerializable):
     message_id: utils.UInt16Field = utils.UInt16Field(
         BinaryMessageId.get_deck_light_response
     )
-    length: utils.UInt16Field = utils.UInt16Field(0)
+    length: utils.UInt16Field = utils.UInt16Field(1)
     setting: utils.UInt8Field = utils.UInt8Field(0)
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -247,6 +247,39 @@ class StartLightAction(utils.BinarySerializable):
     )
 
 
+@dataclass
+class SetDeckLightRequest(utils.BinarySerializable):
+    """Set the deck light on or off."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.set_deck_light_request
+    )
+    length: utils.UInt16Field = utils.UInt16Field(1)
+    # Set to 0 for off, 1 for on
+    setting: utils.UInt8Field = utils.UInt8Field(0)
+
+
+@dataclass
+class GetDeckLightRequest(utils.BinarySerializable):
+    """Get the deck light status."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.get_deck_light_request
+    )
+    length: utils.UInt16Field = utils.UInt16Field(0)
+
+
+@dataclass
+class GetDeckLightResponse(utils.BinarySerializable):
+    """Contains deck light status."""
+
+    message_id: utils.UInt16Field = utils.UInt16Field(
+        BinaryMessageId.get_deck_light_response
+    )
+    length: utils.UInt16Field = utils.UInt16Field(0)
+    setting: utils.UInt8Field = utils.UInt8Field(0)
+
+
 BinaryMessageDefinition = Union[
     Echo,
     Ack,
@@ -266,6 +299,9 @@ BinaryMessageDefinition = Union[
     AddLightActionRequest,
     ClearLightActionStagingQueue,
     StartLightAction,
+    SetDeckLightRequest,
+    GetDeckLightRequest,
+    GetDeckLightResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
@@ -53,6 +53,7 @@ async def get_door_state(messenger: Optional[BinaryMessenger]) -> bool:
 
 
 async def set_deck_light(setting: int, messenger: Optional[BinaryMessenger]) -> bool:
+    """Turn the deck light on or off."""
     if messenger is None:
         # the EVT bots don't have rear panels...
         return False

--- a/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
@@ -45,24 +45,37 @@ def mock_binary_messenger(mock_usb_driver: AsyncMock) -> BinaryMessenger:
     return msg
 
 
+async def prepare_mock_response(
+    messenger: BinaryMessenger, driver: AsyncMock, value: BinaryMessageDefinition
+) -> None:
+    """Mock getting a response from the binary messenger.
+
+    The messenger has a dedicated reader task that uses the driver as an async
+    iterator. In order to correctly mock getting a message from the driver, we
+    should stop the reader task, load the driver iterator with the value we want,
+    and then restart the async reader task. The next time the readre has a chance
+    to run, it will read the value we specified.
+    """
+    await messenger.stop()
+    driver.__aiter__.return_value = [value]
+    messenger.start()
+
+
 @pytest.mark.parametrize("set", [True, False])
 async def test_set_deck_light(
     mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, set: bool
 ) -> None:
     """Test setting the deck light."""
-    # start() MUST be called in the test, not the fixture
-    mock_binary_messenger.start()
-
     expected = SetDeckLightRequest(setting=UInt8Field(set))
 
     # Correct response = good
-    mock_usb_driver.__aiter__.return_value = [Ack()]
+    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, Ack())
     assert await set_deck_light(set, mock_binary_messenger)
     mock_usb_driver.write.assert_called_once_with(message=expected)
     mock_usb_driver.write.reset_mock()
 
     # Incorrect response = bad
-    mock_usb_driver.__aiter__.return_value = [AckFailed()]
+    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, AckFailed())
     assert not await set_deck_light(set, mock_binary_messenger)
     mock_usb_driver.write.assert_called_once_with(message=expected)
 
@@ -72,20 +85,18 @@ async def test_get_deck_light(
     mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, set: bool
 ) -> None:
     """Test getting the deck light."""
-    mock_binary_messenger.start()
-
     # Correct response
-    mock_usb_driver.__aiter__.return_value = [
-        GetDeckLightResponse(setting=UInt8Field(set))
-    ]
-
+    await prepare_mock_response(
+        mock_binary_messenger,
+        mock_usb_driver,
+        GetDeckLightResponse(setting=UInt8Field(set)),
+    )
     assert await get_deck_light_state(mock_binary_messenger) == set
 
     mock_usb_driver.write.assert_called_once_with(message=GetDeckLightRequest())
 
     # Error getting a response should default to False
-    mock_usb_driver.__aiter__.return_value = [AckFailed()]
-
+    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, AckFailed())
     assert await get_deck_light_state(mock_binary_messenger) is False
 
 
@@ -94,18 +105,15 @@ async def test_get_door_state(
     mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, state: bool
 ) -> None:
     """Test getting the deck light."""
-    mock_binary_messenger.start()
-
     # Correct response
-    mock_usb_driver.__aiter__.return_value = [
-        DoorSwitchStateInfo(door_open=UInt8Field(state))
-    ]
-
+    await prepare_mock_response(
+        mock_binary_messenger,
+        mock_usb_driver,
+        DoorSwitchStateInfo(door_open=UInt8Field(state)),
+    )
     assert await get_door_state(mock_binary_messenger) == state
-
     mock_usb_driver.write.assert_called_once_with(message=DoorSwitchStateRequest())
 
     # Error getting a response should default to False
-    mock_usb_driver.__aiter__.return_value = [AckFailed()]
-
+    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, AckFailed())
     assert await get_door_state(mock_binary_messenger) is False

--- a/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
@@ -1,0 +1,111 @@
+"""Test rear panel integration."""
+import pytest
+from mock import AsyncMock
+
+from opentrons_hardware.drivers.binary_usb.bin_serial import SerialUsbDriver
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger
+from opentrons_hardware.firmware_bindings.utils import UInt8Field
+
+from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
+    BinaryMessageDefinition,
+    Ack,
+    AckFailed,
+    GetDeckLightResponse,
+    SetDeckLightRequest,
+    GetDeckLightRequest,
+    DoorSwitchStateInfo,
+    DoorSwitchStateRequest,
+)
+
+from opentrons_hardware.hardware_control.rear_panel_settings import (
+    get_deck_light_state,
+    get_door_state,
+    set_deck_light,
+)
+
+
+@pytest.fixture
+def mock_usb_driver() -> AsyncMock:
+    """Mock communication."""
+    mock = AsyncMock(SerialUsbDriver)
+
+    # Ensure the write() function returns as normal
+    async def mock_write(message: BinaryMessageDefinition) -> int:
+        print(f"Sending message: {message}")
+        return message.get_size()
+
+    mock.write.side_effect = mock_write
+    return mock
+
+
+@pytest.fixture
+def mock_binary_messenger(mock_usb_driver: AsyncMock) -> BinaryMessenger:
+    """BinaryMessenger with a mock usb driver."""
+    msg = BinaryMessenger(driver=mock_usb_driver)
+    return msg
+
+
+@pytest.mark.parametrize("set", [True, False])
+async def test_set_deck_light(
+    mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, set: bool
+) -> None:
+    """Test setting the deck light."""
+    # start() MUST be called in the test, not the fixture
+    mock_binary_messenger.start()
+
+    expected = SetDeckLightRequest(setting=UInt8Field(set))
+
+    # Correct response = good
+    mock_usb_driver.__aiter__.return_value = [Ack()]
+    assert await set_deck_light(set, mock_binary_messenger)
+    mock_usb_driver.write.assert_called_once_with(message=expected)
+    mock_usb_driver.write.reset_mock()
+
+    # Incorrect response = bad
+    mock_usb_driver.__aiter__.return_value = [AckFailed()]
+    assert not await set_deck_light(set, mock_binary_messenger)
+    mock_usb_driver.write.assert_called_once_with(message=expected)
+
+
+@pytest.mark.parametrize("set", [True, False])
+async def test_get_deck_light(
+    mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, set: bool
+) -> None:
+    """Test getting the deck light."""
+    mock_binary_messenger.start()
+
+    # Correct response
+    mock_usb_driver.__aiter__.return_value = [
+        GetDeckLightResponse(setting=UInt8Field(set))
+    ]
+
+    assert await get_deck_light_state(mock_binary_messenger) == set
+
+    mock_usb_driver.write.assert_called_once_with(message=GetDeckLightRequest())
+
+    # Error getting a response should default to False
+    mock_usb_driver.__aiter__.return_value = [AckFailed()]
+
+    assert await get_deck_light_state(mock_binary_messenger) is False
+
+
+@pytest.mark.parametrize("state", [True, False])
+async def test_get_door_state(
+    mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, state: bool
+) -> None:
+    """Test getting the deck light."""
+    mock_binary_messenger.start()
+
+    # Correct response
+    mock_usb_driver.__aiter__.return_value = [
+        DoorSwitchStateInfo(door_open=UInt8Field(state))
+    ]
+
+    assert await get_door_state(mock_binary_messenger) == state
+
+    mock_usb_driver.write.assert_called_once_with(message=DoorSwitchStateRequest())
+
+    # Error getting a response should default to False
+    mock_usb_driver.__aiter__.return_value = [AckFailed()]
+
+    assert await get_door_state(mock_binary_messenger) is False

--- a/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
@@ -103,7 +103,7 @@ async def test_get_deck_light(
 async def test_get_door_state(
     mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, state: bool
 ) -> None:
-    """Test getting the deck light."""
+    """Test getting the door state."""
     # Correct response
     await prepare_mock_response(
         mock_binary_messenger,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
@@ -31,7 +31,6 @@ def mock_usb_driver() -> AsyncMock:
 
     # Ensure the write() function returns as normal
     async def mock_write(message: BinaryMessageDefinition) -> int:
-        print(f"Sending message: {message}")
         return message.get_size()
 
     mock.write.side_effect = mock_write

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -130,7 +130,7 @@ async def post_home_robot(
 async def get_robot_light_state(
     hardware: HardwareControlAPI = Depends(get_hardware),
 ) -> control.RobotLightState:
-    light_state = hardware.get_lights()
+    light_state = await hardware.get_lights()
     return control.RobotLightState(on=light_state.get("rails", False))
 
 

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -65,7 +65,9 @@ class CheckSession(BaseSession):
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
-        session_controls_lights = not configuration.hardware.get_lights()["rails"]
+        session_controls_lights = not (await configuration.hardware.get_lights())[
+            "rails"
+        ]
         await configuration.hardware.cache_instruments()
         await configuration.hardware.home()
         try:

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -50,7 +50,9 @@ class DeckCalibrationSession(BaseSession):
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
-        session_controls_lights = not configuration.hardware.get_lights()["rails"]
+        session_controls_lights = not (await configuration.hardware.get_lights())[
+            "rails"
+        ]
         await configuration.hardware.cache_instruments()
         try:
             deck_cal_user_flow = DeckCalibrationUserFlow(

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -69,7 +69,9 @@ class PipetteOffsetCalibrationSession(BaseSession):
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
-        session_controls_lights = not configuration.hardware.get_lights()["rails"]
+        session_controls_lights = not (await configuration.hardware.get_lights())[
+            "rails"
+        ]
         await configuration.hardware.cache_instruments()
         await configuration.hardware.home()
         try:

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -63,7 +63,9 @@ class TipLengthCalibration(BaseSession):
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
-        session_controls_lights = not configuration.hardware.get_lights()["rails"]
+        session_controls_lights = not (await configuration.hardware.get_lights())[
+            "rails"
+        ]
         await configuration.hardware.cache_instruments()
         await configuration.hardware.home()
         try:


### PR DESCRIPTION
# Overview

Adds messages & integration to control the deck lights on the Flex. This includes new messages that work with https://github.com/Opentrons/ot3-firmware/pull/622 and adds them to the ot3controller class to enable the deck light control.

After adding this PR with the correct rear-panel update, you can control the deck lights using the ot3repl interface or just by sending the HTTP POST/GET commands for the lights. The app seems to block out control of the light still.

# Test Plan

Push the hardware & api targets to a robot and use the HTTP interface to set the light on & off with  a POST request, and check that 1) the light actually turns on/off 2) sending a GET request gets the correct light value.

Need to test on an OT-2 as well since this changes a function to async.

Tested on
- [x] Flex
- [x] OT-2

# Changelog

- Added message definitions for setting & getting the deck light status from the rear panel board
- Changed `get_lights` to an async function because it needs to communicate with the rear panel board
- Updated OT3 Controller to use the new deck light commands to set/get deck light status

# Review requests

- Changing `get_lights` to be async seems pretty low-risk because of our SynchronousAdapter usage, but is there some danger that I'm completely missing?

# Risk assessment

Low as long as it passes smoke testing on both robot types