### PR TITLE
docs(api): Remove accidental public mentions of private members of opentrons.types

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -63,8 +63,13 @@ Modules
 
 Useful Types and Definitions
 ----------------------------
+
+..
+   The opentrons.types module contains a mixture of public Protocol API things and private internal things.
+   Explicitly name the things that we expect to be public, excluding everything else.
+
 .. automodule:: opentrons.types
-   :members:
+   :members: Point, Location, Mount
 
 
 Executing and Simulating Protocols

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -69,7 +69,7 @@ Useful Types and Definitions
    Explicitly name the things that we expect to be public, excluding everything else.
 
 .. automodule:: opentrons.types
-   :members: Point, Location, Mount
+   :members: PipetteNotAttachedError, Point, Location, Mount
 
 
 Executing and Simulating Protocols


### PR DESCRIPTION
# Overview

The `opentrons.types` module has a mixture of things that are meant to be public parts of the Python Protocol API, and private things that are just there circumstantially.

Meanwhile, our documentation is currently configured to expose on  docs.opentrons.com *every* `opentrons.types` member with a docstring. This accidentally publicizes a lot of the private stuff. This PR fixes the configuration to remove that private stuff from docs.opentrons.com.

This work is part of RLAB-256 (deck slot renaming), since one of the problematic members is `DeckSlotName`.

# Changelog

Keep these members on docs.opentrons.com:

* `Mount`
  * Not documented usefully (just the default "An enumeration"), but [apparently used](https://github.com/search?q=repo%3AOpentrons%2FProtocols+mount.left&type=code).
* `Point`
  * Definitely used and [encouraged elsewhere in the docs](https://docs.opentrons.com/v2/robot_position.html?highlight=point#points-and-locations).
* `Location`
  * Definitely used and [intentionally publicly documented](https://docs.opentrons.com/v2/new_protocol_api.html?highlight=location#opentrons.types.Location). 
* `PipetteNotAttachedError`
  * Looks questionable to me, but it's apparently there [intentionally](https://docs.opentrons.com/v2/new_protocol_api.html?highlight=hw_pipette#opentrons.protocol_api.InstrumentContext.hw_pipette), so. 🤷 

Remove these members from docs.opentrons.com:

* `DeckSlotName`
  * Not documented usefully. Just the default "An enumeration." This changed in my PR #12593, but that was accidental. I expected the type to be private.
  * @jbleon95 and I think this is never used as an input or return type of anything in the Protocol API.
  * Apparently [not used](https://github.com/search?q=repo%3AOpentrons%2FProtocols%20deckslotname&type=code) in any protocols by our Applications Engineering team.
* `MountType`
  * I'm not sure what the deal is with this and why we have both it and `Mount`, but it seems internal.
  * Not documented usefully. Just the default "An enumeration."
  * [Not used](https://github.com/search?q=repo%3AOpentrons%2FProtocols%20mounttype&type=code) in any protocols by our Applications Engineering team.
* `OT3MountType`
  * Ditto.
* `TransferTipPolicy`
  * Not documented usefully (just the default "An enumeration").
  * [Not used](https://github.com/search?q=repo%3AOpentrons%2FProtocols%20transfertippolicy&type=code) in any protocols by our Applications Engineering team.
  * Not part of any other public interface in the Protocol API, as far as I can tell.

And if someone ever adds a new member to `opentrons.types`, keep it off docs.opentrons.com unless we explicitly add it.

# Review requests

Double-check my thinking what I'm keeping and what I'm removing.

Preview the changes: http://sandbox.docs.opentrons.com/memoryhole_deckslotname/v2/new_protocol_api.html#useful-types-and-definitions

# Risk assessment

Low.
