### PR TITLE
feat(api): expose versions of connected micros

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -43,6 +43,8 @@ from .ot3utils import (
     create_tip_action_group,
     PipetteAction,
     sub_system_to_node_id,
+    NODEID_SUBSYSTEM,
+    USBTARGET_SUBSYSTEM,
 )
 
 try:
@@ -112,6 +114,7 @@ from opentrons.hardware_control.types import (
     UpdateStatus,
     mount_to_subsystem,
     DoorState,
+    OT3SubSystem,
 )
 from opentrons.hardware_control.errors import (
     MustHomeError,
@@ -244,9 +247,18 @@ class OT3Controller:
         self._initialized = value
 
     @property
-    def fw_version(self) -> Optional[str]:
+    def fw_version(self) -> Dict[OT3SubSystem, int]:
         """Get the firmware version."""
-        return None
+        subsystem_map: Dict[Union[NodeId, USBTarget], OT3SubSystem] = deepcopy(
+            cast(Dict[Union[NodeId, USBTarget], OT3SubSystem], USBTARGET_SUBSYSTEM)
+        )
+        subsystem_map.update(
+            cast(Dict[Union[NodeId, USBTarget], OT3SubSystem], NODEID_SUBSYSTEM)
+        )
+        return {
+            subsystem_map[node.application_for()]: device.version
+            for node, device in self._network_info.device_info.items()
+        }
 
     @property
     def update_required(self) -> bool:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -31,6 +31,7 @@ from .ot3utils import (
     create_gripper_jaw_home_group,
     create_tip_action_group,
     PipetteAction,
+    NODEID_SUBSYSTEM,
 )
 
 from opentrons_hardware.firmware_bindings.constants import (
@@ -56,6 +57,7 @@ from opentrons.hardware_control.types import (
     MotorStatus,
     PipetteSubType,
     UpdateStatus,
+    OT3SubSystem,
 )
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control import status_bar
@@ -483,9 +485,11 @@ class OT3Simulator:
         }
 
     @property
-    def fw_version(self) -> Optional[str]:
+    def fw_version(self) -> Dict[OT3SubSystem, int]:
         """Get the firmware version."""
-        return None
+        return {
+            NODEID_SUBSYSTEM[node.application_for()]: 0 for node in self._present_nodes
+        }
 
     @property
     def update_required(self) -> bool:

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -22,6 +22,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     PipetteType,
     SensorId,
     PipetteTipActionType,
+    USBTarget,
 )
 from opentrons_hardware.firmware_update.types import FirmwareUpdateStatus, StatusElement
 from opentrons_hardware.hardware_control.motion_planning import (
@@ -66,6 +67,25 @@ SUBSYSTEM_NODEID: Dict[OT3SubSystem, NodeId] = {
     OT3SubSystem.pipette_left: NodeId.pipette_left,
     OT3SubSystem.pipette_right: NodeId.pipette_right,
     OT3SubSystem.gripper: NodeId.gripper,
+}
+
+NODEID_SUBSYSTEM: Dict[NodeId, OT3SubSystem] = {
+    NodeId.gantry_x: OT3SubSystem.gantry_x,
+    NodeId.gantry_x_bootloader: OT3SubSystem.gantry_x,
+    NodeId.gantry_y: OT3SubSystem.gantry_y,
+    NodeId.gantry_y_bootloader: OT3SubSystem.gantry_y,
+    NodeId.head: OT3SubSystem.head,
+    NodeId.head_bootloader: OT3SubSystem.head,
+    NodeId.pipette_left: OT3SubSystem.pipette_left,
+    NodeId.pipette_left_bootloader: OT3SubSystem.pipette_left,
+    NodeId.pipette_right: OT3SubSystem.pipette_right,
+    NodeId.pipette_right_bootloader: OT3SubSystem.pipette_right,
+    NodeId.gripper: OT3SubSystem.gripper,
+    NodeId.gripper_bootloader: OT3SubSystem.gripper,
+}
+
+USBTARGET_SUBSYSTEM: Dict[USBTarget, OT3SubSystem] = {
+    USBTarget.rear_panel: OT3SubSystem.rear_panel
 }
 
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -385,10 +385,11 @@ class OT3API(
         Return the firmware version of the connected hardware.
         """
         from_backend = self._backend.fw_version
-        if from_backend is None:
+        uniques = set(version for version in from_backend.values())
+        if not from_backend:
             return "unknown"
         else:
-            return from_backend
+            return ", ".join(str(version) for version in uniques)
 
     @property
     def fw_version(self) -> str:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1234,7 +1234,6 @@ def test_fw_version(
     versions: Dict[OT3SubSystem, int],
     version_str: str,
 ) -> None:
-    backend = ot3_hardware.managed_obj._backend
     with patch(
         "opentrons.hardware_control.ot3api.OT3Simulator.fw_version",
         new_callable=PropertyMock,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -4,7 +4,7 @@ from typing import Iterator, Union, Dict, Tuple, List
 from typing_extensions import Literal
 from math import copysign
 import pytest
-from mock import AsyncMock, patch, Mock, call
+from mock import AsyncMock, patch, Mock, call, PropertyMock
 from opentrons.config.types import (
     GantryLoad,
     CapacitivePassSettings,
@@ -30,6 +30,7 @@ from opentrons.hardware_control.types import (
     InstrumentProbeType,
     LiquidNotFound,
     EarlyLiquidSenseTrigger,
+    OT3SubSystem,
 )
 from opentrons.hardware_control.errors import (
     GripperNotAttachedError,
@@ -1210,3 +1211,33 @@ async def test_light_settings(
     check = await ot3_hardware.get_lights()
     assert check["rails"] != setting
     assert not check["button"]
+
+
+@pytest.mark.parametrize(
+    "versions,version_str",
+    [
+        ({}, "unknown"),
+        ({OT3SubSystem.pipette_right: 2}, "2"),
+        (
+            {
+                OT3SubSystem.pipette_left: 2,
+                OT3SubSystem.gantry_x: 2,
+                OT3SubSystem.gantry_y: 2,
+            },
+            "2",
+        ),
+        ({OT3SubSystem.gripper: 3, OT3SubSystem.head: 1}, "1, 3"),
+    ],
+)
+def test_fw_version(
+    ot3_hardware: ThreadManager[OT3API],
+    versions: Dict[OT3SubSystem, int],
+    version_str: str,
+) -> None:
+    backend = ot3_hardware.managed_obj._backend
+    with patch(
+        "opentrons.hardware_control.ot3api.OT3Simulator.fw_version",
+        new_callable=PropertyMock,
+    ) as mock_fw_version:
+        mock_fw_version.return_value = versions
+        assert ot3_hardware.get_fw_version() == version_str


### PR DESCRIPTION
Implement the get_fw_version method of OT3API to return a stringified representation of all unique firmware versions for attached microcontrollers on the system.

This is a not-great way of exposing this data programmatically, but this element is only used for display purposes so I think it's ok. In all normal cases (i.e. except during update) this will only return a single version.

Closes RCORE-731

## Testing
- [x] Put on a robot and check that the app displays the correct firmware version
- [x] Attach a pipette that has the wrong firmware and check that the firmware version is displayed
