### PR TITLE
chore(build): Do not pass -i to ssh when there is no identity file

### DIFF
--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -3,7 +3,7 @@
 find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-is-ot3 = $(shell ssh $(if $(2),"-i $(2)") $(3) root@$(1) systemctl status opentrons-robot-app)
+is-ot3 = $(shell ssh $(if $(2),-i $(2)) $(3) root@$(1) systemctl status opentrons-robot-app)
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var
@@ -35,8 +35,8 @@ $(if $(is-windows), echo "when using windows with an openSSH version larger then
 
 define push-python-package
 $(if $(is-ot3), echo "This is an OT-3. Use 'make push-ot3' instead." && exit 1)
-scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
-ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
+scp $(if $(2),-i $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh $(if $(2),-i $(2)) $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
@@ -54,8 +54,8 @@ endef
 # argument 8 is either egg or dist (default egg)
 define push-python-sdist
 $(if $(is-ot3), ,echo "This is an OT-2. Use 'make push' instead." && exit 1)
-scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
-ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
+scp $(if $(2),-i $(2)) $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
+ssh $(if $(2),-i $(2)) $(3) root@$(1) \
 "function cleanup () { rm -f /var/$(notdir $(4)) ; rm -rf /var/$(notdir $(4))-unzip; mount -o remount,ro / ; } ;\
  mkdir -p /var/$(notdir $(4))-unzip ; \
  cd /var/$(notdir $(4))-unzip && tar xf ../$(notdir $(4)) ; \
@@ -75,7 +75,7 @@ endef
 # argument 4 is the service name
 
 define restart-service
-ssh $(if $(2),"-i $(2)") $(3)  root@$(1) \
+ssh $(if $(2),-i $(2)) $(3)  root@$(1) \
 "systemctl restart $(4)"
 endef
 
@@ -86,6 +86,6 @@ endef
 # argument 3 is any further ssh options, quoted
 # argument 4 is the unit file path
 define push-systemd-unit
-	scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh $(if $(2),"-i $(2)") $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+	scp $(if $(2),-i $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
+	ssh $(if $(2),-i $(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -3,7 +3,7 @@
 find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-is-ot3 = $(shell ssh $(id-file-arg $(2)) $(3) root@$(1) systemctl status opentrons-robot-app)
+is-ot3 = $(shell ssh $(if $(2),"-i $(2)") $(3) root@$(1) systemctl status opentrons-robot-app)
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var
@@ -13,7 +13,7 @@ ssh-version-output = $(shell ssh -V 2>&1)
 ssh-version-words=$(subst _, ,$(filter OpenSSH_%, $(ssh-version-output)))
 ssh-version-label=$(or $(filter %p1$(comma),$(ssh-version-words)), $(filter %p1,$(ssh-version-words)))
 ssh-version-number=$(subst ., ,$(firstword $(subst p, ,$(ssh-version-label))))
-checked-ssh-version=$(if $(ssh-version-number),$(ssh-version-number),$(warning "Could not find ssh version for version $(ssh-version-output), scp flags may be wrong")))
+checked-ssh-version=$(if $(ssh-version-number),$(ssh-version-number),"$(warning Could not find ssh version for version $(ssh-version-output), scp flags may be wrong")))
 is-in-version=$(findstring $(firstword $(checked-ssh-version)),$(allowed-ssh-versions))
 # when using an OpenSSH version larger than 8.9,
 # we need to add a flag to use legacy scp with SFTP protocol
@@ -29,13 +29,14 @@ $(if $(is-windows), echo "when using windows with an openSSH version larger then
 # package.
 #
 # argument 1 is the host to push to
-# argument 2 is the identity file to use, if any
+# argument 2 is the identity key to use
 # argument 3 is any further ssh options, quoted
 # argument 4 is the path to the wheel file
+
 define push-python-package
 $(if $(is-ot3), echo "This is an OT-3. Use 'make push-ot3' instead." && exit 1)
-scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
-ssh $(id-file-arg $(2)) $(3) root@$(1) \
+scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
@@ -44,7 +45,7 @@ endef
 
 # push-python-sdist: push an sdist to an ot3
 # argument 1 is the host to push to
-# argument 2 is the identity file to use, if any
+# argument 2 is the identity key to use, if any
 # argument 3 is any further ssh options, quoted
 # argument 4 is the path to the sdist locally
 # argument 5 is the path to go to on the remote side
@@ -53,8 +54,8 @@ endef
 # argument 8 is either egg or dist (default egg)
 define push-python-sdist
 $(if $(is-ot3), ,echo "This is an OT-2. Use 'make push' instead." && exit 1)
-scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
-ssh $(id-file-arg $(2)) $(3) root@$(1) \
+scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
+ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
 "function cleanup () { rm -f /var/$(notdir $(4)) ; rm -rf /var/$(notdir $(4))-unzip; mount -o remount,ro / ; } ;\
  mkdir -p /var/$(notdir $(4))-unzip ; \
  cd /var/$(notdir $(4))-unzip && tar xf ../$(notdir $(4)) ; \
@@ -69,28 +70,22 @@ endef
 # restart-service: ssh to a robot and restart one of its systemd units
 #
 # argument 1 is the host to push to
-# argument 2 is the identity file to use, if any
+# argument 2 is the identity key to use
 # argument 3 is any further ssh options, quoted
 # argument 4 is the service name
+
 define restart-service
-ssh $(id-file-arg $(2)) $(3)  root@$(1) \
+ssh $(if $(2),"-i $(2)") $(3)  root@$(1) \
 "systemctl restart $(4)"
 endef
 
 # push-systemd-unit: move a systemd unit file to the robot
 # 
 # argument 1 is the host to push to
-# argument 2 is the identity file to use, if any
+# argument 2 is the identity key to use
 # argument 3 is any further ssh options, quoted
 # argument 4 is the unit file path
 define push-systemd-unit
-	scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh $(id-file-arg $(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
-endef
-
-# id-file-arg: Internal helper for generating the -i arg for ssh/scp commands
-#
-# argument 1 is the identity file to use, if any
-define id-file-arg
-    $(if $(1),"-i$($1)")
+	scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
+	ssh $(if $(2),"-i $(2)") $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -3,7 +3,7 @@
 find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-is-ot3 = $(shell ssh $(id-file-arg $(2)) $(3) root@$(1) systemctl status opentrons-robot-app)
+is-ot3 = $(shell ssh $(call id-file-arg,$(2)) $(3) root@$(1) systemctl status opentrons-robot-app)
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var
@@ -34,8 +34,8 @@ $(if $(is-windows), echo "when using windows with an openSSH version larger then
 # argument 4 is the path to the wheel file
 define push-python-package
 $(if $(is-ot3), echo "This is an OT-3. Use 'make push-ot3' instead." && exit 1)
-scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
-ssh $(id-file-arg $(2)) $(3) root@$(1) \
+scp $(call id-file-arg,$(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh $(call id-file-arg,$(2)) $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
@@ -53,8 +53,8 @@ endef
 # argument 8 is either egg or dist (default egg)
 define push-python-sdist
 $(if $(is-ot3), ,echo "This is an OT-2. Use 'make push' instead." && exit 1)
-scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
-ssh $(id-file-arg $(2)) $(3) root@$(1) \
+scp $(call id-file-arg,$(2)) $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
+ssh $(call id-file-arg,$(2)) $(3) root@$(1) \
 "function cleanup () { rm -f /var/$(notdir $(4)) ; rm -rf /var/$(notdir $(4))-unzip; mount -o remount,ro / ; } ;\
  mkdir -p /var/$(notdir $(4))-unzip ; \
  cd /var/$(notdir $(4))-unzip && tar xf ../$(notdir $(4)) ; \
@@ -73,7 +73,7 @@ endef
 # argument 3 is any further ssh options, quoted
 # argument 4 is the service name
 define restart-service
-ssh $(id-file-arg $(2)) $(3)  root@$(1) \
+ssh $(call id-file-arg,$(2)) $(3)  root@$(1) \
 "systemctl restart $(4)"
 endef
 
@@ -84,8 +84,8 @@ endef
 # argument 3 is any further ssh options, quoted
 # argument 4 is the unit file path
 define push-systemd-unit
-	scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh $(id-file-arg $(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+	scp $(call id-file-arg,$(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
+	ssh $(call id-file-arg,$(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef
 
 # id-file-arg: Internal helper for generating the -i arg for ssh/scp commands

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -3,7 +3,7 @@
 find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-is-ot3 = $(shell ssh $(if $(2),"-i $(2)") $(3) root@$(1) systemctl status opentrons-robot-app)
+is-ot3 = $(shell ssh $(id-file-arg $(2)) $(3) root@$(1) systemctl status opentrons-robot-app)
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var
@@ -13,7 +13,7 @@ ssh-version-output = $(shell ssh -V 2>&1)
 ssh-version-words=$(subst _, ,$(filter OpenSSH_%, $(ssh-version-output)))
 ssh-version-label=$(or $(filter %p1$(comma),$(ssh-version-words)), $(filter %p1,$(ssh-version-words)))
 ssh-version-number=$(subst ., ,$(firstword $(subst p, ,$(ssh-version-label))))
-checked-ssh-version=$(if $(ssh-version-number),$(ssh-version-number),"$(warning Could not find ssh version for version $(ssh-version-output), scp flags may be wrong")))
+checked-ssh-version=$(if $(ssh-version-number),$(ssh-version-number),$(warning "Could not find ssh version for version $(ssh-version-output), scp flags may be wrong")))
 is-in-version=$(findstring $(firstword $(checked-ssh-version)),$(allowed-ssh-versions))
 # when using an OpenSSH version larger than 8.9,
 # we need to add a flag to use legacy scp with SFTP protocol
@@ -29,14 +29,13 @@ $(if $(is-windows), echo "when using windows with an openSSH version larger then
 # package.
 #
 # argument 1 is the host to push to
-# argument 2 is the identity key to use
+# argument 2 is the identity file to use, if any
 # argument 3 is any further ssh options, quoted
 # argument 4 is the path to the wheel file
-
 define push-python-package
 $(if $(is-ot3), echo "This is an OT-3. Use 'make push-ot3' instead." && exit 1)
-scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
-ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
+scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh $(id-file-arg $(2)) $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
@@ -45,7 +44,7 @@ endef
 
 # push-python-sdist: push an sdist to an ot3
 # argument 1 is the host to push to
-# argument 2 is the identity key to use, if any
+# argument 2 is the identity file to use, if any
 # argument 3 is any further ssh options, quoted
 # argument 4 is the path to the sdist locally
 # argument 5 is the path to go to on the remote side
@@ -54,8 +53,8 @@ endef
 # argument 8 is either egg or dist (default egg)
 define push-python-sdist
 $(if $(is-ot3), ,echo "This is an OT-2. Use 'make push' instead." && exit 1)
-scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
-ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
+scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
+ssh $(id-file-arg $(2)) $(3) root@$(1) \
 "function cleanup () { rm -f /var/$(notdir $(4)) ; rm -rf /var/$(notdir $(4))-unzip; mount -o remount,ro / ; } ;\
  mkdir -p /var/$(notdir $(4))-unzip ; \
  cd /var/$(notdir $(4))-unzip && tar xf ../$(notdir $(4)) ; \
@@ -70,22 +69,28 @@ endef
 # restart-service: ssh to a robot and restart one of its systemd units
 #
 # argument 1 is the host to push to
-# argument 2 is the identity key to use
+# argument 2 is the identity file to use, if any
 # argument 3 is any further ssh options, quoted
 # argument 4 is the service name
-
 define restart-service
-ssh $(if $(2),"-i $(2)") $(3)  root@$(1) \
+ssh $(id-file-arg $(2)) $(3)  root@$(1) \
 "systemctl restart $(4)"
 endef
 
 # push-systemd-unit: move a systemd unit file to the robot
 # 
 # argument 1 is the host to push to
-# argument 2 is the identity key to use
+# argument 2 is the identity file to use, if any
 # argument 3 is any further ssh options, quoted
 # argument 4 is the unit file path
 define push-systemd-unit
-	scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh $(if $(2),"-i $(2)") $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+	scp $(id-file-arg $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
+	ssh $(id-file-arg $(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+endef
+
+# id-file-arg: Internal helper for generating the -i arg for ssh/scp commands
+#
+# argument 1 is the identity file to use, if any
+define id-file-arg
+    $(if $(1),"-i$($1)")
 endef

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -91,6 +91,4 @@ endef
 # id-file-arg: Internal helper for generating the -i arg for ssh/scp commands
 #
 # argument 1 is the identity file to use, if any
-define id-file-arg
-    $(if $(1),"-i$($1)")
-endef
+id-file-arg = $(if $(1),-i $(1))

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -35,8 +35,8 @@ $(if $(is-windows), echo "when using windows with an openSSH version larger then
 
 define push-python-package
 $(if $(is-ot3), echo "This is an OT-3. Use 'make push-ot3' instead." && exit 1)
-scp -i $(2) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
-ssh -i $(2) $(3) root@$(1) \
+scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
@@ -75,7 +75,7 @@ endef
 # argument 4 is the service name
 
 define restart-service
-ssh -i "$(2)" $(3)  root@$(1) \
+ssh $(if $(2),"-i $(2)") $(3)  root@$(1) \
 "systemctl restart $(4)"
 endef
 
@@ -86,6 +86,6 @@ endef
 # argument 3 is any further ssh options, quoted
 # argument 4 is the unit file path
 define push-systemd-unit
-	scp -i $(2) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh -i $(2) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+	scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
+	ssh $(if $(2),"-i $(2)") $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -3,7 +3,7 @@
 find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-is-ot3 = $(shell ssh $(if $(2),-i $(2)) $(3) root@$(1) systemctl status opentrons-robot-app)
+is-ot3 = $(shell ssh $(if $(2),"-i $(2)") $(3) root@$(1) systemctl status opentrons-robot-app)
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var
@@ -35,8 +35,8 @@ $(if $(is-windows), echo "when using windows with an openSSH version larger then
 
 define push-python-package
 $(if $(is-ot3), echo "This is an OT-3. Use 'make push-ot3' instead." && exit 1)
-scp $(if $(2),-i $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
-ssh $(if $(2),-i $(2)) $(3) root@$(1) \
+scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
 "function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
@@ -54,8 +54,8 @@ endef
 # argument 8 is either egg or dist (default egg)
 define push-python-sdist
 $(if $(is-ot3), ,echo "This is an OT-2. Use 'make push' instead." && exit 1)
-scp $(if $(2),-i $(2)) $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
-ssh $(if $(2),-i $(2)) $(3) root@$(1) \
+scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) $(4) root@$(1):/var/$(notdir $(4))
+ssh $(if $(2),"-i $(2)") $(3) root@$(1) \
 "function cleanup () { rm -f /var/$(notdir $(4)) ; rm -rf /var/$(notdir $(4))-unzip; mount -o remount,ro / ; } ;\
  mkdir -p /var/$(notdir $(4))-unzip ; \
  cd /var/$(notdir $(4))-unzip && tar xf ../$(notdir $(4)) ; \
@@ -75,7 +75,7 @@ endef
 # argument 4 is the service name
 
 define restart-service
-ssh $(if $(2),-i $(2)) $(3)  root@$(1) \
+ssh $(if $(2),"-i $(2)") $(3)  root@$(1) \
 "systemctl restart $(4)"
 endef
 
@@ -86,6 +86,6 @@ endef
 # argument 3 is any further ssh options, quoted
 # argument 4 is the unit file path
 define push-systemd-unit
-	scp $(if $(2),-i $(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh $(if $(2),-i $(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+	scp $(if $(2),"-i $(2)") $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
+	ssh $(if $(2),"-i $(2)") $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef


### PR DESCRIPTION
# Overview

This fixes these warnings when running `make push`:

```
Warning: Identity file  not accessible: No such file or directory.
```

These warnings happen when we're not using any SSH identity file, such as when we're pushing to OT-3s. We're passing `-i ""` but we should just not pass `-i` at all.

Parts of `scripts/push.mk` already account for this, but it looks like we missed a few spots.


# Test Plan

I've tested this by doing a top-level `make push-ot3 host=foo` to an OT-3.


# Review requests

I'm copy-pasting the `$(if ...)` expression from elsewhere in this file. Is there a good way to do this with less duplication?

Is the quoting correct, or at least good enough?


# Risk assessment

No risk to production code, but I'm sure a lot of Opentrons people will be very annoyed if this breaks.