### PR TITLE
feat(hardware): add messages to fetch lifetime motor usage data

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -101,6 +101,8 @@ class MessageId(int, Enum):
     pipette_info_response = 0x307
     gripper_info_response = 0x308
     set_serial_number = 0x30A
+    get_motor_usage_request = 0x30B
+    get_motor_usage_response = 0x30C
 
     stop_request = 0x00
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -829,3 +829,25 @@ class PushTipPresenceNotification(BaseMessage):
     message_id: Literal[
         MessageId.tip_presence_notification
     ] = MessageId.tip_presence_notification
+
+
+@dataclass
+class GetMotorUsageRequest(EmptyPayloadMessage):
+    """Prompt a motor to send it's total lifetime usage."""
+
+    message_id: Literal[
+        MessageId.get_motor_usage_request
+    ] = MessageId.get_motor_usage_request
+
+
+@dataclass
+class GetMotorUsageResponse(BaseMessage):
+    """Motor response with total lifetime usage."""
+
+    payload: payloads.GetMotorUsageResponsePayload
+    payload_type: Type[
+        payloads.GetMotorUsageResponsePayload
+    ] = payloads.GetMotorUsageResponsePayload
+    message_id: Literal[
+        MessageId.get_motor_usage_response
+    ] = MessageId.get_motor_usage_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -92,6 +92,8 @@ MessageDefinition = Union[
     defs.SetGripperErrorTolerance,
     defs.PushTipPresenceNotification,
     defs.TipStatusQueryRequest,
+    defs.GetMotorUsageRequest,
+    defs.GetMotorUsageResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -568,3 +568,10 @@ class SerialNumberPayload(EmptyPayload):
     """A payload with a serial number."""
 
     serial: SerialField
+
+
+@dataclass(eq=False)
+class GetMotorUsageResponsePayload(EmptyPayload):
+    """A payload with motor lifetime usage."""
+
+    distance_um: utils.UInt64Field

--- a/hardware/opentrons_hardware/scripts/dump_eeprom.py
+++ b/hardware/opentrons_hardware/scripts/dump_eeprom.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""blow away and reset EEPROM file systems."""
+
+import asyncio
+import logging
+import argparse
+from logging.config import dictConfig
+from typing import Dict, Any
+from typing_extensions import Final
+
+from opentrons_hardware.drivers.can_bus import build, CanMessenger
+from opentrons_hardware.firmware_bindings import utils, ArbitrationId
+from opentrons_hardware.firmware_bindings.constants import MessageId
+from opentrons_hardware.firmware_bindings.messages import (
+    MessageDefinition,
+    message_definitions,
+    payloads,
+)
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+
+logger = logging.getLogger(__name__)
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "stream_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "basic",
+            "level": logging.DEBUG,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["stream_handler"],
+            "level": logging.DEBUG,
+        },
+    },
+}
+
+TARGETS: Final[Dict[str, NodeId]] = {
+    "head": NodeId.head,
+    "gantry-x": NodeId.gantry_x,
+    "gantry-y": NodeId.gantry_y,
+    "pipette-left": NodeId.pipette_left,
+    "pipette-right": NodeId.pipette_right,
+    "gripper": NodeId.gripper,
+}
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Script entrypoint."""
+    with open(args.file, "w") as f:
+
+        def handle_read_resp(
+            message: MessageDefinition, arbitration_id: ArbitrationId
+        ) -> None:
+            """Called by can messenger when a message arrives."""
+            if isinstance(message, message_definitions.ReadFromEEPromResponse):
+                f.write(
+                    "".join("{:02x} ".format(x) for x in message.payload.data.value)
+                )
+                f.write("\n")
+
+        async with build.driver(build_settings(args)) as driver, CanMessenger(
+            driver
+        ) as messenger:
+            messenger.add_listener(
+                handle_read_resp,
+                lambda arbitration_id: bool(
+                    arbitration_id.parts.message_id == MessageId.read_eeprom_response
+                ),
+            )
+
+            await dump_eeprom(
+                messenger,
+                TARGETS[args.target],
+                256 if args.old_version else 16384,
+            )
+
+
+async def dump_eeprom(messenger: CanMessenger, node: NodeId, limit: int) -> None:
+    """Wipe out all of the data used for the general purpose file system."""
+    start = 0
+    max_read = 8
+    while start < limit:
+        read_len = min(max_read, limit - start)
+        read_msg = message_definitions.ReadFromEEPromRequest(
+            payload=payloads.EEPromReadPayload(
+                address=utils.UInt16Field(start),
+                data_length=utils.UInt16Field(read_len),
+            )
+        )
+        start += read_len
+        await messenger.send(node, read_msg)
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    add_can_args(parser)
+    parser.add_argument(
+        "--target",
+        help="The FW subsystem to be cleared.",
+        type=str,
+        required=True,
+        choices=TARGETS.keys(),
+    )
+    parser.add_argument(
+        "--file",
+        help="file where to save the dump file.",
+        type=str,
+        default="/var/log/eeprom_dump.hex",
+        required=False,
+    )
+    parser.add_argument(
+        "--less-logs",
+        help="Set log level to INFO, so we see less logs.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--old-version",
+        help="Enable this flag to clear eeprom on the older 256 Byte eeproms.",
+        action="store_true",
+        default=False,
+    )
+
+    args = parser.parse_args()
+
+    def _set_log_lvl_warn(d: Dict[str, Any]) -> None:
+        for k in d.keys():
+            if isinstance(d[k], dict):
+                _set_log_lvl_warn(d[k])
+            elif k == "level":
+                d[k] = logging.WARNING
+
+    if args.less_logs:
+        _set_log_lvl_warn(LOG_CONFIG)
+    dictConfig(LOG_CONFIG)
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/reset_eeprom.py
+++ b/hardware/opentrons_hardware/scripts/reset_eeprom.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""blow away and reset EEPROM file systems."""
+
+import asyncio
+import logging
+import argparse
+from logging.config import dictConfig
+from typing import Dict, Any
+from typing_extensions import Final
+
+from opentrons_hardware.drivers.can_bus import build, CanMessenger
+from opentrons_hardware.firmware_bindings import utils
+from opentrons_hardware.firmware_bindings.messages import (
+    message_definitions,
+    payloads,
+    fields,
+)
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.scripts.can_args import add_can_args, build_settings
+
+logger = logging.getLogger(__name__)
+
+LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"}
+    },
+    "handlers": {
+        "stream_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "basic",
+            "level": logging.DEBUG,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["stream_handler"],
+            "level": logging.DEBUG,
+        },
+    },
+}
+
+TARGETS: Final[Dict[str, NodeId]] = {
+    "head": NodeId.head,
+    "gantry-x": NodeId.gantry_x,
+    "gantry-y": NodeId.gantry_y,
+    "pipette-left": NodeId.pipette_left,
+    "pipette-right": NodeId.pipette_right,
+    "gripper": NodeId.gripper,
+}
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Script entrypoint."""
+    async with build.driver(build_settings(args)) as driver, CanMessenger(
+        driver
+    ) as messenger:
+
+        await clear_eeprom(
+            messenger, TARGETS[args.target], 256 if args.old_verison else 16384,
+            "FFFFFFFFFFFFFFFF" if args.old_verison else "0000000000000000"
+        )
+
+
+async def clear_eeprom(messenger: CanMessenger, node: NodeId, limit: int, filler: str) -> None:
+    """Wipe out all of the data used for the general purpose file system."""
+    start = 30
+    max_write = 8
+    while start < limit:
+        write_msg = message_definitions.WriteToEEPromRequest(
+            payload=payloads.EEPromDataPayload(
+                address=utils.UInt16Field(start),
+                data_length=utils.UInt16Field(min(max_write, limit - start)),
+                data=fields.EepromDataField.from_string(filler),
+            )
+        )
+        await messenger.ensure_send(node, write_msg)
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        help="The FW subsystem to be cleared.",
+        type=str,
+        required=True,
+        choices=TARGETS.keys(),
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help=(
+            "Developer logging level. At DEBUG or below, logs are written "
+            "to console; at INFO or above, logs are only written to "
+            "provision_gripper_debug.log"
+        ),
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="WARNING",
+    )
+    parser.add_argument(
+        "--old-version",
+        help=("enable this flag to clear eeprom on the older 256 Byte eeproms"),
+        action="store_true",
+        default=False,
+    )
+    add_can_args(parser)
+
+    args = parser.parse_args()
+
+    def _set_log_lvl_warn(d: Dict[str, Any]) -> None:
+        for k in d.keys():
+            if isinstance(d[k], dict):
+                _set_log_lvl_warn(d[k])
+            elif k == "level":
+                d[k] = logging.WARNING
+
+    if args.less_logs:
+        _set_log_lvl_warn(LOG_CONFIG)
+    dictConfig(LOG_CONFIG)
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This adds two new can messages one for requesting motor lifetime usage and its response.

It also adds two helper scripts for the eeprom one to reset the values to default and one to dump the values to a hex file

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
