### PR TITLE
feat(api): allow volume input for blowout

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -41,4 +41,4 @@ typing-extensions = ">=4.0.0,<5"
 pytest-profiling = "~=1.7.0"
 # TODO(mc, 2022-03-31): upgrade sphinx, remove this subdep pin
 jinja2 = ">=2.3,<3.1"
-hypothesis = "~=6.36.1"
+hypothesis = ">=6.36,<7"

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -41,3 +41,4 @@ typing-extensions = ">=4.0.0,<5"
 pytest-profiling = "~=1.7.0"
 # TODO(mc, 2022-03-31): upgrade sphinx, remove this subdep pin
 jinja2 = ">=2.3,<3.1"
+hypothesis = "~=6.36.1"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "56bdb8a3920bdbbe892d92f1babf10db2ba961c3d282867855fead7e60a5b26c"
+            "sha256": "0acab80b4d5241d5772e43710c403f85c00b19be4227fc93df07de1db0b35e7c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -56,11 +56,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "babel": {
             "hashes": [
@@ -328,6 +328,14 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2022.7.29"
+        },
+        "hypothesis": {
+            "hashes": [
+                "sha256:7202ea05759f591adf6c1887edbd4d53c049821284f630c5ec8ec3f3f57fd46b",
+                "sha256:7789664e0b487f6553492500738d6ed29ee1af143857d605b296d112154a4057"
+            ],
+            "index": "pypi",
+            "version": "==6.36.2"
         },
         "idna": {
             "hashes": [
@@ -656,11 +664,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
-                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.0"
+            "version": "==23.1"
         },
         "pathspec": {
             "hashes": [
@@ -752,11 +760,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08",
-                "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"
+                "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4",
+                "sha256:7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.2.0"
+            "version": "==3.5.0"
         },
         "pluggy": {
             "hashes": [
@@ -973,11 +981,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
-                "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
+                "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
+                "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==2.28.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.29.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -1009,6 +1017,13 @@
                 "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
             ],
             "version": "==2.2.0"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
         },
         "sphinx": {
             "hashes": [

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -60,8 +60,6 @@ class PipetteConfig:
     default_dispense_flow_rates: Dict[str, float]
     model: PipetteModel
     default_tipracks: List[LabwareUri]
-    # shaft_ul_per_mm: float
-    # default_blowout_volume: float
 
 
 # Notes:
@@ -217,8 +215,6 @@ def load(
         ),
         model=pipette_model,
         default_tipracks=cfg["defaultTipracks"],
-        # default_blowout_volume=cfg["defaultBlowOutVolume"],
-        # shaft_ul_per_mm=cfg["shaftUlPerMm"]
     )
 
     return res

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -60,6 +60,8 @@ class PipetteConfig:
     default_dispense_flow_rates: Dict[str, float]
     model: PipetteModel
     default_tipracks: List[LabwareUri]
+    # shaft_ul_per_mm: float
+    # default_blowout_volume: float
 
 
 # Notes:
@@ -215,6 +217,8 @@ def load(
         ),
         model=pipette_model,
         default_tipracks=cfg["defaultTipracks"],
+        # default_blowout_volume=cfg["defaultBlowOutVolume"],
+        # shaft_ul_per_mm=cfg["shaftUlPerMm"]
     )
 
     return res

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -962,16 +962,27 @@ class API(
         else:
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
 
-    async def blow_out(self, mount: top_types.Mount) -> None:
+    async def blow_out(
+        self, mount: top_types.Mount, microliters: Optional[float] = None
+    ) -> None:
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette
         """
-        blowout_spec = self.plan_check_blow_out(mount)
+        blowout_spec = self.plan_check_blow_out(mount, microliters)
+
+        instrument = self.get_pipette(mount)
+        max_blowout_pos = instrument.config.blow_out
+        # start at the bottom position and move additional distance det. by plan_check_blow_out
+        blowout_distance = instrument.config.bottom - blowout_spec.plunger_distance
+
+        if blowout_distance < max_blowout_pos:
+            raise ValueError("Blow out distance exceeds plunger position limit")
+
         self._backend.set_active_current({blowout_spec.axis: blowout_spec.current})
         target_pos = target_position_from_plunger(
             mount,
-            blowout_spec.plunger_distance,
+            blowout_distance,
             self._current_position,
         )
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -963,13 +963,13 @@ class API(
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
 
     async def blow_out(
-        self, mount: top_types.Mount, microliters: Optional[float] = None
+        self, mount: top_types.Mount, volume: Optional[float] = None
     ) -> None:
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette
         """
-        blowout_spec = self.plan_check_blow_out(mount, microliters)
+        blowout_spec = self.plan_check_blow_out(mount, volume)
 
         instrument = self.get_pipette(mount)
         max_blowout_pos = instrument.config.blow_out

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -97,7 +97,7 @@ class PipetteDict(InstrumentDict):
     default_blow_out_speeds: Dict[str, float]
     ready_to_aspirate: bool
     has_tip: bool
-    # default_blow_out_volume: float
+    default_blow_out_volume: float
 
 
 class GripperDict(InstrumentDict):

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -97,6 +97,7 @@ class PipetteDict(InstrumentDict):
     default_blow_out_speeds: Dict[str, float]
     ready_to_aspirate: bool
     has_tip: bool
+    default_blow_out_volume: float
 
 
 class GripperDict(InstrumentDict):

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -97,7 +97,7 @@ class PipetteDict(InstrumentDict):
     default_blow_out_speeds: Dict[str, float]
     ready_to_aspirate: bool
     has_tip: bool
-    default_blow_out_volume: float
+    # default_blow_out_volume: float
 
 
 class GripperDict(InstrumentDict):

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -355,6 +355,8 @@ class Pipette(AbstractInstrument[pipette_config.PipetteConfig]):
     # want this to unbounded.
     @functools.lru_cache(maxsize=100)
     def ul_per_mm(self, ul: float, action: UlPerMmAction) -> float:
+        if action == "blowout":
+            action = "dispense"
         sequence = self._config.ul_per_mm[action]
         return pipette_config.piecewise_volume_conversion(ul, sequence)
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -620,15 +620,16 @@ class PipetteHandlerProvider(Generic[MountType]):
     ) -> LiquidActionSpec[OT3Axis]:
         ...
 
-    def plan_check_blow_out(self, mount, microliters: Optional[float] = None):  # type: ignore[no-untyped-def]
+    def plan_check_blow_out(self, mount, volume: Optional[float] = None):  # type: ignore[no-untyped-def]
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
         speed = self.plunger_speed(
             instrument, instrument.blow_out_flow_rate, "dispense"
         )
-        if microliters:
-            distance_mm = instrument.ul_per_mm(microliters, "dispense")
+        # TODO(cm, 04/23): change this to use schema v2 configs
+        if volume is not None:
+            distance_mm = instrument.ul_per_mm(volume, "dispense")
         else:
             distance_mm = instrument.config.blow_out
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -609,14 +609,15 @@ class PipetteHandlerProvider(Generic[MountType]):
             )
 
     @overload
+
     def plan_check_blow_out(
-        self, mount: top_types.Mount, microliters: Optional[float] = None
+        self, mount: top_types.Mount, volume: Optional[float] = None
     ) -> LiquidActionSpec[Axis]:
         ...
 
     @overload
     def plan_check_blow_out(
-        self, mount: OT3Mount, microliters: Optional[float] = None
+        self, mount: OT3Mount, volume: Optional[float] = None
     ) -> LiquidActionSpec[OT3Axis]:
         ...
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -609,7 +609,6 @@ class PipetteHandlerProvider(Generic[MountType]):
             )
 
     @overload
