### PR TITLE
feat(api): accept deck coordinate names for PAPIv2 methods that take a deck name

### DIFF
--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -70,6 +70,7 @@ def ensure_deck_slot(deck_slot: Union[int, str]) -> DeckSlotName:
         raise TypeError(f"Deck slot must be a string or integer, but got {deck_slot}")
 
     try:
+        # TODO(jbl 2023-04-25) this should raise an error when below version 2.15 and using deck coordinates
         return DeckSlotName.from_primitive(deck_slot)
     except ValueError as e:
         raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -70,7 +70,7 @@ def ensure_deck_slot(deck_slot: Union[int, str]) -> DeckSlotName:
         raise TypeError(f"Deck slot must be a string or integer, but got {deck_slot}")
 
     try:
-        return DeckSlotName(str(deck_slot))
+        return DeckSlotName.from_primitive(deck_slot)
     except ValueError as e:
         raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -183,6 +183,27 @@ class OT3MountType(str, enum.Enum):
     GRIPPER = "gripper"
 
 
+DECK_COORDINATE_TO_SLOT_NAME = {
+    "D1": "1",
+    "D2": "2",
+    "D3": "3",
+    "C1": "4",
+    "C2": "5",
+    "C3": "6",
+    "B1": "7",
+    "B2": "8",
+    "B3": "9",
+    "A1": "10",
+    "A2": "11",
+    "A3": "12",
+}
+
+DECK_SLOT_NAME_TO_COORDINATE = {
+    slot_name: coordinate
+    for coordinate, slot_name in DECK_COORDINATE_TO_SLOT_NAME.items()
+}
+
+
 # TODO(mc, 2020-11-09): this makes sense in shared-data or other common
 # model library
 # https://github.com/Opentrons/opentrons/pull/6943#discussion_r519029833
@@ -204,11 +225,16 @@ class DeckSlotName(str, enum.Enum):
 
     @classmethod
     def from_primitive(cls, value: DeckLocation) -> DeckSlotName:
-        str_val = str(value)
+        str_val = str(value).upper()
+        if str_val in DECK_COORDINATE_TO_SLOT_NAME:
+            str_val = DECK_COORDINATE_TO_SLOT_NAME[str_val]
         return cls(str_val)
 
     def as_int(self) -> int:
         return int(self.value)
+
+    def as_coordinate(self) -> str:
+        return DECK_SLOT_NAME_TO_COORDINATE[self.value]
 
     def __str__(self) -> str:
         """Stringify to a simple integer string."""

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -66,8 +66,12 @@ def test_ensure_pipette_input_invalid() -> None:
     [
         ("1", DeckSlotName.SLOT_1),
         (1, DeckSlotName.SLOT_1),
+        ("d1", DeckSlotName.SLOT_1),
+        ("D1", DeckSlotName.SLOT_1),
         (12, DeckSlotName.FIXED_TRASH),
         ("12", DeckSlotName.FIXED_TRASH),
+        ("a3", DeckSlotName.FIXED_TRASH),
+        ("A3", DeckSlotName.FIXED_TRASH),
     ],
 )
 def test_ensure_deck_slot(input_value: Union[str, int], expected: DeckSlotName) -> None:

--- a/robot-server/tests/integration/http_api/protocols/test_deck_coordinate_load.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_deck_coordinate_load.tavern.yaml
@@ -33,8 +33,8 @@ stages:
             - id: !anystr
               status: pending
   - name: Retry until analyses status is completed and result is ok.
-    max_retries: 5
-    delay_after: 1
+    max_retries: 10
+    delay_after: 0.1
     request:
       url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
       method: GET
@@ -47,3 +47,4 @@ stages:
           - id: '{analysis_id}'
             status: completed
             result: ok
+  # TODO(jbl 2023-04-25) When returning deck coordinates is implemented, check output here

