### PR TITLE
feat(api): support get_max_travel_z for Flex and enable use_virtual_pipettes

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -24,10 +24,15 @@ _MOTOR_AXIS_TO_HARDWARE_AXIS: Dict[MotorAxis, HardwareAxis] = {
     MotorAxis.RIGHT_PLUNGER: HardwareAxis.C,
 }
 
-# Max height of the gantry at home position without any tips. This is the same value returned by the OT3Simulator,
-# which uses machine to deck transform math with the default carriage and mount values from config.defaults_ot3.py.
-# This height was validated by peaking at the non-virtual simulation values for GEN3 single and multi P50s and
-# single, multi and 96-channel P1000 pipettes on both the left and right mounts.
+# The height of the bottom of the pipette nozzle at home position without any tips.
+# We rely on this being the same for every OT-3 pipette.
+#
+# We found this number by peeking at the height that OT3Simulator returns for these pipettes:
+#   * Single- and 8-Channel P50 GEN3
+#   * Single-, 8-, and 96-channel P1000 GEN3
+#
+# That OT3Simulator return value is what Protocol Engine uses for simulation when Protocol Engine
+# is configured to not virtualize pipettes, so this number should match it.
 VIRTUAL_MAX_OT3_HEIGHT = 248.0
 
 

--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -24,8 +24,10 @@ _MOTOR_AXIS_TO_HARDWARE_AXIS: Dict[MotorAxis, HardwareAxis] = {
     MotorAxis.RIGHT_PLUNGER: HardwareAxis.C,
 }
 
-# Max height of the gantry at home position without any tips.
-# Same value returned by simulating Hardware API.
+# Max height of the gantry at home position without any tips. This is the same value returned by the OT3Simulator,
+# which uses machine to deck transform math with the default carriage and mount values from config.defaults_ot3.py.
+# This height was validated by peaking at the non-virtual simulation values for GEN3 single and multi P50s and
+# single, multi and 96-channel P1000 pipettes on both the left and right mounts.
 VIRTUAL_MAX_OT3_HEIGHT = 248.0
 
 