-
     def plan_check_blow_out(
         self, mount: top_types.Mount, volume: Optional[float] = None
     ) -> LiquidActionSpec[Axis]:

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -217,6 +217,7 @@ class PipetteHandlerProvider(Generic[MountType]):
                 "default_dispense_flow_rates",
                 "back_compat_names",
             ]
+
             instr_dict = instr.as_dict()
             # TODO (spp, 2021-08-27): Revisit this logic. Why do we need to build
             #  this dict newly every time? Any why only a few items are being updated?
@@ -609,26 +610,25 @@ class PipetteHandlerProvider(Generic[MountType]):
 
     @overload
     def plan_check_blow_out(
-        self, mount: top_types.Mount, microliters: Optional[float]
+        self, mount: top_types.Mount, microliters: Optional[float] = None
     ) -> LiquidActionSpec[Axis]:
         ...
 
     @overload
     def plan_check_blow_out(
-        self, mount: OT3Mount, microliters: Optional[float]
+        self, mount: OT3Mount, microliters: Optional[float] = None
     ) -> LiquidActionSpec[OT3Axis]:
         ...
 
-    def plan_check_blow_out(self, mount, microliters: Optional[float]):  # type: ignore[no-untyped-def]
+    def plan_check_blow_out(self, mount, microliters: Optional[float] = None):  # type: ignore[no-untyped-def]
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
         speed = self.plunger_speed(
             instrument, instrument.blow_out_flow_rate, "dispense"
         )
