### PR TITLE
fix(app): when exiting from AttachProbe, display correct text

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -13,7 +13,7 @@
   "recalibrate_pipette": "recalibrate {{mount}} pipette",
   "calibrate_pipette": "calibrate {{mount}} pipette",
   "pip_recal_success": "{{pipetteName}} successfully recalibrated",
-  "stand_back": "Stand Back, robot is in motion",
+  "stand_back": "Stand back, robot is in motion",
   "pipette_calibrating": "Stand back, connect and secure, {{pipetteName}} is calibrating",
   "progress_will_be_lost": "{{flow}} progress will be lost",
   "are_you_sure_exit": "Are you sure you want to exit before completing {{flow}}?",

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -111,9 +111,13 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     return (
       <InProgressModal
         alternativeSpinner={isExiting ? null : pipetteProbeVid}
-        description={t('pipette_calibrating', {
-          pipetteName: displayName,
-        })}
+        description={
+          isExiting
+            ? t('stand_back')
+            : t('pipette_calibrating', {
+                pipetteName: displayName,
+              })
+        }
       >
         {isExiting ? undefined : (
           <Flex marginX={isOnDevice ? '4.5rem' : '8.5625rem'}>

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -107,7 +107,7 @@ describe('AttachProbe', () => {
       isExiting: true,
     }
     const { getByText } = render(props)
-    getByText('Stand Back, robot is in motion')
+    getByText('Stand back, robot is in motion')
     expect(
       screen.queryByText(
         'The calibration probe will touch the sides of the calibration square in slot C2 to determine its exact position'

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
 import { LEFT, SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
@@ -98,6 +98,21 @@ describe('AttachProbe', () => {
       'The calibration probe will touch the sides of the calibration square in slot C2 to determine its exact position'
     )
     getByTestId('Pipette_Probing_1.webm')
+  })
+
+  it('returns the correct information when robot is in motion during exiting', () => {
+    props = {
+      ...props,
+      isRobotMoving: true,
+      isExiting: true,
+    }
+    const { getByText } = render(props)
+    getByText('Stand Back, robot is in motion')
+    expect(
+      screen.queryByText(
+        'The calibration probe will touch the sides of the calibration square in slot C2 to determine its exact position'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('renders the error modal screen when errorMessage is true', () => {


### PR DESCRIPTION
closes RQA-722

# Overview

When exiting directly from the `AttachProbe` page and the robot is in motion, it now displays the correct text on the modal.

# Test Plan

- go through calibration flow. When you exit from the `AttachProbe` page, the modal should display `Stand back, robot is in motion'

# Changelog

- add logic to ProgressModal text in `AttachProbe`, fix test

# Review requests

- see test plan

# Risk assessment

low