### PR TITLE
feat(component): add pressed colors

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,5 +12,9 @@ module.exports = {
     '../components/**/*.stories.@(js|jsx|ts|tsx)',
     '../app/**/*.stories.@(js|jsx|ts|tsx)',
   ],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    'storybook-addon-pseudo-states',
+  ],
 }

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -31,6 +31,7 @@ export const opacity90HexCode = 'e6' // 90% opacity
 export const blueEnabled = '#006cfa'
 export const blueHover = '#0061e0'
 export const bluePressed = '#0050b8'
+export const medBluePressed = '#9cb9e0'
 
 // colors black
 export const darkBlackEnabled = '#16212d'
@@ -114,12 +115,13 @@ export const darkBlack_forty = `${darkBlackEnabled}${opacity40HexCode}`
 export const darkBlack_twenty = `${darkBlackEnabled}${opacity20HexCode}`
 
 export const light_one = '#d0d0d0'
+export const light_one_pressed = '#b4b6b8'
 export const light_two = '#e0e0e0'
 
 export const highlightPurple_one = '#9c3ba4'
-export const highlightPurple_one_pressed = '#af62b6'
+export const highlightPurple_one_pressed = '#883792'
 export const highlightPurple_two = '#e7c3e9'
-export const highlightPurple_two_pressed = '#bda3c3'
+export const highlightPurple_two_pressed = '#c8abcd'
 
 // touchscreen foundational color
 export const foundationalBlue = '#b4d4ff'
@@ -128,14 +130,18 @@ export const foundationalBlue = '#b4d4ff'
 export const green_one = '#027e23'
 export const green_two = '#2ebd55'
 export const green_three = '#a1ffbc'
+export const green_three_pressed = '#8cdea7'
 export const green_four = '#baffcd'
 
 export const yellow_one = '#7a5200'
 export const yellow_two = '#ec930f'
 export const yellow_three = '#ffe1a4'
+export const yellow_three_pressed = '#dcc492'
 export const yellow_four = '#ffe9be'
 
 export const red_one = errorText
 export const red_two = '#e31e1e'
+export const red_two_pressed = '#c41e20'
 export const red_three = '#fbcdcd'
+export const red_three_pressed = '#d9b3b5'
 // export const red_four = errorText

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "semver": "^7.3.8",
     "shx": "^0.3.3",
     "simple-git": "^3.15.1",
+    "storybook-addon-pseudo-states": "^1.15.5",
     "style-loader": "^1.1.3",
     "stylelint": "^11.0.0",
     "stylelint-config-standard": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19355,6 +19355,11 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
+storybook-addon-pseudo-states@^1.15.5:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-1.15.5.tgz#47d40391440dff235c05938c5b033aa655dda38e"
+  integrity sha512-DVngZ4121lJ6s42vKNfmLCBKhBMhh01D7sCV/LohP0rZoVW6Zws552g906Wan5R14gnArAlPCxQ+zbgm7QqxDA==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add new pressed colors and update existing pressed colors

new colors
https://www.figma.com/file/OIdG64Q5cgvEw82ish5Eee/Design-System-(Flex)?node-id=1108-54851&t=Ur1U6a6ltNcXSkQt-0

* I searched all hex codes I added in our code base , but there is no line that uses any  pressed colors

Also add https://storybook.js.org/addons/storybook-addon-pseudo-states to make Design QA a little bit easier.
Need `make teardown-js && make setup-js`


https://user-images.githubusercontent.com/474225/229219922-a2aeaf61-8d7c-4a53-8c49-44ca4d691deb.mov



close RAUT-390
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
not required
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add new pressed colors
- update purples' pressed colors
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- added / updated hex codes are the same as Figma
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
