### PR TITLE
refactor(app): pipette flow wizard header text cleanup

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -12,7 +12,7 @@
   "before_you_begin": "Before you begin",
   "begin_calibration": "Begin calibration",
   "cal_pipette": "Calibrate pipette",
-  "calibrate_96_channel": "Calibrate 96-Channel pipette",
+  "calibrate_96_channel": "Calibrate 96-Channel Pipette",
   "calibrate_pipette": "calibrate {{mount}} pipette",
   "calibration_probe_touching": "The calibration probe will touch the sides of the calibration square in slot {{slotNumber}} to determine its exact position",
   "cancel_attachment": "cancel attachment",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -22,7 +22,10 @@
   "connect_and_secure_pipette": "connect and secure pipette",
   "continue": "Continue",
   "critical_unskippable_step": "this is a critical step that cannot be skipped",
+  "detach_96_attach_mount": "Detach 96-Channel Pipette and Attach {{mount}} Pipette",
   "detach_96_channel": "Detach 96-Channel Pipette",
+  "detach_mount_attach_96": "Detach {{mount}} Pipette and Attach 96-Channel Pipette",
+  "detach_pipettes_attach_96": "Detach Pipettes and Attach 96-Channel Pipette",
   "detach_and_reattach": "Detach and reattach pipette",
   "detach_mounting_plate_instructions": "Hold onto the plate so it does not fall. Then remove the pins on the plate from the slots on the gantry carriage.",
   "detach_pipette_to_attach_96": "Detach {{pipetteName}} and attach 96-Channel pipette",
@@ -62,6 +65,7 @@
   "remove_labware_to_get_started": "<block>To get started, remove labware from the deck and clean up the working area to make calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration probe is included with the robot and should be stored on the front pillar of the robot.</block>",
   "remove_labware": "<block>To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration probe is included with the robot and should be stored on the front pillar of the robot.</block>",
   "remove_probe": "unlatch the calibration probe, remove it from the nozzle, and return it to its storage location.",
+  "replace_pipette": "replace {{mount}} pipette",
   "single_mount_attached_error": "Single mount pipette is selected when this is the 96 channel flow",
   "single_or_8_channel": "{{single}} or {{eight}} pipette",
   "something_seems_wrong": "There may be a problem with your pipette. Exit setup and contact Opentrons Support for assistance.",
@@ -70,9 +74,5 @@
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",
-  "z_axis_still_attached": "z-axis screw still secure",
-  "detach_96_attach_mount": "Detach 96-Channel Pipette and Attach {{mount}} Pipette",
-  "detach_mount_attach_96": "Detach {{mount}} Pipette and Attach 96-Channel Pipette",
-  "detach_pipettes_attach_96": "Detach Pipettes and Attach 96-Channel Pipette",
-  "replace_pipette": "Replace {{mount}} Pipette"
+  "z_axis_still_attached": "z-axis screw still secure"
 }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -22,6 +22,7 @@ import { getIsOnDevice } from '../../../redux/config'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { useAttachedPipettesFromInstrumentsQuery } from '../../Devices/hooks/useAttachedPipettesFromInstrumentsQuery'
 import { getPipetteWizardSteps } from '../getPipetteWizardSteps'
+import { usePipetteFlowWizardHeaderText } from '../hooks'
 import { ExitModal } from '../ExitModal'
 import { FLOWS, SECTIONS } from '../constants'
 import { UnskippableModal } from '../UnskippableModal'
@@ -38,6 +39,7 @@ jest.mock('../../../redux/robot-api')
 jest.mock('../UnskippableModal')
 jest.mock('../../../redux/config')
 jest.mock('../../Devices/hooks/useAttachedPipettesFromInstrumentsQuery')
+jest.mock('../hooks')
 
 const mockUseAttachedPipettesFromInstrumentsQuery = useAttachedPipettesFromInstrumentsQuery as jest.MockedFunction<
   typeof useAttachedPipettesFromInstrumentsQuery
