### PR TITLE
refactor(api): Remove homing when moving to maintain position

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -59,8 +59,6 @@ class MoveToMaintenancePositionImplementation(
         """Move the requested mount to a maintenance deck slot."""
         hardware_mount = params.mount.to_hw_mount()
 
-        await self._hardware_api.home()
-
         calibration_coordinates = self._state_view.labware.get_calibration_coordinates(
             offset=_INSTRUMENT_ATTACH_OFFSET
         )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -40,11 +40,6 @@ async def test_calibration_move_to_location_implementation(
     assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
-        await hardware_api.home(),
-        times=1,
-    )
-
-    decoy.verify(
         await hardware_api.move_to(mount=Mount.LEFT, abs_position=Point(x=1, y=2, z=3)),
         times=1,
     )


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RLIQ-327.
removes home command from move to maintenance position command.

# Test Plan

- Practice attach/detach/calibrate from the app. make sure all works correctly. 
- Do the same after power cycling the robot after it is in the maintenance position. 

# Changelog

- Removed home command from move_to_maintenance_position.

# Risk assessment

low. just removed homing before moving the gantry. the app should take care of homing when needed.