### PR TITLE
Remove unused py executables

### DIFF
--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -166,9 +166,14 @@ module.exports = function beforeBuild(context) {
       return true
     })
     .then(() => {
+      if (!isWin) {
+        console.log(
+          `Not windows (${platform}), not removing python executables`
+        )
+        return true
+      }
+
       console.log('Removing unused executables to reduce codesign problems')
-      return isWin
-        ? removeUnusedPyExecutables(PYTHON_DESTINATION, platformName)
-        : Promise.resolve(true)
+      return removeUnusedPyExecutables(PYTHON_DESTINATION, platformName)
     })
 }

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -168,11 +168,12 @@ module.exports = function beforeBuild(context) {
         'pandas==1.4.3',
       ])
     })
-    .then(({ stdout }) => {
+    .then(result => {
       console.log(
         "`opentrons` and `pandas` packages installed to app's Python environment"
       )
-      console.debug('pip output:', stdout)
+      console.debug('full result', result)
+      console.debug('pip output:', result.stdout)
       // must return a truthy value, or else electron-builder will
       // skip installing project dependencies into the package
       return true

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -93,18 +93,24 @@ const logCheckingDir = dirpath => {
 
 const removeUnusedPyExecutables = root =>
   Promise.all(
-    ['bin', 'setuptools', path.join('pip', '_vendor', 'distlib')].map(subdir =>
-      logCheckingDir(
+    ['bin', 'setuptools', path.join('pip', '_vendor', 'distlib')]
+      .map(subdir =>
         path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
-      ).then(entries => {
-        console.log(
-          `Removing all exes from the following list: ${entries.join(', ')}`
-        )
-        return entries.map(entry =>
-          entry.endsWith('exe') ? removeAndLog(entry) : logNotRemoving(entry)
-        )
-      })
-    )
+      )
+      .map(dirToCheck =>
+        logCheckingDir(dirToCheck).then(entries => {
+          console.log(
+            `Removing all exes from the following list: ${entries.join(', ')}`
+          )
+          return entries
+            .map(entry => path.join(dirToCheck, entry))
+            .map(entry =>
+              entry.endsWith('exe')
+                ? removeAndLog(entry)
+                : logNotRemoving(entry)
+            )
+        })
+      )
   )
 
 module.exports = function beforeBuild(context) {

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -177,6 +177,10 @@ module.exports = function beforeBuild(context) {
       // skip installing project dependencies into the package
       return true
     })
+    .catch(error) => {
+      console.log('heres an error when doing pip stuff', error)
+      return true
+    }
     .then(() => {
       if (!isWin) {
         console.log(

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -177,10 +177,10 @@ module.exports = function beforeBuild(context) {
       // skip installing project dependencies into the package
       return true
     })
-    .catch(error) => {
+    .catch(error => {
       console.log('heres an error when doing pip stuff', error)
       return true
-    }
+    })
     .then(() => {
       if (!isWin) {
         console.log(

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -81,15 +81,9 @@ const removeAndLog = filename => {
   return fs.unlink(filename)
 }
 
-const logNotRemoving = filename => {
-  console.log(`not removing ${filename}`)
-  return Promise.resolve(true)
-}
+const logNotRemoving = filename => Promise.resolve(true)
 
-const logCheckingDir = dirpath => {
-  console.log(`Checking directory ${dirpath}`)
-  return fs.readdir(dirpath)
-}
+const logCheckingDir = dirpath => fs.readdir(dirpath)
 
 const removeUnusedPyExecutables = root =>
   Promise.all(
@@ -98,24 +92,20 @@ const removeUnusedPyExecutables = root =>
         path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
       )
       .map(dirToCheck =>
-        logCheckingDir(dirToCheck).then(entries => {
-          console.log(
-            `Removing all exes from the following list: ${entries.join(', ')}`
-          )
-          return entries
+        logCheckingDir(dirToCheck).then(entries =>
+          entries
             .map(entry => path.join(dirToCheck, entry))
             .map(entry =>
               entry.endsWith('exe')
                 ? removeAndLog(entry)
                 : logNotRemoving(entry)
             )
-        })
+        )
       )
   )
 
 module.exports = function beforeBuild(context) {
   const { platform, arch, electronPlatformName } = context
-  console.log(context)
   const platformName = electronPlatformName ?? platform.nodeName
   const standalonePython = getPythonVersion(platformName, arch)
   const isWin = platformName === 'win32'
@@ -176,10 +166,6 @@ module.exports = function beforeBuild(context) {
       console.debug('pip output:', result.stdout)
       // must return a truthy value, or else electron-builder will
       // skip installing project dependencies into the package
-      return true
-    })
-    .catch(error => {
-      console.log('heres an error when doing pip stuff', error)
       return true
     })
     .then(() => {

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -86,17 +86,20 @@ const logNotRemoving = filename => {
   return Promise.resolve(true)
 }
 
+const logCheckingDir = dirpath => {
+  console.log(`Checking directory ${dirpath}`)
+  return fs.readdir(dirpath)
+}
+
 const removeUnusedPyExecutables = root =>
   ['bin', 'setuptools', path.join('pip', '_vendor', 'distlib')].map(subdir =>
-    fs
-      .readdir(
-        path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
+    logCheckingDir(
+      path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
+    ).then(entries =>
+      entries.map(entry =>
+        entry.endsWith('exe') ? removeAndLog(entry) : logNotRemoving(entry)
       )
-      .then(entries =>
-        entries.map(entry =>
-          entry.endsWith('exe') ? removeAndLog(entry) : logNotRemoving(entry)
-        )
-      )
+    )
   )
 
 module.exports = function beforeBuild(context) {

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -104,9 +104,10 @@ const removeUnusedPyExecutables = root =>
 
 module.exports = function beforeBuild(context) {
   const { platform, arch, electronPlatformName } = context
+  console.log(context)
   const platformName = electronPlatformName ?? platform.nodeName
   const standalonePython = getPythonVersion(platformName, arch)
-  const isWin = platform === 'win32'
+  const isWin = platformName === 'win32'
   if (!USE_PYTHON) {
     return Promise.resolve(true)
   }
@@ -168,12 +169,12 @@ module.exports = function beforeBuild(context) {
     .then(() => {
       if (!isWin) {
         console.log(
-          `Not windows (${platform}), not removing python executables`
+          `Not windows (${platformName}), not removing python executables`
         )
         return true
       }
 
       console.log('Removing unused executables to reduce codesign problems')
-      return removeUnusedPyExecutables(PYTHON_DESTINATION, platformName)
+      return removeUnusedPyExecutables(PYTHON_DESTINATION)
     })
 }

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -95,11 +95,14 @@ const removeUnusedPyExecutables = root =>
   ['bin', 'setuptools', path.join('pip', '_vendor', 'distlib')].map(subdir =>
     logCheckingDir(
       path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
-    ).then(entries =>
-      entries.map(entry =>
+    ).then(entries => {
+      console.log(
+        `Removing all exes from the following list: ${entries.join(', ')}`
+      )
+      return entries.map(entry =>
         entry.endsWith('exe') ? removeAndLog(entry) : logNotRemoving(entry)
       )
-    )
+    })
   )
 
 module.exports = function beforeBuild(context) {
@@ -176,5 +179,9 @@ module.exports = function beforeBuild(context) {
 
       console.log('Removing unused executables to reduce codesign problems')
       return removeUnusedPyExecutables(PYTHON_DESTINATION)
+    })
+    .then(() => {
+      console.log('Python installed and all is done')
+      return true
     })
 }

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -92,17 +92,19 @@ const logCheckingDir = dirpath => {
 }
 
 const removeUnusedPyExecutables = root =>
-  ['bin', 'setuptools', path.join('pip', '_vendor', 'distlib')].map(subdir =>
-    logCheckingDir(
-      path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
-    ).then(entries => {
-      console.log(
-        `Removing all exes from the following list: ${entries.join(', ')}`
-      )
-      return entries.map(entry =>
-        entry.endsWith('exe') ? removeAndLog(entry) : logNotRemoving(entry)
-      )
-    })
+  Promise.all(
+    ['bin', 'setuptools', path.join('pip', '_vendor', 'distlib')].map(subdir =>
+      logCheckingDir(
+        path.join(root, path.join(PYTHON_SITE_PACKAGES_TARGET_WINDOWS, subdir))
+      ).then(entries => {
+        console.log(
+          `Removing all exes from the following list: ${entries.join(', ')}`
+        )
+        return entries.map(entry =>
+          entry.endsWith('exe') ? removeAndLog(entry) : logNotRemoving(entry)
+        )
+      })
+    )
   )
 
 module.exports = function beforeBuild(context) {


### PR DESCRIPTION
Sometimes, our windows builds fail to sign. We don't 100% know why, but one theory is the following:
- On windows, all executables that we're packaging in the build must be signed
- There's quite a lot of executables in the python install we package along with the app
   - This isn't typical of electron builders, even those of our app on other platforms
- On windows, the way builds are signed appears to involve writing a keyfile to a temp dir that's reused across builds
- That key file is used to sign everything
    - because electron-builder wants to be fast, multiple signatures are parallelized
- The process of signing, in parallel via multiple processes, a whole bunch of executables using one keyfile races and sometimes causes a conflict; this hasn't been noticed and fixed because most builds don't have this many executables in them

One fix for this, or at least to decrease its likelihood, might be to remove many of the executables from the build. We don't really need any of them except for the core python, so why not.

Unfortunately the only way to test this (aside from making sure the offline analysis still works without all those executables) is by doing a build a whole bunch and seeing how frequently it fails to sign.
