### PR TITLE
fix(app): check for Opentrons Flex robot model in useIsOt3

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useIsOT3.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsOT3.test.tsx
@@ -55,4 +55,15 @@ describe('useIsOT3 hook', () => {
 
     expect(result.current).toEqual(true)
   })
+  it('returns true when given a discoverable OT-3 robot name with an Opentrons Flex model', () => {
+    when(mockGetRobotModelByName)
+      .calledWith(undefined as any, 'otie')
+      .mockReturnValue('Opentrons Flex')
+
+    const { result } = renderHook(() => useIsOT3('otie'), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual(true)
+  })
 })

--- a/app/src/redux/discovery/constants.ts
+++ b/app/src/redux/discovery/constants.ts
@@ -27,5 +27,5 @@ export const RE_HOSTNAME_IPV4_LL: RegExp = /^169\.254\.\d+\.\d+$/
 export const RE_HOSTNAME_LOCALHOST: RegExp = /^localhost$/
 export const RE_HOSTNAME_LOOPBACK: RegExp = /^127\.0\.0\.1$/
 
-export const RE_ROBOT_MODEL_OT3: RegExp = /^OT-3.*/
+export const RE_ROBOT_MODEL_OT3: RegExp = /^(OT-3)|(Opentrons Flex).*/
 export const RE_ROBOT_MODEL_OT2: RegExp = /^OT-2.*/


### PR DESCRIPTION
fix RQA-760, RQA-761

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We changed `getRobotModelByName` to return "Opentrons Flex" but were still checking for "OT-3" in the regex for `useIsOt3` so we were always getting false. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Connect to an Opentrons Flex, make sure that `useIsOt3` returns true
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added "Opentrons Flex" to the regex for `useIsOt3`
- Added a test case to make sure this will also return true
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Verify this fixes the above problem
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
