### PR TITLE
refactor(app-shell-odd): move electron store config to non temp dir

### DIFF
--- a/app-shell-odd/src/config/index.ts
+++ b/app-shell-odd/src/config/index.ts
@@ -47,7 +47,10 @@ let _log: Logger | undefined
 const store = (): Store => {
   if (_store == null) {
     // perform store migration if loading for the first time
-    _store = (new Store({ defaults: DEFAULTS_V12 }) as unknown) as Store<Config>
+    _store = (new Store({
+      defaults: DEFAULTS_V12,
+      cwd: '/data/ODD',
+    }) as unknown) as Store<Config>
     _store.store = migrate((_store.store as unknown) as ConfigV12)
   }
   return _store


### PR DESCRIPTION
# Overview

Currently electron store was storing our config file in `/tmp` which means it was not getting persisted across boots. I moved the config into a new dir inside of `/data`