### PR TITLE
fix(app): fix ODD protocol setup step text size

### DIFF
--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
@@ -99,9 +99,11 @@ function ProtocolSetupStep({
             name={status === 'ready' ? 'ot-check' : 'ot-alert'}
           />
         ) : null}
-        <StyledText as="h1">{title}</StyledText>
+        <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+          {title}
+        </StyledText>
         <Flex flex="1" justifyContent={JUSTIFY_END}>
-          <StyledText as="h2" textAlign={TEXT_ALIGN_RIGHT}>
+          <StyledText as="p" textAlign={TEXT_ALIGN_RIGHT}>
             {detail}
             {subDetail != null && detail != null ? <br /> : null}
             {subDetail}


### PR DESCRIPTION
# Overview

Quick text size fix now that `StyledText` usage has been standardized according to the design system. `ProtocolSetup` steps now have `h4` + `p` instead of `h1` + `h2` 

Before:
![Screen Shot 2023-05-02 at 5 51 35 PM](https://user-images.githubusercontent.com/4731953/235794022-05f9f9c4-cd4f-4025-987f-6c02ee09fceb.png)

After:
![Screen Shot 2023-05-02 at 5 51 03 PM](https://user-images.githubusercontent.com/4731953/235794021-e3836a0a-f25c-431d-8210-2cb1cb74d78f.png)



# Risk assessment
low
