### PR TITLE
feat(api): ot3 status bar tuning

### DIFF
--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -555,6 +555,7 @@ class StatusBarState(enum.Enum):
     UPDATING = 7
     ACTIVATION = 8
     DISCO = 9
+    OFF = 10
 
     def transient(self) -> bool:
         return self.value in {

--- a/hardware/opentrons_hardware/hardware_control/status_bar.py
+++ b/hardware/opentrons_hardware/hardware_control/status_bar.py
@@ -151,7 +151,7 @@ class StatusBar:
             ),
             ColorStep(
                 transition_type=LightTransitionType.instant,
-                transition_time_ms=1000,
+                transition_time_ms=750,
                 color=color,
             ),
             ColorStep(


### PR DESCRIPTION
# Overview

Had an in-person session with Jackson to go through the status bar actions. This PR adds some adjustments to the animations based on that feedback. We might adjust the RGB values of the Disco animation down the road, but otherwise the animations are approved.

# Test Plan

All tested on a robot through ot3repl

# Changelog

- Updated Disco to end with the Confirmation animation
- Updated error flashing with a shorter On time
- Added an Off state
- Adjusted the Activation to match the confluence doc

# Review requests


# Risk assessment

Low
