### PR TITLE
fix(api,hardware): update devices in bootloader

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -163,7 +163,7 @@ def node_id_to_subsystem(node_id: NodeId) -> "OT3SubSystem":
     node_to_subsystem = {
         node: subsystem for subsystem, node in SUBSYSTEM_NODEID.items()
     }
-    return node_to_subsystem[node_id]
+    return node_to_subsystem[node_id.application_for()]
 
 
 def get_current_settings(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -202,9 +202,11 @@ def fw_update_info() -> Dict[NodeId, str]:
 
 @pytest.fixture
 def fw_node_info() -> Dict[NodeId, DeviceInfoCache]:
-    node_cache1 = DeviceInfoCache(NodeId.head, 1, "12345678", None, PCBARevision(None))
+    node_cache1 = DeviceInfoCache(
+        NodeId.head, 1, "12345678", None, PCBARevision(None), subidentifier=0
+    )
     node_cache2 = DeviceInfoCache(
-        NodeId.gantry_x, 1, "12345678", None, PCBARevision(None)
+        NodeId.gantry_x, 1, "12345678", None, PCBARevision(None), subidentifier=0
     )
     return {NodeId.head: node_cache1, NodeId.gantry_x: node_cache2}
 

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -31,6 +31,27 @@ class NodeId(int, Enum):
     head_bootloader = head | 0xF
     gripper_bootloader = gripper | 0xF
 
+    def is_bootloader(self) -> bool:
+        """Whether this node ID is a bootloader."""
+        return bool(self.value & 0xF == 0xF)
+
+    def bootloader_for(self) -> "NodeId":
+        """The associated bootloader node ID for the node.
+
+        This is safe to call on any node id, including ones that are already bootloaders.
+        """
+        return NodeId(self.value | 0xF)
+
+    def application_for(self) -> "NodeId":
+        """The associated core node ID for the node (i.e. head, not head_l).
+
+        This is safe to call on any node ID, including non-core application node IDs like
+        head_l. It will always give the code node ID.
+        """
+        # in c this would be & ~0xf but in python that gives 0x10 for some reason
+        # so let's write out the whole byte
+        return NodeId(self.value & 0xF0)
+
 
 # make these negative numbers so there is no chance they overlap with NodeId
 @unique
@@ -38,6 +59,14 @@ class USBTarget(int, Enum):
     """List of firmware targets connected over usb."""
 
     rear_panel = -1
+
+    def is_bootloader(self) -> bool:
+        """Whether this is a bootloader id (always false)."""
+        return False
+
+    def application_for(self) -> "USBTarget":
+        """The corresponding application id."""
+        return self
 
 
 FirmwareTarget = Union[NodeId, USBTarget]

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -65,6 +65,7 @@ class DeviceInfoResponse(utils.BinarySerializable):
     flags: VersionFlagsField = VersionFlagsField(0)
     shortsha: FirmwareShortSHADataField = FirmwareShortSHADataField(bytes())
     revision: OptionalRevisionField = OptionalRevisionField("", "", "")
+    subidentifier: utils.UInt8Field = utils.UInt8Field(0)
 
     @classmethod
     def build(cls, data: bytes) -> "DeviceInfoResponse":
@@ -102,8 +103,16 @@ class DeviceInfoResponse(utils.BinarySerializable):
 
         revision = OptionalRevisionField.build(data[data_iter:])
 
+        data_iter = data_iter + revision.NUM_BYTES
+        try:
+            subidentifier = utils.UInt8Field.build(
+                int.from_bytes(data[data_iter : data_iter + 1], "big")
+            )
+        except IndexError:
+            subidentifier = utils.UInt8Field.build(0)
+
         return DeviceInfoResponse(
-            message_id, length, version, flags, shortsha, revision
+            message_id, length, version, flags, shortsha, revision, subidentifier
         )
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -4,6 +4,7 @@
 #  from __future__ import annotations
 from dataclasses import dataclass, field, asdict
 from . import message_definitions
+from typing import Iterator
 
 from .fields import (
     FirmwareShortSHADataField,
@@ -83,16 +84,29 @@ class DeviceInfoResponsePayload(_DeviceInfoResponsePayloadBase):
         consumed_by_super = _DeviceInfoResponsePayloadBase.get_size()
         superdict = asdict(_DeviceInfoResponsePayloadBase.build(data))
         message_index = superdict.pop("message_index")
+
+        # we want to parse this by adding extra 0s that may not be necessary,
+        # which is annoying and complex, so let's wrap it in an iterator
+        def _data_for_optionals(consumed: int, buf: bytes) -> Iterator[bytes]:
+            extended = buf + b"\x00\x00\x00\x00"
+            yield extended[consumed:]
+            consumed += 4
+            extended = extended + b"\x00"
+            yield extended[consumed : consumed + 1]
+
+        optionals_yielder = _data_for_optionals(consumed_by_super, data)
         inst = cls(
             **superdict,
-            revision=OptionalRevisionField.build(
-                (data + b"\x00\x00\x00\x00")[consumed_by_super:]
+            revision=OptionalRevisionField.build(next(optionals_yielder)),
+            subidentifier=utils.UInt8Field.build(
+                int.from_bytes(next(optionals_yielder), "big")
             ),
         )
         inst.message_index = message_index
         return inst
 
     revision: OptionalRevisionField
+    subidentifier: utils.UInt8Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -254,7 +254,7 @@ class RunUpdate:
         initiator = FirmwareUpdateInitiator(messenger)
         downloader = FirmwareUpdateDownloader(messenger)
 
-        target = Target(system_node=node_id)
+        target = Target.from_single_node(node_id)
 
         logger.info(f"Initiating FW Update on {target}.")
         await self._status_queue.put((node_id, (FirmwareUpdateStatus.updating, 0)))

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -297,7 +297,7 @@ class RunUpdate:
         else:
             logger.info("Skipping erase step.")
 
-        logger.info(f"Downloading FW to {target.bootloader_node}.")
+        logger.info(f"Downloading {filepath} to {target.bootloader_node}.")
         with open(filepath) as f:
             hex_processor = HexRecordProcessor.from_file(f)
             async for download_progress in downloader.run(

--- a/hardware/opentrons_hardware/firmware_update/utils.py
+++ b/hardware/opentrons_hardware/firmware_update/utils.py
@@ -86,7 +86,6 @@ class FirmwareUpdateType(Enum):
         """Return FirmwareUpdateType with given node."""
         lookup = {
             NodeId.head: cls.head,
-            NodeId.head: cls.head,
             NodeId.gantry_x: cls.gantry_x,
             NodeId.gantry_y: cls.gantry_y,
             NodeId.gripper: cls.gripper,

--- a/hardware/opentrons_hardware/firmware_update/utils.py
+++ b/hardware/opentrons_hardware/firmware_update/utils.py
@@ -291,7 +291,7 @@ def _should_update(
     force: bool,
 ) -> bool:
     if version_cache.target.is_bootloader():
-        log.info(f"Update required {version_cache.target} (in bootloader)")
+        log.info(f"Update required for {version_cache.target} (in bootloader)")
         return True
     if force:
         log.info(f"Update required for {version_cache.target} (forced)")

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -43,6 +43,7 @@ class DeviceInfoCache:
     shortsha: str
     flags: Any
     revision: PCBARevision
+    subidentifier: int
 
     def __repr__(self) -> str:
         """Readable representation of the device info."""
@@ -276,6 +277,7 @@ def _parse_usb_device_info_response(
                 revision=PCBARevision(
                     message.revision.revision, message.revision.tertiary
                 ),
+                subidentifier=message.subidentifier.value,
             )
         except (ValueError, UnicodeDecodeError) as e:
             log.error(f"Could not parse DeviceInfoResponse {e}")
@@ -304,6 +306,7 @@ def _parse_can_device_info_response(
                 revision=PCBARevision(
                     message.payload.revision.revision, message.payload.revision.tertiary
                 ),
+                subidentifier=message.payload.subidentifier.value,
             )
         except (ValueError, UnicodeDecodeError) as e:
             log.error(f"Could not parse DeviceInfoResponse {e}")

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_messages/test_payloads.py
@@ -57,6 +57,7 @@ def test_old_get_device_info() -> None:
     assert reparsed_old.revision.primary is None
     assert reparsed_old.revision.secondary is None
     assert reparsed_old.revision.tertiary is None
+    assert reparsed_old.subidentifier.value == 0
 
 
 def test_padded_old_get_device_info() -> None:
@@ -75,6 +76,7 @@ def test_padded_old_get_device_info() -> None:
     assert reparsed_old.revision.primary is None
     assert reparsed_old.revision.secondary is None
     assert reparsed_old.revision.tertiary is None
+    assert reparsed_old.subidentifier.value == 0
 
 
 def test_new_get_device_info() -> None:
@@ -84,6 +86,7 @@ def test_new_get_device_info() -> None:
         flags=fields.VersionFlagsField(0x55667788),
         shortsha=fields.FirmwareShortSHADataField(b"abcdef12"),
         revision=fields.OptionalRevisionField.build(b"a1\x00\x00"),
+        subidentifier=utils.UInt8Field.build(9),
     )
     new.message_index = utils.UInt32Field(0)
     ser = new.serialize()
@@ -94,3 +97,4 @@ def test_new_get_device_info() -> None:
     assert reparsed_new.revision.primary == new.revision.primary
     assert reparsed_new.revision.secondary == new.revision.secondary
     assert reparsed_new.revision.tertiary == new.revision.tertiary
+    assert reparsed_new.subidentifier == new.subidentifier

--- a/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_initiater.py
@@ -9,7 +9,7 @@ from opentrons_hardware.firmware_bindings import (
 )
 from opentrons_hardware.firmware_bindings.messages import MessageDefinition, fields
 from opentrons_hardware.firmware_bindings.messages import message_definitions, payloads
-from opentrons_hardware.firmware_bindings.utils import UInt32Field
+from opentrons_hardware.firmware_bindings.utils import UInt32Field, UInt8Field
 
 from opentrons_hardware.firmware_update import initiator
 from opentrons_hardware.firmware_update.errors import BootloaderNotReady
@@ -39,6 +39,7 @@ async def test_messaging(
                     flags=fields.VersionFlagsField(0),
                     shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
                     revision=fields.OptionalRevisionField.build(b""),
+                    subidentifier=UInt8Field(0),
                 )
             )
             can_message_notifier.notify(
@@ -53,7 +54,7 @@ async def test_messaging(
                 ),
             )
 
-    target = Target(system_node=NodeId.head)
+    target = Target.from_single_node(NodeId.head)
 
     mock_messenger.send.side_effect = responder
 
@@ -88,6 +89,7 @@ async def test_retry(
                 flags=fields.VersionFlagsField(0),
                 shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
                 revision=fields.OptionalRevisionField.build(b""),
+                subidentifier=UInt8Field(0),
             )
         ),
         None,
@@ -112,7 +114,7 @@ async def test_retry(
                     ),
                 )
 
-    target = Target(system_node=NodeId.head)
+    target = Target.from_single_node(NodeId.head)
 
     mock_messenger.send.side_effect = responder
 
@@ -145,7 +147,7 @@ async def test_bootloader_not_ready(
     mock_messenger: AsyncMock,
 ) -> None:
     """It should raise an error when bootloader never responds."""
-    target = Target(system_node=NodeId.head)
+    target = Target.from_single_node(NodeId.head)
 
     retry_count = 3
     with pytest.raises(BootloaderNotReady):

--- a/hardware/tests/opentrons_hardware/firmware_update/test_run.py
+++ b/hardware/tests/opentrons_hardware/firmware_update/test_run.py
@@ -81,7 +81,7 @@ async def test_run_update(
     mock_hex_record_processor = MagicMock()
     mock_hex_record_builder.return_value = mock_hex_record_processor
 
-    target = Target(system_node=NodeId.head)
+    target = Target.from_single_node(NodeId.head)
     update_details: Dict[FirmwareTarget, str] = {
         target.system_node: hex_file_path,
     }
@@ -137,8 +137,8 @@ async def test_run_updates(
     hex_file_2 = str()
     mock_hex_record_processor = MagicMock()
     mock_hex_record_builder.return_value = mock_hex_record_processor
-    target_1 = Target(system_node=NodeId.gantry_x)
-    target_2 = Target(system_node=NodeId.gantry_y)
+    target_1 = Target.from_single_node(NodeId.gantry_x)
+    target_2 = Target.from_single_node(NodeId.gantry_y)
     update_details: Dict[FirmwareTarget, str] = {
         target_1.system_node: hex_file_1,
         target_2.system_node: hex_file_2,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -67,6 +67,7 @@ class MockCanStatusResponder:
                         flags=fields.VersionFlagsField(0),
                         shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
                         revision=fields.OptionalRevisionField.build(b""),
+                        subidentifier=utils.UInt8Field(0),
                     )
                 )
                 asyncio.get_running_loop().call_soon(
@@ -110,6 +111,7 @@ class MockUSBStatusResponder:
                     flags=fields.VersionFlagsField(0),
                     shortsha=fields.FirmwareShortSHADataField(b"abcdef0"),
                     revision=fields.OptionalRevisionField.build(b""),
+                    subidentifier=utils.UInt8Field(0),
                 )
                 asyncio.get_running_loop().call_soon(
                     callback,


### PR DESCRIPTION
Currently, if we have a device in its bootloader during our network probe, we probably don't update its firmware properly. That's for a couple reasons:
- If it's a pipette, we don't actually know what pipette type it is, since it won't be in attached pipettes and the bootloader can't give us the type
- Even if it's not, we might not handle the node id properly

This commit fixes both problems.

For pipettes, we take advantage of the device subidentifier recently introduced to the device info response payload. That subidentifier is device-specific; for the pipettes it will be the pipette type, and for others it isn't specified and is 0. That means that we can now find the right pipette type for a pipette that is stuck in its bootloader. It also means we can simplify the hardware interface by no longer requiring the attached pipettes dict, though we only want that once we're confident all pipettes have the new bootloader.

As a fallback for everything else, we should now explicitly handle bootloader nodes at every stage.

Closes RQA-584

## Testing
- This should be tested both with and without https://github.com/Opentrons/ot3-firmware/pull/624 
- WIthout a bootloader with that PR merged, it should update things that aren't pipettes that are in the bootloader when the firmware update query begins; for pipettes, it should have additional logging
- With that bootloader update, pipettes that are in a bootloader when the update query occurs should get updated

- Put on a flex, and make sure everything gets updated when they're in their application both
   - [x]  with the firmware update
   - [x] and without the ot3-firmware pull
- Put on a flex, and test a pipette of each type and one non-pipette by forcing them into their bootloader and showing that
   - ~[ ] without the ot3-firmware update, a non-pipette now gets updated if stuck in the bootloader~
   - [x] without the ot3-firmware update, a pipette in its bootloader still doesn't get updated, but we get a better log
   - ~[ ] with the ot3-firmware update, a non-pipette now gets updated if stuck in the bootloader~
   - [x] with the ot3-firmware update, a pipette now gets updated if stuck in the bootloader
- [x] also pipettes should say the right pipette type in their device infos both in bootloader and application
## Review Requests
- This ended up being bigger than I'd hoped; does it all make sense?

## Note
Non-pipettes, or rather things in the "core" node set, won't get updated because we just won't boot without them. That should be fixed, but I'm going to do it in a second PR since it doesn't really have anything to do with bootloaders or pipette types at this point.