### PR TITLE
refactor(shared-data): use new force polynomial for DVT gripper

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -295,7 +295,7 @@ def create_gripper_jaw_grip_group(
 ) -> MoveGroup:
     step = create_gripper_jaw_step(
         duration=np.float64(GRIPPER_JAW_GRIP_TIME),
-        duty_cycle=np.float32(duty_cycle),
+        duty_cycle=np.float32(round(duty_cycle)),
         stop_condition=stop_condition,
         move_type=MoveType.grip,
     )

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
@@ -3,7 +3,7 @@ import argparse
 import asyncio
 from pathlib import Path
 
-from hardware_testing.data import ui
+from hardware_testing.data import ui, get_git_description
 from hardware_testing.data.csv_report import RESULTS_OVERVIEW_TITLE
 from hardware_testing.opentrons_api import helpers_ot3
 from hardware_testing.opentrons_api.types import OT3Mount, OT3Axis
@@ -42,7 +42,7 @@ async def _main(cfg: TestConfig) -> None:
         report.set_operator(input("enter operator name: "))
     else:
         report.set_operator("simulation")
-    report.set_version("unknown")  # FIXME: figure out what this should be
+    report.set_version(get_git_description())
 
     # RUN TESTS
     for section, test_run in cfg.tests.items():

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_force.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_force.py
@@ -152,11 +152,15 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
         # GRIP AND MEASURE FORCE
         print(f"gripping at {duty_cycle}% duty cycle")
         found_forces = list()
-        for i in range(NUM_DUTY_CYCLE_TRIALS):
+        # take 2x extra samples, because we'll remove min/max later
+        for i in range(NUM_DUTY_CYCLE_TRIALS + 2):
             actual_force = await _grip_and_read_force(api, gauge, duty=duty_cycle)
             print(f" - trial {i + 1}/{NUM_DUTY_CYCLE_TRIALS} = {actual_force} N")
             found_forces.append(actual_force)
-        actual_force = sum(found_forces) / float(NUM_DUTY_CYCLE_TRIALS)
+        # remove min/max forces
+        forces_without_outliers = sorted(found_forces)[1:-1]
+        # calculate average
+        actual_force = sum(forces_without_outliers) / float(NUM_DUTY_CYCLE_TRIALS)
         print(f"average = {actual_force} N")
         tag = _get_test_tag(duty_cycle=duty_cycle)
         report(section, tag, [duty_cycle, actual_force, CSVResult.PASS])

--- a/shared-data/gripper/definitions/1/gripperV1.1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.1.json
@@ -5,9 +5,9 @@
   "displayName": "Gripper V1.1",
   "gripForceProfile": {
     "polynomial": [
-      [0, 3.64726],
-      [1, 1.37251],
-      [2, 0.02215]
+      [0, 3.47784],
+      [1, 1.37276],
+      [2, 0.02030]
     ],
     "defaultGripForce": 15.0,
     "defaultHomeForce": 12.0,

--- a/shared-data/gripper/definitions/1/gripperV1.1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.1.json
@@ -5,9 +5,9 @@
   "displayName": "Gripper V1.1",
   "gripForceProfile": {
     "polynomial": [
-      [0, 0.0365],
-      [1, 0.0137],
-      [2, 0.000221]
+      [0, 3.64726],
+      [1, 1.37251],
+      [2, 0.02215]
     ],
     "defaultGripForce": 15.0,
     "defaultHomeForce": 12.0,

--- a/shared-data/gripper/definitions/1/gripperV1.1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.1.json
@@ -7,7 +7,7 @@
     "polynomial": [
       [0, 3.47784],
       [1, 1.37276],
-      [2, 0.02030]
+      [2, 0.0203]
     ],
     "defaultGripForce": 15.0,
     "defaultHomeForce": 12.0,

--- a/shared-data/gripper/definitions/1/gripperV1.1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.1.json
@@ -5,8 +5,9 @@
   "displayName": "Gripper V1.1",
   "gripForceProfile": {
     "polynomial": [
-      [0, -0.282],
-      [1, 2.09]
+      [0, 0.0365],
+      [1, 0.0137],
+      [2, 0.000221]
     ],
     "defaultGripForce": 15.0,
     "defaultHomeForce": 12.0,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We are using an improved force polynomial for the DVT gripper units. Testing can be found [here].(https://docs.google.com/spreadsheets/d/1p_Z_eVt5fouws_gBYR0INqEejncHodFJad9dh1YBlpw/edit#gid=1020213898)
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
