### PR TITLE
fix(app): fix modal header padding to align with hi-fi

### DIFF
--- a/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/ModalHeader.tsx
@@ -24,7 +24,8 @@ export function ModalHeader(props: ModalHeaderProps): JSX.Element {
       color={isError ? COLORS.white : COLORS.black}
       height="6.25rem"
       width="100%"
-      padding={isError ? SPACING.spacing5 : SPACING.spacing6}
+      paddingX={SPACING.spacing6}
+      paddingY={isError ? SPACING.spacing5 : SPACING.spacing6}
       flexDirection={DIRECTION_ROW}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       alignItems={ALIGN_CENTER}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix the unmatched padding

[design]
https://www.figma.com/file/AoTLAYuWawlaWItB1umOjr/Release%3A-Opentrons-Flex-Touchscreen-Designs?node-id=10876-275394&t=AjfDmp73cbUDDAyI-0

isError === true: paddingY: 24px
![Screenshot 2023-05-03 at 9 20 18 AM](https://user-images.githubusercontent.com/474225/235929745-cfea70a1-e630-44a9-a960-16e8b40f6086.png)

isError === false: paddingY: 32px 
![Screenshot 2023-05-03 at 9 20 34 AM](https://user-images.githubusercontent.com/474225/235929746-0d44e68b-92b0-4d67-b579-32429cd38235.png)



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
not required
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update ModalHeader padding
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
