### PR TITLE
refactor(shared-data): Minor deck cleanup

### DIFF
--- a/shared-data/deck/schemas/3.json
+++ b/shared-data/deck/schemas/3.json
@@ -155,7 +155,7 @@
               },
               "boundingBox": { "$ref": "#/definitions/boundingBox" },
               "displayName": {
-                "description": "An optional human-readable nickname for this slot Eg \"Slot 1\" or \"Fixed Trash\"",
+                "description": "A human-readable nickname for this slot Eg \"Slot 1\" or \"Fixed Trash\"",
                 "type": "string"
               },
               "compatibleModuleTypes": {

--- a/shared-data/python/mypy.ini
+++ b/shared-data/python/mypy.ini
@@ -12,10 +12,6 @@ warn_untyped_fields = True
 
 # TODO(mc, 2022-01-20): fix and remove all of the overrides below
 
-[mypy-opentrons_shared_data.deck.*]
-disallow_untyped_defs = False
-warn_return_any = False
-
 [mypy-opentrons_shared_data.labware.*]
 warn_return_any = False
 

--- a/shared-data/python/opentrons_shared_data/deck/__init__.py
+++ b/shared-data/python/opentrons_shared_data/deck/__init__.py
@@ -1,7 +1,7 @@
 """
 opentrons_shared_data.deck: types and bindings for deck definitions
 """
-from typing import Dict, NamedTuple, overload, TYPE_CHECKING
+from typing import Dict, NamedTuple, cast, overload, TYPE_CHECKING
 from typing_extensions import Final
 import json
 
@@ -46,12 +46,14 @@ def load(name: str, version: int) -> "DeckDefinition":
     ...
 
 
-def load(name, version=DEFAULT_DECK_DEFINITION_VERSION):
+def load(name: str, version: int = DEFAULT_DECK_DEFINITION_VERSION) -> object:
     return json.loads(load_shared_data(f"deck/definitions/{version}/{name}.json"))
 
 
 def load_schema(version: int) -> "DeckSchema":
-    return json.loads(load_shared_data(f"deck/schemas/{version}.json"))
+    return cast(
+        "DeckSchema", json.loads(load_shared_data(f"deck/schemas/{version}.json"))
+    )
 
 
 def get_calibration_square_position_in_slot(slot: int) -> Offset:


### PR DESCRIPTION
# Overview

Some trivial refactors in `shared-data`.

# Test plan

None needed.

# Changelog

* Fix some schema documentation that says `displayName` is optional. It's required.
* Fix some old type-checking overrides.

# Review requests

Are there any other easy things that we want to squeeze in here?

# Risk assessment

No risk.
