### PR TITLE
feat(hardware): add tip presence query request message

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -159,6 +159,7 @@ class MessageId(int, Enum):
     attached_tools_request = 0x700
     tools_detected_notification = 0x701
     tip_presence_notification = 0x702
+    get_tip_status_request = 0x703
 
     fw_update_initiate = 0x60
     fw_update_data = 0x61

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -803,6 +803,18 @@ class SetGripperErrorTolerance(BaseMessage):  # noqa: D101
 
 
 @dataclass
+class TipStatusQueryRequest(EmptyPayloadMessage):
+    """Request to query the tip presence pin.
+
+    The response should be a PushTipPresenceNotification.
+    """
+
+    message_id: Literal[
+        MessageId.get_tip_status_request
+    ] = MessageId.get_tip_status_request
+
+
+@dataclass
 class PushTipPresenceNotification(BaseMessage):
     """Hardware triggered notification of ejector flag status.
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -91,6 +91,7 @@ MessageDefinition = Union[
     defs.BrushedMotorConfResponse,
     defs.SetGripperErrorTolerance,
     defs.PushTipPresenceNotification,
+    defs.TipStatusQueryRequest,
 ]
 
 


### PR DESCRIPTION
## Overview

Hardware team has requested a tip presence query message to manually request tip state. This will help with some tests they are running internally.

[Firmware PR](https://github.com/Opentrons/ot3-firmware/pull/632). 

Closes RLIQ-359.