### PR TITLE
fix(robot-server): memory cache analyses

### DIFF
--- a/robot-server/robot_server/protocols/analysis_memcache.py
+++ b/robot-server/robot_server/protocols/analysis_memcache.py
@@ -1,0 +1,65 @@
+"""A simple size-limited memory cache used for large resources."""
+from typing import Generic, TypeVar, Deque, Type, Dict
+from logging import getLogger
+
+from collections import deque
+
+_log = getLogger(__name__)
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class MemoryCache(Generic[K, V]):
+    """A cache of some resource V by some key K."""
+
+    _cache: Dict[K, V]
+    _cache_order: Deque[K]
+    _cache_size: int
+
+    def __init__(self, size_limit: int, _keyhint: Type[K], _valhint: Type[V]) -> None:
+        assert size_limit > 0, f"Cache size must be above 0 but was {size_limit}"
+        _, _ = _keyhint, _valhint
+        self._cache = {}
+        self._cache_order = deque()
+        self._cache_size = size_limit
+
+    def contains(self, key: K) -> bool:
+        """Returns True if the key is cached."""
+        return key in self._cache
+
+    def get(self, key: K) -> V:
+        """Get a cache element, raising KeyError if it is not cached."""
+        return self._cache[key]
+
+    def _pop_eldest(self, key: K) -> None:
+        if len(self._cache) < self._cache_size:
+            return
+        if key in self._cache:
+            return
+
+        try:
+            eldest = self._cache_order.pop()
+        except IndexError:
+            _log.error(
+                f"cache order queue was empty with {len(self._cache)} elements in cache"
+            )
+            raise
+        try:
+            del self._cache[eldest]
+        except KeyError:
+            _log.error(f"oldest-cached analysis id {eldest} was not present")
+            raise
+
+    def insert(self, key: K, value: V) -> None:
+        """Insert a cache element by its key.
+
+        If this cache element would make the cache larger than its size limit, the oldest entry
+        will be removed.
+
+        If this cache element has the same key as another, the cache will not change and neither will
+        the age of the element.
+        """
+        self._pop_eldest(key)
+        self._cache[key] = value
+        self._cache_order.appendleft(key)

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -1,0 +1,232 @@
+"""Completed analysis storage and access."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from logging import getLogger
+from dataclasses import dataclass
+import sqlalchemy
+import anyio
+
+from robot_server.persistence import analysis_table, sqlite_rowid
+from robot_server.persistence import legacy_pickle
+
+from .analysis_models import CompletedAnalysis
+from .analysis_memcache import MemoryCache
+
+
+_log = getLogger(__name__)
+
+
+@dataclass
+class CompletedAnalysisResource:
+    """A protocol analysis that's been completed, storable in a SQL database.
+
+    See `CompletedAnalysisStore`.
+    """
+
+    id: str  # Already in completed_analysis, but pulled out for efficient querying.
+    protocol_id: str
+    analyzer_version: str
+    completed_analysis: CompletedAnalysis
+
+    async def to_sql_values(self) -> Dict[str, object]:
+        """Return this data as a dict that can be passed to a SQLALchemy insert.
+
+        This potentially involves heavy serialization, so it's offloaded
+        to a worker thread.
+
+        Do not modify anything while serialization is ongoing in its worker thread.
+
+        Avoid calling this from inside a SQL transaction, since it might be slow.
+        """
+
+        def serialize_completed_analysis() -> bytes:
+            return legacy_pickle.dumps(self.completed_analysis.dict())
+
+        serialized_completed_analysis = await anyio.to_thread.run_sync(
+            serialize_completed_analysis,
+            # Cancellation may orphan the worker thread,
+            # but that should be harmless in this case.
+            cancellable=True,
+        )
+
+        return {
+            "id": self.id,
+            "protocol_id": self.protocol_id,
+            "analyzer_version": self.analyzer_version,
+            "completed_analysis": serialized_completed_analysis,
+        }
+
+    @classmethod
+    async def from_sql_row(
+        cls, sql_row: sqlalchemy.engine.Row, current_analyzer_version: str
+    ) -> CompletedAnalysisResource:
+        """Extract the data from a SQLAlchemy row object.
+
+        This potentially involves heavy parsing, so it's offloaded to a worker thread.
+
+        Avoid calling this from inside a SQL transaction, since it might be slow.
+        """
+        analyzer_version = sql_row.analyzer_version
+        if analyzer_version != current_analyzer_version:
+            _log.warning(
+                f'Analysis in database was created under version "{analyzer_version}",'
+                f' but we are version "{current_analyzer_version}".'
+                f" This may cause compatibility problems."
+            )
+        assert isinstance(analyzer_version, str)
+
+        id = sql_row.id
+        assert isinstance(id, str)
+
+        protocol_id = sql_row.protocol_id
+        assert isinstance(protocol_id, str)
+
+        def parse_completed_analysis() -> CompletedAnalysis:
+            return CompletedAnalysis.parse_obj(
+                legacy_pickle.loads(sql_row.completed_analysis)
+            )
+
+        completed_analysis = await anyio.to_thread.run_sync(
+            parse_completed_analysis,
+            # Cancellation may orphan the worker thread,
+            # but that should be harmless in this case.
+            cancellable=True,
+        )
+
+        return cls(
+            id=id,
+            protocol_id=protocol_id,
+            analyzer_version=analyzer_version,
+            completed_analysis=completed_analysis,
+        )
+
+
+class CompletedAnalysisStore:
+    """A SQL-persistent and memory-cached store of protocol analyses that are completed.
+
+    To make accesses to analyses faster, this class does its own in-memory caching of
+    completed analyses. This is an annoying thing to have to do, but we can't use an LRU
+    cache because the access methods are async, and lru_cache doesn't work with those.
+    """
+
+    _memcache: MemoryCache[str, CompletedAnalysisResource]
+    _sql_engine: sqlalchemy.engine.Engine
+    _current_analyzer_version: str
+
+    def __init__(
+        self,
+        sql_engine: sqlalchemy.engine.Engine,
+        memory_cache: MemoryCache[str, CompletedAnalysisResource],
+        current_analyzer_version: str,
+    ) -> None:
+        self._sql_engine = sql_engine
+        self._memcache = memory_cache
+        self._current_analyzer_version = current_analyzer_version
+
+    async def get_by_id(self, analysis_id: str) -> Optional[CompletedAnalysisResource]:
+        """Return the analysis with the given ID, if it exists."""
+        try:
+            return self._memcache.get(analysis_id)
+        except KeyError:
+            pass
+        statement = sqlalchemy.select(analysis_table).where(
+            analysis_table.c.id == analysis_id
+        )
+        with self._sql_engine.begin() as transaction:
+            try:
+                result = transaction.execute(statement).one()
+            except sqlalchemy.exc.NoResultFound:
+                return None
+        resource = await CompletedAnalysisResource.from_sql_row(
+            result, self._current_analyzer_version
+        )
+        self._memcache.insert(resource.id, resource)
+        return resource
+
+    async def get_by_protocol(
+        self, protocol_id: str
+    ) -> List[CompletedAnalysisResource]:
+        """Return all analyses associated with the given protocol, oldest-added first.
+
+        If protocol_id doesn't point to a valid protocol, returns an empty list;
+        doesn't raise an error.
+        """
+        id_statement = (
+            sqlalchemy.select(analysis_table.c.id)
+            .where(analysis_table.c.protocol_id == protocol_id)
+            .order_by(sqlite_rowid)
+        )
+        with self._sql_engine.begin() as transaction:
+            ordered_analyses_for_protocol = [
+                row.id for row in transaction.execute(id_statement).all()
+            ]
+
+        analysis_set = set(ordered_analyses_for_protocol)
+        cached_analyses = {
+            analysis_id
+            for analysis_id in ordered_analyses_for_protocol
+            if self._memcache.contains(analysis_id)
+        }
+        uncached_analyses = analysis_set - cached_analyses
+
+        # Because we'll be loading whatever resources are not currently cached from sql
+        # using an async method, if this method is called reentrantly then inserting those
+        # newly-fetched resources into the memcache could race and eject resources we just
+        # added and were about to return. To prevent this, we'll make a second memcache just
+        # for this coroutine - the cache class itself is light, python is pass-by-reference,
+        # so we shouldn't incur much extra memory, and since we're using an unlimited cache
+        # that bypasses the size checks we should be pretty cheap timewise also.
+        local_memcache = MemoryCache(
+            max(len(ordered_analyses_for_protocol), 1), str, CompletedAnalysisResource
+        )
+        for key in cached_analyses:
+            local_memcache.insert(key, self._memcache.get(key))
+
+        if uncached_analyses:
+            statement = (
+                sqlalchemy.select(analysis_table)
+                .where(analysis_table.c.id.in_(uncached_analyses))
+                .order_by(sqlite_rowid)
+            )
+            with self._sql_engine.begin() as transaction:
+                results = transaction.execute(statement).all()
+            for r in results:
+                resource = await CompletedAnalysisResource.from_sql_row(
+                    r, self._current_analyzer_version
+                )
+                local_memcache.insert(resource.id, resource)
+                self._memcache.insert(resource.id, resource)
+
+        return [
+            local_memcache.get(analysis_id)
+            for analysis_id in ordered_analyses_for_protocol
+        ]
+
+    def get_ids_by_protocol(self, protocol_id: str) -> List[str]:
+        """Like `get_by_protocol()`, but return only the ID of each analysis."""
+        statement = (
+            sqlalchemy.select(analysis_table.c.id)
+            .where(analysis_table.c.protocol_id == protocol_id)
+            .order_by(sqlite_rowid)
+        )
+        with self._sql_engine.begin() as transaction:
+            results = transaction.execute(statement).all()
+
+        result_ids: List[str] = []
+        for row in results:
+            assert isinstance(row.id, str)
+            result_ids.append(row.id)
+
+        return result_ids
+
+    async def add(self, completed_analysis_resource: CompletedAnalysisResource) -> None:
+        """Add a resource to the store."""
+        statement = analysis_table.insert().values(
+            await completed_analysis_resource.to_sql_values()
+        )
+        with self._sql_engine.begin() as transaction:
+            transaction.execute(statement)
+        self._memcache.insert(
+            completed_analysis_resource.id, completed_analysis_resource
+        )

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import List, NamedTuple
 
 from sqlalchemy.engine import Engine as SQLEngine
-import sqlalchemy
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
@@ -36,8 +35,6 @@ from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
 )
-
-from robot_server.persistence import analysis_table
 
 
 @pytest.fixture
@@ -256,115 +253,3 @@ async def test_update_infers_status_from_errors(
     analysis = (await subject.get_by_protocol("protocol-id"))[0]
     assert isinstance(analysis, CompletedAnalysis)
     assert analysis.result == expected_result
-
-
-async def test_completed_analyses_use_cache(
-    subject: AnalysisStore, protocol_store: ProtocolStore, sql_engine: SQLEngine
-) -> None:
-    """It should return analyses without using SQL the second time the analyses are accessed."""
-    protocol_store.insert(make_dummy_protocol_resource(protocol_id="protocol-id"))
-
-    labware = pe_types.LoadedLabware(
-        id="labware-id",
-        loadName="load-name",
-        definitionUri="namespace/load-name/42",
-        location=pe_types.DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        offsetId=None,
-    )
-
-    pipette = pe_types.LoadedPipette(
-        id="pipette-id",
-        pipetteName=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-
-    subject.add_pending(protocol_id="protocol-id", analysis_id="analysis-id")
-    await subject.update(
-        analysis_id="analysis-id",
-        labware=[labware],
-        pipettes=[pipette],
-        modules=[],
-        commands=[],
-        errors=[],
-        liquids=[],
-    )
-    analysis_from_sql = await subject.get("analysis-id")
-    # The analysis should now be cached, and if we delete it out from under the store we
-    # should still be able to retrieve it
-    with sql_engine.begin() as transaction:
-        transaction.execute(
-            sqlalchemy.delete(analysis_table).where(
-                analysis_table.c.id == "analysis-id"
-            )
-        )
-
-    analysis_from_cache = await subject.get("analysis-id")
-    # the cached analysis should be the same as the old one
-    assert analysis_from_cache == analysis_from_sql
-    # and in fact it should be the same object
-    assert analysis_from_cache is analysis_from_sql
-
-
-async def test_completed_analysis_cache_is_bounded(
-    subject: AnalysisStore, protocol_store: ProtocolStore, sql_engine: SQLEngine
-) -> None:
-    """It should eject old elements from the cache to avoid exceeding the cache limit."""
-    labware = pe_types.LoadedLabware(
-        id="labware-id",
-        loadName="load-name",
-        definitionUri="namespace/load-name/42",
-        location=pe_types.DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        offsetId=None,
-    )
-
-    pipette = pe_types.LoadedPipette(
-        id="pipette-id",
-        pipetteName=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-    subject._completed_store._cache_size = 2
-    for protocol_id, analysis_id in (
-        ("protocol-id-1", "analysis-id-1"),
-        ("protocol-id-2", "analysis-id-2"),
-        ("protocol-id-3", "analysis-id-3"),
-    ):
-        protocol_store.insert(make_dummy_protocol_resource(protocol_id=protocol_id))
-
-        subject.add_pending(protocol_id=protocol_id, analysis_id=analysis_id)
-        await subject.update(
-            analysis_id=analysis_id,
-            labware=[labware],
-            pipettes=[pipette],
-            modules=[],
-            commands=[],
-            errors=[],
-            liquids=[],
-        )
-
-    # we now have 3 protocols in sql and a cache limit of 2. That means we should be able
-    # to do our little cache-hit check with two of them
-    analysis_1_from_sql = await subject.get("analysis-id-1")
-    analysis_2_from_sql = await subject.get("analysis-id-2")
-    with sql_engine.begin() as transaction:
-        transaction.execute(
-            sqlalchemy.delete(analysis_table).where(
-                analysis_table.c.id.in_(("analysis-id-1", "analysis-id-2"))
-            )
-        )
-    analysis_1_from_cache = await subject.get("analysis-id-1")
-    analysis_2_from_cache = await subject.get("analysis-id-2")
-
-    assert analysis_1_from_sql is analysis_1_from_cache
-    assert analysis_2_from_sql is analysis_2_from_cache
-
-    # if we now do this with the third, it should also work
-    analysis_3_from_sql = await subject.get("analysis-id-3")
-    analysis_3_from_cache = await subject.get("analysis-id-3")
-    assert analysis_3_from_sql is analysis_3_from_cache
-    # but now analysis-1 - since it was  the first added - should not be in the cache, and since
-    # we deleted it from the database if we try and retrieve it again we can't
-    with pytest.raises(AnalysisNotFoundError):
-        await subject.get("analysis-id-1")
-
-    # but 2 should still be in the cache
-    assert await subject.get("analysis-id-2") is analysis_2_from_cache

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -104,7 +104,6 @@ async def test_get_by_analysis_id_prefers_cache(
     # return the identity-same resource
     decoy.when(memcache.get("analysis-id")).then_return(resource)
     assert (await subject.get_by_id("analysis-id")) is resource
-    decoy.verify(memcache.get("analysis-id"))
 
 
 async def test_get_by_analysis_falls_back_to_sql(

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -1,0 +1,188 @@
+"""Test the CompletedAnalysisStore."""
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy.engine import Engine
+from decoy import Decoy
+
+from robot_server.protocols.completed_analysis_store import (
+    CompletedAnalysisResource,
+    CompletedAnalysisStore,
+)
+from opentrons.protocol_reader import (
+    ProtocolSource,
+    JsonProtocolConfig,
+)
+from robot_server.protocols.analysis_memcache import MemoryCache
+from robot_server.protocols.analysis_models import CompletedAnalysis, AnalysisResult
+from robot_server.protocols.protocol_store import (
+    ProtocolStore,
+    ProtocolResource,
+)
+
+
+@pytest.fixture
+def memcache(decoy: Decoy) -> MemoryCache[str, CompletedAnalysisResource]:
+    """Get a memcache mock."""
+    return decoy.mock(cls=MemoryCache)
+
+
+@pytest.fixture
+def subject(
+    memcache: MemoryCache[str, CompletedAnalysisResource],
+    sql_engine: Engine,
+) -> CompletedAnalysisStore:
+    """Get a subject."""
+    return CompletedAnalysisStore(sql_engine, memcache, "2")
+
+
+@pytest.fixture
+def protocol_store(sql_engine: Engine) -> ProtocolStore:
+    """Return a `ProtocolStore` linked to the same database as the subject under test.
+
+    `ProtocolStore` is tested elsewhere.
+    We only need it here to prepare the database for our `AnalysisStore` tests.
+    An analysis always needs a protocol to link to.
+    """
+    return ProtocolStore.create_empty(sql_engine=sql_engine)
+
+
+def make_dummy_protocol_resource(protocol_id: str) -> ProtocolResource:
+    """Return a placeholder `ProtocolResource` to insert into a `ProtocolStore`.
+
+    Args:
+        protocol_id: The ID to give to the new `ProtocolResource`.
+    """
+    return ProtocolResource(
+        protocol_id=protocol_id,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        source=ProtocolSource(
+            directory=Path("/dev/null"),
+            main_file=Path("/dev/null"),
+            config=JsonProtocolConfig(schema_version=123),
+            files=[],
+            metadata={},
+            robot_type="OT-2 Standard",
+            content_hash="abc123",
+        ),
+        protocol_key=None,
+    )
+
+
+def _completed_analysis_resource(
+    analysis_id: str, protocol_id: str
+) -> CompletedAnalysisResource:
+    return CompletedAnalysisResource(
+        analysis_id,
+        protocol_id,
+        "2",
+        CompletedAnalysis(
+            id=analysis_id,
+            result=AnalysisResult.OK,
+            pipettes=[],
+            labware=[],
+            modules=[],
+            commands=[],
+            errors=[],
+            liquids=[],
+        ),
+    )
+
+
+async def test_get_by_analysis_id_prefers_cache(
+    subject: CompletedAnalysisStore,
+    sql_engine: Engine,
+    memcache: MemoryCache[str, CompletedAnalysisResource],
+    protocol_store: ProtocolStore,
+    decoy: Decoy,
+) -> None:
+    """It should return analyses without using SQL the second time the analyses are accessed."""
+    resource = _completed_analysis_resource("analysis-id", "protocol-id")
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id"))
+    # When we retrieve a resource via its id we should see it query the cache, and it should
+    # return the identity-same resource
+    decoy.when(memcache.get("analysis-id")).then_return(resource)
+    assert (await subject.get_by_id("analysis-id")) is resource
+    decoy.verify(memcache.get("analysis-id"))
+
+
+async def test_get_by_analysis_falls_back_to_sql(
+    subject: CompletedAnalysisStore,
+    sql_engine: Engine,
+    memcache: MemoryCache[str, CompletedAnalysisResource],
+    protocol_store: ProtocolStore,
+    decoy: Decoy,
+) -> None:
+    """It should return analyses from sql if they are not cached."""
+    resource = _completed_analysis_resource("analysis-id", "protocol-id")
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id"))
+    await subject.add(resource)
+    # the analysis is not cached
+    decoy.when(memcache.get("analysis-id")).then_raise(KeyError())
+    analysis_from_sql = await subject.get_by_id("analysis-id")
+    # the cached analysis should be value-equal to what we entered
+    assert analysis_from_sql == resource
+
+
+async def test_get_by_analysis_id_caches_results(
+    subject: CompletedAnalysisStore,
+    sql_engine: Engine,
+    memcache: MemoryCache[str, CompletedAnalysisResource],
+    protocol_store: ProtocolStore,
+    decoy: Decoy,
+) -> None:
+    """It should cache successful fetches from sql."""
+    resource = _completed_analysis_resource("analysis-id", "protocol-id")
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id"))
+    await subject.add(resource)
+    # the analysis is not cached
+    decoy.when(memcache.get("analysis-id")).then_raise(KeyError())
+    from_sql = await subject.get_by_id("analysis-id")
+    assert from_sql == resource
+    decoy.verify(memcache.insert("analysis-id", from_sql))
+
+
+async def test_get_ids_by_protocol(
+    subject: CompletedAnalysisStore, sql_engine: Engine, protocol_store: ProtocolStore
+) -> None:
+    """It should return correct analysis id lists."""
+    resource_1 = _completed_analysis_resource("analysis-id-1", "protocol-id-1")
+    resource_2 = _completed_analysis_resource("analysis-id-2", "protocol-id-1")
+    resource_3 = _completed_analysis_resource("analysis-id-3", "protocol-id-2")
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id-1"))
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id-2"))
+    await subject.add(resource_1)
+    await subject.add(resource_2)
+    await subject.add(resource_3)
+    assert sorted(subject.get_ids_by_protocol("protocol-id-1")) == sorted(
+        ["analysis-id-1", "analysis-id-2"]
+    )
+
+
+async def test_get_by_protocol(
+    subject: CompletedAnalysisStore,
+    sql_engine: Engine,
+    memcache: MemoryCache[str, CompletedAnalysisResource],
+    protocol_store: ProtocolStore,
+    decoy: Decoy,
+) -> None:
+    """It should get analysis by protocol with appropriate caching."""
+    resource_1 = _completed_analysis_resource("analysis-id-1", "protocol-id-1")
+    resource_2 = _completed_analysis_resource("analysis-id-2", "protocol-id-1")
+    resource_3 = _completed_analysis_resource("analysis-id-3", "protocol-id-2")
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id-1"))
+    protocol_store.insert(make_dummy_protocol_resource("protocol-id-2"))
+    decoy.when(memcache.insert("analysis-id-1", resource_1)).then_return(None)
+    decoy.when(memcache.insert("analysis-id-2", resource_2)).then_return(None)
+    decoy.when(memcache.insert("analysis-id-3", resource_3)).then_return(None)
+    await subject.add(resource_1)
+    await subject.add(resource_2)
+    await subject.add(resource_3)
+    decoy.when(memcache.get("analysis-id-1")).then_raise(KeyError())
+    decoy.when(memcache.get("analysis-id-2")).then_return(resource_2)
+    decoy.when(memcache.contains("analysis-id-1")).then_return(False)
+    decoy.when(memcache.contains("analysis-id-2")).then_return(True)
+    decoy.when(memcache.insert("analysis-id-1", resource_1)).then_return(None)
+    resources = await subject.get_by_protocol("protocol-id-1")
+    assert resources == [resource_1, resource_2]

--- a/robot-server/tests/protocols/test_memcache.py
+++ b/robot-server/tests/protocols/test_memcache.py
@@ -1,0 +1,24 @@
+"""Tests for the analysis memory cache."""
+import pytest
+
+from robot_server.protocols.analysis_memcache import MemoryCache
+
+
+def test_cache_ejects_old_values() -> None:
+    """It should eject old values when the size limit is reached."""
+    subject = MemoryCache(3, str, str)
+    for val in range(4):
+        subject.insert(f"key-{val}", f"value-{val}")
+    assert not subject.contains("key-0")
+    with pytest.raises(KeyError):
+        subject.get("key-0")
+
+
+def test_cache_retains_new_values() -> None:
+    """It should not eject new values when the size limit is reached."""
+    subject = MemoryCache(3, str, str)
+    for val in range(4):
+        subject.insert(f"key-{val}", f"value-{val}")
+    for val in range(1, 4):
+        assert subject.contains(f"key-{val}")
+        assert subject.get(f"key-{val}") == f"value-{val}"


### PR DESCRIPTION
Getting analysis results can really bog down the robot server - in fact, it can block the event loop such that new http requests get stalled, and that means that apps will mark the server unhealthy.

Recently, the app started asking for analyses much more frequently, which would cause the robot server to bog down more frequently, which would cause the app to mark the robot unhealthy more frequently. This was an unintended change, and reverting it fixes the robot unhealthiness; but getting analysis results still threatens to bog down the server, so this memcache should fix the problem on the server.

We have similar problems (and solutions) for other heavy resources like runs and protocols; but there we do the caching with functools.lru_cache. This is not possible for analysis results because we get analysis results with async functions, for a very good reason; so instead, we need a custom cache implementation.

This cache implementation uses a python dict to hold the result objects; since there are limited places to add results, we can add things to the cache when they're added to the database and add them to the cache when we get things from the database. We use a deque to maintain a FIFO for cache eviction.

## Review requests
Caches like this aren't really my wheelhouse; think about the behavior here and whether it's correct.

## Testing
- [ ] put this on a robot with a lot of protocols stored and retrieve analyses and see if it falls over

Supercedes #12640 