### PR TITLE
fix(app): dismiss current run after pipette flow completes

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -11,6 +11,7 @@ import {
   useCreateRunMutation,
   useStopRunMutation,
   useDeleteRunMutation,
+  useDismissCurrentRunMutation,
   usePipettesQuery,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
@@ -21,7 +22,6 @@ import {
 } from '../../../redux/pipettes/__fixtures__'
 import * as RobotApi from '../../../redux/robot-api'
 import { getIsOnDevice } from '../../../redux/config'
-import { useCloseCurrentRun } from '../../ProtocolUpload/hooks'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { getPipetteWizardSteps } from '../getPipetteWizardSteps'
 import { ExitModal } from '../ExitModal'
@@ -63,8 +63,8 @@ const mockUseDeleteRunMutation = useDeleteRunMutation as jest.MockedFunction<
 const mockUseStopRunMutation = useStopRunMutation as jest.MockedFunction<
   typeof useStopRunMutation
 >
-const mockUseCloseCurrentRun = useCloseCurrentRun as jest.MockedFunction<
-  typeof useCloseCurrentRun
+const mockUseDismissCurrentRunMutation = useDismissCurrentRunMutation as jest.MockedFunction<
+  typeof useDismissCurrentRunMutation
 >
 const mockUseRunStatus = useRunStatus as jest.MockedFunction<
   typeof useRunStatus
@@ -92,7 +92,7 @@ describe('PipetteWizardFlows', () => {
   let props: React.ComponentProps<typeof PipetteWizardFlows>
   let mockCreateRun: jest.Mock
   let mockStopRun: jest.Mock
-  let mockCloseCurrentRun: jest.Mock
+  let mockDismissCurrentRun: jest.Mock
   let mockDeleteRun: jest.Mock
   let refetchPromise: Promise<void>
   let mockRefetch: jest.Mock
@@ -107,7 +107,7 @@ describe('PipetteWizardFlows', () => {
     }
     mockCreateRun = jest.fn()
     mockStopRun = jest.fn()
-    mockCloseCurrentRun = jest.fn()
+    mockDismissCurrentRun = jest.fn()
     mockDeleteRun = jest.fn()
     refetchPromise = Promise.resolve()
     mockRefetch = jest.fn(() => refetchPromise)
@@ -128,8 +128,8 @@ describe('PipetteWizardFlows', () => {
       chainRunCommands: mockChainRunCommands,
       isCommandMutationLoading: false,
     })
-    mockUseCloseCurrentRun.mockReturnValue({
-      closeCurrenRun: mockCloseCurrentRun,
+    mockUseDismissCurrentRunMutation.mockReturnValue({
+      dismissCurrenRun: mockDismissCurrentRun,
     } as any)
     mockUseRunStatus.mockReturnValue('idle')
     mockGetPipetteWizardSteps.mockReturnValue([

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -20,6 +20,7 @@ import {
   useHost,
   useCreateRunMutation,
   useStopRunMutation,
+  useDismissCurrentRunMutation,
   useDeleteRunMutation,
 } from '@opentrons/react-api-client'
 
@@ -103,8 +104,10 @@ export const PipetteWizardFlows = (
     },
     host
   )
+  const { dismissCurrentRun } = useDismissCurrentRunMutation()
   const { stopRun, isLoading: isStopLoading } = useStopRunMutation({
     onSuccess: () => {
+      dismissCurrentRun(runId)
       if (currentStep.section === SECTIONS.DETACH_PROBE) {
         proceed()
       } else {


### PR DESCRIPTION
fix RQA-626
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
We want to dismiss the runs we're using for pipette attach/detach/calibrate flows once the flow is complete (successfully or exited early)

Note: this is a temporary change to make ABR testing more smooth - the FE maintenance run work will make this irrelevant

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
Run through any pipette flow and confirm that once you exit, there is not a current run

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
Once the run is successfully stopped, issue `dismissCurrentRunMutation`

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Run through the test plan, ensure code change looks sound
# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
