### PR TITLE
feat(odd): liquid details modal for ODD 

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -166,5 +166,6 @@
   "liquids_not_in_setup": "Liquids not in setup",
   "initial_liquids_num": "{{num}} initial liquids",
   "opening": "Opening...",
-  "closing": "Closing..."
+  "closing": "Closing...",
+  "total_vol": "total volume"
 }

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -63,7 +63,6 @@ export function Modal(props: ModalProps): JSX.Element {
         aria-label={`modal_${modalSize}`}
         onClick={e => {
           e.stopPropagation()
-          onOutsideClick(e)
         }}
       >
         {header != null ? (

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -52,7 +52,7 @@ export function Modal(props: ModalProps): JSX.Element {
     >
       <Flex
         backgroundColor={isError ? COLORS.red_two : COLORS.white}
-        border={isError ? `0.375rem solid ${COLORS.red_two}` : 'none'}
+        border={`0.375rem solid ${isError ? COLORS.red_two : COLORS.white}`}
         width={modalWidth}
         height="max-content"
         maxHeight="32.5rem"

--- a/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.tsx
@@ -48,7 +48,11 @@ export function ModalHeader(props: ModalHeaderProps): JSX.Element {
         </StyledText>
       </Flex>
       {hasExitIcon && onClick != null ? (
-        <Flex onClick={onClick} aria-label="closeIcon">
+        <Flex
+          onClick={onClick}
+          aria-label="closeIcon"
+          alignItems={ALIGN_CENTER}
+        >
           <Icon size="3.5rem" name="ot-close" />
         </Flex>
       ) : null}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -1,4 +1,5 @@
 import {
+  ALIGN_CENTER,
   BORDERS,
   Box,
   COLORS,
@@ -6,14 +7,15 @@ import {
   DIRECTION_ROW,
   Flex,
   Icon,
-  JUSTIFY_FLEX_END,
+  JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   SIZE_1,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { MICRO_LITERS, ODD_MEDIA_QUERY_SPECS } from '@opentrons/shared-data'
+import { MICRO_LITERS } from '@opentrons/shared-data'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { css } from 'styled-components'
 import { Divider } from '../../../../atoms/structure'
@@ -46,12 +48,8 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
   } = props
   const trackEvent = useTrackEvent()
   const isOdd = useSelector(getIsOnDevice)
+  const { t } = useTranslation('protocol_setup')
 
-  const LIQUID_CARD_ODD_STYLE = css`
-    border-color: ${COLORS.medGreyEnabled};
-    border: 4px solid ${COLORS.medGreyEnabled};
-    border-radius: 12px;
-  `
   const LIQUID_CARD_STYLE = css`
     ${BORDERS.cardOutlineBorder}
     &:hover {
@@ -61,20 +59,14 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
   `
   const ACTIVE_STYLE = css`
     background-color: ${isOdd ? COLORS.medBlue : COLORS.lightBlue};
-    border: ${isOdd ? `4px` : `1px`} solid ${COLORS.blueEnabled};
-    border-radius: ${isOdd ? `12px` : 0};
+    border: ${isOdd ? SPACING.spacing2 : `1px`} solid ${COLORS.blueEnabled};
+    border-radius: ${isOdd ? `0.75rem` : 0};
   `
-
-  const P_STYLE = css`
-    ${TYPOGRAPHY.pRegular};
-
-    @media ${ODD_MEDIA_QUERY_SPECS} {
-      font-size: 22px;
-      line-height: 28px;
-      font-weight: 400;
-    }
+  const LIQUID_CARD_ODD_STYLE = css`
+    border-color: ${COLORS.medGreyEnabled};
+    border: ${SPACING.spacing2} solid ${COLORS.medGreyEnabled};
+    border-radius: ${BORDERS.size_three};
   `
-
   const volumePerWellRange = getWellRangeForLiquidLabwarePair(
     volumeByWell,
     labwareWellOrdering
@@ -85,20 +77,105 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     trackEvent({ name: 'highlightLiquidInDetailModal', properties: {} })
   }
 
-  return (
+  return isOdd ? (
     <Box
-      css={
-        selectedValue === liquidId
-          ? ACTIVE_STYLE
-          : isOdd
-          ? LIQUID_CARD_ODD_STYLE
-          : LIQUID_CARD_STYLE
-      }
+      css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_ODD_STYLE}
+      borderRadius={BORDERS.radiusSoftCorners}
+      backgroundColor={COLORS.white}
+      onClick={() => setSelectedValue(liquidId)}
+      width="19.875rem"
+      minHeight="max-content"
+      aria-label="liquidBox_odd"
+    >
+      <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing4}>
+        <Flex
+          css={BORDERS.cardOutlineBorder}
+          padding={SPACING.spacing3}
+          height="3rem"
+          width="3rem"
+          backgroundColor={COLORS.white}
+          justifyContent={JUSTIFY_CENTER}
+          alignItems={ALIGN_CENTER}
+        >
+          <Icon name="circle" color={displayColor} size="1.4rem" />
+        </Flex>
+        <StyledText
+          fontSize={TYPOGRAPHY.fontSize22}
+          lineHeight={TYPOGRAPHY.lineHeight28}
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          marginTop="0.75rem"
+        >
+          {displayName}
+        </StyledText>
+        <StyledText
+          fontSize={TYPOGRAPHY.fontSize22}
+          lineHeight={TYPOGRAPHY.lineHeight28}
+          color={COLORS.darkGreyEnabled}
+        >
+          {description != null ? description : null}
+        </StyledText>
+        <Flex
+          backgroundColor={COLORS.darkBlack_twenty}
+          borderRadius={BORDERS.radiusSoftCorners}
+          height="2.75rem"
+          padding={`${SPACING.spacing3} 0.75rem`}
+          alignItems={TYPOGRAPHY.textAlignCenter}
+          marginTop="1rem"
+          width="max-content"
+        >
+          {Object.values(volumeByWell).reduce((prev, curr) => prev + curr, 0)}{' '}
+          {MICRO_LITERS} {t('total_vol')}
+        </Flex>
+      </Flex>
+      {selectedValue === liquidId ? (
+        <>
+          <Box borderBottom={`3px solid ${COLORS.darkBlack_twenty}`} />
+          <Flex
+            padding={SPACING.spacing4}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+          >
+            {volumePerWellRange.map((well, index) => {
+              return (
+                <Flex
+                  key={index}
+                  flexDirection={DIRECTION_ROW}
+                  justifyContent={JUSTIFY_SPACE_BETWEEN}
+                  paddingBottom={
+                    index !== volumePerWellRange.length - 1
+                      ? SPACING.spacing3
+                      : '0'
+                  }
+                >
+                  <StyledText
+                    lineHeight={TYPOGRAPHY.lineHeight28}
+                    fontSize={TYPOGRAPHY.fontSize22}
+                    color={COLORS.darkBlack_seventy}
+                  >
+                    {well.wellName}
+                  </StyledText>
+                  <StyledText
+                    lineHeight={TYPOGRAPHY.lineHeight28}
+                    fontSize={TYPOGRAPHY.fontSize22}
+                    color={COLORS.darkBlack_seventy}
+                  >
+                    {well.volume} {MICRO_LITERS}
+                  </StyledText>
+                </Flex>
+              )
+            })}
+          </Flex>
+        </>
+      ) : null}
+    </Box>
+  ) : (
+    <Box
+      css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
       borderRadius={BORDERS.radiusSoftCorners}
       padding={SPACING.spacing4}
       backgroundColor={COLORS.white}
       onClick={handleSelectedValue}
-      width={isOdd ? `318px` : `10.3rem`}
+      width="10.3rem"
       minHeight="max-content"
       data-testid="LiquidDetailCard_box"
     >
@@ -109,60 +186,37 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
         <Flex
           css={BORDERS.cardOutlineBorder}
           padding={SPACING.spacing3}
-          height={isOdd ? `48px` : `max-content`}
-          width={isOdd ? `48px` : `max-content`}
+          height="max-content"
+          width="max-content"
           backgroundColor={COLORS.white}
-          justifyContent="center"
-          alignItems="center"
         >
-          <Icon
-            name="circle"
-            color={displayColor}
-            size={isOdd ? `22.4px` : SIZE_1}
-          />
+          <Icon name="circle" color={displayColor} size={SIZE_1} />
         </Flex>
         <StyledText
-          as={isOdd ? undefined : 'h3'}
-          fontSize={isOdd ? '22px' : null}
+          as="h3"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           marginTop={SPACING.spacing3}
         >
           {displayName}
         </StyledText>
-        <StyledText css={P_STYLE} color={COLORS.darkGreyEnabled}>
+        <StyledText as="p" color={COLORS.darkGreyEnabled}>
           {description != null ? description : null}
         </StyledText>
-        {isOdd ? (
-          <Flex
-            backgroundColor={COLORS.darkBlack_twenty}
-            borderRadius={BORDERS.radiusSoftCorners}
-            height="2.75rem"
-            padding={`${SPACING.spacing3} 0.75rem`}
-            alignItems={TYPOGRAPHY.textAlignCenter}
-            marginRight={SPACING.spacing3}
-          >
+
+        <Flex
+          backgroundColor={COLORS.darkBlackEnabled + '1A'}
+          borderRadius={BORDERS.radiusSoftCorners}
+          height="max-content"
+          width="max-content"
+          paddingY={SPACING.spacing2}
+          paddingX={SPACING.spacing3}
+          marginTop={SPACING.spacing3}
+        >
+          <StyledText as="p">
             {Object.values(volumeByWell).reduce((prev, curr) => prev + curr, 0)}{' '}
             {MICRO_LITERS}
-          </Flex>
-        ) : (
-          <Flex
-            backgroundColor={COLORS.darkBlackEnabled + '1A'}
-            borderRadius={BORDERS.radiusSoftCorners}
-            height="max-content"
-            width="max-content"
-            paddingY={SPACING.spacing2}
-            paddingX={SPACING.spacing3}
-            marginTop={SPACING.spacing3}
-          >
-            <StyledText css={P_STYLE}>
-              {Object.values(volumeByWell).reduce(
-                (prev, curr) => prev + curr,
-                0
-              )}{' '}
-              {MICRO_LITERS}
-            </StyledText>
-          </Flex>
-        )}
+          </StyledText>
+        </Flex>
       </Flex>
       {selectedValue === liquidId ? (
         <>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -1,3 +1,7 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   BORDERS,
@@ -14,16 +18,24 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { MICRO_LITERS } from '@opentrons/shared-data'
-import * as React from 'react'
-import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
-import { css } from 'styled-components'
 import { Divider } from '../../../../atoms/structure'
 import { StyledText } from '../../../../atoms/text'
 import { useTrackEvent } from '../../../../redux/analytics'
 import { getIsOnDevice } from '../../../../redux/config'
 import { getWellRangeForLiquidLabwarePair } from './utils'
 
+const LIQUID_CARD_STYLE = css`
+  ${BORDERS.cardOutlineBorder}
+  &:hover {
+    border: 1px solid ${COLORS.medGreyHover};
+    cursor: pointer;
+  }
+`
+const LIQUID_CARD_ODD_STYLE = css`
+  border-color: ${COLORS.medGreyEnabled};
+  border: ${SPACING.spacing2} solid ${COLORS.medGreyEnabled};
+  border-radius: ${BORDERS.size_three};
+`
 interface LiquidDetailCardProps {
   liquidId: string
   displayName: string
@@ -47,25 +59,13 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     labwareWellOrdering,
   } = props
   const trackEvent = useTrackEvent()
-  const isOdd = useSelector(getIsOnDevice)
+  const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('protocol_setup')
 
-  const LIQUID_CARD_STYLE = css`
-    ${BORDERS.cardOutlineBorder}
-    &:hover {
-      border: 1px solid ${COLORS.medGreyHover};
-      cursor: pointer;
-    }
-  `
   const ACTIVE_STYLE = css`
-    background-color: ${isOdd ? COLORS.medBlue : COLORS.lightBlue};
-    border: ${isOdd ? SPACING.spacing2 : `1px`} solid ${COLORS.blueEnabled};
-    border-radius: ${isOdd ? `0.75rem` : 0};
-  `
-  const LIQUID_CARD_ODD_STYLE = css`
-    border-color: ${COLORS.medGreyEnabled};
-    border: ${SPACING.spacing2} solid ${COLORS.medGreyEnabled};
-    border-radius: ${BORDERS.size_three};
+    background-color: ${isOnDevice ? COLORS.medBlue : COLORS.lightBlue};
+    border: ${isOnDevice ? SPACING.spacing2 : `1px`} solid ${COLORS.blueEnabled};
+    border-radius: ${isOnDevice ? BORDERS.size_three : 0};
   `
   const volumePerWellRange = getWellRangeForLiquidLabwarePair(
     volumeByWell,
@@ -77,7 +77,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     trackEvent({ name: 'highlightLiquidInDetailModal', properties: {} })
   }
 
-  return isOdd ? (
+  return isOnDevice ? (
     <Box
       css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_ODD_STYLE}
       borderRadius={BORDERS.radiusSoftCorners}
@@ -120,11 +120,13 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
           height="2.75rem"
           padding={`${SPACING.spacing3} 0.75rem`}
           alignItems={TYPOGRAPHY.textAlignCenter}
-          marginTop="1rem"
+          marginTop={SPACING.spacing4}
           width="max-content"
         >
-          {Object.values(volumeByWell).reduce((prev, curr) => prev + curr, 0)}{' '}
-          {MICRO_LITERS} {t('total_vol')}
+          <>
+            {Object.values(volumeByWell).reduce((prev, curr) => prev + curr, 0)}{' '}
+            {MICRO_LITERS} {t('total_vol')}
+          </>
         </Flex>
       </Flex>
       {selectedValue === liquidId ? (
@@ -138,7 +140,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
             {volumePerWellRange.map((well, index) => {
               return (
                 <Flex
-                  key={index}
+                  key={`${well.wellName}_${index}`}
                   flexDirection={DIRECTION_ROW}
                   justifyContent={JUSTIFY_SPACE_BETWEEN}
                   paddingBottom={
@@ -224,7 +226,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
           {volumePerWellRange.map((well, index) => {
             return (
               <Flex
-                key={index}
+                key={`${well.wellName}_${index}`}
                 flexDirection={DIRECTION_ROW}
                 justifyContent={JUSTIFY_SPACE_BETWEEN}
                 paddingBottom={

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidDetailCard.tsx
@@ -6,17 +6,20 @@ import {
   DIRECTION_ROW,
   Flex,
   Icon,
+  JUSTIFY_FLEX_END,
   JUSTIFY_SPACE_BETWEEN,
   SIZE_1,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { MICRO_LITERS } from '@opentrons/shared-data'
+import { MICRO_LITERS, ODD_MEDIA_QUERY_SPECS } from '@opentrons/shared-data'
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import { css } from 'styled-components'
 import { Divider } from '../../../../atoms/structure'
 import { StyledText } from '../../../../atoms/text'
 import { useTrackEvent } from '../../../../redux/analytics'
+import { getIsOnDevice } from '../../../../redux/config'
 import { getWellRangeForLiquidLabwarePair } from './utils'
 
 interface LiquidDetailCardProps {
@@ -42,19 +45,36 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     labwareWellOrdering,
   } = props
   const trackEvent = useTrackEvent()
+  const isOdd = useSelector(getIsOnDevice)
 
+  const LIQUID_CARD_ODD_STYLE = css`
+    border-color: ${COLORS.medGreyEnabled};
+    border: 4px solid ${COLORS.medGreyEnabled};
+    border-radius: 12px;
+  `
   const LIQUID_CARD_STYLE = css`
     ${BORDERS.cardOutlineBorder}
-
     &:hover {
       border: 1px solid ${COLORS.medGreyHover};
       cursor: pointer;
     }
   `
   const ACTIVE_STYLE = css`
-    background-color: ${COLORS.lightBlue};
-    border: 1px solid ${COLORS.blueEnabled};
+    background-color: ${isOdd ? COLORS.medBlue : COLORS.lightBlue};
+    border: ${isOdd ? `4px` : `1px`} solid ${COLORS.blueEnabled};
+    border-radius: ${isOdd ? `12px` : 0};
   `
+
+  const P_STYLE = css`
+    ${TYPOGRAPHY.pRegular};
+
+    @media ${ODD_MEDIA_QUERY_SPECS} {
+      font-size: 22px;
+      line-height: 28px;
+      font-weight: 400;
+    }
+  `
+
   const volumePerWellRange = getWellRangeForLiquidLabwarePair(
     volumeByWell,
     labwareWellOrdering
@@ -64,14 +84,21 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     setSelectedValue(liquidId)
     trackEvent({ name: 'highlightLiquidInDetailModal', properties: {} })
   }
+
   return (
     <Box
-      css={selectedValue === liquidId ? ACTIVE_STYLE : LIQUID_CARD_STYLE}
+      css={
+        selectedValue === liquidId
+          ? ACTIVE_STYLE
+          : isOdd
+          ? LIQUID_CARD_ODD_STYLE
+          : LIQUID_CARD_STYLE
+      }
       borderRadius={BORDERS.radiusSoftCorners}
       padding={SPACING.spacing4}
       backgroundColor={COLORS.white}
       onClick={handleSelectedValue}
-      width="10.3rem"
+      width={isOdd ? `318px` : `10.3rem`}
       minHeight="max-content"
       data-testid="LiquidDetailCard_box"
     >
@@ -82,40 +109,60 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
         <Flex
           css={BORDERS.cardOutlineBorder}
           padding={SPACING.spacing3}
-          height="max-content"
-          width="max-content"
+          height={isOdd ? `48px` : `max-content`}
+          width={isOdd ? `48px` : `max-content`}
           backgroundColor={COLORS.white}
+          justifyContent="center"
+          alignItems="center"
         >
-          <Icon name="circle" color={displayColor} size={SIZE_1} />
+          <Icon
+            name="circle"
+            color={displayColor}
+            size={isOdd ? `22.4px` : SIZE_1}
+          />
         </Flex>
         <StyledText
-          as="h3"
+          as={isOdd ? undefined : 'h3'}
+          fontSize={isOdd ? '22px' : null}
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           marginTop={SPACING.spacing3}
         >
           {displayName}
         </StyledText>
-        <StyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          color={COLORS.darkGreyEnabled}
-        >
+        <StyledText css={P_STYLE} color={COLORS.darkGreyEnabled}>
           {description != null ? description : null}
         </StyledText>
-        <Flex
-          backgroundColor={COLORS.darkBlackEnabled + '1A'}
-          borderRadius={BORDERS.radiusSoftCorners}
-          height="max-content"
-          width="max-content"
-          paddingY={SPACING.spacing2}
-          paddingX={SPACING.spacing3}
-          marginTop={SPACING.spacing3}
-        >
-          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+        {isOdd ? (
+          <Flex
+            backgroundColor={COLORS.darkBlack_twenty}
+            borderRadius={BORDERS.radiusSoftCorners}
+            height="2.75rem"
+            padding={`${SPACING.spacing3} 0.75rem`}
+            alignItems={TYPOGRAPHY.textAlignCenter}
+            marginRight={SPACING.spacing3}
+          >
             {Object.values(volumeByWell).reduce((prev, curr) => prev + curr, 0)}{' '}
             {MICRO_LITERS}
-          </StyledText>
-        </Flex>
+          </Flex>
+        ) : (
+          <Flex
+            backgroundColor={COLORS.darkBlackEnabled + '1A'}
+            borderRadius={BORDERS.radiusSoftCorners}
+            height="max-content"
+            width="max-content"
+            paddingY={SPACING.spacing2}
+            paddingX={SPACING.spacing3}
+            marginTop={SPACING.spacing3}
+          >
+            <StyledText css={P_STYLE}>
+              {Object.values(volumeByWell).reduce(
+                (prev, curr) => prev + curr,
+                0
+              )}{' '}
+              {MICRO_LITERS}
+            </StyledText>
+          </Flex>
+        )}
       </Flex>
       {selectedValue === liquidId ? (
         <>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -126,8 +126,7 @@ export const LiquidsLabwareDetailsModal = (
   return isODD ? (
     <OddModal
       modalSize="large"
-      //  bug in modal component that i want to wait to fix until i merge the modal pr
-      onOutsideClick={() => console.log('wire this up')}
+      onOutsideClick={closeModal}
       header={{
         title: labwareName,
         hasExitIcon: true,

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -135,7 +135,7 @@ export const LiquidsLabwareDetailsModal = (
     >
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        height="24.70375rem"
+        height="23.70375rem"
         css={HIDE_SCROLLBAR}
         minWidth="10.313rem"
         overflowY="scroll"
@@ -146,7 +146,7 @@ export const LiquidsLabwareDetailsModal = (
       <Flex width="38.75rem">
         <Flex marginLeft={SPACING.spacing6}>
           <svg
-            viewBox="0.5 1.2 127 78"
+            viewBox="0.5 2.2 127 78"
             height="100%"
             width="100%"
             transform="scale(1, -1)"

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -43,7 +43,7 @@ export const LiquidsLabwareDetailsModal = (
 ): JSX.Element | null => {
   const { liquidId, labwareId, runId, closeModal } = props
   const { t } = useTranslation('protocol_setup')
-  const isODD = useSelector(getIsOnDevice)
+  const isOnDevice = useSelector(getIsOnDevice)
   const currentLiquidRef = React.useRef<HTMLDivElement>(null)
   const protocolData = useMostRecentCompletedAnalysis(runId)
   const commands = protocolData?.commands ?? []
@@ -99,7 +99,7 @@ export const LiquidsLabwareDetailsModal = (
       )}
     />
   )
-  const liquidCard = filteredLiquidsInLoadOrder.map((liquid, index) => {
+  const liquidCard = filteredLiquidsInLoadOrder.map(liquid => {
     const labwareInfoEntry = Object.entries(labwareInfo).find(
       entry => entry[0] === liquid.id
     )
@@ -107,7 +107,7 @@ export const LiquidsLabwareDetailsModal = (
       labwareInfoEntry != null && (
         <Flex
           width="100%"
-          key={index}
+          key={liquid.id}
           ref={selectedValue === liquid.id ? currentLiquidRef : undefined}
         >
           <LiquidDetailCard
@@ -123,7 +123,7 @@ export const LiquidsLabwareDetailsModal = (
     )
   })
 
-  return isODD ? (
+  return isOnDevice ? (
     <OddModal
       modalSize="large"
       onOutsideClick={closeModal}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/LiquidsLabwareDetailsModal.tsx
@@ -81,77 +81,78 @@ export const LiquidsLabwareDetailsModal = (
     }
   `
   if (protocolData == null) return null
-
   const liquidIds = filteredLiquidsInLoadOrder.map(liquid => liquid.id)
   const disabledLiquidIds = liquidIds.filter(id => id !== selectedValue)
+  const labwareRender = (
+    <LabwareRender
+      definition={getSlotLabwareDefinition(labwareId, protocolData.commands)}
+      wellFill={wellFill}
+      wellLabelOption="SHOW_LABEL_INSIDE"
+      highlightedWells={
+        selectedValue != null
+          ? getWellGroupForLiquidId(labwareInfo, selectedValue)
+          : {}
+      }
+      disabledWells={getDisabledWellGroupForLiquidId(
+        labwareInfo,
+        disabledLiquidIds
+      )}
+    />
+  )
+  const liquidCard = filteredLiquidsInLoadOrder.map((liquid, index) => {
+    const labwareInfoEntry = Object.entries(labwareInfo).find(
+      entry => entry[0] === liquid.id
+    )
+    return (
+      labwareInfoEntry != null && (
+        <Flex
+          width="100%"
+          key={index}
+          ref={selectedValue === liquid.id ? currentLiquidRef : undefined}
+        >
+          <LiquidDetailCard
+            {...liquid}
+            liquidId={liquid.id}
+            volumeByWell={labwareInfoEntry[1][0].volumeByWell}
+            labwareWellOrdering={labwareWellOrdering}
+            setSelectedValue={setSelectedValue}
+            selectedValue={selectedValue}
+          />
+        </Flex>
+      )
+    )
+  })
 
   return isODD ? (
     <OddModal
       modalSize="large"
-      onOutsideClick={closeModal}
-      header={{ title: labwareName, hasExitIcon: true, onClick: closeModal }}
+      //  bug in modal component that i want to wait to fix until i merge the modal pr
+      onOutsideClick={() => console.log('wire this up')}
+      header={{
+        title: labwareName,
+        hasExitIcon: true,
+        onClick: closeModal,
+      }}
     >
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        overflowY="auto"
+        height="24.70375rem"
         css={HIDE_SCROLLBAR}
         minWidth="10.313rem"
-        gridGap={SPACING.spacing3}
+        overflowY="scroll"
+        gridGap={SPACING.spacing4}
       >
-        {filteredLiquidsInLoadOrder.map((liquid, index) => {
-          const labwareInfoEntry = Object.entries(labwareInfo).find(
-            entry => entry[0] === liquid.id
-          )
-          return (
-            labwareInfoEntry != null && (
-              <Flex
-                key={index}
-                ref={selectedValue === liquid.id ? currentLiquidRef : undefined}
-              >
-                <LiquidDetailCard
-                  {...liquid}
-                  liquidId={liquid.id}
-                  volumeByWell={labwareInfoEntry[1][0].volumeByWell}
-                  labwareWellOrdering={labwareWellOrdering}
-                  setSelectedValue={setSelectedValue}
-                  selectedValue={selectedValue}
-                />
-              </Flex>
-            )
-          )
-        })}
+        {liquidCard}
       </Flex>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        width="100%"
-        maxHeight="365.53px"
-        marginLeft={SPACING.spacing4}
-        marginTop={SPACING.spacing3}
-      >
-        <Flex flex="1 1 30rem" flexDirection={DIRECTION_COLUMN}>
+      <Flex width="38.75rem">
+        <Flex marginLeft={SPACING.spacing6}>
           <svg
-            viewBox="0 -15 130 100"
-            height="94%"
-            width="94%"
+            viewBox="0.5 1.2 127 78"
+            height="100%"
+            width="100%"
             transform="scale(1, -1)"
           >
-            <LabwareRender
-              definition={getSlotLabwareDefinition(
-                labwareId,
-                protocolData.commands
-              )}
-              wellFill={wellFill}
-              wellLabelOption="SHOW_LABEL_INSIDE"
-              highlightedWells={
-                selectedValue != null
-                  ? getWellGroupForLiquidId(labwareInfo, selectedValue)
-                  : {}
-              }
-              disabledWells={getDisabledWellGroupForLiquidId(
-                labwareInfo,
-                disabledLiquidIds
-              )}
-            />
+            {labwareRender}
           </svg>
         </Flex>
       </Flex>
@@ -164,7 +165,7 @@ export const LiquidsLabwareDetailsModal = (
       childrenPadding={0}
       width="45rem"
     >
-      {/* <Box
+      <Box
         paddingX={SPACING.spacing4}
         paddingTop={SPACING.spacing4}
         backgroundColor={COLORS.fundamentalsBackground}
@@ -179,30 +180,7 @@ export const LiquidsLabwareDetailsModal = (
             minWidth="10.313rem"
             gridGap={SPACING.spacing3}
           >
-            {filteredLiquidsInLoadOrder.map((liquid, index) => {
-              const labwareInfoEntry = Object.entries(labwareInfo).find(
-                entry => entry[0] === liquid.id
-              )
-              return (
-                labwareInfoEntry != null && (
-                  <Flex
-                    key={index}
-                    ref={
-                      selectedValue === liquid.id ? currentLiquidRef : undefined
-                    }
-                  >
-                    <LiquidDetailCard
-                      {...liquid}
-                      liquidId={liquid.id}
-                      volumeByWell={labwareInfoEntry[1][0].volumeByWell}
-                      labwareWellOrdering={labwareWellOrdering}
-                      setSelectedValue={setSelectedValue}
-                      selectedValue={selectedValue}
-                    />
-                  </Flex>
-                )
-              )
-            })}
+            {liquidCard}
           </Flex>
           <Flex
             flexDirection={DIRECTION_COLUMN}
@@ -250,28 +228,12 @@ export const LiquidsLabwareDetailsModal = (
             </Flex>
             <Flex flex="1 1 30rem" flexDirection={DIRECTION_COLUMN}>
               <svg viewBox="0 -10 130 100" transform="scale(1, -1)">
-                <LabwareRender
-                  definition={getSlotLabwareDefinition(
-                    labwareId,
-                    protocolData.commands
-                  )}
-                  wellFill={wellFill}
-                  wellLabelOption="SHOW_LABEL_INSIDE"
-                  highlightedWells={
-                    selectedValue != null
-                      ? getWellGroupForLiquidId(labwareInfo, selectedValue)
-                      : {}
-                  }
-                  disabledWells={getDisabledWellGroupForLiquidId(
-                    labwareInfo,
-                    disabledLiquidIds
-                  )}
-                />
+                {labwareRender}
               </svg>
             </Flex>
           </Flex>
         </Flex>
-      </Box> */}
+      </Box>
     </Modal>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidDetailCard.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidDetailCard.test.tsx
@@ -1,16 +1,29 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
-import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
+import {
+  nestedTextMatcher,
+  renderWithProviders,
+  SPACING,
+  COLORS,
+} from '@opentrons/components'
+import { i18n } from '../../../../../i18n'
 import { useTrackEvent } from '../../../../../redux/analytics'
+import { getIsOnDevice } from '../../../../../redux/config'
 import { LiquidDetailCard } from '../LiquidDetailCard'
 
 jest.mock('../../../../../redux/analytics')
+jest.mock('../../../../../redux/config')
 
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
+const mockGetIsOnDevice = getIsOnDevice as jest.MockedFunction<
+  typeof getIsOnDevice
+>
 const render = (props: React.ComponentProps<typeof LiquidDetailCard>) => {
-  return renderWithProviders(<LiquidDetailCard {...props} />)
+  return renderWithProviders(<LiquidDetailCard {...props} />, {
+    i18nInstance: i18n,
+  })[0]
 }
 let mockTrackEvent: jest.Mock
 
@@ -20,6 +33,7 @@ describe('LiquidDetailCard', () => {
   beforeEach(() => {
     mockTrackEvent = jest.fn()
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
+    mockGetIsOnDevice.mockReturnValue(false)
     props = {
       liquidId: '0',
       displayName: 'Mock Liquid',
@@ -37,13 +51,13 @@ describe('LiquidDetailCard', () => {
   })
 
   it('renders liquid name, description, total volume', () => {
-    const [{ getByText, getAllByText }] = render(props)
+    const { getByText, getAllByText } = render(props)
     getByText('Mock Liquid')
     getByText('Mock Description')
     getAllByText(nestedTextMatcher('100 µL'))
   })
   it('renders clickable box, clicking on it calls track event', () => {
-    const [{ getByTestId }] = render(props)
+    const { getByTestId } = render(props)
     fireEvent.click(getByTestId('LiquidDetailCard_box'))
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: 'highlightLiquidInDetailModal',
@@ -51,7 +65,7 @@ describe('LiquidDetailCard', () => {
     })
   })
   it('renders well volume information if selected', () => {
-    const [{ getByText, getAllByText }] = render({
+    const { getByText, getAllByText } = render({
       ...props,
       selectedValue: '0',
     })
@@ -60,12 +74,23 @@ describe('LiquidDetailCard', () => {
     getAllByText(nestedTextMatcher('50 µL'))
   })
   it('renders well range for volume info if selected', () => {
-    const [{ getByText }] = render({
+    const { getByText } = render({
       ...props,
       selectedValue: '0',
       volumeByWell: { A1: 50, B1: 50, C1: 50, D1: 50 },
     })
     getByText('A1: D1')
     getByText(nestedTextMatcher('50 µL'))
+  })
+  it('renders liquid name, description, total volume for odd, and clicking item selects the box', () => {
+    mockGetIsOnDevice.mockReturnValue(true)
+    const { getByText, getAllByText, getByLabelText } = render(props)
+    getByText('Mock Liquid')
+    getByText('Mock Description')
+    getAllByText(nestedTextMatcher('100 µL'))
+    getAllByText(nestedTextMatcher('total volume'))
+    expect(getByLabelText('liquidBox_odd')).toHaveStyle(
+      `border: ${SPACING.spacing2} solid ${COLORS.medGreyEnabled}`
+    )
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/LiquidsLabwareDetailsModal.test.tsx
@@ -8,12 +8,13 @@ import {
   LabwareRender,
 } from '@opentrons/components'
 import { parseLiquidsInLoadOrder } from '@opentrons/api-client'
-import { getSlotLabwareName } from '../../utils/getSlotLabwareName'
-import { getSlotLabwareDefinition } from '../../utils/getSlotLabwareDefinition'
-import { getLiquidsByIdForLabware, getWellFillFromLabwareId } from '../utils'
+import { getIsOnDevice } from '../../../../../redux/config'
 import { useLabwareRenderInfoForRunById } from '../../../../Devices/hooks'
 import { useMostRecentCompletedAnalysis } from '../../../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { mockDefinition } from '../../../../../redux/custom-labware/__fixtures__'
+import { getSlotLabwareName } from '../../utils/getSlotLabwareName'
+import { getSlotLabwareDefinition } from '../../utils/getSlotLabwareDefinition'
+import { getLiquidsByIdForLabware, getWellFillFromLabwareId } from '../utils'
 import { LiquidsLabwareDetailsModal } from '../LiquidsLabwareDetailsModal'
 import { LiquidDetailCard } from '../LiquidDetailCard'
 
@@ -27,12 +28,13 @@ jest.mock('@opentrons/components', () => {
   }
 })
 jest.mock('@opentrons/api-client')
+jest.mock('../../../../../redux/config')
+jest.mock('../../../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
+jest.mock('../../../../Devices/hooks')
 jest.mock('../../utils/getSlotLabwareName')
 jest.mock('../../utils/getSlotLabwareDefinition')
-jest.mock('../../../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
 jest.mock('../utils')
 jest.mock('../LiquidDetailCard')
-jest.mock('../../../../Devices/hooks')
 
 const mockLiquidDetailCard = LiquidDetailCard as jest.MockedFunction<
   typeof LiquidDetailCard
@@ -60,6 +62,9 @@ const mockUseLabwareRenderInfoForRunById = useLabwareRenderInfoForRunById as jes
 >
 const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
   typeof useMostRecentCompletedAnalysis
+>
+const mockGetIsOnDevice = getIsOnDevice as jest.MockedFunction<
+  typeof getIsOnDevice
 >
 const render = (
   props: React.ComponentProps<typeof LiquidsLabwareDetailsModal>
@@ -119,7 +124,7 @@ describe('LiquidsLabwareDetailsModal', () => {
     mockUseMostRecentCompletedAnalysis.mockReturnValue(
       {} as CompletedProtocolAnalysis
     )
-
+    mockGetIsOnDevice.mockReturnValue(false)
     when(mockLabwareRender)
       .mockReturnValue(<div></div>) // this (default) empty div will be returned when LabwareRender isn't called with expected props
       .calledWith(
@@ -148,6 +153,15 @@ describe('LiquidsLabwareDetailsModal', () => {
     getByText(nestedTextMatcher('mock LiquidDetailCard'))
   })
   it('should render labware render with well fill', () => {
+    mockGetWellFillFromLabwareId.mockReturnValue({
+      C1: '#ff4888',
+      C2: '#ff4888',
+    })
+    const [{ getByText }] = render(props)
+    getByText('mock labware render with well fill')
+  })
+  it('should render labware render with well fill on odd', () => {
+    mockGetIsOnDevice.mockReturnValue(true)
     mockGetWellFillFromLabwareId.mockReturnValue({
       C1: '#ff4888',
       C2: '#ff4888',


### PR DESCRIPTION
closes RLIQ-353

# Overview
Modify the liquid details modal to match ODD designs

<img width="984" alt="Screen Shot 2023-04-06 at 2 54 41 PM" src="https://user-images.githubusercontent.com/66035149/230469578-e1091d41-c1f6-4ceb-99f8-8ca205e1a9e3.png">

# Test Plan

- review modal on both desktop app and ODD, desktop app should retain correct UI and ODD should have correct UI

# Changelog

- add `getIsOnDevice` selector in `LiquidDetailCard` and `LiquidsLabwareDetailsModal`, update modals
- use the new `Modal` component
- small tweak to `Modal` to fix propagation bug. (addressing https://github.com/Opentrons/opentrons/pull/12426#discussion_r1160787777 but this was also partially addressed in https://github.com/Opentrons/opentrons/pull/12463)

# Review requests

- see test plan

# Risk assessment

low