### PR TITLE
fix(api): always validate edge during OT3 calibration

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -149,7 +149,7 @@ async def find_edge_binary(
     slot_edge_nominal: Point,
     search_axis: Union[Literal[OT3Axis.X, OT3Axis.Y]],
     direction_if_hit: Literal[1, -1],
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
     """
     Find the true position of one edge of the calibration slot in the deck.
@@ -231,7 +231,7 @@ async def find_slot_center_binary(
     hcapi: OT3API,
     mount: OT3Mount,
     estimated_center: Point,
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
     """Find the center of the calibration slot by binary-searching its edges.
     Returns the XY-center of the slot.
@@ -487,7 +487,7 @@ async def find_calibration_structure_center(
     mount: OT3Mount,
     nominal_center: Point,
     method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
 
     # Perform xy offset search
@@ -508,7 +508,7 @@ async def _calibrate_mount(
     mount: OT3Mount,
     slot: int = 5,
     method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
     """
     Run automatic calibration for the tool attached to the specified mount.
@@ -562,7 +562,7 @@ async def find_calibration_structure_position(
     mount: OT3Mount,
     nominal_center: Point,
     method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
     """Find the calibration square offset given an arbitry postition on the deck."""
     # Find the estimated structure plate height. This will be used to baseline the edge detection points.
@@ -667,7 +667,7 @@ async def calibrate_gripper_jaw(
     probe: GripperProbe,
     slot: int = 5,
     method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
     """
     Run automatic calibration for gripper jaw.
@@ -711,7 +711,7 @@ async def calibrate_pipette(
     mount: Literal[OT3Mount.LEFT, OT3Mount.RIGHT],
     slot: int = 5,
     method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
-    raise_verify_error: bool = False,
+    raise_verify_error: bool = True,
 ) -> Point:
     """
     Run automatic calibration for pipette.

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -294,7 +294,7 @@ async def find_calibration_structure_height(
     z_prep_point = nominal_center + PREP_OFFSET_DEPTH
     structure_z = await _probe_deck_at(hcapi, mount, z_prep_point, z_pass_settings)
     z_limit = nominal_center.z - z_pass_settings.max_overrun_distance_mm
-    if isclose(z_limit, structure_z, abs_tol=0.001):
+    if (structure_z < z_limit) or isclose(z_limit, structure_z, abs_tol=0.001):
         raise CalibrationStructureNotFoundError(structure_z, z_limit)
     LOG.info(f"autocalibration: found structure at {structure_z}")
     return structure_z

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -346,7 +346,11 @@ async def test_calibrate_mount_errors(
         ot3_hardware.managed_obj, "reset_instrument_offset", AsyncMock()
     ) as reset_instrument_offset, patch.object(
         ot3_hardware.managed_obj, "save_instrument_offset", AsyncMock()
-    ) as save_instrument_offset:
+    ) as save_instrument_offset, patch(
+        "opentrons.hardware_control.ot3_calibration.find_calibration_structure_height",
+        AsyncMock(spec=find_calibration_structure_height),
+    ) as find_deck:
+        find_deck.return_value = 10
         mock_data_analysis.return_value = (-1000, 1000)
 
         await ot3_hardware.home()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Per hardware team's request, it should be the default behavior to validate the found edge each time and raise an error when the edge cannot be validated. 
