### PR TITLE
fix(api): increase instrument calibration z limit

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -39,7 +39,7 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
     z_offset=ZSenseSettings(
         pass_settings=CapacitivePassSettings(
             prep_distance_mm=4.0,
-            max_overrun_distance_mm=2.0,
+            max_overrun_distance_mm=5.0,
             speed_mm_per_s=1.0,
             sensor_threshold_pf=3.0,
         ),

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -241,7 +241,7 @@ async def test_deck_not_found(
     override_cal_config: None,
 ) -> None:
     await ot3_hardware.home()
-    mock_capacitive_probe.side_effect = (-3,)
+    mock_capacitive_probe.side_effect = (-25,)
     with pytest.raises(CalibrationStructureNotFoundError):
         await find_calibration_structure_height(
             ot3_hardware,


### PR DESCRIPTION
This makes the system more robust to a kind of error we're seeing with instrument calibration where rerunning it will sometimes fail to reach the deck. This might be because of another issue around homing, but this will definitely fix it in the meantime.

Closes RQA-725
