### PR TITLE
refactor(odd): instruments setup touchups

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -174,5 +174,6 @@
   "calibration_status": "calibration status",
   "total_vol": "total volume",
   "calibrated": "calibrated",
-  "calibrate": "calibrate"
+  "calibrate": "calibrate",
+  "96_mount": "left + right mount"
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -168,9 +168,11 @@
   "opening": "Opening...",
   "closing": "Closing...",
   "calibration": "Calibration",
-  "mount": "{{mount}} Mount",
-  "no_data": "No data",
+  "mount": "{{mount}} mount",
+  "no_data": "no data",
   "attach": "attach",
   "calibration_status": "calibration status",
-  "total_vol": "total volume"
+  "total_vol": "total volume",
+  "calibrated": "calibrated",
+  "calibrate": "calibrate"
 }

--- a/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
@@ -6,15 +6,15 @@ import {
   NINETY_SIX_CHANNEL,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
-import type { Mount } from '../../redux/pipettes/types'
 import { ChoosePipette } from '../PipetteWizardFlows/ChoosePipette'
 import { FLOWS } from '../PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../PipetteWizardFlows'
 import { GripperWizardFlows } from '../GripperWizardFlows'
 import { GRIPPER_FLOW_TYPES } from '../GripperWizardFlows/constants'
-import type { InstrumentData } from '@opentrons/api-client'
-import type { SelectablePipettes } from '../PipetteWizardFlows/types'
 import { LabeledMount } from './LabeledMount'
+import type { InstrumentData } from '@opentrons/api-client'
+import type { Mount } from '../../redux/pipettes/types'
+import type { SelectablePipettes } from '../PipetteWizardFlows/types'
 
 interface AttachedInstrumentMountItemProps {
   mount: Mount | 'extension'

--- a/app/src/organisms/InstrumentMountItem/LabeledMount.tsx
+++ b/app/src/organisms/InstrumentMountItem/LabeledMount.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
   ALIGN_CENTER,
@@ -13,9 +14,8 @@ import {
   ALIGN_FLEX_START,
   BORDERS,
 } from '@opentrons/components'
-import type { Mount } from '../../redux/pipettes/types'
 import { StyledText } from '../../atoms/text'
-import { useTranslation } from 'react-i18next'
+import type { Mount } from '../../redux/pipettes/types'
 
 const MountButton = styled.button<{ isAttached: boolean }>`
   display: flex;

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -60,7 +60,7 @@ interface ProtocolInstrumentMountItemProps {
 export function ProtocolInstrumentMountItem(
   props: ProtocolInstrumentMountItemProps
 ): JSX.Element {
-  const { t } = useTranslation('protocol_setup')
+  const { t, i18n } = useTranslation('protocol_setup')
   const { mount, attachedInstrument, speccedName } = props
 
   const [showChoosePipetteModal, setShowChoosePipetteModal] = React.useState(
@@ -97,7 +97,9 @@ export function ProtocolInstrumentMountItem(
             flexDirection={DIRECTION_COLUMN}
             gridGap={SPACING.spacing2}
           >
-            <MountLabel>{t('mount', { mount })}</MountLabel>
+            <MountLabel>
+              {i18n.format(t('mount', { mount }), 'capitalize')}
+            </MountLabel>
             <SpeccedInstrumentName>
               {mount === 'extension'
                 ? getGripperDisplayName(speccedName as GripperModel)
@@ -123,7 +125,10 @@ export function ProtocolInstrumentMountItem(
             <CalibrationStatus
               color={isAttachedWithCal ? COLORS.green_one : COLORS.yellow_one}
             >
-              {isAttachedWithCal ? t('calibrated') : t('no_data')}
+              {i18n.format(
+                t(isAttachedWithCal ? 'calibrated' : 'no_data'),
+                'capitalize'
+              )}
             </CalibrationStatus>
           </Flex>
           <Flex flex="1">
@@ -131,12 +136,12 @@ export function ProtocolInstrumentMountItem(
               onClick={
                 attachedInstrument != null ? handleCalibrate : handleAttach
               }
-              buttonText={
-                attachedInstrument != null ? t('calibrate') : t('attach')
-              }
+              buttonText={i18n.format(
+                t(attachedInstrument != null ? 'calibrate' : 'attach'),
+                'capitalize'
+              )}
               buttonType="default"
               buttonCategory="rounded"
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
             />
           </Flex>
         </Flex>
@@ -161,7 +166,6 @@ export function ProtocolInstrumentMountItem(
 const MountLabel = styled.p`
   font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
   text-align: ${TYPOGRAPHY.textAlignLeft};
-  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
   font-size: ${TYPOGRAPHY.fontSize22};
   line-height: ${TYPOGRAPHY.lineHeight28};
 `
@@ -169,7 +173,6 @@ const MountLabel = styled.p`
 const SpeccedInstrumentName = styled.p`
   font-weight: ${TYPOGRAPHY.fontWeightRegular};
   text-align: ${TYPOGRAPHY.textAlignLeft};
-  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
   font-size: ${TYPOGRAPHY.fontSize22};
   line-height: ${TYPOGRAPHY.lineHeight28};
 `
@@ -177,7 +180,6 @@ const SpeccedInstrumentName = styled.p`
 const CalibrationStatus = styled.p`
   font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
   text-align: ${TYPOGRAPHY.textAlignLeft};
-  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
   font-size: ${TYPOGRAPHY.fontSize22};
   line-height: ${TYPOGRAPHY.lineHeight28};
   color: ${({ color }) => color};

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -85,6 +85,7 @@ export function ProtocolInstrumentMountItem(
       attachedInstrument
     )
   }
+  const is96ChannelPipette = speccedName === 'p1000_96'
   // TODO: check for presence of calibration data once instruments endpoint
   // returns calibration data for pipettes
   const isAttachedWithCal = attachedInstrument != null
@@ -98,7 +99,10 @@ export function ProtocolInstrumentMountItem(
             gridGap={SPACING.spacing2}
           >
             <MountLabel>
-              {i18n.format(t('mount', { mount }), 'capitalize')}
+              {i18n.format(
+                is96ChannelPipette ? t('96_mount') : t('mount', { mount }),
+                'capitalize'
+              )}
             </MountLabel>
             <SpeccedInstrumentName>
               {mount === 'extension'

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -42,6 +42,17 @@ describe('ProtocolInstrumentMountItem', () => {
     getByText('Flex 8-Channel 1000 μL')
     getByText('Attach')
   })
+  it('renders the correct information when there is no pipette attached for 96 channel', () => {
+    props = {
+      ...props,
+      speccedName: 'p1000_96',
+    }
+    const { getByText } = render(props)
+    getByText('Left + right mount')
+    getByText('No data')
+    getByText('Flex 96-Channel 1000 μL')
+    getByText('Attach')
+  })
   it('renders the correct information when there is a pipette attached with cal data', () => {
     props = {
       ...props,

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+import { LEFT, renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { ProtocolInstrumentMountItem } from '..'
+
+const mockGripperData = {
+  instrumentModel: 'gripper_v1',
+  instrumentType: 'gripper',
+  mount: 'extension',
+  serialNumber: 'ghi789',
+}
+const mockLeftPipetteData = {
+  instrumentModel: 'p1000_multi_gen3',
+  instrumentType: 'p1000',
+  mount: 'left',
+  serialNumber: 'def456',
+}
+
+const render = (
+  props: React.ComponentProps<typeof ProtocolInstrumentMountItem>
+) => {
+  return renderWithProviders(<ProtocolInstrumentMountItem {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('ProtocolInstrumentMountItem', () => {
+  let props: React.ComponentProps<typeof ProtocolInstrumentMountItem>
+  beforeEach(() => {
+    props = {
+      mount: LEFT,
+      attachedInstrument: null,
+      attachedCalibrationData: null,
+      speccedName: 'p1000_multi_gen3',
+    }
+  })
+
+  it('renders the correct information when there is no pipette attached', () => {
+    const { getByText } = render(props)
+    getByText('Left mount')
+    getByText('No data')
+    getByText('Flex 8-Channel 1000 μL')
+    getByText('Attach')
+  })
+  it('renders the correct information when there is a pipette attached with cal data', () => {
+    props = {
+      ...props,
+      mount: LEFT,
+      attachedInstrument: mockLeftPipetteData as any,
+    }
+    const { getByText } = render(props)
+    getByText('Left mount')
+    getByText('Calibrated')
+    getByText('Flex 8-Channel 1000 μL')
+    getByText('Calibrate')
+  })
+  it.todo(
+    'renders the pipette with no cal data and the calibration button and clicking on it launches the correct flow '
+  )
+  it.todo(
+    'renders the attach button and clicking on it launches the correct flow '
+  )
+  it('renders the correct information when gripper needs to be atached', () => {
+    props = {
+      ...props,
+      mount: 'extension',
+      speccedName: 'gripperV1',
+    }
+    const { getByText } = render(props)
+    getByText('Extension mount')
+    getByText('No data')
+    getByText('Gripper V1')
+    getByText('Attach')
+  })
+  it('renders the correct information when gripper is attached', () => {
+    props = {
+      ...props,
+      mount: 'extension',
+      speccedName: 'gripperV1',
+      attachedInstrument: mockGripperData as any,
+    }
+    const { getByText } = render(props)
+    getByText('Extension mount')
+    getByText('Calibrated')
+    getByText('Gripper V1')
+  })
+})

--- a/app/src/organisms/ProtocolSetupInstruments/__tests__/ProtocolSetupInstruments.test.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/__tests__/ProtocolSetupInstruments.test.tsx
@@ -10,8 +10,8 @@ import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
 import { useMostRecentCompletedAnalysis } from '../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
-import { ProtocolSetupInstruments } from '..'
 import { mockRecentAnalysis } from '../__fixtures__'
+import { ProtocolSetupInstruments } from '..'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock(
@@ -89,7 +89,7 @@ describe('ProtocolSetupInstruments', () => {
     const [{ getByText, getByRole }] = render()
     getByText('Instruments')
     getByText('Location')
-    getByText('calibration status')
+    getByText('Calibration Status')
     getByRole('button', { name: 'continue' })
   })
 

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -103,7 +103,7 @@ export function ProtocolSetupInstruments({
         <ProtocolInstrumentMountItem
           key="extension"
           mount="extension"
-          speccedName={'attachedGripperMatch?.instrumentModel' as GripperModel}
+          speccedName={attachedGripperMatch?.instrumentModel as GripperModel}
           attachedInstrument={attachedGripperMatch}
           attachedCalibrationData={
             attachedGripperMatch?.data.calibratedOffset ?? null

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -99,11 +99,11 @@ export function ProtocolSetupInstruments({
           />
         )
       })}
-      {usesGripper && attachedGripperMatch != null ? (
+      {usesGripper ? (
         <ProtocolInstrumentMountItem
           key="extension"
           mount="extension"
-          speccedName={attachedGripperMatch?.instrumentModel as GripperModel}
+          speccedName={'gripperV1' as GripperModel}
           attachedInstrument={attachedGripperMatch}
           attachedCalibrationData={
             attachedGripperMatch?.data.calibratedOffset ?? null

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -1,3 +1,6 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
 import {
   COLORS,
   ALIGN_CENTER,
@@ -7,9 +10,6 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import * as React from 'react'
-import styled from 'styled-components'
-import { useTranslation } from 'react-i18next'
 import {
   useAllPipetteOffsetCalibrationsQuery,
   useInstrumentsQuery,
@@ -19,9 +19,9 @@ import { ContinueButton } from '../ProtocolSetupModules'
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { ProtocolInstrumentMountItem } from '../InstrumentMountItem'
 
-import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 import type { GripperData, PipetteData } from '@opentrons/api-client'
 import type { GripperModel } from '@opentrons/shared-data'
+import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 
 export interface ProtocolSetupInstrumentsProps {
   runId: string
@@ -32,7 +32,7 @@ export function ProtocolSetupInstruments({
   runId,
   setSetupScreen,
 }: ProtocolSetupInstrumentsProps): JSX.Element {
-  const { t } = useTranslation('protocol_setup')
+  const { t, i18n } = useTranslation('protocol_setup')
   const { data: attachedInstruments } = useInstrumentsQuery()
   const {
     data: allPipettesCalibrationData,
@@ -69,7 +69,9 @@ export function ProtocolSetupInstruments({
         paddingX={SPACING.spacing5}
       >
         <ColumnLabel>{t('location')}</ColumnLabel>
-        <ColumnLabel>{t('calibration_status')}</ColumnLabel>
+        <ColumnLabel>
+          {i18n.format(t('calibration_status'), 'sentenceCase')}
+        </ColumnLabel>
       </Flex>
       {(mostRecentAnalysis?.pipettes ?? []).map(loadedPipette => {
         const attachedPipetteMatch =
@@ -97,11 +99,11 @@ export function ProtocolSetupInstruments({
           />
         )
       })}
-      {usesGripper ? (
+      {usesGripper && attachedGripperMatch != null ? (
         <ProtocolInstrumentMountItem
           key="extension"
           mount="extension"
-          speccedName={attachedGripperMatch?.instrumentModel as GripperModel}
+          speccedName={'attachedGripperMatch?.instrumentModel' as GripperModel}
           attachedInstrument={attachedGripperMatch}
           attachedCalibrationData={
             attachedGripperMatch?.data.calibratedOffset ?? null


### PR DESCRIPTION
closes RCORE-735

# Overview

A few touchups to the instruments setup to match designs. 💅 

# Test Plan

- on an ODD, go to run setup with a protocol and click on the instruments setup section. It should match the hi fi designs.

# Changelog

- various cleanup with i18n formatter, adding some forgotten i18n keys, and cleaning up import order
- create test for `ProtocolInstrumentMountItem`

# Review requests

- see test plan

# Risk assessment

low