### PR TITLE
feat(app): disable proceed to run if correct Flex pipettes are not at…

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -88,7 +88,8 @@ export function SetupPipetteCalibrationItem({
     button = pipetteMismatchInfo
   } else if (!attached) {
     subText = t('attach_pipette_calibration')
-    button = (
+    // remove the button for attach until flex pipette flows work in run setup
+    button = !isOT3 ? (
       <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
         <TertiaryButton
           as={RRDLink}
@@ -98,7 +99,7 @@ export function SetupPipetteCalibrationItem({
           {t('attach_pipette_cta')}
         </TertiaryButton>
       </Flex>
-    )
+    ) : undefined
   } else {
     button = (
       <>

--- a/app/src/organisms/Devices/hooks/useRunCalibrationStatus.ts
+++ b/app/src/organisms/Devices/hooks/useRunCalibrationStatus.ts
@@ -51,8 +51,8 @@ export function useRunCalibrationStatus(
     const pipetteIsMatch =
       pipette?.requestedPipetteMatch === MATCH ||
       pipette?.requestedPipetteMatch === INEXACT_MATCH
-    // TODO(bh, 8/18/2022): remove isOT3 condition after OT-3 pipette calibration is implemented
-    if (pipette !== null && !pipetteIsMatch && !isOT3) {
+
+    if (pipette !== null && !pipetteIsMatch) {
       calibrationStatus = {
         complete: false,
         reason: 'attach_pipette_failure_reason',


### PR DESCRIPTION
…tached (#12441)

Note: this is a second pr for #12441 after it was reverted in internal-release 0.3.0. This PR is targeted on 0.3.0 but SHOULD NOT be merged there; instead, wait until that release is concluded and merge it to `edge`.

This shouldn't be merged until https://github.com/Opentrons/opentrons/pull/12503 is merged

fix RLIQ-357

