### PR TITLE
fix(api): Keep command keys stable across boots

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/hash_command_params.py
+++ b/api/src/opentrons/protocol_engine/commands/hash_command_params.py
@@ -8,7 +8,7 @@ from .command_unions import CommandCreate
 
 # TODO(mm, 2023-04-28):
 # This implementation will not notice that commands are different if they have different params
-# but share the same commandType. We should also hash command params.
+# but share the same commandType. We should also hash command params. (Jira RCORE-326.)
 def hash_command_params(
     create: CommandCreate, last_hash: Optional[str]
 ) -> Optional[str]:

--- a/api/src/opentrons/protocol_engine/commands/hash_command_params.py
+++ b/api/src/opentrons/protocol_engine/commands/hash_command_params.py
@@ -6,10 +6,9 @@ from .command import CommandIntent
 from .command_unions import CommandCreate
 
 
-# TODO(mc, 2022-11-02): this implementation is overly simplistic
-# and exists solely for demostration purposes.
-# Give it a real implementation with tests
-# https://opentrons.atlassian.net/browse/RCORE-326
+# TODO(mm, 2023-04-28):
+# This implementation will not notice that commands are different if they have different params
+# but share the same commandType. We should also hash command params.
 def hash_command_params(
     create: CommandCreate, last_hash: Optional[str]
 ) -> Optional[str]:
@@ -32,6 +31,8 @@ def hash_command_params(
     if create.intent == CommandIntent.SETUP:
         return None
     else:
+        # We avoid Python's built-in hash() function because it's not stable across
+        # runs of the Python interpreter. (Jira RSS-215.)
         last_contribution = b"" if last_hash is None else last_hash.encode("ascii")
         this_contribution = md5(create.commandType.encode("ascii")).digest()
         to_hash = last_contribution + this_contribution

--- a/api/src/opentrons/protocol_engine/commands/hash_command_params.py
+++ b/api/src/opentrons/protocol_engine/commands/hash_command_params.py
@@ -29,8 +29,10 @@ def hash_command_params(
         The command hash, if the command is a protocol command.
         `None` if the command is a setup command.
     """
-
-    last_contribution = b"" if last_hash is None else last_hash.encode("ascii")
-    this_contribution = md5(create.commandType.encode("ascii")).digest()
-    to_hash = last_contribution + this_contribution
-    return md5(to_hash).hexdigest()
+    if create.intent == CommandIntent.SETUP:
+        return None
+    else:
+        last_contribution = b"" if last_hash is None else last_hash.encode("ascii")
+        this_contribution = md5(create.commandType.encode("ascii")).digest()
+        to_hash = last_contribution + this_contribution
+        return md5(to_hash).hexdigest()

--- a/api/src/opentrons/protocol_engine/commands/hash_command_params.py
+++ b/api/src/opentrons/protocol_engine/commands/hash_command_params.py
@@ -1,4 +1,5 @@
 """Hash command params into idempotent keys to track commands from analysis to run."""
+from hashlib import md5
 from typing import Optional
 
 from .command import CommandIntent
@@ -28,8 +29,8 @@ def hash_command_params(
         The command hash, if the command is a protocol command.
         `None` if the command is a setup command.
     """
-    return (
-        f"{hash((last_hash, create.commandType))}"
-        if create.intent != CommandIntent.SETUP
-        else None
-    )
+
+    last_contribution = b"" if last_hash is None else last_hash.encode("ascii")
+    this_contribution = md5(create.commandType.encode("ascii")).digest()
+    to_hash = last_contribution + this_contribution
+    return md5(to_hash).hexdigest()

--- a/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
@@ -1,0 +1,59 @@
+from opentrons.protocol_engine import CommandIntent
+from opentrons.protocol_engine import commands
+from opentrons.protocol_engine.commands.hash_command_params import hash_command_params
+
+
+def test_equivalent_commands() -> None:
+    a = commands.BlowOutInPlaceCreate(
+        params=commands.BlowOutInPlaceParams(
+            pipetteId="abc123",
+            flowRate=123,
+        )
+    )
+    b = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=123)
+    )
+    c = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=123)
+    )
+
+    assert hash_command_params(b, None) == hash_command_params(c, None)
+
+    a_hash = hash_command_params(a, None)
+    assert hash_command_params(b, a_hash) == hash_command_params(c, a_hash)
+
+
+def test_nonequivalent_commands() -> None:
+    a = commands.BlowOutInPlaceCreate(
+        params=commands.BlowOutInPlaceParams(
+            pipetteId="abc123",
+            flowRate=123,
+        )
+    )
+    b = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=123)
+    )
+
+    assert hash_command_params(a, None) != hash_command_params(b, None)
+
+
+def test_repeated_commands() -> None:
+    a = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=123)
+    )
+    b = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=123)
+    )
+
+    a_hash = hash_command_params(a, None)
+    b_hash = hash_command_params(b, a_hash)
+    assert a_hash != b_hash
+
+
+def test_setup_command() -> None:
+    """Setup commands should always hash to None."""
+    setup_command = commands.WaitForDurationCreate(
+        params=commands.WaitForDurationParams(seconds=123),
+        intent=CommandIntent.SETUP,
+    )
+    assert hash_command_params(setup_command, None) == None

--- a/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
@@ -1,9 +1,12 @@
+"""Tests for hash_command_params."""
+
 from opentrons.protocol_engine import CommandIntent
 from opentrons.protocol_engine import commands
 from opentrons.protocol_engine.commands.hash_command_params import hash_command_params
 
 
 def test_equivalent_commands() -> None:
+    """Equivalent commands should have the same hash."""
     a = commands.BlowOutInPlaceCreate(
         params=commands.BlowOutInPlaceParams(
             pipetteId="abc123",
@@ -24,6 +27,7 @@ def test_equivalent_commands() -> None:
 
 
 def test_nonequivalent_commands() -> None:
+    """Nonequivalent commands should have different hashes."""
     a = commands.BlowOutInPlaceCreate(
         params=commands.BlowOutInPlaceParams(
             pipetteId="abc123",
@@ -38,6 +42,7 @@ def test_nonequivalent_commands() -> None:
 
 
 def test_repeated_commands() -> None:
+    """Repeated commands should hash differently, even though they're equivalent in isolation."""
     a = commands.WaitForDurationCreate(
         params=commands.WaitForDurationParams(seconds=123)
     )
@@ -56,4 +61,4 @@ def test_setup_command() -> None:
         params=commands.WaitForDurationParams(seconds=123),
         intent=CommandIntent.SETUP,
     )
-    assert hash_command_params(setup_command, None) == None
+    assert hash_command_params(setup_command, None) is None


### PR DESCRIPTION
# Overview

Fixes RSS-215. See that ticket for details.

# Test Plan

I've reproduced the original problem on an OT-3, and run this branch on an OT-3 and confirmed that it fixes it.

# Changelog

* Do not use Python's built-in `hash()` function to compute Protocol Engine command `key`s, because [it changes across runs of the Python interpreter](https://docs.python.org/3/reference/datamodel.html#object.__hash__:~:text=By%20default%2C%20the%20__hash__()%20values%20of%20str%20and%20bytes%20objects%20are%20%E2%80%9Csalted%E2%80%9D%20with%20an%20unpredictable%20random%20value.). Instead, compute the hash "manually" with `hashlib.md5`.
* Add tests for this function. The tests can't cover this particular bug, unfortunately, but we should have them anyway.

# Review requests


# Risk assessment

Low.