### PR TITLE
refactor(api): remove homing when moving to maintain position

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -59,8 +59,6 @@ class MoveToMaintenancePositionImplementation(
         """Move the requested mount to a maintenance deck slot."""
         hardware_mount = params.mount.to_hw_mount()
 
-        await self._hardware_api.home()
-
         calibration_coordinates = self._state_view.labware.get_calibration_coordinates(
             offset=_INSTRUMENT_ATTACH_OFFSET
         )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -40,11 +40,6 @@ async def test_calibration_move_to_location_implementation(
     assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
-        await hardware_api.home(),
-        times=1,
-    )
-
-    decoy.verify(
         await hardware_api.move_to(mount=Mount.LEFT, abs_position=Point(x=1, y=2, z=3)),
         times=1,
     )


### PR DESCRIPTION
This reverts commit 337947e242a634efeb83dbaab0441298de9d9ce5.

That commit was itself a revert of 31a8ea8e312de461389a26eca091c2e904f04306 because that commit was merged too early.

The net effect of this commit is to get back to the functionality introduced in #12576
