### PR TITLE
fix(app): fix vertical spacing between module controls on run details

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -5,7 +5,7 @@ import {
   Flex,
   SPACING,
   JUSTIFY_CENTER,
-  Box,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 import { StyledText } from '../../../atoms/text'
 import { ModuleCard } from '../../ModuleCard'
@@ -53,7 +53,11 @@ export const ProtocolRunModuleControls = ({
       paddingBottom={SPACING.spacing3}
       paddingX={SPACING.spacing4}
     >
-      <Box flex="50%">
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        flex="50%"
+        gridGap={SPACING.spacing3}
+      >
         {leftColumnModules.map((module, index) =>
           module.attachedModuleMatch != null ? (
             <ModuleCard
@@ -66,8 +70,12 @@ export const ProtocolRunModuleControls = ({
             />
           ) : null
         )}
-      </Box>
-      <Box flex="50%">
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        flex="50%"
+        gridGap={SPACING.spacing3}
+      >
         {rightColumnModules.map((module, index) =>
           module.attachedModuleMatch != null ? (
             <ModuleCard
@@ -80,7 +88,7 @@ export const ProtocolRunModuleControls = ({
             />
           ) : null
         )}
-      </Box>
+      </Flex>
     </Flex>
   )
 }


### PR DESCRIPTION
# Overview

add proper grid gap between items in each column of the module controls on the run details page.

Closes RQA-574

<img width="636" alt="Screen Shot 2023-03-30 at 10 46 09 AM" src="https://user-images.githubusercontent.com/4731953/228874613-144de42b-ec40-46a1-b1da-8b809687e598.png">

# Risk assessment
low