### PR TITLE
fix(app-shell-odd): make sure there is enough space on device before copying app tar file.

### DIFF
--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -70,9 +70,9 @@ dist-ot3: package-deps
 .PHONY: push-ot3
 push-ot3: dist-ot3
 	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
-	ssh $(ssh_opts) root@$(host) "rm -rf opentrons-robot-app.tar.gz && mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
 	scp -r $(ssh_opts) ./opentrons-robot-app.tar.gz root@$(host):
-	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app"
+	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
+	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app && rm -rf opentrons-robot-app.tar.gz"
 	rm -rf opentrons-robot-app.tar.gz
 
 # development

--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -70,7 +70,7 @@ dist-ot3: package-deps
 .PHONY: push-ot3
 push-ot3: dist-ot3
 	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
-	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
+	ssh $(ssh_opts) root@$(host) "rm -rf opentrons-robot-app.tar.gz && mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
 	scp -r $(ssh_opts) ./opentrons-robot-app.tar.gz root@$(host):
 	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app"
 	rm -rf opentrons-robot-app.tar.gz


### PR DESCRIPTION
# Overview

If the scp or clean-up function failed for whatever reason, we would end up in a state where we did not have enough space on the system to scp the new app shell tar file. This pr will remove the tar file before attempting to scp the new one, in case it was not previously removed.

# Test Plan

- [x] test pushing file to odd
- [x] cancel push midway and push file again


# Changelog

- attempt to remove the old app shell tar file in case it was not previously removed.

# Review requests

- test on ODD

# Risk assessment
Low, flex work