### PR TITLE
refactor(api): Refactor DeckSlotName for explicitness and type safety

### DIFF
--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -236,7 +236,7 @@ class LegacyProtocolCore(
         """Load a module."""
         resolved_type = ModuleType.from_model(model)
         resolved_location = self._deck_layout.resolve_module_location(
-            resolved_type, deck_slot
+            resolved_type, (None if deck_slot is None else deck_slot.id)
         )
 
         selected_hardware = None

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -363,7 +363,7 @@ class Labware:
         if isinstance(labware_location, AbstractModuleCore):
             return self._core_map.get(labware_location)
 
-        return labware_location
+        return None if labware_location is None else labware_location.id
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -237,7 +237,7 @@ class ModuleContext(CommandPublisher):
 
         class_name = self.__class__.__name__
         display_name = self._core.get_display_name()
-        location = self._core.get_deck_slot().value
+        location = self._core.get_deck_slot().id
 
         return f"{class_name} at {display_name} on {location} lw {self.labware}"
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -78,9 +78,9 @@ class MovementHandler:
         #  fails saying that h/s latch is closed even when it is not.
         log.info(f"H/S movement restrictors: {hs_movement_restrictors}")
 
-        dest_slot_int = int(
-            self._state_store.geometry.get_ancestor_slot_name(labware_id)
-        )
+        dest_slot_int = self._state_store.geometry.get_ancestor_slot_name(
+            labware_id
+        ).as_int()
 
         self._hs_movement_flagger.raise_if_movement_restricted(
             hs_movement_restrictors=hs_movement_restrictors,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -622,7 +622,7 @@ class ModuleView(HasState[ModuleState]):
     ) -> LabwareOffsetVector:
         """Get the module's offset vector computed with slot transform."""
         definition = self.get_definition(module_id)
-        slot = self.get_location(module_id).slotName.value
+        slot = self.get_location(module_id).slotName.id
 
         pre_transform = array(
             (

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -882,7 +882,7 @@ class ModuleView(HasState[ModuleState]):
             HeaterShakerMovementRestrictors(
                 plate_shaking=substate.is_plate_shaking,
                 latch_closed=substate.is_labware_latch_closed,
-                deck_slot=int(self.get_location(substate.module_id).slotName),
+                deck_slot=self.get_location(substate.module_id).slotName.as_int(),
             )
             for substate in hs_substates
         ]

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -172,10 +172,10 @@ class MotionView:
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:
-            pipette_deck_slot = int(
-                self._geometry.get_ancestor_slot_name(current_well.labware_id)
-            )
-            hs_deck_slot = int(self._modules.get_location(hs_module_id).slotName)
+            pipette_deck_slot = self._geometry.get_ancestor_slot_name(
+                current_well.labware_id
+            ).as_int()
+            hs_deck_slot = self._modules.get_location(hs_module_id).slotName.as_int()
             conflicting_slots = get_east_west_slots(hs_deck_slot) + [hs_deck_slot]
             pipette_blocking = pipette_deck_slot in conflicting_slots
         return pipette_blocking
@@ -187,10 +187,10 @@ class MotionView:
         pipette_blocking = True
         current_well = self._pipettes.get_current_well()
         if current_well is not None:
-            pipette_deck_slot = int(
-                self._geometry.get_ancestor_slot_name(current_well.labware_id)
-            )
-            hs_deck_slot = int(self._modules.get_location(hs_module_id).slotName)
+            pipette_deck_slot = self._geometry.get_ancestor_slot_name(
+                current_well.labware_id
+            ).as_int()
+            hs_deck_slot = self._modules.get_location(hs_module_id).slotName.as_int()
             conflicting_slots = get_adjacent_slots(hs_deck_slot) + [hs_deck_slot]
             pipette_blocking = pipette_deck_slot in conflicting_slots
         return pipette_blocking

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -208,11 +208,7 @@ DECK_SLOT_NAME_TO_COORDINATE = {
 # model library
 # https://github.com/Opentrons/opentrons/pull/6943#discussion_r519029833
 class DeckSlotName(enum.Enum):
-    """Deck slot identifiers.
-
-    The result of `.value` is a private implementation detail.
-    Use the custom methods and properties like `.id` and `.as_int()` instead.
-    """
+    """Deck slot identifiers."""
 
     SLOT_1 = "1"
     SLOT_2 = "2"
@@ -245,6 +241,8 @@ class DeckSlotName(enum.Enum):
         """This slot's unique ID, as it appears in the deck definition.
 
         This can be used to look up slot details in the deck definition.
+
+        This is preferred over `.value` or `.__str__()` for explicitness.
         """
         return self.value
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -207,8 +207,12 @@ DECK_SLOT_NAME_TO_COORDINATE = {
 # TODO(mc, 2020-11-09): this makes sense in shared-data or other common
 # model library
 # https://github.com/Opentrons/opentrons/pull/6943#discussion_r519029833
-class DeckSlotName(str, enum.Enum):
-    """Deck slot identifiers."""
+class DeckSlotName(enum.Enum):
+    """Deck slot identifiers.
+
+    The result of `.value` is a private implementation detail.
+    Use the custom methods and properties like `.id` and `.as_int()` instead.
+    """
 
     SLOT_1 = "1"
     SLOT_2 = "2"
@@ -236,9 +240,20 @@ class DeckSlotName(str, enum.Enum):
     def as_coordinate(self) -> str:
         return DECK_SLOT_NAME_TO_COORDINATE[self.value]
 
+    @property
+    def id(self) -> str:
+        """This slot's unique ID, as it appears in the deck definition.
+
+        This can be used to look up slot details in the deck definition.
+        """
+        return self.value
+
     def __str__(self) -> str:
-        """Stringify to a simple integer string."""
-        return str(self.value)
+        """Stringify to the unique ID.
+
+        For explicitness, prefer using `.id` instead.
+        """
+        return self.id
 
 
 class TransferTipPolicy(enum.Enum):

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -358,7 +358,9 @@ def test_load_module(
     decoy.when(mock_hw_mod_2.model()).then_return("model-2")
 
     decoy.when(
-        mock_deck.resolve_module_location(ModuleType.TEMPERATURE, DeckSlotName.SLOT_1)
+        mock_deck.resolve_module_location(
+            ModuleType.TEMPERATURE, DeckSlotName.SLOT_1.id
+        )
     ).then_return(42)
 
     decoy.when(mock_deck.position_for(42)).then_return(Location(Point(1, 2, 3), None))

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -801,8 +801,7 @@
     "DeckSlotName": {
       "title": "DeckSlotName",
       "description": "Deck slot identifiers.",
-      "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
-      "type": "string"
+      "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]
     },
     "DeckSlotLocation": {
       "title": "DeckSlotLocation",


### PR DESCRIPTION
# Overview

Refactor our `DeckSlotName` enum for explicitness and improved type safety.

This work goes towards RLAB-256 and other tickets in the RLAB-199 epic.

# Test Plan

Make sure CI keeps passing.

# Changelog

* Do not subclass `DeckSlotName` from `str`. I consider subclassing enums from `str` [smelly in general](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3479896162/Don+t+subclass+Python+enums+from+str+proposed), and we've been hitting this a little bit in RLAB-199 because it makes it more difficult for us to audit how deck slot IDs flow through our code.
    * This stops people from using `DeckSlotName` values as `str`s. To replace that, when something expects the deck slot ID string, it should now request it explicitly with a new property, `slot.id`.
    * `str(slot)` is equivalent to `slot.id`, as before. But it's now discouraged for new code.
* Fix a few places that were doing `int(slot)` to do `slot.as_int()` instead.

# Review requests


# Risk assessment

Low.
