### PR TITLE
feat(odd): menuList and MenuItem ODD support

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,7 +6,7 @@ import { i18n } from '../app/src/i18n'
 export const customViewports = {
   onDeviceDisplay: {
     name: 'Touchscreen',
-    hover: 'none',
+    type: 'tablet',
     styles: {
       width: '1024px',
       height: '600px',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,23 @@
-export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
-}
-
 import React from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { GlobalStyle } from '../app/src/atoms/GlobalStyle'
 import { i18n } from '../app/src/i18n'
+
+export const customViewports = {
+  onDeviceDisplay: {
+    name: 'Touchscreen',
+    hover: 'none',
+    styles: {
+      width: '1024px',
+      height: '600px',
+    },
+  },
+}
+
+export const parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' },
+  viewport: { viewports: customViewports },
+}
 
 // Global decorator to apply the styles to all stories
 export const decorators = [

--- a/app/src/atoms/MenuList/MenuItem.stories.tsx
+++ b/app/src/atoms/MenuList/MenuItem.stories.tsx
@@ -14,4 +14,7 @@ const Template: Story<React.ComponentProps<typeof MenuItem>> = args => (
 export const Primary = Template.bind({})
 Primary.args = {
   children: 'Example menu btn',
+  isAlert: false,
+  isOnDevice: false,
+  disabled: false,
 }

--- a/app/src/atoms/MenuList/MenuItem.stories.tsx
+++ b/app/src/atoms/MenuList/MenuItem.stories.tsx
@@ -14,7 +14,6 @@ const Template: Story<React.ComponentProps<typeof MenuItem>> = args => (
 export const Primary = Template.bind({})
 Primary.args = {
   children: 'Example menu btn',
-  isAlert: false,
   disabled: false,
 }
 

--- a/app/src/atoms/MenuList/MenuItem.stories.tsx
+++ b/app/src/atoms/MenuList/MenuItem.stories.tsx
@@ -15,6 +15,11 @@ export const Primary = Template.bind({})
 Primary.args = {
   children: 'Example menu btn',
   isAlert: false,
-  isOnDevice: false,
   disabled: false,
+}
+
+Primary.parameters = {
+  viewport: {
+    defaultViewport: 'onDeviceDisplay',
+  },
 }

--- a/app/src/atoms/MenuList/MenuItem.tsx
+++ b/app/src/atoms/MenuList/MenuItem.tsx
@@ -4,44 +4,48 @@ import {
   COLORS,
   TYPOGRAPHY,
   ALIGN_CENTER,
+  RESPONSIVENESS,
 } from '@opentrons/components'
 
-import type { PrimitiveComponent } from '@opentrons/components'
-
-type BtnComponent = PrimitiveComponent<'button'>
-interface ButtonProps {
+export const MenuItem = styled.button<{
   isAlert?: boolean
-  isOnDevice?: boolean
-}
-
-export const MenuItem: BtnComponent = styled.button<ButtonProps>`
-  align-items: ${({ isOnDevice }) => (isOnDevice ? ALIGN_CENTER : 'auto')};
-  text-align: ${({ isOnDevice }) =>
-    isOnDevice ? TYPOGRAPHY.textAlignCenter : TYPOGRAPHY.textAlignLeft};
-  font-size: ${({ isOnDevice }) =>
-    isOnDevice ? TYPOGRAPHY.fontSize28 : TYPOGRAPHY.fontSizeP};
+}>`
+  text-align: ${TYPOGRAPHY.textAlignLeft};
+  font-size: ${TYPOGRAPHY.fontSizeP};
   background-color: ${({ isAlert }) =>
     isAlert ? COLORS.errorEnabled : COLORS.transparent};
   color: ${({ isAlert }) => (isAlert ? COLORS.white : COLORS.darkBlackEnabled)};
-  padding: ${({ isOnDevice }) =>
-    isOnDevice
-      ? `1.625rem 1.5rem`
-      : `${SPACING.spacing3} 0.75rem ${SPACING.spacing3} 0.75rem`};
-  height: ${({ isOnDevice }) => (isOnDevice ? '4.875rem' : 'auto')};
-  line-height: ${({ isOnDevice }) =>
-    isOnDevice ? TYPOGRAPHY.lineHeight36 : 'auto'};
+  padding: ${SPACING.spacing3} 0.75rem ${SPACING.spacing3} 0.75rem;
 
   &:hover,
   &:active {
-    background-color: ${({ isOnDevice }) =>
-      isOnDevice ? COLORS.darkBlack_twenty : COLORS.lightBlue};
+    background-color: ${COLORS.lightBlue};
   }
 
   &:disabled {
     background-color: ${COLORS.transparent};
-    color: ${({ isOnDevice }) =>
-      isOnDevice
-        ? COLORS.darkBlack_sixty
-        : `${COLORS.black}${COLORS.opacity50HexCode}`};
+    color: ${COLORS.black}${COLORS.opacity50HexCode};
+  }
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    align-items: ${ALIGN_CENTER};
+    text-align: ${TYPOGRAPHY.textAlignCenter};
+    font-size: ${TYPOGRAPHY.fontSize28};
+    background-color: ${({ isAlert }) =>
+      isAlert ? COLORS.errorEnabled : COLORS.transparent};
+    color: ${({ isAlert }) =>
+      isAlert ? COLORS.white : COLORS.darkBlackEnabled};
+    padding: 1.625rem 1.5rem;
+    height: 4.875rem;
+    line-height: ${TYPOGRAPHY.lineHeight36};
+    &:hover,
+    &:active {
+      background-color: ${COLORS.darkBlack_twenty};
+    }
+
+    &:disabled {
+      background-color: ${COLORS.transparent};
+      color: ${COLORS.darkBlack_sixty};
+    }
   }
 `

--- a/app/src/atoms/MenuList/MenuItem.tsx
+++ b/app/src/atoms/MenuList/MenuItem.tsx
@@ -15,34 +15,33 @@ interface ButtonProps {
 }
 
 export const MenuItem: BtnComponent = styled.button<ButtonProps>`
-  align-items: ${props => (props.isOnDevice ? ALIGN_CENTER : 'auto')};
-  text-align: ${props =>
-    props.isOnDevice ? TYPOGRAPHY.textAlignCenter : TYPOGRAPHY.textAlignLeft};
-  font-size: ${props =>
-    props.isOnDevice ? TYPOGRAPHY.fontSize28 : TYPOGRAPHY.fontSizeP};
-  background-color: ${props =>
-    props.isAlert ? COLORS.errorEnabled : COLORS.transparent};
-  color: ${props => (props.isAlert ? COLORS.white : COLORS.darkBlackEnabled)};
-  padding: ${props =>
-    props.isOnDevice
+  align-items: ${({ isOnDevice }) => (isOnDevice ? ALIGN_CENTER : 'auto')};
+  text-align: ${({ isOnDevice }) =>
+    isOnDevice ? TYPOGRAPHY.textAlignCenter : TYPOGRAPHY.textAlignLeft};
+  font-size: ${({ isOnDevice }) =>
+    isOnDevice ? TYPOGRAPHY.fontSize28 : TYPOGRAPHY.fontSizeP};
+  background-color: ${({ isAlert }) =>
+    isAlert ? COLORS.errorEnabled : COLORS.transparent};
+  color: ${({ isAlert }) => (isAlert ? COLORS.white : COLORS.darkBlackEnabled)};
+  padding: ${({ isOnDevice }) =>
+    isOnDevice
       ? `1.625rem 1.5rem`
       : `${SPACING.spacing3} 0.75rem ${SPACING.spacing3} 0.75rem`};
-  height: ${props => (props.isOnDevice ? '4.875rem' : 'auto')};
-  line-height: ${props =>
-    props.isOnDevice ? TYPOGRAPHY.lineHeight36 : 'auto'};
+  height: ${({ isOnDevice }) => (isOnDevice ? '4.875rem' : 'auto')};
+  line-height: ${({ isOnDevice }) =>
+    isOnDevice ? TYPOGRAPHY.lineHeight36 : 'auto'};
 
   &:hover,
   &:active {
-    background-color: ${props =>
-      props.isOnDevice ? COLORS.darkBlack_twenty : COLORS.lightBlue};
+    background-color: ${({ isOnDevice }) =>
+      isOnDevice ? COLORS.darkBlack_twenty : COLORS.lightBlue};
   }
 
-
-  &:disabled,
-  &.disabled {
+  &:disabled {
     background-color: ${COLORS.transparent};
-    color: ${props =>
-      props.isOnDevice
+    color: ${({ isOnDevice }) =>
+      isOnDevice
         ? COLORS.darkBlack_sixty
-        : `${COLORS.black} ${COLORS.opacity50HexCode}`};
+        : `${COLORS.black}${COLORS.opacity50HexCode}`};
+  }
 `

--- a/app/src/atoms/MenuList/MenuItem.tsx
+++ b/app/src/atoms/MenuList/MenuItem.tsx
@@ -1,30 +1,48 @@
 import styled from 'styled-components'
 import {
   SPACING,
-  Btn,
   COLORS,
-  TEXT_ALIGN_LEFT,
   TYPOGRAPHY,
+  ALIGN_CENTER,
 } from '@opentrons/components'
 
 import type { PrimitiveComponent } from '@opentrons/components'
 
 type BtnComponent = PrimitiveComponent<'button'>
+interface ButtonProps {
+  isAlert?: boolean
+  isOnDevice?: boolean
+}
 
-export const MenuItem: BtnComponent = styled(Btn)`
-  text-align: ${TEXT_ALIGN_LEFT};
-  font-size: ${TYPOGRAPHY.fontSizeP};
-  background-color: ${COLORS.transparent};
-  color: ${COLORS.darkBlackEnabled};
-  padding: ${SPACING.spacing3} 0.75rem ${SPACING.spacing3} 0.75rem;
+export const MenuItem: BtnComponent = styled.button<ButtonProps>`
+  align-items: ${props => (props.isOnDevice ? ALIGN_CENTER : 'auto')};
+  text-align: ${props =>
+    props.isOnDevice ? TYPOGRAPHY.textAlignCenter : TYPOGRAPHY.textAlignLeft};
+  font-size: ${props =>
+    props.isOnDevice ? TYPOGRAPHY.fontSize28 : TYPOGRAPHY.fontSizeP};
+  background-color: ${props =>
+    props.isAlert ? COLORS.errorEnabled : COLORS.transparent};
+  color: ${props => (props.isAlert ? COLORS.white : COLORS.darkBlackEnabled)};
+  padding: ${props =>
+    props.isOnDevice
+      ? `1.625rem 1.5rem`
+      : `${SPACING.spacing3} 0.75rem ${SPACING.spacing3} 0.75rem`};
+  height: ${props => (props.isOnDevice ? '4.875rem' : 'auto')};
+  line-height: ${props =>
+    props.isOnDevice ? TYPOGRAPHY.lineHeight36 : 'auto'};
 
-  &:hover {
-    background-color: ${COLORS.lightBlue};
+  &:hover,
+  &:active {
+    background-color: ${props =>
+      props.isOnDevice ? COLORS.darkBlack_twenty : COLORS.lightBlue};
   }
+
 
   &:disabled,
   &.disabled {
     background-color: ${COLORS.transparent};
-    color: ${COLORS.black}${COLORS.opacity50HexCode};
-  }
+    color: ${props =>
+      props.isOnDevice
+        ? COLORS.darkBlack_sixty
+        : `${COLORS.black} ${COLORS.opacity50HexCode}`};
 `

--- a/app/src/atoms/MenuList/MenuItem.tsx
+++ b/app/src/atoms/MenuList/MenuItem.tsx
@@ -5,11 +5,13 @@ import {
   TYPOGRAPHY,
   ALIGN_CENTER,
   RESPONSIVENESS,
+  StyleProps,
 } from '@opentrons/components'
 
-export const MenuItem = styled.button<{
+interface ButtonProps extends StyleProps {
   isAlert?: boolean
-}>`
+}
+export const MenuItem = styled.button<ButtonProps>`
   text-align: ${TYPOGRAPHY.textAlignLeft};
   font-size: ${TYPOGRAPHY.fontSizeP};
   background-color: ${({ isAlert }) =>

--- a/app/src/atoms/MenuList/MenuItem.tsx
+++ b/app/src/atoms/MenuList/MenuItem.tsx
@@ -9,14 +9,14 @@ import {
 } from '@opentrons/components'
 
 interface ButtonProps extends StyleProps {
+  /** optional isAlert boolean to turn the background red, only seen in ODD */
   isAlert?: boolean
 }
 export const MenuItem = styled.button<ButtonProps>`
   text-align: ${TYPOGRAPHY.textAlignLeft};
   font-size: ${TYPOGRAPHY.fontSizeP};
-  background-color: ${({ isAlert }) =>
-    isAlert ? COLORS.errorEnabled : COLORS.transparent};
-  color: ${({ isAlert }) => (isAlert ? COLORS.white : COLORS.darkBlackEnabled)};
+  background-color: ${COLORS.transparent};
+  color: ${COLORS.darkBlackEnabled};
   padding: ${SPACING.spacing3} 0.75rem ${SPACING.spacing3} 0.75rem;
 
   &:hover,
@@ -42,12 +42,15 @@ export const MenuItem = styled.button<ButtonProps>`
     line-height: ${TYPOGRAPHY.lineHeight36};
     &:hover,
     &:active {
-      background-color: ${COLORS.darkBlack_twenty};
+      background-color: ${({ isAlert }) =>
+        isAlert ? COLORS.errorEnabled : COLORS.darkBlack_twenty};
     }
 
     &:disabled {
-      background-color: ${COLORS.transparent};
-      color: ${COLORS.darkBlack_sixty};
+      background-color: ${({ isAlert }) =>
+        isAlert ? COLORS.errorEnabled : COLORS.transparent};
+      color: ${({ isAlert }) =>
+        isAlert ? COLORS.white : COLORS.darkBlack_sixty};
     }
   }
 `

--- a/app/src/atoms/MenuList/MenuList.stories.tsx
+++ b/app/src/atoms/MenuList/MenuList.stories.tsx
@@ -1,48 +1,41 @@
 import * as React from 'react'
-import { css } from 'styled-components'
-import {
-  Flex,
-  TYPOGRAPHY,
-  COLORS,
-  TEXT_ALIGN_LEFT,
-  SPACING,
-} from '@opentrons/components'
 import { MenuList } from './index'
+import { MenuItem } from './MenuItem'
 
 import type { Story, Meta } from '@storybook/react'
 
 export default {
   title: 'App/Atoms/MenuList',
   component: MenuList,
+  onClick: { action: 'clicked' },
 } as Meta
 
 const Template: Story<React.ComponentProps<typeof MenuList>> = args => (
   <MenuList {...args} />
 )
 
-const style = css`
-  width: auto;
-  text-align: ${TEXT_ALIGN_LEFT};
-  font-size: ${TYPOGRAPHY.fontSizeP};
-  padding-bottom: ${TYPOGRAPHY.fontSizeH6};
-  background-color: transparent;
-  color: ${COLORS.darkBlackEnabled};
-  padding-left: ${TYPOGRAPHY.fontSizeLabel};
-  padding-right: ${TYPOGRAPHY.fontSizeLabel};
-  padding-top: ${SPACING.spacing3};
-
-  &:hover {
-    background-color: ${COLORS.lightBlue};
-  }
-
-  &:disabled,
-  &.disabled {
-    color: ${COLORS.darkGreyDisabled};
-  }
-`
-const btn = <Flex css={style}>{'Example menu btn'}</Flex>
-
+const menuBtn = 'example menu btn'
 export const Primary = Template.bind({})
 Primary.args = {
-  buttons: [btn, btn],
+  children: (
+    <>
+      <MenuItem>{menuBtn}</MenuItem>
+      <MenuItem>{menuBtn}</MenuItem>
+      <MenuItem>{menuBtn}</MenuItem>
+    </>
+  ),
+}
+
+export const IsOnDevice = Template.bind({})
+IsOnDevice.args = {
+  isOnDevice: true,
+  children: (
+    <>
+      <MenuItem isOnDevice={true}>{menuBtn}</MenuItem>
+      <MenuItem isOnDevice={true}>{menuBtn}</MenuItem>
+      <MenuItem isOnDevice={true} isAlert={true}>
+        {menuBtn}
+      </MenuItem>
+    </>
+  ),
 }

--- a/app/src/atoms/MenuList/MenuList.stories.tsx
+++ b/app/src/atoms/MenuList/MenuList.stories.tsx
@@ -25,17 +25,3 @@ Primary.args = {
     </>
   ),
 }
-
-export const IsOnDevice = Template.bind({})
-IsOnDevice.args = {
-  isOnDevice: true,
-  children: (
-    <>
-      <MenuItem isOnDevice={true}>{menuBtn}</MenuItem>
-      <MenuItem isOnDevice={true}>{menuBtn}</MenuItem>
-      <MenuItem isOnDevice={true} isAlert={true}>
-        {menuBtn}
-      </MenuItem>
-    </>
-  ),
-}

--- a/app/src/atoms/MenuList/__tests__/MenuList.test.tsx
+++ b/app/src/atoms/MenuList/__tests__/MenuList.test.tsx
@@ -12,12 +12,22 @@ describe('MenuList', () => {
   let props: React.ComponentProps<typeof MenuList>
   beforeEach(() => {
     props = {
-      buttons: [mockBtn],
+      children: mockBtn,
     }
   })
 
-  it('renders a child', () => {
+  it('renders a child not on device', () => {
     const { getByText } = render(props)
     getByText('mockBtn')
+  })
+  it('renders isOnDevice child, clicking background overlay calls onClick', () => {
+    props = {
+      ...props,
+      isOnDevice: true,
+      onClick: jest.fn(),
+    }
+    const { getByLabelText } = render(props)
+    getByLabelText('BackgroundOverlay_ModalShell').click()
+    expect(props.onClick).toHaveBeenCalled()
   })
 })

--- a/app/src/atoms/MenuList/index.tsx
+++ b/app/src/atoms/MenuList/index.tsx
@@ -3,17 +3,37 @@ import {
   COLORS,
   POSITION_ABSOLUTE,
   DIRECTION_COLUMN,
-  ButtonProps,
   Flex,
   SPACING,
+  BORDERS,
+  JUSTIFY_CENTER,
 } from '@opentrons/components'
+import { ModalShell } from '../../molecules/Modal'
 
 interface MenuListProps {
-  buttons: Array<ButtonProps | null | undefined>
+  children: React.ReactNode
+  isOnDevice?: boolean
+  onClick?: React.MouseEventHandler
 }
 
 export const MenuList = (props: MenuListProps): JSX.Element | null => {
-  return (
+  const { children, isOnDevice = false, onClick = null } = props
+  return isOnDevice && onClick != null ? (
+    <ModalShell
+      borderRadius={BORDERS.size_three}
+      width="18.0625rem"
+      onOutsideClick={onClick}
+      isOnDeviceDisplay
+    >
+      <Flex
+        boxShadow={BORDERS.shadowSmall}
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_CENTER}
+      >
+        {children}
+      </Flex>
+    </ModalShell>
+  ) : (
     <Flex
       borderRadius="4px 4px 0px 0px"
       zIndex={10}
@@ -23,8 +43,9 @@ export const MenuList = (props: MenuListProps): JSX.Element | null => {
       top="2.6rem"
       right={`calc(50% + ${String(SPACING.spacing2)})`}
       flexDirection={DIRECTION_COLUMN}
+      width="max-content"
     >
-      {props.buttons}
+      {children}
     </Flex>
   )
 }

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -67,28 +67,26 @@ export const ModuleOverflowMenu = (
 
   return (
     <Flex position={POSITION_RELATIVE}>
-      <MenuList
-        buttons={[
-          menuOverflowItemsByModuleType[module.moduleType].map(
-            (item: any, index: number) => {
-              return (
-                <React.Fragment key={`${index}_${String(module.moduleType)}`}>
-                  <MenuItem
-                    key={`${index}_${String(module.moduleModel)}`}
-                    onClick={() => item.onClick(item.isSecondary)}
-                    data-testid={`module_setting_${String(module.moduleModel)}`}
-                    disabled={item.disabledReason || isDisabled}
-                    whiteSpace="nowrap"
-                  >
-                    {item.setSetting}
-                  </MenuItem>
-                  {item.menuButtons}
-                </React.Fragment>
-              )
-            }
-          ),
-        ]}
-      />
+      <MenuList>
+        {menuOverflowItemsByModuleType[module.moduleType].map(
+          (item: any, index: number) => {
+            return (
+              <React.Fragment key={`${index}_${String(module.moduleType)}`}>
+                <MenuItem
+                  key={`${index}_${String(module.moduleModel)}`}
+                  onClick={() => item.onClick(item.isSecondary)}
+                  data-testid={`module_setting_${String(module.moduleModel)}`}
+                  disabled={item.disabledReason || isDisabled}
+                  whiteSpace="nowrap"
+                >
+                  {item.setSetting}
+                </MenuItem>
+                {item.menuButtons}
+              </React.Fragment>
+            )
+          }
+        )}
+      </MenuList>
     </Flex>
   )
 }

--- a/app/src/organisms/OnDeviceDisplay/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/OnDeviceDisplay/Navigation/NavigationMenu.tsx
@@ -27,7 +27,6 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
     <MenuList onClick={onClick} isOnDevice={true}>
       <MenuItem
         key="home-gantry"
-        isOnDevice={true}
         onClick={() => dispatch(home(robotName, ROBOT))}
       >
         <Flex>
@@ -41,11 +40,7 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
           </StyledText>
         </Flex>
       </MenuItem>
-      <MenuItem
-        key="restart"
-        isOnDevice={true}
-        onClick={() => dispatch(restartRobot(robotName))}
-      >
+      <MenuItem key="restart" onClick={() => dispatch(restartRobot(robotName))}>
         <Flex>
           <Icon
             name="restart"
@@ -58,7 +53,7 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
           </StyledText>
         </Flex>
       </MenuItem>
-      <MenuItem key="light" isOnDevice={true} onClick={toggleLights}>
+      <MenuItem key="light" onClick={toggleLights}>
         <Flex>
           <Icon
             name="light"

--- a/app/src/organisms/OnDeviceDisplay/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/OnDeviceDisplay/Navigation/NavigationMenu.tsx
@@ -1,21 +1,11 @@
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import {
-  ALIGN_CENTER,
-  BORDERS,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_CENTER,
-  TYPOGRAPHY,
-  SPACING,
-  SIZE_2,
-} from '@opentrons/components'
+import { COLORS, Flex, Icon, SPACING, SIZE_2 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
-import { ModalShell } from '../../../molecules/Modal'
+import { MenuList } from '../../../atoms/MenuList'
+import { MenuItem } from '../../../atoms/MenuList/MenuItem'
 import { home, ROBOT } from '../../../redux/robot-controls'
 import { restartRobot } from '../../../redux/robot-admin'
 import { useLights } from '../../Devices/hooks'
@@ -34,85 +24,56 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
   const dispatch = useDispatch<Dispatch>()
 
   return (
-    <ModalShell
-      borderRadius={BORDERS.size_three}
-      onOutsideClick={onClick}
-      width="18.0625rem"
-      isOnDeviceDisplay
-    >
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        justifyContent={JUSTIFY_CENTER}
-        padding={`0rem ${SPACING.spacingL}`}
+    <MenuList onClick={onClick} isOnDevice={true}>
+      <MenuItem
+        key="home-gantry"
+        isOnDevice={true}
+        onClick={() => dispatch(home(robotName, ROBOT))}
       >
-        <Flex
-          alignItems={ALIGN_CENTER}
-          height="4.875rem"
-          onClick={() => dispatch(home(robotName, ROBOT))}
-        >
+        <Flex>
           <Icon
             name="home-gantry"
             aria-label="home-gantry_icon"
             size={SIZE_2}
-            color={COLORS.black}
           />
-          <StyledText
-            fontSize={TYPOGRAPHY.fontSize28}
-            lineHeight={TYPOGRAPHY.lineHeight36}
-            marginLeft={SPACING.spacing5}
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-            textAlign={TYPOGRAPHY.textAlignCenter}
-          >
+          <StyledText marginLeft={SPACING.spacing5}>
             {t('home_gantry')}
           </StyledText>
         </Flex>
-        <Flex
-          alignItems={ALIGN_CENTER}
-          height="4.875rem"
-          onClick={() => dispatch(restartRobot(robotName))}
-        >
+      </MenuItem>
+      <MenuItem
+        key="restart"
+        isOnDevice={true}
+        onClick={() => dispatch(restartRobot(robotName))}
+      >
+        <Flex>
           <Icon
             name="restart"
             size={SIZE_2}
             color={COLORS.black}
             aria-label="restart_icon"
           />
-          <StyledText
-            fontSize={TYPOGRAPHY.fontSize28}
-            lineHeight={TYPOGRAPHY.lineHeight36}
-            marginLeft={SPACING.spacing5}
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-            textAlign={TYPOGRAPHY.textAlignCenter}
-          >
+          <StyledText marginLeft={SPACING.spacing5}>
             {t('robot_controls:restart_label')}
           </StyledText>
         </Flex>
-        <Flex
-          alignItems={ALIGN_CENTER}
-          height="4.875rem"
-          onClick={toggleLights}
-        >
+      </MenuItem>
+      <MenuItem key="light" isOnDevice={true} onClick={toggleLights}>
+        <Flex>
           <Icon
             name="light"
             size={SIZE_2}
             color={COLORS.black}
             aria-label="light_icon"
           />
-          <StyledText
-            color={COLORS.black}
-            fontSize={TYPOGRAPHY.fontSize28}
-            marginLeft={SPACING.spacing5}
-            lineHeight={TYPOGRAPHY.lineHeight36}
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-            textAlign={TYPOGRAPHY.textAlignCenter}
-          >
+          <StyledText marginLeft={SPACING.spacing5}>
             {i18n.format(
               t(lightsOn ? 'lights_off' : 'lights_on'),
               'capitalize'
             )}
           </StyledText>
         </Flex>
-      </Flex>
-    </ModalShell>
+      </MenuItem>
+    </MenuList>
   )
 }

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
@@ -3,29 +3,20 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useQueryClient } from 'react-query'
 import { useHistory } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import {
-  ALIGN_CENTER,
-  BORDERS,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_CENTER,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import { Flex, Icon, SPACING } from '@opentrons/components'
 import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
 import { useCreateRunMutation, useHost } from '@opentrons/react-api-client'
 
 import { MAXIMUM_PINNED_PROTOCOLS } from '../../../App/constants'
 import { StyledText } from '../../../atoms/text'
-import { ModalShell } from '../../../molecules/Modal'
+import { MenuList } from '../../../atoms/MenuList'
+import { MenuItem } from '../../../atoms/MenuList/MenuItem'
 import { SmallModalChildren } from '../../../molecules/Modal/OnDeviceDisplay'
 import { useToaster } from '../../../organisms/ToasterOven'
 import { getPinnedProtocolIds, updateConfigValue } from '../../../redux/config'
 
-import type { Dispatch } from '../../../redux/types'
 import type { UseLongPressResult } from '@opentrons/components'
+import type { Dispatch } from '../../../redux/types'
 
 export function LongPressModal(props: {
   longpress: UseLongPressResult
@@ -137,73 +128,30 @@ export function LongPressModal(props: {
           handleCloseMaxPinsAlert={() => longpress?.setIsLongPressed(false)}
         />
       ) : (
-        <ModalShell
-          borderRadius={BORDERS.size_three}
-          onOutsideClick={handleCloseModal}
-          width="15.625rem"
-        >
-          <Flex
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Flex
-              alignItems={ALIGN_CENTER}
-              gridGap={SPACING.spacingSM}
-              height="4.875rem"
-              padding={SPACING.spacing5}
-              onClick={handleRunClick}
-              as="button"
-            >
-              <Icon name="play-circle" size="1.75rem" color={COLORS.black} />
-              <StyledText
-                fontSize="1.375rem"
-                lineHeight="1.5rem"
-                fontWeight={TYPOGRAPHY.fontWeightRegular}
-                textAlign={TYPOGRAPHY.textAlignCenter}
-              >
+        <MenuList onClick={handleCloseModal} isOnDevice={true}>
+          <MenuItem onClick={handleRunClick} key="play-circle">
+            <Flex>
+              <Icon name="play-circle" size="1.75rem" />
+              <StyledText marginLeft={SPACING.spacing5}>
                 {t('run_protocol')}
               </StyledText>
             </Flex>
-            <Flex
-              alignItems={ALIGN_CENTER}
-              gridGap={SPACING.spacingSM}
-              height="4.875rem"
-              padding={SPACING.spacing5}
-              onClick={handlePinClick}
-              as="button"
-            >
-              <Icon name="pin" size="1.875rem" color={COLORS.black} />
-              <StyledText
-                fontSize="1.375rem"
-                lineHeight="1.5rem"
-                fontWeight={TYPOGRAPHY.fontWeightRegular}
-                textAlign={TYPOGRAPHY.textAlignCenter}
-              >
+          </MenuItem>
+          <MenuItem onClick={handlePinClick} key="pin">
+            <Flex>
+              <Icon name="pin" size="1.875rem" />
+              <StyledText marginLeft={SPACING.spacing5}>
                 {pinned ? t('unpin_protocol') : t('pin_protocol')}
               </StyledText>
             </Flex>
-            <Flex
-              alignItems={ALIGN_CENTER}
-              backgroundColor={COLORS.errorEnabled}
-              gridGap={SPACING.spacingSM}
-              height="4.875rem"
-              padding={SPACING.spacing5}
-              onClick={handleDeleteClick}
-              as="button"
-            >
-              <Icon name="trash" size="1.875rem" color={COLORS.white} />
-              <StyledText
-                color={COLORS.white}
-                fontSize="1.375rem"
-                lineHeight="1.5rem"
-                fontWeight={TYPOGRAPHY.fontWeightRegular}
-                textAlign={TYPOGRAPHY.textAlignCenter}
-              >
-                {t('delete_protocol')}
-              </StyledText>
+          </MenuItem>
+          <MenuItem onClick={handleDeleteClick} key="trash" isAlert={true}>
+            <Flex>
+              <Icon name="trash" size="1.875rem" />
+              <StyledText>{t('delete_protocol')}</StyledText>
             </Flex>
-          </Flex>
-        </ModalShell>
+          </MenuItem>
+        </MenuList>
       )}
     </>
   )


### PR DESCRIPTION
closes RAUT-403

# Overview

Change `MenuList` and `MenuItem` to be used as the overflow menu in ODD

https://user-images.githubusercontent.com/66035149/232887525-238b58ce-42c1-4c15-a920-b6206d3f6998.mov



# Test Plan

Review the storybooks for `MenuList` and `MenuItem` and review the menu buttons in the desktop app to make sure they retain correct UI and review the Navigation menu in the ODD to make sure it has correct Ui.

# Changelog

- Change `MenuItem` to take in `isAlert` prop and use media query, modify storybook and test
- Change `MenuList` to take in `isOnDevice` and `OnClick` props, change `button` prop to be `children` and fix all usages of it in the desktop (it was only used in Module overflow menu). Modify storybook and test
- Change `NavigationMenu` to use `MenuItem` and `MenuList`
- add ODD viewport to `storybook/preview`

# Review requests

- see test plan

# Risk assessment

low