### PR TITLE
feat(protocol-designer): update deploy scripts

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -206,6 +206,6 @@ jobs:
           aws configure set output json --profile identity
           aws configure set region us-east-2 --profile deploy
           aws configure set role_arn arn:aws:iam::043748923082:role/administrator --profile deploy
-          aws configure set source_profile default --profile deploy
+          aws configure set source_profile identity --profile deploy
           aws s3 sync ./dist s3://sandbox.designer.opentrons.com/${{ env.OT_BRANCH }} --acl=public-read --profile=deploy
         shell: bash

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -205,7 +205,7 @@ jobs:
           aws configure set region us-east-2 --profile identity
           aws configure set output json --profile identity
           aws configure set region us-east-2 --profile deploy
-          aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
-          aws configure set source_profile identity --profile deploy
+          aws configure set role_arn arn:aws:iam::043748923082:role/administrator --profile deploy
+          aws configure set source_profile default --profile deploy
           aws s3 sync ./dist s3://sandbox.designer.opentrons.com/${{ env.OT_BRANCH }} --acl=public-read --profile=deploy
         shell: bash

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -205,7 +205,7 @@ jobs:
           aws configure set region us-east-2 --profile identity
           aws configure set output json --profile identity
           aws configure set region us-east-2 --profile deploy
-          aws configure set role_arn arn:aws:iam::043748923082:role/administrator --profile deploy
+          aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
           aws configure set source_profile identity --profile deploy
           aws s3 sync ./dist s3://sandbox.designer.opentrons.com/${{ env.OT_BRANCH }} --acl=public-read --profile=deploy
         shell: bash

--- a/scripts/deploy/assume-role.js
+++ b/scripts/deploy/assume-role.js
@@ -1,0 +1,23 @@
+const AWS = require('aws-sdk')
+
+function getAssumeRole(roleArn, roleSessionName) {
+  const sts = new AWS.STS({ apiVersion: '2011-06-15' })
+
+  return new Promise((resolve, reject) => {
+    sts.assumeRole(
+      {
+        RoleArn: roleArn,
+        RoleSessionName: roleSessionName,
+      },
+      (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data.Credentials)
+        }
+      }
+    )
+  })
+}
+
+module.exports = { getAssumeRole }

--- a/scripts/deploy/create-invalidation.js
+++ b/scripts/deploy/create-invalidation.js
@@ -1,0 +1,23 @@
+const AWS = require('aws-sdk')
+
+function getCreateInvalidation(productionCredentials, cloudfrontArn) {
+  const cloudfront = new AWS.CloudFront({
+    apiVersion: '2019-03-26',
+    region: 'us-east-1',
+    credentials: productionCredentials,
+  })
+  const distributionId = cloudfrontArn.split('/')[1]
+  const cloudFrontParams = {
+    DistributionId: distributionId,
+    InvalidationBatch: {
+      CallerReference: Date.now().toString(),
+      Paths: {
+        Quantity: 1,
+        Items: ['/*'],
+      },
+    },
+  }
+  return cloudfront.createInvalidation(cloudFrontParams).promise()
+}
+
+module.exports = { getCreateInvalidation }

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -17,7 +17,7 @@ const dryrun = !flags.includes('--deploy')
 
 assert(projectDomain, USAGE)
 