-
         if microliters:
-            distance_mm = microliters / instrument.ul_per_mm(microliters, "dispense")
+            distance_mm = instrument.ul_per_mm(microliters, "dispense")
         else:
             distance_mm = instrument.config.blow_out
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -472,7 +472,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         if action == "aspirate":
             sequence = self._active_tip_settings.aspirate[specific_tip]
         elif action == "blowout":
-            print(f"ul per mm = {self._config.shaft_ul_per_mm}")
             return self._config.shaft_ul_per_mm
         else:
             sequence = self._active_tip_settings.dispense[specific_tip]

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -471,6 +471,8 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     ) -> float:
         if action == "aspirate":
             sequence = self._active_tip_settings.aspirate[specific_tip]
+        elif action == "blowout":
+            return self._config.shaft_ul_per_mm
         else:
             sequence = self._active_tip_settings.dispense[specific_tip]
         return piecewise_volume_conversion(ul, sequence)

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -472,6 +472,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         if action == "aspirate":
             sequence = self._active_tip_settings.aspirate[specific_tip]
         elif action == "blowout":
+            print(f"ul per mm = {self._config.shaft_ul_per_mm}")
             return self._config.shaft_ul_per_mm
         else:
             sequence = self._active_tip_settings.dispense[specific_tip]

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -605,7 +605,6 @@ class PipetteHandlerProvider:
             ul = volume
 
         distance_mm = ul / instrument.ul_per_mm(ul, "blowout")
-        # breakpoint()
         return LiquidActionSpec(
             axis=OT3Axis.of_main_tool_actuator(mount),
             volume=0,
@@ -644,7 +643,6 @@ class PipetteHandlerProvider:
 
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)
-        print(f"has tip = {instrument.has_tip}")
         if instrument.has_tip:
             raise TipAttachedError("Cannot pick up tip with a tip attached")
         self._ihp_log.debug(f"Picking up tip on {mount.name}")
@@ -825,7 +823,6 @@ class PipetteHandlerProvider:
             (OT3Axis.of_main_tool_actuator(mount),),
             is_96_chan,
         )
-        # breakpoint()
 
         seq_ot3 = seq_builder_ot3()
         return (

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -589,7 +589,7 @@ class PipetteHandlerProvider:
         )
 
     def plan_check_blow_out(
-        self, mount: OT3Mount, microliters: Optional[float] = None
+        self, mount: OT3Mount, volume: Optional[float] = None
     ) -> LiquidActionSpec:
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
@@ -599,11 +599,11 @@ class PipetteHandlerProvider:
             instrument.blow_out_flow_rate,
             "blowout",
         )
