### PR TITLE
fix(app): do not poll protocol analyses on device page

### DIFF
--- a/app/src/organisms/Devices/hooks/useDownloadRunLog.ts
+++ b/app/src/organisms/Devices/hooks/useDownloadRunLog.ts
@@ -1,14 +1,18 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { HostConfig, getRun, getCommands } from '@opentrons/api-client'
+import {
+  HostConfig,
+  getRun,
+  getCommands,
+  getProtocol,
+} from '@opentrons/api-client'
 import { DEFAULT_PARAMS as DEFAULT_COMMANDS_PARAMS } from '@opentrons/react-api-client/src/runs/useAllCommandsQuery'
 import { IconProps } from '@opentrons/components'
 import { useHost } from '@opentrons/react-api-client'
 
 import { ERROR_TOAST, INFO_TOAST } from '../../../atoms/Toast'
 import { useToaster } from '../../../organisms/ToasterOven'
-import { useProtocolDetailsForRun } from './useProtocolDetailsForRun'
 import { downloadFile } from '../utils'
 
 export function useDownloadRunLog(
@@ -21,7 +25,6 @@ export function useDownloadRunLog(
 
   const { makeToast } = useToaster()
 
-  const { displayName } = useProtocolDetailsForRun(runId)
   const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
 
   const downloadRunLog = (): void => {
@@ -40,13 +43,32 @@ export function useDownloadRunLog(
               ...runRecord,
               commands,
             }
-            const protocolName = displayName ?? runRecord.data.protocolId ?? ''
+            const protocolId = response.data.data.protocolId ?? null
             const createdAt = new Date(runRecord.data.createdAt).toISOString()
-            const fileName = `${robotName}_${String(
-              protocolName
-            )}_${createdAt}.json`
-            setIsLoading(false)
-            downloadFile(runDetails, fileName)
+            let fileName = `${robotName}_${
+              runRecord.data.protocolId ?? ''
+            }_${createdAt}.json`
+
+            if (protocolId != null) {
+              getProtocol(host as HostConfig, protocolId)
+                .then(response => {
+                  const protocolName = response.data.data.metadata.protocolName
+
+                  fileName =
+                    protocolName != null
+                      ? `${robotName}_${String(protocolName)}_${createdAt}.json`
+                      : fileName
+                  setIsLoading(false)
+                  downloadFile(runDetails, fileName)
+                })
+                .catch((e: Error) => {
+                  setIsLoading(false)
+                  makeToast(e.message, ERROR_TOAST)
+                })
+            } else {
+              setIsLoading(false)
+              downloadFile(runDetails, fileName)
+            }
           })
           .catch((e: Error) => {
             setIsLoading(false)


### PR DESCRIPTION

# Overview
This PR removes a call to a hook that was polling the protocol analyses endpoints from the device page. This was causing the robot to stall and appear unresponsive.


# Changelog

- do not poll protocol analyses on device page


# Review requests
Go to the internal releases robot in the office and make sure we are no longer spamming the protocol analyses endpoints anymore

# Risk assessment
Low