### PR TITLE
fix(odd): correct inconsistent padding for the nav menu

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/Navigation/index.tsx
+++ b/app/src/organisms/OnDeviceDisplay/Navigation/index.tsx
@@ -55,6 +55,7 @@ export function Navigation({ routes }: { routes: RouteProps[] }): JSX.Element {
         flexDirection={DIRECTION_ROW}
         alignItems={ALIGN_CENTER}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
+        paddingTop={SPACING.spacingXXL}
         marginBottom={SPACING.spacing5}
       >
         <Flex

--- a/app/src/pages/OnDeviceDisplay/InstrumentsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/InstrumentsDashboard.tsx
@@ -16,7 +16,7 @@ export const InstrumentsDashboard = (): JSX.Element => {
   >(null)
 
   return (
-    <Flex padding={SPACING.spacingXXL} flexDirection={DIRECTION_COLUMN}>
+    <Flex padding={`0 ${SPACING.spacingXXL}`} flexDirection={DIRECTION_COLUMN}>
       <Navigation routes={onDeviceDisplayRoutes} />
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing3}>
         <AttachedInstrumentMountItem

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/index.tsx
@@ -118,7 +118,7 @@ export function ProtocolDashboard(): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       minHeight="25rem"
-      padding={SPACING.spacing6}
+      padding={`0 ${SPACING.spacingXXL}`}
     >
       <Navigation routes={onDeviceDisplayRoutes} />
       {pinnedProtocols.length > 0 && (

--- a/app/src/pages/OnDeviceDisplay/RobotDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotDashboard.tsx
@@ -37,10 +37,7 @@ export function RobotDashboard(): JSX.Element {
     MAXIMUM_RECENT_RUN_PROTOCOLS
   )
   return (
-    <Flex
-      padding={`0 ${SPACING.spacingXXL} ${SPACING.spacingXXL} ${SPACING.spacingXXL}`}
-      flexDirection={DIRECTION_COLUMN}
-    >
+    <Flex padding={`0 ${SPACING.spacingXXL}`} flexDirection={DIRECTION_COLUMN}>
       <Navigation routes={onDeviceDisplayRoutes} />
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         {sortedProtocols.length === 0 ? (

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard.tsx
@@ -86,23 +86,34 @@ export function RobotSettingsDashboard(): JSX.Element {
   const devToolsOn = useSelector(getDevtoolsEnabled)
 
   return (
+    // This top level Flexbox only exists to position the temporary
+    // "To ODD Menu" button on the bottom. When it goes, so can this.
     <Flex
-      padding={SPACING.spacingXXL}
+      padding="0"
       flexDirection={DIRECTION_COLUMN}
       columnGap={SPACING.spacing3}
     >
       {currentOption != null ? (
-        <SettingsContent
-          currentOption={currentOption}
-          setCurrentOption={setCurrentOption}
-          networkConnection={networkConnection}
-          robotName={robotName}
-          robotServerVersion={robotServerVersion ?? 'Unknown'}
-          isUpdateAvailable={isUpdateAvailable}
-          devToolsOn={devToolsOn}
-        />
+        <Flex
+          padding={SPACING.spacingXXL}
+          flexDirection={DIRECTION_COLUMN}
+          columnGap={SPACING.spacing3}
+        >
+          <SettingsContent
+            currentOption={currentOption}
+            setCurrentOption={setCurrentOption}
+            networkConnection={networkConnection}
+            robotName={robotName}
+            robotServerVersion={robotServerVersion ?? 'Unknown'}
+            isUpdateAvailable={isUpdateAvailable}
+            devToolsOn={devToolsOn}
+          />
+        </Flex>
       ) : (
-        <>
+        <Flex
+          padding={`0 ${SPACING.spacingXXL}`}
+          flexDirection={DIRECTION_COLUMN}
+        >
           <Navigation routes={onDeviceDisplayRoutes} />
 
           {/* Network Settings */}
@@ -191,12 +202,12 @@ export function RobotSettingsDashboard(): JSX.Element {
             enabledDevTools
             devToolsOn={devToolsOn}
           />
-        </>
+        </Flex>
       )}
 
       <Flex
         alignSelf={ALIGN_FLEX_END}
-        marginTop={SPACING.spacing5}
+        padding={SPACING.spacingXXL}
         width="fit-content"
       >
         <Link to="menu">


### PR DESCRIPTION

# Overview

This PR corrects inconsistent padding for the nav menu on the four ODD home screens.

Closes RAUT-411

# Test Plan

Manually tested pages and compared with Figma. Screen capture attached.

# Changelog

Gave Navigation component its own padding and changed pages calling it so they didn't override it.

# Review requests

None.

# Risk assessment

None.

https://user-images.githubusercontent.com/2960/234084469-9f7be77e-916a-4276-b068-05aa36bc1f4d.mov

