### PR TITLE
fix(api): Fix Python runs hanging in `stop-requested` when you cancel them in between commands

### DIFF
--- a/api/src/opentrons/protocol_engine/clients/transports.py
+++ b/api/src/opentrons/protocol_engine/clients/transports.py
@@ -107,6 +107,17 @@ class ChildThreadTransport(AbstractSyncTransport):
             error = command.error
             raise ProtocolEngineError(f"{error.errorType}: {error.detail}")
 
+        # FIXME(mm, 2023-04-10): This assert can easily trigger from this sequence:
+        #
+        # 1. The engine is paused.
+        # 2. The user's Python script calls this method to start a new command,
+        #    which remains `queued` because of the pause.
+        # 3. The engine is stopped.
+        #
+        # The returned command will be `queued`, so it won't have a result.
+        #
+        # We need to figure out a proper way to report this condition to callers
+        # so they correctly interpret it as an intentional stop, not an internal error.
         assert command.result is not None, f"Expected Command {command} to have result"
 
         return command.result

--- a/api/src/opentrons/protocol_engine/execution/queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/queue_worker.py
@@ -73,9 +73,11 @@ class QueueWorker:
                     condition=self._state_store.commands.get_next_to_execute
                 )
             except RunStoppedError:
+                # There are no more commands that we should execute, either because the run has
+                # completed on its own, or because a client requested it to stop.
                 break
             else:
                 await self._command_executor.execute(command_id=command_id)
-                # Yield to the event loop in case we're executing a long run of commands
-                # that never yields internally. For example, a long run of comment commands.
+                # Yield to the event loop in case we're executing a long sequence of commands
+                # that never yields internally. For example, a long sequence of comment commands.
                 await asyncio.sleep(0)

--- a/api/src/opentrons/protocol_engine/execution/queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/queue_worker.py
@@ -70,7 +70,7 @@ class QueueWorker:
         while True:
             try:
                 command_id = await self._state_store.wait_for(
-                    condition=self._state_store.commands.get_next_queued
+                    condition=self._state_store.commands.get_next_to_execute
                 )
             except RunStoppedError:
                 break

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -216,7 +216,7 @@ class ProtocolEngine:
             CommandExecutionFailedError: if any protocol command failed.
         """
         await self._state_store.wait_for(
-            condition=self._state_store.commands.get_all_complete
+            condition=self._state_store.commands.get_all_commands_final
         )
 
     async def finish(

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -166,9 +166,12 @@ class ProtocolEngine:
         return self._state_store.commands.get(command_id)
 
     async def wait_for_command(self, command_id: str) -> None:
-        """Wait for a command to be completed."""
+        """Wait for a command to be completed.
+
+        Will also return if the engine was stopped before it reached the command.
+        """
         await self._state_store.wait_for(
-            self._state_store.commands.get_is_complete,
+            self._state_store.commands.get_command_is_final,
             command_id=command_id,
         )
 
@@ -185,7 +188,9 @@ class ProtocolEngine:
                 the command in state.
 
         Returns:
-            The completed command, whether it succeeded or failed.
+            The command. If the command completed, it will be succeeded or failed.
+            If the engine was stopped before it reached the command,
+            the command will be queued.
         """
         command = self.add_command(request)
         await self.wait_for_command(command.id)

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -535,7 +535,8 @@ class CommandView(HasState[CommandState]):
         """Get whether all added commands have completed.
 
         Raises:
-            CommandExecutionFailedError: if any added command failed.
+            CommandExecutionFailedError: if any added command failed, and its `intent` wasn't
+            `setup`.
         """
         no_command_running = self._state.running_command_id is None
         no_command_queued = len(self._state.queued_command_ids) == 0

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -317,7 +317,6 @@ class CommandStore(HasState[CommandState], HandlesActions):
             if not self._state.run_result:
                 self._state.queue_status = QueueStatus.PAUSED
                 self._state.run_result = RunResult.STOPPED
-                self._state.queued_command_ids.clear()
 
         elif isinstance(action, FinishAction):
             if not self._state.run_result:
@@ -541,9 +540,12 @@ class CommandView(HasState[CommandState]):
             `setup`.
         """
         no_command_running = self._state.running_command_id is None
-        no_command_queued = len(self._state.queued_command_ids) == 0
+        no_command_to_execute = (
+            self._state.run_result is not None
+            or len(self._state.queued_command_ids) == 0
+        )
 
-        if no_command_running and no_command_queued:
+        if no_command_running and no_command_to_execute:
             for command_id in self._state.all_command_ids:
                 command = self._state.commands_by_id[command_id].command
                 if command.error and command.intent != CommandIntent.SETUP:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -460,7 +460,7 @@ class CommandView(HasState[CommandState]):
 
         return None
 
-    def get_next_queued(self) -> Optional[str]:
+    def get_next_to_execute(self) -> Optional[str]:
         """Return the next command in line to be executed.
 
         Returns:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -543,13 +543,6 @@ class CommandView(HasState[CommandState]):
         else:
             return False
 
