### PR TITLE
refactor(app): show whether flex pipettes and gripper are calibrated

### DIFF
--- a/api-client/src/instruments/types.ts
+++ b/api-client/src/instruments/types.ts
@@ -18,6 +18,10 @@ export interface PipetteData {
     channels: number
     min_volume: number
     max_volume: number
+    calibratedOffset: {
+      offset: [number, number, number]
+      source: string
+    }
   }
   instrumentName: string
   instrumentModel: string

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -133,5 +133,6 @@
   "missing_pipettes_plural": "missing {{count}} pipettes",
   "missing_both": "missing hardware",
   "have_not_run": "No recent runs",
-  "have_not_run_description": "After you run some protocols, they will appear here."
+  "have_not_run_description": "After you run some protocols, they will appear here.",
+  "calibration_needed": "Calibration needed. <calLink>Calibrate now</calLink>"
 }

--- a/app/src/molecules/InstrumentCard/index.tsx
+++ b/app/src/molecules/InstrumentCard/index.tsx
@@ -32,6 +32,7 @@ interface InstrumentCardProps extends StyleProps {
   instrumentDiagramProps?: InstrumentDiagramProps
   // special casing the gripper at least for now
   isGripperAttached?: boolean
+  banner?: React.ReactNode
 }
 
 /**
@@ -46,6 +47,7 @@ export function InstrumentCard(props: InstrumentCardProps): JSX.Element {
     isGripperAttached = false,
     label,
     menuOverlayItems,
+    banner,
     ...styleProps
   } = props
 
@@ -91,6 +93,7 @@ export function InstrumentCard(props: InstrumentCardProps): JSX.Element {
         gridGap={SPACING.spacing1}
         paddingRight={SPACING.spacing5}
       >
+        {banner}
         <StyledText
           textTransform={TYPOGRAPHY.textTransformUppercase}
           color={COLORS.darkGreyEnabled}

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -42,7 +42,6 @@ export function InstrumentsAndModules({
   robotName,
 }: InstrumentsAndModulesProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
-
   const attachedPipettes = usePipettesQuery(
     {},
     {
@@ -82,6 +81,7 @@ export function InstrumentsAndModules({
   const pipetteOffsetCalibrations =
     useAllPipetteOffsetCalibrationsQuery({
       refetchInterval: FETCH_PIPETTE_CAL_POLL,
+      enabled: !isOT3,
     })?.data?.data ?? []
   const leftMountOffsetCalibration = getOffsetCalibrationForMount(
     pipetteOffsetCalibrations,
@@ -140,13 +140,25 @@ export function InstrumentsAndModules({
                     ? getPipetteModelSpecs(attachedPipettes.left?.model) ?? null
                     : null
                 }
-                pipetteOffsetCalibration={leftMountOffsetCalibration}
+                isPipetteCalibrated={
+                  isOT3
+                    ? attachedInstruments?.data?.find(i => i.mount === 'left')
+                        ?.data?.calibratedOffset != null
+                    : leftMountOffsetCalibration != null
+                }
                 mount={LEFT}
                 robotName={robotName}
                 is96ChannelAttached={is96ChannelAttached}
               />
               {isOT3 ? (
-                <GripperCard attachedGripper={extensionInstrument} />
+                <GripperCard
+                  attachedGripper={extensionInstrument}
+                  isCalibrated={
+                    attachedInstruments?.data?.find(
+                      i => i.mount === 'extension'
+                    )?.data?.calibratedOffset != null
+                  }
+                />
               ) : null}
               {leftColumnModules.map((module, index) => (
                 <ModuleCard
@@ -173,7 +185,13 @@ export function InstrumentsAndModules({
                         null
                       : null
                   }
-                  pipetteOffsetCalibration={rightMountOffsetCalibration}
+                  isPipetteCalibrated={
+                    isOT3
+                      ? attachedInstruments?.data?.find(
+                          i => i.mount === 'right'
+                        )?.data?.calibratedOffset != null
+                      : rightMountOffsetCalibration != null
+                  }
                   mount={RIGHT}
                   robotName={robotName}
                   is96ChannelAttached={false}

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -8,7 +8,7 @@ import { getHasCalibrationBlock } from '../../../../redux/config'
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
 import { AskForCalibrationBlockModal } from '../../../CalibrateTipLength'
 import { useCalibratePipetteOffset } from '../../../CalibratePipetteOffset/useCalibratePipetteOffset'
-import { useDeckCalibrationData } from '../../hooks'
+import { useDeckCalibrationData, useIsOT3 } from '../../hooks'
 import { PipetteOverflowMenu } from '../PipetteOverflowMenu'
 import { AboutPipetteSlideout } from '../AboutPipetteSlideout'
 import { PipetteCard } from '..'
@@ -50,6 +50,7 @@ const mockAboutPipettesSlideout = AboutPipetteSlideout as jest.MockedFunction<
 const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
   typeof useDispatchApiRequest
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const render = (props: React.ComponentProps<typeof PipetteCard>) => {
   return renderWithProviders(<PipetteCard {...props} />, {
@@ -65,6 +66,7 @@ describe('PipetteCard', () => {
   beforeEach(() => {
     startWizard = jest.fn()
     dispatchApiRequest = jest.fn()
+    when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(false)
     when(mockAboutPipettesSlideout).mockReturnValue(
       <div>mock about slideout</div>
     )
@@ -97,7 +99,7 @@ describe('PipetteCard', () => {
       robotName: mockRobotName,
       pipetteId: 'id',
       is96ChannelAttached: false,
-      pipetteOffsetCalibration: null,
+      isPipetteCalibrated: false,
     })
     getByText('left Mount')
     getByText('Left Pipette')
@@ -109,7 +111,7 @@ describe('PipetteCard', () => {
       robotName: mockRobotName,
       pipetteId: 'id',
       is96ChannelAttached: true,
-      pipetteOffsetCalibration: null,
+      isPipetteCalibrated: false,
     })
     getByText('Both Mounts')
     const overflowButton = getByRole('button', {
@@ -126,7 +128,7 @@ describe('PipetteCard', () => {
       robotName: mockRobotName,
       pipetteId: 'id',
       is96ChannelAttached: false,
-      pipetteOffsetCalibration: null,
+      isPipetteCalibrated: false,
     })
     getByText('right Mount')
     getByText('Right Pipette')
@@ -137,7 +139,7 @@ describe('PipetteCard', () => {
       mount: RIGHT,
       robotName: mockRobotName,
       is96ChannelAttached: false,
-      pipetteOffsetCalibration: null,
+      isPipetteCalibrated: false,
     })
     getByText('right Mount')
     getByText('Empty')
@@ -148,10 +150,32 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       is96ChannelAttached: false,
-      pipetteOffsetCalibration: null,
+      isPipetteCalibrated: false,
     })
     getByText('left Mount')
     getByText('Empty')
+  })
+  it('does not render banner to calibrate for ot2 pipette if not calibrated', () => {
+    when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(false)
+    const { queryByText } = render({
+      pipetteInfo: mockLeftSpecs,
+      mount: LEFT,
+      robotName: mockRobotName,
+      is96ChannelAttached: false,
+      isPipetteCalibrated: false,
+    })
+    expect(queryByText('Calibrate now')).toBeNull()
+  })
+  it('renders banner to calibrate for ot3 pipette if not calibrated', () => {
+    when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(true)
+    const { getByText } = render({
+      pipetteInfo: { ...mockLeftSpecs, name: 'p300_single_gen3' },
+      mount: LEFT,
+      robotName: mockRobotName,
+      is96ChannelAttached: false,
+      isPipetteCalibrated: false,
+    })
+    getByText('Calibrate now')
   })
   it('renders kebab icon, opens and closes overflow menu on click', () => {
     const { getByRole, getByText, queryByText } = render({
@@ -159,7 +183,7 @@ describe('PipetteCard', () => {
       mount: RIGHT,
       robotName: mockRobotName,
       is96ChannelAttached: false,
-      pipetteOffsetCalibration: null,
+      isPipetteCalibrated: false,
     })
 
     const overflowButton = getByRole('button', {

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 import {
   Box,
   Flex,
@@ -40,12 +41,12 @@ import type {
   PipetteWizardFlow,
   SelectablePipettes,
 } from '../../PipetteWizardFlows/types'
-import { PipetteOffsetCalibration } from '../../../redux/calibration/api-types'
+import { Banner } from '../../../atoms/Banner'
 
 interface PipetteCardProps {
   pipetteInfo: PipetteModelSpecs | null
   pipetteId?: AttachedPipette['id'] | null
-  pipetteOffsetCalibration: PipetteOffsetCalibration | null
+  isPipetteCalibrated: boolean
   mount: Mount
   robotName: string
   is96ChannelAttached: boolean
@@ -55,7 +56,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const { t } = useTranslation(['device_details', 'protocol_setup'])
   const {
     pipetteInfo,
-    pipetteOffsetCalibration,
+    isPipetteCalibrated,
     mount,
     robotName,
     pipetteId,
@@ -188,6 +189,27 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             flex="100%"
             paddingLeft={SPACING.spacing3}
           >
+            {isOT3PipetteAttached && !isPipetteCalibrated ? (
+              <Banner type="error" marginBottom={SPACING.spacing2}>
+                <Trans
+                  t={t}
+                  i18nKey="calibration_needed"
+                  components={{
+                    calLink: (
+                      <StyledText
+                        as="p"
+                        css={css`
+                          text-decoration: underline;
+                          cursor: pointer;
+                          margin-left: 0.5rem;
+                        `}
+                        onClick={handleCalibrate}
+                      />
+                    ),
+                  }}
+                />
+              </Banner>
+            ) : null}
             <StyledText
               textTransform={TYPOGRAPHY.textTransformUppercase}
               color={COLORS.darkGreyEnabled}
@@ -238,7 +260,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               handleSettingsSlideout={handleSettingsSlideout}
               handleAboutSlideout={handleAboutSlideout}
               handleCalibrate={handleCalibrate}
-              isPipetteCalibrated={pipetteOffsetCalibration != null}
+              isPipetteCalibrated={isPipetteCalibrated}
             />
           </Box>
           {menuOverlay}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -151,7 +151,9 @@ export function RobotOverview({
           </Box>
         </Flex>
       </Flex>
-      {!isRobotBusy ? <CalibrationStatusBanner robotName={robotName} /> : null}
+      {robotModel === 'OT-2' && !isRobotBusy ? (
+        <CalibrationStatusBanner robotName={robotName} />
+      ) : null}
       <Flex
         borderBottom={BORDERS.lineBorder}
         marginBottom={SPACING.spacing4}

--- a/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -199,6 +199,7 @@ describe('InstrumentsAndModules', () => {
     render()
     expect(mockUseAllPipetteOffsetCalibrationsQuery).toHaveBeenCalledWith({
       refetchInterval: 30000,
+      enabled: true,
     })
     expect(mockUsePipettesQuery).toHaveBeenCalledWith(
       {},

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -1,7 +1,11 @@
-import { InstrumentData } from '@opentrons/api-client'
-import { getGripperDisplayName, GripperModel } from '@opentrons/shared-data'
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
+import { InstrumentData } from '@opentrons/api-client'
+import { SPACING } from '@opentrons/components'
+import { getGripperDisplayName, GripperModel } from '@opentrons/shared-data'
+import { Banner } from '../../atoms/Banner'
+import { StyledText } from '../../atoms/text'
 import { InstrumentCard } from '../../molecules/InstrumentCard'
 import { GripperWizardFlows } from '../GripperWizardFlows'
 import { GRIPPER_FLOW_TYPES } from '../GripperWizardFlows/constants'
@@ -9,10 +13,12 @@ import { GripperWizardFlowType } from '../GripperWizardFlows/types'
 
 interface GripperCardProps {
   attachedGripper: InstrumentData | null
+  isCalibrated: boolean
 }
 
 export function GripperCard({
   attachedGripper,
+  isCalibrated,
 }: GripperCardProps): JSX.Element {
   const { t } = useTranslation(['device_details', 'shared'])
   const [
@@ -62,6 +68,29 @@ export function GripperCard({
                 attachedGripper.instrumentModel as GripperModel
               )
             : t('shared:empty')
+        }
+        banner={
+          attachedGripper != null && !isCalibrated ? (
+            <Banner type="error" marginBottom={SPACING.spacing2}>
+              <Trans
+                t={t}
+                i18nKey="calibration_needed"
+                components={{
+                  calLink: (
+                    <StyledText
+                      as="p"
+                      css={css`
+                        text-decoration: underline;
+                        cursor: pointer;
+                        margin-left: 0.5rem;
+                      `}
+                      onClick={handleCalibrate}
+                    />
+                  ),
+                }}
+              />
+            </Banner>
+          ) : null
         }
         isGripperAttached={attachedGripper != null}
         label={t('shared:extension_mount')}


### PR DESCRIPTION
# Overview

show warnings in the device detail page instrument cards if an attached instrument has not been calibrated

Re: RAUT-407

# Test Plan

Skip calibrating a pipette/gripper after attaching through the desktop app.
You should see a red banner with a on the instrument card of the device detail page.

# Changelog

- only show Calibration Dashboard linking top level banner for OT2 detail pages
- Add banners to instrument cards if calibration is missing for an attached instrument.

# Risk assessment
low
