### PR TITLE
refactor(hardware): add send_and_receive for rear panel communication

### DIFF
--- a/hardware/opentrons_hardware/drivers/binary_usb/binary_messenger.py
+++ b/hardware/opentrons_hardware/drivers/binary_usb/binary_messenger.py
@@ -62,12 +62,7 @@ class SendAndReceiveListener:
         )
         await self._messenger.send(message)
         try:
-            tasks = asyncio.all_tasks()
-            for task in tasks:
-                # print(f"Task: {task}")
-                pass
             await asyncio.wait_for(self._event.wait(), self._timeout)
-            # await evt.wait()
         except asyncio.TimeoutError:
             log.error("response timed out")
         finally:

--- a/hardware/opentrons_hardware/drivers/binary_usb/binary_messenger.py
+++ b/hardware/opentrons_hardware/drivers/binary_usb/binary_messenger.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import asyncio
 from inspect import Traceback
-from typing import Optional, Callable, Tuple, Dict
+from typing import Optional, Callable, Tuple, Dict, Type
 
 import logging
 
@@ -12,6 +12,7 @@ from opentrons_hardware.firmware_bindings.binary_constants import BinaryMessageI
 
 from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
     BinaryMessageDefinition,
+    AckFailed,
 )
 
 from opentrons_hardware.firmware_bindings.utils import BinarySerializableException
@@ -23,6 +24,56 @@ BinaryMessageListenerCallback = Callable[[BinaryMessageDefinition], None]
 
 
 BinaryMessageListenerCallbackFilter = Callable[[BinaryMessageId], bool]
+
+
+class SendAndReceiveListener:
+    """Helper class for sending a message and ensuring a response."""
+
+    def __init__(
+        self,
+        messenger: BinaryMessenger,
+        response_type: Type[BinaryMessageDefinition],
+        timeout: float = 1.0,
+    ) -> None:
+        """Create a new SendAndReceiveListener."""
+        self._event = asyncio.Event()
+        self._messenger = messenger
+        self._response_type = response_type
+        self._timeout = timeout
+        self._response: Optional[BinaryMessageDefinition] = None
+
+    def __call__(self, message: BinaryMessageDefinition) -> None:
+        """When called as a listener, mark the message as received."""
+        if isinstance(message, self._response_type) or isinstance(message, AckFailed):
+            self._response = message
+            self._event.set()
+
+    async def send_and_receive(
+        self, message: BinaryMessageDefinition
+    ) -> Optional[BinaryMessageDefinition]:
+        """Send a message and await the response."""
+        self._event.clear()
+        self._response = None
+        self._messenger.add_listener(
+            self,
+            lambda message_id: bool(
+                int(message_id) == self._response_type().message_id.value
+            ),
+        )
+        await self._messenger.send(message)
+        try:
+            tasks = asyncio.all_tasks()
+            for task in tasks:
+                # print(f"Task: {task}")
+                pass
+            await asyncio.wait_for(self._event.wait(), self._timeout)
+            # await evt.wait()
+        except asyncio.TimeoutError:
+            log.error("response timed out")
+        finally:
+            self._messenger.remove_listener(self)
+
+        return self._response
 
 
 class BinaryMessenger:
@@ -66,7 +117,7 @@ class BinaryMessenger:
 
     def start(self) -> None:
         """Start the reader task."""
-        if self._task and not self._task.done():
+        if self.reader_is_active():
             log.warning("task already running.")
             return
         self._task = asyncio.get_event_loop().create_task(self._read_task_shield())
@@ -82,6 +133,10 @@ class BinaryMessenger:
 
         else:
             log.warning("task not running.")
