### PR TITLE
chore(build): Make sure machine is reachable before attempting to scp files.

### DIFF
--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -26,7 +26,7 @@ is-windows=$(findstring $(PLATFORM), Windows)
 $(if $(is-windows), echo "when using windows with an openSSH version larger then 9 add -O flag to scp command. see comments for more details")
 
 # Make sure the machine is recheable before trying to scp files
-assert-online=$(shell ping -t 1 $(1) 2>&1 > /dev/null || echo "Machine $(1) is unreachable" && exit 1)
+assert-online=$(if $(shell ssh $(call id-file-arg,$(2)) $(3) -o ConnectTimeout=5 -o ConnectionAttempts=1 root@$(1) echo 0),,$(error Machine $(1) might be offline))
 
 # push-python-package: execute a push to the robot of a particular python
 # package.


### PR DESCRIPTION
# Overview

Fixes misleading message printed when the push command fails because of a network error.

# Test Plan

- [x] Make sure `make push-ot3 host=<ip-addr>` still works for OT3
- [x] Make sure `make push host=<ip-addr>` still works for OT2
- [x] Make sure make push still works on Windows, Mac, and Linux
- [x] Make sure we print "Machine <ip-addr> is unreachable" if robot is offline.

# Changelog

- add assert-online function to check if the machine responds to ping

# Review requests

- Make sure this works for you

# Risk assessment
Low
