### PR TITLE
chore(docs): Fix up descriptions of Yarn and jpeg dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,7 @@ You will need the following tools installed to develop on the Opentrons platform
 - ssh
 - Python v3.7
 - Node.js v16
+- [Yarn 1][yarn]
 
 See [DEV_SETUP.md](./DEV_SETUP.md) for our recommended development setup guides for macOS, Windows, and Linux.
 
@@ -422,8 +423,7 @@ An OT-2's filesystem is mounted from two separate locations. `/data`, `/var`, an
 [commit-message-how-to]: https://chris.beams.io/posts/git-commit/
 [makefiles]: https://en.wikipedia.org/wiki/Makefile
 [nvm]: https://github.com/creationix/nvm
-[yarn]: https://yarnpkg.com/
-[yarn-install]: https://yarnpkg.com/en/docs/install
+[yarn]: https://classic.yarnpkg.com/
 [commitizen]: https://github.com/commitizen/cz-cli
 [conventional-commits]: https://conventionalcommits.org/
 [lerna]: https://github.com/lerna/lerna

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -153,7 +153,7 @@ eval "$(pyenv init -)"
 `/hardware` depends on the Python library Pillow. On ARM Macs, `pip` will build Pillow from source, which requires [jpeg](https://formulae.brew.sh/formula/jpeg) to be installed.
 
 ```shell
-brew install jpeg
+brew install jpeg-turbo
 ```
 
 ### Windows


### PR DESCRIPTION
# Overview

This fixes a couple of things in our dev setup guide.


# Changelog

Mention Yarn as a top-level dependency, because it's required for `make setup` to work. Be sure to specifically mention Yarn 1, which is apparently a different beast from Yarn 2.

Replace a suggestion to install the `jpeg` Homebrew package with `jpeg-turbo`. The original instructions with `jpeg` don't work anymore since Homebrew/homebrew-core#107511. Basically, `jpeg-turbo` is an alternative implementation of the `jpeg` interface, and has become Homebrew's preferred implementation. `jpeg` no longer has the privilege of automatically being made visible to the system once installed, and `jpeg-turbo` now does.


# Review requests

None in particular.


# Risk assessment

No risk.
