### PR TITLE
chore: remove worst log spam offenders

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1111,7 +1111,7 @@ class OT3API(
             self._log.info(f"{str(zero_length_error)}, ignoring")
             return
         self._log.info(
-            f"move: {target_position} becomes {machine_pos} from {origin} "
+            f"move: deck {target_position} becomes machine {machine_pos} from {origin} "
             f"requiring {moves}"
         )
         async with contextlib.AsyncExitStack() as stack:

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -82,7 +82,7 @@ class MoveManager(Generic[AxisKey]):
                         self._blend_log.append(blend_log)
                     break
             if move_utils.all_blended(self._constraints, self._blend_log[i]):
-                log.info(
+                log.debug(
                     f"built {len(self._blend_log[i])} moves with "
                     f"{sum(list(m.nonzero_blocks for m in self._blend_log[i]))} "
                     f"non-zero blocks after {i+1} iteration(s)"

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -357,12 +357,12 @@ class MoveScheduler:
             in_group = (node_id, seq_id) in self._moves[group_id]
             self._moves[group_id].remove((node_id, seq_id))
             self._completion_queue.put_nowait((arbitration_id, message))
-            log.info(
+            log.debug(
                 f"Received completion for {node_id} group {group_id} seq {seq_id}"
                 f", which {'is' if in_group else 'isn''t'} in group"
             )
             if not self._moves[group_id]:
-                log.info(f"Move group {group_id+self._start_at_index} has completed.")
+                log.debug(f"Move group {group_id+self._start_at_index} has completed.")
                 self._event.set()
         except KeyError:
             log.warning(
@@ -448,7 +448,7 @@ class MoveScheduler:
         ):
             self._event.clear()
 
-            log.info(f"Executing move group {group_id}.")
+            log.debug(f"Executing move group {group_id}.")
             self._current_group = group_id - self._start_at_index
             error = await can_messenger.ensure_send(
                 node_id=NodeId.broadcast,

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -17,6 +17,14 @@ def initialize_logging() -> None:
     dictConfig(c)
 
 
+class _LogBelow:
+    def __init__(self, level: int) -> "_LogBelow":
+        self._log_below_level = level
+
+    def __call__(self, record: LogRecord) -> bool:
+        return record.levelno < self._log_below_level
+
+
 def _robot_log_config(log_level: int) -> Dict[str, Any]:
     """Logging configuration for robot deployment"""
     return {
@@ -25,37 +33,55 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
         "formatters": {
             "message_only": {"format": "%(message)s"},
         },
+        "filters": {"records_below_warning": {"()": _LogBelow, "level": logging.WARN}},
         "handlers": {
-            "robot_server": {
+            "unit_only": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+            },
+            "syslog_plus_unit": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
                 "SYSLOG_IDENTIFIER": "opentrons-api",
-            }
+            },
+            "syslog_plus_unit_above_warn": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.WARN,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFER": "opentrons-api",
+            },
+            "unit_only_below_warn": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "filters": ["records_below_warning"],
+            },
         },
         "loggers": {
             "robot_server": {
-                "handlers": ["robot_server"],
+                "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,
             },
             "uvicorn.error": {
-                "handlers": ["robot_server"],
+                "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,
             },
             "fastapi": {
-                "handlers": ["robot_server"],
+                "handlers": ["unit_only"],
                 "level": log_level,
                 "propagate": False,
             },
             "starlette": {
-                "handlers": ["robot_server"],
+                "handlers": ["unit_only"],
                 "level": log_level,
                 "propagate": False,
             },
             "sqlalchemy": {
-                "handlers": ["robot_server"],
+                "handlers": ["syslog_plus_unit_above_warn", "unit_only_below_warn"],
                 # SQLAlchemy's logging is slightly unusual:
                 # they set up their logger with a default level of WARN by itself,
                 # so even if we enabled propagation, we'd have to override the level

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -18,10 +18,10 @@ def initialize_logging() -> None:
 
 
 class _LogBelow:
-    def __init__(self, level: int) -> "_LogBelow":
+    def __init__(self, level: int) -> None:
         self._log_below_level = level
 
-    def __call__(self, record: LogRecord) -> bool:
+    def __call__(self, record: logging.LogRecord) -> bool:
         return record.levelno < self._log_below_level
 
 


### PR DESCRIPTION
robot-server
-------------

A lot of internal middleware was putting pretty verbose logs in both the unit log (i.e. journalctl -u opentrons-robot-server),which I think is reasonable, and to the syslog ident opentrons-api (i.e.journalctl -t opentrons-api), which I think is not. This includes every sql statement the robot server ever makes, every http route interaction...

By adding some handlers that specifically only log to journald without the syslog ident and some that have both, we can tune what goes where. Now,
- sqlalchemy output _above or at warn_ will go to the syslog ident, since it's likely to be an issue
- sqlalchemy output below warn will go only to robot-server unit logs
- http middleware output goes to only robot-server unit logs
- general robot_server logs originating from our code go to the syslog ident

Note that when a log "goes to the syslog ident", that's in addition to the unit logs. So if you want to know everything include http messages and such, do journalctl -u opentrons-robot-server and if you want to know just robotics relevant stuff do journalctl -t opentrons-api.

api and hardware
---------------

Don't log every dang motion group

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
