### PR TITLE
fix(app): remove text selection ui

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -182,7 +182,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
 
   return (
     <ApiHostProvider hostname="localhost">
-      <Box width="100%">
+      <Box width="100%" css="user-select: none;">
         {Boolean(isIdle) ? (
           <SleepScreen />
         ) : (


### PR DESCRIPTION


# Overview

This PR removes the ability to long-press text to get the copy menu on the ODD. There's no need to select text and the ui for it gets in the way (see attached photo).

![IMG_3069](https://user-images.githubusercontent.com/2960/234147206-89259b6c-7a89-4f30-a7db-34e9d2df2200.JPG)

Closes RAUT-413

# Test Plan

Manually verified the text selection ui is gone.

# Changelog

- Added "user-select: none;" to box containing the entire odd app

# Review requests

Try to select text. I dare you.

# Risk assessment

NOTE: You can still right click to get the Inspect Element option in the simulated ODD app, but you cannot do so on the actual ODD via the dev tools. You *can* drill down inside the dev tools to inspect individual elements, but not by clicking on the element itself. Not a fan, but can't keep that and turn off the rest of the ui on that hardware seems like.

