### PR TITLE
refactor(app,robot-server): Rename referencingRunIds -> referencingRuns

### DIFF
--- a/api-client/src/protocols/types.ts
+++ b/api-client/src/protocols/types.ts
@@ -19,7 +19,7 @@ export interface ProtocolMetadata {
 
 export interface Protocol {
   links?: {
-    referencingRunIds: [
+    referencingRuns: [
       {
         id: string
         href: string

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
@@ -72,9 +72,9 @@ export function LongPressModal(props: {
           response =>
             response.data.links?.referencingRuns.map(({ id }) => id) ?? []
         )
-        .then(referencingRuns => {
+        .then(referencingRunIds => {
           return Promise.all(
-            referencingRuns?.map(runId => deleteRun(host, runId))
+            referencingRunIds?.map(runId => deleteRun(host, runId))
           )
         })
         .then(() => deleteProtocol(host, protocolId))

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/LongPressModal.tsx
@@ -70,11 +70,11 @@ export function LongPressModal(props: {
       getProtocol(host, protocolId)
         .then(
           response =>
-            response.data.links?.referencingRunIds.map(({ id }) => id) ?? []
+            response.data.links?.referencingRuns.map(({ id }) => id) ?? []
         )
-        .then(referencingRunIds => {
+        .then(referencingRuns => {
           return Promise.all(
-            referencingRunIds?.map(runId => deleteRun(host, runId))
+            referencingRuns?.map(runId => deleteRun(host, runId))
           )
         })
         .then(() => deleteProtocol(host, protocolId))

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/LongPressModal.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/LongPressModal.test.tsx
@@ -70,7 +70,7 @@ describe('Long Press Modal', () => {
     when(mockGetProtocol)
       .calledWith(MOCK_HOST_CONFIG, 'mockProtocol1')
       .mockResolvedValue({
-        data: { links: { referencingRunIds: [{ id: '1' }, { id: '2' }] } },
+        data: { links: { referencingRuns: [{ id: '1' }, { id: '2' }] } },
       } as any)
     const { result } = renderHook(() => useLongPress())
     result.current.isLongPressed = true

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -130,7 +130,7 @@ describe('ODDProtocolDetails', () => {
     when(mockGetProtocol)
       .calledWith(MOCK_HOST_CONFIG, 'fakeProtocolId')
       .mockResolvedValue({
-        data: { links: { referencingRunIds: [{ id: '1' }, { id: '2' }] } },
+        data: { links: { referencingRuns: [{ id: '1' }, { id: '2' }] } },
       } as any)
     const [{ getByText }] = render()
     const deleteButton = getByText('Delete protocol').closest('button')

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -295,10 +295,10 @@ export function ProtocolDetails(): JSX.Element | null {
       getProtocol(host, protocolId)
         .then(
           response =>
-            response.data.links?.referencingRunIds.map(({ id }) => id) ?? []
+            response.data.links?.referencingRuns.map(({ id }) => id) ?? []
         )
-        .then(referencingRunIds =>
-          Promise.all(referencingRunIds?.map(runId => deleteRun(host, runId)))
+        .then(referencingRuns =>
+          Promise.all(referencingRuns?.map(runId => deleteRun(host, runId)))
         )
         .then(() => deleteProtocol(host, protocolId))
         .then(() => history.goBack())

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -297,8 +297,8 @@ export function ProtocolDetails(): JSX.Element | null {
           response =>
             response.data.links?.referencingRuns.map(({ id }) => id) ?? []
         )
-        .then(referencingRuns =>
-          Promise.all(referencingRuns?.map(runId => deleteRun(host, runId)))
+        .then(referencingRunIds =>
+          Promise.all(referencingRunIds?.map(runId => deleteRun(host, runId)))
         )
         .then(() => deleteProtocol(host, protocolId))
         .then(() => history.goBack())

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -332,7 +332,7 @@ async def get_protocol_by_id(
         raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
     analyses = analysis_store.get_summaries_by_protocol(protocol_id=protocolId)
-    referencingRuns = protocol_store.get_referencing_run_ids(protocolId)
+    referencing_run_ids = protocol_store.get_referencing_run_ids(protocolId)
 
     data = Protocol.construct(
         id=protocolId,
@@ -349,8 +349,8 @@ async def get_protocol_by_id(
 
     links = ProtocolLinks.construct(
         referencingRuns=[
-            RunLink.construct(id=runId, href=f"/runs/{runId}")
-            for runId in referencingRuns
+            RunLink.construct(id=run_id, href=f"/runs/{run_id}")
+            for run_id in referencing_run_ids
         ]
     )
 

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -104,7 +104,7 @@ class RunLink(BaseModel):
 class ProtocolLinks(BaseModel):
     """Links returned along with a protocol resource."""
 
-    referencingRunIds: List[RunLink] = Field(
+    referencingRuns: List[RunLink] = Field(
         ...,
         description="Links to runs that reference the protocol.",
     )
@@ -332,7 +332,7 @@ async def get_protocol_by_id(
         raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
     analyses = analysis_store.get_summaries_by_protocol(protocol_id=protocolId)
-    referencingRunIds = protocol_store.get_referencing_run_ids(protocolId)
+    referencingRuns = protocol_store.get_referencing_run_ids(protocolId)
 
     data = Protocol.construct(
         id=protocolId,
@@ -348,9 +348,9 @@ async def get_protocol_by_id(
     )
 
     links = ProtocolLinks.construct(
-        referencingRunIds=[
+        referencingRuns=[
             RunLink.construct(id=runId, href=f"/runs/{runId}")
-            for runId in referencingRunIds
+            for runId in referencingRuns
         ]
     )
 

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -70,7 +70,7 @@ stages:
             - id: '{analysis_id}'
               status: completed
         links: 
-          referencingRunIds: []
+          referencingRuns: []
   - name: Get protocol analysis by ID
     request:
       url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -251,7 +251,7 @@ async def test_get_protocol_by_id(
         key="dummy-key-111",
     )
 
-    assert result.content.links == ProtocolLinks.construct(referencingRunIds=[])
+    assert result.content.links == ProtocolLinks.construct(referencingRuns=[])
     assert result.status_code == 200
 
 


### PR DESCRIPTION
# Overview

This is a small naming tweak for part of the HTTP API that hasn't been released publicly yet. This API was added in #12326 (RCORE-700).

# Test Plan

* [x] Confirmed with `make -C robot-server dev` and `make -C app dev OT_APP_IS_ON_DEVICE=1` that the "delete protocol" button in the ODD app still works.
* [x] Confirmed with Postman that the response looks as described.

# Changelog

Change `GET /protocol` responses from this:

```json
{
  "data": "...",
  "links": {
    "referencingRunIds": [
      {
        "id": "blah",
        "href": "/runs/blah"
      }
    ]
  }
}
```

To this:

```json
{
  "data": "...",
  "links": {
    "referencingRuns": [    <-- CHANGED
      {
        "id": "blah",
        "href": "/runs/blah"
      }
    ]
  }
}
```

Since it's a list of links that *have* IDs (as well as `href`s), rather than a list of IDs.

# Review requests

None in particular. Code review should be sufficient.

# Risk assessment

Low.

This will break clients that are talking to different-versioned robot servers, but we already don't expect that to work all the time.