### PR TITLE
refactor(api): remove `fail_on_not_homed` param in OT-3

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -470,8 +470,7 @@ class OT3Controller:
         )
 
     def check_encoder_status(self, axes: Sequence[OT3Axis]) -> bool:
-        """If any of the encoder statuses is ok, parking can proceed."""
-        return any(
+        return all(
             isinstance(status, MotorStatus) and status.encoder_ok
             for status in self._get_motor_status(axes)
         )

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -212,10 +212,15 @@ class OT3Simulator:
     @ensure_yield
     async def update_motor_status(self) -> None:
         """Retreieve motor and encoder status and position from all present nodes"""
-        # Simulate condition at boot, status would not be ok
-        self._motor_status.update(
-            (node, MotorStatus(False, False)) for node in self._present_nodes
-        )
+        if not self._motor_status:
+            # Simulate condition at boot, status would not be ok
+            self._motor_status.update(
+                (node, MotorStatus(False, False)) for node in self._present_nodes
+            )
+        else:
+            self._motor_status.update(
+                (node, MotorStatus(True, True)) for node in self._present_nodes
+            )
 
     @ensure_yield
     async def update_motor_estimation(self, axes: Sequence[OT3Axis]) -> None:
@@ -236,7 +241,7 @@ class OT3Simulator:
 
     def check_encoder_status(self, axes: Sequence[OT3Axis]) -> bool:
         """If any of the encoder statuses is ok, parking can proceed."""
-        return any(
+        return all(
             isinstance(status, MotorStatus) and status.encoder_ok
             for status in self._get_motor_status(axes)
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -794,9 +794,13 @@ class OT3API(
         if refresh:
             await self.refresh_positions()
 
-        z_ax = OT3Axis.by_mount(mount)
-        tool_ax = OT3Axis.of_main_tool_actuator(mount)
-        position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, tool_ax]
+        xyz = [OT3Axis.X, OT3Axis.Y,  OT3Axis.by_mount(mount)]
+        if mount == OT3Mount.GRIPPER:
+            # OT3Axis.G motor status always return False because it is a brushed motor,
+            # so we should skip
+            position_axes = xyz
+        else:
+            position_axes = xyz.append(OT3Axis.of_main_tool_actuator(mount))
 
         valid_motor = self._current_position and self._backend.check_motor_status(position_axes)
         if not valid_motor:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -798,9 +798,8 @@ class OT3API(
         tool_ax = OT3Axis.of_main_tool_actuator(mount)
         position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, tool_ax]
 
-        if not (
-            self._current_position and self._backend.check_motor_status(position_axes)
-        ):
+        valid_motor = self._current_position and self._backend.check_motor_status(position_axes)
+        if not valid_motor:
             raise MustHomeError(
                 f"Current position of {str(mount)} is unknown; please home motors."
             )
@@ -862,9 +861,8 @@ class OT3API(
         tool_ax = OT3Axis.of_main_tool_actuator(mount)
         position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, tool_ax]
 
-        if not (
-            self._backend.check_motor_status(position_axes) and self._encoder_position
-        ):
+        valid_encoder = self._encoder_position and self._backend.check_encoder_status(position_axes)
+        if not valid_encoder:
             raise MustHomeError(
                 f"Encoder position of {str(mount)} is unknown, please home motors."
             )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -799,8 +799,10 @@ class OT3API(
         if refresh:
             await self.refresh_positions()
 
-        position_axes = [OT3Axis.X, OT3Axis.Y,  OT3Axis.by_mount(mount)]
-        valid_motor = self._current_position and self._backend.check_motor_status(position_axes)
+        position_axes = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
+        valid_motor = self._current_position and self._backend.check_motor_status(
+            position_axes
+        )
         if not valid_motor:
             raise MustHomeError(
                 f"Current position of {str(mount)} is invalid; please home motors."
@@ -864,8 +866,10 @@ class OT3API(
                 f"Cannot return encoder position for {mount} if no gripper is attached"
             )
 
-        position_axes = [OT3Axis.X, OT3Axis.Y,  OT3Axis.by_mount(mount)]
-        valid_motor = self._encoder_position and self._backend.check_encoder_status(position_axes)
+        position_axes = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
+        valid_motor = self._encoder_position and self._backend.check_encoder_status(
+            position_axes
+        )
         if not valid_motor:
             raise MustHomeError(
                 f"Encoder position of {str(mount)} is invalid; please home motors."

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -776,11 +776,10 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         critical_point: Optional[CriticalPoint] = None,
         refresh: bool = False,
-        fail_on_not_homed: bool = False,
     ) -> Dict[Axis, float]:
         realmount = OT3Mount.from_mount(mount)
         ot3_pos = await self.current_position_ot3(
-            realmount, critical_point, refresh, fail_on_not_homed
+            realmount, critical_point, refresh
         )
         return self._axis_map_from_ot3axis_map(ot3_pos)
 
@@ -788,31 +787,26 @@ class OT3API(
         self,
         mount: OT3Mount,
         critical_point: Optional[CriticalPoint] = None,
-        # TODO(mc, 2021-11-15): combine with `refresh` for more reliable
-        # position reporting when motors are not homed
         refresh: bool = False,
-        fail_on_not_homed: bool = False,
     ) -> Dict[OT3Axis, float]:
         """Return the postion (in deck coords) of the critical point of the
         specified mount.
         """
-        z_ax = OT3Axis.by_mount(mount)
-        plunger_ax = OT3Axis.of_main_tool_actuator(mount)
-        position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, plunger_ax]
-
-        if fail_on_not_homed and (
-            not self._backend.check_motor_status(position_axes)
-            or not self._current_position
-        ):
-            raise MustHomeError(
-                f"Current position of {str(mount)} pipette is unknown, please home."
-            )
-
-        elif not self._current_position and not refresh:
-            raise MustHomeError("Current position is unknown; please home motors.")
-
         if refresh:
             await self.refresh_positions()
+
+        z_ax = OT3Axis.by_mount(mount)
+        tool_ax = OT3Axis.of_main_tool_actuator(mount)
+        position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, tool_ax]
+
+        if not (
+            self._current_position and
+            self._backend.check_motor_status(position_axes)
+        ):
+            raise MustHomeError(
+                f"Current position of {str(mount)} is unknown; please home motors."
+            )
+
         return self._effector_pos_from_carriage_pos(
             OT3Mount.from_mount(mount), self._current_position, critical_point
         )
@@ -847,13 +841,12 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         critical_point: Optional[CriticalPoint] = None,
         refresh: bool = False,
-        fail_on_not_homed: bool = False,
     ) -> Dict[Axis, float]:
         """
         Return the encoder position in absolute deck coords specified mount.
         """
         ot3pos = await self.encoder_current_position_ot3(
-            mount, critical_point, refresh, fail_on_not_homed
+            mount, critical_point, refresh
         )
         return {ot3ax.to_axis(): value for ot3ax, value in ot3pos.items()}
 
@@ -862,33 +855,31 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         critical_point: Optional[CriticalPoint] = None,
         refresh: bool = False,
-        fail_on_not_homed: bool = False,
     ) -> Dict[OT3Axis, float]:
         """
         Return the encoder position in absolute deck coords specified mount.
         """
-        z_ax = OT3Axis.by_mount(mount)
-        plunger_ax = OT3Axis.of_main_tool_actuator(mount)
-        position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, plunger_ax]
+        if refresh:
+            await self.refresh_positions()
 
