### PR TITLE
refactor(odd): add isError boolean prop to Modal for red background

### DIFF
--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.stories.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { COLORS, Flex, BORDERS } from '@opentrons/components'
+import { COLORS, Flex, BORDERS, SPACING } from '@opentrons/components'
 import { Modal } from './Modal'
 import type { Story, Meta } from '@storybook/react'
 
@@ -27,7 +27,11 @@ Default.args = {
     iconColor: COLORS.black,
   },
   children: (
-    <Flex height="23.5rem" borderRadius={`0 ${BORDERS.size_three}`}>
+    <Flex
+      borderRadius={`0 ${BORDERS.size_three}`}
+      paddingTop={SPACING.spacing6}
+      height="23.5rem"
+    >
       children goes here
     </Flex>
   ),

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.stories.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.stories.tsx
@@ -28,7 +28,7 @@ Default.args = {
   },
   children: (
     <Flex
-      borderRadius={`0 ${BORDERS.size_three}`}
+      borderRadius={`0px 0px ${BORDERS.size_three} ${BORDERS.size_three}`}
       paddingTop={SPACING.spacing6}
       height="23.5rem"
     >

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.stories.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { COLORS, Flex } from '@opentrons/components'
+import { COLORS, Flex, BORDERS } from '@opentrons/components'
 import { Modal } from './Modal'
 import type { Story, Meta } from '@storybook/react'
 
@@ -26,5 +26,10 @@ Default.args = {
     iconName: 'information',
     iconColor: COLORS.black,
   },
-  children: <Flex>children goes here</Flex>,
+  children: (
+    <Flex height="23.5rem" borderRadius={`0 ${BORDERS.size_three}`}>
+      children goes here
+    </Flex>
+  ),
+  isError: false,
 }

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -10,7 +10,7 @@ import {
 import { BackgroundOverlay } from '../../BackgroundOverlay'
 import { ModalHeader } from './ModalHeader'
 
-import type { ModalHeaderProps, ModalSize } from './types'
+import type { ModalHeaderBaseProps, ModalSize } from './types'
 
 interface ModalProps {
   /** clicking anywhere outside of the modal closes it  */
@@ -18,10 +18,17 @@ interface ModalProps {
   children: React.ReactNode
   /** for small, medium, or large modal sizes, medium by default */
   modalSize?: ModalSize
-  header?: ModalHeaderProps
+  header?: ModalHeaderBaseProps
+  isError?: boolean
 }
 export function Modal(props: ModalProps): JSX.Element {
-  const { modalSize = 'medium', onOutsideClick, children, header } = props
+  const {
+    modalSize = 'medium',
+    onOutsideClick,
+    children,
+    header,
+    isError,
+  } = props
 
   let modalWidth: string = '45.625rem'
   switch (modalSize) {
@@ -43,7 +50,8 @@ export function Modal(props: ModalProps): JSX.Element {
       justifyContent={JUSTIFY_CENTER}
     >
       <Flex
-        backgroundColor={COLORS.white}
+        backgroundColor={isError ? COLORS.red_two : COLORS.white}
+        border={isError ? `0.375rem solid ${COLORS.red_two}` : 'none'}
         width={modalWidth}
         maxHeight="32.5rem"
         borderRadius={BORDERS.size_three}
@@ -51,6 +59,10 @@ export function Modal(props: ModalProps): JSX.Element {
         margin={SPACING.spacing6}
         flexDirection={DIRECTION_COLUMN}
         aria-label={`modal_${modalSize}`}
+        onClick={e => {
+          e.stopPropagation()
+          onOutsideClick(e)
+        }}
       >
         {header != null ? (
           <ModalHeader
@@ -58,9 +70,12 @@ export function Modal(props: ModalProps): JSX.Element {
             iconName={header.iconName}
             iconColor={header.iconColor}
             hasExitIcon={header.hasExitIcon}
+            onClick={onOutsideClick}
+            isError={isError}
           />
         ) : null}
         <Flex
+          backgroundColor={COLORS.white}
           paddingX={SPACING.spacing6}
           paddingBottom={SPACING.spacing6}
           paddingTop={header != null ? '0rem' : SPACING.spacing6}

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -53,6 +53,7 @@ export function Modal(props: ModalProps): JSX.Element {
         backgroundColor={isError ? COLORS.red_two : COLORS.white}
         border={isError ? `0.375rem solid ${COLORS.red_two}` : 'none'}
         width={modalWidth}
+        height="max-content"
         maxHeight="32.5rem"
         borderRadius={BORDERS.size_three}
         boxShadow={BORDERS.shadowSmall}

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -18,6 +18,7 @@ interface ModalProps {
   children: React.ReactNode
   /** for small, medium, or large modal sizes, medium by default */
   modalSize?: ModalSize
+  /** see ModalHeader component for more details */
   header?: ModalHeaderBaseProps
   isError?: boolean
 }

--- a/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.stories.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.stories.tsx
@@ -34,4 +34,5 @@ Default.args = {
   hasExitIcon: true,
   iconName: 'information',
   iconColor: COLORS.black,
+  isError: false,
 }

--- a/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.tsx
@@ -7,14 +7,20 @@ import {
   Icon,
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
+  COLORS,
 } from '@opentrons/components'
 import { StyledText } from '../../../atoms/text'
-import type { ModalHeaderProps } from './types'
+import type { ModalHeaderBaseProps } from './types'
 
+interface ModalHeaderProps extends ModalHeaderBaseProps {
+  isError?: boolean
+}
 export function ModalHeader(props: ModalHeaderProps): JSX.Element {
-  const { title, hasExitIcon, iconName, iconColor, onClick } = props
+  const { title, hasExitIcon, iconName, iconColor, onClick, isError } = props
   return (
     <Flex
+      backgroundColor={isError ? COLORS.red_two : COLORS.white}
+      color={isError ? COLORS.white : COLORS.black}
       height="6.25rem"
       width="100%"
       padding={SPACING.spacing6}
@@ -27,7 +33,7 @@ export function ModalHeader(props: ModalHeaderProps): JSX.Element {
           <Icon
             aria-label={`icon_${iconName}`}
             name={iconName}
-            color={iconColor}
+            color={isError ? COLORS.white : iconColor}
             size={SPACING.spacing6}
             alignSelf={ALIGN_CENTER}
             marginRight={SPACING.spacing4}
@@ -41,7 +47,7 @@ export function ModalHeader(props: ModalHeaderProps): JSX.Element {
           {title}
         </StyledText>
       </Flex>
-      {hasExitIcon ? (
+      {hasExitIcon && onClick != null ? (
         <Flex onClick={onClick} aria-label="closeIcon">
           <Icon size="3.5rem" name="ot-close" />
         </Flex>

--- a/app/src/molecules/Modal/OnDeviceDisplay/__tests__/Modal.test.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/__tests__/Modal.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { renderWithProviders } from '@opentrons/components'
+import { renderWithProviders, COLORS } from '@opentrons/components'
 import { ModalHeader } from '../ModalHeader'
 import { Modal } from '../Modal'
 
@@ -44,5 +44,20 @@ describe('Modal', () => {
     const { getByText, getByLabelText } = render(props)
     getByText('children')
     getByLabelText('modal_small')
+  })
+  it('presses the background overlay and calls onoutsideClick', () => {
+    const { getByLabelText } = render(props)
+    getByLabelText('BackgroundOverlay').click()
+    expect(props.onOutsideClick).toHaveBeenCalled()
+  })
+  it('renders red background when isError is true', () => {
+    props = {
+      ...props,
+      isError: true,
+    }
+    const { getByLabelText } = render(props)
+    expect(getByLabelText('modal_medium')).toHaveStyle(
+      `backgroundColor: ${COLORS.red_two}`
+    )
   })
 })

--- a/app/src/molecules/Modal/OnDeviceDisplay/__tests__/ModalHeader.test.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/__tests__/ModalHeader.test.tsx
@@ -32,4 +32,16 @@ describe('ModalHeader', () => {
     getByLabelText('closeIcon').click()
     expect(props.onClick).toHaveBeenCalled()
   })
+  it('should render the header with red when isError is true', () => {
+    props = {
+      ...props,
+      isError: true,
+      iconName: 'information',
+      iconColor: COLORS.black,
+    }
+    const { getByLabelText } = render(props)
+    expect(getByLabelText('icon_information')).toHaveStyle(
+      `color: ${COLORS.white}`
+    )
+  })
 })

--- a/app/src/molecules/Modal/OnDeviceDisplay/types.ts
+++ b/app/src/molecules/Modal/OnDeviceDisplay/types.ts
@@ -2,9 +2,9 @@ import type { IconName } from '@opentrons/components'
 
 export type ModalSize = 'small' | 'medium' | 'large'
 
-export interface ModalHeaderProps {
+export interface ModalHeaderBaseProps {
   title: string
-  onClick?: () => void
+  onClick?: React.MouseEventHandler
   hasExitIcon?: boolean
   iconName?: IconName
   iconColor?: string


### PR DESCRIPTION
closes RAUT-399

# Overview

Allow for a red background modal + modal header 

# Test Plan

- examine the story in storybook for `modal` and `modalHeader`, should properly show a red background with white information

# Changelog

- add prop to `Modal` and `ModalHeader`, update tests and story
- fix a small bug in `Modal` that allows for closing the modal when you click on the background overlay.

# Review requests

- see test plan

# Risk assessment

low