### PR TITLE
fix(app): button text from labware prep to labware setup

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -38,7 +38,6 @@
   "plug_in_required_module": "Plug in and power up the required module to continue",
   "plug_in_required_module_plural": "Plug in and power up the required modules to continue",
   "proceed_to_labware_setup_step": "Proceed to labware setup",
-  "proceed_to_labware_setup_prep": "Proceed to labware prep",
   "proceed_to_module_setup_step": "Proceed to module setup",
   "proceed_to_liquid_setup_step": "Proceed to liquid setup",
   "attach_pipette_cta": "Attach Pipette",

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModules.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModules.test.tsx
@@ -63,13 +63,13 @@ describe('SetupModules', () => {
     getByRole('button', { name: 'Map View' })
   })
 
-  it('should render Proceed to labware prep CTA that is enabled', () => {
+  it('should render Proceed to labware setup CTA that is enabled', () => {
     const { getByRole } = render(props)
-    const button = getByRole('button', { name: 'Proceed to labware prep' })
+    const button = getByRole('button', { name: 'Proceed to labware setup' })
     expect(button).toBeEnabled()
   })
 
-  it('should render a disabled Proceed to labware prep CTA if the protocol requests modules and they are not all attached to the robot', () => {
+  it('should render a disabled Proceed to labware setup CTA if the protocol requests modules and they are not all attached to the robot', () => {
     when(mockUseUnmatchedModulesForProtocol)
       .calledWith(MOCK_ROBOT_NAME, MOCK_RUN_ID)
       .mockReturnValue({
@@ -77,7 +77,7 @@ describe('SetupModules', () => {
         remainingAttachedModules: [mockTemperatureModule],
       })
     const { getByRole } = render(props)
-    const button = getByRole('button', { name: 'Proceed to labware prep' })
+    const button = getByRole('button', { name: 'Proceed to labware setup' })
     expect(button).toBeDisabled()
   })
 

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/index.tsx
@@ -51,7 +51,7 @@ export const SetupModules = ({
           padding={`${String(SPACING.spacing3)} ${String(SPACING.spacing4)}`}
           {...targetProps}
         >
-          {t('proceed_to_labware_setup_prep')}
+          {t('proceed_to_labware_setup_step')}
         </PrimaryButton>
       </Flex>
       {missingModuleIds.length > 0 || runHasStarted ? (


### PR DESCRIPTION
closes RQA-579

# Overview

proceed to labware CTA now says `Proceed to labware setup`

<img width="897" alt="Screen Shot 2023-03-28 at 12 45 04 PM" src="https://user-images.githubusercontent.com/66035149/228310590-64a7e90e-21fc-4dae-9f92-cee1301e3be9.png">

# Test Plan

- go to protocol setup and with a module in the protocol, open the module setup accordion. the proceed to button CTA should say correct text

# Changelog

- remove instances of `prepare for labware prep` - removing the i18n key, use the `prepare for labware setup` i18n key and update the test

# Review requests

- see test plan

# Risk assessment

low