@@ -67,6 +69,10 @@ const mockUnskippableModal = UnskippableModal as jest.MockedFunction<
 const mockGetIsOnDevice = getIsOnDevice as jest.MockedFunction<
   typeof getIsOnDevice
 >
+const mockUsePipetteFlowWizardHeaderText = usePipetteFlowWizardHeaderText as jest.MockedFunction<
+  typeof usePipetteFlowWizardHeaderText
+>
+
 const render = (props: React.ComponentProps<typeof PipetteWizardFlows>) => {
   return renderWithProviders(<PipetteWizardFlows {...props} />, {
     i18nInstance: i18n,
@@ -130,11 +136,14 @@ describe('PipetteWizardFlows', () => {
     mockGetRequestById.mockReturnValue(null)
     mockUnskippableModal.mockReturnValue(<div>mock unskippable modal</div>)
     mockGetIsOnDevice.mockReturnValue(false)
+    mockUsePipetteFlowWizardHeaderText.mockReturnValue(
+      'mock wizard header text'
+    )
   })
   it('renders the correct information, calling the correct commands for the calibration flow', async () => {
     const { getByText, getByRole } = render(props)
     //  first page
-    getByText('Recalibrate Left Pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     getByText(
       'To get started, remove labware from the deck and clean up the working area to make calibration easier. Also gather the needed equipment shown to the right.'
@@ -216,7 +225,7 @@ describe('PipetteWizardFlows', () => {
   it('renders the correct first page for calibrating single mount when rendering from on device display', () => {
     mockGetIsOnDevice.mockReturnValue(true)
     const { getByText } = render(props)
-    getByText('Recalibrate Left Pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     getByText(
       'To get started, remove labware from the deck and clean up the working area to make calibration easier. Also gather the needed equipment shown to the right.'
@@ -270,7 +279,7 @@ describe('PipetteWizardFlows', () => {
       },
     ])
     const { getByText } = render(props)
-    getByText('Detach Left Pipette')
+    getByText('mock wizard header text')
     //  TODO(jr 11/11/22): finish the rest of the test
   })
 
@@ -316,7 +325,7 @@ describe('PipetteWizardFlows', () => {
       },
     ])
     const { getByText, getByRole } = render(props)
-    getByText('Attach Left Pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     // page 1
     const getStarted = getByRole('button', { name: 'Move gantry to front' })
@@ -373,7 +382,7 @@ describe('PipetteWizardFlows', () => {
       },
     ])
     const { getByText, getByRole } = render(props)
-    getByText('Attach 96-Channel Pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     // page 1
     const getStarted = getByRole('button', { name: 'Move gantry to front' })
@@ -437,7 +446,7 @@ describe('PipetteWizardFlows', () => {
       },
     ])
     const { getByText, getByRole } = render(props)
-    getByText('Detach 96-Channel Pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     // page 1
     const getStarted = getByRole('button', { name: 'Move gantry to front' })
@@ -508,7 +517,7 @@ describe('PipetteWizardFlows', () => {
       },
     ])
     const { getByText, getByRole } = render(props)
-    getByText('Detach Flex 1-Channel 1000 μL and Attach 96-Channel Pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     // page 1
     const getStarted = getByRole('button', { name: 'Move gantry to front' })
@@ -539,7 +548,7 @@ describe('PipetteWizardFlows', () => {
     }
     const { getByText, getByRole } = render(props)
     //  first page
-    getByText('Calibrate 96-Channel pipette')
+    getByText('mock wizard header text')
     getByText('Before you begin')
     getByRole('button', { name: 'Move gantry to front' }).click()
     await waitFor(() => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
@@ -1,0 +1,422 @@
+import * as React from 'react'
+import { I18nextProvider } from 'react-i18next'
+import { renderHook } from '@testing-library/react-hooks'
+import { LEFT } from '@opentrons/components'
+import {
+  NINETY_SIX_CHANNEL,
+  RIGHT,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
+import { i18n } from '../../../i18n'
+import {
+  mock96ChannelAttachedPipetteInformation,
+  mockAttachedPipetteInformation,
+} from '../../../redux/pipettes/__fixtures__'
+import { FLOWS } from '../constants'
+import { usePipetteFlowWizardHeaderText } from '../hooks'
+
+describe('usePipetteFlowWizardHeaderText', () => {
+  let wrapper: React.FunctionComponent<{}>
+  beforeEach(() => {
+    wrapper = ({ children }) => (
+      <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+    )
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('should return correct title for calibrating single mount', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Calibrate Left Pipette')
+  })
+  it('should return correct title for calibrating single mount with cal data', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: true,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Recalibrate Left Pipette')
+  })
+  it('should return correct title for calibrating 96 channel', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: NINETY_SIX_CHANNEL,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Calibrate 96-Channel Pipette')
+  })
+  it('should return correct title for attaching single mount', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.ATTACH,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Attach Left Pipette')
+  })
+  it('should return correct title for attaching 96 channel', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.ATTACH,
+          mount: LEFT,
+          selectedPipette: NINETY_SIX_CHANNEL,
+          hasCalData: false,
+          isGantryEmpty: true,
+          attachedPipettes: {
+            left: null,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Attach 96-Channel Pipette')
+  })
+  it('should return correct title for attaching 96 channel with pipette attached', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.ATTACH,
+          mount: LEFT,
+          selectedPipette: NINETY_SIX_CHANNEL,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual(
+      'Detach Flex 1-Channel 1000 μL and Attach 96-Channel Pipette'
+    )
+  })
+  it('should return correct title for detaching single mount', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.DETACH,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Detach Left Pipette')
+  })
+  it('should return correct title for detaching 96 channel', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.DETACH,
+          mount: LEFT,
+          selectedPipette: NINETY_SIX_CHANNEL,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mock96ChannelAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Detach 96-Channel Pipette')
+  })
+  it('should return correct title for calibrating single mount from pipette info', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p1000_single_gen3',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Calibrate Left Pipette')
+  })
+  it('should return correct title for detaching 96 channel from pipette info and attaching other pipette', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mock96ChannelAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p1000_single_gen3',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual(
+      'Detach 96-Channel Pipette and Attach Left Pipette'
+    )
+  })
+  it('should return correct title for attaching 96 channel from pipette info', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: true,
+          attachedPipettes: {
+            left: null,
+            right: null,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p1000_96',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Attach 96-Channel Pipette')
+  })
+  it('should return correct title for detaching pieptte and attaching 96 channel from pipette info on left mount', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p1000_96',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual(
+      'Detach Right Pipette and Attach 96-Channel Pipette'
+    )
+  })
+  it('should return correct title for detaching pipette and attaching 96 channel from pipette info from right mount', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: RIGHT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: null,
+            right: mockAttachedPipetteInformation,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p1000_96',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual(
+      'Detach Left Pipette and Attach 96-Channel Pipette'
+    )
+  })
+  it('should return correct title for detaching 2 pipettes and attaching 96 channel from pipette info', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: RIGHT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: mockAttachedPipetteInformation,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p1000_96',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual(
+      'Detach Pipettes and Attach 96-Channel Pipette'
+    )
+  })
+  it('should return correct title when replacing single mount pipette with pipette info', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: mockAttachedPipetteInformation,
+            right: null,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p50_single_gen3',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Replace Left Pipette')
+  })
+  it('should return correct title when attaching single mount pipette with pipette info', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: LEFT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: true,
+          attachedPipettes: {
+            left: null,
+            right: null,
+          },
+          pipetteInfo: [
+            {
+              id: 'id',
+              pipetteName: 'p50_single_gen3',
+              mount: LEFT,
+            },
+          ],
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Attach Left Pipette')
+  })
+})

