### PR TITLE
chore: Add release notes for PR #11561

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -4,6 +4,16 @@ For more details about this release, please see the full [technical change log][
 
 ---
 
+# Internal Release 0.6.0
+
+## Update notes
+
+This update changes the internal format in which the robot stores runs and protocols.
+The first time the robot starts up with this update, it may take several extra minutes to initialize while it performs this migration.
+While this is ongoing, the on-device display will mistakenly show that the robot has no runs or protocols.
+Within 10 minutes, your old runs and protocols should show up and the robot should be usable as normal.
+
+
 # Internal Release 0.4.0
 
 This is internal release 0.4.0 for the Opentrons Flex robot software, involving both robot control and the on-device display.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,16 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## OT-2 Software Changes in 7.0.0
+
+### Update notes
+
+This update changes the internal format in which the robot stores runs and protocols.
+The first time the robot starts up with this update, it may take several extra minutes to initialize while it performs this migration.
+Within 10 minutes, the robot should be usable as normal, with all the runs and protocols that were there before.
+
+---
+
 ## OT-2 Software Changes in 6.3.0
 
 Welcome to the v6.3.0 release of the OT-2 software!
@@ -27,6 +37,7 @@ Welcome to the v6.3.0 release of the OT-2 software!
     - Python protocols specifying an `apiLevel` of 2.14
 
 ---
+
 ## OT-2 Software Changes in 6.2.1
 
 Welcome to the v6.2.1 release of the OT-2 software! This hotfix release addresses a few problems.


### PR DESCRIPTION
# Overview

This adds release notes for PR #11561. This should merge into `edge` when PR #11561 merges into `edge`.

The `internal-release_0.5.0` branch has already been cut off of `edge`, so it won't make it into that. I'm assuming it will make it into `internal-release_0.6.0`.

I also added a note to the *public* release notes file, because this seems like the kind of thing that would otherwise be easy for us to forget. Note that PR #11561 is a `refactor`, so it won't show up in the autogenerated changelogs.

# Review requests

* Is it correct to put this in the v0.6.0 internal release notes?
* Is my "Update notes" subheading an okay place to put this, for now?