### PR TITLE
chore: add canbus logging to serial log

### DIFF
--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -56,6 +56,11 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "level": logging.DEBUG,
                 "propagate": False,
             },
+            "opentrons_hardware.drivers.can_bus.can_messenger": {
+                "handlers": ["serial"],
+                "level": logging.DEBUG,
+                "propagate": False,
+            },
             "__main__": {"handlers": ["api"], "level": level_value},
         },
     }
@@ -98,6 +103,11 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
             "opentrons_hardware": {
                 "handlers": ["api"],
                 "level": level_value,
+            },
+            "opentrons_hardware.drivers.can_bus.can_messenger": {
+                "handlers": ["serial"],
+                "level": logging.DEBUG,
+                "propagate": False,
             },
             "__main__": {"handlers": ["api"], "level": level_value},
         },

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -61,6 +61,11 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "level": logging.DEBUG,
                 "propagate": False,
             },
+            "opentrons_hardware.drivers.binary_usb.bin_serial": {
+                "handlers": ["serial"],
+                "level": logging.DEBUG,
+                "propagate": False,
+            },
             "__main__": {"handlers": ["api"], "level": level_value},
         },
     }
@@ -105,6 +110,11 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "level": level_value,
             },
             "opentrons_hardware.drivers.can_bus.can_messenger": {
+                "handlers": ["serial"],
+                "level": logging.DEBUG,
+                "propagate": False,
+            },
+            "opentrons_hardware.drivers.binary_usb.bin_serial": {
                 "handlers": ["serial"],
                 "level": logging.DEBUG,
                 "propagate": False,

--- a/hardware/opentrons_hardware/drivers/binary_usb/bin_serial.py
+++ b/hardware/opentrons_hardware/drivers/binary_usb/bin_serial.py
@@ -74,6 +74,7 @@ class SerialUsbDriver:
             log.error("Unable to send message to unconnected device")
             return 0
         try:
+            log.debug(f"binary write: {message}")
             return int(
                 await self._loop.run_in_executor(
                     self._executor, self._port.write, message.serialize()
@@ -111,7 +112,9 @@ class SerialUsbDriver:
                     ),
                 )
                 data = b"".join([header_data, message_data])
-                return message_def.build(data)  # type: ignore[return-value]
+                msg = message_def.build(data)
+                log.debug(f"binary read: {msg}")
+                return msg  # type: ignore[return-value]
             else:
                 return None
         except serial.SerialException as e:


### PR DESCRIPTION
It will now be automatically downloaded by the app when you download logs, just like the motor controller board used to be.
