### PR TITLE
fix(shared-data): update flex fixed-trash for dvt

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
@@ -10,9 +10,9 @@
   "version": 1,
   "namespace": "opentrons",
   "dimensions": {
-    "xDimension": 210.75,
-    "yDimension": 79.75,
-    "zDimension": 187.5
+    "xDimension": 246.5,
+    "yDimension": 91.5,
+    "zDimension": 174.5
   },
   "parameters": {
     "format": "trash",
@@ -24,12 +24,12 @@
   "wells": {
     "A1": {
       "shape": "rectangular",
-      "yDimension": 165.67,
-      "xDimension": 107.11,
+      "yDimension": 78,
+      "xDimension": 225,
       "totalLiquidVolume": 3200000,
       "depth": 172.5,
-      "x": 105.375,
-      "y": 39.875,
+      "x": 106.25,
+      "y": 43,
       "z": -132.5
     }
   },

--- a/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
@@ -12,7 +12,7 @@
   "dimensions": {
     "xDimension": 246.5,
     "yDimension": 91.5,
-    "zDimension": 174.5
+    "zDimension": 40
   },
   "parameters": {
     "format": "trash",
@@ -27,10 +27,10 @@
       "yDimension": 78,
       "xDimension": 225,
       "totalLiquidVolume": 3200000,
-      "depth": 172.5,
+      "depth": 40,
       "x": 106.25,
       "y": 43,
-      "z": -132.5
+      "z": 0
     }
   },
   "brand": {
@@ -45,6 +45,6 @@
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
-    "z": -132.5
+    "z": 0
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
@@ -28,8 +28,8 @@
       "xDimension": 225,
       "totalLiquidVolume": 3200000,
       "depth": 40,
-      "x": 106.25,
-      "y": 43,
+      "x": 123.25,
+      "y": 45.75,
       "z": 0
     }
   },
@@ -43,8 +43,8 @@
     }
   ],
   "cornerOffsetFromSlot": {
-    "x": 0,
-    "y": 0,
+    "x": -17,
+    "y": -2.75,
     "z": 0
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
@@ -45,6 +45,6 @@
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
-    "z": -94
+    "z": -132.5
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json
@@ -27,10 +27,10 @@
       "yDimension": 165.67,
       "xDimension": 107.11,
       "totalLiquidVolume": 3200000,
-      "depth": 187.5,
+      "depth": 172.5,
       "x": 105.375,
       "y": 39.875,
-      "z": 0
+      "z": -132.5
     }
   },
   "brand": {


### PR DESCRIPTION
This fixed trash bin has changed shapes.
## Review requests
- is it, like, ok that the position is negative? The depth really does extend below the deck

## testing
- should drop stuff a lot closer to the trash now