### PR TITLE
build: fix github checkout tag handling

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -91,6 +91,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -135,6 +141,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -104,6 +104,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -193,6 +199,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -110,6 +110,12 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -43,6 +43,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -46,6 +46,12 @@ jobs:
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - name: 'install libudev for usb-detection'
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'cache yarn cache'
@@ -78,6 +84,12 @@ jobs:
     runs-on: 'ubuntu-20.04'
     steps:
       - uses: 'actions/checkout@v3'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -111,6 +123,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -148,6 +166,12 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -45,6 +45,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: 'actions/checkout@v3'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -85,6 +91,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -116,6 +128,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
@@ -153,6 +171,12 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -150,6 +150,12 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'


### PR DESCRIPTION
The github actions/checkout action tries to smoothly handle tag changes by converting annotated tags to lightweight tags when you specify an annotated tag to checkout:
https://github.com/actions/checkout/issues/290

This breaks our version-gathering infrastructure in the case where multiple annotated tags point to a single commit. The one that's checked out - which is usually the most recent one, that we want the git describe command to return - won't be returned properly because (a) it isn't annotated and we're not passing --tags and we don't want to because we really like having tag annotations and (b) the history is slightly wrong since now it's a lightweight tag on the specific commit and for that we need --contains, and we don't want to do that because we don't want containing tags.

We can fix this by undoing the tag rewriting by forcing an update back to the original annotated tag from the server and then checking it out.

This should be testable by pushing a couple tags to this branch on the same commit and inspecting the resultant build logs.

Closes RQA-602