### PR TITLE
fix(api): we should always call ot3controller.gripper_home_jaw() to home G axis

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -71,8 +71,11 @@ DEFAULT_LEFT_MOUNT_OFFSET: Final[Offset] = (-13.5, -60.5, 255.675)
 DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (40.5, -60.5, 255.675)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (84.55, -12.75, 93.85)
 DEFAULT_Z_RETRACT_DISTANCE: Final = 2
+<<<<<<< HEAD
 DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE: Final = 25
 DEFAULT_SAFE_HOME_DISTANCE: Final = 5
+=======
+>>>>>>> 014073790 (call home_gripper_jaw)
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={
@@ -379,9 +382,6 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
         ),
         z_retract_distance=robot_settings.get(
             "z_retract_distance", DEFAULT_Z_RETRACT_DISTANCE
-        ),
-        grip_jaw_home_duty_cycle=robot_settings.get(
-            "grip_jaw_home_duty_cycle", DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE
         ),
         safe_home_distance=robot_settings.get(
             "safe_home_distance", DEFAULT_SAFE_HOME_DISTANCE

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -71,11 +71,7 @@ DEFAULT_LEFT_MOUNT_OFFSET: Final[Offset] = (-13.5, -60.5, 255.675)
 DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (40.5, -60.5, 255.675)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (84.55, -12.75, 93.85)
 DEFAULT_Z_RETRACT_DISTANCE: Final = 2
-<<<<<<< HEAD
-DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE: Final = 25
 DEFAULT_SAFE_HOME_DISTANCE: Final = 5
-=======
->>>>>>> 014073790 (call home_gripper_jaw)
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -175,7 +175,6 @@ class OT3Config:
     motion_settings: OT3MotionSettings
     current_settings: OT3CurrentSettings
     z_retract_distance: float
-    grip_jaw_home_duty_cycle: float
     safe_home_distance: float
     deck_transform: OT3Transform
     carriage_offset: Offset

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -608,6 +608,9 @@ class OT3Controller:
             A dictionary containing the new positions of each axis
         """
         checked_axes = [axis for axis in axes if self._axis_is_present(axis)]
+        assert (
+            OT3Axis.G not in checked_axes
+        ), "Please home G axis using gripper_home_jaw()"
         if not checked_axes:
             return {}
 
@@ -621,8 +624,6 @@ class OT3Controller:
             if runner
         ]
         positions = await asyncio.gather(*coros)
-        if OT3Axis.G in checked_axes:
-            await self.gripper_home_jaw(self._configuration.grip_jaw_home_duty_cycle)
         if OT3Axis.Q in checked_axes:
             await self.tip_action(
                 [OT3Axis.Q],

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -110,7 +110,6 @@ ot3_dummy_settings = {
     },
     "log_level": "NADA",
     "z_retract_distance": 10,
-    "grip_jaw_home_duty_cycle": 25,
     "safe_home_distance": 5,
     "deck_transform": [[-0.5, 0, 1], [0.1, -2, 4], [0, 0, -1]],
     "carriage_offset": (1, 2, 3),

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -84,19 +84,18 @@ def mock_home(ot3_hardware):
 
 
 async def test_home(ot3_hardware, mock_home):
-    # this is only valid for Axis G, for other axes, check out test_ot3_api.py
     with mock.patch("opentrons.hardware_control.ot3api.deck_from_machine") as dfm_mock:
-        dfm_mock.return_value = {OT3Axis.G: 20}
-        await ot3_hardware._home([OT3Axis.G])
+        dfm_mock.return_value = {OT3Axis.X: 20}
+        await ot3_hardware._home([OT3Axis.X])
 
-        mock_home.assert_called_once_with([OT3Axis.G])
+        mock_home.assert_called_once_with([OT3Axis.X])
         assert dfm_mock.call_count == 2
         dfm_mock.assert_called_with(
             mock_home.return_value,
             ot3_hardware._transforms.deck_calibration.attitude,
             ot3_hardware._transforms.carriage_offset,
         )
-    assert ot3_hardware._current_position[OT3Axis.G] == 20
+    assert ot3_hardware._current_position[OT3Axis.X] == 20
 
 
 async def test_home_unmet(ot3_hardware, mock_home):

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -420,10 +420,11 @@ async def test_liquid_probe(
     fake_liquid_settings: LiquidProbeSettings,
     mock_instrument_handlers: Tuple[Mock],
     mock_current_position_ot3: AsyncMock,
+    mock_ungrip: AsyncMock,
     mock_home_plunger: AsyncMock,
 ) -> None:
+    mock_ungrip.return_value = None
     backend = ot3_hardware.managed_obj._backend
-
     await ot3_hardware.home()
     mock_move_to.return_value = None
 
@@ -490,9 +491,10 @@ async def test_liquid_sensing_errors(
     mock_instrument_handlers: Tuple[Mock],
     mock_current_position_ot3: AsyncMock,
     mock_home_plunger: AsyncMock,
+    mock_ungrip: AsyncMock,
 ) -> None:
     backend = ot3_hardware.managed_obj._backend
-
+    mock_ungrip.return_value = None
     await ot3_hardware.home()
     mock_move_to.return_value = None
 
@@ -787,6 +789,8 @@ async def test_gripper_action(
     mock_ungrip.assert_called_once()
     mock_ungrip.reset_mock()
     await ot3_hardware.home([OT3Axis.G])
+    mock_ungrip.assert_called_once()
+    mock_ungrip.reset_mock()
     await ot3_hardware.grip(5.0)
     mock_grip.assert_called_once_with(
         gc.duty_cycle_by_force(5.0, gripper_config.grip_force_profile),
@@ -956,7 +960,9 @@ async def test_save_instrument_offset(
 async def test_pick_up_tip_full_tiprack(
     ot3_hardware: ThreadManager[OT3API],
     mock_instrument_handlers: Tuple[Mock],
+    mock_ungrip: AsyncMock,
 ) -> None:
+    mock_ungrip.return_value = None
     await ot3_hardware.home()
     _, pipette_handler = mock_instrument_handlers
     backend = ot3_hardware.managed_obj._backend


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
There are currently two different methods of homing the gripper jaw:
1. `ot3api.home()` which calls `ot3controller.home()` and uses a default duty cycle value in the robot configs to ungrip
2. `ot3api.home_gripper_jaw()` which calls `ot3controller.gripper_home_jaw()` and calculates the ungrip duty cycle using the gripper definition

We really should just stick to using 2. to make sure we're using the proper ungrip duty cycle based on the gripper model. 

# Changelog
* `ot3api.home([OT3Axis.G])` reroutes to `ot3api.home_gripper_jaw()`
* ignore GripperNotAttached error whenever we call home jaw to match home behavior for other nodes
*  remove `DEFAULT_GRIPPER_JAW_HOME_DUTY_CYCLE` in robot config