### PR TITLE
feat(api): Add gripper wiggle when picking up from a module

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -51,6 +51,8 @@ Some things are known not to work, and are listed below. Specific compatibility 
   - All the above is now in the robot-server unit logs, which can be accessed via `journalctl -u opentrons-robot-server`
 - Protocol analysis should be a _lot_ faster
 - Fixed an issue where pinging `GET /instruments` during automated calibration would cause calibration to fail
+- Increased reliability of automated calibration
+- Increased reliability of gripper pickups from modules
 
 ## Big Things That Do Work Please Do Report Bugs About Them
 ### Robot Control

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -137,6 +137,27 @@ class LabwareMovementHandler:
 
         await ot3api.grip(force_newtons=LABWARE_GRIP_FORCE)
 
+        if isinstance(current_location, ModuleLocation):
+            # TODO: This is a nasty hard-coded implementation to add a wiggle
+            # to dislodge plates from *all* modules. This should be changed to
+            # check configuration values on a per-module basis for 1) whether
+            # to wiggle at all 2) how much to wiggle.
+            # See https://opentrons.atlassian.net/browse/RCORE-749
+            WIGGLE_Z_LIFT = 0.5
+            WIGGLE_MAG = 0.5
+            # Lift the gripper a tiny bit in the Z axis
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(z=WIGGLE_Z_LIFT))
+
+            # Shake in the Y axis
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(y=WIGGLE_MAG))
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(y=-2 * WIGGLE_MAG))
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(y=WIGGLE_MAG))
+
+            # Shake in the X axis
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(x=WIGGLE_MAG))
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(x=-2 * WIGGLE_MAG))
+            await ot3api.move_rel(mount=gripper_mount, delta=Point(x=WIGGLE_MAG))
+
         new_labware_offset = (
             self._state_store.labware.get_labware_offset(new_offset_id).vector
             if new_offset_id


### PR DESCRIPTION

# Overview

Some modules exhibit "sticking" when lifting a labware plate with the gripper; part of the labware sticks to the surface enough that, when the gripper pulls it up, the labware either becomes severely crooked _or_ the gripper slips and leaves the labware behind. This seems to be due to some combination of the surface finish on the module and the calibrated offset of the gripper, i.e. being off by a small amount in one axis can cause the gripper to fail to pick up.

Testing with various gripper/module combinations has showed that adding a small "wiggle" noticeably improves the reliability of pickups. The sequence of a "wiggle" is as follows:
* The gripper moves down and grabs the plate as normal
* The gripper picks the plate up a small amount 
  * Pick up magnitude is 0.5mm
* The gripper moves the plate a small amount in each direction in the Y axis, and then X axis
  * Magnitude is 0.5mm each direction for now.
* The gripper homes all the way up and the script proceeds as normal

Added a ticket https://opentrons.atlassian.net/browse/RCORE-749 for future work to add this to per-module settings.

# Test Plan

We have tested picking plates up from all Flex-compatible modules (TC2, TD2, HS) with the wiggle. Particularly, we tested the Thermocycler after closing the lid and cycling temperature a few different ways, which normally exacerbates sticking.

Situations where the gripper struggled to pick up from modules (particularly the Thermocycler) were fixed by adding the wiggle. Additionally, situations that were working fine (e.g. room temperature TD2) still work just as well.

"Working fine" means that the plate is picked up, it is straight, and when it's placed into another spot the alignment is correct.

Will also make sure CI passes, in case this messes with any tests.

# Changelog

* Added wiggle with a TODO statement
* Added internal release notes for wiggling
* _Added internal release notes for previous PR_ #12588

# Review requests


# Risk assessment

Pretty low, we tested this a lot on hardware.
