### PR TITLE
docs(protocol-engine): Clarify loadModule docs and deprecate result.definition

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -24,6 +24,11 @@ class LoadModuleParams(BaseModel):
             "\n\n"
             "Protocol Engine will look for a connected module that either"
             " exactly matches this one, or is compatible."
+            "\n\n"
+            " For example, if you request a `temperatureModuleV1` here,"
+            " Protocol Engine might load a `temperatureModuleV1` or a `temperatureModuleV2`."
+            "\n\n"
+            " The model that it finds connected will be available through `result.model`."
         ),
     )
 
@@ -57,18 +62,26 @@ class LoadModuleResult(BaseModel):
         description="An ID to reference this module in subsequent commands."
     )
 
-    # TODO (spp, 2021-11-24): Evaluate if this needs to be in the result
-    definition: ModuleDefinition = Field(description="The definition of this module.")
+    # TODO(mm, 2023-04-13): Remove this field. Jira RSS-221.
+    definition: ModuleDefinition = Field(
+        deprecated=True,
+        description=(
+            "The definition of the connected module."
+            " This field is an implementation detail. We might change or remove it without warning."
+            " Do not access it or rely on it being present."
+        ),
+    )
 
     model: ModuleModel = Field(
         ...,
         description=(
             "The hardware model of the connected module."
-            " May be different than the requested model"
-            " if the connected module is still compatible."
+            " This can be different from the exact model that this command requested."
+            " See `params.model`."
             "\n\n"
             "This field is only meaningful in the run's actual execution,"
             " not in the protocol's analysis."
+            " In analysis, it will be an arbitrary placeholder."
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_command_schema_snapshot.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_command_schema_snapshot.py
@@ -8,9 +8,10 @@ The Python models for Protocol Engine commands do not match the shared JSON sche
 
 If this change is accidental, undo the changes to our Python models.
 
-Or, if this change is intentional, update the shared JSON schema by running:
+Or, if this change is intentional, update the shared JSON schema by running this from the monorepo root:
 
     make -C api command-schema COMMAND_SCHEMA_VERSION=<version number>
+    make format
 
 ...and include the updated JSON schema file in your pull request.
 """

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -983,7 +983,7 @@
       "type": "object",
       "properties": {
         "model": {
-          "description": "The model name of the module to load.\n\nProtocol Engine will look for a connected module that either exactly matches this one, or is compatible.",
+          "description": "The model name of the module to load.\n\nProtocol Engine will look for a connected module that either exactly matches this one, or is compatible.\n\n For example, if you request a `temperatureModuleV1` here, Protocol Engine might load a `temperatureModuleV1` or a `temperatureModuleV2`.\n\n The model that it finds connected will be available through `result.model`.",
           "allOf": [
             {
               "$ref": "#/definitions/ModuleModel"


### PR DESCRIPTION
# Changelog

Per RSS-221, we want to remove the `definition` field from `loadModule` results, eventually. In the mean time, this PR formally marks it as deprecated in our documentation.

![Screenshot 2023-04-13 at 10 59 02 AM](https://user-images.githubusercontent.com/3236864/231808184-0857d12e-7d52-4839-b101-6040f00751ea.png)

This PR also clarifies some things about `params.model` vs. `result.model`.

# Review requests

App+UI people: is this deprecation okay?

# Risk assessment

No risk. Changes are just to documentation.