### PR TITLE
feat(robot-server): add Flex instrument updates

### DIFF
--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Lint
         run: make -C robot-server lint
       - name: Test
-        run: make -C robot-server test-cov
+        run: make -C robot-server test-cov test_opts="-m 'not ot3_only'"
       - name: Ensure assets build
         run: make -C robot-server sdist wheel
       - name: Upload coverage report

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -564,6 +564,11 @@ class OT3API(
         self._gripper_handler.gripper = g
 
     def get_all_attached_instr(self) -> Dict[OT3Mount, Optional[InstrumentDict]]:
+        # NOTE (spp, 2023-03-07): The return type of this method indicates that
+        #  if a particular mount has no attached instrument then it will provide a
+        #  None value for that mount. But in reality, we get an empty dict.
+        #  We should either not call the value Optional, or have `_attached_...` return
+        #  a None for empty mounts.
         return {
             OT3Mount.LEFT: self.attached_pipettes[top_types.Mount.LEFT],
             OT3Mount.RIGHT: self.attached_pipettes[top_types.Mount.RIGHT],

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -2,6 +2,7 @@
 import threading
 import logging
 import asyncio
+import inspect
 import functools
 import weakref
 from typing import (
@@ -14,6 +15,8 @@ from typing import (
     cast,
     Sequence,
     Mapping,
+    AsyncGenerator,
+    Union,
 )
 from .adapters import SynchronousAdapter
 from .modules.mod_abc import AbstractModule
@@ -29,7 +32,11 @@ class ThreadManagerException(Exception):
 
 
 WrappedReturn = TypeVar("WrappedReturn", contravariant=True)
+WrappedYield = TypeVar("WrappedYield", contravariant=True)
 WrappedCoro = TypeVar("WrappedCoro", bound=Callable[..., Awaitable[WrappedReturn]])
+WrappedAGenFunc = TypeVar(
+    "WrappedAGenFunc", bound=Callable[..., AsyncGenerator[WrappedYield, None]]
+)
 
 
 async def call_coroutine_threadsafe(
@@ -44,6 +51,71 @@ async def call_coroutine_threadsafe(
     )
     wrapped = asyncio.wrap_future(fut)
     return await wrapped
+
+
+async def execute_asyncgen_threadsafe(
+    loop: asyncio.AbstractEventLoop,
+    agenfunc: WrappedAGenFunc,
+    *args: Sequence[Any],
+    **kwargs: Mapping[str, Any],
+) -> AsyncGenerator[WrappedYield, None]:
+
+    # This function should bridge an async generator function between two asyncio
+    # loops running in different threads. There are several stages to this because
+    # there are several stages to generator execution.
+
+    # These clues will help us later
+    class _DoneSingleton:
+        pass
+
+    async def _build_queue() -> "asyncio.Queue[Union[WrappedYield, _DoneSingleton]]":
+        return asyncio.Queue(maxsize=1)
+
+    yield_queue = await asyncio.wrap_future(
+        cast(
+            "asyncio.Future[asyncio.Queue[Union[WrappedYield, _DoneSingleton]]]",
+            asyncio.run_coroutine_threadsafe(_build_queue(), loop),
+        )
+    )
+
+    # the async generator function needs to run on the target loop. it is not a coroutine
+    # and cannot be run with run_coroutine_threadsafe in the same way. however, we can
+    # make a coroutine that _can_, and that exhausts the async generator and puts what
+    # the generator yields into a queue. since something later will have to combine
+    # awaiting yield results and the function finishing, we can now use the _DoneSingleton
+    # to short circuit the caller waiting for a yield result when the function is done.
+    # in addition, the queue being 1 element max should give us similar "backpressure"
+    # behavior as an async for.
+    async def _inner_agen_wrap() -> None:
+        item: WrappedYield
+        try:
+            async for item in agenfunc(*args, **kwargs):
+                await yield_queue.put(item)
+        finally:
+            await yield_queue.put(_DoneSingleton())
+
+    # as promised, we can run our coroutine pretty easily now. note that this coroutine
+    # returns None, because it is handling the generator yields internally.
+    fut = cast(
+        "asyncio.Future[None]",
+        asyncio.run_coroutine_threadsafe(_inner_agen_wrap(), loop),
+    )
+
+    # now we have to bridge the output of the generator to the calling loop. this is
+    # fun because this uses an asyncio queue which isn't thread safe. so we also need
+    # to pull stuff out of the asyncio queue via the other loop
+    while not fut.done():
+        getter = cast(
+            "asyncio.Future[Union[WrappedYield, _DoneSingleton]]",
+            asyncio.run_coroutine_threadsafe(yield_queue.get(), loop),
+        )
+        asyncio_getter = asyncio.wrap_future(getter)
+        item = await asyncio_getter
+        if isinstance(item, _DoneSingleton):
+            break
+        yield item
+    # if there was an exception then this should re-raise it in the calling loop
+    _ = fut.result()
 
 
 WrappedObj = TypeVar("WrappedObj", bound=AsyncioConfigurable, covariant=True)
@@ -84,6 +156,22 @@ class CallBridger(Generic[WrappedObj]):
             fut = asyncio.run_coroutine_threadsafe(attr, loop)
             wrapped = asyncio.wrap_future(fut)
             return wrapped
+
+        elif inspect.isasyncgenfunction(attr):
+            # Return a wrapper that will exectue the resulting async generator
+            # in managed thread loop
+
+            @functools.wraps(attr)
+            async def wrapper(
+                *args: Sequence[Any], **kwargs: Mapping[str, Any]
+            ) -> AsyncGenerator[WrappedYield, None]:
+                item: WrappedYield
+                async for item in execute_asyncgen_threadsafe(
+                    loop, attr, *args, **kwargs
+                ):
+                    yield item
+
+            return wrapper
 
         return attr
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -2,7 +2,6 @@ import enum
 import logging
 from dataclasses import dataclass
 from typing import (
-    NamedTuple,
     Optional,
     cast,
     Tuple,
@@ -322,15 +321,16 @@ class PipetteSubType(enum.Enum):
 class UpdateState(enum.Enum):
     """Update state to map from lower level FirmwareUpdateStatus"""
 
-    queued = enum.auto()
-    updating = enum.auto()
-    done = enum.auto()
+    queued = "queued"
+    updating = "updating"
+    done = "done"
 
     def __str__(self) -> str:
-        return self.name
+        return self.value
 
 
-class UpdateStatus(NamedTuple):
+@dataclass(frozen=True)
+class UpdateStatus:
     subsystem: OT3SubSystem
     state: UpdateState
     progress: int
@@ -343,8 +343,7 @@ class InstrumentUpdateStatus:
     progress: int
 
 
-
-@dataclass
+@dataclass(frozen=True)
 class InstrumentFWInfo:
     mount: OT3Mount
     update_required: bool

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -336,15 +336,12 @@ class UpdateStatus(NamedTuple):
     progress: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class InstrumentUpdateStatus:
     mount: OT3Mount
     status: UpdateState
     progress: int
 
-    def update(self, status: UpdateState, progress: int) -> None:
-        self.status = status
-        self.progress = progress
 
 
 @dataclass

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -359,4 +359,5 @@ class RunUpdate:
             except asyncio.TimeoutError:
                 pass
             if task.done():
+                _ = task.result()
                 break

--- a/robot-server/robot_server/errors/global_errors.py
+++ b/robot-server/robot_server/errors/global_errors.py
@@ -23,3 +23,10 @@ class InvalidRequest(ErrorDetails):
 
     id: Literal["InvalidRequest"] = "InvalidRequest"
     title: str = "Invalid Request"
+
+
+class IDNotFound(ErrorDetails):
+    """An error returned when an ID is specified incorrectly."""
+
+    id: Literal["IDNotFound"] = "IDNotFound"
+    title: str = "ID Not Found"

--- a/robot-server/robot_server/errors/robot_errors.py
+++ b/robot-server/robot_server/errors/robot_errors.py
@@ -1,0 +1,25 @@
+"""Error types related to many robot interactions."""
+
+from typing_extensions import Literal
+from .error_responses import ErrorDetails
+
+
+class InstrumentNotFound(ErrorDetails):
+    """An error returned when a request specifies a missing instrument."""
+
+    id: Literal["InstrumentNotFound"] = "InstrumentNotFound"
+    title: str = "Instrument Not Found"
+
+
+class NotSupportedOnOT2(ErrorDetails):
+    """An error returned when an operation is not supported on an OT2."""
+
+    id: Literal["NotSupportedOnOT2"] = "NotSupportedOnOT2"
+    title: str = "Not Supported On OT-2"
+
+
+class NotSupportedOnFlex(ErrorDetails):
+    """An error returned when an operation is not supported on a Flex."""
+
+    id: Literal["NotSupportedOnFlex"] = "NotSupportedOnFlex"
+    title: str = "Not Supported On Flex"

--- a/robot-server/robot_server/instruments/__init__.py
+++ b/robot-server/robot_server/instruments/__init__.py
@@ -1,4 +1,4 @@
-"""Endpoints for getting information about the robot's attached instruments."""
+"""Endpoints for getting information on & updating the robot's attached instruments."""
 from .router import instruments_router
 
 __all__ = ["instruments_router"]

--- a/robot-server/robot_server/instruments/firmware_update_manager.py
+++ b/robot-server/robot_server/instruments/firmware_update_manager.py
@@ -1,0 +1,333 @@
+"""Class to monitor firmware update status."""
+from datetime import datetime
+from typing import Dict, Union, TYPE_CHECKING, Iterable, Iterator, Optional, Any
+from typing_extensions import Literal
+
+# TODO: Remove when on py 3.11 when this isn't a different class anymore
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+from asyncio import Lock, Queue, wait_for, QueueEmpty
+from dataclasses import dataclass
+from enum import Enum, auto
+import logging
+
+from opentrons.hardware_control.types import (
+    UpdateState,
+    subsystem_to_mount,
+    OT3SubSystem,
+    OT3Mount,
+)
+from robot_server.service.task_runner import TaskRunner
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from opentrons.hardware_control.ot3api import OT3API
+
+
+class UpdateIdNotFound(KeyError):
+    """Specified update ID not present."""
+
+
+class InstrumentNotFound(ValueError):
+    """Specified instrument not present."""
+
+
+class UpdateIdExists(ValueError):
+    """An update was specified with the same ID as a running one."""
+
+
+class UpdateFailed(RuntimeError):
+    """Error raised when the information from hardware controller points to a failed update."""
+
+
+class UpdateInProgress(RuntimeError):
+    """Error raised when an update is already ongoing on the same device."""
+
+
+class _UpdatePacketType(Enum):
+    progress = auto()
+    error = auto()
+    complete = auto()
+
+
+@dataclass
+class _UpdateProgressPacket:
+    progress: int
+    status: UpdateState
+    packet_type: Literal[_UpdatePacketType.progress] = _UpdatePacketType.progress
+
+
+@dataclass
+class _UpdateErrorPacket:
+    exc: Exception
+    packet_type: Literal[_UpdatePacketType.error] = _UpdatePacketType.error
+
+
+@dataclass
+class _UpdateCompletePacket:
+    packet_type: Literal[_UpdatePacketType.complete] = _UpdatePacketType.complete
+
+
+_UpdatePacket = Union[_UpdateProgressPacket, _UpdateErrorPacket, _UpdateCompletePacket]
+
+
+class _UpdateProcess:
+    """State storage and routing for a firmware update."""
+
+    _status_queue: "Queue[_UpdatePacket]"
+    _hw_handle: "OT3API"
+    _mount: OT3Mount
+    _status_cache: Optional[_UpdatePacket]
+    _created_at: datetime
+    _update_id: str
+
+    def __init__(
+        self, hw_handle: "OT3API", mount: OT3Mount, created_at: datetime, update_id: str
+    ) -> None:
+        self._status_queue = Queue()
+        self._hw_handle = hw_handle
+        self._mount = mount
+        self._status_cache = None
+        self._status_cache_lock = Lock()
+        self._created_at = created_at
+        self._update_id = update_id
+        in_progress = self._hw_handle.get_firmware_update_progress()
+
+        def _mounts_in_subsystem_list(
+            subsystem: Iterable[OT3SubSystem],
+        ) -> Iterator[OT3Mount]:
+            for subsys in subsystem:
+                try:
+                    mount = subsystem_to_mount(subsys)
+                except KeyError:
+                    continue
+                else:
+                    yield mount
+
+        in_progress_instruments = list(_mounts_in_subsystem_list(in_progress.keys()))
+        if in_progress_instruments:
+            raise UpdateInProgress()
+
+        if not self._hw_handle.get_all_attached_instr()[self._mount]:
+            raise InstrumentNotFound()
+
+    @property
+    def status_cache(self) -> _UpdatePacket:
+        if not self._status_cache:
+            raise RuntimeError(
+                "Update process was not started before asking for status"
+            )
+        return self._status_cache
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
+
+    @property
+    def mount(self) -> OT3Mount:
+        return self._mount
+
+    @property
+    def update_id(self) -> str:
+        return self._update_id
+
+    async def _update_task(self) -> None:
+        try:
+            async for update in self._hw_handle.update_instrument_firmware(self.mount):
+                await self._status_queue.put(
+                    _UpdateProgressPacket(update.progress, update.status)
+                )
+            await self._status_queue.put(_UpdateProgressPacket(100, UpdateState.done))
+        except Exception as e:
+            log.exception('Failed to update firmware')
+            await self._status_queue.put(_UpdateErrorPacket(e))
+
+    def get_handle(self) -> "UpdateProcessHandle":
+        return UpdateProcessHandle(self)
+
+    async def provide_latest_progress(self) -> _UpdatePacket:
+        """Updates the status cache with the latest update if there is one."""
+        while self._status_cache is None:
+            self._status_cache = await self._status_queue.get()
+        maybe_latest = self._drain_queue_provide_last()
+        if maybe_latest:
+            self._status_cache = maybe_latest
+
+        return self.status_cache
+
+    def _drain_queue_provide_last(self) -> Optional[_UpdatePacket]:
+        """Drains the status queue to provide the latest update.
+
+        Note that this code does not yield. It should be acceptably fast because get_nowait() is
+        designed for this; and the lack of yielding makes this function as a whole atomic in an
+        async context. If multiple tasks call this function, the first to do so gets the update and
+        the rest get None.
+        """
+        packet: Optional[_UpdatePacket] = None
+        while True:
+            try:
+                packet = self._status_queue.get_nowait()
+            except QueueEmpty:
+                return packet
+
+
+@dataclass
+class ProcessDetails:
+    """The static details of an update process that are set when it starts."""
+
+    created_at: datetime
+    mount: OT3Mount
+    update_id: str
+
+
+@dataclass
+class UpdateProgress:
+    """The current progress of an update process."""
+
+    state: UpdateState
+    progress: int
+
+
+@dataclass
+class UpdateProcessSummary:
+    """The full information of an update process."""
+
+    details: ProcessDetails
+    progress: UpdateProgress
+
+
+class UpdateProcessHandle:
+    """The external interface to get status notifications from the update process."""
+
+    _update_proc: _UpdateProcess
+    _proc_details: ProcessDetails
+
+    def __init__(self, update_proc: _UpdateProcess) -> None:
+        self._update_proc = update_proc
+        self._proc_details = ProcessDetails(
+            update_proc.created_at, update_proc.mount, update_proc.update_id
+        )
+
+    async def get_progress(self) -> UpdateProgress:
+        """Get the progress of the update process for which this is a handle.
+
+        This function is async-reentrant in that each call will provide the latest status at that
+        time, though each call may return something different depending on when they're called.
+
+        Normal progress updates are returned; this function may also raise an exception that has
+        been conveyed from inside the update process.
+        """
+        status = await self._update_proc.provide_latest_progress()
+        if status.packet_type is _UpdatePacketType.error:
+            raise UpdateFailed() from status.exc
+        elif status.packet_type is _UpdatePacketType.complete:
+            return UpdateProgress(UpdateState.done, 100)
+        else:
+            return UpdateProgress(status.status, status.progress)
+
+    @property
+    def process_details(self) -> ProcessDetails:
+        """Get the static process details for the process for which this is a handle."""
+        return self._proc_details
+
+    async def get_process_summary(self) -> UpdateProcessSummary:
+        """Get a full summary, inclusive of static details and progress, for the handled process."""
+        return UpdateProcessSummary(self.process_details, await self.get_progress())
+
+    def __eq__(self, other: Any) -> bool:
+        """This eq overload makes handles equal if they refer to the same process."""
+        if isinstance(other, UpdateProcessHandle):
+            return self._update_proc is other._update_proc
+        return NotImplemented
+
+
+class FirmwareUpdateManager:
+    """State storage and progress monitoring for instrument firmware updates."""
+
+    _running_updates: Dict[str, _UpdateProcess]
+    #: A store for any updates that are currently running
+    _management_lock: Lock
+    #: A lock for accessing the store, mostly to avoid spurious toctou problems with it
+
+    _task_runner: TaskRunner
+    _hardware_handle: "OT3API"
+
+    def __init__(self, task_runner: TaskRunner, hw_handle: "OT3API") -> None:
+        self._running_updates = {}
+        self._task_runner = task_runner
+        self._management_lock = Lock()
+        self._hardware_handle = hw_handle
+
+    async def _get(self, update_id: str) -> _UpdateProcess:
+        async with self._management_lock:
+            try:
+                return self._running_updates[update_id]
+            except KeyError as e:
+                raise UpdateIdNotFound() from e
+
+    async def _emplace(
+        self, update_id: str, mount: OT3Mount, creation_time: datetime
+    ) -> _UpdateProcess:
+        if update_id in self._running_updates:
+            raise UpdateIdExists()
+        self._running_updates[update_id] = _UpdateProcess(
+            self._hardware_handle, mount, creation_time, update_id
+        )
+        self._task_runner.run(self._running_updates[update_id]._update_task)
+        return self._running_updates[update_id]
+
+    def get_update_process_handle(self, update_id: str) -> UpdateProcessHandle:
+        """Get a handle for a process by its update id.
+
+        This is the way to get access to a running process - the process object itself should
+        not be touched outside this object or the task runner.
+        """
+        try:
+            return self._running_updates[update_id].get_handle()
+        except KeyError as ke:
+            raise UpdateIdNotFound() from ke
+
+    async def start_update_process(
+        self,
+        update_id: str,
+        mount: OT3Mount,
+        created_at: datetime,
+        start_timeout_s: float,
+    ) -> UpdateProcessHandle:
+        """Try to begin an update process, checking preconditions, and return a handle if successful.
+
+        This function is responsible for checking hardware preconditions: does the requested instrument
+        exist, etc. It also will start an update process and convey any exceptions that are raised
+        immediately (though later exceptions may need to be found by getting progress through the
+        handle).
+        """
+        try:
+            return await wait_for(
+                self._start_and_get_process(update_id, mount, created_at),
+                start_timeout_s,
+            )
+        except FuturesTimeoutError as fte:
+            # wait_for raises the timeouterror from concurrent.futures instead of the global one, so
+            # transform it because cmon
+            raise TimeoutError from fte
+
+    async def _start_and_get_process(
+        self, update_id: str, mount: OT3Mount, creation_time: datetime
+    ) -> UpdateProcessHandle:
+        async with self._management_lock:
+            process = await self._emplace(update_id, mount, creation_time)
+            await process.provide_latest_progress()
+        return process.get_handle()
+
+    async def complete_update_process(self, update_id: str) -> None:
+        """Mark an update process as complete.
+
+        This should probably only be called when a process is marked done, but all it really does is
+        eject the process from the internal store so that future status calls will indicate the process
+        is gone.
+        """
+        try:
+            self._running_updates.pop(update_id)
+        except KeyError as ke:
+            raise UpdateIdNotFound() from ke

--- a/robot-server/robot_server/instruments/firmware_update_manager.py
+++ b/robot-server/robot_server/instruments/firmware_update_manager.py
@@ -140,7 +140,7 @@ class _UpdateProcess:
                 )
             await self._status_queue.put(_UpdateProgressPacket(100, UpdateState.done))
         except Exception as e:
-            log.exception('Failed to update firmware')
+            log.exception("Failed to update firmware")
             await self._status_queue.put(_UpdateErrorPacket(e))
 
     def get_handle(self) -> "UpdateProcessHandle":

--- a/robot-server/robot_server/instruments/router.py
+++ b/robot-server/robot_server/instruments/router.py
@@ -1,7 +1,11 @@
 """Instruments routes."""
-from typing import Optional, List, Dict
+from datetime import datetime
+from typing import Optional, List, Dict, Union
+from typing_extensions import Final
 
 from fastapi import APIRouter, status, Depends
+from typing_extensions import Literal
+
 from opentrons.protocol_engine.errors import HardwareNotSupportedError
 
 from robot_server.hardware import get_hardware
@@ -9,12 +13,20 @@ from robot_server.service.json_api import (
     SimpleMultiBody,
     PydanticResponse,
     MultiBodyMeta,
+    RequestModel,
+    SimpleBody,
+)
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
 )
 
 from opentrons.types import Mount
 from opentrons.protocol_engine.types import Vec3f
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import UpdateState, OT3Mount
 from opentrons.hardware_control.dev_types import PipetteDict, GripperDict
 from opentrons_shared_data.gripper.gripper_definition import GripperModelStr
 
@@ -26,9 +38,81 @@ from .instrument_models import (
     Gripper,
     AttachedInstrument,
     GripperCalibrationData,
+    UpdateCreate,
+    UpdateProgressData,
 )
+from .firmware_update_manager import (
+    FirmwareUpdateManager,
+    UpdateIdNotFound as _UpdateIdNotFound,
+    UpdateIdExists as _UpdateIdExists,
+    UpdateFailed as _UpdateFailed,
+    InstrumentNotFound as _InstrumentNotFound,
+    UpdateInProgress as _UpdateInProgress,
+    UpdateProcessSummary,
+)
+from ..errors import ErrorDetails, ErrorBody
+from ..errors.global_errors import IDNotFound
+from ..errors.robot_errors import InstrumentNotFound, NotSupportedOnOT2
+from ..service.dependencies import get_unique_id, get_current_time
+from ..service.task_runner import TaskRunner, get_task_runner
 
 instruments_router = APIRouter()
+
+_firmware_update_manager_accessor = AppStateAccessor[FirmwareUpdateManager](
+    "firmware_update_manager"
+)
+
+UPDATE_CREATE_TIMEOUT_S: Final = 5
+
+
+async def get_firmware_update_manager(
+    app_state: AppState = Depends(get_app_state),
+    hardware_api: HardwareControlAPI = Depends(get_hardware),
+    task_runner: TaskRunner = Depends(get_task_runner),
+) -> FirmwareUpdateManager:
+    """Get an update manager to track firmware update statuses."""
+    update_manager = _firmware_update_manager_accessor.get_from(app_state)
+
+    if update_manager is None:
+        try:
+            ot3_hardware = ensure_ot3_hardware(hardware_api=hardware_api)
+        except HardwareNotSupportedError as e:
+            raise NotSupportedOnOT2(detail=str(e)).as_error(
+                status.HTTP_403_FORBIDDEN
+            ) from e
+        update_manager = FirmwareUpdateManager(
+            task_runner=task_runner, hw_handle=ot3_hardware
+        )
+        _firmware_update_manager_accessor.set_on(app_state, update_manager)
+    return update_manager
+
+
+class NoUpdateAvailable(ErrorDetails):
+    """An error if no update is available for the specified mount."""
+
+    id: Literal["NoUpdateAvailable"] = "NoUpdateAvailable"
+    title: str = "No Update Available"
+
+
+class UpdateInProgress(ErrorDetails):
+    """An error thrown if there is already an update in progress."""
+
+    id: Literal["UpdateInProgress"] = "UpdateInProgress"
+    title: str = "An update is already in progress."
+
+
+class TimeoutStartingUpdate(ErrorDetails):
+    """Error raised when the update took too long to start."""
+
+    id: Literal["TimeoutStartingUpdate"] = "TimeoutStartingUpdate"
+    title: str = "Timeout Starting Update"
+
+
+class FirmwareUpdateFailed(ErrorDetails):
+    """An error if a firmware update failed for some reason."""
+
+    id: Literal["FirmwareUpdateFailed"] = "FirmwareUpdateFailed"
+    title: str = "Firmware Update Failed"
 
 
 def _pipette_dict_to_pipette_res(pipette_dict: PipetteDict, mount: Mount) -> Pipette:
@@ -39,6 +123,9 @@ def _pipette_dict_to_pipette_res(pipette_dict: PipetteDict, mount: Mount) -> Pip
             instrumentName=pipette_dict["name"],
             instrumentModel=pipette_dict["model"],
             serialNumber=pipette_dict["pipette_id"],
+            currentFirmwareVersion=pipette_dict.get("fw_current_version"),
+            firmwareUpdateRequired=pipette_dict.get("fw_update_required"),
+            nextAvailableFirmwareVersion=pipette_dict.get("fw_next_version"),
             data=PipetteData(
                 channels=pipette_dict["channels"],
                 min_volume=pipette_dict["min_volume"],
@@ -54,6 +141,9 @@ def _gripper_dict_to_gripper_res(gripper_dict: GripperDict) -> Gripper:
         mount=MountType.EXTENSION.value,
         instrumentModel=GripperModelStr(str(gripper_dict["model"])),
         serialNumber=gripper_dict["gripper_id"],
+        currentFirmwareVersion=gripper_dict["fw_current_version"],
+        firmwareUpdateRequired=gripper_dict["fw_update_required"],
+        nextAvailableFirmwareVersion=gripper_dict.get("fw_next_version"),
         data=GripperData(
             jawState=gripper_dict["state"].name.lower(),
             calibratedOffset=GripperCalibrationData.construct(
@@ -108,6 +198,171 @@ async def get_attached_instruments(
         content=SimpleMultiBody.construct(
             data=response_data,
             meta=MultiBodyMeta(cursor=0, totalLength=len(response_data)),
+        ),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+async def _create_and_remove_if_error(
+    manager: FirmwareUpdateManager,
+    update_id: str,
+    mount: OT3Mount,
+    created_at: datetime,
+    timeout: float,
+) -> UpdateProcessSummary:
+    try:
+        handle = await manager.start_update_process(
+            update_id,
+            mount,
+            created_at,
+            UPDATE_CREATE_TIMEOUT_S,
+        )
+        return await handle.get_process_summary()
+    except Exception:
+        try:
+            await manager.complete_update_process(update_id)
+        except Exception:
+            pass
+        raise
+
+
+@instruments_router.post(
+    path="/instruments/updates",
+    summary="Initiate a firmware update on a specific instrument.",
+    description="Update the firmware of the instrument attached to the specified mount"
+    " if a firmware update is available for it.",
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_201_CREATED: {"model": SimpleBody[UpdateProgressData]},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[InstrumentNotFound]},
+        status.HTTP_409_CONFLICT: {"model": ErrorBody[UpdateInProgress]},
+        status.HTTP_412_PRECONDITION_FAILED: {"model": ErrorBody[NoUpdateAvailable]},
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "model": ErrorBody[Union[FirmwareUpdateFailed, UpdateInProgress]]
+        },
+    },
+)
+async def update_firmware(
+    request_body: RequestModel[UpdateCreate],
+    update_process_id: str = Depends(get_unique_id),
+    created_at: datetime = Depends(get_current_time),
+    hardware: HardwareControlAPI = Depends(get_hardware),
+    firmware_update_manager: FirmwareUpdateManager = Depends(
+        get_firmware_update_manager
+    ),
+) -> PydanticResponse[SimpleBody[UpdateProgressData]]:
+    """Update the firmware of the OT3 instrument on the specified mount.
+
+    Arguments:
+        request_body: Optional request body with instrument to update. If not specified,
+                      will start an update of all attached instruments.
+        update_process_id: Generated ID to assign to the update resource.
+        created_at: Timestamp to attach to created update resource.
+        hardware: hardware controller instance.
+        firmware_update_manager: Injected manager for firmware updates.
+    """
+    mount_to_update = request_body.data.mount
+    ot3_mount = MountType.to_ot3_mount(mount_to_update)
+    await hardware.cache_instruments()
+
+    try:
+        summary = await _create_and_remove_if_error(
+            firmware_update_manager,
+            update_process_id,
+            ot3_mount,
+            created_at,
+            UPDATE_CREATE_TIMEOUT_S,
+        )
+    except _InstrumentNotFound:
+        raise InstrumentNotFound(
+            detail=f"No instrument found on {mount_to_update} mount."
+        ).as_error(status.HTTP_404_NOT_FOUND)
+    except _UpdateInProgress:
+        raise UpdateInProgress(
+            detail=f"{mount_to_update} is already either queued for update"
+            f" or is currently updating"
+        ).as_error(status.HTTP_409_CONFLICT)
+    except _UpdateFailed as e:
+        raise FirmwareUpdateFailed(detail=str(e)).as_error(
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+    except TimeoutError as e:
+        raise TimeoutStartingUpdate(detail=str(e)).as_error(
+            status.HTTP_408_REQUEST_TIMEOUT
+        )
+    except _UpdateIdExists:
+        raise UpdateInProgress(
+            detail="An update is already ongoing with this ID."
+        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    return await PydanticResponse.create(
+        content=SimpleBody.construct(
+            data=UpdateProgressData(
+                id=summary.details.update_id,
+                createdAt=summary.details.created_at,
+                mount=MountType.from_ot3_mount(
+                    summary.details.mount
+                ).value_as_literal(),
+                updateStatus=summary.progress.state,
+                updateProgress=summary.progress.progress,
+            )
+        ),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+@instruments_router.get(
+    path="/instruments/updates/{update_id}",
+    summary="Get specified firmware update process' information.",
+    description="Get firmware update status & progress of the specified update.",
+    responses={
+        status.HTTP_200_OK: {"model": SimpleMultiBody[UpdateProgressData]},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[IDNotFound]},
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "model": ErrorBody[FirmwareUpdateFailed]
+        },
+    },
+)
+async def get_firmware_update_status(
+    update_id: str,
+    firmware_update_manager: FirmwareUpdateManager = Depends(
+        get_firmware_update_manager
+    ),
+) -> PydanticResponse[SimpleBody[UpdateProgressData]]:
+    """Get status of instrument firmware update.
+
+    update_id: the ID to get the status of
+    firmware_update_manager: The firmware update manage rcontrolling the update processes.
+    """
+    try:
+        handle = firmware_update_manager.get_update_process_handle(update_id)
+        summary = await handle.get_process_summary()
+    except _UpdateIdNotFound as e:
+        raise IDNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+    except _UpdateFailed as e:
+        raise FirmwareUpdateFailed(detail=str(e)).as_error(
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+
+    if summary.progress.state == UpdateState.done:
+        try:
+            await firmware_update_manager.complete_update_process(update_id)
+        except _UpdateIdNotFound:
+            # this access could theoretically race, and that's fine if we already got
+            # here.
+            pass
+
+    return await PydanticResponse.create(
+        content=SimpleBody.construct(
+            data=UpdateProgressData(
+                id=summary.details.update_id,
+                createdAt=summary.details.created_at,
+                mount=MountType.from_ot3_mount(
+                    summary.details.mount
+                ).value_as_literal(),
+                updateStatus=summary.progress.state,
+                updateProgress=summary.progress.progress,
+            )
         ),
         status_code=status.HTTP_200_OK,
     )

--- a/robot-server/scripts/update_flex_tools.py
+++ b/robot-server/scripts/update_flex_tools.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Update tools attached to a flex via the HTTP interface.
+"""
+import argparse
+import sys
+from typing import List
+from dataclasses import dataclass
+from urllib.parse import urljoin
+import time
+
+import requests
+
+@dataclass
+class Robot:
+    url: str
+    session: requests.Session
+
+    def url_for(self, path: str) -> str:
+        return urljoin(self.url, path)
+
+def robot_from_address(addr: str) -> Robot:
+    session = requests.Session()
+    session.headers.update({'opentrons-version': '*'})
+    robot = Robot(f'http://{addr}:31950', session)
+    resp = session.get(robot.url_for('/health'))
+    assert resp.status_code == 200, f'Could not reach robot at {addr}'
+    assert 'OT-2' not in resp.json().get('robot_model', 'OT-2 Standard'), f'{addr} is an OT-2'
+    return robot
+
+
+def find_tools_to_update(robot: Robot) -> List[str]:
+    instr_resp = robot.session.get(robot.url_for('/instruments'))
+    assert instr_resp.status_code == 200, 'Could not fetch instruments'
+    instr_dict = instr_resp.json()
+    return [instr['mount'] for instr in instr_dict['data'] if instr['firmwareUpdateRequired'] == True]
+
+def update_tool(robot: Robot, tool: str):
+    start_resp = robot.session.post(
+        robot.url_for('/instruments/updates'), json={'data': {'mount': tool}})
+    assert start_resp.status_code == 201, f'Could not start update: {start_resp.status_code}, {start_resp.content}'
+    process_details = start_resp.json()
+    update_id = process_details['data']['id']
+    print(f"Began update for {tool} as {update_id}")
+    while True:
+        time.sleep(1)
+        status_resp = robot.session.get(robot.url_for(f'/instruments/updates/{update_id}'))
+        status_body = status_resp.json()
+        assert status_resp.status_code == 200, f'Update failed: {status_resp.status_code} {status_body}'
+        print(f'{status_body["data"]["updateStatus"]}, {status_body["data"]["updateProgress"]}% done')
+        if status_body['data']['updateStatus'] == 'done':
+            break
+
+
+def argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description='Update any tools attached to a flex that require updates')
+    parser.add_argument('addr', metavar='ADDR', help='The address of the robot to update')
+    parser.add_argument('-o', '--only', nargs="*", metavar='ONLY', choices=['left', 'right', 'extension'],
+                        help='Only update the specified mounts (if they need it)')
+    return parser
+
+def limit_tools(require_updates: List[str], limit: List[str]) -> List[str]:
+    if limit:
+        limited = [tool for tool in require_updates if tool in limit]
+        not_updated = [tool for tool in require_updates if tool not in limit]
+        print(f'Not updating {", ".join(not_updated)} (not in --only)')
+        return limited
+    else:
+        return require_updates
+
+def run_update(addr: str, only: List[str]) -> None:
+    robot = robot_from_address(addr)
+    tools = find_tools_to_update(robot)
+    print(', '.join([t for t in ['left', 'right', 'extension'] if t not in tools]) + ' up to date')
+    to_update = limit_tools(tools, only)
+    for tool in to_update:
+        update_tool(robot, tool)
+
+
+def main() -> int:
+    parser = argparser()
+    args = parser.parse_args()
+    try:
+        run_update(args.addr, args.only)
+        return 0
+    except Exception as e:
+        print(f"Failed to update robot: {e}")
+        return -1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/robot-server/scripts/update_flex_tools.py
+++ b/robot-server/scripts/update_flex_tools.py
@@ -11,6 +11,7 @@ import time
 
 import requests
 
+
 @dataclass
 class Robot:
     url: str
@@ -19,46 +20,73 @@ class Robot:
     def url_for(self, path: str) -> str:
         return urljoin(self.url, path)
 
+
 def robot_from_address(addr: str) -> Robot:
     session = requests.Session()
-    session.headers.update({'opentrons-version': '*'})
-    robot = Robot(f'http://{addr}:31950', session)
-    resp = session.get(robot.url_for('/health'))
-    assert resp.status_code == 200, f'Could not reach robot at {addr}'
-    assert 'OT-2' not in resp.json().get('robot_model', 'OT-2 Standard'), f'{addr} is an OT-2'
+    session.headers.update({"opentrons-version": "*"})
+    robot = Robot(f"http://{addr}:31950", session)
+    resp = session.get(robot.url_for("/health"))
+    assert resp.status_code == 200, f"Could not reach robot at {addr}"
+    assert "OT-2" not in resp.json().get(
+        "robot_model", "OT-2 Standard"
+    ), f"{addr} is an OT-2"
     return robot
 
 
 def find_tools_to_update(robot: Robot) -> List[str]:
-    instr_resp = robot.session.get(robot.url_for('/instruments'))
-    assert instr_resp.status_code == 200, 'Could not fetch instruments'
+    instr_resp = robot.session.get(robot.url_for("/instruments"))
+    assert instr_resp.status_code == 200, "Could not fetch instruments"
     instr_dict = instr_resp.json()
-    return [instr['mount'] for instr in instr_dict['data'] if instr['firmwareUpdateRequired'] == True]
+    return [
+        instr["mount"]
+        for instr in instr_dict["data"]
+        if instr["firmwareUpdateRequired"] == True
+    ]
+
 
 def update_tool(robot: Robot, tool: str):
     start_resp = robot.session.post(
-        robot.url_for('/instruments/updates'), json={'data': {'mount': tool}})
-    assert start_resp.status_code == 201, f'Could not start update: {start_resp.status_code}, {start_resp.content}'
+        robot.url_for("/instruments/updates"), json={"data": {"mount": tool}}
+    )
+    assert (
+        start_resp.status_code == 201
+    ), f"Could not start update: {start_resp.status_code}, {start_resp.content}"
     process_details = start_resp.json()
-    update_id = process_details['data']['id']
+    update_id = process_details["data"]["id"]
     print(f"Began update for {tool} as {update_id}")
     while True:
         time.sleep(1)
-        status_resp = robot.session.get(robot.url_for(f'/instruments/updates/{update_id}'))
+        status_resp = robot.session.get(
+            robot.url_for(f"/instruments/updates/{update_id}")
+        )
         status_body = status_resp.json()
-        assert status_resp.status_code == 200, f'Update failed: {status_resp.status_code} {status_body}'
-        print(f'{status_body["data"]["updateStatus"]}, {status_body["data"]["updateProgress"]}% done')
-        if status_body['data']['updateStatus'] == 'done':
+        assert (
+            status_resp.status_code == 200
+        ), f"Update failed: {status_resp.status_code} {status_body}"
+        print(
+            f'{status_body["data"]["updateStatus"]}, {status_body["data"]["updateProgress"]}% done'
+        )
+        if status_body["data"]["updateStatus"] == "done":
             break
 
 
 def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description='Update any tools attached to a flex that require updates')
-    parser.add_argument('addr', metavar='ADDR', help='The address of the robot to update')
-    parser.add_argument('-o', '--only', nargs="*", metavar='ONLY', choices=['left', 'right', 'extension'],
-                        help='Only update the specified mounts (if they need it)')
+        description="Update any tools attached to a flex that require updates"
+    )
+    parser.add_argument(
+        "addr", metavar="ADDR", help="The address of the robot to update"
+    )
+    parser.add_argument(
+        "-o",
+        "--only",
+        nargs="*",
+        metavar="ONLY",
+        choices=["left", "right", "extension"],
+        help="Only update the specified mounts (if they need it)",
+    )
     return parser
+
 
 def limit_tools(require_updates: List[str], limit: List[str]) -> List[str]:
     if limit:
@@ -69,10 +97,14 @@ def limit_tools(require_updates: List[str], limit: List[str]) -> List[str]:
     else:
         return require_updates
 
+
 def run_update(addr: str, only: List[str]) -> None:
     robot = robot_from_address(addr)
     tools = find_tools_to_update(robot)
-    print(', '.join([t for t in ['left', 'right', 'extension'] if t not in tools]) + ' up to date')
+    print(
+        ", ".join([t for t in ["left", "right", "extension"] if t not in tools])
+        + " up to date"
+    )
     to_update = limit_tools(tools, only)
     for tool in to_update:
         update_tool(robot, tool)
@@ -88,5 +120,6 @@ def main() -> int:
         print(f"Failed to update robot: {e}")
         return -1
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/robot-server/tests/instruments/test_firmware_update_manager.py
+++ b/robot-server/tests/instruments/test_firmware_update_manager.py
@@ -1,0 +1,363 @@
+"""Tests for UpdateProgressMonitor."""
+from __future__ import annotations
+import asyncio
+
+import pytest
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, AsyncIterator, Union, Any
+from decoy import Decoy
+
+from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.hardware_control.types import (
+    OT3Mount,
+    InstrumentUpdateStatus,
+    UpdateState,
+    OT3SubSystem,
+    UpdateStatus,
+)
+from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+
+from robot_server.service.task_runner import TaskRunner
+from robot_server.instruments.firmware_update_manager import (
+    FirmwareUpdateManager,
+    InstrumentNotFound,
+    UpdateIdNotFound,
+    UpdateFailed,
+    UpdateProcessSummary,
+    UpdateProgress,
+    ProcessDetails,
+    UpdateIdExists,
+    UpdateInProgress,
+)
+
+if TYPE_CHECKING:
+    from opentrons.hardware_control.ot3api import OT3API
+
+
+@pytest.fixture
+def decoy_task_runner(decoy: Decoy) -> TaskRunner:
+    """Get a mocked out TaskRunner."""
+    return decoy.mock(cls=TaskRunner)
+
+
+@pytest.fixture
+async def task_runner() -> AsyncIterator[TaskRunner]:
+    """Get a real task runner that will be cleaned up properly."""
+    runner = TaskRunner()
+    try:
+        yield runner
+    finally:
+        await runner.cancel_all_and_clean_up()
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
+def ot3_hardware_api(decoy: Decoy) -> OT3API:
+    """Get a mocked out OT3API."""
+    try:
+        from opentrons.hardware_control.ot3api import OT3API
+
+        return decoy.mock(cls=OT3API)
+    except ImportError:
+        return None  # type: ignore[return-value]
+
+
+def get_sample_pipette_dict(
+    name: PipetteName,
+    model: PipetteModel,
+    pipette_id: str,
+    fw_update_required: bool,
+) -> PipetteDict:
+    """Return a sample PipetteDict."""
+    pipette_dict: PipetteDict = {  # type: ignore [typeddict-item]
+        "name": name,
+        "model": model,
+        "pipette_id": pipette_id,
+        "back_compat_names": ["p10_single"],
+        "min_volume": 1,
+        "max_volume": 1,
+        "channels": 1,
+        "fw_update_required": fw_update_required,
+        "fw_current_version": 1,
+    }
+    return pipette_dict
+
+
+def get_default_pipette_dict() -> PipetteDict:
+    """Get a pipette dict with a normal setup to save some typing."""
+    return get_sample_pipette_dict(
+        "p10_multi", PipetteModel("abc"), "my-pipette-id", True
+    )
+
+
+def mock_right_present_no_updates(ot3_hardware_api: OT3API, decoy: Decoy) -> OT3API:
+    """Set up a hardware controller for update testing."""
+    decoy.when(ot3_hardware_api.get_firmware_update_progress()).then_return({})
+    decoy.when(ot3_hardware_api.get_all_attached_instr()).then_return(
+        {OT3Mount.RIGHT: get_default_pipette_dict()}
+    )
+    return ot3_hardware_api
+
+
+def build_firmware_progress_injector(
+    decoy: Decoy, ot3_hardware_api: OT3API, mount: OT3Mount
+) -> "asyncio.Queue[Union[Exception, UpdateStatus]]":
+    """Utility function to get a queue to inject progress updates."""
+    queue: "asyncio.Queue[Union[Exception, UpdateStatus]]" = asyncio.Queue()
+
+    async def _inject(*_: Any, **__: Any) -> AsyncIterator[InstrumentUpdateStatus]:
+        while True:
+            item = await queue.get()
+            if isinstance(item, Exception):
+                raise item
+            else:
+                yield InstrumentUpdateStatus(mount, item.state, item.progress)
+                if item.state == UpdateState.done:
+                    return
+
+    decoy.when(ot3_hardware_api.update_instrument_firmware(mount)).then_do(_inject)
+    return queue
+
+
+@pytest.mark.ot3_only
+async def test_start_update(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should create an update resource and save to memory."""
+    created_at = datetime(year=2023, month=12, day=2)
+    mock_right_present_no_updates(ot3_hardware_api, decoy)
+    inject_queue = build_firmware_progress_injector(
+        decoy, ot3_hardware_api, OT3Mount.RIGHT
+    )
+    await inject_queue.put(
+        UpdateStatus(OT3SubSystem.pipette_right, UpdateState.updating, 2)
+    )
+
+    expected_data = UpdateProcessSummary(
+        ProcessDetails(created_at, OT3Mount.RIGHT, "update-id"),
+        UpdateProgress(UpdateState.updating, 2),
+    )
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    handle = await subject.start_update_process(
+        update_id="update-id",
+        mount=OT3Mount.RIGHT,
+        created_at=created_at,
+        start_timeout_s=0.5,
+    )
+
+    assert (await handle.get_process_summary()) == expected_data
+    assert subject.get_update_process_handle("update-id") == handle
+
+
+@pytest.mark.ot3_only
+async def test_create_update_resource_without_update_progress(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should fail to create resource when there is no update progress from HC."""
+    created_at = datetime(year=2023, month=12, day=2)
+    mock_right_present_no_updates(ot3_hardware_api, decoy)
+    # We'll build a queue so the status requests waits infinitely, and we'll never put
+    # anything in it so it times out
+    _ = build_firmware_progress_injector(decoy, ot3_hardware_api, OT3Mount.RIGHT)
+
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+
+    with pytest.raises(TimeoutError):
+        await subject.start_update_process(
+            update_id="update-id",
+            mount=OT3Mount.RIGHT,
+            created_at=created_at,
+            start_timeout_s=0.5,
+        )
+
+
+@pytest.mark.ot3_only
+async def test_get_completed_update_progress(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should provide a valid status for an existent resource with no status from hardware API."""
+    created_at = datetime(year=2023, month=12, day=2)
+    mock_right_present_no_updates(ot3_hardware_api, decoy)
+    inject_queue = build_firmware_progress_injector(
+        decoy, ot3_hardware_api, OT3Mount.RIGHT
+    )
+    await inject_queue.put(
+        UpdateStatus(
+            subsystem=OT3SubSystem.pipette_right, state=UpdateState.done, progress=100
+        )
+    )
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    await subject.start_update_process(
+        update_id="update-id",
+        created_at=created_at,
+        mount=OT3Mount.RIGHT,
+        start_timeout_s=1,
+    )
+
+    handle = subject.get_update_process_handle("update-id")
+    status = await handle.get_process_summary()
+    assert status == UpdateProcessSummary(
+        details=ProcessDetails(
+            created_at=created_at,
+            update_id="update-id",
+            mount=OT3Mount.RIGHT,
+        ),
+        progress=UpdateProgress(
+            state=UpdateState.done,
+            progress=100,
+        ),
+    )
+
+
+@pytest.mark.ot3_only
+async def test_start_update_on_missing_instrument(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should raise error if instrument is no longer attached."""
+    created_at = datetime(year=2023, month=12, day=2)
+    decoy.when(ot3_hardware_api.get_firmware_update_progress()).then_return({})
+    decoy.when(ot3_hardware_api.get_all_attached_instr()).then_return(
+        {OT3Mount.RIGHT: None}
+    )
+
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    with pytest.raises(InstrumentNotFound):
+        await subject.start_update_process(
+            update_id="update-id",
+            created_at=created_at,
+            mount=OT3Mount.RIGHT,
+            start_timeout_s=1,
+        )
+    with pytest.raises(UpdateIdNotFound):
+        subject.get_update_process_handle("update-id")
+
+
+@pytest.mark.ot3_only
+async def test_start_update_with_same_id_twice(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should raise an error if an update is created twice."""
+    created_at = datetime(year=2023, month=12, day=2)
+    mock_right_present_no_updates(ot3_hardware_api, decoy)
+    inject_queue = build_firmware_progress_injector(
+        decoy, ot3_hardware_api, OT3Mount.RIGHT
+    )
+    await inject_queue.put(
+        UpdateStatus(
+            subsystem=OT3SubSystem.pipette_right, state=UpdateState.done, progress=100
+        )
+    )
+
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    _ = await subject.start_update_process("update-id-1", OT3Mount.RIGHT, created_at, 1)
+    with pytest.raises(UpdateIdExists):
+        await subject.start_update_process(
+            "update-id-1",
+            OT3Mount.LEFT,
+            created_at + timedelta(minutes=10),
+            start_timeout_s=1,
+        )
+
+
+@pytest.mark.ot3_only
+async def test_start_update_while_update_in_progress(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should refuse to update a device that is already being updated."""
+    created_at = datetime(year=2023, month=12, day=2)
+    inject_queue = build_firmware_progress_injector(
+        decoy, ot3_hardware_api, OT3Mount.RIGHT
+    )
+    await inject_queue.put(
+        UpdateStatus(
+            subsystem=OT3SubSystem.pipette_right, state=UpdateState.done, progress=100
+        )
+    )
+    decoy.when(ot3_hardware_api.get_firmware_update_progress()).then_return(
+        {
+            OT3SubSystem.pipette_right: UpdateStatus(
+                subsystem=OT3SubSystem.pipette_right,
+                state=UpdateState.updating,
+                progress=10,
+            )
+        }
+    )
+    decoy.when(ot3_hardware_api.get_all_attached_instr()).then_return(
+        {OT3Mount.RIGHT: get_default_pipette_dict()}
+    )
+
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    with pytest.raises(UpdateInProgress):
+        await subject.start_update_process(
+            "update-id-1", OT3Mount.RIGHT, created_at, start_timeout_s=1
+        )
+
+
+@pytest.mark.ot3_only
+async def test_update_failure(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should raise error if an instrument completes update process but still requires update."""
+    created_at = datetime(year=2023, month=12, day=2)
+    mock_right_present_no_updates(ot3_hardware_api, decoy)
+    inject_queue = build_firmware_progress_injector(
+        decoy, ot3_hardware_api, OT3Mount.RIGHT
+    )
+    await inject_queue.put(
+        UpdateStatus(OT3SubSystem.pipette_right, UpdateState.updating, 2)
+    )
+
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    handle = await subject.start_update_process(
+        update_id="update-id",
+        created_at=created_at,
+        mount=OT3Mount.RIGHT,
+        start_timeout_s=1,
+    )
+    assert (await handle.get_progress()) == UpdateProgress(UpdateState.updating, 2)
+    await inject_queue.put(RuntimeError("Oh no! Something went wrong!"))
+    # Need a yield to let the update task pull the inject queue
+    await asyncio.sleep(0)
+    with pytest.raises(UpdateFailed):
+        await handle.get_progress()
+
+
+@pytest.mark.ot3_only
+async def test_immediate_update_failure(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should raise error if an instrument completes update process but still requires update."""
+    created_at = datetime(year=2023, month=12, day=2)
+    inject_queue = build_firmware_progress_injector(
+        decoy, ot3_hardware_api, OT3Mount.RIGHT
+    )
+    mock_right_present_no_updates(ot3_hardware_api, decoy)
+    await inject_queue.put(
+        UpdateStatus(
+            subsystem=OT3SubSystem.pipette_right,
+            state=UpdateState.updating,
+            progress=42,
+        )
+    )
+    await inject_queue.put(RuntimeError("Oh no! Something went wrong!"))
+
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+    handle = await subject.start_update_process(
+        update_id="update-id",
+        created_at=created_at,
+        mount=OT3Mount.RIGHT,
+        start_timeout_s=1,
+    )
+    with pytest.raises(UpdateFailed):
+        await handle.get_process_summary()
+
+
+@pytest.mark.ot3_only
+def test_get_non_existent_update_progress(
+    decoy: Decoy, ot3_hardware_api: OT3API, task_runner: TaskRunner
+) -> None:
+    """It should raise an error when fetching status using a non-existent ID."""
+    subject = FirmwareUpdateManager(hw_handle=ot3_hardware_api, task_runner=task_runner)
+
+    with pytest.raises(UpdateIdNotFound):
+        subject.get_update_process_handle("update-id")

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -1,17 +1,26 @@
 """Tests for /instruments routes."""
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
-from typing import TYPE_CHECKING, cast
-from decoy import Decoy
+from typing import TYPE_CHECKING, cast, Optional
+from decoy import Decoy, matchers
 
 from opentrons.calibration_storage.types import CalibrationStatus, SourceType
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.hardware_control.dev_types import (
+    PipetteDict,
+    GripperDict,
+)
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
 )
-from opentrons.hardware_control.types import GripperJawState
+from opentrons.hardware_control.types import (
+    GripperJawState,
+    OT3Mount,
+    UpdateState,
+)
 from opentrons.protocol_engine.types import Vec3f
 from opentrons.types import Point, Mount
 from opentrons_shared_data.gripper.gripper_definition import (
@@ -19,6 +28,7 @@ from opentrons_shared_data.gripper.gripper_definition import (
     GripperModel,
 )
 from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from robot_server.errors import ApiError
 
 from robot_server.instruments.instrument_models import (
     Gripper,
@@ -26,8 +36,30 @@ from robot_server.instruments.instrument_models import (
     Pipette,
     PipetteData,
     GripperCalibrationData,
+    UpdateCreate,
+    UpdateProgressData,
 )
-from robot_server.instruments.router import get_attached_instruments
+from robot_server.instruments.router import (
+    get_attached_instruments,
+    update_firmware,
+    get_firmware_update_status,
+    get_firmware_update_manager,
+    UPDATE_CREATE_TIMEOUT_S,
+)
+from robot_server.instruments.firmware_update_manager import (
+    FirmwareUpdateManager,
+    UpdateIdNotFound,
+    UpdateProcessHandle,
+    UpdateProcessSummary,
+    UpdateProgress,
+    ProcessDetails,
+    InstrumentNotFound,
+    UpdateInProgress,
+    UpdateFailed,
+)
+from robot_server.service.json_api import RequestModel
+from robot_server.service.task_runner import TaskRunner
+
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
@@ -39,10 +71,25 @@ def hardware_api(decoy: Decoy) -> HardwareControlAPI:
     return decoy.mock(cls=HardwareControlAPI)
 
 
+@pytest.fixture
+def task_runner(decoy: Decoy) -> TaskRunner:
+    """Get a mocked out TaskRunner."""
+    return decoy.mock(cls=TaskRunner)
+
+
+@pytest.fixture
+def firmware_update_manager(decoy: Decoy) -> FirmwareUpdateManager:
+    """Get a mock UpdateProgressMonitor."""
+    return decoy.mock(cls=FirmwareUpdateManager)
+
+
 def get_sample_pipette_dict(
     name: PipetteName,
     model: PipetteModel,
     pipette_id: str,
+    fw_update_required: Optional[bool] = None,
+    fw_current_version: Optional[int] = None,
+    fw_next_version: Optional[int] = None,
 ) -> PipetteDict:
     """Return a sample PipetteDict."""
     pipette_dict: PipetteDict = {  # type: ignore [typeddict-item]
@@ -53,6 +100,9 @@ def get_sample_pipette_dict(
         "min_volume": 1,
         "max_volume": 1,
         "channels": 1,
+        "fw_update_required": fw_update_required,
+        "fw_current_version": fw_current_version,
+        "fw_next_version": fw_next_version,
     }
     return pipette_dict
 
@@ -69,9 +119,6 @@ def ot3_hardware_api(decoy: Decoy) -> OT3API:
         return None  # type: ignore[return-value]
 
 
-# TODO (spp, 2022-01-17): remove xfail once robot server test flow is set up to handle
-#  OT2 vs OT3 tests correclty
-@pytest.mark.xfail
 @pytest.mark.ot3_only
 async def test_get_instruments_empty(
     decoy: Decoy,
@@ -85,46 +132,55 @@ async def test_get_instruments_empty(
     assert result.status_code == 200
 
 
-# TODO (spp, 2022-01-17): remove xfail once robot server test flow is set up to handle
-#  OT2 vs OT3 tests correclty
-@pytest.mark.xfail
 @pytest.mark.ot3_only
 async def test_get_all_attached_instruments(
     decoy: Decoy,
     ot3_hardware_api: OT3API,
 ) -> None:
     """It should get data of all attached instruments."""
+    left_pipette_dict = get_sample_pipette_dict(
+        name="p10_multi",
+        model=PipetteModel("abc"),
+        pipette_id="my-pipette-id",
+        fw_current_version=123,
+        fw_next_version=234,
+        fw_update_required=False,
+    )
+    left_pipette_dict.update({"fw_next_version": 234})
+    right_pipette_dict = get_sample_pipette_dict(
+        name="p20_multi_gen2",
+        model=PipetteModel("xyz"),
+        pipette_id="my-other-pipette-id",
+        fw_current_version=123,
+        fw_next_version=None,
+        fw_update_required=True,
+    )
 
     def rehearse_instrument_retrievals() -> None:
         decoy.when(ot3_hardware_api.attached_gripper).then_return(
-            {
-                "model": GripperModel.v1,
-                "gripper_id": "GripperID321",
-                "display_name": "my-special-gripper",
-                "state": GripperJawState.UNHOMED,
-                "calibration_offset": GripperCalibrationOffset(
-                    offset=Point(x=1, y=2, z=3),
-                    source=SourceType.default,
-                    status=CalibrationStatus(markedBad=False),
-                    last_modified=None,
-                ),
-                "fw_update_required": False,
-                "fw_current_version": 1,
-                "fw_next_version": None,
-            }
+            cast(
+                GripperDict,
+                {
+                    "model": GripperModel.v1,
+                    "fw_current_version": 123,
+                    "fw_update_required": True,
+                    "gripper_id": "GripperID321",
+                    "display_name": "my-special-gripper",
+                    "state": GripperJawState.UNHOMED,
+                    "calibration_offset": GripperCalibrationOffset(
+                        offset=Point(x=1, y=2, z=3),
+                        source=SourceType.default,
+                        status=CalibrationStatus(markedBad=False),
+                        last_modified=None,
+                    ),
+                    "fw_next_version": None,
+                },
+            )
         )
         decoy.when(ot3_hardware_api.attached_pipettes).then_return(
             {
-                Mount.LEFT: get_sample_pipette_dict(
-                    name="p10_multi",
-                    model=PipetteModel("abc"),
-                    pipette_id="my-pipette-id",
-                ),
-                Mount.RIGHT: get_sample_pipette_dict(
-                    name="p20_multi_gen2",
-                    model=PipetteModel("xyz"),
-                    pipette_id="my-other-pipette-id",
-                ),
+                Mount.LEFT: left_pipette_dict,
+                Mount.RIGHT: right_pipette_dict,
             }
         )
 
@@ -132,6 +188,13 @@ async def test_get_all_attached_instruments(
     # cache_instruments is called before fetching attached pipette and gripper data.
     decoy.when(await ot3_hardware_api.cache_instruments()).then_do(
         rehearse_instrument_retrievals
+    )
+
+    decoy.when(ot3_hardware_api.attached_pipettes).then_return(
+        {
+            Mount.LEFT: left_pipette_dict,
+            Mount.RIGHT: right_pipette_dict,
+        }
     )
     result = await get_attached_instruments(hardware=ot3_hardware_api)
 
@@ -142,6 +205,9 @@ async def test_get_all_attached_instruments(
             instrumentName="p10_multi",
             instrumentModel=PipetteModel("abc"),
             serialNumber="my-pipette-id",
+            currentFirmwareVersion=123,
+            firmwareUpdateRequired=False,
+            nextAvailableFirmwareVersion=234,
             data=PipetteData(
                 channels=1,
                 min_volume=1,
@@ -154,6 +220,9 @@ async def test_get_all_attached_instruments(
             instrumentName="p20_multi_gen2",
             instrumentModel=PipetteModel("xyz"),
             serialNumber="my-other-pipette-id",
+            currentFirmwareVersion=123,
+            firmwareUpdateRequired=True,
+            nextAvailableFirmwareVersion=None,
             data=PipetteData(
                 channels=1,
                 min_volume=1,
@@ -165,6 +234,8 @@ async def test_get_all_attached_instruments(
             instrumentType="gripper",
             instrumentModel=GripperModelStr("gripperV1"),
             serialNumber="GripperID321",
+            currentFirmwareVersion=123,
+            firmwareUpdateRequired=True,
             data=GripperData(
                 jawState="unhomed",
                 calibratedOffset=GripperCalibrationData(
@@ -209,6 +280,9 @@ async def test_get_ot2_instruments(
             instrumentName="p20_multi_gen2",
             instrumentModel=PipetteModel("xyz"),
             serialNumber="pipette-id",
+            currentFirmwareVersion=None,
+            firmwareUpdateRequired=None,
+            nextAvailableFirmwareVersion=None,
             data=PipetteData(
                 channels=1,
                 min_volume=1,
@@ -216,3 +290,280 @@ async def test_get_ot2_instruments(
             ),
         )
     ]
+
+
+def get_good_start_status(
+    mount: OT3Mount, update_id: str, created: datetime
+) -> UpdateProcessSummary:
+    """Utility function to set up what an update process should return."""
+    return UpdateProcessSummary(
+        details=ProcessDetails(created_at=created, mount=mount, update_id=update_id),
+        progress=UpdateProgress(state=UpdateState.updating, progress=10),
+    )
+
+
+async def decoy_ok_fw_update_start(
+    decoy: Decoy,
+    firmware_update_manager: FirmwareUpdateManager,
+    update_id: str,
+    mount: OT3Mount,
+    created_at: datetime,
+    start_timeout_s: float,
+    first_summary: UpdateProcessSummary,
+) -> UpdateProcessHandle:
+    """Utility function to set up a properly-started update process."""
+    uph_decoy = decoy.mock(cls=UpdateProcessHandle)
+    decoy.when(
+        await firmware_update_manager.start_update_process(
+            update_id, mount, created_at, start_timeout_s
+        )
+    ).then_return(uph_decoy)
+    decoy.when(await uph_decoy.get_process_summary()).then_return(first_summary)
+    return uph_decoy
+
+
+@pytest.mark.ot3_only
+async def test_update_instrument_firmware(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+    task_runner: TaskRunner,
+) -> None:
+    """It should call start an update in the firmware update manager."""
+    update_id = "update-id"
+    update_resource_created_at = datetime(year=2023, month=1, day=1)
+    expected_status = get_good_start_status(
+        OT3Mount.LEFT, "update-id", update_resource_created_at
+    )
+    expected_update_response = UpdateProgressData(
+        id=update_id,
+        createdAt=update_resource_created_at,
+        mount="left",
+        updateStatus=expected_status.progress.state,
+        updateProgress=expected_status.progress.progress,
+    )
+    _ = await decoy_ok_fw_update_start(
+        decoy,
+        firmware_update_manager,
+        update_id,
+        OT3Mount.LEFT,
+        update_resource_created_at,
+        UPDATE_CREATE_TIMEOUT_S,
+        get_good_start_status(OT3Mount.LEFT, update_id, update_resource_created_at),
+    )
+
+    update_result = await update_firmware(
+        request_body=RequestModel(data=UpdateCreate(mount="left")),
+        update_process_id=update_id,
+        created_at=update_resource_created_at,
+        hardware=ot3_hardware_api,
+        firmware_update_manager=firmware_update_manager,
+    )
+
+    assert update_result.content.data == expected_update_response
+    assert update_result.status_code == 201
+
+    decoy.verify(
+        await ot3_hardware_api.cache_instruments(),
+        await firmware_update_manager.start_update_process(
+            update_id,
+            OT3Mount.LEFT,
+            update_resource_created_at,
+            UPDATE_CREATE_TIMEOUT_S,
+        ),
+    )
+
+
+@pytest.mark.ot3_only
+async def test_update_instrument_firmware_times_out(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+) -> None:
+    """It should raise an UpdateInfoNotAvailable error when timed out trying to fetch status."""
+    update_id = "update-id"
+    update_resource_created_at = datetime(year=2023, month=1, day=1)
+    decoy.when(
+        await firmware_update_manager.start_update_process(
+            update_id,
+            OT3Mount.LEFT,
+            update_resource_created_at,
+            UPDATE_CREATE_TIMEOUT_S,
+        )
+    ).then_raise(TimeoutError())
+    decoy.when(
+        await firmware_update_manager.complete_update_process("update-id")
+    ).then_return(None)
+
+    with pytest.raises(ApiError) as exc_info:
+        await update_firmware(
+            request_body=RequestModel(data=UpdateCreate(mount="left")),
+            update_process_id=update_id,
+            created_at=update_resource_created_at,
+            hardware=ot3_hardware_api,
+            firmware_update_manager=firmware_update_manager,
+        )
+    assert exc_info.value.status_code == 408
+    assert exc_info.value.content["errors"][0]["id"] == "TimeoutStartingUpdate"
+    decoy.verify(
+        await firmware_update_manager.complete_update_process(update_id),
+    )
+
+
+@pytest.mark.ot3_only
+async def test_update_instrument_firmware_without_instrument(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+) -> None:
+    """It should raise error when updating a mount with no instrument."""
+    update_id = "update-id"
+    update_resource_created_at = datetime(year=2023, month=1, day=1)
+
+    decoy.when(
+        await firmware_update_manager.start_update_process(
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+        ),
+    ).then_raise(InstrumentNotFound())
+    with pytest.raises(ApiError) as exc_info:
+        await update_firmware(
+            request_body=RequestModel(data=UpdateCreate(mount="left")),
+            update_process_id=update_id,
+            created_at=update_resource_created_at,
+            hardware=ot3_hardware_api,
+            firmware_update_manager=firmware_update_manager,
+        )
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "InstrumentNotFound"
+
+
+@pytest.mark.ot3_only
+async def test_update_instrument_firmware_with_conflicting_update(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+) -> None:
+    """It should raise an error when updating an instrument that is already updating."""
+    update_id = "update-id"
+    update_resource_created_at = datetime(year=2023, month=1, day=1)
+    decoy.when(
+        firmware_update_manager.start_update_process(
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+        )
+    ).then_raise(UpdateInProgress())
+    with pytest.raises(ApiError) as exc_info:
+        await update_firmware(
+            request_body=RequestModel(data=UpdateCreate(mount="left")),
+            update_process_id=update_id,
+            created_at=update_resource_created_at,
+            hardware=ot3_hardware_api,
+            firmware_update_manager=firmware_update_manager,
+        )
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["id"] == "UpdateInProgress"
+
+
+@pytest.mark.ot3_only
+async def test_update_task_immediate_failure(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+) -> None:
+    """It should call hardware control's firmware update method and create update resource."""
+    update_id = "update-id"
+    update_resource_created_at = datetime(year=2023, month=1, day=1)
+
+    decoy.when(
+        firmware_update_manager.start_update_process(
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+            matchers.Anything(),
+        )
+    ).then_raise(UpdateFailed())
+
+    with pytest.raises(ApiError) as exc_info:
+        await update_firmware(
+            request_body=RequestModel(data=UpdateCreate(mount="left")),
+            update_process_id=update_id,
+            created_at=update_resource_created_at,
+            hardware=ot3_hardware_api,
+            firmware_update_manager=firmware_update_manager,
+        )
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.content["errors"][0]["id"] == "FirmwareUpdateFailed"
+
+
+@pytest.mark.ot3_only
+async def test_get_firmware_update_status(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+) -> None:
+    """It should get firmware update status of specified update process."""
+    expected_response = UpdateProgressData(
+        id="shiny-new-update-id",
+        createdAt=datetime(year=3000, month=12, day=1),
+        mount="extension",
+        updateStatus=UpdateState.done,
+        updateProgress=123,
+    )
+    handle = decoy.mock(cls=UpdateProcessHandle)
+
+    decoy.when(
+        firmware_update_manager.get_update_process_handle("shiny-new-update-id")
+    ).then_return(handle)
+    decoy.when(await handle.get_process_summary()).then_return(
+        UpdateProcessSummary(
+            details=ProcessDetails(
+                created_at=datetime(year=3000, month=12, day=1),
+                mount=OT3Mount.GRIPPER,
+                update_id="shiny-new-update-id",
+            ),
+            progress=UpdateProgress(state=UpdateState.done, progress=123),
+        )
+    )
+
+    update_status = await get_firmware_update_status(
+        update_id="shiny-new-update-id", firmware_update_manager=firmware_update_manager
+    )
+
+    assert update_status.content.data == expected_response
+    assert update_status.status_code == 200
+
+
+@pytest.mark.ot3_only
+async def test_get_firmware_update_status_of_wrong_id(
+    decoy: Decoy,
+    ot3_hardware_api: OT3API,
+    firmware_update_manager: FirmwareUpdateManager,
+) -> None:
+    """It should raise error when fetching status of an invalid update resource."""
+    decoy.when(
+        firmware_update_manager.get_update_process_handle("imaginary-update-id")
+    ).then_raise(UpdateIdNotFound("womp womp..."))
+
+    with pytest.raises(ApiError) as exc_info:
+        await get_firmware_update_status(
+            update_id="imaginary-update-id",
+            firmware_update_manager=firmware_update_manager,
+        )
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "IDNotFound"
+
+
+@pytest.mark.ot3_only
+async def test_get_firmware_update_manager_is_singleton(
+    ot3_hardware_api: OT3API,
+) -> None:
+    """It should return the same instance of UpdateProgressMonitor in multiple calls."""
+    manager1 = await get_firmware_update_manager(hardware_api=ot3_hardware_api)
+    manager2 = await get_firmware_update_manager(hardware_api=ot3_hardware_api)
+
+    assert manager1 is manager2


### PR DESCRIPTION
This PR adds support for running Flex tool (pipette and gripper) firmware updates via the robot server, using two new routes.

`POST /instruments/update  {"data": {"mount": "left" | "right" | "extension"}}` starts a firmware update and gives you an id
`GET /instruments/update/:id` gets the progress of the ongoing firmware update

Clients should be able to poll the update endpoint as fast as they want, though progress is internally limited to integer percentages. This should also be safe for multiple clients to be simultaneously polling, though it's unclear how other clients would know it was happening.

## Open Questions
### Is this the right API?
I mean, generally I'm open to different opinions about this, but I have two specific things I wonder:
- We're much more likely now to have multiple clients, of course. We probably want to have the ODD do something when you're attaching a pipette and it needs a firmware update. That, to me, means we need a really fast `GET /instrument/updates` that returns a list of IDs of ongoing firmware updates
- It doesn't feel like we've got a clean way for things to know when an update is done. Right now, you get an update that says the state is "done" and then the update id goes away. You're guaranteed to get the "done" or "error" state because we only remove finished updates after the poll, but then again that means we're modifying resources in a `GET`. One other way to do this might be to require an explicit `DELETE /instruments/updates/:id`, or something where clients can "register interest" or something and later say "ok i'm done"
 
### Is this a good robot server PR?
I think we've got ok tests for the route handler and the update manager, but I don't know if we have some more needs around there

## Testing
All our testing can be done using the lovely script. What we need to test is all on a flex, and is:
- [x] You can update one device at a time, when that device is connected and running its application firmware with a version that is wrong and needs an update
- [ ] You can update multiple devices at a time, see above
- [ ] If you hit the endpoint and there's no devices attached, you don't get to do an update
- [ ] If you hit the endpoint and pull the device away, you get an error

## Known Improvements
- This definitely doesn't handle a pipette that has a broken application and boots right to its bootloader. This is a fully recoverable state technically, but right now it wouldn't show up in `GET /instruments` or internally in `get_all_attached_instrs()` so we can't update it using the API we've added here. 

Honestly, I think the right path may be to have an API that is not pipettes but subsystems. We have these enumerated anyway, and these work on a different level than instruments and shouldn't be entangled.

## Review Requests and Advice
- Go commit-by-commit and appreciate my lovely commit messages and organization (also it'll be easier to follow I hope)

## Risks
- None, nothing is calling these routes and without callers they don't do anything.

Closes RCORE-482, RCORE-483
Supercedes #12263