### PR TITLE
feat(app): disable proceed to run if correct Flex pipettes aren't attached

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -88,7 +88,8 @@ export function SetupPipetteCalibrationItem({
     button = pipetteMismatchInfo
   } else if (!attached) {
     subText = t('attach_pipette_calibration')
-    button = (
+    // remove the button for attach until flex pipette flows work in run setup
+    button = !isOT3 ? (
       <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
         <TertiaryButton
           as={RRDLink}
@@ -98,7 +99,7 @@ export function SetupPipetteCalibrationItem({
           {t('attach_pipette_cta')}
         </TertiaryButton>
       </Flex>
-    )
+    ) : undefined
   } else {
     button = (
       <>

--- a/app/src/organisms/Devices/hooks/useRunCalibrationStatus.ts
+++ b/app/src/organisms/Devices/hooks/useRunCalibrationStatus.ts
@@ -51,8 +51,8 @@ export function useRunCalibrationStatus(
     const pipetteIsMatch =
       pipette?.requestedPipetteMatch === MATCH ||
       pipette?.requestedPipetteMatch === INEXACT_MATCH
-    // TODO(bh, 8/18/2022): remove isOT3 condition after OT-3 pipette calibration is implemented
-    if (pipette !== null && !pipetteIsMatch && !isOT3) {
+
+    if (pipette !== null && !pipetteIsMatch) {
       calibrationStatus = {
         complete: false,
         reason: 'attach_pipette_failure_reason',


### PR DESCRIPTION
fix RLIQ-357

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
To make Flex testing more stable and intuitive before we wire up the run setup pipette flows, let's show whether or not the correct pipettes are attached but not allow the user to correct this from the run setup page

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
1. Send a protocol to a Flex that needs pipettes that aren't attached
2. Verify that the calibration status is "Calibration Needed"
3. Required pipettes are displayed as not attached but no CTA is available to attach them
4. Send a protocol to a Flex that has correct pipettes attached
5. You should be able to proceed to run

# Changelog
1. Start including Flex pipettes attachment in run calibration status
2. Hide "attach pipette" button if Flex pipette needs to be attached until we wire up the flows for run setup

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Run through test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