--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -53,10 +53,7 @@ async def create_simulating_runner(
             ignore_pause=True,
             use_virtual_modules=True,
             use_virtual_gripper=True,
-            use_virtual_pipettes=(
-                robot_type != "OT-3 Standard"
-                and not feature_flags.disable_fast_protocol_upload()
-            ),
+            use_virtual_pipettes=(not feature_flags.disable_fast_protocol_upload()),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -20,6 +20,7 @@ from opentrons.protocol_engine.execution.gantry_mover import (
     HardwareGantryMover,
     VirtualGantryMover,
     create_gantry_mover,
+    VIRTUAL_MAX_OT3_HEIGHT,
 )
 
 
@@ -379,12 +380,13 @@ async def test_virtual_get_position_default(
     assert result == Point(x=0, y=0, z=0)
 
 
-def test_virtual_get_max_travel_z(
+def test_virtual_get_max_travel_z_ot2(
     decoy: Decoy,
     mock_state_view: StateView,
     virtual_subject: VirtualGantryMover,
 ) -> None:
-    """It should get the max travel z height with the state store."""
+    """It should get the max travel z height with the state store for an OT-2."""
+    decoy.when(mock_state_view.config.robot_type).then_return("OT-2 Standard")
     decoy.when(
         mock_state_view.pipettes.get_instrument_max_height_ot2("pipette-id")
     ).then_return(42)
@@ -393,6 +395,20 @@ def test_virtual_get_max_travel_z(
     result = virtual_subject.get_max_travel_z("pipette-id")
 
     assert result == 22.0
+
+
+def test_virtual_get_max_travel_z_ot3(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    virtual_subject: VirtualGantryMover,
+) -> None:
+    """It should get the max travel z height with the state store."""
+    decoy.when(mock_state_view.config.robot_type).then_return("OT-3 Standard")
+    decoy.when(mock_state_view.tips.get_tip_length("pipette-id")).then_return(48)
+
+    result = virtual_subject.get_max_travel_z("pipette-id")
+
+    assert result == VIRTUAL_MAX_OT3_HEIGHT - 48.0
 
 
 async def test_virtual_move_relative(

--- a/shared-data/pipette/definitions/1/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteNameSpecs.json
@@ -649,7 +649,7 @@
         "2.0": 7.85
       }
     },
-    "channels": 96,
+    "channels": 8,
     "minVolume": 1,
     "maxVolume": 1000,
     "smoothieConfigs": {

--- a/shared-data/pipette/definitions/1/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteNameSpecs.json
@@ -649,9 +649,9 @@
         "2.0": 7.85
       }
     },
-    "channels": 8,
+    "channels": 96,
     "minVolume": 1,
-    "maxVolume": 50,
+    "maxVolume": 1000,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,
       "homePosition": 230.15,


### PR DESCRIPTION
# Overview

Closes RCORE-655.

This PR adds support for calculating `max_travel_z` while analyzing an `OT-3 Standard` robot type protocol, and enables the `use_virtual_pipettes` field for those protocols. The value used for the max height is the same one the OT3 Hardware API is using, but avoids making a call to the hardware API.

With `use_virtual_pipettes` on, significant speed-ups both on the app and robot side analysis have been seen, with speedups of 66% seen for real science protocols on the robot, and up to 90% for pipette heavy protocols.

# Test Plan

Analysis was tested on a number of protocols, including science ones such as `OT-3 Omega HDQ DNA Extraction: Bacteria- Tissue Protocol Park Tips` and the 96-channel protocol `Omega HDQ DNA Extraction: Bacteria 96 channel testing` on both the app and the Flex to ensure they still successfully analyze

Additionally, for speed calculations, the following protocol was tested both with and without the `use_virtual_pipettes` flag on.

```
from opentrons.types import Location

metadata = {
    'protocolName': 'use_virtual_pipettes speed test',
}

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.14"
}

def run(context):
    p1000rack = context.load_labware('opentrons_96_tiprack_1000ul', 1)
    p1000 = context.load_instrument('p1000_single_gen3', 'left', tip_racks=[p1000rack])
    labware = context.load_labware("corning_96_wellplate_360ul_flat", 3)
    well1 = labware.wells()[0]
    well2 = labware.wells()[1]
    well3 = labware.wells()[2]

    p1000.pick_up_tip()

    for _ in range(20000):
        p1000.aspirate(location=well1, volume=100)

        p1000.dispense(location=well2)

       p1000.blow_out(location=well1)

        p1000.touch_tip(location=well3)

        p1000.move_to(well1.bottom())

        # Test move to coordinates
        p1000.move_to(Location(point=well1.top().point, labware=None))


    p1000.drop_tip()
``` 

Without the flag on, this takes over 10 minutes to simulate on the app running on an M1 MacBook Pro. With the flag on, this protocol only takes 1 minute to complete analysis.

# Changelog

- Add simulated value for OT-3/Flex `get_instrument_max_height` for use in analysis/simulation
- Remove check to use `use_virtual_pipettes` for OT-2 only, enabling it for OT-3/Flex
- Fixed incorrect value in `shared_data` for 96 channel pipette that was causing simulated runs to incorrectly fail analysis

# Review requests

- The simulated max instrument height was chosen to match what the hardware controller was returning with the OT3Simulator. Does using this value make sense, or should it be adjusted somewhat?

# Risk assessment
Lowish, this only affects analysis and no changes have been made that will affect actual runs. I've done my due diligence in testing around 10 OT-3 protocols I have loaded, to ensure they still pass. While most of the code has been running successfully on the OT-2 since end of February (and is in 6.3), there is always the small chance of a false failed run. However this feature can be turned off and returned to pre-existing behavior by enabling the `disableFastProtocolUpload` FF