### PR TITLE
fix(app): remove unnecessary polls from and data caching from run detail page

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -16,11 +16,7 @@ import {
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   RunStatus,
 } from '@opentrons/api-client'
-import {
-  useRunQuery,
-  useModulesQuery,
-  usePipettesQuery,
-} from '@opentrons/react-api-client'
+import { useRunQuery, useModulesQuery } from '@opentrons/react-api-client'
 import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
 import {
   Box,
@@ -380,7 +376,10 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
   const history = useHistory()
   const { t } = useTranslation('run_details')
   const attachedModules =
-    useModulesQuery({ refetchInterval: EQUIPMENT_POLL_MS })?.data?.data ?? []
+    useModulesQuery({
+      refetchInterval: EQUIPMENT_POLL_MS,
+      enabled: runStatus != null && START_RUN_STATUSES.includes(runStatus),
+    })?.data?.data ?? []
   const trackEvent = useTrackEvent()
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
   const [targetProps, tooltipProps] = useHoverTooltip()

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -122,8 +122,6 @@ export function ProtocolRunHeader({
   const { analysisErrors } = useProtocolAnalysisErrors(runId)
   const isRunCurrent = Boolean(useRunQuery(runId)?.data?.data?.current)
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
-  // NOTE: we are polling pipettes, though not using their value directly here
-  usePipettesQuery({}, { refetchInterval: EQUIPMENT_POLL_MS })
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
 
   React.useEffect(() => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibration.tsx
@@ -14,12 +14,6 @@ import * as PipetteConstants from '../../../redux/pipettes/constants'
 import { useRunPipetteInfoByMount } from '../hooks'
 import { SetupPipetteCalibrationItem } from './SetupPipetteCalibrationItem'
 
-import {
-  useAllPipetteOffsetCalibrationsQuery,
-  usePipettesQuery,
-} from '@opentrons/react-api-client'
-
-const PIPETTE_POLL_FETCH_MS = 5000
 interface SetupPipetteCalibrationProps {
   robotName: string
   runId: string
@@ -30,12 +24,7 @@ export function SetupPipetteCalibration({
   runId,
 }: SetupPipetteCalibrationProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-  const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
-
-  usePipettesQuery({}, { refetchInterval: PIPETTE_POLL_FETCH_MS })
-  useAllPipetteOffsetCalibrationsQuery({
-    refetchInterval: PIPETTE_POLL_FETCH_MS,
-  })
+  const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibration.tsx
@@ -24,7 +24,7 @@ export function SetupTipLengthCalibration({
   runId,
 }: SetupTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
-  const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
+  const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>

--- a/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
@@ -14,14 +14,16 @@ import {
   COLORS,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useDeleteCalibrationMutation } from '@opentrons/react-api-client'
+import {
+  useAllPipetteOffsetCalibrationsQuery,
+  useDeleteCalibrationMutation,
+} from '@opentrons/react-api-client'
 import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { TertiaryButton } from '../../../atoms/buttons'
 import {
   useAttachedPipettes,
   useDeckCalibrationData,
-  usePipetteOffsetCalibrations,
   useRunHasStarted,
 } from '../hooks'
 import { useDashboardCalibrateTipLength } from '../../../pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength'
@@ -57,8 +59,8 @@ export function SetupTipLengthCalibrationButton({
   ] = useDashboardCalibrateTipLength(robotName)
   const { deleteCalibration } = useDeleteCalibrationMutation()
   const attachedPipettes = useAttachedPipettes()
-  const offsetCalibrations = usePipetteOffsetCalibrations()
-
+  const offsetCalibrations =
+    useAllPipetteOffsetCalibrationsQuery()?.data?.data ?? []
   const offsetCalsToDelete = offsetCalibrations?.filter(
     cal =>
       cal.pipette === attachedPipettes[mount]?.id &&

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibration.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibration.test.tsx
@@ -50,12 +50,10 @@ const render = () => {
 
 describe('SetupPipetteCalibration', () => {
   beforeEach(() => {
-    when(mockUseRunPipetteInfoByMount)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        left: PIPETTE_INFO,
-        right: null,
-      })
+    when(mockUseRunPipetteInfoByMount).calledWith(RUN_ID).mockReturnValue({
+      left: PIPETTE_INFO,
+      right: null,
+    })
     when(mockSetupPipetteCalibrationItem).mockReturnValue(
       <div>Mock SetupPipetteCalibrationItem</div>
     )
@@ -73,12 +71,10 @@ describe('SetupPipetteCalibration', () => {
     expect(getAllByText('Mock SetupPipetteCalibrationItem')).toHaveLength(1)
   })
   it('renders two SetupPipetteCalibrationItems when protocol run requires two pipettes', () => {
-    when(mockUseRunPipetteInfoByMount)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        left: PIPETTE_INFO,
-        right: PIPETTE_INFO,
-      })
+    when(mockUseRunPipetteInfoByMount).calledWith(RUN_ID).mockReturnValue({
+      left: PIPETTE_INFO,
+      right: PIPETTE_INFO,
+    })
     const { getAllByText } = render()
     expect(getAllByText('Mock SetupPipetteCalibrationItem')).toHaveLength(2)
   })

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupTipLengthCalibration.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupTipLengthCalibration.test.tsx
@@ -51,12 +51,10 @@ const render = () => {
 
 describe('SetupTipLengthCalibration', () => {
   beforeEach(() => {
-    when(mockUseRunPipetteInfoByMount)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        left: PIPETTE_INFO,
-        right: null,
-      })
+    when(mockUseRunPipetteInfoByMount).calledWith(RUN_ID).mockReturnValue({
+      left: PIPETTE_INFO,
+      right: null,
+    })
     when(mockSetupTipLengthCalibrationButton).mockReturnValue(
       <div>Mock SetupTipLengthCalibrationButton</div>
     )
@@ -81,12 +79,10 @@ describe('SetupTipLengthCalibration', () => {
     expect(queryByText('Last calibrated:')).toBeFalsy()
   })
   it('renders two tip length calibrations when protocol run requires two pipettes', () => {
-    when(mockUseRunPipetteInfoByMount)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        left: PIPETTE_INFO,
-        right: PIPETTE_INFO,
-      })
+    when(mockUseRunPipetteInfoByMount).calledWith(RUN_ID).mockReturnValue({
+      left: PIPETTE_INFO,
+      right: PIPETTE_INFO,
+    })
     const { getAllByText, queryByText } = render()
 
     expect(getAllByText('pipette 1')).toHaveLength(2)
@@ -99,7 +95,7 @@ describe('SetupTipLengthCalibration', () => {
   })
   it('renders last calibrated date when available', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith(ROBOT_NAME, RUN_ID)
+      .calledWith(RUN_ID)
       .mockReturnValue({
         left: {
           ...PIPETTE_INFO,
@@ -120,7 +116,7 @@ describe('SetupTipLengthCalibration', () => {
   })
   it('renders not calibrated yet when not calibrated', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith(ROBOT_NAME, RUN_ID)
+      .calledWith(RUN_ID)
       .mockReturnValue({
         left: {
           ...PIPETTE_INFO,

--- a/app/src/organisms/Devices/hooks/__tests__/useRunCalibrationStatus.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunCalibrationStatus.test.tsx
@@ -27,7 +27,7 @@ describe('useRunCalibrationStatus hook', () => {
   beforeEach(() => {
     when(mockUseDeckCalibrationStatus).calledWith('otie').mockReturnValue('OK')
 
-    when(mockUseRunPipetteInfoByMount).calledWith('otie', '1').mockReturnValue({
+    when(mockUseRunPipetteInfoByMount).calledWith('1').mockReturnValue({
       left: null,
       right: null,
     })
@@ -59,7 +59,7 @@ describe('useRunCalibrationStatus hook', () => {
   })
   it('should return attach pipette if missing', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith('otie', '1')
+      .calledWith('1')
       .mockReturnValue({
         left: {
           requestedPipetteMatch: 'incompatible',
@@ -85,7 +85,7 @@ describe('useRunCalibrationStatus hook', () => {
   })
   it('should return calibrate pipette if cal date null', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith('otie', '1')
+      .calledWith('1')
       .mockReturnValue({
         left: {
           requestedPipetteMatch: 'match',
@@ -111,7 +111,7 @@ describe('useRunCalibrationStatus hook', () => {
   })
   it('should return calibrate tip rack if cal date null', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith('otie', '1')
+      .calledWith('1')
       .mockReturnValue({
         left: {
           requestedPipetteMatch: 'match',
@@ -137,7 +137,7 @@ describe('useRunCalibrationStatus hook', () => {
   })
   it('should ignore tip rack calibration for the OT-3', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith('otie', '1')
+      .calledWith('1')
       .mockReturnValue({
         left: {
           requestedPipetteMatch: 'match',
@@ -163,7 +163,7 @@ describe('useRunCalibrationStatus hook', () => {
   })
   it('should return complete if everything is calibrated', () => {
     when(mockUseRunPipetteInfoByMount)
-      .calledWith('otie', '1')
+      .calledWith('1')
       .mockReturnValue({
         left: {
           requestedPipetteMatch: 'match',

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -179,7 +179,7 @@ describe('useRunPipetteInfoByMount hook', () => {
       .calledWith('1')
       .mockReturnValue(null)
     when(mockUseStoredProtocolAnalysis).calledWith('1').mockReturnValue(null)
-    const { result } = renderHook(() => useRunPipetteInfoByMount('otie', '1'))
+    const { result } = renderHook(() => useRunPipetteInfoByMount('1'))
     expect(result.current).toStrictEqual({
       left: null,
       right: null,
@@ -187,7 +187,7 @@ describe('useRunPipetteInfoByMount hook', () => {
   })
 
   it('should return run pipette info by mount', () => {
-    const { result } = renderHook(() => useRunPipetteInfoByMount('otie', '1'))
+    const { result } = renderHook(() => useRunPipetteInfoByMount('1'))
     expect(result.current).toStrictEqual({
       left: ({
         id: 'pipetteId',

--- a/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -6,6 +6,7 @@ import {
   getLoadedLabwareDefinitionsByUri,
   RunTimeCommand,
 } from '@opentrons/shared-data'
+import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
 import _tiprack10ul from '@opentrons/shared-data/labware/definitions/2/opentrons_96_tiprack_10ul/1.json'
 
 import {
@@ -24,7 +25,6 @@ import { useMostRecentCompletedAnalysis } from '../../../LabwarePositionCheck/us
 import {
   useAttachedPipetteCalibrations,
   useAttachedPipettes,
-  useTipLengthCalibrations,
   useRunPipetteInfoByMount,
   useStoredProtocolAnalysis,
 } from '..'
@@ -45,6 +45,7 @@ jest.mock('@opentrons/shared-data', () => {
     getLoadedLabwareDefinitionsByUri: jest.fn(),
   }
 })
+jest.mock('@opentrons/react-api-client')
 jest.mock('../../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
 jest.mock('../useAttachedPipetteCalibrations')
 jest.mock('../useAttachedPipettes')
@@ -61,8 +62,8 @@ const mockUseAttachedPipetteCalibrations = useAttachedPipetteCalibrations as jes
 const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
   typeof useAttachedPipettes
 >
-const mockUseTipLengthCalibrations = useTipLengthCalibrations as jest.MockedFunction<
-  typeof useTipLengthCalibrations
+const mockUseAllTipLengthCalibrationsQuery = useAllTipLengthCalibrationsQuery as jest.MockedFunction<
+  typeof useAllTipLengthCalibrationsQuery
 >
 const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
   typeof useMostRecentCompletedAnalysis
@@ -147,9 +148,9 @@ describe('useRunPipetteInfoByMount hook', () => {
     when(mockUseAttachedPipettes)
       .calledWith()
       .mockReturnValue(ATTACHED_PIPETTES)
-    when(mockUseTipLengthCalibrations)
+    when(mockUseAllTipLengthCalibrationsQuery)
       .calledWith()
-      .mockReturnValue(TIP_LENGTH_CALIBRATIONS)
+      .mockReturnValue({ data: { data: TIP_LENGTH_CALIBRATIONS } } as any)
     when(mockUseMostRecentCompletedAnalysis)
       .calledWith('1')
       .mockReturnValue(PROTOCOL_DETAILS.protocolData as any)

--- a/app/src/organisms/Devices/hooks/useLastRunCommandKey.ts
+++ b/app/src/organisms/Devices/hooks/useLastRunCommandKey.ts
@@ -31,7 +31,6 @@ export function useLastRunCommandKey(runId: string): string | null {
         runStatus != null && LIVE_RUN_STATUSES.includes(runStatus)
           ? LIVE_RUN_COMMANDS_POLL_MS
           : Infinity,
-      keepPreviousData: true,
     }
   )
   return commandsData?.data?.[0]?.intent !== 'setup'

--- a/app/src/organisms/Devices/hooks/useRunCalibrationStatus.ts
+++ b/app/src/organisms/Devices/hooks/useRunCalibrationStatus.ts
@@ -15,7 +15,7 @@ export function useRunCalibrationStatus(
   runId: string
 ): ProtocolCalibrationStatus {
   const deckCalStatus = useDeckCalibrationStatus(robotName)
-  const runPipetteInfoByMount = useRunPipetteInfoByMount(robotName, runId)
+  const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
   const runPipetteInfoValues = Object.values(runPipetteInfoByMount)
   const isOT3 = useIsOT3(robotName)
 

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -8,7 +8,6 @@ import { MATCH, INEXACT_MATCH, INCOMPATIBLE } from '../../../redux/pipettes'
 import {
   useAttachedPipetteCalibrations,
   useAttachedPipettes,
-  useTipLengthCalibrations,
   useStoredProtocolAnalysis,
 } from '.'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
@@ -23,6 +22,7 @@ import type {
   LabwareDefinition2,
   PipetteNameSpecs,
 } from '@opentrons/shared-data'
+import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
 
 const EMPTY_MOUNTS = { left: null, right: null }
 
@@ -37,7 +37,6 @@ export interface PipetteInfo {
 }
 
 export function useRunPipetteInfoByMount(
-  robotName: string,
   runId: string
 ): {
   [mount in Mount]: PipetteInfo | null
@@ -49,7 +48,7 @@ export function useRunPipetteInfoByMount(
   const attachedPipettes = useAttachedPipettes()
   const attachedPipetteCalibrations =
     useAttachedPipetteCalibrations() ?? EMPTY_MOUNTS
-  const tipLengthCalibrations = useTipLengthCalibrations() ?? []
+  const tipLengthCalibrations = useAllTipLengthCalibrationsQuery()?.data?.data ?? []
 
   if (protocolData == null) {
     return EMPTY_MOUNTS

--- a/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
+++ b/app/src/organisms/Devices/hooks/useRunPipetteInfoByMount.ts
@@ -4,6 +4,7 @@ import {
   getLabwareDefURI,
   getLoadedLabwareDefinitionsByUri,
 } from '@opentrons/shared-data'
+import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
 import { MATCH, INEXACT_MATCH, INCOMPATIBLE } from '../../../redux/pipettes'
 import {
   useAttachedPipetteCalibrations,
@@ -22,7 +23,6 @@ import type {
   LabwareDefinition2,
   PipetteNameSpecs,
 } from '@opentrons/shared-data'
-import { useAllTipLengthCalibrationsQuery } from '@opentrons/react-api-client'
 
 const EMPTY_MOUNTS = { left: null, right: null }
 
@@ -48,7 +48,8 @@ export function useRunPipetteInfoByMount(
   const attachedPipettes = useAttachedPipettes()
   const attachedPipetteCalibrations =
     useAttachedPipetteCalibrations() ?? EMPTY_MOUNTS
-  const tipLengthCalibrations = useAllTipLengthCalibrationsQuery()?.data?.data ?? []
+  const tipLengthCalibrations =
+    useAllTipLengthCalibrationsQuery()?.data?.data ?? []
 
   if (protocolData == null) {
     return EMPTY_MOUNTS

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -63,7 +63,6 @@ const OT3_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
   'SLOT_10_EXPANSION',
   'CALIBRATION_CUTOUTS',
 ]
-const EQUIPMENT_POLL_MS = 2000
 
 const LabwareThumbnail = styled.svg`
   transform: scale(1, -1);
@@ -100,7 +99,7 @@ export function ProtocolSetupLabware({
     mostRecentAnalysis != null
       ? getLabwareRenderInfo(mostRecentAnalysis, deckDef)
       : {}
-  const moduleQuery = useModulesQuery({ refetchInterval: EQUIPMENT_POLL_MS })
+  const moduleQuery = useModulesQuery()
   const attachedModules = moduleQuery?.data?.data ?? []
   const protocolModulesInfo =
     mostRecentAnalysis != null

--- a/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -66,7 +66,7 @@ describe('RunProgressMeter', () => {
       .calledWith(NON_DETERMINISTIC_RUN_ID)
       .mockReturnValue(null)
     when(mockUseAllCommandsQuery)
-      .calledWith(NON_DETERMINISTIC_RUN_ID)
+      .calledWith(NON_DETERMINISTIC_RUN_ID, { cursor: null, pageLength: 1 })
       .mockReturnValue(mockUseAllCommandsResponseNonDeterministic)
     when(mockUseCommandQuery)
       .calledWith(NON_DETERMINISTIC_RUN_ID, NON_DETERMINISTIC_COMMAND_ID)


### PR DESCRIPTION
# Overview

Tailor the data that we monitor during a live run to the status of that run. Only fetch equipment
while not running, and poll calibration values during setup only.

Re: RESC-119

# Changelog

- in `ProtocolRunHeader` disabled `GET /modules` poll once the run is active.
- now that pipettes, modules, pipette offset, deck, and tip length calibration data are accessed using react-api-client, remove calls to queries where the only intent was to bust the query cache. Rely solely on a single refetch interval from a top level component where relevant.
- remove the now-unused `robotName` param from `useRunPipetteInfoByMount`
- remove `keepPreviousData` option from commands query now that we only need to fetch the most recent command
- remove redundant logic for fetching run command info on the `RunProgressMeter`, also only fetch the currently executing command as opposed to all commands on a poll.

# Review requests

Please run a protocol, with modules, and perform attach or calibrate from the Calibration Step of protocol setup. All fields should update when pipettes are attached, modules are turned on, etc.

# Risk assessment
medium, this touches critical infrastructure in the setup/run protocol flows