+
+    def reader_is_active(self) -> bool:
+        """Check if the reader task is currently active."""
+        return self._task is not None and not self._task.done()
 
     def add_listener(
         self,
@@ -133,6 +188,16 @@ class BinaryMessenger:
     def get_driver(self) -> SerialUsbDriver:
         """Return the underling driver for this messenger."""
         return self._drive
+
+    async def send_and_receive(
+        self,
+        message: BinaryMessageDefinition,
+        response_type: Type[BinaryMessageDefinition],
+        timeout: float = 1.0,
+    ) -> Optional[BinaryMessageDefinition]:
+        """Send a message and await a specific response message."""
+        listener = SendAndReceiveListener(self, response_type, timeout)
+        return await listener.send_and_receive(message)
 
 
 class BinaryWaitableCallback:

--- a/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
@@ -1,30 +1,18 @@
 """Utilities for updating the rear-panel settings."""
 import logging
-import asyncio
 from opentrons_hardware.drivers.binary_usb import BinaryMessenger
 from opentrons_hardware.firmware_bindings.messages.binary_message_definitions import (
-    BinaryMessageDefinition,
     DoorSwitchStateRequest,
     DoorSwitchStateInfo,
     SetDeckLightRequest,
     GetDeckLightRequest,
     GetDeckLightResponse,
+    Ack,
 )
 from opentrons_hardware.firmware_bindings import utils
-from opentrons_hardware.firmware_bindings.binary_constants import BinaryMessageId
-from typing import Callable, cast, List, Optional
+from typing import cast, Optional
 
 log = logging.getLogger(__name__)
-
-
-def _create_listener(
-    event: asyncio.Event, responses: List[BinaryMessageDefinition]
-) -> Callable[[BinaryMessageDefinition], None]:
-    def _listener(message: BinaryMessageDefinition) -> None:
-        responses.append(message)
-        event.set()
-
-    return _listener
 
 
 async def get_door_state(messenger: Optional[BinaryMessenger]) -> bool:
@@ -32,24 +20,13 @@ async def get_door_state(messenger: Optional[BinaryMessenger]) -> bool:
     if messenger is None:
         # the EVT bots don't have switches so just return that the door is closed
         return False
-    event = asyncio.Event()
-    responses: List[BinaryMessageDefinition] = list()
-    listener = _create_listener(event, responses)
-    messenger.add_listener(
-        listener,
-        lambda message_id: bool(message_id == BinaryMessageId.door_switch_state_info),
+    response = await messenger.send_and_receive(
+        message=DoorSwitchStateRequest(),
+        response_type=DoorSwitchStateInfo,
     )
-    await messenger.send(DoorSwitchStateRequest())
-    try:
-        await asyncio.wait_for(event.wait(), 1.0)
-    except asyncio.TimeoutError:
-        log.error("door switch request timed out before response")
-    finally:
-        messenger.remove_listener(listener)
-    if len(responses) > 0:
-        return bool(cast(DoorSwitchStateInfo, responses[0]).door_open.value)
-    # in case of timeout (no messages received) just return closed
-    return False
+    if response is None:
+        return False
+    return bool(cast(DoorSwitchStateInfo, response).door_open.value)
 
 
 async def set_deck_light(setting: int, messenger: Optional[BinaryMessenger]) -> bool:
@@ -57,45 +34,22 @@ async def set_deck_light(setting: int, messenger: Optional[BinaryMessenger]) -> 
     if messenger is None:
         # the EVT bots don't have rear panels...
         return False
-
-    event = asyncio.Event()
-    responses: List[BinaryMessageDefinition] = list()
-    listener = _create_listener(event, responses)
-    messenger.add_listener(
-        listener,
-        lambda message_id: bool(message_id == BinaryMessageId.ack),
+    response = await messenger.send_and_receive(
+        message=SetDeckLightRequest(setting=utils.UInt8Field(setting)),
+        response_type=Ack,
     )
-
-    await messenger.send(SetDeckLightRequest(setting=utils.UInt8Field(setting)))
-    try:
-        await asyncio.wait_for(event.wait(), 1.0)
-    except asyncio.TimeoutError:
-        log.error("set deck light request timed out before response")
-    finally:
-        messenger.remove_listener(listener)
-    return len(responses) > 0
+    return response is not None
 
 
 async def get_deck_light_state(messenger: Optional[BinaryMessenger]) -> bool:
     """Returns true if the light is currently on."""
     if messenger is None:
-        # the EVT bots don't have rear panels...
+        # the EVT bots don't have switches so just return that the door is closed
         return False
-    event = asyncio.Event()
-    responses: List[BinaryMessageDefinition] = list()
-    listener = _create_listener(event, responses)
-    messenger.add_listener(
-        listener,
-        lambda message_id: bool(message_id == BinaryMessageId.get_deck_light_response),
+    response = await messenger.send_and_receive(
+        message=GetDeckLightRequest(),
+        response_type=GetDeckLightResponse,
     )
-    await messenger.send(GetDeckLightRequest())
-    try:
-        await asyncio.wait_for(event.wait(), 1.0)
-    except asyncio.TimeoutError:
-        log.error("get deck light request timed out before response")
-    finally:
-        messenger.remove_listener(listener)
-    if len(responses) > 0:
-        return bool(cast(GetDeckLightResponse, responses[0]).setting.value > 0)
-    # in case of timeout (no messages received) just return off
-    return False
+    if response is None:
+        return False
+    return bool(cast(GetDeckLightResponse, response).setting.value)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_rear_panel_settings.py
@@ -1,6 +1,10 @@
 """Test rear panel integration."""
+from __future__ import annotations
+from asyncio import Queue
 import pytest
 from mock import AsyncMock
+import asyncio
+from typing import AsyncGenerator
 
 from opentrons_hardware.drivers.binary_usb.bin_serial import SerialUsbDriver
 from opentrons_hardware.drivers.binary_usb import BinaryMessenger
@@ -25,94 +29,112 @@ from opentrons_hardware.hardware_control.rear_panel_settings import (
 
 
 @pytest.fixture
-def mock_usb_driver() -> AsyncMock:
+async def incoming_messages() -> Queue[BinaryMessageDefinition]:
+    """Incoming message queue.
+
+    To emulate sending a message to a messenger, add to this queue.
+    """
+    return asyncio.Queue()
+
+
+@pytest.fixture
+async def read_queue() -> Queue[BinaryMessageDefinition]:
+    """Incoming message queue.
+
+    This queue is just used internally by the mock driver to
+    move messages into the read queue only when appropriate.
+    """
+    return asyncio.Queue()
+
+
+@pytest.fixture
+async def mock_usb_driver(
+    incoming_messages: Queue[BinaryMessageDefinition],
+    read_queue: Queue[BinaryMessageDefinition],
+) -> AsyncMock:
     """Mock communication."""
     mock = AsyncMock(SerialUsbDriver)
 
     # Ensure the write() function returns as normal
     async def mock_write(message: BinaryMessageDefinition) -> int:
+        if not incoming_messages.empty():
+            read_queue.put_nowait(await incoming_messages.get())
         return message.get_size()
 
     mock.write.side_effect = mock_write
+    mock.__aiter__.side_effect = lambda: mock
+    mock.__anext__.side_effect = read_queue.get
     return mock
 
 
 @pytest.fixture
-def mock_binary_messenger(mock_usb_driver: AsyncMock) -> BinaryMessenger:
+async def mock_binary_messenger(
+    mock_usb_driver: AsyncMock,
+) -> AsyncGenerator[BinaryMessenger, None]:
     """BinaryMessenger with a mock usb driver."""
     msg = BinaryMessenger(driver=mock_usb_driver)
-    return msg
-
-
-async def prepare_mock_response(
-    messenger: BinaryMessenger, driver: AsyncMock, value: BinaryMessageDefinition
-) -> None:
-    """Mock getting a response from the binary messenger.
-
-    The messenger has a dedicated reader task that uses the driver as an async
-    iterator. In order to correctly mock getting a message from the driver, we
-    should stop the reader task, load the driver iterator with the value we want,
-    and then restart the async reader task. The next time the readre has a chance
-    to run, it will read the value we specified.
-    """
-    await messenger.stop()
-    driver.__aiter__.return_value = [value]
-    messenger.start()
+    msg.start()
+    yield msg
+    await msg.stop()
 
 
 @pytest.mark.parametrize("set", [True, False])
 async def test_set_deck_light(
-    mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, set: bool
+    mock_binary_messenger: BinaryMessenger,
+    mock_usb_driver: AsyncMock,
+    incoming_messages: Queue[BinaryMessageDefinition],
+    set: bool,
 ) -> None:
     """Test setting the deck light."""
     expected = SetDeckLightRequest(setting=UInt8Field(set))
 
     # Correct response = good
-    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, Ack())
+    incoming_messages.put_nowait(Ack())
     assert await set_deck_light(set, mock_binary_messenger)
     mock_usb_driver.write.assert_called_once_with(message=expected)
     mock_usb_driver.write.reset_mock()
 
     # Incorrect response = bad
-    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, AckFailed())
+    incoming_messages.put_nowait(AckFailed())
     assert not await set_deck_light(set, mock_binary_messenger)
     mock_usb_driver.write.assert_called_once_with(message=expected)
 
 
 @pytest.mark.parametrize("set", [True, False])
 async def test_get_deck_light(
-    mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, set: bool
+    mock_binary_messenger: BinaryMessenger,
+    mock_usb_driver: AsyncMock,
+    incoming_messages: Queue[BinaryMessageDefinition],
+    set: bool,
 ) -> None:
     """Test getting the deck light."""
     # Correct response
-    await prepare_mock_response(
-        mock_binary_messenger,
-        mock_usb_driver,
-        GetDeckLightResponse(setting=UInt8Field(set)),
-    )
+    incoming_messages.put_nowait(GetDeckLightResponse(setting=UInt8Field(set)))
     assert await get_deck_light_state(mock_binary_messenger) == set
 
     mock_usb_driver.write.assert_called_once_with(message=GetDeckLightRequest())
 
     # Error getting a response should default to False
-    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, AckFailed())
+    incoming_messages.put_nowait(AckFailed())
     assert await get_deck_light_state(mock_binary_messenger) is False
 
 
 @pytest.mark.parametrize("state", [True, False])
 async def test_get_door_state(
-    mock_binary_messenger: BinaryMessenger, mock_usb_driver: AsyncMock, state: bool
+    mock_binary_messenger: BinaryMessenger,
+    mock_usb_driver: AsyncMock,
+    incoming_messages: Queue[BinaryMessageDefinition],
+    state: bool,
 ) -> None:
     """Test getting the door state."""
     # Correct response
-    await prepare_mock_response(
-        mock_binary_messenger,
-        mock_usb_driver,
-        DoorSwitchStateInfo(door_open=UInt8Field(state)),
-    )
+    incoming_messages.put_nowait(DoorSwitchStateInfo(door_open=UInt8Field(state)))
+
     assert await get_door_state(mock_binary_messenger) == state
     mock_usb_driver.write.assert_called_once_with(message=DoorSwitchStateRequest())
 
     # Error getting a response should default to False
-    await prepare_mock_response(mock_binary_messenger, mock_usb_driver, AckFailed())
+    incoming_messages.put_nowait(AckFailed())
     assert await get_door_state(mock_binary_messenger) is False
+
+    await mock_binary_messenger.stop()


### PR DESCRIPTION


# Overview

A lot of code was getting duplicated for rear panel communication, and most interactions with the rear-panel board follow a simple 1:1 message:response ratio. This PR adds a function to the binary messenger class that will send a message and await a specific response.

# Test Plan

Pushed to an OT-3 and tested using the `api.set_lights` and `api.get_lights` functions using ot3repl. They still work fine.

# Changelog

- Updated BinaryMessenger tests to use asyncio queues for pushing messages, and to only push the messages after calling `write` to simulate getting a response
- Added code for performing send_and_receive operations with the rear panel board

# Review requests


# Risk assessment

Lowwwwwwwww