### PR TITLE
fix(docs): well dimensions are attributes, not methods

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -282,7 +282,7 @@ Use :py:attr:`.Well.depth` to get the distance in mm between the very top of the
 
 Diameter
 ^^^^^^^^
-Use :py:attr:`.Well.diameter` to get the diameter of a given well in mm. Since diameter is a circular measurement, this attribute is only present on labware with circular wells. If the well is not circular, the value returned will be ``None``. Use length and width (see below) for non-circular wells.
+Use :py:attr:`.Well.diameter` to get the diameter of a given well in mm. Since diameter is a circular measurement, this attribute is only present on labware with circular wells. If the well is not circular, the value will be ``None``. Use length and width (see below) for non-circular wells.
 
 .. code-block:: python
     :substitutions:
@@ -296,7 +296,7 @@ Use :py:attr:`.Well.diameter` to get the diameter of a given well in mm. Since d
 
 Length
 ^^^^^^
-Use :py:attr:`.Well.length` to get the length of a given well in mm. Length is defined as the distance along the robot's x-axis (left to right). This attribute is only present on rectangular wells. If the well is not rectangular, the value returned will be ``None``. Use diameter (see above) for circular wells.
+Use :py:attr:`.Well.length` to get the length of a given well in mm. Length is defined as the distance along the robot's x-axis (left to right). This attribute is only present on rectangular wells. If the well is not rectangular, the value will be ``None``. Use diameter (see above) for circular wells.
 
 .. code-block:: python
     :substitutions:
@@ -310,7 +310,7 @@ Use :py:attr:`.Well.length` to get the length of a given well in mm. Length is d
 
 Width
 ^^^^^
-Use :py:attr:`.Well.width` to get the width of a given well in mm. Width is defined as the distance along the y-axis (front to back). This attribute is only present on rectangular wells. If the well is not rectangular, the value returned will be ``None``. Use diameter (see above) for circular wells.
+Use :py:attr:`.Well.width` to get the width of a given well in mm. Width is defined as the distance along the y-axis (front to back). This attribute is only present on rectangular wells. If the well is not rectangular, the value will be ``None``. Use diameter (see above) for circular wells.
 
 
 .. code-block:: python

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -264,12 +264,12 @@ The ``load_liquid`` arguments include a volume amount (``volume=n`` in µL). Thi
 Well Dimensions
 ***************
 
-The functions in the :ref:`new-well-access` section above return a single :py:class:`.Well` object or a larger object representing many wells. :py:class:`.Well` objects have methods that provide information about their physical shape, such as the depth or diameter, as specified in their corresponding labware definition. These properties can be used for different applications, such as calculating the volume of a well or a :ref:`position-relative-labware`.
+The functions in the :ref:`new-well-access` section above return a single :py:class:`.Well` object or a larger object representing many wells. :py:class:`.Well` objects have attributes that provide information about their physical shape, such as the depth or diameter, as specified in their corresponding labware definition. These properties can be used for different applications, such as calculating the volume of a well or a :ref:`position-relative-labware`.
 
 Depth
 ^^^^^
 
-Use :py:meth:`.Well.depth` to get the distance in mm between the very top of the well and the very bottom. For example, a conical well's depth is measured from the top center to the bottom center of the well.
+Use :py:attr:`.Well.depth` to get the distance in mm between the very top of the well and the very bottom. For example, a conical well's depth is measured from the top center to the bottom center of the well.
 
 .. code-block:: python
     :substitutions:
@@ -282,7 +282,7 @@ Use :py:meth:`.Well.depth` to get the distance in mm between the very top of the
 
 Diameter
 ^^^^^^^^
-Use :py:meth:`.Well.diameter` to get the diameter of a given well in mm. Since diameter is a circular measurement, this method only works for labware with circular wells. If the well is not circular, the value returned will be ``None``. Use length and width (see below) for non-circular wells.
+Use :py:attr:`.Well.diameter` to get the diameter of a given well in mm. Since diameter is a circular measurement, this attribute is only present on labware with circular wells. If the well is not circular, the value returned will be ``None``. Use length and width (see below) for non-circular wells.
 
 .. code-block:: python
     :substitutions:
@@ -296,7 +296,7 @@ Use :py:meth:`.Well.diameter` to get the diameter of a given well in mm. Since d
 
 Length
 ^^^^^^
-Use :py:meth:`.Well.length` to get the length of a given well in mm. Length is defined as the distance along the robot's x-axis (left to right). This method only works with rectangular wells. If the well is not rectangular, the value returned will be ``None``. Use diameter (see above) for circular wells.
+Use :py:attr:`.Well.length` to get the length of a given well in mm. Length is defined as the distance along the robot's x-axis (left to right). This attribute is only present on rectangular wells. If the well is not rectangular, the value returned will be ``None``. Use diameter (see above) for circular wells.
 
 .. code-block:: python
     :substitutions:
@@ -310,7 +310,7 @@ Use :py:meth:`.Well.length` to get the length of a given well in mm. Length is d
 
 Width
 ^^^^^
-Use :py:meth:`.Well.width` to get the width of a given well in mm. Width is defined as the distance along the y-axis (front to back). This method only works with rectangular wells. If the well is not rectangular, the value returned will be ``None``. Use diameter (see above) for circular wells.
+Use :py:attr:`.Well.width` to get the width of a given well in mm. Width is defined as the distance along the y-axis (front to back). This attribute is only present on rectangular wells. If the well is not rectangular, the value returned will be ``None``. Use diameter (see above) for circular wells.
 
 
 .. code-block:: python


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Python API docs erroneously referenced well dimensions as methods of the `Well` class rather than attributes. This PR corrects the error.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Check prose and test cross-reference links [in sandbox](http://sandbox.docs.opentrons.com/docs-fix-well-attrs/v2/new_labware.html#well-dimensions).

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Changed `:py:meth:` cross-references to `:py:attr:` for relevant attributes
- Rewrote prose to describe them as "attributes…of" rather than "methods…on" the `Well` class

# Review requests

<!--
Describe any requests for your reviewers here.
-->

See testing plan.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

nil, docs prose only