### PR TITLE
feat(app): add homing to pipette flows where needed 

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -120,6 +120,7 @@ export const BeforeBeginning = (
           mount: mount,
         },
       },
+      { commandType: 'home' as const, params: {} },
       {
         // @ts-expect-error calibration type not yet supported
         commandType: 'calibration/moveToMaintenancePosition' as const,
@@ -139,6 +140,7 @@ export const BeforeBeginning = (
   }
 
   const SingleMountAttachCommand: CreateCommand[] = [
+    { commandType: 'home' as const, params: {} },
     {
       // @ts-expect-error calibration type not yet supported
       commandType: 'calibration/moveToMaintenancePosition' as const,
@@ -149,6 +151,7 @@ export const BeforeBeginning = (
   ]
 
   const NinetySixChannelAttachCommand: CreateCommand[] = [
+    { commandType: 'home' as const, params: {} },
     {
       // @ts-expect-error calibration type not yet supported
       commandType: 'calibration/moveToMaintenancePosition' as const,

--- a/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
@@ -10,11 +10,13 @@ import {
   AlertPrimaryButton,
 } from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
+import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { FLOWS } from './constants'
 import type { PipetteWizardFlow } from './types'
 
 interface ExitModalProps {
+  isRobotMoving: boolean
   proceed: () => void
   goBack: () => void
   flowType: PipetteWizardFlow
@@ -22,7 +24,7 @@ interface ExitModalProps {
 }
 
 export function ExitModal(props: ExitModalProps): JSX.Element {
-  const { goBack, proceed, flowType, isOnDevice } = props
+  const { goBack, proceed, flowType, isOnDevice, isRobotMoving } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
 
   let flowTitle: string = t('pipette_calibration')
@@ -36,6 +38,7 @@ export function ExitModal(props: ExitModalProps): JSX.Element {
       break
     }
   }
+  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
 
   return (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
@@ -16,7 +16,7 @@ import { FLOWS } from './constants'
 import type { PipetteWizardFlow } from './types'
 
 interface ExitModalProps {
-  isRobotMoving: boolean
+  isRobotMoving?: boolean
   proceed: () => void
   goBack: () => void
   flowType: PipetteWizardFlow

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -118,7 +118,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
             },
           },
         ],
-        false
+        true
       ).then(() => {
         proceed()
       })

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -8,6 +8,7 @@ import {
   SecondaryButton,
 } from '@opentrons/components'
 import { NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
+import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { SmallButton } from '../../atoms/buttons'
 import { CheckPipetteButton } from './CheckPipetteButton'
@@ -30,6 +31,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
     attachedPipettes,
     mount,
     handleCleanUpAndClose,
+    chainRunCommands,
     currentStepIndex,
     totalStepCount,
     selectedPipette,
@@ -37,6 +39,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
     isFetching,
     setFetching,
     hasCalData,
+    isRobotMoving,
   } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
@@ -93,6 +96,32 @@ export const Results = (props: ResultsProps): JSX.Element => {
   const handleProceed = (): void => {
     if (currentStepIndex === totalStepCount || !isSuccess) {
       handleCleanUpAndClose()
+    } else if (
+      isSuccess &&
+      flowType === FLOWS.ATTACH &&
+      currentStepIndex !== totalStepCount
+    ) {
+      const axis = mount === 'left' ? 'leftPlunger' : 'rightPlunger'
+      chainRunCommands(
+        [
+          {
+            commandType: 'home' as const,
+            params: {
+              axes: [axis],
+            },
+          },
+          {
+            // @ts-expect-error calibration type not yet supported
+            commandType: 'calibration/moveToMaintenancePosition' as const,
+            params: {
+              mount: mount,
+            },
+          },
+        ],
+        false
+      ).then(() => {
+        proceed()
+      })
     } else {
       proceed()
     }
@@ -140,6 +169,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       </>
     )
   }
+  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
 
   return (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -91,6 +91,7 @@ describe('BeforeBeginning', () => {
               pipetteName: 'p1000_single_gen3',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -157,6 +158,7 @@ describe('BeforeBeginning', () => {
       fireEvent.click(proceedBtn)
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -197,6 +199,7 @@ describe('BeforeBeginning', () => {
               pipetteName: 'p1000_single_gen3',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -242,6 +245,7 @@ describe('BeforeBeginning', () => {
       fireEvent.click(proceedBtn)
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -298,6 +302,7 @@ describe('BeforeBeginning', () => {
               pipetteName: 'p1000_single_gen3',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: RIGHT },
@@ -349,6 +354,7 @@ describe('BeforeBeginning', () => {
               pipetteName: 'p1000_single_gen3',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -408,6 +414,7 @@ describe('BeforeBeginning', () => {
               pipetteName: 'p1000_single_gen3',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -155,6 +155,7 @@ describe('PipetteWizardFlows', () => {
               pipetteName: 'p1000_single_gen3',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -323,6 +324,7 @@ describe('PipetteWizardFlows', () => {
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -379,6 +381,7 @@ describe('PipetteWizardFlows', () => {
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -450,6 +453,7 @@ describe('PipetteWizardFlows', () => {
               pipetteName: 'p1000_96',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -512,6 +516,7 @@ describe('PipetteWizardFlows', () => {
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
@@ -548,6 +553,7 @@ describe('PipetteWizardFlows', () => {
               pipetteName: 'p1000_96',
             },
           },
+          { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -35,7 +35,9 @@ describe('Results', () => {
       mount: LEFT,
       goBack: jest.fn(),
       proceed: jest.fn(),
-      chainRunCommands: jest.fn(),
+      chainRunCommands: jest
+        .fn()
+        .mockImplementationOnce(() => Promise.resolve()),
       isRobotMoving: false,
       maintenanceRunId: RUN_ID_1,
       attachedPipettes: { left: mockAttachedPipetteInformation, right: null },
@@ -85,7 +87,23 @@ describe('Results', () => {
     getByText('Calibrate pipette')
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.chainRunCommands).toHaveBeenCalledWith(
+      [
+        {
+          commandType: 'home' as const,
+          params: {
+            axes: ['leftPlunger'],
+          },
+        },
+        {
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: {
+            mount: 'left',
+          },
+        },
+      ],
+      true
+    )
   })
   it('renders the correct information when pipette wizard is a fail for attach flow', async () => {
     props = {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -76,8 +76,8 @@ export const PipetteWizardFlows = (
   const [isFetchingPipettes, setIsFetchingPipettes] = React.useState<boolean>(
     false
   )
-  const hasCalData =
-    attachedPipettes[mount]?.data.calibratedOffset.last_modified != null
+  const hasCalData = false
+  // attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
   const goBack = (): void => {
     setCurrentStepIndex(
       currentStepIndex !== pipetteWizardSteps.length - 1 ? 0 : currentStepIndex
@@ -128,7 +128,12 @@ export const PipetteWizardFlows = (
     setIsExiting(true)
     if (maintenanceRunId == null) handleClose()
     else {
-      deleteMaintenanceRun(maintenanceRunId)
+      chainRunCommands(
+        [{ commandType: 'home' as const, params: {} }],
+        true
+      ).then(() => {
+        deleteMaintenanceRun(maintenanceRunId)
+      })
     }
   }
   const {
@@ -161,6 +166,7 @@ export const PipetteWizardFlows = (
   }
   const exitModal = (
     <ExitModal
+      isRobotMoving={isRobotMoving}
       goBack={cancelExit}
       proceed={handleCleanUpAndClose}
       flowType={flowType}

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -76,8 +76,8 @@ export const PipetteWizardFlows = (
   const [isFetchingPipettes, setIsFetchingPipettes] = React.useState<boolean>(
     false
   )
-  const hasCalData = false
-  // attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
+  const hasCalData =
+    attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
   const goBack = (): void => {
     setCurrentStepIndex(
       currentStepIndex !== pipetteWizardSteps.length - 1 ? 0 : currentStepIndex


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We're removing the built-in `home` from the `calibration/moveToMaintenancePosition` command, so now we need to explicitly issue `home` commands where necessary in the pipette flows.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Run through an attach/calibration and a detach flow, verify that homing appears correctly.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
1. Home at the beginning of each flow
2. Home the plunger once a pipette is added
3. Home at the end or early exit of each flow

# Review requests
Make sure these cases are covered
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
