### PR TITLE
feat(shared-data): Add backwards compatible pipettes to new pipette configurations

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -511,6 +511,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
                 "fw_update_required": self._fw_update_info.update_required,
                 "fw_current_version": self._fw_update_info.current_version,
                 "fw_next_version": self._fw_update_info.next_version,
+                "back_compat_names": self._config.pipette_backcompat_names,
             }
         )
         return self._config_as_dict

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -215,6 +215,7 @@ class PipetteHandlerProvider:
                 "default_aspirate_flow_rates",
                 "default_blow_out_flow_rates",
                 "default_dispense_flow_rates",
+                "back_compat_names",
             ]
 
             instr_dict = instr.as_dict()

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": ["p10_multi"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": ["p10_multi"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 3.5,
-  "shaftULperMM": 9.621
+  "shaftULperMM": 9.621,
+  "backCompatNames": ["p300_multi"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 3.5,
-  "shaftULperMM": 9.621
+  "shaftULperMM": 9.621,
+  "backCompatNames": ["p300_multi"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
@@ -31,5 +31,6 @@
   },
   "channels": 8,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
   },
+  "backCompatNames": [],
   "channels": 8,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 8, 12, 96]
   },
+  "backCompatNames": [],
   "channels": 96,
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 8, 12, 96]
   },
+  "backCompatNames": [],
   "channels": 96,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
@@ -28,6 +28,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 8, 12, 96]
   },
+  "backCompatNames": [],
   "channels": 96,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
@@ -35,6 +35,7 @@
     "partialTipSupported": true,
     "availableConfigurations": [1, 8, 12, 96]
   },
+  "backCompatNames": [],
   "channels": 96,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 9.0,
-  "shaftULperMM": 63.617
+  "shaftULperMM": 63.617,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 9.0,
-  "shaftULperMM": 63.617
+  "shaftULperMM": 63.617,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 9.0,
-  "shaftULperMM": 63.617
+  "shaftULperMM": 63.617,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 9.0,
-  "shaftULperMM": 63.617
+  "shaftULperMM": 63.617,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 6.0,
-  "shaftULperMM": 28.274
+  "shaftULperMM": 28.274,
+  "backCompatNames": ["p1000_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 6.0,
-  "shaftULperMM": 28.274
+  "shaftULperMM": 28.274,
+  "backCompatNames": ["p1000_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 6.0,
-  "shaftULperMM": 28.274
+  "shaftULperMM": 28.274,
+  "backCompatNames": ["p1000_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
@@ -25,6 +25,7 @@
     "environment": { "count": 1 }
   },
   "partialTipConfigurations": { "partialTipSupported": false },
+  "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
@@ -25,6 +25,7 @@
     "environment": { "count": 1 }
   },
   "partialTipConfigurations": { "partialTipSupported": false },
+  "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
@@ -25,6 +25,7 @@
     "environment": { "count": 1 }
   },
   "partialTipConfigurations": { "partialTipSupported": false },
+  "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": ["p10_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": ["p10_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 1.0,
-  "shaftULperMM": 0.785
+  "shaftULperMM": 0.785,
+  "backCompatNames": ["p10_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 5.0,
-  "shaftULperMM": 19.635
+  "shaftULperMM": 19.635,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 3.5,
-  "shaftULperMM": 9.621
+  "shaftULperMM": 9.621,
+  "backCompatNames": ["p300_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 3.5,
-  "shaftULperMM": 9.621
+  "shaftULperMM": 9.621,
+  "backCompatNames": ["p300_single"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
@@ -31,5 +31,6 @@
   },
   "channels": 1,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
@@ -33,5 +33,6 @@
   },
   "channels": 1,
   "shaftDiameter": 2.0,
-  "shaftULperMM": 3.142
+  "shaftULperMM": 3.142,
+  "backCompatNames": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -25,6 +25,7 @@
     "environment": { "count": 1 }
   },
   "partialTipConfigurations": { "partialTipSupported": false },
+  "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -25,6 +25,7 @@
     "environment": { "count": 1 }
   },
   "partialTipConfigurations": { "partialTipSupported": false },
+  "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -25,6 +25,7 @@
     "environment": { "count": 1 }
   },
   "partialTipConfigurations": { "partialTipSupported": false },
+  "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785

--- a/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
+++ b/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
@@ -83,13 +83,19 @@
     "displayCategory",
     "channels",
     "model",
-    "displayName"
+    "displayName",
+    "backCompatNames"
   ],
   "properties": {
     "additionalProperties": false,
     "$otSharedSchema": {
       "type": "string",
       "description": "The path to a valid Opentrons shared schema relative to the shared-data directory, without its extension. For instance, #/pipette/schemas/2/pipettePropertiesSchema.json is a reference to this schema."
+    },
+    "backCompatNames": {
+      "type": "array",
+      "description": "Array of pipette names that are compatible with the given pipette",
+      "items": { "type": "string" }
     },
     "channels": { "$ref": "#/definitions/channels" },
     "partialTipConfigurations": {

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -213,6 +213,11 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
         description="The display or full product name of the pipette.",
         alias="displayName",
     )
+    pipette_backcompat_names: List[str] = Field(
+        ...,
+        description="A list of pipette names that are compatible with this pipette.",
+        alias="backCompatNames",
+    )
     pipette_type: PipetteModelType = Field(
         ...,
         description="The pipette model type (related to number of channels).",


### PR DESCRIPTION
# Overview

To support fully transitioning to the new pip schema on the app side, we need to include the list of backwards compatible pipettes which is used to detect whether a pipette attached to the robot can be used as a replacement for the pipette specified.

Eventually this key will want to just be a volume range once we support loading pipettes by volume/channels.

I also took the opportunity to remove some migration stuff from the `build_json` script since we will not need to use that moving forward.

# Test Plan

- Throw this on a robot and make sure you can still successfully load supported pipettes in a protocol on a Flex.