### PR TITLE
fix(api): Don't adjust Z probing height on the fly during find-edge-binary

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -192,7 +192,7 @@ async def find_edge_binary(
             # In this block, we've hit the deck
             LOG.info(f"hit at {interaction_pos}, stride size: {stride}")
             # store the final found Z height found
-            # because the height
+            # because the height is most accurate next to the edge
             final_z_height_found = interaction_pos
             if copysign(stride, direction_if_hit) == stride:
                 # If we're in direction_if_hit direction, the last probe was on the deck,

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -227,7 +227,7 @@ async def find_edge_binary(
     # remove probe offset so we actually get position of the edge
     found_edge = checking_pos - critical_edge_offset(search_axis, direction_if_hit)
     # use the last-found Z height as the edge's most true Z position
-    found_edge.z = final_z_height_found
+    found_edge = found_edge._replace(z=final_z_height_found)
     return found_edge
 
 

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -190,8 +190,6 @@ async def find_edge_binary(
         if hit_deck:
             LOG.info(f"hit at {interaction_pos}, stride size: {stride}")
             # In this block, we've hit the deck
-            # update the fonud deck value
-            checking_pos = checking_pos._replace(z=interaction_pos)
             if copysign(stride, direction_if_hit) == stride:
                 # If we're in direction_if_hit direction, the last probe was on the deck,
                 # so we want to continue

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -181,6 +181,7 @@ async def find_edge_binary(
         search_axis, direction_if_hit
     )
     stride = edge_settings.search_initial_tolerance_mm * direction_if_hit
+    final_z_height_found = slot_edge_nominal.z
     for _ in range(edge_settings.search_iteration_limit):
         LOG.info(f"Checking position {checking_pos}")
         interaction_pos = await _probe_deck_at(
@@ -188,8 +189,11 @@ async def find_edge_binary(
         )
         hit_deck = _deck_hit(interaction_pos, checking_pos.z, edge_settings)
         if hit_deck:
-            LOG.info(f"hit at {interaction_pos}, stride size: {stride}")
             # In this block, we've hit the deck
+            LOG.info(f"hit at {interaction_pos}, stride size: {stride}")
+            # store the final found Z height found
+            # because the height
+            final_z_height_found = interaction_pos
             if copysign(stride, direction_if_hit) == stride:
                 # If we're in direction_if_hit direction, the last probe was on the deck,
                 # so we want to continue
@@ -222,6 +226,8 @@ async def find_edge_binary(
             LOG.warning(e)
     # remove probe offset so we actually get position of the edge
     found_edge = checking_pos - critical_edge_offset(search_axis, direction_if_hit)
+    # use the last-found Z height as the edge's most true Z position
+    found_edge.z = final_z_height_found
     return found_edge
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

No need to adjust the Z height during probe while going through the binary-search sequence. We can instead use the same Z height found from the initial deck-height Z probe.

This avoids an issue we found in testing where the pipette was moving downwards in a stairway pattern, eventually colliding with the deck. The cause was from a bad configuration, but this PR makes that type of motion impossible.

Note that this does not change how we are calculating the final Z position. That is still calculated from average the Z height of all 4x edges.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Test default settings, using a working pipette, and check it successfully calibrates
- Update the `max_overrun_distance_mm` and `overrun_tolerance_mm` to both be equal to `0.5` mm, and check that no collisions occur and that the Z height does not step down during the binary-search. It is OK that the calibration fails, just no collisions should happen

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
