### PR TITLE
fix(app): lpc: fix command ordering in pick up tip

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -37,6 +37,7 @@ Some things are known not to work, and are listed below. Specific compatibility 
 - More focus on visuals around alignment, sizing, and spacing, especially between screens - this is mostly catchup from removing the menu bar
 - Recently-run protocols is now populated!
 - In general, it's pretty doable to run protocols and pre-protocol from the ODD; give it a try by sending a protocol to the flex with the "send to OT3" button in the desktop app
+- LPC shouldn't drag tipracks around anymore
 
 ### Robot Control
 - Even more acceleration changes from hardware testing

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -15,6 +15,7 @@ This is still pretty early in the process, so some things are known not to work,
   - Flex instrument calibration shows up now
   - 96-channels should show up in the instruments page and work in protocols
   - We don't cause a lot of instrument polling anymore on the robot
+- LPC shouldn't drag tipracks around anymore
 
 
 ## Big Things That Don't Work Yet So Don't Report Bugs About Them

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -204,20 +204,20 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
     chainRunCommands(
       [
         {
-          commandType: 'moveLabware' as const,
-          params: {
-            labwareId: labwareId,
-            newLocation: 'offDeck',
-            strategy: 'manualMoveWithoutPause',
-          },
-        },
-        {
           commandType: 'moveToWell' as const,
           params: {
             pipetteId: pipetteId,
             labwareId: FIXED_TRASH_ID,
             wellName: 'A1',
             wellLocation: { origin: 'top' as const },
+          },
+        },
+        {
+          commandType: 'moveLabware' as const,
+          params: {
+            labwareId: labwareId,
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
           },
         },
       ],

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -375,20 +375,20 @@ describe('PickUpTip', () => {
       3,
       [
         {
-          commandType: 'moveLabware',
-          params: {
-            labwareId: 'labwareId1',
-            newLocation: 'offDeck',
-            strategy: 'manualMoveWithoutPause',
-          },
-        },
-        {
           commandType: 'moveToWell',
           params: {
             pipetteId: 'pipetteId1',
             labwareId: 'fixedTrash',
             wellName: 'A1',
             wellLocation: { origin: 'top' },
+          },
+        },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
           },
         },
       ],


### PR DESCRIPTION
In LPC, when we picked up a tip that we'd actually use for the rest of LPC, we'd remove the tiprack labware before moving to the trash. This is incorrect - that labware is still physically present, since we haven't told the user to remove it. We used to get away with it, because it used to be that pick_up_tip ended with a z-home that got the pipette up high enough that even if PE thought the deck was empty we wouldn't collide.

Now, though, on the Flex we removed that home because it is slow and we don't need it anymore, and if we tell PE that the tiprack disappeared and then tell it to move the pipette to the trash, it will just zip it straight over to the trash... dragging along that tiprack, which is still physically present.

To fix this, just move to the trash before we remove the labware.

## Risk assessment
- Low: this is a behavior change, but it's definitely more correct

## Testing
 - Ran this on a flex that previously would drag the tiprack around every time, and now you get the nice clean move-up-to-clear-labware behavior
