### PR TITLE
feat(api): make fw updates optional when building the hardware controller

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -172,7 +172,9 @@ class OT3Controller:
     _tool_detector: detector.OneshotToolDetector
 
     @classmethod
-    async def build(cls, config: OT3Config, use_usb_bus: bool = False) -> OT3Controller:
+    async def build(
+        cls, config: OT3Config, use_usb_bus: bool = False, check_updates: bool = True
+    ) -> OT3Controller:
         """Create the OT3Controller instance.
 
         Args:
@@ -191,13 +193,16 @@ class OT3Controller:
                     "No rear panel device found, probably an EVT bot, disable rearPanelIntegration feature flag if it is"
                 )
                 raise e
-        return cls(config, driver=driver, usb_driver=usb_driver)
+        return cls(
+            config, driver=driver, usb_driver=usb_driver, check_updates=check_updates
+        )
 
     def __init__(
         self,
         config: OT3Config,
         driver: AbstractCanDriver,
         usb_driver: Optional[SerialUsbDriver] = None,
+        check_updates: bool = True,
     ) -> None:
         """Construct.
 
@@ -215,6 +220,7 @@ class OT3Controller:
         self._position = self._get_home_position()
         self._encoder_position = self._get_home_position()
         self._motor_status = {}
+        self._check_updates = check_updates
         self._update_required = False
         self._initialized = False
         self._update_tracker: Optional[UpdateProgress] = None
@@ -244,7 +250,7 @@ class OT3Controller:
 
     @property
     def update_required(self) -> bool:
-        return self._update_required
+        return self._update_required and self._check_updates
 
     @update_required.setter
     def update_required(self, value: bool) -> None:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -92,6 +92,7 @@ from .types import (
     GripperProbe,
     EarlyLiquidSenseTrigger,
     LiquidNotFound,
+    UpdateState,
     UpdateStatus,
 )
 from .errors import MustHomeError, GripperNotAttachedError