--- a/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { renderHook } from '@testing-library/react-hooks'
-import { LEFT } from '@opentrons/components'
 import {
   NINETY_SIX_CHANNEL,
   RIGHT,
+  LEFT,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
@@ -14,6 +14,12 @@ import {
 } from '../../../redux/pipettes/__fixtures__'
 import { FLOWS } from '../constants'
 import { usePipetteFlowWizardHeaderText } from '../hooks'
+
+const BASE_PROPS_FOR_RUN_SETUP = {
+  flowType: FLOWS.CALIBRATE,
+  selectedPipette: SINGLE_MOUNT_PIPETTES,
+  hasCalData: false,
+}
 
 describe('usePipetteFlowWizardHeaderText', () => {
   let wrapper: React.FunctionComponent<{}>
@@ -45,6 +51,27 @@ describe('usePipetteFlowWizardHeaderText', () => {
       }
     )
     expect(result.current).toEqual('Calibrate Left Pipette')
+  })
+  it('should return correct title for calibrating single mount for right pipette', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.CALIBRATE,
+          mount: RIGHT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: null,
+            right: mockAttachedPipetteInformation,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Calibrate Right Pipette')
   })
   it('should return correct title for calibrating single mount with cal data', () => {
     const { result } = renderHook(
@@ -108,6 +135,27 @@ describe('usePipetteFlowWizardHeaderText', () => {
       }
     )
     expect(result.current).toEqual('Attach Left Pipette')
+  })
+  it('should return correct title for attaching single mount for right pipette', () => {
+    const { result } = renderHook(
+      () =>
+        usePipetteFlowWizardHeaderText({
+          flowType: FLOWS.ATTACH,
+          mount: RIGHT,
+          selectedPipette: SINGLE_MOUNT_PIPETTES,
+          hasCalData: false,
+          isGantryEmpty: false,
+          attachedPipettes: {
+            left: null,
+            right: mockAttachedPipetteInformation,
+          },
+          pipetteInfo: null,
+        }),
+      {
+        wrapper,
+      }
+    )
+    expect(result.current).toEqual('Attach Right Pipette')
   })
   it('should return correct title for attaching 96 channel', () => {
     const { result } = renderHook(
@@ -199,10 +247,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: LEFT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: false,
           attachedPipettes: {
             left: mockAttachedPipetteInformation,
@@ -226,10 +272,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: LEFT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: false,
           attachedPipettes: {
             left: mock96ChannelAttachedPipetteInformation,
@@ -255,10 +299,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: LEFT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: true,
           attachedPipettes: {
             left: null,
@@ -282,10 +324,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: LEFT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: false,
           attachedPipettes: {
             left: mockAttachedPipetteInformation,
@@ -311,10 +351,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: RIGHT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: false,
           attachedPipettes: {
             left: null,
@@ -340,10 +378,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: RIGHT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: false,
           attachedPipettes: {
             left: mockAttachedPipetteInformation,
@@ -369,10 +405,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: LEFT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: false,
           attachedPipettes: {
             left: mockAttachedPipetteInformation,
@@ -396,10 +430,8 @@ describe('usePipetteFlowWizardHeaderText', () => {
     const { result } = renderHook(
       () =>
         usePipetteFlowWizardHeaderText({
-          flowType: FLOWS.CALIBRATE,
+          ...BASE_PROPS_FOR_RUN_SETUP,
           mount: LEFT,
-          selectedPipette: SINGLE_MOUNT_PIPETTES,
-          hasCalData: false,
           isGantryEmpty: true,
           attachedPipettes: {
             left: null,

--- a/app/src/organisms/PipetteWizardFlows/hooks.tsx
+++ b/app/src/organisms/PipetteWizardFlows/hooks.tsx
@@ -1,0 +1,127 @@
+import { useTranslation } from 'react-i18next'
+import capitalize from 'lodash/capitalize'
+import {
+  LEFT,
+  LoadedPipette,
+  PipetteMount,
+  RIGHT,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
+import { FLOWS } from './constants'
+import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
+import type { PipetteWizardFlow, SelectablePipettes } from './types'
+
+interface PipetteFlowWizardHeaderTextProps {
+  flowType: PipetteWizardFlow
+  mount: PipetteMount
+  selectedPipette: SelectablePipettes
+  hasCalData: boolean
+  isGantryEmpty: boolean
+  attachedPipettes: AttachedPipettesFromInstrumentsQuery
+  pipetteInfo: LoadedPipette[] | null
+}
+
+export function usePipetteFlowWizardHeaderText(
+  props: PipetteFlowWizardHeaderTextProps
+): string {
+  const {
+    flowType,
+    mount,
+    selectedPipette,
+    hasCalData,
+    isGantryEmpty,
+    attachedPipettes,
+    pipetteInfo,
+  } = props
+  const { t, i18n } = useTranslation('pipette_wizard_flows')
+
+  let wizardTitle: string = 'unknown page'
+
+  const leftPipette = pipetteInfo?.find(pipette => pipette.mount === 'left')
+  const mountPipette = pipetteInfo?.find(pipette => pipette.mount === mount)
+  const capitalizedMount = capitalize(mount)
+
+  if (pipetteInfo == null) {
+    switch (flowType) {
+      case FLOWS.CALIBRATE: {
+        if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+          wizardTitle = i18n.format(
+            t(hasCalData ? 'recalibrate_pipette' : 'calibrate_pipette', {
+              mount: mount,
+            }),
+            'sentenceCase'
+          )
+        } else {
+          wizardTitle = t('calibrate_96_channel')
+        }
+        break
+      }
+      case FLOWS.ATTACH: {
+        if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+          wizardTitle = i18n.format(
+            t('attach_pipette', { mount: mount }),
+            'sentenceCase'
+          )
+        } else {
+          wizardTitle = isGantryEmpty
+            ? t('attach_96_channel')
+            : t('attach_96_channel_plus_detach', {
+                pipetteName:
+                  attachedPipettes[LEFT]?.displayName ??
+                  attachedPipettes[RIGHT]?.displayName,
+              })
+        }
+        break
+      }
+      case FLOWS.DETACH: {
+        if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
+          wizardTitle = i18n.format(
+            t('detach_pipette', { mount: mount }),
+            'sentenceCase'
+          )
+        } else {
+          wizardTitle = t('detach_96_channel')
+        }
+        break
+      }
+    }
+  } else {
+    if (mountPipette?.pipetteName === attachedPipettes[mount]?.instrumentName) {
+      return i18n.format(
+        t('calibrate_pipette', {
+          mount: mount,
+        }),
+        'sentenceCase'
+      )
+    } else if (
+      attachedPipettes[LEFT]?.data.channels === 96 &&
+      mountPipette?.pipetteName !== 'p1000_96'
+    ) {
+      return t('detach_96_attach_mount', { mount: capitalizedMount })
+    } else if (leftPipette?.pipetteName === 'p1000_96') {
+      if (isGantryEmpty) {
+        return t('attach_96_channel')
+      } else if (
+        attachedPipettes[LEFT] != null &&
+        attachedPipettes[RIGHT] == null
+      ) {
+        return t('detach_mount_attach_96', { mount: capitalize(RIGHT) })
+      } else if (
+        attachedPipettes[LEFT] == null &&
+        attachedPipettes[RIGHT] != null
+      ) {
+        return t('detach_mount_attach_96', { mount: capitalize(LEFT) })
+      } else {
+        return t('detach_pipettes_attach_96')
+      }
+    } else if (mountPipette != null && attachedPipettes[mount] == null) {
+      return i18n.format(
+        t('attach_pipette', { mount: capitalizedMount }),
+        'sentenceCase'
+      )
+    } else if (mountPipette != null && attachedPipettes[mount] != null) {
+      return t('replace_pipette', { mount: capitalizedMount })
+    }
+  }
+  return wizardTitle
+}

--- a/app/src/organisms/PipetteWizardFlows/hooks.tsx
+++ b/app/src/organisms/PipetteWizardFlows/hooks.tsx
@@ -120,7 +120,7 @@ export function usePipetteFlowWizardHeaderText(
         'sentenceCase'
       )
     } else if (mountPipette != null && attachedPipettes[mount] != null) {
-      return t('replace_pipette', { mount: capitalizedMount })
+      return i18n.format(t('replace_pipette', { mount: mount }), 'sentenceCase')
     }
   }
   return wizardTitle

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import startCase from 'lodash/startCase'
 import { useConditionalConfirm } from '@opentrons/components'
 import {
   LEFT,
   NINETY_SIX_CHANNEL,
-  SINGLE_MOUNT_PIPETTES,
   RIGHT,
   LoadedPipette,
 } from '@opentrons/shared-data'
@@ -15,7 +13,6 @@ import {
   useCreateMaintenanceRunMutation,
   useDeleteMaintenanceRunMutation,
 } from '@opentrons/react-api-client'
-import type { Mount } from '../../redux/pipettes/types'
 
 import { ModalShell } from '../../molecules/Modal'
 import { Portal } from '../../App/portal'
@@ -24,6 +21,7 @@ import { WizardHeader } from '../../molecules/WizardHeader'
 import { useChainMaintenanceCommands } from '../../resources/runs/hooks'
 import { getIsOnDevice } from '../../redux/config'
 import { useAttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
+import { usePipetteFlowWizardHeaderText } from './hooks'
 import { getPipetteWizardSteps } from './getPipetteWizardSteps'
 import { getPipetteWizardStepsForProtocol } from './getPipetteWizardStepsForProtocol'
 import { FLOWS, SECTIONS } from './constants'
@@ -39,7 +37,6 @@ import { MountingPlate } from './MountingPlate'
 import { UnskippableModal } from './UnskippableModal'
 
 import type { PipetteMount } from '@opentrons/shared-data'
-import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
 
 interface PipetteWizardFlowsProps {
@@ -74,6 +71,7 @@ export const PipetteWizardFlows = (
           props.pipetteInfo,
           mount
         )
+
   const host = useHost()
   const [maintenanceRunId, setMaintenanceRunId] = React.useState<string>('')
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
@@ -84,6 +82,17 @@ export const PipetteWizardFlows = (
   )
   const hasCalData =
     attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
+
+  const wizardTitle = usePipetteFlowWizardHeaderText({
+    flowType,
+    mount,
+    selectedPipette,
+    hasCalData,
+    isGantryEmpty,
+    attachedPipettes,
+    pipetteInfo: props.pipetteInfo ?? null,
+  })
+
   const goBack = (): void => {
     setCurrentStepIndex(
       currentStepIndex !== pipetteWizardSteps.length - 1 ? 0 : currentStepIndex
@@ -280,22 +289,6 @@ export const PipetteWizardFlows = (
       <MountingPlate {...currentStep} {...calibrateBaseProps} />
     )
   }
-  const wizardTitle =
-    props.pipetteInfo == null
-      ? PipetteFlowWizardHeaderText(
-          flowType,
-          mount,
-          selectedPipette,
-          hasCalData,
-          isGantryEmpty,
-          attachedPipettes
-        )
-      : ProtocolPipetteFlowWizardHeaderText(
-          attachedPipettes,
-          props.pipetteInfo,
-          mount
-        )
-
   const is96ChannelUnskippableStep =
     currentStep.section === SECTIONS.CARRIAGE ||
     currentStep.section === SECTIONS.MOUNTING_PLATE ||
@@ -347,96 +340,4 @@ export const PipetteWizardFlows = (
       )}
     </Portal>
   )
-}
-
-const ProtocolPipetteFlowWizardHeaderText = (
-  attachedPipettes: AttachedPipettesFromInstrumentsQuery,
-  pipetteInfo: LoadedPipette[],
-  mount: Mount
-): string => {
-  const { t } = useTranslation('pipette_wizard_flows')
-  const leftPipette = pipetteInfo.find(pipette => pipette.mount === 'left')
-  const mountPipette = pipetteInfo.find(pipette => pipette.mount === mount)
-  if (mountPipette?.pipetteName === attachedPipettes[mount]?.instrumentName) {
-    return t('calibrate_pipette', {
-      mount: mount,
-    })
-  } else if (
-    attachedPipettes[LEFT]?.data.channels === 96 &&
-    mountPipette?.pipetteName !== 'p1000_96'
-  ) {
-    return t('detach_96_attach_mount', { mount: mount })
-  } else if (leftPipette?.pipetteName === 'p1000_96') {
-    if (attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null) {
-      return t('attach_96_channel')
-    } else if (
-      attachedPipettes[LEFT] != null &&
-      attachedPipettes[RIGHT] == null
-    ) {
-      return t('detach_mount_attach_96', { mount: RIGHT })
-    } else if (
-      attachedPipettes[LEFT] == null &&
-      attachedPipettes[RIGHT] != null
-    ) {
-      return t('detach_mount_attach_96', { mount: LEFT })
-    } else {
-      return t('detach_pipettes_attach_96')
-    }
-  } else if (mountPipette != null && attachedPipettes[mount] == null) {
-    return t('attach_pipette', { mount: mount })
-  } else if (mountPipette != null && attachedPipettes[mount] != null) {
-    return t('replace_pipette', { mount: mount })
-  }
-  return 'unknown page'
-}
-
-const PipetteFlowWizardHeaderText = (
-  flowType: PipetteWizardFlow,
-  mount: PipetteMount,
-  selectedPipette: SelectablePipettes,
-  hasCalData: boolean,
-  isGantryEmpty: boolean,
-  attachedPipettes: AttachedPipettesFromInstrumentsQuery
-): string => {
-  const { t } = useTranslation('pipette_wizard_flows')
-
-  let wizardTitle: string = 'unknown page'
-  switch (flowType) {
-    case FLOWS.CALIBRATE: {
-      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        wizardTitle = startCase(
-          t(hasCalData ? 'recalibrate_pipette' : 'calibrate_pipette', {
-            mount: mount,
-          })
-        )
-      } else {
-        wizardTitle = t('calibrate_96_channel')
-      }
-      break
-    }
-    case FLOWS.ATTACH: {
-      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        wizardTitle = startCase(t('attach_pipette', { mount: mount }))
-      } else {
-        wizardTitle = isGantryEmpty
-          ? t('attach_96_channel')
-          : t('attach_96_channel_plus_detach', {
-              pipetteName:
-                attachedPipettes[LEFT]?.displayName ??
-                attachedPipettes[RIGHT]?.displayName,
-            })
-      }
-      break
-    }
-    case FLOWS.DETACH: {
-      if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        wizardTitle = startCase(t('detach_pipette', { mount: mount }))
-      } else {
-        wizardTitle = t('detach_96_channel')
-      }
-      break
-    }
-  }
-
-  return wizardTitle
 }


### PR DESCRIPTION
closes RLIQ-391

# Overview

clean up the wizard header text for pipette flows so they match designs

# Test Plan

- test on a robot! looks through the different types of flows to make sure the header is correct

# Changelog

- move the functions out of `PipetteWizardFlows` and combine into a hook and use that hook instead. (had to create a hook because the function takes in `useTranslation`)
- create the hook
- test the hook thoroughly to make sure text is capitalized as expected and logic is correct

# Review requests

see test plan

# Risk assessment

low
