### PR TITLE
Revert "tests(api): fix flaky thermocycler integration tests"

### DIFF
--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -10,8 +10,6 @@ from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.modules import Thermocycler
 from opentrons.hardware_control.modules.types import TemperatureStatus
 
-from opentrons.hardware_control.modules.thermocycler import ThermocyclerDriverFactory
-
 from .build_module import build_module
 
 
@@ -23,22 +21,6 @@ async def thermocycler(
     poll_interval_seconds: float,
 ) -> AsyncGenerator[Thermocycler, None]:
     """Return a Thermocycler test subject."""
-
-    # The Thermocycler builder talks to the TCP port, sometimes before it
-    # is initialized. This loop is intended to prevent the tests from being
-    # flaky and sometimes failing to build the module.
-    port = "socket://127.0.0.1:{emulator_settings.thermocycler_proxy.driver_port}"
-    for _ in range(3):
-        try:
-            await ThermocyclerDriverFactory.create(
-                port=port,
-                loop=None,
-            )
-        except Exception:
-            await asyncio.sleep(0.1)
-        else:
-            continue
-
     module = await build_module(
         Thermocycler,
         port=emulator_settings.thermocycler_proxy.driver_port,


### PR DESCRIPTION
Reverts Opentrons/opentrons#12419

It didn't work ([see here](https://github.com/Opentrons/opentrons/actions/runs/4600886054/jobs/8128136178)). Ah! Well. Nevertheless,