-        if fail_on_not_homed and (
-            not self._backend.check_motor_status(position_axes)
-            or not self._encoder_position
+        z_ax = OT3Axis.by_mount(mount)
+        tool_ax = OT3Axis.of_main_tool_actuator(mount)
+        position_axes = [OT3Axis.X, OT3Axis.Y, z_ax, tool_ax]
+
+        if not (
+            self._backend.check_motor_status(position_axes)
+            and self._encoder_position
         ):
             raise MustHomeError(
-                f"Current position of {str(mount)} pipette is unknown, please home."
+                f"Encoder position of {str(mount)} is unknown, please home motors."
             )
-        elif not self._encoder_position and not refresh:
-            raise MustHomeError("Encoder position is unknown; please home motors.")
-        async with self._motion_lock:
-            if refresh:
-                await self.refresh_positions()
-            ot3pos = self._effector_pos_from_carriage_pos(
-                OT3Mount.from_mount(mount),
-                self._encoder_position,
-                critical_point,
-            )
-            return ot3pos
+        
+        ot3pos = self._effector_pos_from_carriage_pos(
+            OT3Mount.from_mount(mount),
+            self._encoder_position,
+            critical_point,
+        )
+        return ot3pos
 
     def _effector_pos_from_carriage_pos(
         self,
@@ -918,9 +909,6 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         critical_point: Optional[CriticalPoint] = None,
         refresh: bool = False,
-        # TODO(mc, 2021-11-15): combine with `refresh` for more reliable
-        # position reporting when motors are not homed
-        fail_on_not_homed: bool = False,
     ) -> top_types.Point:
         """Return the position of the critical point as pertains to the gantry."""
         realmount = OT3Mount.from_mount(mount)
@@ -928,7 +916,6 @@ class OT3API(
             realmount,
             critical_point,
             refresh,
-            fail_on_not_homed,
         )
         return top_types.Point(
             x=cur_pos[OT3Axis.X],
@@ -949,13 +936,15 @@ class OT3API(
         relative to the deck, at the specified speed."""
         realmount = OT3Mount.from_mount(mount)
 
-        # Refresh current position
+        # Cache current position from backend
         await self._cache_current_position()
         await self._cache_encoder_position()
 
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
         if not self._backend.check_motor_status(axes_moving):
-            await self.home(axes_moving)
+            raise MustHomeError(
+                f"Inaccurate motor position for {str(realmount)}, please home motors."
+            )
 
         target_position = target_position_from_absolute(
             realmount,
@@ -988,37 +977,25 @@ class OT3API(
         speed: Optional[float] = None,
         max_speeds: Union[None, Dict[Axis, float], OT3AxisMap[float]] = None,
         check_bounds: MotionChecks = MotionChecks.NONE,
-        fail_on_not_homed: bool = False,
         _check_stalls: bool = False,  # For testing only
     ) -> None:
         """Move the critical point of the specified mount by a specified
         displacement in a specified direction, at the specified speed."""
-
-        # TODO: Remove the fail_on_not_homed and make this the behavior all the time.
-        # Having the optional arg makes the bug stick around in existing code and we
-        # really want to fix it when we're not gearing up for a release.
-        mhe = MustHomeError(
-            "Cannot make a relative move because absolute position is unknown"
-        )
-
         realmount = OT3Mount.from_mount(mount)
+
+        # Cache current position from backend
+        await self._cache_current_position()
+        await self._cache_encoder_position()
+
         axes_moving = [OT3Axis.X, OT3Axis.Y, OT3Axis.by_mount(mount)]
         if not self._backend.check_motor_status([axis for axis in axes_moving]):
-            if fail_on_not_homed:
-                raise mhe
-            else:
-                await self.home(axes_moving)
-
-        # Refresh current position
-        await self.refresh_positions()
+            raise MustHomeError(
+                f"Inaccurate motor position for {str(realmount)}, please home motors."
+            )
 
         target_position = target_position_from_relative(
             realmount, delta, self._current_position
         )
-        if fail_on_not_homed and not self._backend.check_motor_status(
-            [axis for axis in axes_moving if axis is not None]
-        ):
-            raise mhe
         if max_speeds:
             checked_max: Optional[OT3AxisMap[float]] = {
                 OT3Axis.from_axis(k): v for k, v in max_speeds.items()

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -393,7 +393,6 @@ async def test_move_to_without_homing_first(
         instr_data = AttachedGripper(config=gripper_config, id="test")
         await ot3_hardware.cache_gripper(instr_data)
 
-    print(ot3_hardware._current_position)
     ot3_hardware._backend._motor_status = {}
     assert not ot3_hardware._backend.check_motor_status(homed_axis)
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -393,6 +393,7 @@ async def test_move_to_without_homing_first(
         instr_data = AttachedGripper(config=gripper_config, id="test")
         await ot3_hardware.cache_gripper(instr_data)
 
+    print(ot3_hardware._current_position)
     ot3_hardware._backend._motor_status = {}
     assert not ot3_hardware._backend.check_motor_status(homed_axis)
 
@@ -400,7 +401,7 @@ async def test_move_to_without_homing_first(
         mount,
         Point(0.001, 0.001, 0.001),
     )
-    mock_home.assert_called_once_with(homed_axis)
+    mock_home.assert_called_once()
     assert ot3_hardware._backend.check_motor_status(homed_axis)
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Now that we have encoders on the OT-3, we can find out whether or each axis has been homed by checking the encoder status. With this additional information, the hardware control API can figure out when we need to raise a MustHomeError without having to rely on the `fail_on_not_homed` param.

Theoretically, each axis equipped with an encoder should only need to home _once_ between power cycles. This means we can do the following on the OT-3 safely during:

### A. a movement command (`move_to`, `move_rel`)
After powering up, an axis MUST first home to prepare for motion. If the hardware controller encounters a move command before any of the axes has a chance to home, instead of blocking the move, the robot can just home itself and proceed with the move. 

However, if the robot has homed before but the motor position is no longer accurate, we should raise an MustHomeError and block the move because it can cause a crash. In order to proceed, user intervention is required to determine the course of actions.

### B. a position-retrieval command (`encoder_position`, `gantry_position`)
We should always raise the daunting MustHomeError if (1) the robot has not been homed, or (2) if the positions are not accurate. In both cases, there's nothing worth reporting and we just should let the user know. 



# Review Request
Am I missing something? Could this cause any catastrophic failure that I didn't think of?

