### PR TITLE
chore(ci): Update actions/github-script to latest v6

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: 'set complex environment variables'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -142,7 +142,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: 'set complex environment variables'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -142,7 +142,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -142,7 +142,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -66,7 +66,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -119,7 +119,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -208,7 +208,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libsystemd-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -66,7 +66,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -119,7 +119,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -208,7 +208,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libsystemd-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -66,7 +66,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -119,7 +119,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -208,7 +208,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev libsystemd-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -115,7 +115,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -115,7 +115,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -115,7 +115,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           project: 'api'
       - name: 'set complex environment variables'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           project: 'api'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           project: 'api'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -48,7 +48,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -48,7 +48,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -48,7 +48,7 @@ jobs:
           node-version: '16'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -155,7 +155,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -155,7 +155,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -155,7 +155,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -160,7 +160,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -160,7 +160,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -160,7 +160,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -92,7 +92,7 @@ jobs:
           project: 'shared-data/python'
           python-version: ${{ matrix.python }}
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -162,7 +162,7 @@ jobs:
         with:
           project: 'shared-data/python'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.1.1
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -92,7 +92,7 @@ jobs:
           project: 'shared-data/python'
           python-version: ${{ matrix.python }}
       - name: 'set complex environment variables'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -162,7 +162,7 @@ jobs:
         with:
           project: 'shared-data/python'
       - name: 'set complex environment variables'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -92,7 +92,7 @@ jobs:
           project: 'shared-data/python'
           python-version: ${{ matrix.python }}
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -162,7 +162,7 @@ jobs:
         with:
           project: 'shared-data/python'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)


### PR DESCRIPTION
# Changelog

Update our `actions/github-script` CI dependency from v6.1.1 to the latest version, which is currently [v6.4.1](https://github.com/actions/github-script/releases/tag/v6.4.1).

This is intended to resolve some of these warnings of deprecation and imminent removal, which @ecormany noticed:

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

(We need at least [v6.3.2](https://github.com/actions/github-script/releases/tag/v6.3.2) to benefit from this fix.)

Also, pin to just the major version, like `v6`, instead of the patch version, like `v6.4.1`, per [our written guidance](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/837779482/Continuous+integration+CI#Choose-version-constraints-wisely). (Full disclosure: I wrote that guidance and I don't necessarily know what I'm doing.)

# Test Plan

* [x] Make sure CI is still passing.
* [x] Make sure that these steps are no longer showing the warning above.

# Review requests

Do we have any reason to believe that our written guidance to prefer `v6` instead of `v6.4.1` is bad? Should we update it?

# Risk assessment

Low. Failures in CI should be obvious.