### PR TITLE
tests(api): fix flaky thermocycler integration tests

### DIFF
--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -30,7 +30,8 @@ async def thermocycler(
     for _ in range(3):
         try:
             await ThermocyclerDriverFactory.create(
-                emulator_settings.thermocycler_proxy.driver_port
+                port=emulator_settings.thermocycler_proxy.driver_port,
+                loop=asyncio.get_running_loop(),
             )
         except KeyError:
             asyncio.sleep(0.1)

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -10,6 +10,8 @@ from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.modules import Thermocycler
 from opentrons.hardware_control.modules.types import TemperatureStatus
 
+from opentrons.hardware_control.modules.thermocycler import ThermocyclerDriverFactory
+
 from .build_module import build_module
 
 
@@ -25,21 +27,24 @@ async def thermocycler(
     # The Thermocycler builder talks to the TCP port, sometimes before it
     # is initialized. This loop is intended to prevent the tests from being
     # flaky and sometimes failing to build the module.
-
+    port = "socket://127.0.0.1:{emulator_settings.thermocycler_proxy.driver_port}"
     for _ in range(3):
         try:
-            module = await build_module(
-                Thermocycler,
-                port=emulator_settings.thermocycler_proxy.driver_port,
-                execution_manager=execution_manager,
-                poll_interval_seconds=poll_interval_seconds,
+            await ThermocyclerDriverFactory.create(
+                port=port,
+                loop=None,
             )
         except Exception:
-            await module.cleanup()
             await asyncio.sleep(0.1)
         else:
             continue
 
+    module = await build_module(
+        Thermocycler,
+        port=emulator_settings.thermocycler_proxy.driver_port,
+        execution_manager=execution_manager,
+        poll_interval_seconds=poll_interval_seconds,
+    )
     yield module
     await module.cleanup()
 


### PR DESCRIPTION
# Overview

The integration tests for the Thermocycler tend to be flaky, and will sometimes fail. The failures seem to stem from communication issues in the factory class that builds the Thermocycler. The `emulation_app` fixture waits on the emulation server to report that the modules are connected, but this doesn't check that communication is actually up & running.

This PR adds a loop to the thermocycler fixture to check that the module can actually be initialized. It gives 3 attempts (arbitrary number) to initialize the fixture, yielding the asyncio loop if an attempt fails.

# Test Plan

Run the workflow for api testing a few times and make sure this reliably works! Ran it 3 times and it succeeded each time.

# Changelog

- Added retry-loop to initialize thermocycler integration test fixture

# Review requests

- Does it make sense that this would fix the tests??? I hate this kind of situation where you can't really prove it's a fix, just have to run past the MTTF and assume that means it works now.

# Risk assessment

Low, tests only & this test suite fails all the time.
