### PR TITLE
feat(app, shared-data): wire up pipette flows to protocol setup on app and odd

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -70,5 +70,9 @@
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",
-  "z_axis_still_attached": "z-axis screw still secure"
+  "z_axis_still_attached": "z-axis screw still secure",
+  "detach_96_attach_mount": "Detach 96-Channel Pipette and Attach {{mount}} Pipette",
+  "detach_mount_attach_96": "Detach {{mount}} Pipette and Attach 96-Channel Pipette",
+  "detach_pipettes_attach_96": "Detach Pipettes and Attach 96-Channel Pipette",
+  "replace_pipette": "Replace {{mount}} Pipette"
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -109,7 +109,6 @@ export function SetupPipetteCalibrationItem({
         </Flex>
       )
     } else {
-      flowType = 'CALIBRATE'
       button = (
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
           <TertiaryButton
@@ -123,6 +122,7 @@ export function SetupPipetteCalibrationItem({
       )
     }
   } else {
+    flowType = 'CALIBRATE'
     button = (
       <>
         <Flex
@@ -167,7 +167,6 @@ export function SetupPipetteCalibrationItem({
     )
   }
 
-  // temporarily present valid pipette calibration for OT-3
   const attachedCalibratedDate = pipetteInfo.pipetteCalDate
 
   return (

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -18,12 +18,16 @@ import {
   JUSTIFY_FLEX_END,
   WRAP,
 } from '@opentrons/components'
-
+import {
+  NINETY_SIX_CHANNEL,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
 import { TertiaryButton } from '../../../atoms/buttons'
 import { Banner } from '../../../atoms/Banner'
 import * as PipetteConstants from '../../../redux/pipettes/constants'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { PipetteWizardFlows } from '../../PipetteWizardFlows'
+import { FLOWS } from '../../PipetteWizardFlows/constants'
 import { useDeckCalibrationData, useIsOT3 } from '../hooks'
 import { SetupCalibrationItem } from './SetupCalibrationItem'
 
@@ -48,7 +52,9 @@ export function SetupPipetteCalibrationItem({
 }: SetupPipetteCalibrationItemProps): JSX.Element | null {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
   const deviceDetailsUrl = `/devices/${robotName}`
-  const [showFlexPipetteFlow, setShowFlexPipetteFlow] = React.useState(false)
+  const [showFlexPipetteFlow, setShowFlexPipetteFlow] = React.useState<boolean>(
+    false
+  )
   const { isDeckCalibrated } = useDeckCalibrationData(robotName)
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
 
@@ -97,7 +103,7 @@ export function SetupPipetteCalibrationItem({
   } else if (!attached) {
     subText = t('attach_pipette_calibration')
     if (isOT3) {
-      flowType = 'ATTACH'
+      flowType = FLOWS.ATTACH
       button = (
         <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
           <TertiaryButton
@@ -122,7 +128,7 @@ export function SetupPipetteCalibrationItem({
       )
     }
   } else {
-    flowType = 'CALIBRATE'
+    flowType = FLOWS.CALIBRATE
     button = (
       <>
         <Flex
@@ -178,8 +184,8 @@ export function SetupPipetteCalibrationItem({
           closeFlow={() => setShowFlexPipetteFlow(false)}
           selectedPipette={
             pipetteInfo.pipetteSpecs.channels === 96
-              ? '96-Channel'
-              : 'Single-Channel_and_8-Channel'
+              ? NINETY_SIX_CHANNEL
+              : SINGLE_MOUNT_PIPETTES
           }
           pipetteInfo={mostRecentAnalysis?.pipettes}
         />

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -68,20 +68,21 @@ export function ProtocolInstrumentMountItem(
   const [showPipetteWizardFlow, setShowPipetteWizardFlow] = React.useState(
     false
   )
-  const [flowType, setFlowType] = React.useState('attach')
+  const [flowType, setFlowType] = React.useState('ATTACH')
   const selectedPipette =
     speccedName === 'p1000_96' ? NINETY_SIX_CHANNEL : SINGLE_MOUNT_PIPETTES
 
   const handleCalibrate: React.MouseEventHandler = () => {
-    setFlowType('calibrate')
+    setFlowType('CALIBRATE')
     setShowPipetteWizardFlow(true)
   }
   const handleAttach: React.MouseEventHandler = () => {
-    setFlowType('attach')
+    setFlowType('ATTACH')
     setShowPipetteWizardFlow(true)
   }
   const is96ChannelPipette = speccedName === 'p1000_96'
-  const isAttachedWithCal = attachedInstrument?.data?.calibratedOffset != null
+  const isAttachedWithCal =
+    attachedInstrument?.data?.calibratedOffset?.last_modified != null
   return (
     <>
       <MountItem isReady={isAttachedWithCal}>

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -14,14 +14,16 @@ import {
   JUSTIFY_FLEX_START,
 } from '@opentrons/components'
 import {
+  CompletedProtocolAnalysis,
   getGripperDisplayName,
   getPipetteNameSpecs,
+  NINETY_SIX_CHANNEL,
   PipetteName,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 
 import { SmallButton } from '../../atoms/buttons'
-import { ChoosePipette } from '../PipetteWizardFlows/ChoosePipette'
+import { PipetteWizardFlows } from '../PipetteWizardFlows'
 
 import type {
   InstrumentData,
@@ -30,7 +32,6 @@ import type {
 } from '@opentrons/api-client'
 import type { GripperModel } from '@opentrons/shared-data'
 import type { Mount } from '../../redux/pipettes/types'
-import type { SelectablePipettes } from '../PipetteWizardFlows/types'
 
 export const MountItem = styled.div<{ isReady: boolean }>`
   display: flex;
@@ -50,6 +51,7 @@ export const MountItem = styled.div<{ isReady: boolean }>`
 `
 interface ProtocolInstrumentMountItemProps {
   mount: Mount | 'extension'
+  mostRecentAnalysis?: CompletedProtocolAnalysis | null
   attachedInstrument: InstrumentData | null
   attachedCalibrationData:
     | PipetteOffsetCalibration
@@ -61,34 +63,25 @@ export function ProtocolInstrumentMountItem(
   props: ProtocolInstrumentMountItemProps
 ): JSX.Element {
   const { t, i18n } = useTranslation('protocol_setup')
-  const { mount, attachedInstrument, speccedName } = props
+  const { mount, attachedInstrument, speccedName, mostRecentAnalysis } = props
 
-  const [showChoosePipetteModal, setShowChoosePipetteModal] = React.useState(
+  const [showPipetteWizardFlow, setShowPipetteWizardFlow] = React.useState(
     false
   )
-  const [
-    selectedPipette,
-    setSelectedPipette,
-  ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
+  const [flowType, setFlowType] = React.useState('attach')
+  const selectedPipette =
+    speccedName === 'p1000_96' ? NINETY_SIX_CHANNEL : SINGLE_MOUNT_PIPETTES
 
   const handleCalibrate: React.MouseEventHandler = () => {
-    console.log(
-      'TODO: handle calibrate wizard after maintenance runs are real',
-      mount,
-      attachedInstrument
-    )
+    setFlowType('calibrate')
+    setShowPipetteWizardFlow(true)
   }
   const handleAttach: React.MouseEventHandler = () => {
-    console.log(
-      'TODO: handle attach wizard after maintenance runs are real',
-      mount,
-      attachedInstrument
-    )
+    setFlowType('attach')
+    setShowPipetteWizardFlow(true)
   }
   const is96ChannelPipette = speccedName === 'p1000_96'
-  // TODO: check for presence of calibration data once instruments endpoint
-  // returns calibration data for pipettes
-  const isAttachedWithCal = attachedInstrument != null
+  const isAttachedWithCal = attachedInstrument?.data?.calibratedOffset != null
   return (
     <>
       <MountItem isReady={isAttachedWithCal}>
@@ -150,17 +143,13 @@ export function ProtocolInstrumentMountItem(
           </Flex>
         </Flex>
       </MountItem>
-      {showChoosePipetteModal ? (
-        <ChoosePipette
-          proceed={() => {
-            setShowChoosePipetteModal(false)
-          }}
-          setSelectedPipette={setSelectedPipette}
+      {showPipetteWizardFlow ? (
+        <PipetteWizardFlows
+          flowType={flowType}
+          closeFlow={() => setShowPipetteWizardFlow(false)}
           selectedPipette={selectedPipette}
-          exit={() => {
-            setShowChoosePipetteModal(false)
-          }}
           mount={mount as Mount}
+          pipetteInfo={mostRecentAnalysis?.pipettes}
         />
       ) : null}
     </>

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -23,6 +23,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { SmallButton } from '../../atoms/buttons'
+import { FLOWS } from '../PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../PipetteWizardFlows'
 
 import type {
@@ -65,19 +66,20 @@ export function ProtocolInstrumentMountItem(
   const { t, i18n } = useTranslation('protocol_setup')
   const { mount, attachedInstrument, speccedName, mostRecentAnalysis } = props
 
-  const [showPipetteWizardFlow, setShowPipetteWizardFlow] = React.useState(
-    false
-  )
-  const [flowType, setFlowType] = React.useState('ATTACH')
+  const [
+    showPipetteWizardFlow,
+    setShowPipetteWizardFlow,
+  ] = React.useState<boolean>(false)
+  const [flowType, setFlowType] = React.useState<string>(FLOWS.ATTACH)
   const selectedPipette =
     speccedName === 'p1000_96' ? NINETY_SIX_CHANNEL : SINGLE_MOUNT_PIPETTES
 
   const handleCalibrate: React.MouseEventHandler = () => {
-    setFlowType('CALIBRATE')
+    setFlowType(FLOWS.CALIBRATE)
     setShowPipetteWizardFlow(true)
   }
   const handleAttach: React.MouseEventHandler = () => {
-    setFlowType('ATTACH')
+    setFlowType(FLOWS.ATTACH)
     setShowPipetteWizardFlow(true)
   }
   const is96ChannelPipette = speccedName === 'p1000_96'

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -1,19 +1,49 @@
 import * as React from 'react'
 import { LEFT, renderWithProviders } from '@opentrons/components'
+import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../i18n'
+import { PipetteWizardFlows } from '../../PipetteWizardFlows'
 import { ProtocolInstrumentMountItem } from '..'
+
+jest.mock('../../PipetteWizardFlows')
+
+const mockPipetteWizardFlows = PipetteWizardFlows as jest.MockedFunction<
+  typeof PipetteWizardFlows
+>
 
 const mockGripperData = {
   instrumentModel: 'gripper_v1',
   instrumentType: 'gripper',
   mount: 'extension',
   serialNumber: 'ghi789',
+  data: {
+    calibratedOffset: {
+      offset: {
+        x: 1,
+        y: 2,
+        z: 4,
+      },
+      source: 'standard',
+      last_modified: 'date',
+    },
+  },
 }
 const mockLeftPipetteData = {
   instrumentModel: 'p1000_multi_gen3',
   instrumentType: 'p1000',
   mount: 'left',
   serialNumber: 'def456',
+  data: {
+    calibratedOffset: {
+      offset: {
+        x: 1,
+        y: 2,
+        z: 4,
+      },
+      source: 'standard',
+      last_modified: 'date',
+    },
+  },
 }
 
 const render = (
@@ -33,6 +63,7 @@ describe('ProtocolInstrumentMountItem', () => {
       attachedCalibrationData: null,
       speccedName: 'p1000_multi_gen3',
     }
+    mockPipetteWizardFlows.mockReturnValue('pipette wizard flow' as any)
   })
 
   it('renders the correct information when there is no pipette attached', () => {
@@ -65,12 +96,38 @@ describe('ProtocolInstrumentMountItem', () => {
     getByText('Flex 8-Channel 1000 μL')
     getByText('Calibrate')
   })
-  it.todo(
-    'renders the pipette with no cal data and the calibration button and clicking on it launches the correct flow '
-  )
-  it.todo(
-    'renders the attach button and clicking on it launches the correct flow '
-  )
+  it('renders the pipette with no cal data and the calibration button and clicking on it launches the correct flow ', () => {
+    props = {
+      ...props,
+      mount: LEFT,
+      attachedInstrument: {
+        ...mockLeftPipetteData,
+        data: {
+          calibratedOffset: null,
+        },
+      } as any,
+    }
+    const { getByText } = render(props)
+    getByText('Left mount')
+    getByText('No data')
+    getByText('Flex 8-Channel 1000 μL')
+    const button = getByText('Calibrate')
+    fireEvent.click(button)
+    getByText('pipette wizard flow')
+  })
+  it('renders the attach button and clicking on it launches the correct flow ', () => {
+    props = {
+      ...props,
+      mount: LEFT,
+    }
+    const { getByText } = render(props)
+    getByText('Left mount')
+    getByText('No data')
+    getByText('Flex 8-Channel 1000 μL')
+    const button = getByText('Attach')
+    fireEvent.click(button)
+    getByText('pipette wizard flow')
+  })
   it('renders the correct information when gripper needs to be atached', () => {
     props = {
       ...props,

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -63,7 +63,7 @@ describe('ProtocolInstrumentMountItem', () => {
       attachedCalibrationData: null,
       speccedName: 'p1000_multi_gen3',
     }
-    mockPipetteWizardFlows.mockReturnValue('pipette wizard flow' as any)
+    mockPipetteWizardFlows.mockReturnValue(<div>pipette wizard flow</div>)
   })
 
   it('renders the correct information when there is no pipette attached', () => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -1,4 +1,4 @@
-import { LEFT, RIGHT } from '@opentrons/shared-data'
+import { LEFT, RIGHT, LoadedPipette } from '@opentrons/shared-data'
 import {
   mock96ChannelAttachedPipetteInformation,
   mockAttachedPipetteInformation,
@@ -6,30 +6,18 @@ import {
 import { FLOWS, SECTIONS } from '../constants'
 import { getPipetteWizardStepsForProtocol } from '../getPipetteWizardStepsForProtocol'
 
-import type { PipetteInfo } from '../../Devices/hooks'
 import type { PipetteWizardStep } from '../types'
 
-const mockPipetteInfo = {
-  requestedPipetteMatch: 'incompatible',
-  pipetteCalDate: null,
-  pipetteSpecs: {
-    displayName: 'pipette 1',
-    name: 'p1000_96',
-  },
-} as PipetteInfo
+const mockPipetteInfo = [
+  { id: '123', pipetteName: 'p1000_96', mount: 'left' },
+] as LoadedPipette[]
 
-const mockPipettesInProtocolNotEmpty = {
-  left: { ...mockPipetteInfo, pipetteSpecs: { name: 'p1000_single_gen3' } },
-  right: null,
-}
-const mockPipettesInProtocolMulti = {
-  left: { ...mockPipetteInfo, pipetteSpecs: { name: 'p1000_multi_gen3' } },
-  right: null,
-}
-const mockPipettesInProtocol96Channel = {
-  left: mockPipetteInfo,
-  right: null,
-}
+const mockPipettesInProtocolNotEmpty = [
+  { id: '123', pipetteName: 'p1000_single_gen3', mount: 'left' },
+]
+const mockPipettesInProtocolMulti = [
+  { id: '123', pipetteName: 'p1000_multi_gen3', mount: 'left' },
+]
 const mockSingleMountPipetteAttached = {
   left: mockAttachedPipetteInformation,
   right: null,
@@ -41,14 +29,13 @@ describe('getPipetteWizardStepsForProtocol', () => {
     expect(
       getPipetteWizardStepsForProtocol(
         mockSingleMountPipetteAttached,
-        {
-          left: {
-            pipetteCalDate: 'cal date',
-            requestedPipetteMatch: 'match',
-            pipetteSpecs: { name: 'p1000_single_gen3' },
+        [
+          {
+            id: '123',
+            pipetteName: 'p1000_single_gen3',
+            mount: 'left',
           },
-          right: null,
-        } as any,
+        ],
         LEFT
       )
     ).toStrictEqual(mockFlowSteps)
@@ -56,14 +43,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
   it('returns an empty array when there is no pipette attached and no pipette is needed', () => {
     const mockFlowSteps = [] as PipetteWizardStep[]
     expect(
-      getPipetteWizardStepsForProtocol(
-        { left: null, right: null },
-        {
-          left: null,
-          right: null,
-        } as any,
-        LEFT
-      )
+      getPipetteWizardStepsForProtocol({ left: null, right: null }, [], LEFT)
     ).toStrictEqual(mockFlowSteps)
   })
   it('returns the calibration flow only when correct pipette is attached but there is no pip cal data', () => {
@@ -87,15 +67,14 @@ describe('getPipetteWizardStepsForProtocol', () => {
     ] as PipetteWizardStep[]
     expect(
       getPipetteWizardStepsForProtocol(
-        { left: null, right: mockAttachedPipetteInformation },
         {
           left: null,
           right: {
-            pipetteCalDate: null,
-            requestedPipetteMatch: 'match',
-            pipetteSpecs: { name: 'p1000_single_gen3' },
-          },
-        } as any,
+            ...mockAttachedPipetteInformation,
+            data: { calibratedOffset: undefined as any },
+          } as any,
+        },
+        [{ id: '123', pipetteName: 'p1000_single_gen3', mount: 'right' }],
         RIGHT
       )
     ).toStrictEqual(mockFlowSteps)
@@ -259,7 +238,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
     expect(
       getPipetteWizardStepsForProtocol(
         { left: mockAttachedPipetteInformation, right: null },
-        mockPipettesInProtocol96Channel as any,
+        mockPipetteInfo as any,
         LEFT
       )
     ).toStrictEqual(mockFlowSteps)
@@ -317,7 +296,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
     expect(
       getPipetteWizardStepsForProtocol(
         { left: null, right: mockAttachedPipetteInformation },
-        mockPipettesInProtocol96Channel as any,
+        mockPipetteInfo as any,
         LEFT
       )
     ).toStrictEqual(mockFlowSteps)
@@ -389,7 +368,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
           left: mockAttachedPipetteInformation,
           right: mockAttachedPipetteInformation,
         },
-        mockPipettesInProtocol96Channel as any,
+        mockPipetteInfo as any,
         LEFT
       )
     ).toStrictEqual(mockFlowSteps)
@@ -473,7 +452,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
     expect(
       getPipetteWizardStepsForProtocol(
         { left: null, right: null },
-        mockPipettesInProtocol96Channel as any,
+        mockPipetteInfo as any,
         LEFT
       )
     ).toStrictEqual(mockFlowSteps)

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -1,31 +1,30 @@
-import { LEFT, RIGHT } from '@opentrons/shared-data'
-import * as PipetteConstants from '../../redux/pipettes/constants'
+import { LEFT, LoadedPipette, RIGHT } from '@opentrons/shared-data'
 import { FLOWS, SECTIONS } from './constants'
 import type { Mount } from '../../redux/pipettes/types'
-import type {
-  AttachedPipettesFromInstrumentsQuery,
-  PipetteInfo,
-} from '../Devices/hooks'
+import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 import type { PipetteWizardStep } from './types'
 
 export const getPipetteWizardStepsForProtocol = (
   attachedPipettes: AttachedPipettesFromInstrumentsQuery,
-  pipetteInfoByMount: { [mount in Mount]: PipetteInfo | null },
+  pipetteInfo: LoadedPipette[],
   mount: Mount
 ): PipetteWizardStep[] => {
-  const noPipetteRequiredInProtocol = pipetteInfoByMount[mount] == null
-  const requiredPipetteName =
-    pipetteInfoByMount[mount]?.requestedPipetteMatch !== PipetteConstants.MATCH
-      ? pipetteInfoByMount[mount]?.pipetteSpecs.name
-      : null
+  const requiredPipette = pipetteInfo.find(pipette => pipette.mount === mount)
   const nintySixChannelAttached =
     attachedPipettes[LEFT]?.instrumentName === 'p1000_96'
 
-  //    return calibration flow only if correct pipette is attached and pipette cal null
+  //  return empty array when correct pipette is attached && pipette cal not needed or
+  //  no pipette is required in the protocol
   if (
-    requiredPipetteName == null &&
-    !noPipetteRequiredInProtocol &&
-    pipetteInfoByMount[mount]?.pipetteCalDate == null
+    (requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName &&
+      attachedPipettes[mount]?.data.calibratedOffset != null) ||
+    requiredPipette == null
+  ) {
+    return []
+    //    return calibration flow only if correct pipette is attached and pipette cal null
+  } else if (
+    requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName &&
+    attachedPipettes[mount]?.data.calibratedOffset == null
   ) {
     return [
       {
@@ -45,19 +44,8 @@ export const getPipetteWizardStepsForProtocol = (
       },
       { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.CALIBRATE },
     ]
-  }
-  //  return empty array when correct pipette is attached && pipette cal not needed or
-  //  no pipette is required in the protocol
-  else if (
-    (requiredPipetteName == null &&
-      !noPipetteRequiredInProtocol &&
-      pipetteInfoByMount[mount]?.pipetteCalDate != null) ||
-    noPipetteRequiredInProtocol
-  ) {
-    return []
-    //  if required pipette is not the 96-channel and a pipette attached to gantry
   } else if (
-    requiredPipetteName !== 'p1000_96' &&
+    requiredPipette.pipetteName !== 'p1000_96' &&
     attachedPipettes[mount] != null
   ) {
     //    96-channel pipette attached and need to attach single mount pipette
@@ -65,25 +53,25 @@ export const getPipetteWizardStepsForProtocol = (
       return [
         {
           section: SECTIONS.BEFORE_BEGINNING,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.DETACH,
         },
         {
           section: SECTIONS.DETACH_PIPETTE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.DETACH,
         },
         {
           section: SECTIONS.MOUNTING_PLATE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.DETACH,
         },
         {
           section: SECTIONS.CARRIAGE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.DETACH,
         },
-        { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.DETACH },
+        { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: mount,
@@ -155,7 +143,7 @@ export const getPipetteWizardStepsForProtocol = (
     }
     //  Single mount pipette attached to both mounts and need to attach 96-channel pipette
   } else if (
-    requiredPipetteName === 'p1000_96' &&
+    requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] != null
   ) {
@@ -184,44 +172,44 @@ export const getPipetteWizardStepsForProtocol = (
       { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
       {
         section: SECTIONS.BEFORE_BEGINNING,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.CARRIAGE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.MOUNTING_PLATE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.MOUNT_PIPETTE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
-      { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.ATTACH },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
       {
         section: SECTIONS.ATTACH_PROBE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.DETACH_PROBE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.RESULTS,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.CALIBRATE,
       },
     ]
     //  Single mount pipette attached to left mount and need to attach 96-channel pipette
   } else if (
-    requiredPipetteName === 'p1000_96' &&
+    requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] == null
   ) {
@@ -239,44 +227,44 @@ export const getPipetteWizardStepsForProtocol = (
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
         section: SECTIONS.BEFORE_BEGINNING,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.CARRIAGE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.MOUNTING_PLATE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.MOUNT_PIPETTE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
-      { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.ATTACH },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
       {
         section: SECTIONS.ATTACH_PROBE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.DETACH_PROBE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.RESULTS,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.CALIBRATE,
       },
     ]
     //  Single mount pipette attached to right mount and need to attach 96-channel pipette
   } else if (
-    requiredPipetteName === 'p1000_96' &&
+    requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] == null &&
     attachedPipettes[RIGHT] != null
   ) {
@@ -294,80 +282,80 @@ export const getPipetteWizardStepsForProtocol = (
       { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
       {
         section: SECTIONS.BEFORE_BEGINNING,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.CARRIAGE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.MOUNTING_PLATE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.MOUNT_PIPETTE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
-      { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.ATTACH },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
       {
         section: SECTIONS.ATTACH_PROBE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.DETACH_PROBE,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.RESULTS,
-        mount: mount,
+        mount: LEFT,
         flowType: FLOWS.CALIBRATE,
       },
     ]
     //  if no pipette is attached to gantry
   } else {
     //  Gantry empty and need to attach 96-channel pipette
-    if (requiredPipetteName === 'p1000_96') {
+    if (requiredPipette.pipetteName === 'p1000_96') {
       return [
         {
           section: SECTIONS.BEFORE_BEGINNING,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.ATTACH,
         },
         {
           section: SECTIONS.CARRIAGE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.ATTACH,
         },
         {
           section: SECTIONS.MOUNTING_PLATE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.ATTACH,
         },
         {
           section: SECTIONS.MOUNT_PIPETTE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.ATTACH,
         },
-        { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.ATTACH },
+        { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
         {
           section: SECTIONS.ATTACH_PROBE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.ATTACH,
         },
         {
           section: SECTIONS.DETACH_PROBE,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.ATTACH,
         },
         {
           section: SECTIONS.RESULTS,
-          mount: mount,
+          mount: LEFT,
           flowType: FLOWS.CALIBRATE,
         },
       ]

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -8,12 +8,14 @@ import {
   NINETY_SIX_CHANNEL,
   SINGLE_MOUNT_PIPETTES,
   RIGHT,
+  LoadedPipette,
 } from '@opentrons/shared-data'
 import {
   useHost,
   useCreateMaintenanceRunMutation,
   useDeleteMaintenanceRunMutation,
 } from '@opentrons/react-api-client'
+import type { Mount } from '../../redux/pipettes/types'
 
 import { ModalShell } from '../../molecules/Modal'
 import { Portal } from '../../App/portal'
@@ -23,6 +25,7 @@ import { useChainMaintenanceCommands } from '../../resources/runs/hooks'
 import { getIsOnDevice } from '../../redux/config'
 import { useAttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 import { getPipetteWizardSteps } from './getPipetteWizardSteps'
+import { getPipetteWizardStepsForProtocol } from './getPipetteWizardStepsForProtocol'
 import { FLOWS, SECTIONS } from './constants'
 import { BeforeBeginning } from './BeforeBeginning'
 import { AttachProbe } from './AttachProbe'
@@ -36,6 +39,7 @@ import { MountingPlate } from './MountingPlate'
 import { UnskippableModal } from './UnskippableModal'
 
 import type { PipetteMount } from '@opentrons/shared-data'
+import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
 
 interface PipetteWizardFlowsProps {
@@ -44,6 +48,7 @@ interface PipetteWizardFlowsProps {
   selectedPipette: SelectablePipettes
   closeFlow: () => void
   onComplete?: () => void
+  pipetteInfo?: LoadedPipette[]
 }
 
 export const PipetteWizardFlows = (
@@ -55,13 +60,20 @@ export const PipetteWizardFlows = (
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
   const isGantryEmpty =
     attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null
-  const pipetteWizardSteps = getPipetteWizardSteps(
-    flowType,
-    mount,
-    selectedPipette,
-    isGantryEmpty,
-    attachedPipettes
-  )
+  const pipetteWizardSteps =
+    props.pipetteInfo == null
+      ? getPipetteWizardSteps(
+          flowType,
+          mount,
+          selectedPipette,
+          isGantryEmpty,
+          attachedPipettes
+        )
+      : getPipetteWizardStepsForProtocol(
+          attachedPipettes,
+          props.pipetteInfo,
+          mount
+        )
   const host = useHost()
   const [maintenanceRunId, setMaintenanceRunId] = React.useState<string>('')
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
@@ -268,43 +280,21 @@ export const PipetteWizardFlows = (
       <MountingPlate {...currentStep} {...calibrateBaseProps} />
     )
   }
-  let wizardTitle: string = 'unknown page'
-  switch (flowType) {
-    case FLOWS.CALIBRATE: {
-      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        wizardTitle = startCase(
-          t(hasCalData ? 'recalibrate_pipette' : 'calibrate_pipette', {
-            mount: mount,
-          })
+  const wizardTitle =
+    props.pipetteInfo == null
+      ? PipetteFlowWizardHeaderText(
+          flowType,
+          mount,
+          selectedPipette,
+          hasCalData,
+          isGantryEmpty,
+          attachedPipettes
         )
-      } else {
-        wizardTitle = t('calibrate_96_channel')
-      }
-      break
-    }
-    case FLOWS.ATTACH: {
-      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        wizardTitle = startCase(t('attach_pipette', { mount: mount }))
-      } else {
-        wizardTitle = isGantryEmpty
-          ? t('attach_96_channel')
-          : t('attach_96_channel_plus_detach', {
-              pipetteName:
-                attachedPipettes[LEFT]?.displayName ??
-                attachedPipettes[RIGHT]?.displayName,
-            })
-      }
-      break
-    }
-    case FLOWS.DETACH: {
-      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        wizardTitle = startCase(t('detach_pipette', { mount: mount }))
-      } else {
-        wizardTitle = t('detach_96_channel')
-      }
-      break
-    }
-  }
+      : ProtocolPipetteFlowWizardHeaderText(
+          attachedPipettes,
+          props.pipetteInfo,
+          mount
+        )
 
   const is96ChannelUnskippableStep =
     currentStep.section === SECTIONS.CARRIAGE ||
@@ -357,4 +347,96 @@ export const PipetteWizardFlows = (
       )}
     </Portal>
   )
+}
+
+const ProtocolPipetteFlowWizardHeaderText = (
+  attachedPipettes: AttachedPipettesFromInstrumentsQuery,
+  pipetteInfo: LoadedPipette[],
+  mount: Mount
+): string => {
+  const { t } = useTranslation('pipette_wizard_flows')
+  const leftPipette = pipetteInfo.find(pipette => pipette.mount === 'left')
+  const mountPipette = pipetteInfo.find(pipette => pipette.mount === mount)
+  if (mountPipette?.pipetteName === attachedPipettes[mount]?.instrumentName) {
+    return t('calibrate_pipette', {
+      mount: mount,
+    })
+  } else if (
+    attachedPipettes[LEFT]?.data.channels === 96 &&
+    mountPipette?.pipetteName !== 'p1000_96'
+  ) {
+    return t('detach_96_attach_mount', { mount: mount })
+  } else if (leftPipette?.pipetteName === 'p1000_96') {
+    if (attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null) {
+      return t('attach_96_channel')
+    } else if (
+      attachedPipettes[LEFT] != null &&
+      attachedPipettes[RIGHT] == null
+    ) {
+      return t('detach_mount_attach_96', { mount: RIGHT })
+    } else if (
+      attachedPipettes[LEFT] == null &&
+      attachedPipettes[RIGHT] != null
+    ) {
+      return t('detach_mount_attach_96', { mount: LEFT })
+    } else {
+      return t('detach_pipettes_attach_96')
+    }
+  } else if (mountPipette != null && attachedPipettes[mount] == null) {
+    return t('attach_pipette', { mount: mount })
+  } else if (mountPipette != null && attachedPipettes[mount] != null) {
+    return t('replace_pipette', { mount: mount })
+  }
+  return 'unknwn page'
+}
+
+const PipetteFlowWizardHeaderText = (
+  flowType: PipetteWizardFlow,
+  mount: PipetteMount,
+  selectedPipette: SelectablePipettes,
+  hasCalData: boolean,
+  isGantryEmpty: boolean,
+  attachedPipettes: AttachedPipettesFromInstrumentsQuery
+): string => {
+  const { t } = useTranslation('pipette_wizard_flows')
+
+  let wizardTitle: string = 'unknown page'
+  switch (flowType) {
+    case FLOWS.CALIBRATE: {
+      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+        wizardTitle = startCase(
+          t(hasCalData ? 'recalibrate_pipette' : 'calibrate_pipette', {
+            mount: mount,
+          })
+        )
+      } else {
+        wizardTitle = t('calibrate_96_channel')
+      }
+      break
+    }
+    case FLOWS.ATTACH: {
+      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+        wizardTitle = startCase(t('attach_pipette', { mount: mount }))
+      } else {
+        wizardTitle = isGantryEmpty
+          ? t('attach_96_channel')
+          : t('attach_96_channel_plus_detach', {
+              pipetteName:
+                attachedPipettes[LEFT]?.displayName ??
+                attachedPipettes[RIGHT]?.displayName,
+            })
+      }
+      break
+    }
+    case FLOWS.DETACH: {
+      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+        wizardTitle = startCase(t('detach_pipette', { mount: mount }))
+      } else {
+        wizardTitle = t('detach_96_channel')
+      }
+      break
+    }
+  }
+
+  return wizardTitle
 }

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -387,7 +387,7 @@ const ProtocolPipetteFlowWizardHeaderText = (
   } else if (mountPipette != null && attachedPipettes[mount] != null) {
     return t('replace_pipette', { mount: mount })
   }
-  return 'unknwn page'
+  return 'unknown page'
 }
 
 const PipetteFlowWizardHeaderText = (

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -83,6 +83,7 @@ export function ProtocolSetupInstruments({
             mount={loadedPipette.mount}
             speccedName={loadedPipette.pipetteName}
             attachedInstrument={attachedPipetteMatch}
+            mostRecentAnalysis={mostRecentAnalysis}
             attachedCalibrationData={
               attachedPipetteMatch != null
                 ? allPipettesCalibrationData?.data.find(

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -147,6 +147,7 @@ export const substepTimelineMultiChannel = (
         const wellsForTips =
           channels &&
           labwareDef &&
+          // @ts-expect-error 96 channels not yet supported
           getWellsForTips(channels, labwareDef, wellName).wellsForTips
         const wellInfo = {
           labwareId,

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -334,7 +334,7 @@ export interface SlotTransforms {
 
 export type ModuleOrientation = 'left' | 'right'
 
-export type PipetteChannels = 1 | 8
+export type PipetteChannels = 1 | 8 | 96
 
 export type PipetteDisplayCategory = typeof GEN1 | typeof GEN2 | typeof GEN3
 

--- a/shared-data/pipette/definitions/1/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteNameSpecs.json
@@ -649,7 +649,7 @@
         "2.0": 7.85
       }
     },
-    "channels": 8,
+    "channels": 96,
     "minVolume": 1,
     "maxVolume": 1000,
     "smoothieConfigs": {

--- a/shared-data/pipette/schemas/1/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/1/pipetteNameSpecsSchema.json
@@ -7,7 +7,7 @@
       "minimum": 0
     },
     "channels": {
-      "enum": [1, 8]
+      "enum": [1, 8, 96]
     },
     "displayCategory": {
       "type": "string",

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -49,6 +49,7 @@ export function dispenseUpdateLiquidState(
     'in dispenseUpdateLiquidState, either volume or useFullVolume are required'
   )
   const { wellsForTips, allWellsShared } = getWellsForTips(
+    // @ts-expect-error 96 channels not yet supported
     pipetteSpec.channels,
     labwareDef,
     wellName

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -23,6 +23,7 @@ export function forAspirate(
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
   const { allWellsShared, wellsForTips } = getWellsForTips(
+    // @ts-expect-error 96 channels not yet supported
     pipetteSpec.channels,
     labwareDef,
     params.wellName


### PR DESCRIPTION
fix RLIQ-217, RLIQ-306, RLIQ-307

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Wire up pipette flows to protocol setup step in app and ODD
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Try the following configurations on the desktop app and odd:
1. Wrong pipette is attached to a mount in run setup, press attach, see that you're prompted to replace the pipette
2. No pipette is attached to a mount in run setup, press attach, see that you're prompted to attach the pipette
3. Correct pipette is attached to a mount but not calibrated, press calibrated, see that the calibrate flow opens
4. Correct pipette is attached and calibrated, status should appear ready 

Note: 96-channel testing and design tweaks will happen later
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Adapt `getPipetteWizardStepsForProtocol` to take in `LoadedPipette` and look at calibration data from attached pipette
2. Add flow launch points to uncalibrated or unattached pipettes needed in a protocol from run setup 
3. Add and adjust testing
4. Add 96 channel to PipetteChannels type

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Make sure code looks sound - I've run through the test plan already but test yourself as well if you can!
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