-    def get_stop_requested(self) -> bool:
-        """Get whether an engine stop has been requested.
-
-        A command may still be executing while the engine is stopping.
-        """
-        return self._state.run_result is not None
-
     def get_is_stopped(self) -> bool:
         """Get whether an engine stop has completed."""
         return self._state.run_completed_at is not None
@@ -574,7 +567,7 @@ class CommandView(HasState[CommandState]):
             SetupCommandNotAllowedError: The engine is running, so a setup command
                 may not be added.
         """
-        if self.get_stop_requested():
+        if self._state.run_result is not None:
             raise RunStoppedError("The run has already stopped.")
 
         elif isinstance(action, PlayAction):

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -467,8 +467,8 @@ class CommandView(HasState[CommandState]):
             The ID of the earliest queued command, if any.
 
         Raises:
-            RunStoppedError: The engine is currently stopped, so
-                there are not queued commands.
+            RunStoppedError: The engine is currently stopped or stopping,
+                so it will never run any more commands.
         """
         if self._state.run_result:
             raise RunStoppedError("Engine was stopped")

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -531,8 +531,10 @@ class CommandView(HasState[CommandState]):
             or (status == CommandStatus.QUEUED and self._state.run_result is not None)
         )
 
-    def get_all_complete(self) -> bool:
-        """Get whether all added commands have completed.
+    def get_all_commands_final(self) -> bool:
+        """Get whether all commands added so far have reached their final `status`.
+
+        See `get_command_is_final()`.
 
         Raises:
             CommandExecutionFailedError: if any added command failed, and its `intent` wasn't

