### PR TITLE
fix(app): prevent lpc from spamming the null jog

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
@@ -72,7 +72,7 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
     //  and clicks "go back" we are able so initialize the live offset to whatever
     //  distance they had already jogged before clicking exit.
     handleJog('x', 1, 0, setJoggedPosition)
-  }, [handleJog])
+  }, [])
 
   let wellsToHighlight: string[] = []
   if (getPipetteNameSpecs(pipetteName)?.channels === 8) {


### PR DESCRIPTION
# Overview

Ensure that the side-effect of jog position initialization doesn't occur on every rerender of LPC panes.

# Review requests

- run LPC successfully

# Risk assessment
low