### PR TITLE
refactor(app-shell-odd): toggle remote dev tools on config change

### DIFF
--- a/app-shell-odd/src/config/index.ts
+++ b/app-shell-odd/src/config/index.ts
@@ -8,6 +8,7 @@ import fs from 'fs-extra'
 
 import { UI_INITIALIZED } from '@opentrons/app/src/redux/shell/actions'
 import * as Cfg from '@opentrons/app/src/redux/config'
+import systemd from '../systemd'
 import { createLogger } from '../log'
 import { DEFAULTS_V12, migrate } from './migrate'
 import { shouldUpdate, getNextValue } from './update'
@@ -77,6 +78,14 @@ export function registerConfig(dispatch: Dispatch): (action: Action) => void {
           action as ConfigValueChangeAction,
           getFullConfig()
         )
+
+        if (path === 'devtools') {
+          systemd.setRemoteDevToolsEnabled(Boolean(nextValue)).catch(err =>
+            log().debug('Something wrong when setting remote dev tools', {
+              err,
+            })
+          )
+        }
 
         // Note (kj:03/02/2023)  this is to change brightness
         if (path === 'onDeviceDisplaySettings.brightness') {


### PR DESCRIPTION
# Overview

This PR toggles the remote app shell odd dev tools when the config value for remote dev tools changes


# Review requests

On a OT-3 dev kit/actual OT3 toggle your dev tools and make sure that remote dev tools also get tuned on/off
# Risk assessment

Low
