### PR TITLE
fix(robot-server): allow /instruments endpoint to support the 96 channel

### DIFF
--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -216,3 +216,42 @@ async def test_get_ot2_instruments(
             ),
         )
     ]
+
+
+async def test_get_96_channel_instruments(
+    decoy: Decoy,
+    hardware_api: HardwareControlAPI,
+) -> None:
+    """It should correctly be able to construct a 96 channel pipette."""
+    # Return attached pipettes
+    decoy.when(hardware_api.attached_instruments).then_return(
+        {
+            Mount.LEFT: {  # type: ignore [typeddict-item]
+                "name": "p1000_96",
+                "model": PipetteModel("xyz"),
+                "pipette_id": "pipette-id",
+                "back_compat_names": [],
+                "min_volume": 1,
+                "max_volume": 1000,
+                "channels": 96,
+            },
+            Mount.RIGHT: cast(PipetteDict, {}),
+        }
+    )
+    result2 = await get_attached_instruments(hardware=hardware_api)
+    decoy.verify(await hardware_api.cache_instruments(), times=0)
+    assert result2.status_code == 200
+    assert result2.content.data == [
+        Pipette.construct(
+            mount="left",
+            instrumentType="pipette",
+            instrumentName="p1000_96",
+            instrumentModel=PipetteModel("xyz"),
+            serialNumber="pipette-id",
+            data=PipetteData(
+                channels=96,
+                min_volume=1,
+                max_volume=1000,
+            ),
+        )
+    ]

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -79,7 +79,7 @@ ConfigUnit = Literal[
 
 Quirk = NewType("Quirk", str)
 
-ChannelCount = Literal[1, 8]
+ChannelCount = Literal[1, 8, 96]
 
 UlPerMmAction = Literal["aspirate", "dispense"]
 


### PR DESCRIPTION
## Overview

This is a temporary fix to allow the /instruments endpoint the ability to return 96 channel pipettes when they are attached. The real fix is to refactor the /instruments endpoint to use v2 validation for pipettes.


Test Cases

- [x] `/instruments` endpoint no longer errors out when 96 channel is attached
- [ ] Can successfully proceed to a protocol run with a 96 channel ❌