### PR TITLE
fix(app): use truncation for a long protocol name

### DIFF
--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -61,7 +61,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
           paddingRight={SPACING.spacing3}
           overflowWrap="anywhere"
         >
-          {`${truncateString(displayName, 80)}; ${t(
+          {`${truncateString(displayName, 80, 65)}; ${t(
             `run_details:status_${currentRunStatus}`
           )}`}
         </StyledText>

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -15,6 +15,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   TYPOGRAPHY,
+  truncateString,
 } from '@opentrons/components'
 
 import { QuaternaryButton } from '../../atoms/buttons'
@@ -60,8 +61,8 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
           paddingRight={SPACING.spacing3}
           overflowWrap="anywhere"
         >
-          {`${String(displayName)}; ${t(
-            `run_details:status_${String(currentRunStatus)}`
+          {`${truncateString(displayName, 80)}; ${t(
+            `run_details:status_${currentRunStatus}`
           )}`}
         </StyledText>
         <Link

--- a/components/src/__tests__/utils.test.ts
+++ b/components/src/__tests__/utils.test.ts
@@ -1,0 +1,26 @@
+import { truncateString } from '../utils'
+
+describe('truncateString', () => {
+  it('when an input string less than max length, return the original input', () => {
+    // Note (kj:05/03/2023) the max length and breakPoints are the same as what we use for the Desktop app
+    const str = 'opentrons-dev'
+    const result = truncateString(str, 80, 65)
+    expect(result).toEqual(str)
+  })
+
+  it('when an input string is more than 80 characters, return the truncated string', () => {
+    const str = `Lorem Ipsum Is Simply Dummy Text Of The Printing And Typesetting Industry. Lorem Ipsum Has Been The Industry's Standard Dummy Text Ever Since The 1500s, When An Unknown Printer Took A Galley Of Type And Scrambled It To Make A Type Specimen Book.Py`
+    const result = truncateString(str, 80, 65)
+    const truncatedStr =
+      'Lorem Ipsum Is Simply Dummy Text Of The Printing And Typesetting ...imen Book.Py'
+    expect(result).toEqual(truncatedStr)
+  })
+
+  it('when an input string is more than 80 characters without specifying the break point, return the truncated string', () => {
+    const str = `Lorem Ipsum Is Simply Dummy Text Of The Printing And Typesetting Industry. Lorem Ipsum Has Been The Industry's Standard Dummy Text Ever Since The 1500s, When An Unknown Printer Took A Galley Of Type And Scrambled It To Make A Type Specimen Book.Py`
+    const result = truncateString(str, 80)
+    const truncatedStr =
+      'Lorem Ipsum Is Simply Dummy Text Of The Printing And Typesetting Industry. Lo...'
+    expect(result).toEqual(truncatedStr)
+  })
+})

--- a/components/src/utils.ts
+++ b/components/src/utils.ts
@@ -50,7 +50,7 @@ export function truncateString(
         breakPoint - maxLength + dots.length
       )}`
     } else {
-      return `${text.slice(0, maxLength)}...`
+      return `${text.slice(0, maxLength - dots.length)}...`
     }
   else return text
 }

--- a/components/src/utils.ts
+++ b/components/src/utils.ts
@@ -34,19 +34,23 @@ export const wellNameSplit = (wellName: string): [string, string] => {
  *
  * @param {string} text - A string param
  * @param {number} maxLength - A maximum length of display
- * @param {string} breakPoint - A point to insert three dots
+ * @param {number} breakPoint - Optional A point to insert three dots
  *
  * @returns {string} Returns the truncated string
  */
 export function truncateString(
   text: string,
   maxLength: number,
-  breakPoint: number
+  breakPoint?: number
 ): string {
   const dots = '...'
   if (text.length > maxLength)
-    return `${text.substring(0, breakPoint)}${dots}${text.slice(
-      breakPoint - maxLength + dots.length
-    )}`
+    if (breakPoint != null) {
+      return `${text.substring(0, breakPoint)}${dots}${text.slice(
+        breakPoint - maxLength + dots.length
+      )}`
+    } else {
+      return `${text.slice(0, maxLength)}...`
+    }
   else return text
 }

--- a/components/src/utils.ts
+++ b/components/src/utils.ts
@@ -50,7 +50,7 @@ export function truncateString(
         breakPoint - maxLength + dots.length
       )}`
     } else {
-      return `${text.slice(0, maxLength - dots.length)}...`
+      return `${text.slice(0, maxLength - dots.length)}${dots}`
     }
   else return text
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When running a long protocol name, the robot card layout is broken by that.
![Screenshot 2023-05-03 at 2 02 07 PM](https://user-images.githubusercontent.com/474225/236006787-cc974bb8-812d-4884-9c16-106976d62a11.png)

close RQA-731

use `truncateString()` to handle this issue.
currently, the max length is 80 characters(this is from the design team) and the break point is 65th character. (This might be updated later)

[related thread](https://opentrons.slack.com/archives/C0509SV0KFY/p1682711918678509)

[after]
![Screenshot 2023-05-03 at 2 02 25 PM](https://user-images.githubusercontent.com/474225/236007158-903419ec-645a-4042-9e3e-3af9a73dc7ce.png)

[less 80 characters]
If the protocol name length is less than 80 characters, the app display without any truncation.

![Screenshot 2023-05-03 at 2 03 13 PM](https://user-images.githubusercontent.com/474225/236007503-0a25b714-caa4-4a61-8f84-fd34b896491a.png)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. upload a long name protocol
2. run the protocol
3. go to `Devices`
4. check the device card layout

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- apply `truncateString` to `protocolName`
- modify truncateString (make breakPoints optional)
- add a test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- when running a long name protocol, it won't break the robot card layout.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
