### PR TITLE
fix(app): show leveling screen where appropriate, clean up step count

### DIFF
--- a/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
+++ b/app/src/organisms/ChangePipette/CheckPipettesButton.tsx
@@ -12,20 +12,19 @@ import {
   SIZE_1,
 } from '@opentrons/components'
 import { PrimaryButton } from '../../atoms/buttons'
-
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
+import { DETACH } from './constants'
 
 export interface CheckPipetteButtonProps {
   robotName: string
   children?: React.ReactNode
-  actualPipette?: PipetteModelSpecs
+  direction?: 'detach' | 'attach'
   onDone?: () => void
 }
 
 export function CheckPipettesButton(
   props: CheckPipetteButtonProps
 ): JSX.Element | null {
-  const { onDone, children, actualPipette } = props
+  const { onDone, children, direction } = props
   const { t } = useTranslation('change_pipette')
   const [isPending, setIsPending] = React.useState(false)
   const { refetch: refetchPipettes } = usePipettesQuery(
@@ -69,7 +68,7 @@ export function CheckPipettesButton(
           marginRight={SPACING.spacing3}
         />
         <StyledText>
-          {actualPipette != null
+          {direction === DETACH
             ? t('confirming_detachment')
             : t('confirming_attachment')}
         </StyledText>
@@ -77,7 +76,7 @@ export function CheckPipettesButton(
     )
   } else if (children == null && !isPending) {
     body =
-      actualPipette != null ? t('confirm_detachment') : t('confirm_attachment')
+      direction === DETACH ? t('confirm_detachment') : t('confirm_attachment')
   }
 
   return (

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -42,6 +42,7 @@ export interface ConfirmPipetteProps {
   setConfirmPipetteLevel: React.Dispatch<React.SetStateAction<boolean>>
   tryAgain: () => void
   exit: () => void
+  nextStep: () => void
   toCalibrationDashboard: () => void
   isDisabled: boolean
 }
@@ -50,7 +51,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   const {
     success,
     mount,
-    tryAgain,
+    nextStep,
     wrongWantedPipette,
     actualPipette,
     setConfirmPipetteLevel,
@@ -106,14 +107,16 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   const isWrongWantedPipette = wrongWantedPipette != null
 
   return !confirmPipetteLevel &&
-    wrongWantedPipette &&
+    (wrongWantedPipette != null || (props.wantedPipette != null && success)) &&
     actualPipette != null &&
     actualPipette.channels === 8 ? (
     <LevelPipette
       mount={mount}
       pipetteModelName={actualPipette.name}
-      back={tryAgain}
-      confirm={() => setConfirmPipetteLevel(true)}
+      confirm={() => {
+        nextStep()
+        setConfirmPipetteLevel(true)
+      }}
     />
   ) : (
     <SimpleWizardBody

--- a/app/src/organisms/ChangePipette/Instructions.tsx
+++ b/app/src/organisms/ChangePipette/Instructions.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
-import { shouldLevel } from '@opentrons/shared-data'
 import {
   Flex,
   DIRECTION_COLUMN,
@@ -18,7 +17,6 @@ import { PrimaryButton } from '../../atoms/buttons'
 import { CheckPipettesButton } from './CheckPipettesButton'
 import { InstructionStep } from './InstructionStep'
 import { PipetteSelection } from './PipetteSelection'
-import { LevelPipette } from './LevelPipette'
 
 import type {
   PipetteNameSpecs,
@@ -38,8 +36,9 @@ interface Props {
   setWantedName: (name: string | null) => void
   back: () => void
   confirm: () => void
-  stepPage: number
-  setStepPage: React.Dispatch<React.SetStateAction<number>>
+  currentStepCount: number
+  nextStep: () => void
+  prevStep: () => void
   attachedWrong: boolean
 }
 
@@ -63,12 +62,18 @@ export function Instructions(props: Props): JSX.Element {
     direction,
     back,
     mount,
-    stepPage,
-    setStepPage,
+    currentStepCount,
+    nextStep,
+    prevStep,
     confirm,
-    attachedWrong,
   } = props
   const { t } = useTranslation('change_pipette')
+
+  React.useEffect(() => {
+    if (direction === 'detach' && currentStepCount === 0) {
+      nextStep()
+    }
+  })
 
   const channels = actualPipette
     ? actualPipette.channels
@@ -81,9 +86,7 @@ export function Instructions(props: Props): JSX.Element {
 
   //  hide continue button if no pipette is selected
   const continueButton = noPipetteSelected ? null : (
-    <PrimaryButton onClick={() => setStepPage(1)}>
-      {t('continue')}
-    </PrimaryButton>
+    <PrimaryButton onClick={() => nextStep()}>{t('continue')}</PrimaryButton>
   )
 
   return (
@@ -95,13 +98,18 @@ export function Instructions(props: Props): JSX.Element {
           marginBottom="12.8rem"
         >
           {direction === 'attach' &&
-          stepPage === 0 &&
+          currentStepCount === 0 &&
           wantedPipette === null ? (
-            <PipetteSelection onPipetteChange={setWantedName} />
+            <PipetteSelection
+              onPipetteChange={pipetteName => {
+                setWantedName(pipetteName)
+                nextStep()
+              }}
+            />
           ) : null}
         </Flex>
       )}
-      {stepPage < 2 ? (
+      {currentStepCount < 3 && (
         <>
           {(actualPipette || wantedPipette) && (
             <Flex
@@ -110,13 +118,13 @@ export function Instructions(props: Props): JSX.Element {
               height="14.5rem"
             >
               <InstructionStep
-                diagram={stepPage === 0 ? 'screws' : 'tab'}
+                diagram={currentStepCount === 1 ? 'screws' : 'tab'}
                 {...{ direction, mount, channels, displayCategory }}
               >
                 <Flex flexDirection={DIRECTION_COLUMN}>
                   <Trans
                     t={t}
-                    i18nKey={stepPage === 0 ? stepOne : stepTwo}
+                    i18nKey={currentStepCount === 1 ? stepOne : stepTwo}
                     components={{
                       h1: (
                         <StyledText
@@ -128,7 +136,7 @@ export function Instructions(props: Props): JSX.Element {
                     }}
                   />
 
-                  {direction === 'attach' && stepPage === 0 ? (
+                  {direction === 'attach' && currentStepCount === 1 ? (
                     channels === 8 ? (
                       <Flex flexDirection={DIRECTION_ROW}>
                         <Trans
@@ -167,44 +175,33 @@ export function Instructions(props: Props): JSX.Element {
           >
             <Btn
               onClick={() => {
-                if (stepPage === 0) {
-                  if (direction === 'detach' || wantedPipette === null) {
-                    back()
-                  } else {
-                    setWantedName(null)
-                  }
+                if (currentStepCount === 0) {
+                  back()
+                } else if (currentStepCount === 1) {
+                  prevStep()
+                  if (wantedPipette != null) setWantedName(null)
+                  if (direction === 'detach') back()
                 } else {
-                  setStepPage(stepPage - 1)
+                  prevStep()
                 }
               }}
             >
               <StyledText css={GO_BACK_BUTTON_STYLE}>{t('go_back')}</StyledText>
             </Btn>
-            {stepPage === 0 ? (
+            {currentStepCount < 2 ? (
               continueButton
             ) : (
               <CheckPipettesButton
                 robotName={robotName}
-                actualPipette={actualPipette ?? undefined}
-                onDone={
-                  wantedPipette != null &&
-                  actualPipette != null &&
-                  shouldLevel(wantedPipette) &&
-                  !attachedWrong
-                    ? () => setStepPage(2)
-                    : confirm
-                }
+                direction={direction}
+                onDone={() => {
+                  confirm()
+                  nextStep()
+                }}
               />
             )}
           </Flex>
         </>
-      ) : (
-        <LevelPipette
-          mount={mount}
-          pipetteModelName={actualPipette ? actualPipette.name : ''}
-          confirm={confirm}
-          back={() => setStepPage(1)}
-        />
       )}
     </>
   )

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -3,12 +3,10 @@ import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
-  ALIGN_FLEX_END,
-  Btn,
-  COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
+  JUSTIFY_FLEX_END,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   TYPOGRAPHY,
@@ -21,7 +19,6 @@ import type { Mount } from '../../redux/pipettes/types'
 interface LevelPipetteProps {
   mount: Mount
   pipetteModelName: string
-  back: () => void
   confirm: () => void
 }
 
@@ -50,7 +47,7 @@ function LevelingVideo(props: {
 }
 
 export function LevelPipette(props: LevelPipetteProps): JSX.Element {
-  const { mount, pipetteModelName, back, confirm } = props
+  const { mount, pipetteModelName, confirm } = props
 
   const { t } = useTranslation('change_pipette')
 
@@ -98,22 +95,7 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
           <LevelingVideo pipetteName={pipetteModelName} mount={mount} />
         </Flex>
       </Flex>
-      <Flex
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-        marginBottom={SPACING.spacing6}
-        marginX={SPACING.spacing6}
-        alignSelf={ALIGN_FLEX_END}
-        marginTop={SPACING.spacing6}
-      >
-        <Btn onClick={back}>
-          <StyledText
-            css={TYPOGRAPHY.pSemiBold}
-            textTransform={TYPOGRAPHY.textTransformCapitalize}
-            color={COLORS.darkGreyEnabled}
-          >
-            {t('go_back')}
-          </StyledText>
-        </Btn>
+      <Flex justifyContent={JUSTIFY_FLEX_END} margin={SPACING.spacing6}>
         <PrimaryButton onClick={confirm}>{t('confirm_level')}</PrimaryButton>
       </Flex>
     </>

--- a/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/CheckPipettesButton.test.tsx
@@ -3,9 +3,7 @@ import { fireEvent } from '@testing-library/react'
 import { usePipettesQuery } from '@opentrons/react-api-client'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
-import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
 import { CheckPipettesButton } from '../CheckPipettesButton'
-import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 jest.mock('@opentrons/react-api-client')
 
@@ -17,14 +15,6 @@ const render = (props: React.ComponentProps<typeof CheckPipettesButton>) => {
     i18nInstance: i18n,
   })[0]
 }
-
-const MOCK_ACTUAL_PIPETTE = {
-  ...mockPipetteInfo.pipetteSpecs,
-  model: 'model',
-  tipLength: {
-    value: 20,
-  },
-} as PipetteModelSpecs
 
 describe('CheckPipettesButton', () => {
   let props: React.ComponentProps<typeof CheckPipettesButton>
@@ -48,6 +38,7 @@ describe('CheckPipettesButton', () => {
     props = {
       robotName: 'otie',
       onDone: jest.fn(),
+      direction: 'attach',
     }
     const { getByLabelText, getByText } = render(props)
     const btn = getByLabelText('Confirm')
@@ -65,7 +56,7 @@ describe('CheckPipettesButton', () => {
     props = {
       robotName: 'otie',
       onDone: jest.fn(),
-      actualPipette: MOCK_ACTUAL_PIPETTE,
+      direction: 'detach',
     }
     const { getByLabelText, getByText } = render(props)
     const btn = getByLabelText('Confirm')
@@ -82,7 +73,6 @@ describe('CheckPipettesButton', () => {
     props = {
       robotName: 'otie',
       onDone: jest.fn(),
-      actualPipette: MOCK_ACTUAL_PIPETTE,
     }
     const { getByLabelText } = render(props)
     const btn = getByLabelText('Confirm')
@@ -98,7 +88,6 @@ describe('CheckPipettesButton', () => {
     } as any)
     props = {
       ...props,
-      actualPipette: MOCK_ACTUAL_PIPETTE,
     }
     const { getByLabelText, getByText } = render(props)
     const btn = getByLabelText('Confirm')

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -100,6 +100,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -128,6 +129,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -164,6 +166,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -200,6 +203,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: MOCK_ACTUAL_PIPETTE,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -232,6 +236,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -268,15 +273,13 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: MOCK_WANTED_PIPETTE,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
 
     const { getByText, getByRole } = render(props)
     getByText('Level the pipette')
-    const goBack = getByRole('button', { name: 'Go back' })
-    fireEvent.click(goBack)
-    expect(props.tryAgain).toHaveBeenCalled()
     const continueBtn = getByRole('button', { name: 'Confirm level' })
     fireEvent.click(continueBtn)
     expect(props.setConfirmPipetteLevel).toHaveBeenCalled()
@@ -299,6 +302,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: MOCK_WANTED_PIPETTE,
       confirmPipetteLevel: true,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -332,6 +336,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -368,6 +373,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }
@@ -397,6 +403,7 @@ describe('ConfirmPipette', () => {
       setWrongWantedPipette: jest.fn(),
       wrongWantedPipette: null,
       confirmPipetteLevel: false,
+      nextStep: jest.fn(),
       setConfirmPipetteLevel: jest.fn(),
       isDisabled: false,
     }

--- a/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/Instructions.test.tsx
@@ -5,19 +5,14 @@ import { LEFT } from '@opentrons/shared-data'
 import { fixtureP10Multi } from '@opentrons/shared-data/pipette/fixtures/name'
 import { i18n } from '../../../i18n'
 import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
-import { LevelPipette } from '../LevelPipette'
 import { Instructions } from '../Instructions'
 import { CheckPipettesButton } from '../CheckPipettesButton'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 jest.mock('../CheckPipettesButton')
-jest.mock('../LevelPipette')
 
 const mockCheckPipettesButton = CheckPipettesButton as jest.MockedFunction<
   typeof CheckPipettesButton
->
-const mockLevelPipette = LevelPipette as jest.MockedFunction<
-  typeof LevelPipette
 >
 
 const render = (props: React.ComponentProps<typeof Instructions>) => {
@@ -48,8 +43,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 0,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 1,
       attachedWrong: false,
     }
     mockCheckPipettesButton.mockReturnValue(
@@ -68,13 +64,13 @@ describe('Instructions', () => {
     fireEvent.click(goBack)
     expect(props.back).toHaveBeenCalled()
     fireEvent.click(cont)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.nextStep).toHaveBeenCalled()
   })
 
   it('renders 2nd page of the detach pipette flow', () => {
     props = {
       ...props,
-      stepPage: 1,
+      currentStepCount: 2,
     }
     const { getByText, getByRole, getByAltText } = render(props)
     getByText('Remove the pipette')
@@ -84,7 +80,7 @@ describe('Instructions', () => {
     getByAltText('detach-left-single-GEN1-tab')
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.prevStep).toHaveBeenCalled()
     getByText('mock check pipettes button')
   })
 
@@ -99,8 +95,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 0,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 0,
       attachedWrong: false,
     }
     const { getByText, getByRole } = render(props)
@@ -122,8 +119,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 0,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 1,
       attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
@@ -140,7 +138,7 @@ describe('Instructions', () => {
     expect(props.setWantedName).toHaveBeenCalled()
     const cont = getByRole('button', { name: 'Continue' })
     fireEvent.click(cont)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.nextStep).toHaveBeenCalled()
   })
 
   it('renders the 2nd page of the attach flow when a p10 single gen 1 is selected', () => {
@@ -154,8 +152,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 1,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 2,
       attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
@@ -166,7 +165,7 @@ describe('Instructions', () => {
     getByAltText('attach-left-single-GEN1-tab')
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.prevStep).toHaveBeenCalled()
     getByText('mock check pipettes button')
   })
 
@@ -181,8 +180,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 0,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 1,
       attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
@@ -198,7 +198,7 @@ describe('Instructions', () => {
     getByAltText('attach-left-multi-GEN1-screws')
     const cont = getByRole('button', { name: 'Continue' })
     fireEvent.click(cont)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.nextStep).toHaveBeenCalled()
   })
 
   it('renders the attach flow 2nd page when a p10 8 channel is selected', () => {
@@ -212,8 +212,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 1,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 2,
       attachedWrong: false,
     }
     const { getByText, getByRole, getByAltText } = render(props)
@@ -224,7 +225,7 @@ describe('Instructions', () => {
     getByAltText('attach-left-multi-GEN1-tab')
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.prevStep).toHaveBeenCalled()
     getByText('mock check pipettes button')
   })
 
@@ -239,8 +240,9 @@ describe('Instructions', () => {
       setWantedName: jest.fn(),
       confirm: jest.fn(),
       back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 1,
+      nextStep: jest.fn(),
+      prevStep: jest.fn(),
+      currentStepCount: 2,
       attachedWrong: true,
     }
     const { getByText, getByRole, getByAltText } = render(props)
@@ -251,27 +253,7 @@ describe('Instructions', () => {
     getByAltText('attach-left-multi-GEN1-tab')
     const goBack = getByRole('button', { name: 'Go back' })
     fireEvent.click(goBack)
-    expect(props.setStepPage).toHaveBeenCalled()
+    expect(props.prevStep).toHaveBeenCalled()
     getByText('mock check pipettes button')
-  })
-
-  it('renders the attach flow 3rd page when a p300 8 channel is selected', () => {
-    mockLevelPipette.mockReturnValue(<div>mockLevelPipette</div>)
-    props = {
-      robotName: 'otie',
-      mount: LEFT,
-      wantedPipette: fixtureP10Multi,
-      actualPipette: fixtureP10Multi as PipetteModelSpecs,
-      displayCategory: 'GEN1',
-      direction: 'attach',
-      setWantedName: jest.fn(),
-      confirm: jest.fn(),
-      back: jest.fn(),
-      setStepPage: jest.fn(),
-      stepPage: 2,
-      attachedWrong: false,
-    }
-    const { getByText } = render(props)
-    getByText('mockLevelPipette')
   })
 })

--- a/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
@@ -60,7 +60,6 @@ describe('LevelPipette', () => {
     props = {
       mount: LEFT,
       pipetteModelName: MOCK_WANTED_PIPETTE.name,
-      back: jest.fn(),
       confirm: jest.fn(),
     }
   })
@@ -91,12 +90,9 @@ describe('LevelPipette', () => {
     getByText(nestedTextMatcher('Gently and slowly push the pipette back up.'))
   })
 
-  it('the CTAs should be clickable', () => {
+  it('the CTA should be clickable', () => {
     const { getByRole } = render(props)
-    const goBack = getByRole('button', { name: 'Go back' })
     const cont = getByRole('button', { name: 'Confirm level' })
-    fireEvent.click(goBack)
-    expect(props.back).toHaveBeenCalled()
     fireEvent.click(cont)
     expect(props.confirm).toHaveBeenCalled()
   })


### PR DESCRIPTION
fix RQA-576

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
The leveling screen was getting skipped in the Instructions step of the attach flow, this refactor cleans things up and moves uses the leveling screen in `ConfirmPipette` instead of `Instructions`

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
1. Run through the single channel detach flow, testing each go back and continue button, and the "try again" loop
2. Run through the multi channel detach flow, testing each go back and continue button, and the "try again" loop
3. Run through the multi channel attach flow, testing each go back and continue button, and the "try again" loop, making sure the leveling screen shows up in the proper location
4. Run through the single channel attach flow, testing each go back and continue button, and the "try again" loop
5. Run through the single channel attach flow, but attach and accept a multi-channel, make sure the leveling screen shows up
6. Run through the single channel attach flow, but attach and accept a single channel, make sure the leveling screen does not show up

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
1. Remove the leveling screen from `Instructions`, always use the one in `ConfirmPipette` to minimize confusion and duplication
2. Centralize the step count logic to `index` with one step variable in state, use this variable to manage the page count in all child components with `nextStep` and `prevStep` functions
3. Solidify the `direction` logic depending on which step we're on
See comments for more clarification

# Review requests

<!--
Describe any requests for your reviewers here.
-->
I ran through the test plan myself, but extra eyes are appreciated!

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low