### PR TITLE
fix(api): hardware_control: stop() in flex works

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -984,10 +984,6 @@ class OT3Controller:
         if error != ErrorCode.ok:
             log.warning(f"Halt stop request failed: {error}")
 
-    async def hard_halt(self) -> None:
-        """Halt the motors."""
-        return None
-
     async def probe(self, axis: OT3Axis, distance: float) -> OT3AxisMap[float]:
         """Probe."""
         return {}

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -88,7 +88,12 @@ from opentrons_hardware.firmware_bindings.constants import (
     PipetteType,
     USBTarget,
     FirmwareTarget,
+    ErrorCode,
 )
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    StopRequest,
+)
+from opentrons_hardware.firmware_bindings.messages.payloads import EmptyPayload
 from opentrons_hardware.hardware_control import status_bar
 
 from opentrons_hardware.firmware_bindings.binary_constants import BinaryMessageId
@@ -973,7 +978,11 @@ class OT3Controller:
 
     async def halt(self) -> None:
         """Halt the motors."""
-        return None
+        error = await self._messenger.ensure_send(
+            NodeId.broadcast, StopRequest(payload=EmptyPayload())
+        )
+        if error != ErrorCode.ok:
+            log.warning(f"Halt stop request failed: {error}")
 
     async def hard_halt(self) -> None:
         """Halt the motors."""

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -563,11 +563,6 @@ class OT3Simulator:
         return None
 
     @ensure_yield
-    async def hard_halt(self) -> None:
-        """Halt the motors."""
-        return None
-
-    @ensure_yield
     async def probe(self, axis: OT3Axis, distance: float) -> OT3AxisMap[float]:
         """Probe."""
         return {}

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -704,7 +704,7 @@ class OT3API(
 
     async def halt(self) -> None:
         """Immediately stop motion."""
-        await self._backend.hard_halt()
+        await self._backend.halt()
         asyncio.run_coroutine_threadsafe(self._execution_manager.cancel(), self._loop)
 
     async def stop(self, home_after: bool = True) -> None:

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -225,6 +225,7 @@ class ErrorCode(int, Enum):
     labware_dropped = 0x09
     estop_released = 0x0A
     motor_busy = 0x0B
+    stop_requested = 0x0C
 
 
 @unique


### PR DESCRIPTION
The protocol runner calls stop() after it cancels a task. Microcontrollers may still be executing moves. If stop() then calls update_position() before the microcontrollers are done, the request will time out and we'll get an error.

Let's force the microcontrollers to be done by sending a stop request and waiting for acknowledgements.

Closes RET-1353

## Testing
-  [x] Try it on a robot and see if it works like we think
- Will need https://github.com/Opentrons/ot3-firmware/pull/639