### PR TITLE
fix(odd): adds disabled state to tabbed button story

### DIFF
--- a/app/src/atoms/buttons/OnDeviceDisplay/TabbedButton.stories.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/TabbedButton.stories.tsx
@@ -14,5 +14,6 @@ export const Tabbed = TabbedButtonTemplate.bind({})
 Tabbed.args = {
   foreground: true,
   children: 'Button text',
+  disabled: false,
   title: 'tabbed button',
 }


### PR DESCRIPTION


# Overview

This PR simply adds a disabled toggle to the story for the tabbed button component for RAUT-362

# Test Plan

None

# Changelog

- Add disabled state toggle to storybook story

# Review requests

None.

# Risk assessment

None.
