### PR TITLE
feat(odd): add ethernet connection details

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -240,5 +240,6 @@
   "update_channel_description": "Stable receives the latest stable releases. Beta allows you to try out new in-progress features before they launch in Stable channel, but they have not completed testing yet.",
   "alpha_description": "Warning: alpha releases are feature-complete but may contain significant bugs.",
   "dev_tools_description": "Enable additional logging and allow access to feature flags.",
-  "attach_a_pipette_before_calibrating": "Attach a pipette in order to perform calibration"
+  "attach_a_pipette_before_calibrating": "Attach a pipette in order to perform calibration",
+  "ethernet_connection_description": "Connect an Ethernet cable to the back of the robot and a network switch or hub."
 }

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
@@ -27,8 +27,9 @@ import type { NetworkConnection } from '../../../pages/OnDeviceDisplay/hooks'
 import type { ChipType } from '../../../atoms/Chip'
 import type { SettingOption } from '../../../pages/OnDeviceDisplay/RobotSettingsDashboard'
 import type { State } from '../../../redux/types'
+import { EthernetConnectionDetails } from '../SetupNetwork/EthernetConnectionDetails'
 
-export type ConnectionType = 'wifi' // TODO (jb 2-24-2023) add 'ethernet' and 'usb' as options once implemented
+export type ConnectionType = 'wifi' | 'ethernet' // TODO (kj: 04/05/2023) add 'usb' as options once implemented
 
 interface NetworkSettingsProps {
   networkConnection: NetworkConnection
@@ -62,7 +63,9 @@ export function NetworkSettings({
     screenTitle = 'network_settings'
   } else if (showDetailsTab === 'wifi') {
     screenTitle = 'wifi'
-  } // TODO (jb 2-24-2023) implement ethernet and usb details screen titles
+  } else if (showDetailsTab === 'ethernet') {
+    screenTitle = 'ethernet'
+  }
 
   const handleChipType = (isConnected: boolean): ChipType => {
     return isConnected ? 'success' : 'neutral'
@@ -83,59 +86,71 @@ export function NetworkSettings({
   }
 
   const renderScreen = (): JSX.Element => {
-    if (showDetailsTab === null) {
-      return (
-        <Flex
-          paddingX={SPACING.spacingXXL}
-          marginTop={SPACING.spacing4}
-          flexDirection={DIRECTION_COLUMN}
-          gridGap={SPACING.spacing3}
-        >
-          {/* wifi */}
-          <NetworkSettingButton
-            buttonTitle={t('wifi')}
-            buttonBackgroundColor={handleButtonBackgroundColor(isWifiConnected)}
-            iconName="wifi"
-            chipType={handleChipType(isWifiConnected)}
-            chipText={handleChipText(isWifiConnected)}
-            chipIconName="ot-check"
-            networkName={activeSsid}
-            displayDetailsTab={() => setShowDetailsTab('wifi')}
+    switch (showDetailsTab) {
+      case 'wifi':
+        return (
+          <WifiConnectionDetails
+            ssid={activeSsid}
+            authType={connectedWifiAuthType}
+            wifiList={list}
+            showHeader={false}
+            showWifiListButton={true}
           />
-          {/* ethernet */}
-          <NetworkSettingButton
-            buttonTitle={t('ethernet')}
-            buttonBackgroundColor={handleButtonBackgroundColor(
-              isEthernetConnected
-            )}
-            iconName="ethernet"
-            chipType={handleChipType(isEthernetConnected)}
-            chipText={handleChipText(isEthernetConnected)}
-            chipIconName="ot-check"
-            displayDetailsTab={() => console.log('Not Implemented')}
+        )
+      case 'ethernet':
+        return (
+          <EthernetConnectionDetails
+            showHeader={false}
+            showWifiListButton={false}
           />
-          {/* usb hard-coded */}
-          <NetworkSettingButton
-            buttonTitle={t('usb')}
-            buttonBackgroundColor={handleButtonBackgroundColor(isUsbConnected)}
-            iconName="usb"
-            chipType={handleChipType(isUsbConnected)}
-            chipText={handleChipText(isUsbConnected)}
-            chipIconName="ot-check"
-            displayDetailsTab={() => console.log('Not Implemented')}
-          />
-        </Flex>
-      )
-    } else {
-      return (
-        <WifiConnectionDetails
-          ssid={activeSsid}
-          authType={connectedWifiAuthType}
-          wifiList={list}
-          showHeader={false}
-          showWifiListButton={true}
-        />
-      )
+        )
+      default:
+        return (
+          <Flex
+            paddingX={SPACING.spacingXXL}
+            marginTop={SPACING.spacing4}
+            flexDirection={DIRECTION_COLUMN}
+            gridGap={SPACING.spacing3}
+          >
+            {/* wifi */}
+            <NetworkSettingButton
+              buttonTitle={t('wifi')}
+              buttonBackgroundColor={handleButtonBackgroundColor(
+                isWifiConnected
+              )}
+              iconName="wifi"
+              chipType={handleChipType(isWifiConnected)}
+              chipText={handleChipText(isWifiConnected)}
+              chipIconName="ot-check"
+              networkName={activeSsid}
+              displayDetailsTab={() => setShowDetailsTab('wifi')}
+            />
+            {/* ethernet */}
+            <NetworkSettingButton
+              buttonTitle={t('ethernet')}
+              buttonBackgroundColor={handleButtonBackgroundColor(
+                isEthernetConnected
+              )}
+              iconName="ethernet"
+              chipType={handleChipType(isEthernetConnected)}
+              chipText={handleChipText(isEthernetConnected)}
+              chipIconName="ot-check"
+              displayDetailsTab={() => setShowDetailsTab('ethernet')}
+            />
+            {/* usb hard-coded */}
+            <NetworkSettingButton
+              buttonTitle={t('usb')}
+              buttonBackgroundColor={handleButtonBackgroundColor(
+                isUsbConnected
+              )}
+              iconName="usb"
+              chipType={handleChipType(isUsbConnected)}
+              chipText={handleChipText(isUsbConnected)}
+              chipIconName="ot-check"
+              displayDetailsTab={() => console.log('Not Implemented')}
+            />
+          </Flex>
+        )
     }
   }
 

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
@@ -21,13 +21,13 @@ import { Chip } from '../../../atoms/Chip'
 import { WifiConnectionDetails } from '../SetupNetwork'
 import { getWifiList } from '../../../redux/networking'
 import { getLocalRobot } from '../../../redux/discovery'
+import { EthernetConnectionDetails } from '../SetupNetwork/EthernetConnectionDetails'
 
 import type { IconName } from '@opentrons/components'
 import type { NetworkConnection } from '../../../pages/OnDeviceDisplay/hooks'
 import type { ChipType } from '../../../atoms/Chip'
 import type { SettingOption } from '../../../pages/OnDeviceDisplay/RobotSettingsDashboard'
 import type { State } from '../../../redux/types'
-import { EthernetConnectionDetails } from '../SetupNetwork/EthernetConnectionDetails'
 
 export type ConnectionType = 'wifi' | 'ethernet' // TODO (kj: 04/05/2023) add 'usb' as options once implemented
 

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/NetworkSettings.tsx
@@ -98,12 +98,7 @@ export function NetworkSettings({
           />
         )
       case 'ethernet':
-        return (
-          <EthernetConnectionDetails
-            showHeader={false}
-            showWifiListButton={false}
-          />
-        )
+        return <EthernetConnectionDetails />
       default:
         return (
           <Flex

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/EthernetConnectionDetails.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/EthernetConnectionDetails.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector, useDispatch } from 'react-redux'
+import { css } from 'styled-components'
+
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  COLORS,
+  TYPOGRAPHY,
+  BORDERS,
+} from '@opentrons/components'
+
+import { StyledText } from '../../../atoms/text'
+import { getNetworkInterfaces, fetchStatus } from '../../../redux/networking'
+import { getLocalRobot } from '../../../redux/discovery'
+
+import type { State, Dispatch } from '../../../redux/types'
+
+const STRETCH_LIST_STYLE = css`
+  width: 100%;
+  padding: ${SPACING.spacing4};
+  background-color: ${COLORS.light_one};
+  border-radius: ${BORDERS.size_three};
+`
+
+export function EthernetConnectionDetails(): JSX.Element {
+  const { t, i18n } = useTranslation(['device_settings', 'shared'])
+  const dispatch = useDispatch<Dispatch>()
+  const localRobot = useSelector(getLocalRobot)
+  const robotName = localRobot?.name != null ? localRobot.name : 'no name'
+  console.log(robotName)
+  const { ethernet } = useSelector((state: State) =>
+    getNetworkInterfaces(state, robotName)
+  )
+
+  React.useEffect(() => {
+    dispatch(fetchStatus(robotName))
+  }, [robotName, dispatch])
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
+      {/* IP Address */}
+      <EthernetDetailsRow
+        title={t('ip_address')}
+        detail={
+          ethernet?.ipAddress != null
+            ? ethernet.ipAddress
+            : i18n.format(t('shared:no_data'), 'capitalize')
+        }
+      />
+      {/* Subnet Mask */}
+      <EthernetDetailsRow
+        title={t('subnet_mask')}
+        detail={
+          ethernet?.subnetMask != null
+            ? ethernet.subnetMask
+            : i18n.format(t('shared:no_data'), 'capitalize')
+        }
+      />
+      {/* MAC Address */}
+      <EthernetDetailsRow
+        title={t('mac_address')}
+        detail={
+          ethernet?.macAddress != null
+            ? ethernet.macAddress
+            : i18n.format(t('shared:no_data'), 'capitalize')
+        }
+      />
+      <Flex marginTop="9rem">
+        <StyledText
+          color={COLORS.darkBlack_seventy}
+          fontSize={TYPOGRAPHY.fontSize28}
+          lineHeight={TYPOGRAPHY.lineHeight36}
+          fontWeight={TYPOGRAPHY.fontWeightRegular}
+          textAlign={TYPOGRAPHY.textAlignCenter}
+        >
+          {t('ethernet_connection_description')}
+        </StyledText>
+      </Flex>
+    </Flex>
+  )
+}
+
+interface EthernetDetailsRowProps {
+  title: string
+  detail: string
+}
+
+const EthernetDetailsRow = ({
+  title,
+  detail,
+}: EthernetDetailsRowProps): JSX.Element => {
+  return (
+    <Flex
+      css={STRETCH_LIST_STYLE}
+      flexDirection={DIRECTION_ROW}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+    >
+      <StyledText
+        fontSize={TYPOGRAPHY.fontSize22}
+        lineHeight={TYPOGRAPHY.lineHeight28}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+      >
+        {title}
+      </StyledText>
+      <StyledText
+        color={COLORS.darkBlack_seventy}
+        fontSize={TYPOGRAPHY.fontSize22}
+        lineHeight={TYPOGRAPHY.lineHeight28}
+        fontWeight={TYPOGRAPHY.fontWeightRegular}
+      >
+        {detail}
+      </StyledText>
+    </Flex>
+  )
+}

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/EthernetConnectionDetails.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/EthernetConnectionDetails.tsx
@@ -32,7 +32,6 @@ export function EthernetConnectionDetails(): JSX.Element {
   const dispatch = useDispatch<Dispatch>()
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
-  console.log(robotName)
   const { ethernet } = useSelector((state: State) =>
     getNetworkInterfaces(state, robotName)
   )
@@ -70,17 +69,19 @@ export function EthernetConnectionDetails(): JSX.Element {
             : i18n.format(t('shared:no_data'), 'capitalize')
         }
       />
-      <Flex marginTop="9rem">
-        <StyledText
-          color={COLORS.darkBlack_seventy}
-          fontSize={TYPOGRAPHY.fontSize28}
-          lineHeight={TYPOGRAPHY.lineHeight36}
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          textAlign={TYPOGRAPHY.textAlignCenter}
-        >
-          {t('ethernet_connection_description')}
-        </StyledText>
-      </Flex>
+      {ethernet?.ipAddress === null || ethernet?.macAddress === null ? (
+        <Flex marginTop="9rem">
+          <StyledText
+            color={COLORS.darkBlack_seventy}
+            fontSize={TYPOGRAPHY.fontSize28}
+            lineHeight={TYPOGRAPHY.lineHeight36}
+            fontWeight={TYPOGRAPHY.fontWeightRegular}
+            textAlign={TYPOGRAPHY.textAlignCenter}
+          >
+            {t('ethernet_connection_description')}
+          </StyledText>
+        </Flex>
+      ) : null}
     </Flex>
   )
 }

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/EthernetConnectionDetails.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/EthernetConnectionDetails.test.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react'
+import { when } from 'jest-when'
+
+import { renderWithProviders } from '@opentrons/components'
+
+import { i18n } from '../../../../i18n'
+import * as Networking from '../../../../redux/networking'
+import { getLocalRobot } from '../../../../redux/discovery'
+import { mockConnectedRobot } from '../../../../redux/discovery/__fixtures__'
+import { EthernetConnectionDetails } from '../EthernetConnectionDetails'
+
+import type { State } from '../../../../redux/types'
+
+jest.mock('../../../../redux/networking')
+jest.mock('../../../../redux/discovery')
+jest.mock('../../../../redux/discovery/selectors')
+
+const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
+  typeof Networking.getNetworkInterfaces
+>
+const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
+  typeof getLocalRobot
+>
+
+const ROBOT_NAME = 'opentrons-robot-name'
+
+const render = () => {
+  return renderWithProviders(<EthernetConnectionDetails />, {
+    i18nInstance: i18n,
+  })
+}
+
+const mockEthernet = {
+  ipAddress: '127.0.0.100',
+  subnetMask: '255.255.255.230',
+  macAddress: 'ET:NT:00:00:00:00',
+  type: Networking.INTERFACE_ETHERNET,
+}
+
+describe('EthernetConnectionDetails', () => {
+  beforeEach(() => {
+    mockGetLocalRobot.mockReturnValue(mockConnectedRobot)
+    when(mockGetNetworkInterfaces)
+      .calledWith({} as State, ROBOT_NAME)
+      .mockReturnValue({
+        wifi: null,
+        ethernet: mockEthernet,
+      })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render ip address, subnet mask, mac address, text and button when ethernet is connected', () => {
+    const [{ getByText }] = render()
+    getByText('IP Address')
+    getByText('Subnet Mask')
+    getByText('MAC Address')
+    getByText(
+      'Connect an Ethernet cable to the back of the robot and a network switch or hub.'
+    )
+    getByText('127.0.0.100')
+    getByText('255.255.255.230')
+    getByText('ET:NT:00:00:00:00')
+  })
+
+  it('should render mac address no data when ethernet is not connected', () => {
+    const notConnectedMockEthernet = {
+      ipAddress: null,
+      subnetMask: null,
+      macAddress: 'ET:NT:00:00:00:11',
+      type: Networking.INTERFACE_ETHERNET,
+    }
+    when(mockGetNetworkInterfaces)
+      .calledWith({} as State, ROBOT_NAME)
+      .mockReturnValue({
+        wifi: null,
+        ethernet: notConnectedMockEthernet,
+      })
+    const [{ getByText, getAllByText }] = render()
+    getByText('IP Address')
+    getByText('Subnet Mask')
+    getByText('MAC Address')
+    expect(getAllByText('No data').length).toBe(2)
+    getByText('ET:NT:00:00:00:11')
+  })
+})

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/EthernetConnectionDetails.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/EthernetConnectionDetails.test.tsx
@@ -53,16 +53,18 @@ describe('EthernetConnectionDetails', () => {
   })
 
   it('should render ip address, subnet mask, mac address, text and button when ethernet is connected', () => {
-    const [{ getByText }] = render()
+    const [{ getByText, queryByText }] = render()
     getByText('IP Address')
     getByText('Subnet Mask')
     getByText('MAC Address')
-    getByText(
-      'Connect an Ethernet cable to the back of the robot and a network switch or hub.'
-    )
     getByText('127.0.0.100')
     getByText('255.255.255.230')
     getByText('ET:NT:00:00:00:00')
+    expect(
+      queryByText(
+        'Connect an Ethernet cable to the back of the robot and a network switch or hub.'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('should render mac address no data when ethernet is not connected', () => {
@@ -84,5 +86,8 @@ describe('EthernetConnectionDetails', () => {
     getByText('MAC Address')
     expect(getAllByText('No data').length).toBe(2)
     getByText('ET:NT:00:00:00:11')
+    getByText(
+      'Connect an Ethernet cable to the back of the robot and a network switch or hub.'
+    )
   })
 })

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/index.ts
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/index.ts
@@ -1,5 +1,6 @@
 export * from './ConnectingNetwork'
 export * from './DisplayWifiList'
+export * from './EthernetConnectionDetails'
 export * from './FailedToConnect'
 export * from './SearchNetwork'
 export * from './SelectAuthenticationType'


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add ethernet connection details
the header part will be fixed by a following PR.

![Screenshot 2023-04-05 at 6 15 29 PM](https://user-images.githubusercontent.com/474225/230224073-f2c26e4c-754a-4389-affa-3dcb373cf4fc.png)


[design]
https://www.figma.com/file/AoTLAYuWawlaWItB1umOjr/Opentrons-Flex-Touchscreen-Designs?node-id=7746-174256&t=w5JjWH46tPGWvvhI-0
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Settings -> Network Settings -> Ethernet 
ethernet is connected: ip address, subnet mask, and mac address are displayed
ethernet is not connected mac address and the connection guide are displayed
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add EthernetConnectionDetails
- add test for EthernetConnectionDetails
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
