### PR TITLE
feat(odd): radio button component

### DIFF
--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.stories.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.stories.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { RadioButton } from '.'
+import type { Story, Meta } from '@storybook/react'
+
+export default {
+  title: 'ODD/Atoms/Buttons/RadioButton',
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+        options: ['large', 'small'],
+      },
+      defaultValue: 'large',
+    },
+    onClick: { action: 'clicked' },
+  },
+} as Meta
+
+const RadioButtonTemplate: Story<
+  React.ComponentProps<typeof RadioButton>
+> = args => <RadioButton {...args} />
+
+export const RadioButtonComponent = RadioButtonTemplate.bind({})
+RadioButtonComponent.args = {
+  buttonLabel: 'Button text',
+  buttonValue: 1,
+  disabled: false,
+  isSelected: false,
+}

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.stories.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.stories.tsx
@@ -5,7 +5,7 @@ import type { Story, Meta } from '@storybook/react'
 export default {
   title: 'ODD/Atoms/Buttons/RadioButton',
   argTypes: {
-    size: {
+    radioButtonType: {
       control: {
         type: 'select',
         options: ['large', 'small'],

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
@@ -59,6 +59,8 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     cursor: not-allowed;
   `
 
+  // TODO: (ew, 2023-04-21): button is not tabbable, so focus state
+  // is not possible on ODD. It's testable in storybook but not in real life.
   const SettingButtonLabel = styled.label`
     border-radius: ${BORDERS.size_four};
     cursor: pointer;

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
@@ -38,16 +38,18 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
 
   const availableButtonStyles = css`
     background: ${COLORS.foundationalBlue};
+
     &:active {
-      background-color: '#94afd4';
+      background-color: #94afd4;
     }
   `
 
   const selectedButtonStyles = css`
     background: ${COLORS.blueEnabled};
     color: ${COLORS.white};
+
     &:active {
-      background-color: '#045dd0';
+      background-color: #045dd0;
     }
   `
 
@@ -65,18 +67,9 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
 
     ${isSelected ? selectedButtonStyles : availableButtonStyles}
     ${disabled && disabledButtonStyles}
-    &:hover {
-      background: ${COLORS.green_four};
-      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
-    }
-    &:focus {
-      background: ${COLORS.green_four};
-      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
-    }
 
-    &:disabled {
-      background-color: ${COLORS.darkBlack_twenty};
-      color: ${COLORS.darkBlack_sixty};
+    &:focus-visible {
+      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
     }
   `
 
@@ -90,7 +83,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
         type="radio"
         value={buttonValue}
       />
-      <SettingButtonLabel role='label' htmlFor={buttonLabel}>
+      <SettingButtonLabel role="label" htmlFor={buttonLabel}>
         <StyledText
           fontSize={isLarge ? TYPOGRAPHY.fontSize28 : TYPOGRAPHY.fontSize22}
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
 } from '@opentrons/components'
 import { StyledText } from '../../text'
+import { ODD_FOCUS_VISIBLE } from './constants'
 
 import type { StyleProps } from '@opentrons/components'
 
@@ -17,7 +18,7 @@ interface RadioButtonProps extends StyleProps {
   onChange: React.ChangeEventHandler<HTMLInputElement>
   disabled?: boolean
   isSelected?: boolean
-  size?: 'large' | 'small'
+  radioButtonType?: 'large' | 'small'
 }
 
 export function RadioButton(props: RadioButtonProps): JSX.Element {
@@ -27,33 +28,33 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     disabled = false,
     isSelected = false,
     onChange,
-    size,
+    radioButtonType = 'large',
   } = props
 
-  const isLarge = size === 'large'
+  const isLarge = radioButtonType === 'large'
 
   const SettingButton = styled.input`
     display: none;
   `
 
-  const availableButtonStyles = css`
+  const AVAILABLE_BUTTON_STYLE = css`
     background: ${COLORS.mediumBlueEnabled};
 
     &:active {
-      background-color: #94afd4;
+      background-color: ${COLORS.mediumBluePressed};
     }
   `
 
-  const selectedButtonStyles = css`
+  const SELECTED_BUTTON_STYLE = css`
     background: ${COLORS.blueEnabled};
     color: ${COLORS.white};
 
     &:active {
-      background-color: #045dd0;
+      background-color: ${COLORS.bluePressed};
     }
   `
 
-  const disabledButtonStyles = css`
+  const DISABLED_BUTTON_STYLE = css`
     background-color: ${COLORS.darkBlack_twenty};
     color: ${COLORS.darkBlack_sixty};
     cursor: not-allowed;
@@ -67,11 +68,11 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     padding: ${isLarge ? SPACING.spacing5 : SPACING.spacingM};
     width: 100%;
 
-    ${isSelected ? selectedButtonStyles : availableButtonStyles}
-    ${disabled && disabledButtonStyles}
+    ${isSelected ? SELECTED_BUTTON_STYLE : AVAILABLE_BUTTON_STYLE}
+    ${disabled && DISABLED_BUTTON_STYLE}
 
     &:focus-visible {
-      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
+      box-shadow: ${ODD_FOCUS_VISIBLE};
     }
   `
 

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
@@ -14,7 +14,7 @@ import type { StyleProps } from '@opentrons/components'
 interface RadioButtonProps extends StyleProps {
   buttonLabel: string
   buttonValue: string | number
-  onClick: () => void
+  onChange: React.ChangeEventHandler<HTMLInputElement>
   disabled?: boolean
   isSelected?: boolean
   size?: 'large' | 'small'
@@ -26,7 +26,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     buttonValue,
     disabled = false,
     isSelected = false,
-    onClick,
+    onChange,
     size,
   } = props
 
@@ -79,7 +79,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
         checked={isSelected}
         disabled={disabled}
         id={buttonLabel}
-        onChange={onClick}
+        onChange={onChange}
         type="radio"
         value={buttonValue}
       />

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+import {
+  TYPOGRAPHY,
+  COLORS,
+  SPACING,
+  BORDERS,
+  Flex,
+} from '@opentrons/components'
+import { StyledText } from '../../text'
+
+import type { StyleProps } from '@opentrons/components'
+
+interface RadioButtonProps extends StyleProps {
+  buttonLabel: string
+  buttonValue: string | number
+  onClick: () => void
+  disabled?: boolean
+  isSelected?: boolean
+  size?: 'large' | 'small'
+}
+
+export function RadioButton(props: RadioButtonProps): JSX.Element {
+  const {
+    buttonLabel,
+    buttonValue,
+    disabled = false,
+    isSelected = false,
+    onClick,
+    size,
+  } = props
+
+  const isLarge = size === 'large'
+
+  const SettingButton = styled.input`
+    display: none;
+  `
+
+  const availableButtonStyles = css`
+    background: ${COLORS.foundationalBlue};
+    &:active {
+      background-color: '#94afd4';
+    }
+  `
+
+  const selectedButtonStyles = css`
+    background: ${COLORS.blueEnabled};
+    color: ${COLORS.white};
+    &:active {
+      background-color: '#045dd0';
+    }
+  `
+
+  const disabledButtonStyles = css`
+    background-color: ${COLORS.darkBlack_twenty};
+    color: ${COLORS.darkBlack_sixty};
+    cursor: not-allowed;
+  `
+
+  const SettingButtonLabel = styled.label`
+    border-radius: ${BORDERS.size_four};
+    cursor: pointer;
+    padding: ${isLarge ? SPACING.spacing5 : SPACING.spacingM};
+    width: 100%;
+
+    ${isSelected ? selectedButtonStyles : availableButtonStyles}
+    ${disabled && disabledButtonStyles}
+    &:hover {
+      background: ${COLORS.green_four};
+      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
+    }
+    &:focus {
+      background: ${COLORS.green_four};
+      box-shadow: 0 0 0 ${SPACING.spacingS} ${COLORS.fundamentalsFocus};
+    }
+
+    &:disabled {
+      background-color: ${COLORS.darkBlack_twenty};
+      color: ${COLORS.darkBlack_sixty};
+    }
+  `
+
+  return (
+    <Flex width="100%">
+      <SettingButton
+        checked={isSelected}
+        disabled={disabled}
+        id={buttonLabel}
+        onChange={onClick}
+        type="radio"
+        value={buttonValue}
+      />
+      <SettingButtonLabel role='label' htmlFor={buttonLabel}>
+        <StyledText
+          fontSize={isLarge ? TYPOGRAPHY.fontSize28 : TYPOGRAPHY.fontSize22}
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          lineHeight={
+            isLarge ? TYPOGRAPHY.lineHeight36 : TYPOGRAPHY.lineHeight28
+          }
+        >
+          {buttonLabel}
+        </StyledText>
+      </SettingButtonLabel>
+    </Flex>
+  )
+}

--- a/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/RadioButton.tsx
@@ -37,7 +37,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
   `
 
   const availableButtonStyles = css`
-    background: ${COLORS.foundationalBlue};
+    background: ${COLORS.mediumBlueEnabled};
 
     &:active {
       background-color: #94afd4;

--- a/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
@@ -23,12 +23,8 @@ describe('RadioButton', () => {
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
-    expect(label).toHaveStyle(
-      `background-color: ${COLORS.foundationalBlue}`
-    )
-    expect(label).toHaveStyle(
-      `padding: ${SPACING.spacing5}`
-    )
+    expect(label).toHaveStyle(`background-color: ${COLORS.foundationalBlue}`)
+    expect(label).toHaveStyle(`padding: ${SPACING.spacing5}`)
   })
   it('renders the large selected button', () => {
     props = {
@@ -38,12 +34,8 @@ describe('RadioButton', () => {
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
-    expect(label).toHaveStyle(
-      `background-color: ${COLORS.blueEnabled}`
-    )
-    expect(label).toHaveStyle(
-      `padding: ${SPACING.spacing5}`
-    )
+    expect(label).toHaveStyle(`background-color: ${COLORS.blueEnabled}`)
+    expect(label).toHaveStyle(`padding: ${SPACING.spacing5}`)
   })
   it('renders the small button', () => {
     props = {
@@ -52,12 +44,8 @@ describe('RadioButton', () => {
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
-    expect(label).toHaveStyle(
-      `background-color: ${COLORS.foundationalBlue}`
-    )
-    expect(label).toHaveStyle(
-      `padding: ${SPACING.spacingM}`
-    )
+    expect(label).toHaveStyle(`background-color: ${COLORS.foundationalBlue}`)
+    expect(label).toHaveStyle(`padding: ${SPACING.spacingM}`)
   })
   it('renders the small selected button', () => {
     props = {
@@ -67,11 +55,7 @@ describe('RadioButton', () => {
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
-    expect(label).toHaveStyle(
-      `background-color: ${COLORS.blueEnabled}`
-    )
-    expect(label).toHaveStyle(
-      `padding: ${SPACING.spacingM}`
-    )
+    expect(label).toHaveStyle(`background-color: ${COLORS.blueEnabled}`)
+    expect(label).toHaveStyle(`padding: ${SPACING.spacingM}`)
   })
 })

--- a/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
@@ -11,7 +11,7 @@ describe('RadioButton', () => {
   let props: React.ComponentProps<typeof RadioButton>
   beforeEach(() => {
     props = {
-      onClick: jest.fn(),
+      onChange: jest.fn(),
       buttonLabel: 'radio button',
       buttonValue: 1,
     }
@@ -23,7 +23,7 @@ describe('RadioButton', () => {
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
-    expect(label).toHaveStyle(`background-color: ${COLORS.foundationalBlue}`)
+    expect(label).toHaveStyle(`background-color: ${COLORS.mediumBlueEnabled}`)
     expect(label).toHaveStyle(`padding: ${SPACING.spacing5}`)
   })
   it('renders the large selected button', () => {
@@ -44,7 +44,7 @@ describe('RadioButton', () => {
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
-    expect(label).toHaveStyle(`background-color: ${COLORS.foundationalBlue}`)
+    expect(label).toHaveStyle(`background-color: ${COLORS.mediumBlueEnabled}`)
     expect(label).toHaveStyle(`padding: ${SPACING.spacingM}`)
   })
   it('renders the small selected button', () => {

--- a/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import { renderWithProviders, COLORS, SPACING } from '@opentrons/components'
+
+import { RadioButton } from '..'
+
+const render = (props: React.ComponentProps<typeof RadioButton>) => {
+  return renderWithProviders(<RadioButton {...props} />)[0]
+}
+
+describe('RadioButton', () => {
+  let props: React.ComponentProps<typeof RadioButton>
+  beforeEach(() => {
+    props = {
+      onClick: jest.fn(),
+      buttonLabel: 'radio button',
+      buttonValue: 1,
+    }
+  })
+  it('renders the large button', () => {
+    props = {
+      ...props,
+      size: 'large',
+    }
+    const { getByRole } = render(props)
+    const label = getByRole('label')
+    expect(label).toHaveStyle(
+      `background-color: ${COLORS.foundationalBlue}`
+    )
+    expect(label).toHaveStyle(
+      `padding: ${SPACING.spacing5}`
+    )
+  })
+  it('renders the large selected button', () => {
+    props = {
+      ...props,
+      isSelected: true,
+      size: 'large',
+    }
+    const { getByRole } = render(props)
+    const label = getByRole('label')
+    expect(label).toHaveStyle(
+      `background-color: ${COLORS.blueEnabled}`
+    )
+    expect(label).toHaveStyle(
+      `padding: ${SPACING.spacing5}`
+    )
+  })
+  it('renders the small button', () => {
+    props = {
+      ...props,
+      size: 'small',
+    }
+    const { getByRole } = render(props)
+    const label = getByRole('label')
+    expect(label).toHaveStyle(
+      `background-color: ${COLORS.foundationalBlue}`
+    )
+    expect(label).toHaveStyle(
+      `padding: ${SPACING.spacingM}`
+    )
+  })
+  it('renders the small selected button', () => {
+    props = {
+      ...props,
+      isSelected: true,
+      size: 'small',
+    }
+    const { getByRole } = render(props)
+    const label = getByRole('label')
+    expect(label).toHaveStyle(
+      `background-color: ${COLORS.blueEnabled}`
+    )
+    expect(label).toHaveStyle(
+      `padding: ${SPACING.spacingM}`
+    )
+  })
+})

--- a/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
+++ b/app/src/atoms/buttons/OnDeviceDisplay/__tests__/RadioButton.test.tsx
@@ -19,7 +19,7 @@ describe('RadioButton', () => {
   it('renders the large button', () => {
     props = {
       ...props,
-      size: 'large',
+      radioButtonType: 'large',
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
@@ -30,7 +30,7 @@ describe('RadioButton', () => {
     props = {
       ...props,
       isSelected: true,
-      size: 'large',
+      radioButtonType: 'large',
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
@@ -40,7 +40,7 @@ describe('RadioButton', () => {
   it('renders the small button', () => {
     props = {
       ...props,
-      size: 'small',
+      radioButtonType: 'small',
     }
     const { getByRole } = render(props)
     const label = getByRole('label')
@@ -51,7 +51,7 @@ describe('RadioButton', () => {
     props = {
       ...props,
       isSelected: true,
-      size: 'small',
+      radioButtonType: 'small',
     }
     const { getByRole } = render(props)
     const label = getByRole('label')

--- a/app/src/atoms/buttons/OnDeviceDisplay/constants.ts
+++ b/app/src/atoms/buttons/OnDeviceDisplay/constants.ts
@@ -1,3 +1,3 @@
 import { SPACING, COLORS } from '@opentrons/components'
 
-export const ODD_FOCUS_VISIBLE = `0 0 0 ${SPACING.spacing1} ${COLORS.fundamentalsFocus}`
+export const ODD_FOCUS_VISIBLE = `0 0 0 ${SPACING.spacing2} ${COLORS.fundamentalsFocus}`

--- a/app/src/atoms/buttons/OnDeviceDisplay/index.ts
+++ b/app/src/atoms/buttons/OnDeviceDisplay/index.ts
@@ -1,4 +1,5 @@
 export { LargeButton } from './LargeButton'
 export { MediumButton } from './MediumButton'
+export { RadioButton } from './RadioButton'
 export { SmallButton } from './SmallButton'
 export { TabbedButton } from './TabbedButton'

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/TouchScreenSleep.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/TouchScreenSleep.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import {
   Flex,
@@ -10,12 +9,10 @@ import {
   Icon,
   ALIGN_CENTER,
   SPACING,
-  COLORS,
-  TYPOGRAPHY,
-  BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
+import { RadioButton } from '../../../atoms/buttons/OnDeviceDisplay'
 import {
   getOnDeviceDisplaySettings,
   updateConfigValue,
@@ -24,24 +21,6 @@ import { SLEEP_NEVER_MS } from '../../../App/constants'
 
 import type { Dispatch } from '../../../redux/types'
 import type { SettingOption } from '../../../pages/OnDeviceDisplay/RobotSettingsDashboard'
-
-interface LabelProps {
-  isSelected?: boolean
-}
-
-const SettingButton = styled.input`
-  display: none;
-`
-
-const SettingButtonLabel = styled.label<LabelProps>`
-  padding: ${SPACING.spacing5};
-  border-radius: ${BORDERS.size_four};
-  height: 5.25rem;
-  cursor: pointer;
-  background: ${({ isSelected }) =>
-    isSelected === true ? COLORS.blueEnabled : COLORS.mediumBlueEnabled};
-  color: ${({ isSelected }) => isSelected === true && COLORS.white};
-`
 
 const SLEEP_TIME_MS = 60 * 1000 // 1 min
 
@@ -96,27 +75,13 @@ export function TouchScreenSleep({
         marginTop={SPACING.spacing5}
       >
         {settingsButtons.map(radio => (
-          <React.Fragment key={`sleep_setting_${radio.label}`}>
-            <SettingButton
-              id={radio.label}
-              type="radio"
-              value={radio.value}
-              checked={radio.value === sleepMs}
-              onChange={handleChange}
-            />
-            <SettingButtonLabel
-              htmlFor={radio.label}
-              isSelected={radio.value === sleepMs}
-            >
-              <StyledText
-                fontSize="1.75rem"
-                lineHeight="1.875rem"
-                fontWeight={TYPOGRAPHY.fontWeightRegular}
-              >
-                {radio.label}
-              </StyledText>
-            </SettingButtonLabel>
-          </React.Fragment>
+          <RadioButton
+            key={`sleep_setting_${radio.label}`}
+            buttonLabel={radio.label}
+            buttonValue={radio.value}
+            onChange={handleChange}
+            isSelected={radio.value === sleepMs}
+          />
         ))}
       </Flex>
     </Flex>


### PR DESCRIPTION
# Overview

This PR adds a radio button component for use on the ODD.

Design: https://www.figma.com/file/OIdG64Q5cgvEw82ish5Eee/Design-System-(Flex)?node-id=1108-58731&t=40X6Wfql6XIyqtAl-0

Closes RAUT-366

# Test Plan

I created both unit tests and storybook stories for the different sizes and states of the radio button.

# Changelog

- Created radio button component
- Created unit tests and storybook stories
- Converted sleep settings screen to use new component

# Review requests

Verify storybook matches design and that sleep settings screen still functions and matches design.

# Risk assessment

Low. The only existing screen using this component is the sleep settings.
