### PR TITLE
fix(api): lock instrument cache during calibration

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -686,18 +686,19 @@ async def calibrate_gripper_jaw(
     the average of the pin offsets, which can be obtained by passing the
     two offsets into the `gripper_pin_offsets_mean` func.
     """
-    try:
-        await hcapi.reset_instrument_offset(OT3Mount.GRIPPER)
-        hcapi.add_gripper_probe(probe)
-        await hcapi.grip(GRIPPER_GRIP_FORCE)
-        offset = await _calibrate_mount(
-            hcapi, OT3Mount.GRIPPER, slot, method, raise_verify_error
-        )
-        LOG.info(f"Gripper {probe.name} probe offset: {offset}")
-        return offset
-    finally:
-        hcapi.remove_gripper_probe()
-        await hcapi.ungrip()
+    async with hcapi.instrument_cache_lock():
+        try:
+            await hcapi.reset_instrument_offset(OT3Mount.GRIPPER)
+            hcapi.add_gripper_probe(probe)
+            await hcapi.grip(GRIPPER_GRIP_FORCE)
+            offset = await _calibrate_mount(
+                hcapi, OT3Mount.GRIPPER, slot, method, raise_verify_error
+            )
+            LOG.info(f"Gripper {probe.name} probe offset: {offset}")
+            return offset
+        finally:
+            hcapi.remove_gripper_probe()
+            await hcapi.ungrip()
 
 
 async def calibrate_gripper(
@@ -725,14 +726,17 @@ async def calibrate_pipette(
     tip has been attached, or the conductive probe has been attached,
     or the probe has been lowered).
     """
-    try:
-        await hcapi.reset_instrument_offset(mount)
-        await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
-        offset = await _calibrate_mount(hcapi, mount, slot, method, raise_verify_error)
-        await hcapi.save_instrument_offset(mount, offset)
-        return offset
-    finally:
-        await hcapi.remove_tip(mount)
+    async with hcapi.instrument_cache_lock():
+        try:
+            await hcapi.reset_instrument_offset(mount)
+            await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+            offset = await _calibrate_mount(
+                hcapi, mount, slot, method, raise_verify_error
+            )
+            await hcapi.save_instrument_offset(mount, offset)
+            return offset
+        finally:
+            await hcapi.remove_tip(mount)
 
 
 async def calibrate_module(
@@ -756,34 +760,35 @@ async def calibrate_module(
     The robot should be homed before calling this function.
     """
 
-    try:
-        # add the probe depending on the mount
-        if mount == OT3Mount.GRIPPER:
-            hcapi.add_gripper_probe(GripperProbe.FRONT)
-        else:
-            await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+    async with hcapi.instrument_cache_lock():
+        try:
+            # add the probe depending on the mount
+            if mount == OT3Mount.GRIPPER:
+                hcapi.add_gripper_probe(GripperProbe.FRONT)
+            else:
+                await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
 
-        LOG.info(
-            f"Starting module calibration for {module_id} at {nominal_position} using {mount}"
-        )
-        # FIXME (ba, 2023-04-04): Well B1 of the module adapter definition includes the z prep offset
-        # of 13x13mm in the nominial position, but we are still using PREP_OFFSET_DEPTH in
-        # find_calibration_structure_height which effectively doubles the offset. We plan
-        # on removing PREP_OFFSET_DEPTH in the near future, but for now just subtract PREP_OFFSET_DEPTH
-        # from the nominal position so we dont have to alter any other part of the system.
-        nominal_position = nominal_position - PREP_OFFSET_DEPTH
-        offset = await find_calibration_structure_position(
-            hcapi, mount, nominal_position, method=CalibrationMethod.BINARY_SEARCH
-        )
-        await hcapi.save_module_offset(module_id, mount, slot, offset)
-        return offset
-    finally:
-        # remove probe
-        if mount == OT3Mount.GRIPPER:
-            hcapi.remove_gripper_probe()
-            await hcapi.ungrip()
-        else:
-            await hcapi.remove_tip(mount)
+            LOG.info(
+                f"Starting module calibration for {module_id} at {nominal_position} using {mount}"
+            )
+            # FIXME (ba, 2023-04-04): Well B1 of the module adapter definition includes the z prep offset
+            # of 13x13mm in the nominial position, but we are still using PREP_OFFSET_DEPTH in
+            # find_calibration_structure_height which effectively doubles the offset. We plan
+            # on removing PREP_OFFSET_DEPTH in the near future, but for now just subtract PREP_OFFSET_DEPTH
+            # from the nominal position so we dont have to alter any other part of the system.
+            nominal_position = nominal_position - PREP_OFFSET_DEPTH
+            offset = await find_calibration_structure_position(
+                hcapi, mount, nominal_position, method=CalibrationMethod.BINARY_SEARCH
+            )
+            await hcapi.save_module_offset(module_id, mount, slot, offset)
+            return offset
+        finally:
+            # remove probe
+            if mount == OT3Mount.GRIPPER:
+                hcapi.remove_gripper_probe()
+                await hcapi.ungrip()
+            else:
+                await hcapi.remove_tip(mount)
 
 
 async def calibrate_belts(
@@ -802,10 +807,11 @@ async def calibrate_belts(
     -------
     A listed matrix of the linear transform in the x and y dimensions that accounts for the stretch of the gantry x and y belts.
     """
-    if mount == OT3Mount.GRIPPER:
-        raise RuntimeError("Must use pipette mount, not gripper")
-    try:
-        await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
-        return await _determine_transform_matrix(hcapi, mount)
-    finally:
-        await hcapi.remove_tip(mount)
+    async with hcapi.instrument_cache_lock():
+        if mount == OT3Mount.GRIPPER:
+            raise RuntimeError("Must use pipette mount, not gripper")
+        try:
+            await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+            return await _determine_transform_matrix(hcapi, mount)
+        finally:
+            await hcapi.remove_tip(mount)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -6,6 +6,7 @@ import logging
 from collections import OrderedDict
 from typing import (
     AsyncIterator,
+    AsyncGenerator,
     cast,
     Callable,
     Dict,
@@ -190,6 +191,7 @@ class OT3API(
         self._config = config
         self._backend = backend
         self._loop = loop
+        self._instrument_cache_lock = asyncio.Lock()
 
         self._callbacks: Set[HardwareEventHandler] = set()
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}
@@ -602,8 +604,12 @@ class OT3API(
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.
         """
-        await self._cache_instruments(require)
-        await self._configure_instruments()
+        if self._instrument_cache_lock.locked():
+            self._log.info("Instrument cache is locked, not refreshing")
+            return
+        async with self.instrument_cache_lock():
+            await self._cache_instruments(require)
+            await self._configure_instruments()
 
     async def _cache_instruments(
         self, require: Optional[Dict[top_types.Mount, PipetteName]] = None
@@ -2029,6 +2035,11 @@ class OT3API(
         end_pos = await self.gantry_position(mount, refresh=True)
         await self.move_to(mount, pass_start_pos)
         return moving_axis.of_point(end_pos)
+
+    @contextlib.asynccontextmanager
+    async def instrument_cache_lock(self) -> AsyncGenerator[None, None]:
+        async with self._instrument_cache_lock:
+            yield
 
     async def capacitive_sweep(
         self,


### PR DESCRIPTION

# Overview

If a desktop app is on the same network as a robot, it will poll the `GET /instruments` endpoint to get the current attached instruments. This process involves loading any saved calibration offsets in the hardware controller. If the robot is currently calibrating an axis, this is a very bad thing! The calibration offsets are cleared at the beginning of calibration and must remain cleared for the entirety of calibration.

This PR adds a simple asyncio lock to disable the `cache_instruments` function. The calibration functions acquire the lock for their entire duration, thus preventing the robot from accidentally applying unwanted offsets.

# Test Plan

Push this to a robot and ping the `GET /instruments` endpoint both during calibration & before/after calibration, while monitoring the logs with `journalctl --follow | grep "opentrons-api\["`
- During calibration, an entry should pop up saying "Instrument cache is locked, not refreshing" and calibration should complete fine
- Outside of calibration, the logs should say "Updating instrument model cache"

The endpoint should always return valid data as well.

# Changelog

- Added a context manager to lock the ot3api `cache_instruments` function
- Acquire aforementioned context manager during any calibration functions


# Review requests

- This worked fine on my testing through the ODD, do other workflows for calibration exist that may present an issue?

# Risk assessment

