### PR TITLE
refactor(app): do not block ODD run flow when pipette cal missing

### DIFF
--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -61,12 +61,7 @@ export function ProtocolInstrumentMountItem(
   props: ProtocolInstrumentMountItemProps
 ): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-  const {
-    mount,
-    attachedInstrument,
-    speccedName,
-    attachedCalibrationData,
-  } = props
+  const { mount, attachedInstrument, speccedName } = props
 
   const [showChoosePipetteModal, setShowChoosePipetteModal] = React.useState(
     false
@@ -90,8 +85,9 @@ export function ProtocolInstrumentMountItem(
       attachedInstrument
     )
   }
-  const isAttachedWithCal =
-    attachedInstrument != null && attachedCalibrationData != null
+  // TODO: check for presence of calibration data once instruments endpoint
+  // returns calibration data for pipettes
+  const isAttachedWithCal = attachedInstrument != null
   return (
     <>
       <MountItem isReady={isAttachedWithCal}>

--- a/app/src/organisms/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ProtocolSetupInstruments/utils.ts
@@ -69,7 +69,6 @@ export function getAreInstrumentsReady(
       loadedPipette,
       attachedInstruments
     )
-    console.log({loadedPipette, attachedInstruments})
     // const calibrationData =
     //   attachedPipetteMatch != null
     //     ? getCalibrationDataForPipetteMatch(

--- a/app/src/organisms/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ProtocolSetupInstruments/utils.ts
@@ -69,14 +69,16 @@ export function getAreInstrumentsReady(
       loadedPipette,
       attachedInstruments
     )
-    const calibrationData =
-      attachedPipetteMatch != null
-        ? getCalibrationDataForPipetteMatch(
-            attachedPipetteMatch,
-            allPipettesCalibrationData
-          )
-        : null
-    return attachedPipetteMatch != null && calibrationData != null
+    console.log({loadedPipette, attachedInstruments})
+    // const calibrationData =
+    //   attachedPipetteMatch != null
+    //     ? getCalibrationDataForPipetteMatch(
+    //         attachedPipetteMatch,
+    //         allPipettesCalibrationData
+    //       )
+    //     : null
+    return attachedPipetteMatch != null // TODO: check for presence of calibration data once instruments endpoint
+    // returns calibration data for pipettes
   })
   const isExtensionMountReady = getProtocolUsesGripper(analysis)
     ? getAttachedGripper(attachedInstruments) != null


### PR DESCRIPTION
# Overview

This PR unblocks the ODD from proceeding to start a run when pipette calibration data is missing. This is because the instruments endpoint does not yet return calibration data for OT-3 pipettes. Once it does, we can begin blocking as expected.


# Risk assessment

Low