### PR TITLE
chore(api): speed up binary search calibration

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -45,12 +45,12 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
         ),
     ),
     edge_sense=EdgeSenseSettings(
-        overrun_tolerance_mm=0.5,
+        overrun_tolerance_mm=0.4,
         early_sense_tolerance_mm=0.5,
         pass_settings=CapacitivePassSettings(
             prep_distance_mm=1,
-            max_overrun_distance_mm=1,
-            speed_mm_per_s=0.5,
+            max_overrun_distance_mm=0.5,
+            speed_mm_per_s=1,
             sensor_threshold_pf=3.0,
         ),
         search_initial_tolerance_mm=8.0,


### PR DESCRIPTION
These config settings are suggested and tested by hardware, and speed up calibration without sacrificing accuracy. We wouldn't want these settings on Z-sense, where they'd linearly affect accuracy, but on the binary test they're fine.
