### PR TITLE
Fix(api): Use absolute path when reading module calibration files

### DIFF
--- a/api/src/opentrons/calibration_storage/ot3/module_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/module_offset.py
@@ -109,7 +109,13 @@ def load_all_module_offsets() -> List[v1.ModuleOffsetModel]:
     files = os.listdir(config.get_opentrons_path("module_calibration_dir"))
     for file in files:
         try:
-            calibrations.append(v1.ModuleOffsetModel(**io.read_cal_file(Path(file))))
+            calibrations.append(
+                v1.ModuleOffsetModel(
+                    **io.read_cal_file(
+                        Path(config.get_opentrons_path("module_calibration_dir") / file)
+                    )
+                )
+            )
         except (json.JSONDecodeError, ValidationError):
             log.warning(
                 f"Malformed module calibrations for {file}. Please factory reset your calibrations."

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -281,7 +281,7 @@ CONFIG_ELEMENTS = (
     ConfigElement(
         "module_calibration_dir",
         "Module Calibration Directory",
-        Path("robot") / "calibrations" / "modules",
+        Path("robot") / "modules",
         ConfigElementType.DIR,
         "The dir where module calibration is stored",
     ),

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -281,7 +281,7 @@ CONFIG_ELEMENTS = (
     ConfigElement(
         "module_calibration_dir",
         "Module Calibration Directory",
-        Path("robot") / "modules",
+        Path("robot") / "calibrations" / "modules",
         ConfigElementType.DIR,
         "The dir where module calibration is stored",
     ),


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RSS-228.
use absolute path instead of relative path when reading the module calibration file.

# Test Plan

Tested on on Flex. works as expected. 

# Risk assessment

low. fixes a bug when trying to write the output of module calibration. 