### PR TITLE
chore(python): Enable --strict-markers in all pytest configurations

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -8,5 +8,5 @@ markers =
         apiv2: This test invocation requires apiv2
         ot2_only: Test only functions using the OT2 hardware
         ot3_only: Test only functions using the OT3 hardware
-addopts = --color=yes
+addopts = --color=yes --strict-markers
 asyncio_mode = auto

--- a/app-testing/pytest.ini
+++ b/app-testing/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 junit_family = legacy
-addopts = -s --junitxml=results/results.xml --log-cli-level info
+addopts = -s --junitxml=results/results.xml --log-cli-level info --strict-markers

--- a/g-code-testing/pytest.ini
+++ b/g-code-testing/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --color=yes
+addopts = --color=yes --strict-markers
 markers =
 	slow: mark test as slow
 	g_code_confirm: mark test as a G-Code confirmation test

--- a/hardware/pytest.ini
+++ b/hardware/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --color=yes
+addopts = --color=yes --strict-markers
 markers =
 	slow: mark test as slow
 	requires_emulator: mark test as requiring emulator

--- a/notify-server/pytest.ini
+++ b/notify-server/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+addopts = --strict-markers
 markers = env_var: marker used by settings unit test

--- a/robot-server/pytest.ini
+++ b/robot-server/pytest.ini
@@ -3,5 +3,5 @@ markers =
         ot2_only: Test only functions using the OT2 hardware
         ot3_only: Test only functions using the OT3 hardware
 tavern-global-cfg = tests/integration/common.yaml
-addopts = --color=yes
+addopts = --color=yes --strict-markers
 asyncio_mode = auto

--- a/server-utils/pytest.ini
+++ b/server-utils/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --color=yes
+addopts = --color=yes --strict-markers
 asyncio_mode = auto

--- a/shared-data/python/pytest.ini
+++ b/shared-data/python/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --color=yes
+addopts = --color=yes --strict-markers

--- a/system-server/pytest.ini
+++ b/system-server/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --cov=system_server --cov-report term-missing:skip-covered --cov-report xml:coverage.xml --color=yes
+addopts = --cov=system_server --cov-report term-missing:skip-covered --cov-report xml:coverage.xml --color=yes --strict-markers
 asyncio_mode = auto
 tavern-global-cfg = tests/integration/common.yaml

--- a/update-server/pytest.ini
+++ b/update-server/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov=otupdate --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+addopts = --cov=otupdate --cov-report term-missing:skip-covered --cov-report xml:coverage.xml --strict-markers
 markers =
         exclude_boot_vfat: tests that ensure success if there's no bootfs
         exclude_boot_vfat_hash: tests that check if there's no boot hash

--- a/usb-bridge/pytest.ini
+++ b/usb-bridge/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=ot3usb --cov-report term-missing:skip-covered --cov-report xml:coverage.xml --color=yes
+addopts = --cov=ot3usb --cov-report term-missing:skip-covered --cov-report xml:coverage.xml --color=yes --strict-markers


### PR DESCRIPTION
# Overview

While working on RLAB-256, I got confused by a silly mistake where I misspelled a pytest mark, like `pytest.mark.ot3only` instead of `pytest.mark.ot3_only`.

It turns out that there's an option to prevent this, [`--strict-markers`](https://docs.pytest.org/en/7.1.x/how-to/mark.html#raising-errors-on-unknown-marks), and it's easy to enable in all of our Python projects. This PR does that.

# Test Plan

Make sure CI keeps passing.

# Review requests

Is there any reason not to do this?

# Risk assessment

No risk.
