### PR TITLE
fix(api): dont log sensor values in cap probes

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1168,7 +1168,6 @@ class OT3Controller:
             speed_mm_per_s,
             sensor_id_for_instrument(probe),
             relative_threshold_pf=sensor_threshold_pf,
-            log_sensor_values=True,
         )
 
         self._position[axis_to_node(moving)] = pos


### PR DESCRIPTION
Unfortunately, logging every sensor value during a capacitive probe lags the canbus enough that we fail to complete some calibration passes. We should investigate this further and see if we can turn it back on.

## Testing
- See if this makes pipette calibration not fail half the time

Closes RQA-634