+        if volume is None:
+            ul = self.get_attached_instrument(mount)["default_blow_out_volume"]
+        else:
+            ul = volume
 
-        ul = (
-            microliters
-            or self.get_attached_instrument(mount)["default_blow_out_volume"]
-        )
         distance_mm = ul / instrument.ul_per_mm(ul, "blowout")
 
         return LiquidActionSpec(

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -271,6 +271,9 @@ class PipetteHandlerProvider:
                     "aspirate",
                 )
             }
+            result[
+                "default_blow_out_volume"
+            ] = instr.active_tip_settings.default_blowout_volume
         return cast(PipetteDict, result)
 
     @property
@@ -374,7 +377,7 @@ class PipetteHandlerProvider:
             )
         if blow_out:
             this_pipette.blow_out_flow_rate = self.plunger_flowrate(
-                this_pipette, blow_out, "dispense"
+                this_pipette, blow_out, "blowout"
             )
 
     def instrument_max_height(
@@ -585,18 +588,28 @@ class PipetteHandlerProvider:
             current=instrument.plunger_motor_current.run,
         )
 
-    def plan_check_blow_out(self, mount: OT3Mount) -> LiquidActionSpec:
+    def plan_check_blow_out(
+        self, mount: OT3Mount, microliters: Optional[float] = None
+    ) -> LiquidActionSpec:
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
         speed = self.plunger_speed(
-            instrument, instrument.blow_out_flow_rate, "dispense"
+            instrument,
+            instrument.blow_out_flow_rate,
+            "blowout",
         )
+
+        ul = (
+            microliters
+            or self.get_attached_instrument(mount)["default_blow_out_volume"]
+        )
+        distance_mm = ul / instrument.ul_per_mm(ul, "blowout")
 
         return LiquidActionSpec(
             axis=OT3Axis.of_main_tool_actuator(mount),
             volume=0,
-            plunger_distance=instrument.plunger_positions.blow_out,
+            plunger_distance=distance_mm,
             speed=speed,
             instr=instrument,
             current=instrument.plunger_motor_current.run,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -605,7 +605,7 @@ class PipetteHandlerProvider:
             ul = volume
 
         distance_mm = ul / instrument.ul_per_mm(ul, "blowout")
-
+        # breakpoint()
         return LiquidActionSpec(
             axis=OT3Axis.of_main_tool_actuator(mount),
             volume=0,
@@ -644,6 +644,7 @@ class PipetteHandlerProvider:
 
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)
+        print(f"has tip = {instrument.has_tip}")
         if instrument.has_tip:
             raise TipAttachedError("Cannot pick up tip with a tip attached")
         self._ihp_log.debug(f"Picking up tip on {mount.name}")
@@ -824,6 +825,7 @@ class PipetteHandlerProvider:
             (OT3Axis.of_main_tool_actuator(mount),),
             is_96_chan,
         )
