### PR TITLE
fix(shared-data): add gripper v1.1 to model number enum

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -12,6 +12,7 @@ from opentrons.util.linal import solve_attitude
 from .types import OT3Mount, OT3Axis, GripperProbe
 from opentrons.types import Point
 from opentrons.config.types import CapacitivePassSettings, EdgeSenseSettings
+from opentrons.hardware_control.instruments.ot3.gripper_handler import GripError
 import json
 
 from opentrons_shared_data.deck import (
@@ -683,7 +684,9 @@ async def calibrate_gripper_jaw(
     two offsets into the `gripper_pin_offsets_mean` func.
     """
     try:
-        if not hcapi._gripper_handler.check_ready_for_jaw_move():
+        try:
+            hcapi._gripper_handler.check_ready_for_jaw_move()
+        except GripError:
             await hcapi.home_gripper_jaw()
         await hcapi.reset_instrument_offset(OT3Mount.GRIPPER)
         hcapi.add_gripper_probe(probe)

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -12,7 +12,6 @@ from opentrons.util.linal import solve_attitude
 from .types import OT3Mount, OT3Axis, GripperProbe
 from opentrons.types import Point
 from opentrons.config.types import CapacitivePassSettings, EdgeSenseSettings
-from opentrons.hardware_control.instruments.ot3.gripper_handler import GripError
 import json
 
 from opentrons_shared_data.deck import (
@@ -684,10 +683,6 @@ async def calibrate_gripper_jaw(
     two offsets into the `gripper_pin_offsets_mean` func.
     """
     try:
-        try:
-            hcapi._gripper_handler.check_ready_for_jaw_move()
-        except GripError:
-            await hcapi.home_gripper_jaw()
         await hcapi.reset_instrument_offset(OT3Mount.GRIPPER)
         hcapi.add_gripper_probe(probe)
         await hcapi.grip(GRIPPER_GRIP_FORCE)

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -683,6 +683,8 @@ async def calibrate_gripper_jaw(
     two offsets into the `gripper_pin_offsets_mean` func.
     """
     try:
+        if not hcapi._gripper_handler.check_ready_for_jaw_move():
+            await hcapi.home_gripper_jaw()
         await hcapi.reset_instrument_offset(OT3Mount.GRIPPER)
         hcapi.add_gripper_probe(probe)
         await hcapi.grip(GRIPPER_GRIP_FORCE)

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -40,6 +40,8 @@ export const HEATERSHAKER_MODULE_V1: 'heaterShakerModuleV1' =
   'heaterShakerModuleV1'
 
 export const GRIPPER_V1: 'gripperV1' = 'gripperV1'
+export const GRIPPER_V1_1: 'gripperV1.1' = 'gripperV1.1'
+export const GRIPPER_MODELS = [GRIPPER_V1, GRIPPER_V1_1]
 
 // pipette display categories
 export const GEN3: 'GEN3' = 'GEN3'

--- a/shared-data/js/gripper.ts
+++ b/shared-data/js/gripper.ts
@@ -14,7 +14,10 @@ export const getGripperDef = (
     case GRIPPER_V1_1:
       return gripperV1_1 as GripperDefinition
     default:
-      throw new Error(`Invalid gripper model ${gripperModel as string}`)
+      console.warn(
+        `Could not find a gripper with model ${gripperModel}, falling back to most recent definition: ${GRIPPER_V1_1}`
+      )
+      return gripperV1_1 as GripperDefinition
   }
 }
 

--- a/shared-data/js/gripper.ts
+++ b/shared-data/js/gripper.ts
@@ -1,6 +1,7 @@
 import gripperV1 from '../gripper/definitions/1/gripperV1.json'
+import gripperV1_1 from '../gripper/definitions/1/gripperV1.1.json'
 
-import { GRIPPER_V1 } from './constants'
+import { GRIPPER_V1, GRIPPER_V1_1 } from './constants'
 
 import type { GripperModel, GripperDefinition } from './types'
 
@@ -10,6 +11,8 @@ export const getGripperDef = (
   switch (gripperModel) {
     case GRIPPER_V1:
       return gripperV1 as GripperDefinition
+    case GRIPPER_V1_1:
+      return gripperV1_1 as GripperDefinition
     default:
       throw new Error(`Invalid gripper model ${gripperModel as string}`)
   }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -19,6 +19,7 @@ import {
   LEFT,
   RIGHT,
   GRIPPER_V1,
+  GRIPPER_V1_1,
 } from './constants'
 import type { INode } from 'svgson'
 import type { RunTimeCommand } from '../protocol'
@@ -204,7 +205,7 @@ export type ModuleModel =
   | ThermocyclerModuleModel
   | HeaterShakerModuleModel
 
-export type GripperModel = typeof GRIPPER_V1
+export type GripperModel = typeof GRIPPER_V1 | typeof GRIPPER_V1_1
 
 export type ModuleModelWithLegacy =
   | ModuleModel


### PR DESCRIPTION
# Overview

This is a patch PR to incorporate the model number of the dvt gripper into internal release 0.3.0. 
Commit was cherrypicked from https://github.com/Opentrons/opentrons/pull/12522

author: @ahiuchingau 

# Test Plan

- Initiate -> complet the attach gripper flow from the desktop app


# Risk assessment

low