@@ -294,10 +295,17 @@ class OT3API(
 
         # check for and start firmware updates if required
         if update_firmware:
+            # NOTE: We are logging to stdout so when the hw controller is
+            # built for CLI, the operator can know when updates are running.
+            stdout_handler = logging.StreamHandler()
+            mod_log.addHandler(stdout_handler)
+            mod_log.info("Checking for firmware updates")
             async for progress in api_instance.update_firmware():
-                # NOTE: We are printing to stdout so when the hw controller is
-                # built for a CLI, the operator can know when updates are running.
-                print(progress)
+                for update in progress:
+                    if update.state == UpdateState.updating:
+                        mod_log.info(update)
+            mod_log.info("Finished firmware updates")
+            mod_log.removeHandler(stdout_handler)
 
         await api_instance._configure_instruments()
         module_controls = await AttachedModulesControl.build(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -288,7 +288,9 @@ class OT3API(
             checked_config = robot_configs.load_ot3()
         else:
             checked_config = config
-        backend = await OT3Controller.build(checked_config, use_usb_bus)
+        backend = await OT3Controller.build(
+            checked_config, use_usb_bus, check_updates=update_firmware
+        )
 
         api_instance = cls(backend, loop=checked_loop, config=checked_config)
         await api_instance._cache_instruments()
@@ -311,9 +313,7 @@ class OT3API(
         api_instance._update_door_state(door_state)
         backend.add_door_state_listener(api_instance._update_door_state)
         checked_loop.create_task(backend.watch(loop=checked_loop))
-        # set the initialized flag based on wether firmware updates are enabled or not
-        # this way we dont raise `FirmwareUpdateRequired` exception when updates are disabled.
-        backend.initialized = update_firmware
+        backend.initialized = True
         return api_instance
 
     @classmethod

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -279,6 +279,7 @@ class OT3API(
         loop: Optional[asyncio.AbstractEventLoop] = None,
         strict_attached_instruments: bool = True,
         use_usb_bus: bool = False,
+        update_firmware: bool = True,
     ) -> "OT3API":
         """Build an ot3 hardware controller."""
         checked_loop = use_or_initialize_loop(loop)
@@ -292,8 +293,11 @@ class OT3API(
         await api_instance._cache_instruments()
 
         # check for and start firmware updates if required
-        async for _ in api_instance.update_firmware():
-            pass
+        if update_firmware:
+            async for progress in api_instance.update_firmware():
+                # NOTE: We are printing to stdout so when the hw controller is
+                # built for a CLI, the operator can know when updates are running.
+                print(progress)
 
         await api_instance._configure_instruments()
         module_controls = await AttachedModulesControl.build(

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -111,11 +111,17 @@ def stop_server() -> None:
 
 
 def build_api() -> ThreadManager[HardwareControlAPI]:
+    # NOTE: We are using StreamHandler so when the hw controller is
+    # being built we can log firmware update progress to stdout.
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+    logging.getLogger().addHandler(stream_handler)
     tm = ThreadManager(
         HCApi.build_hardware_controller,
         use_usb_bus=ff.rear_panel_integration(),
         update_firmware=update_firmware,
     )
+    logging.getLogger().removeHandler(stream_handler)
     tm.managed_thread_ready_blocking()
     return tm
 

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -24,7 +24,7 @@ if os.environ.get("OT2", None):
 else:
     print("Running with OT3 HC. If you dont want this, set an env var named 'OT2'")
     os.environ["OT_API_FF_enableOT3HardwareController"] = "true"
-    if os.environ.get('OT3_DISABLE_FW_UPDATES'):
+    if os.environ.get("OT3_DISABLE_FW_UPDATES"):
         update_firmware = False
         print("OT3 firmware updates are disabled")
 
@@ -112,8 +112,9 @@ def stop_server() -> None:
 
 def build_api() -> ThreadManager[HardwareControlAPI]:
     tm = ThreadManager(
-        HCApi.build_hardware_controller, use_usb_bus=ff.rear_panel_integration(),
-        update_firmware=update_firmware
+        HCApi.build_hardware_controller,
+        use_usb_bus=ff.rear_panel_integration(),
+        update_firmware=update_firmware,
     )
     tm.managed_thread_ready_blocking()
     return tm

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 from logging.config import dictConfig
 
+update_firmware = True
 has_robot_server = True
 if os.environ.get("OPENTRONS_SIMULATION"):
     print("Running with simulators")
@@ -23,6 +24,9 @@ if os.environ.get("OT2", None):
 else:
     print("Running with OT3 HC. If you dont want this, set an env var named 'OT2'")
     os.environ["OT_API_FF_enableOT3HardwareController"] = "true"
+    if os.environ.get('OT3_DISABLE_FW_UPDATES'):
+        update_firmware = False
+        print("OT3 firmware updates are disabled")
 
 from code import interact  # noqa: E402
 from subprocess import run  # noqa: E402
@@ -108,7 +112,8 @@ def stop_server() -> None:
 
 def build_api() -> ThreadManager[HardwareControlAPI]:
     tm = ThreadManager(
-        HCApi.build_hardware_controller, use_usb_bus=ff.rear_panel_integration()
+        HCApi.build_hardware_controller, use_usb_bus=ff.rear_panel_integration(),
+        update_firmware=update_firmware
     )
     tm.managed_thread_ready_blocking()
     return tm


### PR DESCRIPTION
# Overview

Having the firmware on the flex auto-update is great, as it allows the subsystems to stay in sync with the OS build. However, if we are running the hardware controller from CLI we won't know if updates are running which can be confusing. This PR makes firmware updates optional for the purpose of using the hardware controller via other scripts, as well as prints the update progress to stdout so we know if something is updating.

# Test Plan

- [x] Make sure that firmware updates still run on start-up.
- [x] Make sure we can disable firmware updates when running repl with new `OT3_DISABLE_FW_UPDATES` env variable

# Changelog

- add `update_required` optional argument when building the hardware controller which enables/disables auto updates.
- add `OT3_DISABLE_FW_UPDATES` env flag for repl to disable fw updates from CLI.
- print update progress to stdout so we know when updates are running via CLI

# Review requests

- Does this make sense?

# Risk assessment

Low, keeps existing behavior
