### PR TITLE
feat(protocol-designer): remove current usage of getEnabledOt3 selector

### DIFF
--- a/components/src/instrument/PipetteSelect.tsx
+++ b/components/src/instrument/PipetteSelect.tsx
@@ -6,7 +6,6 @@ import {
   getPipetteNameSpecs,
   GEN1,
   GEN2,
-  GEN3,
 } from '@opentrons/shared-data'
 import { Select, CONTEXT_VALUE } from '../forms'
 import styles from './PipetteSelect.css'
@@ -69,12 +68,10 @@ export const PipetteSelect = (props: PipetteSelectProps): JSX.Element => {
   const allowlist = ({ value }: SelectOption): boolean => {
     return !nameBlocklist.some(n => n === value)
   }
-  const gen3options = specsByCategory[GEN3].map(specToOption).filter(allowlist)
   const gen2Options = specsByCategory[GEN2].map(specToOption).filter(allowlist)
   const gen1Options = specsByCategory[GEN1].map(specToOption).filter(allowlist)
   const groupedOptions = [
     ...(enableNoneOption ? [OPTION_NONE] : []),
-    ...(gen3options.length > 0 ? [{ options: gen3options }] : []),
     ...(gen2Options.length > 0 ? [{ options: gen2Options }] : []),
     ...(gen1Options.length > 0 ? [{ options: gen1Options }] : []),
   ]

--- a/components/src/instrument/__tests__/PipetteSelect.test.tsx
+++ b/components/src/instrument/__tests__/PipetteSelect.test.tsx
@@ -6,7 +6,6 @@ import {
   getPipetteNameSpecs,
   GEN1,
   GEN2,
-  GEN3,
 } from '@opentrons/shared-data'
 import { PipetteSelect } from '../PipetteSelect'
 import { Select } from '../../forms'
@@ -49,14 +48,10 @@ describe('PipetteSelect', () => {
       .map(getPipetteNameSpecs)
       .filter((specs): specs is PipetteNameSpecs => specs !== null)
 
-    const gen3Specs = pipetteSpecs.filter(s => s.displayCategory === GEN3)
     const gen2Specs = pipetteSpecs.filter(s => s.displayCategory === GEN2)
     const gen1Specs = pipetteSpecs.filter(s => s.displayCategory === GEN1)
 
     expect(wrapper.find(Select).prop('options')).toEqual([
-      {
-        options: gen3Specs.map(s => ({ value: s.name, label: s.displayName })),
-      },
       {
         options: gen2Specs.map(s => ({ value: s.name, label: s.displayName })),
       },
@@ -74,7 +69,6 @@ describe('PipetteSelect', () => {
       .map(getPipetteNameSpecs)
       .filter((specs): specs is PipetteNameSpecs => specs !== null)
 
-    const gen3Specs = pipetteSpecs.filter(s => s.displayCategory === GEN3)
     const gen2Specs = pipetteSpecs.filter(s => s.displayCategory === GEN2)
     const nameBlocklist = pipetteSpecs
       .filter(s => s.displayCategory === GEN1)
@@ -88,9 +82,6 @@ describe('PipetteSelect', () => {
     )
 
     expect(wrapper.find(Select).prop('options')).toEqual([
-      {
-        options: gen3Specs.map(s => ({ value: s.name, label: s.displayName })),
-      },
       {
         options: gen2Specs.map(s => ({ value: s.name, label: s.displayName })),
       },

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -11,12 +11,10 @@ import {
   getIncompatiblePipetteNames,
   getLabwareDefURI,
   getLabwareDisplayName,
-  OT3_PIPETTES,
 } from '@opentrons/shared-data'
 import isEmpty from 'lodash/isEmpty'
 import reduce from 'lodash/reduce'
 import { i18n } from '../../../localization'
-import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { createCustomTiprackDef } from '../../../labware-defs/actions'
 import { getLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { PipetteDiagram } from './PipetteDiagram'
@@ -83,26 +81,12 @@ export function PipetteFields(props: Props): JSX.Element {
 
   const allLabware = useSelector(getLabwareDefsByURI)
 
-  const enableOT3Support = useSelector(featureFlagSelectors.getEnabledOT3)
-
-  // TODO(sh, 2022-09-29): remove this list of OT-3 tip racks when the feature flag is removed
-  const OT_3_TIP_RACKS = [
-    'opentrons_ot3_96_tiprack_200ul',
-    'opentrons_ot3_96_tiprack_1000ul',
-    'opentrons_ot3_96_tiprack_50ul',
-  ]
-
   type Values<T> = T[keyof T]
 
   const tiprackOptions = reduce<typeof allLabware, DropdownOption[]>(
     allLabware,
     (acc, def: Values<typeof allLabware>) => {
-      if (
-        (!enableOT3Support &&
-          OT_3_TIP_RACKS.includes(def.parameters.loadName)) ||
-        def.metadata.displayCategory !== 'tipRack'
-      )
-        return acc
+      if (def.metadata.displayCategory !== 'tipRack') return acc
       return [
         ...acc,
         {
@@ -117,12 +101,8 @@ export function PipetteFields(props: Props): JSX.Element {
   const initialTabIndex = props.initialTabIndex || 1
 
   const renderPipetteSelect = (props: PipetteSelectProps): JSX.Element => {
-    const { tabIndex, mount, nameBlocklist } = props
+    const { tabIndex, mount } = props
     const pipetteName = values[mount].pipetteName
-    const updatedNameBlockList =
-      nameBlocklist != null && !enableOT3Support
-        ? [...nameBlocklist, ...OT3_PIPETTES]
-        : nameBlocklist
     return (
       <PipetteSelect
         enableNoneOption
@@ -137,7 +117,6 @@ export function PipetteFields(props: Props): JSX.Element {
           onSetFieldValue(targetToClear, null)
           onSetFieldTouched(targetToClear, false)
         }}
-        nameBlocklist={updatedNameBlockList != null ? updatedNameBlockList : []}
         id={`PipetteSelect_${mount}`}
       />
     )


### PR DESCRIPTION
closes RAUT-387

# Overview

To kickoff PD work with Softdel, they will be using the already existing `getEnabledOt3` ff in PD. However, there is some work that was added onto it last year that is no longer relevant since Opentrons Flex support UI is a new design and will have its own Pipette selection (check out design [wireframes](https://www.figma.com/file/30Ggy4HWwFs4nno1gv9qzF/Opentrons-Flex-and-Protocol-Designer?node-id=6-459&t=keEeul2eKj2GbeC5-0) here). So this PR removes the usage of `getEnabledOt3` ff selector from `PipetteFields` and remove GEN3 pipette options in `PipetteSelect`. Which enables Softdel to have a clean, unused FF to work with.

# Test Plan

- open Protocol Designer and enable the OT3 feature flag (type `enablePrereleaseMode()` in console and refresh, go to Settings > toggle the FF on)
- create a new protocol and under pipette selection, there should be no option for OT3 pipettes.

# Changelog

- remove usage of FF in `pipetteFields` and remove GEN3 pipette options from `pipetteSelect`

# Review requests

- follow test plan
- I kept the logic added from [this Pr](https://github.com/Opentrons/opentrons/pull/11525/files#diff-d503c5b3997be05cfbaea0bfe5fce967d55cf831fa0a85be4c74902287bff351) that determines the robot model and deck ID based off the pipette selection. see logic in `fileCreator` I think that is fine to keep and that softDel can use it. Does that make sense to you? 

# Risk assessment

low