### PR TITLE
fix(api): binary search calibration tuning

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -53,8 +53,8 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
             speed_mm_per_s=1,
             sensor_threshold_pf=3.0,
         ),
-        search_initial_tolerance_mm=8.0,
-        search_iteration_limit=9,
+        search_initial_tolerance_mm=12.0,
+        search_iteration_limit=8,
     ),
     probe_length=44.5,
 )

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -305,7 +305,11 @@ async def find_calibration_structure_height(
 
 
 async def _probe_deck_at(
-    api: OT3API, mount: OT3Mount, target: Point, settings: CapacitivePassSettings
+    api: OT3API,
+    mount: OT3Mount,
+    target: Point,
+    settings: CapacitivePassSettings,
+    speed: float = 50,
 ) -> float:
     here = await api.gantry_position(mount)
     abs_transit_height = max(
@@ -313,7 +317,7 @@ async def _probe_deck_at(
     )
     safe_height = max(here.z, target.z, abs_transit_height)
     await api.move_to(mount, here._replace(z=safe_height))
-    await api.move_to(mount, target._replace(z=safe_height))
+    await api.move_to(mount, target._replace(z=safe_height), speed=speed)
     await api.move_to(mount, target._replace(z=abs_transit_height))
     _found_pos = await api.capacitive_probe(
         mount, OT3Axis.by_mount(mount), target.z, settings


### PR DESCRIPTION

# Overview

This PR changes a couple of settings for automated binary search calibration to improve reliability
* The speed when moving between points is lowered to a default of 50mm/s to reduce shaking on the calibration tip
* The initial tolerance & number of iterations is changed to increase the total tolerance of the final verification of the edge
  * The old settings had a final check tolerance of +/- 0.03125mm, which would result in the software thinking the edge was invalid
  * The new settings give a tolerance of +/- 0.09375mm which is very close to our actual tolerance limit of 0.1mm

# Test Plan

Test calibration on a robot + pipette that had been failing calibration. It works goodly now.

# Changelog



# Review requests



# Risk assessment

lo