### PR TITLE
ci(protocol-designer): update aws default region

### DIFF
--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -15,4 +15,4 @@ runs:
   steps:
     - shell: bash
       run: |
-        aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ inputs.destPrefix }} --acl=public-read
+        aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ inputs.destPrefix }} --acl=public-read --profile=deploy

--- a/.github/actions/webstack/deploy-to-sandbox/action.yaml
+++ b/.github/actions/webstack/deploy-to-sandbox/action.yaml
@@ -15,4 +15,4 @@ runs:
   steps:
     - shell: bash
       run: |
-        aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ inputs.destPrefix }} --acl=public-read --profile=deploy
+        aws s3 sync ${{ inputs.distPath }} s3://sandbox.${{ inputs.domain }}/${{ inputs.destPrefix }} --acl=public-read

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -194,6 +194,16 @@ jobs:
         with:
           name: pd-artifact
           path: ./dist
+      - name: 'configure ot3 s3 deploy creds'
+          run: |
+            aws configure set aws_access_key_id ${{ secrets.PD_S3_SANDBOX_KEY_ID }} --profile identity
+            aws configure set aws_secret_access_key ${{ secrets.PD_S3_SANDBOX_SECRET }} --profile identity
+            aws configure set region us-east-2 --profile identity
+            aws configure set output json --profile identity
+            aws configure set region us-east-2 --profile deploy
+            aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
+            aws configure set source_profile identity --profile deploy
+          shell: bash
       - name: 'deploy builds to s3'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.PD_S3_SANDBOX_KEY_ID }}

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -196,8 +196,8 @@ jobs:
           path: ./dist
       - name: 'deploy builds to s3'
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.PD_S3_SANDBOX_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PD_S3_SANDBOX_SECRET }}
           AWS_DEFAULT_REGION: us-east-1
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -194,7 +194,11 @@ jobs:
         with:
           name: pd-artifact
           path: ./dist
-      - name: 'configure ot3 s3 deploy creds'
+      - name: 'configure ot3 s3 deploy creds and deploy'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PD_S3_SANDBOX_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PD_S3_SANDBOX_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           aws configure set aws_access_key_id ${{ secrets.PD_S3_SANDBOX_KEY_ID }} --profile identity
           aws configure set aws_secret_access_key ${{ secrets.PD_S3_SANDBOX_SECRET }} --profile identity
@@ -203,14 +207,5 @@ jobs:
           aws configure set region us-east-2 --profile deploy
           aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
           aws configure set source_profile identity --profile deploy
+          aws s3 sync ./dist s3://sandbox.designer.opentrons.com/${{ env.OT_BRANCH }} --acl=public-read --profile=deploy
         shell: bash
-      - name: 'deploy builds to s3'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.PD_S3_SANDBOX_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PD_S3_SANDBOX_SECRET }}
-          AWS_DEFAULT_REGION: us-east-1
-        uses: './.github/actions/webstack/deploy-to-sandbox'
-        with:
-          domain: 'designer.opentrons.com'
-          distPath: './dist'
-          destPrefix: ${{ env.OT_BRANCH }}

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -195,15 +195,15 @@ jobs:
           name: pd-artifact
           path: ./dist
       - name: 'configure ot3 s3 deploy creds'
-          run: |
-            aws configure set aws_access_key_id ${{ secrets.PD_S3_SANDBOX_KEY_ID }} --profile identity
-            aws configure set aws_secret_access_key ${{ secrets.PD_S3_SANDBOX_SECRET }} --profile identity
-            aws configure set region us-east-2 --profile identity
-            aws configure set output json --profile identity
-            aws configure set region us-east-2 --profile deploy
-            aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
-            aws configure set source_profile identity --profile deploy
-          shell: bash
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.PD_S3_SANDBOX_KEY_ID }} --profile identity
+          aws configure set aws_secret_access_key ${{ secrets.PD_S3_SANDBOX_SECRET }} --profile identity
+          aws configure set region us-east-2 --profile identity
+          aws configure set output json --profile identity
+          aws configure set region us-east-2 --profile deploy
+          aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
+          aws configure set source_profile identity --profile deploy
+        shell: bash
       - name: 'deploy builds to s3'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.PD_S3_SANDBOX_KEY_ID }}

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -198,7 +198,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
-          AWS_DEFAULT_REGION: us-east-2
+          AWS_DEFAULT_REGION: us-east-1
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:
           domain: 'designer.opentrons.com'


### PR DESCRIPTION
# Overview

This PR updates the default aws location for PD sandbox deploys. I also added new gh secrets to be able to deploy to the PL account (confusing, but that is where the new sandbox bucket lives). I created new ones because the old ones are still being used by components library and labware library
