### PR TITLE
fix(api): always use limit switch during `home`

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -72,6 +72,7 @@ DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (40.5, -60.5, 255.675)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (84.55, -12.75, 93.85)
 DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE: Final = 25
+DEFAULT_AXIS_HOME_DISTANCE: Final = 5
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={
@@ -381,6 +382,9 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
         ),
         grip_jaw_home_duty_cycle=robot_settings.get(
             "grip_jaw_home_duty_cycle", DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE
+        ),
+        axis_home_distance=robot_settings.get(
+            "axis_home_distance", DEFAULT_AXIS_HOME_DISTANCE
         ),
         deck_transform=_build_default_transform(
             robot_settings.get("deck_transform", []), DEFAULT_DECK_TRANSFORM

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -72,7 +72,7 @@ DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (40.5, -60.5, 255.675)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (84.55, -12.75, 93.85)
 DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE: Final = 25
-DEFAULT_AXIS_HOME_DISTANCE: Final = 5
+DEFAULT_SAFE_HOME_DISTANCE: Final = 5
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={
@@ -383,8 +383,8 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
         grip_jaw_home_duty_cycle=robot_settings.get(
             "grip_jaw_home_duty_cycle", DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE
         ),
-        axis_home_distance=robot_settings.get(
-            "axis_home_distance", DEFAULT_AXIS_HOME_DISTANCE
+        safe_home_distance=robot_settings.get(
+            "safe_home_distance", DEFAULT_SAFE_HOME_DISTANCE
         ),
         deck_transform=_build_default_transform(
             robot_settings.get("deck_transform", []), DEFAULT_DECK_TRANSFORM

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -176,6 +176,7 @@ class OT3Config:
     current_settings: OT3CurrentSettings
     z_retract_distance: float
     grip_jaw_home_duty_cycle: float
+    axis_home_distance: float
     deck_transform: OT3Transform
     carriage_offset: Offset
     left_mount_offset: Offset

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -176,7 +176,7 @@ class OT3Config:
     current_settings: OT3CurrentSettings
     z_retract_distance: float
     grip_jaw_home_duty_cycle: float
-    axis_home_distance: float
+    safe_home_distance: float
     deck_transform: OT3Transform
     carriage_offset: Offset
     left_mount_offset: Offset

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1166,7 +1166,7 @@ class OT3API(
             await self._update_position_estimation([axis])
             origin, target_pos = await _retrieve_home_position()
             if OT3Axis.to_kind(axis) in [OT3AxisKind.Z, OT3AxisKind.P]:
-                axis_home_dist = self._config.axis_home_distance
+                axis_home_dist = self._config.safe_home_distance
             else:
                 # FIXME: (AA 2/15/23) This is a temporary workaround because of
                 # XY encoder inaccuracy. Otherwise, we should be able to use

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1166,7 +1166,7 @@ class OT3API(
             await self._update_position_estimation([axis])
             origin, target_pos = await _retrieve_home_position()
             if OT3Axis.to_kind(axis) in [OT3AxisKind.Z, OT3AxisKind.P]:
-                distance_from_home = 3.0
+                distance_from_home = 5.0
             else:
                 # FIXME: (AA 2/15/23) This is a temporary workaround because of
                 # XY encoder inaccuracy. Otherwise, we should be able to use

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1166,28 +1166,22 @@ class OT3API(
             await self._update_position_estimation([axis])
             origin, target_pos = await _retrieve_home_position()
             if OT3Axis.to_kind(axis) in [OT3AxisKind.Z, OT3AxisKind.P]:
-                # we can move directly to the home position for accuracy axes
-                # move directly the home position if the stepper position is valid
+                distance_from_home = 3.0
+            else:
+                # FIXME: (AA 2/15/23) This is a temporary workaround because of
+                # XY encoder inaccuracy. Otherwise, we should be able to use
+                # 5.0 mm for all axes.
+                # Move to 20 mm away from the home position and then home
+                distance_from_home = 20.0
+            if origin[axis] - target_pos[axis] > distance_from_home:
+                target_pos[axis] += distance_from_home
                 moves = self._build_moves(origin, target_pos)
                 await self._backend.move(
                     origin,
                     moves[0],
                     MoveStopCondition.none,
                 )
-            else:
-                if origin[axis] - target_pos[axis] > 20.0:
-                    # FIXME: (AA 2/15/23) This is a temporary workaround because of
-                    # XY encoder inaccuracy. We should remove this and move axes directly
-                    # to the home position when we fix the encoder issues.
-                    # Move to 20 mm away from the home position and then home
-                    target_pos[axis] += 20.00
-                    moves = self._build_moves(origin, target_pos)
-                    await self._backend.move(
-                        origin,
-                        moves[0],
-                        MoveStopCondition.none,
-                    )
-                await self._backend.home([axis])
+            await self._backend.home([axis])
         else:
             # both stepper and encoder positions are invalid, must home
             await self._backend.home([axis])

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1166,15 +1166,15 @@ class OT3API(
             await self._update_position_estimation([axis])
             origin, target_pos = await _retrieve_home_position()
             if OT3Axis.to_kind(axis) in [OT3AxisKind.Z, OT3AxisKind.P]:
-                distance_from_home = 5.0
+                axis_home_dist = self._config.axis_home_distance
             else:
                 # FIXME: (AA 2/15/23) This is a temporary workaround because of
                 # XY encoder inaccuracy. Otherwise, we should be able to use
                 # 5.0 mm for all axes.
                 # Move to 20 mm away from the home position and then home
-                distance_from_home = 20.0
-            if origin[axis] - target_pos[axis] > distance_from_home:
-                target_pos[axis] += distance_from_home
+                axis_home_dist = 20.0
+            if origin[axis] - target_pos[axis] > axis_home_dist:
+                target_pos[axis] += axis_home_dist
                 moves = self._build_moves(origin, target_pos)
                 await self._backend.move(
                     origin,

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -111,6 +111,7 @@ ot3_dummy_settings = {
     "log_level": "NADA",
     "z_retract_distance": 10,
     "grip_jaw_home_duty_cycle": 25,
+    "axis_home_distance": 5,
     "deck_transform": [[-0.5, 0, 1], [0.1, -2, 4], [0, 0, -1]],
     "carriage_offset": (1, 2, 3),
     "right_mount_offset": (3, 2, 1),

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -111,7 +111,7 @@ ot3_dummy_settings = {
     "log_level": "NADA",
     "z_retract_distance": 10,
     "grip_jaw_home_duty_cycle": 25,
-    "axis_home_distance": 5,
+    "safe_home_distance": 5,
     "deck_transform": [[-0.5, 0, 1], [0.1, -2, 4], [0, 0, -1]],
     "carriage_offset": (1, 2, 3),
     "right_mount_offset": (3, 2, 1),

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1162,7 +1162,10 @@ async def test_home_axis(
             if axis in [OT3Axis.Z_L, OT3Axis.P_L]:
                 # move is called
                 mock_backend_move.assert_awaited_once()
-                mock_backend_home.assert_not_awaited()
+                move = mock_backend_move.call_args_list[0][0][1][0]
+                assert move.distance == 95.0
+                # then home is called
+                mock_backend_home.assert_awaited_once()
             else:
                 # we move to 20 mm away from home
                 mock_backend_move.assert_awaited_once()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
To speed homing, we've been commanding a `move` request to get axes with good encoder status to move directly to the home position, without checking whether or not the limit switch had been triggered. 

This could cause several problems.
a) When the actual motor to limit switch distance > commanded move distance, hardware controller would think the that motor has homed, but it in fact hasn't. Or,
b) when the actual motor to limit switch distance < commanded move distance, the axes would crash into the limit switch. 

We should actually move all axes to a safe distance away from the limit switch (default here: 5 mm) then call home to engage the limit switch. This will allow us to still speed up the homing process and help preserve positional accuracy. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
