### PR TITLE
fix(api): Allow None serial number when getting module offset

### DIFF
--- a/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/__init__.py
@@ -11,6 +11,7 @@ from .thermocycler_module_substate import (
     ThermocyclerModuleSubState,
     ThermocyclerModuleId,
 )
+from .magnetic_block_substate import MagneticBlockSubState, MagneticBlockId
 
 
 ModuleSubStateType = Union[
@@ -18,6 +19,7 @@ ModuleSubStateType = Union[
     MagneticModuleSubState,
     TemperatureModuleSubState,
     ThermocyclerModuleSubState,
+    MagneticBlockSubState,
 ]
 
 __all__ = [
@@ -29,6 +31,8 @@ __all__ = [
     "TemperatureModuleId",
     "ThermocyclerModuleSubState",
     "ThermocyclerModuleId",
+    "MagneticBlockSubState",
+    "MagneticBlockId",
     # Union of all module substates
     "ModuleSubStateType",
 ]

--- a/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
@@ -8,7 +8,7 @@ MagneticBlockId = NewType("MagneticBlockId", str)
 
 @dataclass(frozen=True)
 class MagneticBlockSubState:
-    """Magnetic Module specific state.
+    """Magnetic Block specific state.
 
     Provides a read-only state access
     for an individual loaded Magnetic Block.

--- a/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
@@ -1,4 +1,4 @@
-"""Magnetic module sub-state."""
+"""Magnetic block sub-state."""
 
 from dataclasses import dataclass
 from typing import NewType

--- a/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
@@ -3,9 +3,6 @@
 from dataclasses import dataclass
 from typing import NewType
 
-from opentrons.protocol_engine.types import MagneticBlockModel
-
-
 MagneticBlockId = NewType("MagneticBlockId", str)
 
 
@@ -13,9 +10,8 @@ MagneticBlockId = NewType("MagneticBlockId", str)
 class MagneticBlockSubState:
     """Magnetic Module specific state.
 
-    Provides calculations and read-only state access
+    Provides a read-only state access
     for an individual loaded Magnetic Block.
     """
 
     module_id: MagneticBlockId
-    model: MagneticBlockModel

--- a/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/magnetic_block_substate.py
@@ -1,0 +1,21 @@
+"""Magnetic module sub-state."""
+
+from dataclasses import dataclass
+from typing import NewType
+
+from opentrons.protocol_engine.types import MagneticBlockModel
+
+
+MagneticBlockId = NewType("MagneticBlockId", str)
+
+
+@dataclass(frozen=True)
+class MagneticBlockSubState:
+    """Magnetic Module specific state.
+
+    Provides calculations and read-only state access
+    for an individual loaded Magnetic Block.
+    """
+
+    module_id: MagneticBlockId
+    model: MagneticBlockModel

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -275,8 +275,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
             )
         elif ModuleModel.is_magnetic_block(actual_model):
             self._state.substate_by_module_id[module_id] = MagneticBlockSubState(
-                module_id=MagneticBlockId(module_id),
-                model=actual_model,
+                module_id=MagneticBlockId(module_id)
             )
 
     def _update_module_calibration(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -356,6 +356,11 @@ def test_get_module_offset_for_ot2_standard(
             DeckSlotName.SLOT_3,
             LabwareOffsetVector(x=0, y=0, z=18.95),
         ),
+        (
+            lazy_fixture("mag_block_v1_def"),
+            DeckSlotName.SLOT_2,
+            LabwareOffsetVector(x=0, y=0, z=38.0),
+        ),
     ],
 )
 def test_get_module_offset_for_ot3_standard(


### PR DESCRIPTION

# Overview

Additional work towards https://opentrons.atlassian.net/browse/RLAB-248. 
Fixes bug when uploading another module besides the Mag block. 
Added mag block substate to PE and added logic for `get_module_offset` when there is no sn. 

# Test Plan

- Upload the following protocol
```
metadata={"apiLevel": "2.15"}


def run(protocol_context):


	# Labware Setup
	p300racks = [protocol_context.load_labware('opentrons_96_tiprack_300ul', '3')]

	p300 = protocol_context.load_instrument('p300_single', 'right', tip_racks=p300racks)

	mag_block = protocol_context.load_module("magneticBlockV1", 6)
	mag_plate = mag_block.load_labware("biorad_96_wellplate_200ul_pcr")

	thermocycler = protocol_context.load_module("thermocycler")
	reaction_plate = thermocycler.load_labware(
	    'biorad_96_wellplate_200ul_pcr')
	
	reaction_plate2 = protocol_context.load_labware(
	    'nest_12_reservoir_15ml', 4)

	trash = protocol_context.load_labware(
		'agilent_1_reservoir_290ml', 1)

	samples = 8

	thermocycler.open_lid()
	p300.transfer(150, [reaction_plate['A1'].top(), reaction_plate['A1'].bottom()], [reaction_plate2['A1'].bottom(), reaction_plate2['A1'].top()])
	
	p300.pick_up_tip()
	p300.aspirate(50, reaction_plate['A1'])
	p300.dispense(50, mag_plate['A1'])

	protocol_context.pause('please replace deck slot')

	reaction_plate3 = thermocycler.load_labware('armadillo_96_wellplate_200ul_pcr_full_skirt')
	p300.drop_tip()
	p300.transfer(150, [reaction_plate['A1'].top(), reaction_plate['A1'].bottom()], [reaction_plate3['A1'].bottom(), reaction_plate3['A1'].top()])
```

- Make sure it passes analysis and it works as expected


# Changelog

- Added MagneticBlockSubState
- `get_module_offset` will use definition defaults if there is no sn.

# Review requests

missing anything? 

# Risk assessment

low. should only effect mag block labware. 
