### PR TITLE
feat(odd): create BackgroundOverlay for modals and menus

### DIFF
--- a/app/src/molecules/BackgroundOverlay/BackgroundOverlay.stories.tsx
+++ b/app/src/molecules/BackgroundOverlay/BackgroundOverlay.stories.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Flex, PrimaryButton } from '@opentrons/components'
+import { StyledText } from '../../atoms/text'
+import { BackgroundOverlay } from './index'
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'ODD/Molecules/BackgroundOverlay',
+} as Meta
+
+const Template: Story<
+  React.ComponentProps<typeof BackgroundOverlay>
+> = args => {
+  const [openOverlay, setOpenOverlay] = React.useState<boolean>(false)
+  return (
+    <Flex>
+      {openOverlay ? (
+        <Flex height="80%" width="80%">
+          <BackgroundOverlay onClick={() => setOpenOverlay(false)} />
+        </Flex>
+      ) : (
+        <PrimaryButton onClick={() => setOpenOverlay(true)}>
+          <StyledText as="h4">Click to open the Background Overlay</StyledText>
+        </PrimaryButton>
+      )}
+    </Flex>
+  )
+}
+export const Default = Template.bind({})

--- a/app/src/molecules/BackgroundOverlay/__tests__/BackgroundOverlay.test.tsx
+++ b/app/src/molecules/BackgroundOverlay/__tests__/BackgroundOverlay.test.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { renderWithProviders } from '@opentrons/components'
+import { BackgroundOverlay } from '..'
+
+const render = (props: React.ComponentProps<typeof BackgroundOverlay>) => {
+  return renderWithProviders(<BackgroundOverlay {...props} />)[0]
+}
+
+describe('BackgroundOverlay', () => {
+  let props: React.ComponentProps<typeof BackgroundOverlay>
+  it('renders background overlay', () => {
+    props = { onClick: jest.fn() }
+    const { getByLabelText } = render(props)
+    getByLabelText('BackgroundOverlay').click()
+    expect(props.onClick).toHaveBeenCalled()
+  })
+})

--- a/app/src/molecules/BackgroundOverlay/index.tsx
+++ b/app/src/molecules/BackgroundOverlay/index.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { COLORS, Flex, POSITION_FIXED } from '@opentrons/components'
+
+export interface BackgroundOverlayProps
+  extends React.ComponentProps<typeof Flex> {
+  //  onClick handler so when you click anywhere in the overlay, the modal/menu closes
+  onClick: React.MouseEventHandler
+}
+
+export function BackgroundOverlay(props: BackgroundOverlayProps): JSX.Element {
+  const { onClick, ...flexProps } = props
+
+  return (
+    <Flex
+      aria-label="BackgroundOverlay"
+      position={POSITION_FIXED}
+      left="0"
+      right="0"
+      top="0"
+      bottom="0"
+      zIndex="1"
+      backgroundColor={COLORS.darkBlack_sixty}
+      onClick={onClick}
+      {...flexProps}
+    />
+  )
+}


### PR DESCRIPTION
closes RAUT-383

# Overview

Create components, test and story for `BackgroundOverlay` used in the background of modals and dropdown menus.

# Test Plan

- check out the story in storybook. You should be able to click anywhere on the overlay and it closes

# Changelog

- create `BackgroundOverlay` in molecules and create component, test, and story

# Review requests

- see test plan

# Risk assessment

low