### PR TITLE
fix(app): move robot overview overflow menu preventDefault

### DIFF
--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -110,15 +110,7 @@ export const RobotOverviewOverflowMenu = (
   useInterval(() => dispatch(fetchWifiList(robot.name)), LIST_REFRESH_MS, true)
 
   return (
-    <Flex
-      data-testid="RobotOverview_overflowMenu"
-      position={POSITION_RELATIVE}
-      onClick={e => {
-        e.preventDefault()
-        e.stopPropagation()
-        setShowOverflowMenu(false)
-      }}
-    >
+    <Flex data-testid="RobotOverview_overflowMenu" position={POSITION_RELATIVE}>
       <Portal level="top">
         {showSoftwareUpdateModal &&
         robot != null &&
@@ -147,6 +139,11 @@ export const RobotOverviewOverflowMenu = (
           top="2.25rem"
           right={0}
           flexDirection={DIRECTION_COLUMN}
+          onClick={e => {
+            e.preventDefault()
+            e.stopPropagation()
+            setShowOverflowMenu(false)
+          }}
         >
           {isRobotOnWrongVersionOfSoftware && !isRobotUnavailable ? (
             <MenuItem


### PR DESCRIPTION
# Overview

moves the robot overview overflow menu `preventDefault` to the menu itself to allow the slideout apply labware offsets checkbox click event.

closes RQA-594

# Test Plan

 - manually verified that the apply labware offsets checkbox and associated label are clickable when there are preexisting offsets

# Changelog

 - Fixes apply labware offsets checkbox bug in robot overview overflow menu

# Review requests

does moving the `preventDefault` have any unintended consequences?

# Risk assessment

low
