### PR TITLE
fix(hardware): change the format of the motor usage response

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -339,3 +339,12 @@ class MoveStopCondition(int, Enum):
     encoder_position = 0x4
     gripper_force = 0x8
     stall = 0x10
+
+@unique
+class MotorUsageValueType(int, Enum):
+    """Type of motor Usage value types."""
+    linear_motor_distance = 0x0
+    left_gear_motor_distance = 0x1
+    right_gear_motor_distance = 0x2
+
+

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -340,11 +340,11 @@ class MoveStopCondition(int, Enum):
     gripper_force = 0x8
     stall = 0x10
 
+
 @unique
 class MotorUsageValueType(int, Enum):
     """Type of motor Usage value types."""
+
     linear_motor_distance = 0x0
     left_gear_motor_distance = 0x1
     right_gear_motor_distance = 0x2
-
-

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -19,6 +19,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     ErrorSeverity,
     MoveStopCondition,
     GearMotorId,
+    MotorUsageValueType,
 )
 
 from opentrons_hardware.firmware_bindings.binary_constants import (
@@ -485,4 +486,4 @@ class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
 
     def __repr__(self) -> str:
         """Repr."""
-        return f"{self.__class__.__name__}(key={self.key}, length={self.length}, usage_data={self.usage_value})"
+        return f"{self.__class__.__name__}(key={MotorUsageValueType(self.key).name}, length={self.length}, usage_data={self.usage_value})"

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -425,7 +425,7 @@ class LightAnimationTypeField(utils.UInt8Field):
 class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
     """A struct for an individual motor usage key, length, value field."""
 
-    NUM_BYTES = 12
+    NUM_BYTES = 11
     FORMAT = f"{NUM_BYTES}s"
 
     @property
@@ -433,7 +433,7 @@ class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
         """The value."""
         val = b""
         val = val + self.key.to_bytes(2, "big")
-        val = val + self.length.to_bytes(2, "big")
+        val = val + self.length.to_bytes(1, "big")
         val = val + self.usage_value.to_bytes(8, "big")
         return val
 
@@ -452,8 +452,8 @@ class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
     @classmethod
     def _parse(cls, data: bytes) -> Tuple[int, int, int]:
         key = cls._usage_field_from_bytes(data, 0, 2)
-        length = cls._usage_field_from_bytes(data, 2, 4)
-        usage_value = cls._usage_field_from_bytes(data, 4, 12)
+        length = cls._usage_field_from_bytes(data, 1, 3)
+        usage_value = cls._usage_field_from_bytes(data, 3, 11)
         if length < 8:
             usage_value = usage_value >> (8-length)*8
         return key, length, usage_value

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -453,6 +453,8 @@ class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
         key = cls._usage_field_from_bytes(data, 0, 2)
         length = cls._usage_field_from_bytes(data, 2, 4)
         usage_value = cls._usage_field_from_bytes(data, 4, 12)
+        if length < 8:
+            usage_value = usage_value >> (8-length)*8
         return key, length, usage_value
 
     @classmethod

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -455,7 +455,7 @@ class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
         length = cls._usage_field_from_bytes(data, 1, 3)
         usage_value = cls._usage_field_from_bytes(data, 3, 11)
         if length < 8:
-            usage_value = usage_value >> (8-length)*8
+            usage_value = usage_value >> (8 - length) * 8
         return key, length, usage_value
 
     @classmethod

--- a/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/fields.py
@@ -452,7 +452,7 @@ class MotorUsageTypeField(utils.BinaryFieldBase[bytes]):
     @classmethod
     def _parse(cls, data: bytes) -> Tuple[int, int, int]:
         key = cls._usage_field_from_bytes(data, 0, 2)
-        length = cls._usage_field_from_bytes(data, 1, 3)
+        length = cls._usage_field_from_bytes(data, 2, 3)
         usage_value = cls._usage_field_from_bytes(data, 3, 11)
         if length < 8:
             usage_value = usage_value >> (8 - length) * 8

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -588,7 +588,7 @@ class GetMotorUsageResponsePayload(_GetMotorUsageResponsePayloadBase):
         """
         consumed = _GetMotorUsageResponsePayloadBase.get_size()
         superdict = asdict(_GetMotorUsageResponsePayloadBase.build(data))
-        num_elements = superdict.pop("num_elements")
+        num_elements = superdict["num_elements"]
         message_index = superdict.pop("message_index")
 
         usage_values: List[MotorUsageTypeField] = []

--- a/hardware/opentrons_hardware/scripts/dump_eeprom.py
+++ b/hardware/opentrons_hardware/scripts/dump_eeprom.py
@@ -81,6 +81,7 @@ async def run(args: argparse.Namespace) -> None:
                 TARGETS[args.target],
                 256 if args.old_version else 16384,
             )
+            await asyncio.sleep(3)
 
 
 async def dump_eeprom(messenger: CanMessenger, node: NodeId, limit: int) -> None:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
 The new format lets us be more flexible on what is sent back from each motor as we add more and different keys to each one.
new motor usage payload needs its own special parser
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
