### PR TITLE
refactor(app): only download run log after user intent established

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -18,10 +18,7 @@ import {
   SIZE_1,
   ALIGN_CENTER,
 } from '@opentrons/components'
-import {
-  useDeleteRunMutation,
-  useAllCommandsQuery,
-} from '@opentrons/react-api-client'
+import { useDeleteRunMutation } from '@opentrons/react-api-client'
 
 import { Divider } from '../../atoms/structure'
 import { Tooltip } from '../../atoms/Tooltip'
@@ -55,6 +52,10 @@ export function HistoricalProtocolRunOverflowMenu(
   const protocolRunOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
   })
+  const { downloadRunLog, isRunLogLoading } = useDownloadRunLog(
+    props.robotName,
+    runId
+  )
 
   return (
     <Flex
@@ -69,7 +70,12 @@ export function HistoricalProtocolRunOverflowMenu(
             ref={protocolRunOverflowWrapperRef}
             data-testid={`HistoricalProtocolRunOverflowMenu_${runId}`}
           >
-            <MenuDropdown {...props} closeOverflowMenu={handleOverflowClick} />
+            <MenuDropdown
+              {...props}
+              downloadRunLog={downloadRunLog}
+              isRunLogLoading={isRunLogLoading}
+              closeOverflowMenu={handleOverflowClick}
+            />
           </Box>
           {menuOverlay}
         </>
@@ -80,25 +86,21 @@ export function HistoricalProtocolRunOverflowMenu(
 
 interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
   closeOverflowMenu: React.MouseEventHandler<HTMLButtonElement>
+  downloadRunLog: () => void
+  isRunLogLoading: boolean
 }
 function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { t } = useTranslation('device_details')
   const history = useHistory()
 
-  const { runId, robotName, robotIsBusy, closeOverflowMenu } = props
-
-  const commands = useAllCommandsQuery(
+  const {
     runId,
-    { cursor: 0, pageLength: 0 },
-    { staleTime: Infinity }
-  )
-  const runTotalCommandCount = commands?.data?.meta?.totalLength ?? 0
-
-  const { downloadRunLog, isRunLogLoading } = useDownloadRunLog(
     robotName,
-    runId,
-    runTotalCommandCount
-  )
+    robotIsBusy,
+    closeOverflowMenu,
+    downloadRunLog,
+    isRunLogLoading,
+  } = props
 
   const isRobotOnWrongVersionOfSoftware = ['upgrade', 'downgrade'].includes(
     useSelector((state: State) => {

--- a/app/src/organisms/Devices/hooks/useDownloadRunLog.ts
+++ b/app/src/organisms/Devices/hooks/useDownloadRunLog.ts
@@ -10,9 +10,6 @@ import { ERROR_TOAST, INFO_TOAST, useToast } from '../../../atoms/Toast'
 import { useProtocolDetailsForRun } from './useProtocolDetailsForRun'
 import { downloadFile } from '../utils'
 
-// TODO(bh, 2022-12-5): consider refactoring -
-// currently, this hook makes run and commands queries for each historical run on device details page load
-// this is not ideal for performance, and doesn't allow for a toast that responds to "download" status
 export function useDownloadRunLog(
   robotName: string,
   runId: string

--- a/app/src/organisms/Devices/hooks/useDownloadRunLog.ts
+++ b/app/src/organisms/Devices/hooks/useDownloadRunLog.ts
@@ -1,7 +1,10 @@
+import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { HostConfig, getRun, getCommands } from '@opentrons/api-client'
+import { DEFAULT_PARAMS as DEFAULT_COMMANDS_PARAMS } from '@opentrons/react-api-client/src/runs/useAllCommandsQuery'
 import { IconProps } from '@opentrons/components'
-import { useAllCommandsQuery, useRunQuery } from '@opentrons/react-api-client'
+import { useHost } from '@opentrons/react-api-client'
 
 import { ERROR_TOAST, INFO_TOAST, useToast } from '../../../atoms/Toast'
 import { useProtocolDetailsForRun } from './useProtocolDetailsForRun'
@@ -12,67 +15,51 @@ import { downloadFile } from '../utils'
 // this is not ideal for performance, and doesn't allow for a toast that responds to "download" status
 export function useDownloadRunLog(
   robotName: string,
-  runId: string,
-  pageLength: number,
-  enabled: boolean = true
+  runId: string
 ): { downloadRunLog: () => void; isRunLogLoading: boolean } {
   const { t } = useTranslation('run_details')
+  const host = useHost()
+  const [isLoading, setIsLoading] = React.useState<boolean>(false)
 
   const { makeToast } = useToast()
 
-  const {
-    data: allCommandsQueryData,
-    error: allCommandsQueryError,
-    isError: isAllCommandsQueryError,
-    isLoading: isCommandsQueryLoading,
-  } = useAllCommandsQuery(
-    runId,
-    {
-      cursor: 0,
-      pageLength,
-    },
-    { enabled, staleTime: Infinity }
-  )
-  const commands = allCommandsQueryData?.data
-
-  const {
-    data: runQueryData,
-    error: runQueryError,
-    isError: isRunQueryError,
-    isLoading: isRunQueryLoading,
-  } = useRunQuery(runId, { enabled, staleTime: Infinity })
-  const run = runQueryData?.data
-
-  const isError = isAllCommandsQueryError || isRunQueryError
-
-  // a loading boolean to indicate when downloadRunLog is available
-  const isRunLogLoading = isCommandsQueryLoading || isRunQueryLoading
-
-  // prioritize display of commands error
-  const errorMessage =
-    allCommandsQueryError?.message ?? runQueryError?.message ?? ''
-
   const { displayName } = useProtocolDetailsForRun(runId)
-  const protocolName = displayName ?? run?.protocolId ?? ''
-
   const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
 
   const downloadRunLog = (): void => {
-    if (isError) {
-      makeToast(errorMessage, ERROR_TOAST)
-    } else if (commands != null && run != null) {
-      makeToast(t('downloading_run_log'), INFO_TOAST, {
-        icon: toastIcon,
+    setIsLoading(true)
+    makeToast(t('downloading_run_log'), INFO_TOAST, {
+      icon: toastIcon,
+    })
+
+    getCommands(host as HostConfig, runId as string, DEFAULT_COMMANDS_PARAMS)
+      .then(response => {
+        const commands = response.data
+        getRun(host as HostConfig, runId as string)
+          .then(response => {
+            const runRecord = response.data
+            const runDetails = {
+              ...runRecord,
+              commands,
+            }
+            const protocolName = displayName ?? runRecord.data.protocolId ?? ''
+            const createdAt = new Date(runRecord.data.createdAt).toISOString()
+            const fileName = `${robotName}_${String(
+              protocolName
+            )}_${createdAt}.json`
+            setIsLoading(false)
+            downloadFile(runDetails, fileName)
+          })
+          .catch((e: Error) => {
+            setIsLoading(false)
+            makeToast(e.message, ERROR_TOAST)
+          })
       })
-      const runDetails = {
-        ...run,
-        commands,
-      }
-      const createdAt = new Date(run.createdAt).toISOString()
-      const fileName = `${robotName}_${String(protocolName)}_${createdAt}.json`
-      downloadFile(runDetails, fileName)
-    }
+      .catch((e: Error) => {
+        setIsLoading(false)
+        makeToast(e.message, ERROR_TOAST)
+      })
   }
 
-  return { downloadRunLog, isRunLogLoading }
+  return { downloadRunLog, isRunLogLoading: isLoading }
 }

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -71,13 +71,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     runStatus === RUN_STATUS_IDLE ||
     runStatus === RUN_STATUS_FINISHING
 
-  // todo (jb 2-16-23) This should be switched out soon for something more performant, see https://opentrons.atlassian.net/browse/RLAB-298
-  const { downloadRunLog } = useDownloadRunLog(
-    robotName,
-    runId,
-    analysisCommands.length,
-    !downloadIsDisabled
-  )
+  const { downloadRunLog } = useDownloadRunLog(robotName, runId)
 
   /**
    * find the analysis command within the analysis


### PR DESCRIPTION
# Overview

In order to minimize fetches of the entire run commands list, only download the run log data when the button is actually enabled and clicked

Closes RQA-595

coauthored by: @shlokamin 

# Review requests

- download the run log from the run detail page successfullly
- download the run log from the historic runs overflow menu the device detail page

# Risk assessment
low