### PR TITLE
refactor(makefile): push system server when pushing to flex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SHARED_DATA_DIR := shared-data
 UPDATE_SERVER_DIR := update-server
 ROBOT_SERVER_DIR := robot-server
 SERVER_UTILS_DIR := server-utils
+SYSTEM_SERVER_DIR := system-server
 HARDWARE_DIR := hardware
 USB_BRIDGE_DIR := usb-bridge
 
@@ -153,6 +154,7 @@ push-ot3:
 	$(MAKE) -C $(NOTIFY_SERVER_DIR) push-no-restart-ot3
 	$(MAKE) -C $(ROBOT_SERVER_DIR) push-ot3
 	$(MAKE) -C $(SERVER_UTILS_DIR) push-ot3
+	$(MAKE) -C $(SYSTEM_SERVER_DIR) push-ot3
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push-ot3
 	$(MAKE) -C $(USB_BRIDGE_DIR) push-ot3
 

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ push:
 	$(MAKE) -C $(ROBOT_SERVER_DIR) push
 	sleep 1
 	$(MAKE) -C $(SERVER_UTILS_DIR) push
+	sleep 1
+	$(MAKE) -C $(SYSTEM_SERVER_DIR) push
 
 
 .PHONY: push-ot3


### PR DESCRIPTION
# Overview

Noticed system server changes didnt get pushed when using the top level push ot3 script — its a small package and doesnt take long to push so I threw it in the top level make file.