### PR TITLE
fix(app): do not load liquids in LPC prep

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
@@ -5,11 +5,8 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import type { RunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
-import type {
-  SetupRunTimeCommand,
-  SetupCreateCommand,
-} from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+import type { CreateCommand, RunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
+import type { SetupRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type {
   HeaterShakerCloseLatchCreateCommand,
   HeaterShakerDeactivateShakerCreateCommand,
@@ -143,10 +140,10 @@ export function getPrepCommands(
 function isLoadCommand(
   command: RunTimeCommand
 ): command is SetupRunTimeCommand {
-  const loadCommands: Array<SetupCreateCommand['commandType']> = [
+  const loadCommands: Array<CreateCommand['commandType']> = [
     'loadLabware',
     'loadModule',
     'loadPipette',
   ]
-  return command.commandType in loadCommands
+  return loadCommands.includes(command.commandType)
 }

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
@@ -5,7 +5,10 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import type { CreateCommand, RunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6'
+import type {
+  CreateCommand,
+  RunTimeCommand,
+} from '@opentrons/shared-data/protocol/types/schemaV6'
 import type { SetupRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type {
   HeaterShakerCloseLatchCreateCommand,

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
@@ -145,10 +145,8 @@ function isLoadCommand(
 ): command is SetupRunTimeCommand {
   const loadCommands: Array<SetupCreateCommand['commandType']> = [
     'loadLabware',
-    'loadLiquid',
     'loadModule',
     'loadPipette',
   ]
-  // @ts-expect-error SetupCommand is more specific than Command, but the whole point of this util :)
-  return loadCommands.includes(command.commandType)
+  return command.commandType in loadCommands
 }


### PR DESCRIPTION
# Overview

Unlike pipettes, modules, and labware, we do not need to load liquids when LPC is started.

# Review requests

- Run LPC on protocol that has `loadLiquid` commands
- without starting the run, confirm that the commands array doesn't contain any `loadLiquids` 

# Risk assessment
low