### PR TITLE
refactor(robot-server): Type migration.created_at as UTCDateTime, not sqlalchemy.DateTime

### DIFF
--- a/robot-server/robot_server/persistence/_tables.py
+++ b/robot-server/robot_server/persistence/_tables.py
@@ -10,7 +10,7 @@ migration_table = sqlalchemy.Table(
     "migration",
     _metadata,
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-    sqlalchemy.Column("created_at", sqlalchemy.DateTime, nullable=False),
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
     sqlalchemy.Column(
         "version",
         sqlalchemy.Integer,


### PR DESCRIPTION
# Overview

A while ago, PR #11006 converted all our usage of `sqlalchemy.DateTime` to a custom `UTCDateTime` wrapper, to make our code more concise and less error-prone. It accidentally missed one spot, though. This PR fixes that up.

See #11006 for the original rationale behind `UTCDateTime`. This is an easy fix while I'm in the neighborhood working on RSS-98. 

# Test plan

I don't think this needs any manual testing. `UTCDateTime` has been used in other columns for a while now. The new usage is also covered by existing integration tests.

# Changelog

* Use the `UTCDateTime` wrapper for the the `created_at` column of the `migration` table, the same way we do for the `created_at` columns of the other tables.

# Review requests

None in particular.

# Risk assessment

Low.