### PR TITLE
fix(api): calibration z checking needs <=

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -294,7 +294,7 @@ async def find_calibration_structure_height(
     z_prep_point = nominal_center + PREP_OFFSET_DEPTH
     structure_z = await _probe_deck_at(hcapi, mount, z_prep_point, z_pass_settings)
     z_limit = nominal_center.z - z_pass_settings.max_overrun_distance_mm
-    if isclose(z_limit, structure_z, abs_tol=0.001):
+    if (structure_z < z_limit) or isclose(z_limit, structure_z, abs_tol=0.001):
         raise CalibrationStructureNotFoundError(structure_z, z_limit)
     LOG.info(f"autocalibration: found structure at {structure_z}")
     return structure_z

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -346,7 +346,11 @@ async def test_calibrate_mount_errors(
         ot3_hardware.managed_obj, "reset_instrument_offset", AsyncMock()
     ) as reset_instrument_offset, patch.object(
         ot3_hardware.managed_obj, "save_instrument_offset", AsyncMock()
-    ) as save_instrument_offset:
+    ) as save_instrument_offset, patch(
+        "opentrons.hardware_control.ot3_calibration.find_calibration_structure_height",
+        AsyncMock(spec=find_calibration_structure_height),
+    ) as find_deck:
+        find_deck.return_value = 10
         mock_data_analysis.return_value = (-1000, 1000)
 
         await ot3_hardware.home()


### PR DESCRIPTION
4ae1fa2caa74f7685e455fb64d5ca8f7ec3d6e97 changed calibration z height checking to use numpy.isclose, but this isn't a sufficient check: we also want to catch the detected height < minimum height. We might overrun, and certainly unit tests are expecting this to be caught.

In addition, an old test needed to be updated for new structure.
