### PR TITLE
fix(app): reinitialize live offset in LPC if user clicks go back in exit confirmation

### DIFF
--- a/app/src/molecules/JogControls/constants.ts
+++ b/app/src/molecules/JogControls/constants.ts
@@ -1,5 +1,6 @@
 import type { StepSize } from './types'
 
+export const NULL_STEP_SIZE_MM = 0 as const
 export const SMALL_STEP_SIZE_MM = 0.1 as const
 export const MEDIUM_STEP_SIZE_MM = 1 as const
 export const LARGE_STEP_SIZE_MM = 10 as const

--- a/app/src/molecules/JogControls/types.ts
+++ b/app/src/molecules/JogControls/types.ts
@@ -1,6 +1,7 @@
 import {
   HORIZONTAL_PLANE,
   VERTICAL_PLANE,
+  NULL_STEP_SIZE_MM,
   SMALL_STEP_SIZE_MM,
   MEDIUM_STEP_SIZE_MM,
   LARGE_STEP_SIZE_MM,
@@ -9,6 +10,7 @@ import {
 export type Axis = 'x' | 'y' | 'z'
 export type Sign = -1 | 1
 export type StepSize =
+  | typeof NULL_STEP_SIZE_MM
   | typeof SMALL_STEP_SIZE_MM
   | typeof MEDIUM_STEP_SIZE_MM
   | typeof LARGE_STEP_SIZE_MM

--- a/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
@@ -66,6 +66,13 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
   const [joggedPosition, setJoggedPosition] = React.useState<VectorOffset>(
     initialPosition
   )
+  React.useEffect(() => {
+    //  NOTE: this will perform a "null" jog when the jog controls mount so
+    //  if a user reaches the "confirm exit" modal (unmounting this component)
+    //  and clicks "go back" we are able so initialize the live offset to whatever
+    //  distance they had already jogged before clicking exit.
+    handleJog('x', 1, 0, setJoggedPosition)
+  }, [handleJog])
 
   let wellsToHighlight: string[] = []
   if (getPipetteNameSpecs(pipetteName)?.channels === 8) {


### PR DESCRIPTION
# Overview

To prevent a confusing visual bug where users may not see the offset that they jogged to after
returning from the clicking go back on the exit confirmation modal. This adds a null jog call when
the jog to well component mounts to ensure that we have a current position of the critical point
regardles off when the jog to well component mounts

Re [RQA-592](https://opentrons.atlassian.net/browse/RQA-592)

# Review requests

1. Run LPC for protocol with Thermocycler

2. When you get to the step for checking offsets, move the gantry to have offsets of 10.0 mm in X, Y, and Z.

3. pressed “Exit”, then “Go Back”

4. The gantry should stay in position the whole time and did not return to home

5. When getting back to the offsets screen the offsets should be as they were before pressing "exit"  (10,10,10)

6. Validate at the end of LPC the offsets are correct

# Risk assessment
low

[RQA-592]: https://opentrons.atlassian.net/browse/RQA-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