### PR TITLE
fix(odd): toast and button design qa fixes

### DIFF
--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -118,15 +118,17 @@ export function Toast(props: ToastProps): JSX.Element {
   } = {
     [ERROR_TOAST]: {
       iconName: 'ot-alert',
-      color: `${showODDStyle ? COLORS.yellow_two : COLORS.errorEnabled}`,
+      color: `${showODDStyle ? COLORS.red_two : COLORS.errorEnabled}`,
       backgroundColor: `${
-        showODDStyle ? COLORS.yellow_four : COLORS.errorBackgroundLight
+        showODDStyle ? COLORS.red_four : COLORS.errorBackgroundLight
       }`,
     },
     [INFO_TOAST]: {
       iconName: 'information',
-      color: COLORS.darkGreyEnabled,
-      backgroundColor: COLORS.darkGreyDisabled,
+      color: `${showODDStyle ? COLORS.grey_two : COLORS.darkGreyEnabled}`,
+      backgroundColor: `${
+        showODDStyle ? COLORS.grey_four : COLORS.darkGreyDisabled
+      }`,
     },
     [SUCCESS_TOAST]: {
       iconName: 'ot-check',
@@ -270,10 +272,20 @@ export function Toast(props: ToastProps): JSX.Element {
       {closeText.length > 0 && (
         <Link role="button" height={SPACING.spacing5}>
           <StyledText
-            color={COLORS.darkBlack_hundred}
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            fontSize={TYPOGRAPHY.fontSize22}
-            lineHeight={TYPOGRAPHY.lineHeight28}
+            color={
+              showODDStyle ? COLORS.darkBlack_hundred : COLORS.darkBlackEnabled
+            }
+            fontSize={
+              showODDStyle ? TYPOGRAPHY.fontSize22 : TYPOGRAPHY.fontSizeP
+            }
+            fontWeight={
+              showODDStyle
+                ? TYPOGRAPHY.fontWeightSemiBold
+                : TYPOGRAPHY.fontWeightRegular
+            }
+            lineHeight={
+              showODDStyle ? TYPOGRAPHY.lineHeight28 : TYPOGRAPHY.lineHeight20
+            }
             textTransform={TYPOGRAPHY.textTransformCapitalize}
             whiteSpace="nowrap"
           >

--- a/app/src/atoms/buttons/OnDeviceDisplay/MediumButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/MediumButton.tsx
@@ -11,6 +11,8 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { StyledText } from '../../text'
+import { ODD_FOCUS_VISIBLE } from './constants'
+
 import type { IconName, StyleProps } from '@opentrons/components'
 
 type MediumButtonTypes =
@@ -116,7 +118,7 @@ export function MediumButton(props: MediumButtonProps): JSX.Element {
       color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
     }
     &:focus-visible {
-      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
+      box-shadow: ${ODD_FOCUS_VISIBLE};
     }
 
     &:active {

--- a/app/src/atoms/buttons/OnDeviceDisplay/TabbedButton.stories.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/TabbedButton.stories.tsx
@@ -12,7 +12,7 @@ const TabbedButtonTemplate: Story<
 > = args => <TabbedButton {...args} />
 export const Tabbed = TabbedButtonTemplate.bind({})
 Tabbed.args = {
-  foreground: true,
+  isSelected: true,
   children: 'Button text',
   disabled: false,
   title: 'tabbed button',

--- a/app/src/atoms/buttons/OnDeviceDisplay/TabbedButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/TabbedButton.tsx
@@ -8,7 +8,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-const FOREGROUND_STYLES = css`
+const SELECTED_STYLE = css`
   background-color: ${COLORS.highlightPurple_one};
   color: ${COLORS.white};
 
@@ -23,7 +23,7 @@ const FOREGROUND_STYLES = css`
   }
 `
 
-const BACKGROUND_STYLES = css`
+const UNSELECTED_STYLE = css`
   background-color: ${COLORS.highlightPurple_two};
   color: ${COLORS.darkBlack_hundred};
 
@@ -39,7 +39,7 @@ const BACKGROUND_STYLES = css`
 `
 
 interface TabbedButtonProps extends React.ComponentProps<typeof Btn> {
-  foreground?: boolean
+  isSelected?: boolean
 }
 
 export const TabbedButton = styled(Btn)<TabbedButtonProps>`
@@ -53,7 +53,7 @@ export const TabbedButton = styled(Btn)<TabbedButtonProps>`
       padding: ${SPACING.spacing4} ${SPACING.spacing5};
       text-transform: ${TYPOGRAPHY.textTransformNone};
 
-      ${props.foreground === true ? FOREGROUND_STYLES : BACKGROUND_STYLES}
+      ${props.isSelected === true ? SELECTED_STYLE : UNSELECTED_STYLE}
 
       ${styleProps}
 

--- a/app/src/atoms/buttons/OnDeviceDisplay/__tests__/TabbedButton.test.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/__tests__/TabbedButton.test.tsx
@@ -13,7 +13,7 @@ const render = (props: React.ComponentProps<typeof TabbedButton>) => {
   return renderWithProviders(<TabbedButton {...props} />)[0]
 }
 
-describe('Background TabbedButton', () => {
+describe('Unselected TabbedButton', () => {
   let props: React.ComponentProps<typeof TabbedButton>
 
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe('Background TabbedButton', () => {
     }
   })
 
-  it('renders background tabbed button with text', () => {
+  it('renders unselected tabbed button with text', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyle(
@@ -46,7 +46,7 @@ describe('Background TabbedButton', () => {
     expect(button).toHaveStyle(`color: ${String(COLORS.darkBlack_hundred)}`)
   })
 
-  it('renders background tabbed button with text and disabled', () => {
+  it('renders unselected tabbed button with text and disabled', () => {
     props.disabled = true
     const { getByText } = render(props)
     const button = getByText('tabbed button')
@@ -55,7 +55,7 @@ describe('Background TabbedButton', () => {
     expect(button).toHaveStyle(`color: #16212d99`)
   })
 
-  it('applies the correct states to the background tabbed button - active', () => {
+  it('applies the correct states to the unselected tabbed button - active', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyleRule(
@@ -67,7 +67,7 @@ describe('Background TabbedButton', () => {
     )
   })
 
-  it('applies the correct states to the background tabbed button - focus', () => {
+  it('applies the correct states to the unselected tabbed button - focus', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyleRule('box-shadow', 'none', {
@@ -75,7 +75,7 @@ describe('Background TabbedButton', () => {
     })
   })
 
-  it('applies the correct states to the background tabbed button - focus-visible', () => {
+  it('applies the correct states to the unselected tabbed button - focus-visible', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyleRule(
@@ -88,17 +88,17 @@ describe('Background TabbedButton', () => {
   })
 })
 
-describe('Foreground TabbedButton', () => {
+describe('Selected TabbedButton', () => {
   let props: React.ComponentProps<typeof TabbedButton>
 
   beforeEach(() => {
     props = {
-      foreground: true,
+      isSelected: true,
       children: 'tabbed button',
     }
   })
 
-  it('renders foreground tabbed button with text', () => {
+  it('renders selected tabbed button with text', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyle(
@@ -122,7 +122,7 @@ describe('Foreground TabbedButton', () => {
     expect(button).toHaveStyle(`color: ${String(COLORS.white)}`)
   })
 
-  it('renders foreground tabbed button with text and disabled', () => {
+  it('renders selected tabbed button with text and disabled', () => {
     props.disabled = true
     const { getByText } = render(props)
     const button = getByText('tabbed button')
@@ -131,7 +131,7 @@ describe('Foreground TabbedButton', () => {
     expect(button).toHaveStyle(`color: #16212d99`)
   })
 
-  it('applies the correct states to the foreground tabbed button - active', () => {
+  it('applies the correct states to the selected tabbed button - active', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyleRule(
@@ -143,7 +143,7 @@ describe('Foreground TabbedButton', () => {
     )
   })
 
-  it('applies the correct states to the foreground tabbed button - focus', () => {
+  it('applies the correct states to the selected tabbed button - focus', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyleRule('box-shadow', 'none', {
@@ -151,7 +151,7 @@ describe('Foreground TabbedButton', () => {
     })
   })
 
-  it('applies the correct states to the foreground tabbed button - focus-visible', () => {
+  it('applies the correct states to the selected tabbed button - focus-visible', () => {
     const { getByText } = render(props)
     const button = getByText('tabbed button')
     expect(button).toHaveStyleRule(

--- a/app/src/molecules/CardButton/__tests__/CardButton.test.tsx
+++ b/app/src/molecules/CardButton/__tests__/CardButton.test.tsx
@@ -49,7 +49,7 @@ describe('CardButton', () => {
     getByText('Find a network in your lab or enter your own.')
     expect(getByTestId('cardButton_icon_wifi')).toBeInTheDocument()
     const button = getByRole('button')
-    expect(button).toHaveStyle(`background-color: ${COLORS.foundationalBlue}`)
+    expect(button).toHaveStyle(`background-color: ${COLORS.mediumBlueEnabled}`)
   })
 
   it('renders the button as disabled', () => {

--- a/app/src/molecules/CardButton/index.tsx
+++ b/app/src/molecules/CardButton/index.tsx
@@ -27,24 +27,24 @@ const CARD_BUTTON_STYLE = css`
   box-shadow: none;
 
   &:focus {
-    background-color: ${COLORS.medBluePressed};
+    background-color: ${COLORS.mediumBluePressed};
     box-shadow: none;
   }
 
   &:hover {
     border: none;
     box-shadow: none;
-    background-color: ${COLORS.foundationalBlue};
+    background-color: ${COLORS.mediumBlueEnabled};
     color: ${COLORS.darkBlackEnabled};
   }
 
   &:focus-visible {
     box-shadow: ${ODD_FOCUS_VISIBLE};
-    background-color: ${COLORS.foundationalBlue};
+    background-color: ${COLORS.mediumBlueEnabled};
   }
 
   &:active {
-    background-color: ${COLORS.medBluePressed};
+    background-color: ${COLORS.mediumBluePressed};
   }
 
   &:disabled {
@@ -84,7 +84,7 @@ export function CardButton(props: CardButtonProps): JSX.Element {
       width="100%"
       css={CARD_BUTTON_STYLE}
       backgroundColor={
-        disabled ? COLORS.darkBlack_twenty : COLORS.foundationalBlue
+        disabled ? COLORS.darkBlack_twenty : COLORS.mediumBlueEnabled
       }
       disabled={disabled}
     >

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/TouchscreenBrightness.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/TouchscreenBrightness.tsx
@@ -48,7 +48,7 @@ const BrightnessTile = styled(Box)`
   height: 8.75rem;
   border-radius: ${BORDERS.size_two};
   background: ${(props: BrightnessTileProps) =>
-    props.isActive ? COLORS.blueEnabled : COLORS.foundationalBlue};
+    props.isActive ? COLORS.blueEnabled : COLORS.mediumBlueEnabled};
 `
 
 // Note The actual brightness is Bright 1 <---> 6 Dark which is opposite to the UI

--- a/components/src/ui-style-constants/colors.ts
+++ b/components/src/ui-style-constants/colors.ts
@@ -113,6 +113,11 @@ export const darkBlack_sixty = `${darkBlackEnabled}${opacity60HexCode}`
 export const darkBlack_forty = `${darkBlackEnabled}${opacity40HexCode}`
 export const darkBlack_twenty = `${darkBlackEnabled}${opacity20HexCode}`
 
+export const grey_one = '#57575c'
+export const grey_two = '#6d6d74'
+export const grey_three = '#d0d0d0'
+export const grey_four = '#e0e0e0'
+
 export const light_one = '#d0d0d0'
 export const light_one_pressed = '#b4b6b8'
 export const light_two = '#e0e0e0'
@@ -144,4 +149,4 @@ export const red_two = '#e31e1e'
 export const red_two_pressed = '#c41e20'
 export const red_three = '#fbcdcd'
 export const red_three_pressed = '#d9b3b5'
-// export const red_four = errorText
+export const red_four = '#ffdddd'


### PR DESCRIPTION

# Overview

This PR consolidates design qa fixes for toasts, medium buttons, and tabbed buttons.

Closes RAUT-361, RAUT-362, and RAUT-379

# Test Plan

Changes have been tested with unit tests and via storybook stories

# Changelog

- Added new grey and red colors
- Used new colors in ODD toasts
- Slimmed the focus border on medium buttons
- Renamed the selected parameter for tabbed buttons
- Fixed broken code in edge due to color renames on another branch

# Review requests


# Risk assessment

Low
