### PR TITLE
fix(components): robotWorkSpace remove classnames add transform

### DIFF
--- a/components/src/hardware-sim/Deck/RobotWorkSpace.css
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.css
@@ -1,4 +1,0 @@
-.robot_work_space {
-  /* reflect horizontally about the center of the DOM elem */
-  transform: scale(1, -1);
-}

--- a/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import cx from 'classnames'
 import { StyleProps, Svg } from '../../primitives'
 import { DeckFromData } from './DeckFromData'
 

--- a/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import cx from 'classnames'
 import { StyleProps, Svg } from '../../primitives'
 import { DeckFromData } from './DeckFromData'
-import styles from './RobotWorkSpace.css'
 
 import type { DeckDefinition, DeckSlot } from '@opentrons/shared-data'
 
@@ -17,7 +16,6 @@ export interface RobotWorkSpaceRenderProps {
 export interface RobotWorkSpaceProps extends StyleProps {
   deckDef?: DeckDefinition
   viewBox?: string | null
-  className?: string
   children?: (props: RobotWorkSpaceRenderProps) => React.ReactNode
   deckLayerBlocklist?: string[]
   id?: string
@@ -68,10 +66,11 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
   }
   return (
     <Svg
-      className={cx(styles.robot_work_space, props.className)}
       viewBox={viewBox || wholeDeckViewBox}
       ref={wrapperRef}
       id={id}
+      /* reflect horizontally about the center of the DOM elem */
+      transform="scale(1, -1)"
       {...styleProps}
     >
       {deckDef != null && (

--- a/labware-library/src/components/labware-ui/Gallery.tsx
+++ b/labware-library/src/components/labware-ui/Gallery.tsx
@@ -19,7 +19,8 @@ export function Gallery(props: GalleryProps): JSX.Element {
     <RobotWorkSpace
       key="center"
       viewBox={`0 0 ${dims.xDimension} ${dims.yDimension}`}
-      className={styles.robot_workspace}
+      width="100%"
+      height="100%"
     >
       {() => <LabwareRender definition={definition} />}
     </RobotWorkSpace>

--- a/labware-library/src/components/labware-ui/styles.css
+++ b/labware-library/src/components/labware-ui/styles.css
@@ -32,11 +32,6 @@
   @apply --aspect-1-1;
 }
 
-.robot_workspace {
-  width: 100%;
-  height: 100%;
-}
-
 .load_name {
   display: flex;
 }

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.css
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.css
@@ -18,8 +18,3 @@
   max-height: calc(100vh - 3rem);
   overflow-y: hidden;
 }
-
-.robot_workspace {
-  width: 100%;
-  height: 100%;
-}

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
@@ -382,7 +382,8 @@ export const DeckSetup = (props: DeckSetupProps): JSX.Element => {
             deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
             deckDef={deckDef}
             viewBox={`${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
-            className={styles.robot_workspace}
+            width="100%"
+            height="100%"
           >
             {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
               <>
@@ -414,7 +415,8 @@ export const NullDeckState = (): JSX.Element => {
           deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
           deckDef={deckDef}
           viewBox={`${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
-          className={styles.robot_workspace}
+          width="100%"
+          height="100%"
         >
           {() => (
             <>

--- a/protocol-library-kludge/src/URLDeck.css
+++ b/protocol-library-kludge/src/URLDeck.css
@@ -1,7 +1,3 @@
-.url_deck {
-  margin: 0 4rem; /* horizontal space for module overhang */
-}
-
 .labware_name_overlay {
   opacity: 0;
 

--- a/protocol-library-kludge/src/URLDeck.tsx
+++ b/protocol-library-kludge/src/URLDeck.tsx
@@ -72,7 +72,7 @@ export class URLDeck extends React.Component<{}> {
         deckDef={DECK_DEF}
         deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
         viewBox={`-35 -35 ${488} ${390}`} // TODO: put these in variables
-        className={styles.url_deck}
+        margin="0 4rem"
       >
         {({ deckSlotsById }): Array<JSX.Element | null> =>
           Object.keys(deckSlotsById).map((slotId): JSX.Element | null => {


### PR DESCRIPTION
closes RQA-746

# Overview

The deck map rendered in PD should not be upside down, neither should the deckmaps/labware anywhere (such as in labware library)

# Test Plan

- in PD make sure that the deck map is not rendered upside down

# Changelog

- remove usage of `classNames` in `RobotWorkSpace` to only use styled components, fix affected components and remove unnecessary css style sheets

# Review requests

see test plan

# Risk assessment

low