### PR TITLE
fix(app): return to top of A1 tip after invalidating pick up in LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -221,17 +221,24 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
       })
   }
   const handleInvalidateTip = (): void => {
-    createRunCommand({
-      command: {
-        commandType: 'dropTip',
-        params: {
-          pipetteId,
-          labwareId,
-          wellName: 'A1',
-        },
+    chainRunCommands([{
+      commandType: 'dropTip',
+      params: {
+        pipetteId,
+        labwareId,
+        wellName: 'A1',
       },
-      waitUntilComplete: true,
-    })
+    },
+    {
+      commandType: 'moveToWell' as const,
+      params: {
+        pipetteId: pipetteId,
+        labwareId: labwareId,
+        wellName: 'A1',
+        wellLocation: { origin: 'top' as const },
+      },
+    }]
+      , true)
       .then(() => {
         registerPosition({ type: 'tipPickUpOffset', offset: null })
         registerPosition({

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -221,24 +221,28 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
       })
   }
   const handleInvalidateTip = (): void => {
-    chainRunCommands([{
-      commandType: 'dropTip',
-      params: {
-        pipetteId,
-        labwareId,
-        wellName: 'A1',
-      },
-    },
-    {
-      commandType: 'moveToWell' as const,
-      params: {
-        pipetteId: pipetteId,
-        labwareId: labwareId,
-        wellName: 'A1',
-        wellLocation: { origin: 'top' as const },
-      },
-    }]
-      , true)
+    chainRunCommands(
+      [
+        {
+          commandType: 'dropTip',
+          params: {
+            pipetteId,
+            labwareId,
+            wellName: 'A1',
+          },
+        },
+        {
+          commandType: 'moveToWell' as const,
+          params: {
+            pipetteId: pipetteId,
+            labwareId: labwareId,
+            wellName: 'A1',
+            wellLocation: { origin: 'top' as const },
+          },
+        },
+      ],
+      true
+    )
       .then(() => {
         registerPosition({ type: 'tipPickUpOffset', offset: null })
         registerPosition({

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -220,18 +220,30 @@ describe('PickUpTip', () => {
       waitUntilComplete: true,
     })
     getByRole('heading', { name: 'Did pipette pick up tip successfully?' })
-    getByRole('button', { name: 'try again' }).click()
-    await expect(props.createRunCommand).toHaveBeenNthCalledWith(3, {
-      command: {
-        commandType: 'dropTip',
-        params: {
-          pipetteId: 'pipetteId1',
-          labwareId: 'labwareId1',
-          wellName: 'A1',
+    await getByRole('button', { name: 'try again' }).click()
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'dropTip',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+          },
         },
-      },
-      waitUntilComplete: true,
-    })
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: undefined },
+          },
+        },
+      ],
+      true
+    )
     await expect(props.registerPosition).toHaveBeenNthCalledWith(3, {
       type: 'tipPickUpOffset',
       offset: null,


### PR DESCRIPTION
# Overview

Instead of initiating a retry jogging to pick up tip in LPC directly from the drop tip location, reissue a moveToWell to the initial position.

Closes RQA-586

# Review requests

- Run LPC and click "Try again" when asked "Did pipette pick up tip successfully?"
- jog and confirm that the live offset shown by the reticle is accurate.

# Risk assessment
low