### PR TITLE
refactor(app): do not render calibration status banner until all data is known

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -27,6 +27,7 @@
   "robot_configuration": "robot configuration",
   "robot_is_busy": "{{robotName}} is busy",
   "robot_is_busy_with_protocol": "{{robotName}} is busy with {{protocolName}} in {{runStatus}} state. Do you want to clear it and proceed?",
+  "start_setup": "Start setup",
   "run_protocol": "Run protocol",
   "show_in_folder": "Show in folder",
   "unavailable_robot_not_listed": "{{count}} unavailable robot is not listed.",

--- a/app/src/assets/localization/en/protocol_list.json
+++ b/app/src/assets/localization/en/protocol_list.json
@@ -11,7 +11,7 @@
   "reanalyze_or_view_error": "<analysisLink>Reanalyze</analysisLink> protocol or view <errorLink>error details</errorLink>",
   "right_mount": "right mount",
   "robot": "robot",
-  "run_now": "Run now",
+  "start_setup": "Start setup",
   "send_to_ot3": "Send to OT-3",
   "show_in_folder": "Show in folder",
   "this_protocol_will_be_trashed": "This protocol will be moved to this computer’s trash and may be unrecoverable.",

--- a/app/src/organisms/CalibrationStatusCard/index.tsx
+++ b/app/src/organisms/CalibrationStatusCard/index.tsx
@@ -34,7 +34,7 @@ export function CalibrationStatusCard({
   setShowHowCalibrationWorksModal,
 }: CalibrationStatusCardProps): JSX.Element {
   const { t } = useTranslation('robot_calibration')
-  const { taskListStatus } = useCalibrationTaskList(robotName)
+  const { taskListStatus } = useCalibrationTaskList()
 
   // start off assuming we are missing calibrations
   let statusLabelBackgroundColor = COLORS.errorEnabled

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -50,7 +50,6 @@ export function CalibrationTaskList({
   const { t } = useTranslation(['robot_calibration', 'device_settings'])
   const history = useHistory()
   const { activeIndex, taskList, taskListStatus } = useCalibrationTaskList(
-    robotName,
     pipOffsetCalLauncher,
     tipLengthCalLauncher,
     deckCalLauncher

--- a/app/src/organisms/Devices/CalibrationStatusBanner.tsx
+++ b/app/src/organisms/Devices/CalibrationStatusBanner.tsx
@@ -28,17 +28,17 @@ export function CalibrationStatusBanner({
   const { taskListStatus, isLoading } = useCalibrationTaskList()
   if (isLoading === true || taskListStatus === 'complete') return null
   return (
-    <Banner
-      type={taskListStatus === 'bad' ? 'warning' : 'error'}
-      width="100%"
-    >
-      <Flex 
+    <Banner type={taskListStatus === 'bad' ? 'warning' : 'error'} width="100%">
+      <Flex
         width="100%"
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_ROW}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        justifyContent={JUSTIFY_SPACE_BETWEEN}
+      >
         <StyledText as="p">
-          {taskListStatus === 'bad' ? t('recalibration_recommended') : t('missing_calibration_data_long')}
+          {taskListStatus === 'bad'
+            ? t('recalibration_recommended')
+            : t('missing_calibration_data_long')}
         </StyledText>
         <RouterLink to={`/devices/${robotName}/robot-settings/calibration`}>
           <StyledText

--- a/app/src/organisms/Devices/CalibrationStatusBanner.tsx
+++ b/app/src/organisms/Devices/CalibrationStatusBanner.tsx
@@ -25,16 +25,15 @@ export function CalibrationStatusBanner({
   robotName,
 }: CalibrationStatusBannerProps): JSX.Element | null {
   const { t } = useTranslation('robot_calibration')
-  const { isLoading } = useCalibrationTaskList()
-  // if (isLoading === true || taskListStatus === 'complete') return null
-  const taskListStatus = 'bad'
+  const { taskListStatus, isLoading } = useCalibrationTaskList()
+  if (isLoading === true || taskListStatus === 'complete') return null
   return (
     <Banner
       type={taskListStatus === 'bad' ? 'warning' : 'error'}
-      flexDirection={DIRECTION_ROW}
       width="100%"
     >
       <Flex 
+        width="100%"
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_SPACE_BETWEEN}>

--- a/app/src/organisms/Devices/CalibrationStatusBanner.tsx
+++ b/app/src/organisms/Devices/CalibrationStatusBanner.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link as RouterLink } from 'react-router-dom'
+
+import {
+  Flex,
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_ROW,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  TEXT_ALIGN_RIGHT,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { Banner } from '../../atoms/Banner'
+import { StyledText } from '../../atoms/text'
+import { useCalibrationTaskList } from './hooks'
+
+interface CalibrationStatusBannerProps {
+  robotName: string
+}
+
+export function CalibrationStatusBanner({
+  robotName,
+}: CalibrationStatusBannerProps): JSX.Element | null {
+  const { t } = useTranslation('robot_calibration')
+  const { isLoading } = useCalibrationTaskList()
+  // if (isLoading === true || taskListStatus === 'complete') return null
+  const taskListStatus = 'bad'
+  return (
+    <Banner
+      type={taskListStatus === 'bad' ? 'warning' : 'error'}
+      flexDirection={DIRECTION_ROW}
+      width="100%"
+    >
+      <Flex 
+        alignItems={ALIGN_CENTER}
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <StyledText as="p">
+          {taskListStatus === 'bad' ? t('recalibration_recommended') : t('missing_calibration_data_long')}
+        </StyledText>
+        <RouterLink to={`/devices/${robotName}/robot-settings/calibration`}>
+          <StyledText
+            as="p"
+            color={COLORS.darkBlackEnabled}
+            paddingRight={SPACING.spacing4}
+            textAlign={TEXT_ALIGN_RIGHT}
+            textDecoration={TYPOGRAPHY.textDecorationUnderline}
+          >
+            {t('launch_calibration_link_text')}
+          </StyledText>
+        </RouterLink>
+      </Flex>
+    </Banner>
+  )
+}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import { Link as RouterLink } from 'react-router-dom'
 
 import {
   Box,
@@ -16,13 +15,11 @@ import {
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SPACING,
-  TEXT_ALIGN_RIGHT,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import OT3_PNG from '../../assets/images/OT3.png'
-import { Banner, BannerType } from '../../atoms/Banner'
 import { ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { CONNECTABLE, getRobotModelByName } from '../../redux/discovery'
@@ -31,12 +28,12 @@ import { RobotStatusHeader } from './RobotStatusHeader'
 import { ReachableBanner } from './ReachableBanner'
 import { RobotOverviewOverflowMenu } from './RobotOverviewOverflowMenu'
 import {
-  useCalibrationTaskList,
   useIsRobotBusy,
   useIsRobotViewable,
   useLights,
   useRobot,
 } from './hooks'
+import { CalibrationStatusBanner } from './CalibrationStatusBanner'
 
 import type { State } from '../../redux/types'
 
@@ -53,27 +50,7 @@ export function RobotOverview({
     'robot_calibration',
   ])
 
-  const { taskListStatus } = useCalibrationTaskList(robotName)
   const isRobotBusy = useIsRobotBusy({ poll: true })
-
-  // start off assuming we are missing calibrations
-  let showCalibrationStatusBanner = true
-  let calibrationStatusBannerType = 'error'
-  let calibrationStatusBannerText = t(
-    'robot_calibration:missing_calibration_data_long'
-  )
-
-  // if the tasklist is empty, though, all calibrations are good
-  if (taskListStatus === 'complete') {
-    showCalibrationStatusBanner = false
-    // if we have tasks and they are all marked bad, then we should
-    // strongly suggest they re-do those calibrations
-  } else if (taskListStatus === 'bad') {
-    calibrationStatusBannerType = 'warning'
-    calibrationStatusBannerText = t(
-      'robot_calibration:recalibration_recommended'
-    )
-  }
 
   const robot = useRobot(robotName)
   const robotModel = useSelector((state: State) =>
@@ -174,37 +151,7 @@ export function RobotOverview({
           </Box>
         </Flex>
       </Flex>
-      {!isRobotBusy && showCalibrationStatusBanner && (
-        <Flex
-          paddingBottom={SPACING.spacing4}
-          flexDirection={DIRECTION_COLUMN}
-          width="100%"
-        >
-          <Banner type={calibrationStatusBannerType as BannerType}>
-            <Flex
-              alignItems={ALIGN_CENTER}
-              flexDirection={DIRECTION_ROW}
-              justifyContent={JUSTIFY_SPACE_BETWEEN}
-              width="100%"
-            >
-              {calibrationStatusBannerText}
-              <RouterLink
-                to={`/devices/${robotName}/robot-settings/calibration`}
-              >
-                <StyledText
-                  as="p"
-                  color={COLORS.darkBlackEnabled}
-                  paddingRight={SPACING.spacing4}
-                  textAlign={TEXT_ALIGN_RIGHT}
-                  textDecoration={TYPOGRAPHY.textDecorationUnderline}
-                >
-                  {t('robot_calibration:launch_calibration_link_text')}
-                </StyledText>
-              </RouterLink>
-            </Flex>
-          </Banner>
-        </Flex>
-      )}
+      {!isRobotBusy ? <CalibrationStatusBanner robotName={robotName} /> : null}
       <Flex
         borderBottom={BORDERS.lineBorder}
         marginBottom={SPACING.spacing4}

--- a/app/src/organisms/Devices/__tests__/CalibrationStatusBanner.test.tsx
+++ b/app/src/organisms/Devices/__tests__/CalibrationStatusBanner.test.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { MemoryRouter } from 'react-router-dom'
+import { i18n } from '../../../i18n'
+import { CalibrationStatusBanner } from '../CalibrationStatusBanner'
+import { useCalibrationTaskList } from '../hooks'
+
+jest.mock('../hooks')
+
+const mockUseCalibrationTaskList = useCalibrationTaskList as jest.MockedFunction<
+  typeof useCalibrationTaskList
+>
+
+const render = (
+  props: React.ComponentProps<typeof CalibrationStatusBanner>
+) => {
+  return renderWithProviders(
+    <MemoryRouter>
+      <CalibrationStatusBanner {...props} />
+    </MemoryRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('CalibrationStatusBanner', () => {
+  let props: React.ComponentProps<typeof CalibrationStatusBanner>
+  beforeEach(() => {
+    props = { robotName: 'otie' }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('should render null if status is complete', () => {
+    mockUseCalibrationTaskList.mockReturnValue({
+      activeIndex: null,
+      taskList: [],
+      taskListStatus: 'complete',
+      isLoading: false,
+    })
+    const { queryByText, queryByRole } = render(props)
+    expect(queryByText('Recalibration recommended')).toBeNull()
+    expect(queryByText('Robot is missing calibration data')).toBeNull()
+    expect(queryByRole('link', { name: 'Go to calibration' })).toBeNull()
+  })
+  it('should render null if loading', () => {
+    mockUseCalibrationTaskList.mockReturnValue({
+      activeIndex: null,
+      taskList: [],
+      taskListStatus: 'complete',
+      isLoading: true,
+    })
+    const { queryByText, queryByRole } = render(props)
+    expect(queryByText('Recalibration recommended')).toBeNull()
+    expect(queryByText('Robot is missing calibration data')).toBeNull()
+    expect(queryByRole('link', { name: 'Go to calibration' })).toBeNull()
+  })
+  it('should render recalibration recommended if status bad', () => {
+    mockUseCalibrationTaskList.mockReturnValue({
+      activeIndex: null,
+      taskList: [],
+      taskListStatus: 'bad',
+      isLoading: false,
+    })
+    const { getByText, queryByText, getByRole } = render(props)
+    expect(getByText('Recalibration recommended')).toBeInTheDocument()
+    expect(queryByText('Robot is missing calibration data')).toBeNull()
+    expect(getByRole('link', { name: 'Go to calibration' })).toBeInTheDocument()
+  })
+  it('should render calibration required if status bad', () => {
+    mockUseCalibrationTaskList.mockReturnValue({
+      activeIndex: null,
+      taskList: [],
+      taskListStatus: 'incomplete',
+      isLoading: false,
+    })
+    const { getByText, queryByText, getByRole } = render(props)
+    expect(getByText('Robot is missing calibration data')).toBeInTheDocument()
+    expect(queryByText('Recalibration recommended')).toBeNull()
+    expect(getByRole('link', { name: 'Go to calibration' })).toBeInTheDocument()
+  })
+})

--- a/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
@@ -134,10 +134,7 @@ describe('useCalibrationTaskList hook', () => {
 
     const { result } = renderHook(
       () =>
-        useCalibrationTaskList(
-          mockTipLengthCalLauncher,
-          mockDeckCalLauncher
-        ),
+        useCalibrationTaskList(mockTipLengthCalLauncher, mockDeckCalLauncher),
       {
         wrapper,
       }

--- a/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useCalibrationTaskList.test.tsx
@@ -99,7 +99,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -136,8 +135,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
-          mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
         ),
@@ -169,7 +166,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -202,7 +198,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -235,7 +230,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -268,7 +262,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -301,7 +294,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -334,7 +326,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -365,7 +356,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -396,7 +386,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -429,7 +418,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -460,7 +448,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -493,7 +480,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -526,7 +512,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -567,7 +552,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -609,7 +593,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher
@@ -652,7 +635,6 @@ describe('useCalibrationTaskList hook', () => {
     const { result } = renderHook(
       () =>
         useCalibrationTaskList(
-          'otie',
           mockPipOffsetCalLauncher,
           mockTipLengthCalLauncher,
           mockDeckCalLauncher

--- a/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
+++ b/app/src/organisms/Devices/hooks/useCalibrationTaskList.ts
@@ -25,9 +25,9 @@ import { getLabwareDefURI, PipetteName } from '@opentrons/shared-data'
 const CALIBRATION_DATA_POLL_MS = 5000
 
 export function useCalibrationTaskList(
-  pipOffsetCalLauncher: DashboardCalOffsetInvoker = () => { },
-  tipLengthCalLauncher: DashboardCalTipLengthInvoker = () => { },
-  deckCalLauncher: DashboardCalDeckInvoker = () => { }
+  pipOffsetCalLauncher: DashboardCalOffsetInvoker = () => {},
+  tipLengthCalLauncher: DashboardCalTipLengthInvoker = () => {},
+  deckCalLauncher: DashboardCalDeckInvoker = () => {}
 ): TaskListProps {
   const { t } = useTranslation(['robot_calibration', 'devices_landing'])
   const { deleteCalibration } = useDeleteCalibrationMutation()
@@ -38,20 +38,30 @@ export function useCalibrationTaskList(
     activeIndex: null,
     taskListStatus: 'incomplete',
     taskList: [],
-    isLoading: false
+    isLoading: false,
   }
   const attachedPipettes = useAttachedPipettes()
 
-  const { data: calStatusData, isLoading: calStatusIsLoading } = useCalibrationStatusQuery({ refetchInterval: CALIBRATION_DATA_POLL_MS })
-  const { data: pipOffsetData, isLoading: pipOffsetIsLoading } = useAllPipetteOffsetCalibrationsQuery({
+  const {
+    data: calStatusData,
+    isLoading: calStatusIsLoading,
+  } = useCalibrationStatusQuery({ refetchInterval: CALIBRATION_DATA_POLL_MS })
+  const {
+    data: pipOffsetData,
+    isLoading: pipOffsetIsLoading,
+  } = useAllPipetteOffsetCalibrationsQuery({
     refetchInterval: CALIBRATION_DATA_POLL_MS,
   })
-  const { data: tipLengthData, isLoading: tipLengthIsLoading } = useAllTipLengthCalibrationsQuery({
+  const {
+    data: tipLengthData,
+    isLoading: tipLengthIsLoading,
+  } = useAllTipLengthCalibrationsQuery({
     refetchInterval: CALIBRATION_DATA_POLL_MS,
   })
 
-  taskList.isLoading = calStatusIsLoading || pipOffsetIsLoading || tipLengthIsLoading
-  // 3 main tasks: Deck, Left Mount, and Right Mount Calibrations 
+  taskList.isLoading =
+    calStatusIsLoading || pipOffsetIsLoading || tipLengthIsLoading
+  // 3 main tasks: Deck, Left Mount, and Right Mount Calibrations
   const deckCalibrations = calStatusData?.deckCalibration ?? null
 
   const isDeckCalibrated =
@@ -79,11 +89,11 @@ export function useCalibrationTaskList(
     deckTask.isComplete = true
     deckTask.footer =
       deckCalibrationData != null &&
-        'lastModified' in deckCalibrationData &&
-        deckCalibrationData.lastModified != null
+      'lastModified' in deckCalibrationData &&
+      deckCalibrationData.lastModified != null
         ? t('last_completed_on', {
-          timestamp: formatTimestamp(deckCalibrationData.lastModified),
-        })
+            timestamp: formatTimestamp(deckCalibrationData.lastModified),
+          })
         : ''
     deckTask.cta = { label: t('recalibrate'), onClick: deckCalLauncher }
   } else {

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -158,7 +158,7 @@ describe('ProtocolDetails', () => {
     expect(getByRole('heading', { name: 'Deck View' })).toBeInTheDocument()
     expect(getByText('mock Deck Thumbnail')).toBeInTheDocument()
   })
-  it('opens choose robot slideout when run protocol button is clicked', () => {
+  it('opens choose robot slideout when Start setup button is clicked', () => {
     const { getByRole, getByText, queryByText } = render({
       mostRecentAnalysis: {
         ...mockMostRecentAnalysis,
@@ -173,7 +173,7 @@ describe('ProtocolDetails', () => {
         },
       },
     })
-    const runProtocolButton = getByRole('button', { name: 'Run protocol' })
+    const runProtocolButton = getByRole('button', { name: 'Start setup' })
     expect(queryByText('mock Choose Robot Slideout')).toBeNull()
     fireEvent.click(runProtocolButton)
     expect(mockTrackEvent).toHaveBeenCalledWith({

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -437,7 +437,7 @@ export function ProtocolDetails(
                   data-testid="ProtocolDetails_runProtocol"
                   disabled={analysisStatus === 'loading'}
                 >
-                  {t('run_protocol')}
+                  {t('start_setup')}
                 </PrimaryButton>
               </Flex>
             </Flex>

--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -127,7 +127,7 @@ export function ProtocolOverflowMenu(
             onClick={handleClickRun}
             data-testid="ProtocolOverflowMenu_run"
           >
-            {t('run_now')}
+            {t('start_setup')}
           </MenuItem>
           <MenuItem
             onClick={handleClickReanalyze}

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolOverflowMenu.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolOverflowMenu.test.tsx
@@ -66,15 +66,15 @@ describe('ProtocolOverflowMenu', () => {
     const button = getByTestId('ProtocolOverflowMenu_overflowBtn')
     fireEvent.click(button)
     getByText('Show in folder')
-    getByText('Run now')
+    getByText('Start setup')
     getByText('Delete')
   })
 
-  it('should call run protocol when clicking run now button', () => {
+  it('should call run protocol when clicking Start setup button', () => {
     const [{ getByTestId, getByText }] = render()
     const button = getByTestId('ProtocolOverflowMenu_overflowBtn')
     fireEvent.click(button)
-    const runButton = getByText('Run now')
+    const runButton = getByText('Start setup')
     fireEvent.click(runButton)
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: 'proceedToRun',

--- a/app/src/organisms/TaskList/types.ts
+++ b/app/src/organisms/TaskList/types.ts
@@ -28,6 +28,7 @@ export interface TaskListProps {
   activeIndex: [number, number] | null
   taskList: TaskProps[]
   taskListStatus: string | null
+  isLoading?: boolean
   generalTaskClickHandler?: () => void
   generalTaskDisabledReason?: string | null
 }


### PR DESCRIPTION
# Overview

To prevent an unnecessary flash of the calibration status banner before the client has received all
calibration information from the robot, render nothing until the full cal status is known. Also change wording from "Run protocol now" to "start setup"

Closes [RAUT-381](https://opentrons.atlassian.net/browse/RAUT-381)

# Changelog

- "run now" and "run protocol" CTA's now read "start setup"

<img width="561" alt="Screen Shot 2023-03-28 at 5 56 40 PM" src="https://user-images.githubusercontent.com/4731953/228376281-4659308e-10dc-4f94-8d77-e42a94d4ecf4.png">
<img width="888" alt="Screen Shot 2023-03-28 at 5 56 46 PM" src="https://user-images.githubusercontent.com/4731953/228376282-291eb6d0-ceeb-44ee-b51e-f3fa91207635.png">

- When navigating to a device detail page, users should no longer see a flash of the "calibration data missing" red banner while we are still fetching calibration data from the robot.

# Risk assessment
low

[RAUT-381]: https://opentrons.atlassian.net/browse/RAUT-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