### PR TITLE
chore(app): remove OnDeviceDisplay folder from atoms/Toast

### DIFF
--- a/app/src/atoms/Toast/ODDToast.stories.tsx
+++ b/app/src/atoms/Toast/ODDToast.stories.tsx
@@ -8,8 +8,8 @@ import {
   PrimaryButton,
   SPACING,
 } from '@opentrons/components'
-import { StyledText } from '../../text'
-import { Toast } from '..'
+import { StyledText } from '../text'
+import { Toast } from '.'
 import type { Story, Meta } from '@storybook/react'
 
 export default {

--- a/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { act, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
-import { Toast } from '../..'
+import { Toast } from '..'
 
 const render = (props: React.ComponentProps<typeof Toast>) => {
   return renderWithProviders(<Toast {...props} displayType="odd" />)[0]


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
remove OnDeviceDisplay folder from atoms/Toast and slide up stories and test

partially close [RAUT-422](https://opentrons.atlassian.net/browse/RAUT-422)
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
none
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- move stories and test for ODD to atoms/Toast
- remove atoms/Toast/OnDeviceDisplay

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-422]: https://opentrons.atlassian.net/browse/RAUT-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