--- a/robot-server/tests/integration/http_api/protocols/test_deck_coordinate_load.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_deck_coordinate_load.tavern.yaml
@@ -1,0 +1,49 @@
+test_name: Upload, analyze, and confirm correctness of loading via deck coordinate names
+
+marks:
+  - usefixtures:
+      - run_server
+      - clean_server_state
+stages:
+  - name: Upload deck_coordinate_load protocol
+    request:
+      url: '{host:s}:{port:d}/protocols'
+      method: POST
+      files:
+        files: 'tests/integration/protocols/deck_coordinate_load.py'
+    response:
+      save:
+        json:
+          protocol_id: data.id
+          analysis_id: data.analysisSummaries[0].id
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          protocolType: python
+          files:
+            - name: deck_coordinate_load.py
+              role: main
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          robotType: OT-2 Standard
+          metadata:
+            protocolName: Deck Coordinate PAPIv2 Test
+          analyses: []
+          analysisSummaries:
+            - id: !anystr
+              status: pending
+  - name: Retry until analyses status is completed and result is ok.
+    max_retries: 5
+    delay_after: 1
+    request:
+      url: '{host:s}:{port:d}/protocols/{protocol_id}/analyses'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          - id: '{analysis_id}'
+            status: completed
+            result: ok

--- a/robot-server/tests/integration/protocols/deck_coordinate_load.py
+++ b/robot-server/tests/integration/protocols/deck_coordinate_load.py
@@ -11,4 +11,6 @@ def run(context):
     module = context.load_module("temperatureModuleV2", "A1")
 
     pipette.move_to(labware.wells()[0].top())
-    module.set_temperature(42)
+    module_labware = module.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt")
+
+    pipette.move_to(module_labware.wells()[0].top())

--- a/robot-server/tests/integration/protocols/deck_coordinate_load.py
+++ b/robot-server/tests/integration/protocols/deck_coordinate_load.py
@@ -1,0 +1,14 @@
+metadata = {
+    "protocolName": "Deck Coordinate PAPIv2 Test",
+}
+
+requirements = {"robotType": "OT-2", "apiLevel": "2.14"}
+
+
+def run(context):
+    pipette = context.load_instrument("p1000_single_gen2", mount="left")
+    labware = context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "d3")
+    module = context.load_module("temperatureModuleV2", "A1")
+
+    pipette.move_to(labware.wells()[0].top())
+    module.set_temperature(42)


### PR DESCRIPTION
# Overview

Closes RLAB-255.

This PR allows PAPIv2 methods that take a `DeckLocation` argument (which is a union of `str` and `int`) to accept deck slot locations in the form of `"A1"`, `"A2"`, `"A3"`, `"B1"`...`"D3"` (case insensitive) in addition to the previous standard of `"1"` or `1`. This is done by modifying the `DeckSlotName.from_primitive` to accept and convert these values to the canonical OT-2 style.

This conversion is happening at the interface level, so internally these values are still numbered Deck Slots, and this PR does not change what is returned by methods that return or iterate over `DeckSlotName`.

Affected methods that now allow coordinate style names are:
- `ProtocolContext.load_labware`
- `ProtocolContext.load_labware_from_definition`
- `ProtocolContext.load_labware_by_name` (this is a deprecated method but works through `load_labware`)
- `ProtocolContext.move_labware`
- `ProtocolContext.load_module`
- `Deck.__getitem__`
- `Deck.right_of`
- `Deck.left_of`
- `Deck.position_for`
- `Deck.get_slot_definition`
- `Deck.get_center_slot`

# Test Plan

In addition to the unit and integration test coverage, the following protocol was tested to make sure that it analyzed correctly for both OT-2 and OT-3 robot types.

```
from opentrons.types import Location, Point


metadata = {
    "protocolName": "Deck Coordinate Input PAPIv2 Test",
}

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.14"
}


def run(context):
    labware = context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "d3")
    module = context.load_module("temperatureModuleV2", "A1")

    context.move_labware(labware=labware, new_location="D2", use_gripper=True)

    deck = context.deck

    assert deck['D2'] is labware
    assert deck['a1'] is module
    assert deck.right_of('d1') is labware
    assert deck.left_of('D3') is labware
    assert isinstance(deck.position_for('B2'), Location)
    assert isinstance(deck.get_slot_center('b2'), Point)
    assert isinstance(deck.get_slot_definition('B2'), dict)
```

# Changelog

- Modified `DeckSlotName` to accept coordinate style names through `from_primitive` class method, and added a method to express the slot as a coordinate string
- Changed `ensure_deck_slot` to use `from_primitive` when constructing the `DeckSlotName` to be returned

# Review requests

- Should I move around the logic/implementation for converting back and forth between numbered and coordinate slots?

# Risk assessment

Low, this only adds support for coordinate style names at the highest level, nothing internal has changed with how we handle DeckSlotNames and associated integer math.