### PR TITLE
fix(app): total volume of liquid fixed to 1 decimal point

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/utils.test.ts
@@ -108,6 +108,25 @@ const MOCK_LABWARE_BY_LIQUID_ID: LabwareByLiquidId = {
   ],
 }
 
+const MOCK_LABWARE_BY_LIQUID_ID_DECIMALS: LabwareByLiquidId = {
+  '4': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A3: 100.1111111,
+        A4: 100,
+        B3: 100,
+        B4: 100,
+        C3: 100,
+        C4: 100,
+        D3: 100,
+        D4: 100,
+      },
+    },
+  ],
+}
+
 const MOCK_LABWARE_BY_LIQUID_ID_FOR_LABWARE = {
   '4': [
     {
@@ -223,6 +242,12 @@ describe('getTotalVolumePerLiquidId', () => {
     const expected = 1000
     expect(
       getTotalVolumePerLiquidId(LIQUID_ID, MOCK_LABWARE_BY_LIQUID_ID)
+    ).toEqual(expected)
+  })
+  it('returns volume of liquid needed accross all labware when there are decimal points', () => {
+    const expected = 800.1
+    expect(
+      getTotalVolumePerLiquidId('4', MOCK_LABWARE_BY_LIQUID_ID_DECIMALS)
     ).toEqual(expected)
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/utils.ts
@@ -39,7 +39,7 @@ export function getTotalVolumePerLiquidId(
     .flatMap(labware => Object.values(labware.volumeByWell))
     .reduce((prev, curr) => prev + curr, 0)
 
-  return totalVolume
+  return parseFloat(totalVolume.toFixed(1))
 }
 
 export function getTotalVolumePerLiquidLabwarePair(

--- a/app/src/organisms/ProtocolDetails/ProtocolLiquidsDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLiquidsDetails.tsx
@@ -36,12 +36,8 @@ export const ProtocolLiquidsDetails = (
     >
       {liquidsInLoadOrder?.map((liquid, index) => {
         return (
-          <>
-            <Flex
-              key={liquid.id}
-              flexDirection={DIRECTION_COLUMN}
-              marginY={SPACING.spacing4}
-            >
+          <React.Fragment key={liquid.id}>
+            <Flex flexDirection={DIRECTION_COLUMN} marginY={SPACING.spacing4}>
               <LiquidsListItemDetails
                 liquidId={liquid.id}
                 displayColor={liquid.displayColor}
@@ -51,7 +47,7 @@ export const ProtocolLiquidsDetails = (
               />
             </Flex>
             {index < liquidsInLoadOrder.length - 1 && <Divider />}
-          </>
+          </React.Fragment>
         )
       })}
     </Flex>


### PR DESCRIPTION
closes RQA-578

# Overview

Total volume is fixed to 1 decimal point in the liquid protocol details and setup

<img width="629" alt="Screen Shot 2023-03-28 at 11 25 46 AM" src="https://user-images.githubusercontent.com/66035149/228288074-7dc512dc-dbfc-4dae-b613-4e1f29f70293.png">

# Test Plan

- test the protocol mentioned in the ticket (ask Me or Derek for the custom labware file or remove the custom labware code in the protocol). The liquids section should display the correct sum rounded to 1 decimal point.

# Changelog

- fixed the unique key warning in `ProtocolLiquidDetails`
- added `toFixed()` to `getTotalVolumePerLiquidId`

# Review requests

- see test plan

# Risk assessment

low