### PR TITLE
fix(app): allow go back to select different pipette during attach

### DIFF
--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -166,7 +166,17 @@ export function Instructions(props: Props): JSX.Element {
             marginTop="5.9rem"
           >
             <Btn
-              onClick={stepPage === 0 ? back : () => setStepPage(stepPage - 1)}
+              onClick={() => {
+                if (stepPage === 0) {
+                  if (direction === 'detach' || wantedPipette === null) {
+                    back()
+                  } else {
+                    setWantedName(null)
+                  }
+                } else {
+                  setStepPage(stepPage - 1)
+                }
+              }}
             >
               <StyledText css={GO_BACK_BUTTON_STYLE}>{t('go_back')}</StyledText>
             </Btn>

--- a/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
@@ -137,7 +137,7 @@ describe('Instructions', () => {
     getByAltText('attach-left-single-GEN1-screws')
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
-    expect(props.back).toHaveBeenCalled()
+    expect(props.setWantedName).toHaveBeenCalled()
     const cont = getByRole('button', { name: 'Continue' })
     fireEvent.click(cont)
     expect(props.setStepPage).toHaveBeenCalled()


### PR DESCRIPTION
fix RQA-582

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
We need to "unselect" the selected pipette when a user clicks the back button once on the screen after they selected a pipette to attach.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
On the attach pipette flow:
1. Select a pipette
2. Press "go back"
3. See that you are taken to the select pipette screen 
4. If you press "go back" again, see that you're taken to the "clear deck" screen
5. Verify that the detach flow is unaffected and "Go back" buttons work appropriately

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Separate out "Go Back" logic in the instructions step for selecting a pipette. If you're on the select page and go back, you should be taken back to the clear deck screen. If you're on the screw pipette page and go back, you should be taken back to select a new pipette.

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Run through test plan
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low