### PR TITLE
fix(app): update leveling text based on pipette model and mount

### DIFF
--- a/app/src/assets/localization/en/change_pipette.json
+++ b/app/src/assets/localization/en/change_pipette.json
@@ -17,7 +17,7 @@
   "tighten_screws_single": "Starting with screw #1, tighten the screws with a clockwise motion.",
   "tighten_screws_multi": "<block>Starting with screw #1, <strong>loosely</strong> tighten the screws with a clockwise motion. You will tighten them fully in a later step.</block>",
   "attach_pipette_type": "Attach a {{pipetteName}} Pipette",
-  "level_the_pipette": "<h1>Level the pipette</h1><block>Using your hand, <strong>gently and slowly</strong> push the pipette up.</block><block>Place the calibration block in slot 1/3 with the tall/short surface on the left/right side.</block><block>Pull the pipette down so <strong>all 8 nozzles touch</strong> the surface of the block.</block><block>While <strong>holding the pipette down,</strong> tighten the three screws.</block><block>Gently and slowly push the pipette back up.</block>",
+  "level_the_pipette": "<h1>Level the pipette</h1><block>Using your hand, <strong>gently and slowly</strong> push the pipette up.</block><block>Place the calibration block in slot {{slot}} with the {{side}} surface on the {{direction}} side.</block><block>Pull the pipette down so <strong>all 8 nozzles touch</strong> the surface of the block.</block><block>While <strong>holding the pipette down,</strong> tighten the three screws.</block><block>Gently and slowly push the pipette back up.</block>",
   "confirm_level": "Confirm level",
   "pipette_movement": "{{mount}} pipette carriage moving {{location}}.",
   "to_front_right": "to front right",

--- a/app/src/organisms/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/ChangePipette/LevelPipette.tsx
@@ -68,6 +68,11 @@ export function LevelPipette(props: LevelPipetteProps): JSX.Element {
             <Trans
               t={t}
               i18nKey={'level_the_pipette'}
+              values={{
+                slot: mount === 'left' ? '3' : '1',
+                side: pipetteModelName === 'p20_mutli_gen2' ? 'short' : 'tall',
+                direction: mount,
+              }}
               components={{
                 strong: (
                   <strong

--- a/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/LevelPipette.test.tsx
@@ -74,7 +74,7 @@ describe('LevelPipette', () => {
     )
     getByText(
       nestedTextMatcher(
-        'Place the calibration block in slot 1/3 with the tall/short surface on the left/right side.'
+        'Place the calibration block in slot 3 with the tall surface on the left side.'
       )
     )
     getByText(


### PR DESCRIPTION
fix RQA-576

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Adjust copy for pipette leveling step based on the pipette and mount

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
Check that copy for pipette/mount combos matches the video files
# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
For P20_multi on the left mount, copy should be:
Place the calibration block in slot 3 with the short surface on the left side
<img width="684" alt="Screen Shot 2023-03-30 at 5 05 02 PM" src="https://user-images.githubusercontent.com/14302493/228965067-e2f3cfdf-940f-4b52-96db-010ab2b95af0.png">

For P20_multi on the right mount, copy should be:
Place the calibration block in slot 1 with the short surface on the right side
<img width="695" alt="Screen Shot 2023-03-30 at 5 01 24 PM" src="https://user-images.githubusercontent.com/14302493/228965352-2f94e2b7-2d3a-439d-be4a-da2e1f7bcb5f.png">


For P300_multi on the left mount, copy should be:
Place the calibration block in slot 3 with the tall surface on the left side
<img width="710" alt="Screen Shot 2023-03-30 at 5 00 37 PM" src="https://user-images.githubusercontent.com/14302493/228965420-8b4e6591-0966-4808-8fb3-fff4a14a96e8.png">


For P300_multi on the right mount, copy should be:
Place the calibration block in slot 1 with the tall surface on the right side
<img width="694" alt="Screen Shot 2023-03-30 at 5 01 05 PM" src="https://user-images.githubusercontent.com/14302493/228971723-2224e320-0fb0-4882-b812-d06485b3e07e.png">


# Review requests

<!--
Describe any requests for your reviewers here.
-->
Look over logic to make sure it covers each case

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low