--- a/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
@@ -42,16 +42,16 @@ async def queue_commands(decoy: Decoy, state_store: StateStore) -> None:
     return "command-id-2" the second time, and raise RunStoppedError the third time.
     """
 
-    def get_next_queued() -> Generator[str, None, None]:
+    def get_next_to_execute() -> Generator[str, None, None]:
         yield "command-id-1"
         yield "command-id-2"
         raise RunStoppedError()
 
-    get_next_queued_results = get_next_queued()
+    get_next_to_execute_results = get_next_to_execute()
 
     decoy.when(
-        await state_store.wait_for(condition=state_store.commands.get_next_queued)
-    ).then_do(lambda *args, **kwargs: next(get_next_queued_results))
+        await state_store.wait_for(condition=state_store.commands.get_next_to_execute)
+    ).then_do(lambda *args, **kwargs: next(get_next_to_execute_results))
 
 
 async def test_start_processes_commands(
@@ -131,7 +131,7 @@ async def test_engine_stopped_exception_breaks_loop_gracefully(
 ) -> None:
     """It should `join` gracefully if a RunStoppedError is raised."""
     decoy.when(
-        await state_store.wait_for(condition=state_store.commands.get_next_queued)
+        await state_store.wait_for(condition=state_store.commands.get_next_to_execute)
     ).then_raise(RunStoppedError("oh no"))
 
     subject.start()

--- a/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
@@ -1,4 +1,6 @@
 """Tests for the command QueueWorker in opentrons.protocol_engine."""
+from typing import Generator
+
 import pytest
 from decoy import Decoy, matchers
 
@@ -34,14 +36,22 @@ def subject(
 
 @pytest.fixture(autouse=True)
 async def queue_commands(decoy: Decoy, state_store: StateStore) -> None:
-    """Load the command queue with 2 queued commands, then stop."""
+    """Load the command queue with 2 queued commands, then stop.
+
+    When state_store.wait_for(...) is called, return "command-id-1" the first time,
+    return "command-id-2" the second time, and raise RunStoppedError the third time.
+    """
+
+    def get_next_queued() -> Generator[str, None, None]:
+        yield "command-id-1"
+        yield "command-id-2"
+        raise RunStoppedError()
+
+    get_next_queued_results = get_next_queued()
+
     decoy.when(
         await state_store.wait_for(condition=state_store.commands.get_next_queued)
-    ).then_return("command-id-1", "command-id-2")
-
-    decoy.when(state_store.commands.get_stop_requested()).then_return(
-        False, False, True
-    )
+    ).then_do(lambda *args, **kwargs: next(get_next_queued_results))
 
 
 async def test_start_processes_commands(
@@ -51,14 +61,6 @@ async def test_start_processes_commands(
     subject: QueueWorker,
 ) -> None:
     """It should pull commands off the queue and execute them."""
-    decoy.when(
-        await state_store.wait_for(condition=state_store.commands.get_next_queued)
-    ).then_return("command-id-1", "command-id-2")
-
-    decoy.when(state_store.commands.get_stop_requested()).then_return(
-        False, False, True
-    )
-
     subject.start()
 
     decoy.verify(

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -1011,30 +1011,3 @@ def test_handles_door_open_and_close_event_after_play(
 
     assert subject.state.queue_status == expected_queue_status
     assert subject.state.is_door_blocking is False
-
-
-def test_command_store_handles_stop_action_with_queued_commands() -> None:
-    """It should clear queued commands."""
-    subject = CommandStore(
-        config=_make_config(block_on_door_open=False), is_door_open=False
-    )
-
-    action = QueueCommandAction(
-        request=commands.WaitForResumeCreate(
-            params=commands.WaitForResumeParams(message="hello world"),
-        ),
-        request_hash=None,
-        created_at=datetime(year=2022, month=1, day=1),
-        command_id="command_id",
-    )
-
-    subject.handle_action(action)
-
-    assert len(subject.state.queued_command_ids) > 0
-    assert subject.state.run_result is None
-
-    subject.handle_action(StopAction())
-
-    assert len(subject.state.queued_command_ids) == 0
-    assert subject.state.queue_status == QueueStatus.PAUSED
-    assert subject.state.run_result == RunResult.STOPPED

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -260,21 +260,6 @@ def test_get_all_complete_setup_not_fatal() -> None:
     assert result is True
 
 
-def test_get_should_stop() -> None:
-    """It should return true if the run_result status is set."""
-    subject = get_command_view(run_result=RunResult.SUCCEEDED)
-    assert subject.get_stop_requested() is True
-
-    subject = get_command_view(run_result=RunResult.FAILED)
-    assert subject.get_stop_requested() is True
-
-    subject = get_command_view(run_result=RunResult.STOPPED)
-    assert subject.get_stop_requested() is True
-
-    subject = get_command_view(run_result=None)
-    assert subject.get_stop_requested() is False
-
-
 def test_get_is_stopped() -> None:
     """It should return true if stop requested and no command running."""
     subject = get_command_view(run_completed_at=None)

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -99,21 +99,21 @@ def test_get_all() -> None:
     assert subject.get_all() == [command_1, command_2, command_3]
 
 
-def test_get_next_queued_returns_first_queued() -> None:
+def test_get_next_to_execute_returns_first_queued() -> None:
     """It should return the next queued command ID."""
     subject = get_command_view(
         queue_status=QueueStatus.RUNNING,
         queued_command_ids=["command-id-1", "command-id-2"],
     )
 
-    assert subject.get_next_queued() == "command-id-1"
+    assert subject.get_next_to_execute() == "command-id-1"
 
 
 @pytest.mark.parametrize(
     "queue_status",
     [QueueStatus.SETUP, QueueStatus.RUNNING],
 )
-def test_get_next_queued_prioritizes_setup_command_queue(
+def test_get_next_to_execute_prioritizes_setup_command_queue(
     queue_status: QueueStatus,
 ) -> None:
     """It should prioritize setup command queue over protocol command queue."""
@@ -123,51 +123,53 @@ def test_get_next_queued_prioritizes_setup_command_queue(
         queued_setup_command_ids=["setup-command-id"],
     )
 
-    assert subject.get_next_queued() == "setup-command-id"
+    assert subject.get_next_to_execute() == "setup-command-id"
 
 
-def test_get_next_queued_returns_none_when_no_pending() -> None:
+def test_get_next_to_execute_returns_none_when_no_queued() -> None:
     """It should return None if there are no queued commands."""
     subject = get_command_view(
         queue_status=QueueStatus.RUNNING,
         queued_command_ids=[],
     )
 
-    assert subject.get_next_queued() is None
+    assert subject.get_next_to_execute() is None
 
 
 @pytest.mark.parametrize("queue_status", [QueueStatus.SETUP, QueueStatus.PAUSED])
-def test_get_next_queued_returns_none_if_not_running(queue_status: QueueStatus) -> None:
+def test_get_next_to_execute_returns_none_if_not_running(
+    queue_status: QueueStatus,
+) -> None:
     """It should not return protocol commands if the engine is not running."""
     subject = get_command_view(
         queue_status=queue_status,
         queued_setup_command_ids=[],
         queued_command_ids=["command-id-1", "command-id-2"],
     )
-    result = subject.get_next_queued()
+    result = subject.get_next_to_execute()
 
     assert result is None
 
 
-def test_get_next_queued_returns_no_commands_if_paused() -> None:
+def test_get_next_to_execute_returns_no_commands_if_paused() -> None:
     """It should not return any type of command if the engine is paused."""
     subject = get_command_view(
         queue_status=QueueStatus.PAUSED,
         queued_setup_command_ids=["setup-id-1", "setup-id-2"],
         queued_command_ids=["command-id-1", "command-id-2"],
     )
-    result = subject.get_next_queued()
+    result = subject.get_next_to_execute()
 
     assert result is None
 
 
 @pytest.mark.parametrize("run_result", RunResult)
-def test_get_next_queued_raises_if_stopped(run_result: RunResult) -> None:
+def test_get_next_to_execute_raises_if_stopped(run_result: RunResult) -> None:
     """It should raise if an engine stop has been requested."""
     subject = get_command_view(run_result=run_result)
 
     with pytest.raises(errors.RunStoppedError):
-        subject.get_next_queued()
+        subject.get_next_to_execute()
 
 
 def test_get_is_running_queue() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -182,7 +182,7 @@ def test_get_is_running_queue() -> None:
     assert subject.get_is_running() is False
 
 
-def test_get_is_complete() -> None:
+def test_get_command_is_final() -> None:
     """It should be able to tell if a command is complete."""
     completed_command = create_succeeded_command(command_id="command-id-1")
     failed_command = create_failed_command(command_id="command-id-2")
@@ -193,10 +193,10 @@ def test_get_is_complete() -> None:
         commands=[completed_command, failed_command, running_command, pending_command]
     )
 
-    assert subject.get_is_complete("command-id-1") is True
-    assert subject.get_is_complete("command-id-2") is True
-    assert subject.get_is_complete("command-id-3") is False
-    assert subject.get_is_complete("command-id-4") is False
+    assert subject.get_command_is_final("command-id-1") is True
+    assert subject.get_command_is_final("command-id-2") is True
+    assert subject.get_command_is_final("command-id-3") is False
+    assert subject.get_command_is_final("command-id-4") is False
 
 
 def test_get_all_complete() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -186,19 +186,38 @@ def test_get_is_running_queue() -> None:
 
 def test_get_command_is_final() -> None:
     """It should be able to tell if a command is complete."""
-    completed_command = create_succeeded_command(command_id="command-id-1")
-    failed_command = create_failed_command(command_id="command-id-2")
-    running_command = create_running_command(command_id="command-id-3")
-    pending_command = create_queued_command(command_id="command-id-4")
+    completed_command = create_succeeded_command(command_id="completed-command-id")
+    failed_command = create_failed_command(command_id="failed-command-id")
+    running_command = create_running_command(command_id="running-command-id")
+    pending_command = create_queued_command(command_id="queued-command-id")
 
     subject = get_command_view(
         commands=[completed_command, failed_command, running_command, pending_command]
     )
 
-    assert subject.get_command_is_final("command-id-1") is True
-    assert subject.get_command_is_final("command-id-2") is True
-    assert subject.get_command_is_final("command-id-3") is False
-    assert subject.get_command_is_final("command-id-4") is False
+    assert subject.get_command_is_final("completed-command-id") is True
+    assert subject.get_command_is_final("failed-command-id") is True
+    assert subject.get_command_is_final("running-command-id") is False
+    assert subject.get_command_is_final("queued-command-id") is False
+
+
+@pytest.mark.parametrize("run_result", RunResult)
+def test_get_command_is_final_when_run_has_result(run_result: RunResult) -> None:
+    """Queued commands are final when the run will never execute any more commands."""
+    completed_command = create_succeeded_command(command_id="completed-command-id")
+    failed_command = create_failed_command(command_id="failed-command-id")
+    running_command = create_running_command(command_id="running-command-id")
+    pending_command = create_queued_command(command_id="queued-command-id")
+
+    subject = get_command_view(
+        commands=[completed_command, failed_command, running_command, pending_command],
+        run_result=run_result,
+    )
+
+    assert subject.get_command_is_final("completed-command-id") is True
+    assert subject.get_command_is_final("failed-command-id") is True
+    assert subject.get_command_is_final("running-command-id") is False
+    assert subject.get_command_is_final("queued-command-id") is True
 
 
 def test_get_all_commands_final() -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -201,18 +201,18 @@ def test_get_command_is_final() -> None:
     assert subject.get_command_is_final("command-id-4") is False
 
 
-def test_get_all_complete() -> None:
+def test_get_all_commands_final() -> None:
     """It should return True if no commands queued or running."""
     subject = get_command_view(queued_command_ids=[])
-    assert subject.get_all_complete() is True
+    assert subject.get_all_commands_final() is True
 
     subject = get_command_view(queued_command_ids=["queued-command-id"])
-    assert subject.get_all_complete() is False
+    assert subject.get_all_commands_final() is False
 
     subject = get_command_view(
         queued_command_ids=[], running_command_id="running-command-id"
     )
-    assert subject.get_all_complete() is False
+    assert subject.get_all_commands_final() is False
 
 
 def test_get_all_complete_fatal_command_failure() -> None:
@@ -235,7 +235,7 @@ def test_get_all_complete_fatal_command_failure() -> None:
     )
 
     with pytest.raises(errors.ProtocolCommandFailedError, match="Oh no"):
-        subject.get_all_complete()
+        subject.get_all_commands_final()
 
 
 def test_get_all_complete_setup_not_fatal() -> None:
@@ -258,7 +258,7 @@ def test_get_all_complete_setup_not_fatal() -> None:
         commands=[completed_command, failed_command],
     )
 
-    result = subject.get_all_complete()
+    result = subject.get_all_commands_final()
     assert result is True
 
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -502,7 +502,9 @@ async def test_wait_until_complete(
     await subject.wait_until_complete()
 
     decoy.verify(
-        await state_store.wait_for(condition=state_store.commands.get_all_complete)
+        await state_store.wait_for(
+            condition=state_store.commands.get_all_commands_final
+        )
     )
 
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -281,7 +281,7 @@ async def test_add_and_execute_command(
 
     decoy.when(
         await state_store.wait_for(
-            condition=state_store.commands.get_is_complete,
+            condition=state_store.commands.get_command_is_final,
             command_id="command-id",
         ),
     ).then_do(_stub_completed)


### PR DESCRIPTION
# Overview

This fixes RSS-134, a bug where Python protocol runs would sometimes hang in the `stop-requested` state when you try to cancel them.

The problem was a kind of deadlock:

* The run will only transition from `stop-requested` to `stopped` *after* the user's Python script exits.
* If the user's Python script is currently paused just before starting a new command, it will only exit *after* that command completes or fails.
* But if you stop the run, that command will never complete or fail. It will forever remain `queued`.
* So, the user's Python script will never exit, and the run will never transition from `stop-requested` to `stopped`.

The solution is to not only wait for the command to succeed or fail before raising out of the user's Python script. We also need to check if the *whole run* has been requested to stop.

This is basically the same solution that we already have for JSON protocols, which don't suffer from this bug, as far as I know.

# Test plan

Following the steps to reproduce in the ticket:

* [x] Test the fix on an OT-2
* [x] Test the fix on an OT-formerly-known-as-3
* [x] Test the fix on a dev server

# Changelog

To fix the bug:

* Change `get_is_complete(command_id)` to return `True` if the run has been requested to stop, even if the command is still `queued`. This matches `get_all_complete()`, which is what JSON protocols use. 

Plus several small refactors to try to make all of this less confusing:

* **Rename `get_is_complete(command_id)` to `get_command_is_final(command_id)`.**

  This clarifies that it might return `True` even if the command has never been *started,* let alone completed. Same for `get_all_complete()`, which is renamed `get_all_commands_final()`.

* **Rename `get_next_queued()` to `get_next_to_execute()`,** which is what the callers really care about. Since https://github.com/Opentrons/opentrons/pull/10885#discussion_r911470192, there can be `queued` commands that will never execute.

* **Delete `get_stop_requested()`.**

  Only one place was using it, and it didn't actually need it. I think this method was dangerous to keep around because it had a confusing name: It returned `True` if the run completed on its own or if it the run encountered an error, *even if the user never requested a stop.*

* **Simplify the meaning of `queued_command_ids`.**

  [Originally](https://github.com/Opentrons/opentrons/pull/9712), it was intended to be a cache of all commands whose `status == "queued"`. [Eventually](https://github.com/Opentrons/opentrons/pull/10885#discussion_r911470192), it gained its own distinct meaning, closer to "all commands that the engine should execute." This was actually part of how we fixed this bug for JSON protocols.

  But in my opinion, overloading `queued_command_ids` like that was confusing and unnecessary. So this PR returns it back to just being a cache of commands whose `status == "queued"`.


# Review requests

The easiest way to review the changes in this PR is to go commit-by-commit.

* Does the removal of the `queued_command_ids.clear()` call look safe to you?
* Can you think of any ways to add automated tests for this?


# Risk assessment

Medium. `CommandView` is not easy to reason about, and the concurrency is not well-covered by tests.