### PR TITLE
fix(app): do not disable heater shaker temp control when shaking

### DIFF
--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -37,9 +37,8 @@ export const HeaterShakerSlideout = (
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const moduleName = getModuleDisplayName(module.moduleModel)
   const modulePart = t('temperature')
-  const isShaking = module.data.speedStatus !== 'idle'
 
-  const sendSetTemperatureOrShakeCommand: React.MouseEventHandler<HTMLInputElement> = e => {
+  const sendSetTemperatureCommand: React.MouseEventHandler<HTMLInputElement> = e => {
     e.preventDefault()
     e.stopPropagation()
 
@@ -89,7 +88,7 @@ export const HeaterShakerSlideout = (
         <SubmitPrimaryButton
           form="HeaterShakerSlideout_submitValue"
           value={t('confirm')}
-          onClick={sendSetTemperatureOrShakeCommand}
+          onClick={sendSetTemperatureCommand}
           disabled={hsValue === null || errorMessage !== null}
           data-testid={`HeaterShakerSlideout_btn_${module.serialNumber}`}
         />
@@ -131,7 +130,6 @@ export const HeaterShakerSlideout = (
               unit: unit,
             })}
             error={errorMessage}
-            disabled={isShaking}
           />
         </form>
       </Flex>

--- a/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
@@ -18,28 +18,6 @@ const render = (props: React.ComponentProps<typeof HeaterShakerSlideout>) => {
   })[0]
 }
 
-const mockMovingHeaterShaker = {
-  id: 'heatershaker_id',
-  moduleModel: 'heaterShakerModuleV1',
-  moduleType: 'heaterShakerModuleType',
-  serialNumber: 'jkl123',
-  hardwareRevision: 'heatershaker_v4.0',
-  firmwareVersion: 'v2.0.0',
-  hasAvailableUpdate: true,
-  data: {
-    labwareLatchStatus: 'idle_closed',
-    speedStatus: 'speeding up',
-    temperatureStatus: 'idle',
-    currentSpeed: null,
-    currentTemperature: null,
-    targetSpeed: null,
-    targetTemp: null,
-    errorDetails: null,
-    status: 'idle',
-  },
-  usbPort: { path: '/dev/ot_module_heatershaker0', port: 1 },
-} as any
-
 describe('HeaterShakerSlideout', () => {
   let props: React.ComponentProps<typeof HeaterShakerSlideout>
   let mockCreateLiveCommand = jest.fn()
@@ -110,16 +88,5 @@ describe('HeaterShakerSlideout', () => {
 
     expect(props.onCloseClick).toHaveBeenCalled()
     expect(input).not.toHaveValue()
-  })
-
-  it('input value is disabled when heater shaker is shaking', () => {
-    props = {
-      module: mockMovingHeaterShaker,
-      isExpanded: true,
-      onCloseClick: jest.fn(),
-    }
-    const { getByTestId } = render(props)
-    const input = getByTestId('heaterShakerModuleV1_setTemp')
-    expect(input).toBeDisabled()
   })
 })


### PR DESCRIPTION
# Overview

Only the shake controls of the heater shaker module need to be disabled if the module is shaking. No need to disable temperature controls too

Closes RQA-617

# Test Plan

- set shake on HS from the module card (both card locations run detail tab as well as device detail)
- set the temperature on HS from the module card (both card locations run detail tab as well as device detail)

# Risk assessment
low