-const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-2' })
+const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-1' })
 
 const stagingBucket = `staging.${projectDomain}`
 const productionBucket = projectDomain

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -70,6 +70,27 @@ productionAssumeRole()
       })
       .then(() => {
         console.log('Promotion to production done\n')
+        const cloudfront = new AWS.CloudFront({
+          apiVersion: '2019-03-26',
+          region: 'us-east-1',
+          credentials: productionCredentials,
+        })
+        const productionCloudfrontArn = `arn:aws:cloudfront::043748923082:distribution/E20OHY6J3BRVIF`
+        const productionDistributionId = productionCloudfrontArn.split('/')[1]
+        const cloudFrontParams = {
+          DistributionId: productionDistributionId,
+          InvalidationBatch: {
+            CallerReference: Date.now().toString(),
+            Paths: {
+              Quantity: 1,
+              Items: ['/*'],
+            },
+          },
+        }
+        return cloudfront.createInvalidation(cloudFrontParams).promise()
+      })
+      .then(() => {
+        console.log('Cache invalidation initiated for production\n')
         process.exit(0)
       })
       .catch(error => {

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -17,30 +17,66 @@ const dryrun = !flags.includes('--deploy')
 
 assert(projectDomain, USAGE)
 
-const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-1' })
+const sts = new AWS.STS({ apiVersion: '2011-06-15' })
 
-const stagingBucket = `staging.${projectDomain}`
-const productionBucket = projectDomain
-
-getDeployMetadata(s3, stagingBucket)
-  .then(deployMetadata => {
-    const { current } = deployMetadata
-    console.log(
-      `Promoting ${projectDomain} ${current} from staging to production\n`
-    )
-
-    return syncBuckets(
-      s3,
-      { bucket: stagingBucket },
-      { bucket: productionBucket },
-      dryrun
+const productionAssumeRole = () => {
+  return new Promise((resolve, reject) => {
+    sts.assumeRole(
+      {
+        RoleArn: 'arn:aws:iam::043748923082:role/administrator',
+        RoleSessionName: 'promoteToProduction',
+      },
+      (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data.Credentials)
+        }
+      }
     )
   })
-  .then(() => {
-    console.log('Promotion to production done\n')
-    process.exit(0)
+}
+
+productionAssumeRole()
+  .then(credentials => {
+    const stagingCredentials = new AWS.Credentials({
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken,
+    })
+
+    const s3 = new AWS.S3({
+      apiVersion: '2006-03-01',
+      region: 'us-east-1',
+      credentials: stagingCredentials,
+    })
+
+    const stagingBucket = `staging.${projectDomain}`
+    const productionBucket = projectDomain
+
+    getDeployMetadata(s3, stagingBucket)
+      .then(deployMetadata => {
+        const { current } = deployMetadata
+        console.log(
+          `Promoting ${projectDomain} ${current} from staging to production\n`
+        )
+
+        return syncBuckets(
+          s3,
+          { bucket: stagingBucket },
+          { bucket: productionBucket },
+          dryrun
+        )
+      })
+      .then(() => {
+        console.log('Promotion to production done\n')
+        process.exit(0)
+      })
+      .catch(error => {
+        console.error(error.message)
+        process.exit(1)
+      })
   })
-  .catch(error => {
-    console.error(error.message)
-    process.exit(1)
+  .catch(err => {
+    console.error(err)
   })

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -39,7 +39,7 @@ const productionAssumeRole = () => {
 
 productionAssumeRole()
   .then(credentials => {
-    const stagingCredentials = new AWS.Credentials({
+    const productionCredentials = new AWS.Credentials({
       accessKeyId: credentials.AccessKeyId,
       secretAccessKey: credentials.SecretAccessKey,
       sessionToken: credentials.SessionToken,
@@ -48,7 +48,7 @@ productionAssumeRole()
     const s3 = new AWS.S3({
       apiVersion: '2006-03-01',
       region: 'us-east-1',
-      credentials: stagingCredentials,
+      credentials: productionCredentials,
     })
 
     const stagingBucket = `staging.${projectDomain}`

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -20,35 +20,70 @@ const dryrun = !flags.includes('--deploy')
 
 assert(projectDomain && tag, USAGE)
 
-const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-1' })
+const sts = new AWS.STS({ apiVersion: '2011-06-15' })
 
-const sandboxBucket = `sandbox.${projectDomain}`
-const stagingBucket = `staging.${projectDomain}`
-
-getDeployMetadata(s3, stagingBucket)
-  .then(prevDeployMetadata => {
-    console.log('Previous deploy metadata: %j', prevDeployMetadata)
-
-    return syncBuckets(
-      s3,
-      { bucket: sandboxBucket, path: tag },
-      { bucket: stagingBucket },
-      dryrun
-    ).then(() =>
-      setDeployMetadata(
-        s3,
-        stagingBucket,
-        '',
-        { previous: prevDeployMetadata.current || null, current: tag },
-        dryrun
-      )
+const stagingAssumeRole = () => {
+  return new Promise((resolve, reject) => {
+    sts.assumeRole(
+      {
+        RoleArn: 'arn:aws:iam::043748923082:role/administrator',
+        RoleSessionName: 'promoteToStaging',
+      },
+      (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data.Credentials)
+        }
+      }
     )
   })
-  .then(() => {
-    console.log('Promotion to staging done\n')
-    process.exit(0)
+}
+
+stagingAssumeRole()
+  .then(credentials => {
+    const stagingCredentials = new AWS.Credentials({
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken,
+    })
+
+    const s3 = new AWS.S3({
+      apiVersion: '2006-03-01',
+      region: 'us-east-1',
+      credentials: stagingCredentials,
+    })
+
+    const sandboxBucket = `sandbox.${projectDomain}`
+    const stagingBucket = `staging.${projectDomain}`
+
+    getDeployMetadata(s3, stagingBucket)
+      .then(prevDeployMetadata => {
+        console.log('Previous deploy metadata: %j', prevDeployMetadata)
+        return syncBuckets(
+          s3,
+          { bucket: sandboxBucket, path: tag },
+          { bucket: stagingBucket },
+          dryrun
+        ).then(() =>
+          setDeployMetadata(
+            s3,
+            stagingBucket,
+            '',
+            { previous: prevDeployMetadata.current || null, current: tag },
+            dryrun
+          )
+        )
+      })
+      .then(() => {
+        console.log('Promotion to staging done\n')
+        process.exit(0)
+      })
+      .catch(error => {
+        console.error(error.message)
+        process.exit(1)
+      })
   })
-  .catch(error => {
-    console.error(error.message)
-    process.exit(1)
+  .catch(err => {
+    console.error(err)
   })

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -77,6 +77,28 @@ stagingAssumeRole()
       })
       .then(() => {
         console.log('Promotion to staging done\n')
+
+        const cloudfront = new AWS.CloudFront({
+          apiVersion: '2019-03-26',
+          region: 'us-east-1',
+          credentials: stagingCredentials,
+        })
+        const stagingCloudfrontArn = `arn:aws:cloudfront::043748923082:distribution/EB2QTLE7OJ8O6`
+        const stagingDistributionId = stagingCloudfrontArn.split('/')[1]
+        const cloudFrontParams = {
+          DistributionId: stagingDistributionId,
+          InvalidationBatch: {
+            CallerReference: Date.now().toString(),
+            Paths: {
+              Quantity: 1,
+              Items: ['/*'],
+            },
+          },
+        }
+        return cloudfront.createInvalidation(cloudFrontParams).promise()
+      })
+      .then(() => {
+        console.log('Cache invalidation initiated for staging\n')
         process.exit(0)
       })
       .catch(error => {

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -20,7 +20,7 @@ const dryrun = !flags.includes('--deploy')
 
 assert(projectDomain && tag, USAGE)
 
-const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-2' })
+const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-1' })
 
 const sandboxBucket = `sandbox.${projectDomain}`
 const stagingBucket = `staging.${projectDomain}`


### PR DESCRIPTION
addresses RLIQ-392 

# Overview

change PD deployment scripts

# Test Plan

you can run the dry run scripts for promoting to staging and promoting to production to verify that it works!

# Changelog

- change time zones to match the s3 buckets
- add `sts.AssumeRole` to assume the role of the PL prod account. this is because the sandbox s3 bucket is in a different account than the staging and production buckets.
- add cache invalidation

# Review requests

there are a few nested promises - i think that's okay? otherwise, check code to make sure it look good 

# Risk assessment

low