### PR TITLE
refactor(odd): various ui pipette flow fixes

### DIFF
--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -28,14 +28,14 @@ const DESCRIPTION_STYLE = css`
   margin-bottom: ${SPACING.spacing3};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    font-weight: 700;
-    font-size: 2rem;
+    font-weight: ${TYPOGRAPHY.fontWeightLevel2_bold};
+    font-size: ${TYPOGRAPHY.fontSize32};
     margin-top: ${SPACING.spacing6};
     margin-bottom: ${SPACING.spacing2};
     margin-left: 4.5rem;
     margin-right: 4.5rem;
     text-align: ${TYPOGRAPHY.textAlignCenter};
-    line-height: 2.625rem;
+    line-height: ${TYPOGRAPHY.lineHeight42};
   }
 `
 export function InProgressModal(props: Props): JSX.Element {
@@ -47,7 +47,7 @@ export function InProgressModal(props: Props): JSX.Element {
       alignItems={ALIGN_CENTER}
       flexDirection={DIRECTION_COLUMN}
       justifyContent={JUSTIFY_CENTER}
-      height="24.625rem"
+      height={isOnDevice ? '31.5625rem' : '24.625rem'}
       padding={SPACING.spacing6}
     >
       {alternativeSpinner ?? (

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -86,7 +86,11 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   }
 
   const pipetteProbeVid = (
-    <Flex marginTop={isOnDevice ? '-5rem' : '-7.6rem'} height="10.2rem">
+    <Flex
+      marginTop={isOnDevice ? '-5rem' : '-7.6rem'}
+      height="10.2rem"
+      paddingTop={SPACING.spacing2}
+    >
       <video
         css={css`
           max-width: 100%;

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -47,7 +47,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
   let header: string = 'unknown results screen'
   let iconColor: string = COLORS.successEnabled
   let isSuccess: boolean = true
-  let buttonText: string = t('shared:exit')
+  let buttonText: string = i18n.format(t('shared:exit'), 'capitalize')
   let subHeader
   switch (flowType) {
     case FLOWS.CALIBRATE: {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -72,6 +72,7 @@ describe('Results', () => {
     expect(getByLabelText('ot-check')).toHaveStyle(
       `color: ${String(COLORS.successEnabled)}`
     )
+    getByText('Exit')
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
     expect(props.proceed).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -373,7 +373,7 @@ export const PipetteWizardFlows = (
           flexDirection={DIRECTION_COLUMN}
           width="100%"
           position={POSITION_ABSOLUTE}
-          backgroundColor={COLORS.fundamentalsBackground}
+          backgroundColor={COLORS.white}
         >
           {wizardHeader}
           {modalContent}

--- a/app/src/organisms/PipetteWizardFlows/utils.tsx
+++ b/app/src/organisms/PipetteWizardFlows/utils.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { LEFT, RIGHT } from '@opentrons/shared-data'
 import { css } from 'styled-components'
+import { LEFT, RIGHT } from '@opentrons/shared-data'
+import { SPACING } from '@opentrons/components'
 import { FLOWS, SECTIONS } from './constants'
 
 import attachLeft18 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_1_8_L.webm'
@@ -66,6 +67,7 @@ export function getPipetteAnimations(
   return (
     <video
       css={css`
+        padding-top: ${SPACING.spacing2};
         max-width: 100%;
         max-height: ${section === SECTIONS.ATTACH_PROBE ||
         section === SECTIONS.DETACH_PROBE


### PR DESCRIPTION
partially addresses RLIQ-360

# Overview

Addresses these:
1. Robot moving screen doesn’t take up whole viewport
2. Assets need padding at the top
3. Asset background contrasted from modal background, a white square is visible around it
4. Last screen exit button not capitalized

# Test Plan

go through odd flows and make sure it fixes the action items mentioned up above.

# Changelog

- replace strings with constants if applicable
- add padding top to videos
- change background color of whole flow to `white`
- add i18n format function to capitalize `Exit` btn text

# Review requests

see test plan

# Risk assessment

low