+        # breakpoint()
 
         seq_ot3 = seq_builder_ot3()
         return (

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1488,14 +1488,15 @@ class OT3API(
         blowout_spec = self._pipette_handler.plan_check_blow_out(realmount, volume)
 
         max_blowout_pos = instrument.plunger_positions.blow_out
-        # start at the bottom position and move additional distance det. by plan_check_blow_out
+        # start at the bottom position and move additional distance
+        # determined by plan_check_blow_out
         blowout_distance = (
             instrument.plunger_positions.bottom + blowout_spec.plunger_distance
         )
         if blowout_distance > max_blowout_pos:
             raise ValueError(
-                f"Blow out distance exceeds plunger position limit\n blowout dist = {blowout_distance}"
-                f"\nmax blowout distance = {max_blowout_pos}"
+                f"Blow out distance exceeds plunger position limit: blowout dist = {blowout_distance}, "
+                f"max blowout distance = {max_blowout_pos}"
             )
 
         await self._backend.set_active_current(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1577,6 +1577,7 @@ class OT3API(
         spec, _add_tip_to_instrs = self._pipette_handler.plan_check_pick_up_tip(
             realmount, tip_length, presses, increment
         )
+        # breakpoint()
 
         if spec.pick_up_motor_actions:
             await self._motor_pick_up_tip(realmount, spec.pick_up_motor_actions)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1477,7 +1477,7 @@ class OT3API(
     async def blow_out(
         self,
         mount: Union[top_types.Mount, OT3Mount],
-        microliters: Optional[float] = None,
+        volume: Optional[float] = None,
     ) -> None:
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
@@ -1485,15 +1485,20 @@ class OT3API(
         """
         realmount = OT3Mount.from_mount(mount)
         instrument = self._pipette_handler.get_pipette(realmount)
-        blowout_spec = self._pipette_handler.plan_check_blow_out(realmount, microliters)
+        blowout_spec = self._pipette_handler.plan_check_blow_out(realmount, volume)
 
         max_blowout_pos = instrument.plunger_positions.blow_out
+        print(f"instrument type = {type(instrument)}")
+        # breakpoint()
         # start at the bottom position and move additional distance det. by plan_check_blow_out
         blowout_distance = (
             instrument.plunger_positions.bottom + blowout_spec.plunger_distance
         )
+        print(f"blowout dist = {blowout_distance}, max blowout = {max_blowout_pos}")
         if blowout_distance > max_blowout_pos:
-            raise ValueError("Blow out distance exceeds plunger position limit")
+            print(f"VALUE ERROR, blowout dist = {blowout_distance}, max blowout = {max_blowout_pos}")
+            raise ValueError(f"Blow out distance exceeds plunger position limit\n blowout dist = {blowout_distance}"
+                             f"max blowout = {max_blowout_pos}")
 
         await self._backend.set_active_current(
             {blowout_spec.axis: blowout_spec.current}

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1488,17 +1488,15 @@ class OT3API(
         blowout_spec = self._pipette_handler.plan_check_blow_out(realmount, volume)
 
         max_blowout_pos = instrument.plunger_positions.blow_out
-        print(f"instrument type = {type(instrument)}")
-        # breakpoint()
         # start at the bottom position and move additional distance det. by plan_check_blow_out
         blowout_distance = (
             instrument.plunger_positions.bottom + blowout_spec.plunger_distance
         )
-        print(f"blowout dist = {blowout_distance}, max blowout = {max_blowout_pos}")
         if blowout_distance > max_blowout_pos:
-            print(f"VALUE ERROR, blowout dist = {blowout_distance}, max blowout = {max_blowout_pos}")
-            raise ValueError(f"Blow out distance exceeds plunger position limit\n blowout dist = {blowout_distance}"
-                             f"max blowout = {max_blowout_pos}")
+            raise ValueError(
+                f"Blow out distance exceeds plunger position limit\n blowout dist = {blowout_distance}"
+                f"\nmax blowout distance = {max_blowout_pos}"
+            )
 
         await self._backend.set_active_current(
             {blowout_spec.axis: blowout_spec.current}
@@ -1582,7 +1580,6 @@ class OT3API(
         spec, _add_tip_to_instrs = self._pipette_handler.plan_check_pick_up_tip(
             realmount, tip_length, presses, increment
         )
-        # breakpoint()
 
         if spec.pick_up_motor_actions:
             await self._motor_pick_up_tip(realmount, spec.pick_up_motor_actions)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1474,19 +1474,34 @@ class OT3API(
         else:
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
 
-    async def blow_out(self, mount: Union[top_types.Mount, OT3Mount]) -> None:
+    async def blow_out(
+        self,
+        mount: Union[top_types.Mount, OT3Mount],
+        microliters: Optional[float] = None,
+    ) -> None:
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette
         """
         realmount = OT3Mount.from_mount(mount)
-        blowout_spec = self._pipette_handler.plan_check_blow_out(realmount)
+        instrument = self._pipette_handler.get_pipette(realmount)
+        blowout_spec = self._pipette_handler.plan_check_blow_out(realmount, microliters)
+
+        max_blowout_pos = instrument.plunger_positions.blow_out
+        # start at the bottom position and move additional distance det. by plan_check_blow_out
+        blowout_distance = (
+            instrument.plunger_positions.bottom + blowout_spec.plunger_distance
+        )
+        if blowout_distance > max_blowout_pos:
+            raise ValueError("Blow out distance exceeds plunger position limit")
+
         await self._backend.set_active_current(
             {blowout_spec.axis: blowout_spec.current}
         )
+
         target_pos = target_position_from_plunger(
             realmount,
-            blowout_spec.plunger_distance,
+            blowout_distance,
             self._current_position,
         )
 

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -81,7 +81,7 @@ class LiquidHandler(
         """
         ...
 
-    async def blow_out(self, mount: Mount, microliters: Optional[float] = None) -> None:
+    async def blow_out(self, mount: Mount, volume: Optional[float] = None) -> None:
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -81,7 +81,7 @@ class LiquidHandler(
         """
         ...
 
-    async def blow_out(self, mount: Mount) -> None:
+    async def blow_out(self, mount: Mount, microliters: Optional[float] = None) -> None:
         """
         Force any remaining liquid to dispense. The liquid will be dispensed at
         the current location of pipette

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -650,7 +650,7 @@ async def test_blowout_flow_rate(sim_and_instr):
         await hw_api.blow_out(mount)
         assert_move_called(
             mock_move,
-            get_plunger_speed(hw_api)(pip, pip.blow_out_flow_rate, "dispense"),
+            get_plunger_speed(hw_api)(pip, pip.blow_out_flow_rate, "blowout"),
         )
 
     hw_api.set_flow_rate(mount, blow_out=2)
@@ -660,7 +660,7 @@ async def test_blowout_flow_rate(sim_and_instr):
         await hw_api.blow_out(types.Mount.LEFT)
         assert_move_called(
             mock_move,
-            get_plunger_speed(hw_api)(pip, 2, "dispense"),
+            get_plunger_speed(hw_api)(pip, 2, "blowout"),
         )
 
     hw_api.set_pipette_speed(mount, blow_out=15)

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1,6 +1,6 @@
 """ Tests for behaviors specific to the OT3 hardware controller.
 """
-from typing import Iterator, Union, Dict, Tuple, List
+from typing import Iterator, Union, Dict, Tuple, List, Any
 from typing_extensions import Literal
 from math import copysign
 import pytest
@@ -385,39 +385,50 @@ def mock_backend_capacitive_pass(
         yield mock_pass
 
 
-@pytest.mark.parametrize(
-    "load_configs",
-    [
-        {OT3Mount.LEFT: {"channels": 1, "version": (3, 3), "model": "p1000"}},
-        {OT3Mount.RIGHT: {"channels": 8, "version": (3, 3), "model": "p50"}},
-        {OT3Mount.LEFT: {"channels": 96, "model": "p1000", "version": (3, 3)}},
-    ],
-)
+load_blowout_configs = [
+    {OT3Mount.LEFT: {"channels": 1, "version": (3, 3), "model": "p1000"}},
+    {OT3Mount.RIGHT: {"channels": 8, "version": (3, 3), "model": "p50"}},
+    {OT3Mount.LEFT: {"channels": 96, "model": "p1000", "version": (3, 3)}},
+]
+
+
+async def prepare_for_mock_blowout(
+    ot3_hardware: ThreadManager[OT3API],
+    mount: OT3Mount,
+    configs: Any,
+) -> Tuple[Any, ThreadManager[OT3API]]:
+    pipette_config = ot3_pipette_config.load_ot3_pipette(
+        ot3_pipette_config.PipetteModelVersionType(
+            PipetteModelType(configs["model"]),
+            PipetteChannelType(configs["channels"]),
+            PipetteVersionType(*configs["version"]),
+        )
+    )
+    instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
+    await ot3_hardware.cache_pipette(mount, instr_data, None)
+    with patch.object(
+        ot3_hardware, "pick_up_tip", AsyncMock(spec=ot3_hardware.liquid_probe)
+    ) as mock_tip_pickup:
+        mock_tip_pickup.side_effect = (
+            ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]
+        ) = (True)
+        if not ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]:
+            await ot3_hardware.pick_up_tip(mount, 100)
+    return instr_data, ot3_hardware
+
+
+@pytest.mark.parametrize("load_configs", load_blowout_configs)
 @given(blowout_volume=strategies.floats(min_value=1, max_value=10))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_blow_out_position(
     ot3_hardware: ThreadManager[OT3API],
-    load_configs: Dict[str, Union[int, str, Tuple[int, int]]],
+    load_configs: List[Dict[str, Any]],
     blowout_volume: float,
 ) -> None:
     for mount, configs in load_configs.items():
-        pipette_config = ot3_pipette_config.load_ot3_pipette(
-            ot3_pipette_config.PipetteModelVersionType(
-                PipetteModelType(configs["model"]),
-                PipetteChannelType(configs["channels"]),
-                PipetteVersionType(*configs["version"]),
-            )
+        instr_data, ot3_hardware = await prepare_for_mock_blowout(
+            ot3_hardware, mount, configs
         )
-        instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
-        await ot3_hardware.cache_pipette(mount, instr_data, None)
-        with patch.object(
-            ot3_hardware, "pick_up_tip", AsyncMock(spec=ot3_hardware.liquid_probe)
-        ) as mock_tip_pickup:
-            mock_tip_pickup.side_effect = (
-                ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]
-            ) = (True)
-            if not ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]:
-                await ot3_hardware.pick_up_tip(mount, 100)
 
         max_allowed_input_distance = (
             instr_data["config"].plunger_positions_configurations.blow_out
@@ -434,46 +445,29 @@ async def test_blow_out_position(
         expected_position = (
             blowout_volume / instr_data["config"].shaft_ul_per_mm
         ) + instr_data["config"].plunger_positions_configurations.bottom
+        # make sure target distance is not more than max blowout position
         assert (
             position_result[pipette_axis]
             < instr_data["config"].plunger_positions_configurations.blow_out
         )
-        assert position_result[pipette_axis] == pytest.approx(expected_position)
+        # make sure calculated position is roughly what we expect
+        assert position_result[pipette_axis] == pytest.approx(
+            expected_position, rel=0.1
+        )
 
 
-@pytest.mark.parametrize(
-    "load_configs",
-    [
-        {OT3Mount.LEFT: {"channels": 1, "version": (3, 3), "model": "p1000"}},
-        {OT3Mount.RIGHT: {"channels": 8, "version": (3, 3), "model": "p50"}},
-        {OT3Mount.LEFT: {"channels": 96, "model": "p1000", "version": (3, 3)}},
-    ],
-)
+@pytest.mark.parametrize("load_configs", load_blowout_configs)
 @given(blowout_volume=strategies.floats(min_value=1, max_value=200))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_blow_out_error(
     ot3_hardware: ThreadManager[OT3API],
-    load_configs: Dict[str, Union[int, str, Tuple[int, int]]],
+    load_configs: List[Dict[str, Any]],
     blowout_volume: float,
 ) -> None:
     for mount, configs in load_configs.items():
-        pipette_config = ot3_pipette_config.load_ot3_pipette(
-            ot3_pipette_config.PipetteModelVersionType(
-                PipetteModelType(configs["model"]),
-                PipetteChannelType(configs["channels"]),
-                PipetteVersionType(*configs["version"]),
-            )
+        instr_data, ot3_hardware = await prepare_for_mock_blowout(
+            ot3_hardware, mount, configs
         )
-        instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
-        await ot3_hardware.cache_pipette(mount, instr_data, None)
-        with patch.object(
-            ot3_hardware, "pick_up_tip", AsyncMock(spec=ot3_hardware.liquid_probe)
-        ) as mock_tip_pickup:
-            mock_tip_pickup.side_effect = (
-                ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]
-            ) = (True)
-            if not ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]:
-                await ot3_hardware.pick_up_tip(mount, 100)
 
         max_allowed_input_distance = (
             instr_data["config"].plunger_positions_configurations.blow_out

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -64,7 +64,7 @@ from opentrons_shared_data.pipette.pipette_definition import (
     PipetteChannelType,
     PipetteVersionType,
 )
-from hypothesis import given, strategies, settings, HealthCheck, assume
+from hypothesis import given, strategies, settings, HealthCheck, assume, example
 
 
 @pytest.fixture
@@ -418,8 +418,9 @@ async def prepare_for_mock_blowout(
 
 
 @pytest.mark.parametrize("load_configs", load_blowout_configs)
-@given(blowout_volume=strategies.floats(min_value=1, max_value=10))
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(blowout_volume=strategies.floats(min_value=0, max_value=10))
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], max_examples=10)
+@example(blowout_volume=0.0)
 async def test_blow_out_position(
     ot3_hardware: ThreadManager[OT3API],
     load_configs: List[Dict[str, Any]],
@@ -457,8 +458,8 @@ async def test_blow_out_position(
 
 
 @pytest.mark.parametrize("load_configs", load_blowout_configs)
-@given(blowout_volume=strategies.floats(min_value=1, max_value=200))
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(blowout_volume=strategies.floats(min_value=0, max_value=200))
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], max_examples=10)
 async def test_blow_out_error(
     ot3_hardware: ThreadManager[OT3API],
     load_configs: List[Dict[str, Any]],

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -449,7 +449,7 @@ async def test_blow_out_position(
         {OT3Mount.LEFT: {"channels": 96, "model": "p1000", "version": (3, 3)}},
     ],
 )
-@given(blowout_volume=strategies.floats(min_value=1, max_value=100))
+@given(blowout_volume=strategies.floats(min_value=1, max_value=200))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_blow_out_error(
     ot3_hardware: ThreadManager[OT3API],

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -80,6 +80,7 @@ def test_get_pipette_static_config() -> None:
         "fw_update_required": False,
         "fw_current_version": 1,
         "fw_next_version": None,
+        "default_blow_out_volume": 10,
     }
 
     result = subject.get_pipette_static_config(pipette_dict)

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -81,7 +81,7 @@ Quirk = NewType("Quirk", str)
 
 ChannelCount = Literal[1, 8, 96]
 
-UlPerMmAction = Literal["aspirate", "dispense"]
+UlPerMmAction = Literal["aspirate", "dispense", "blowout"]
 
 
 class PipetteConfigElement(TypedDict):
@@ -133,6 +133,8 @@ class PipetteNameSpec(TypedDict):
     defaultAspirateFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
+    defaultBlowOutVolume: float
+    shaftUlPerMm: float
     smoothieConfigs: SmoothieConfigs
     defaultTipracks: List[LabwareUri]
 

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -133,8 +133,6 @@ class PipetteNameSpec(TypedDict):
     defaultAspirateFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
-    # defaultBlowOutVolume: float
-    # shaftUlPerMm: float
     smoothieConfigs: SmoothieConfigs
     defaultTipracks: List[LabwareUri]
 

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -133,8 +133,8 @@ class PipetteNameSpec(TypedDict):
     defaultAspirateFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
-    defaultBlowOutVolume: float
-    shaftUlPerMm: float
+    # defaultBlowOutVolume: float
+    # shaftUlPerMm: float
     smoothieConfigs: SmoothieConfigs
     defaultTipracks: List[LabwareUri]
 


### PR DESCRIPTION
This adds an optional input parameter to the api's `blow_out` function, which allows the user to specify a volume in microliters to blow out. Using this parameter will blow out the specified volume past the pipette's bottom position.  