### PR TITLE
refactor(api): Add comments describing some gotchas with ModuleDefinition

### DIFF
--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -343,26 +343,42 @@ class ModuleDefinition(BaseModel):
     """Module definition class."""
 
     otSharedSchema: str = Field("module/schemas/2", description="The current schema.")
+
     moduleType: ModuleType = Field(
         ...,
         description="Module type (Temperature/Magnetic/Thermocycler)",
     )
+
     model: ModuleModel = Field(..., description="Model name of the module")
+
     labwareOffset: LabwareOffsetVector = Field(
         ...,
         description="Labware offset in x, y, z.",
     )
+
     dimensions: ModuleDimensions = Field(..., description="Module dimension")
+
     calibrationPoint: ModuleCalibrationPoint = Field(
         ...,
         description="Calibration point of module.",
     )
+
     displayName: str = Field(..., description="Display name.")
+
     quirks: List[str] = Field(..., description="Module quirks")
+
+    # In releases prior to https://github.com/Opentrons/opentrons/pull/11873 (v6.3.0),
+    # the matrices in slotTransforms were 3x3.
+    # After, they are 4x4, even though there was no schema version bump.
+    #
+    # Because old objects of this class, with the 3x3 matrices, were stored in robot-server's
+    # database, this field needs to stay typed loosely enough to support both sizes.
+    # We can fix this once Jira RSS-221 is resolved.
     slotTransforms: Dict[str, Any] = Field(
         ...,
         description="Dictionary of transforms for each slot.",
     )
+
     compatibleWith: List[ModuleModel] = Field(
         ...,
         description="List of module models this model is compatible with.",

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -339,9 +339,23 @@ class ModuleOffsetVector(BaseModel):
     z: float
 
 
+# TODO(mm, 2023-04-13): Move to shared-data, so this binding can be maintained alongside the JSON
+# schema that it's sourced from. We already do that for labware definitions and JSON protocols.
 class ModuleDefinition(BaseModel):
-    """Module definition class."""
+    """A module definition conforming to module definition schema v3."""
 
+    # Note: This field is misleading.
+    #
+    # This class only models v3 definitions ("module/schemas/3"), not v2 ("module/schemas/2").
+    # labwareOffset is required to have a z-component, for example.
+    #
+    # When parsing from a schema v3 JSON definition into this model,
+    # the definition's `"$otSharedSchema": "module/schemas/3"` field will be thrown away
+    # because it has a dollar sign, which doesn't match this field.
+    # Then, this field will default to "module/schemas/2", because no value was provided.
+    #
+    # We should fix this field once Jira RSS-221 is resolved. RSS-221 makes it difficult to fix
+    # because robot-server has been storing and loading these bad fields in its database.
     otSharedSchema: str = Field("module/schemas/2", description="The current schema.")
 
     moduleType: ModuleType = Field(


### PR DESCRIPTION
# Overview

@jbleon95, @TamarZanzouri and I got confused by some things in the `ModuleDefinition` class. This PR adds comments to explain how it works, and to warn us in the future against doing seemingly innocuous things that might break something.

# Test plan

None needed. Comments only.

# Review requests

Do these comments make sense?

# Risk assessment

No risk. Comments only.