### PR TITLE
fix(api): catch exception when pipette not attached and return no offset 

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -142,10 +142,16 @@ class PipetteHandlerProvider:
         else:
             _reset(mount)
 
-    def get_instrument_offset(self, mount: OT3Mount) -> PipetteOffsetByPipetteMount:
+    def get_instrument_offset(
+        self, mount: OT3Mount
+    ) -> Optional[PipetteOffsetByPipetteMount]:
         """Get the specified pipette's offset."""
         assert mount != OT3Mount.GRIPPER, "Wrong mount type to fetch pipette offset"
-        return self.get_pipette(mount).pipette_offset
+        try:
+            pipette = self.get_pipette(mount)
+        except top_types.PipetteNotAttachedError:
+            return None
+        return pipette.pipette_offset
 
     def reset_instrument_offset(self, mount: OT3Mount, to_default: bool) -> None:
         """


### PR DESCRIPTION
# Overview

fixed bug on edge when trying to get pipette calibration in `instruments` end point.
if there is no pipette attached it raises an exception that propagates to the client. 

# Test Plan

Tested on an OT-3 with no pipettes attached. works as expected. 

# Changelog

- Catch exception raised when getting a pipette that is not attached and return None instead.

# Risk assessment

low. fixes a bug that is currently on edge
