### PR TITLE
fix(api): Exclude existing module offsets when running subsequent module calibrations

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
-from opentrons.types import MountType, Point
+from opentrons.types import MountType
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
@@ -69,19 +69,11 @@ class CalibrateModuleImplementation(
         ot3_mount = OT3Mount.from_mount(params.mount)
         slot = self._state_view.modules.get_location(params.moduleId).slotName.as_int()
         module_serial = self._state_view.modules.get_serial_number(params.moduleId)
-
         # NOTE (ba, 2023-03-31): There are two wells for calibration labware definitions
         # well A1 represents the location calibration square center relative to the adapters bottom-left corner
         # well B1 represents the location of the calibration square probe point relative to the adapters bottom-left corner.
-        calibration_position = self._state_view.geometry.get_well_position(
+        nominal_position = self._state_view.geometry.get_nominal_well_position(
             labware_id=params.labwareId, well_name="B1"
-        )
-        # Subtract the module offset included in get_well_position for new calibration
-        current_offset = self._state_view.modules.get_raw_module_offset(params.moduleId)
-        nominal_position = Point(
-            x=calibration_position.x - current_offset.x,
-            y=calibration_position.y - current_offset.y,
-            z=calibration_position.z - current_offset.z,
         )
 
         # start the calibration

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -91,7 +91,7 @@ class GeometryView:
             min_travel_z = max(min_travel_z, minimum_z_height)
         return min_travel_z
 
-    def get_labware_parent_origin_position(self, labware_id: str) -> Point:
+    def get_labware_parent_nominal_position(self, labware_id: str) -> Point:
         """Get the position of the labware's uncalibrated parent slot (deck or module)."""
         labware_data = self._labware.get(labware_id)
         module_id: Optional[str] = None
@@ -123,12 +123,12 @@ class GeometryView:
 
     def get_labware_parent_position(self, labware_id: str) -> Point:
         """Get the calibrated position of the labware's parent slot (deck or module)."""
-        parent_pos = self.get_labware_parent_origin_position(labware_id)
+        parent_pos = self.get_labware_parent_nominal_position(labware_id)
         cal_offset = ModuleOffsetVector(x=0, y=0, z=0)
         labware_data = self._labware.get(labware_id)
         if isinstance(labware_data.location, ModuleLocation):
             module_id = labware_data.location.moduleId
-            cal_offset = self._modules.get_module_offset_vector(module_id)
+            cal_offset = self._modules.get_module_calibration_offset(module_id)
         return Point(
             x=parent_pos.x + cal_offset.x,
             y=parent_pos.y + cal_offset.y,
@@ -188,7 +188,7 @@ class GeometryView:
         well_name: str,
     ) -> Point:
         """Get the well position without calibration offsets."""
-        parent_pos = self.get_labware_parent_origin_position(labware_id)
+        parent_pos = self.get_labware_parent_nominal_position(labware_id)
         origin_offset = self._labware.get_definition(labware_id).cornerOffsetFromSlot
         well_def = self._labware.get_well_definition(labware_id, well_name)
         return Point(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -15,6 +15,7 @@ from ..types import (
     WellOffset,
     DeckSlotLocation,
     ModuleLocation,
+    ModuleOffsetVector,
     LabwareLocation,
     LabwareOffsetVector,
     DeckType,
@@ -90,11 +91,10 @@ class GeometryView:
             min_travel_z = max(min_travel_z, minimum_z_height)
         return min_travel_z
 
-    def get_labware_parent_position(self, labware_id: str) -> Point:
-        """Get the position of the labware's parent slot (deck or module)."""
+    def get_labware_parent_origin_position(self, labware_id: str) -> Point:
+        """Get the position of the labware's uncalibrated parent slot (deck or module)."""
         labware_data = self._labware.get(labware_id)
         module_id: Optional[str] = None
-
         if isinstance(labware_data.location, DeckSlotLocation):
             slot_name = labware_data.location.slotName
         elif isinstance(labware_data.location, ModuleLocation):
@@ -108,12 +108,11 @@ class GeometryView:
             )
 
         slot_pos = self._labware.get_slot_position(slot_name)
-
         if module_id is None:
             return slot_pos
         else:
             deck_type = DeckType(self._labware.get_deck_definition()["otId"])
-            module_offset = self._modules.get_module_offset(
+            module_offset = self._modules.get_nominal_module_offset(
                 module_id=module_id, deck_type=deck_type
             )
             return Point(
@@ -121,6 +120,20 @@ class GeometryView:
                 y=slot_pos.y + module_offset.y,
                 z=slot_pos.z + module_offset.z,
             )
+
+    def get_labware_parent_position(self, labware_id: str) -> Point:
+        """Get the calibrated position of the labware's parent slot (deck or module)."""
+        parent_pos = self.get_labware_parent_origin_position(labware_id)
+        cal_offset = ModuleOffsetVector(x=0, y=0, z=0)
+        labware_data = self._labware.get(labware_id)
+        if isinstance(labware_data.location, ModuleLocation):
+            module_id = labware_data.location.moduleId
+            cal_offset = self._modules.get_module_offset_vector(module_id)
+        return Point(
+            x=parent_pos.x + cal_offset.x,
+            y=parent_pos.y + cal_offset.y,
+            z=parent_pos.z + cal_offset.z,
+        )
 
     def get_labware_origin_position(self, labware_id: str) -> Point:
         """Get the position of the labware's origin, without calibration."""
@@ -155,21 +168,33 @@ class GeometryView:
         well_def = self._labware.get_well_definition(labware_id, well_name)
         well_depth = well_def.depth
 
+        offset = WellOffset(x=0, y=0, z=well_depth)
         if well_location is not None:
             offset = well_location.offset
-
             if well_location.origin == WellOrigin.TOP:
                 offset = offset.copy(update={"z": offset.z + well_depth})
             elif well_location.origin == WellOrigin.CENTER:
                 offset = offset.copy(update={"z": offset.z + well_depth / 2.0})
 
-        else:
-            offset = WellOffset(x=0, y=0, z=well_depth)
-
         return Point(
             x=labware_pos.x + offset.x + well_def.x,
             y=labware_pos.y + offset.y + well_def.y,
             z=labware_pos.z + offset.z + well_def.z,
+        )
+
+    def get_nominal_well_position(
+        self,
+        labware_id: str,
+        well_name: str,
+    ) -> Point:
+        """Get the well position without calibration offsets."""
+        parent_pos = self.get_labware_parent_origin_position(labware_id)
+        origin_offset = self._labware.get_definition(labware_id).cornerOffsetFromSlot
+        well_def = self._labware.get_well_definition(labware_id, well_name)
+        return Point(
+            x=parent_pos.x + origin_offset.x + well_def.x,
+            y=parent_pos.y + origin_offset.y + well_def.y,
+            z=parent_pos.z + origin_offset.z + well_def.z + well_def.depth,
         )
 
     def get_relative_well_location(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -630,8 +630,8 @@ class ModuleView(HasState[ModuleState]):
         """Get the specified module's dimensions."""
         return self.get_definition(module_id).dimensions
 
-    def get_raw_module_offset(self, module_id: str) -> ModuleOffsetVector:
-        """Get the stored module calibration offset without transforms."""
+    def get_module_offset_vector(self, module_id: str) -> ModuleOffsetVector:
+        """Get the stored module calibration offset."""
         module_serial = self.get(module_id).serialNumber
         if module_serial is not None:
             offset = self._state.module_offset_by_serial.get(module_serial)
@@ -639,7 +639,7 @@ class ModuleView(HasState[ModuleState]):
                 return offset
         return ModuleOffsetVector(x=0, y=0, z=0)
 
-    def get_module_offset(
+    def get_nominal_module_offset(
         self, module_id: str, deck_type: DeckType
     ) -> LabwareOffsetVector:
         """Get the module's offset vector computed with slot transform."""
@@ -663,13 +663,24 @@ class ModuleView(HasState[ModuleState]):
         # Apply the slot transform, if any
         xform = array(xforms_ser_offset)
         xformed = dot(xform, pre_transform)  # type: ignore[no-untyped-call]
+        return LabwareOffsetVector(
+            x=xformed[0],
+            y=xformed[1],
+            z=xformed[2],
+        )
+
+    def get_module_offset(
+        self, module_id: str, deck_type: DeckType
+    ) -> LabwareOffsetVector:
+        """Get the module's offset vector computed with slot transform and calibrated module offsets."""
+        offset_vector = self.get_nominal_module_offset(module_id, deck_type)
 
         # add the calibrated module offset if there is one
-        module_offset = self.get_raw_module_offset(module_id)
+        module_offset = self.get_module_offset_vector(module_id)
         return LabwareOffsetVector(
-            x=xformed[0] + module_offset.x,
-            y=xformed[1] + module_offset.y,
-            z=xformed[2] + module_offset.z,
+            x=offset_vector.x + module_offset.x,
+            y=offset_vector.y + module_offset.y,
+            z=offset_vector.z + module_offset.z,
         )
 
     def get_overall_height(self, module_id: str) -> float:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -630,7 +630,7 @@ class ModuleView(HasState[ModuleState]):
         """Get the specified module's dimensions."""
         return self.get_definition(module_id).dimensions
 
-    def get_module_offset_vector(self, module_id: str) -> ModuleOffsetVector:
+    def get_module_calibration_offset(self, module_id: str) -> ModuleOffsetVector:
         """Get the stored module calibration offset."""
         module_serial = self.get(module_id).serialNumber
         if module_serial is not None:
@@ -676,11 +676,11 @@ class ModuleView(HasState[ModuleState]):
         offset_vector = self.get_nominal_module_offset(module_id, deck_type)
 
         # add the calibrated module offset if there is one
-        module_offset = self.get_module_offset_vector(module_id)
+        cal_offset = self.get_module_calibration_offset(module_id)
         return LabwareOffsetVector(
-            x=offset_vector.x + module_offset.x,
-            y=offset_vector.y + module_offset.y,
-            z=offset_vector.z + module_offset.z,
+            x=offset_vector.x + cal_offset.x,
+            y=offset_vector.y + cal_offset.y,
+            z=offset_vector.z + cal_offset.z,
         )
 
     def get_overall_height(self, module_id: str) -> float:

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -60,7 +60,7 @@ async def test_calibrate_module_implementation(
         location
     )
     decoy.when(
-        subject._state_view.modules.get_module_offset_vector(module_id)
+        subject._state_view.modules.get_module_calibration_offset(module_id)
     ).then_return(ModuleOffsetVector(x=0, y=0, z=0))
     decoy.when(
         subject._state_view.geometry.get_nominal_well_position(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -59,6 +59,9 @@ async def test_calibrate_module_implementation(
     decoy.when(subject._state_view.modules.get_location(module_id)).then_return(
         location
     )
+    decoy.when(subject._state_view.modules.get_raw_module_offset(module_id)).then_return(
+        ModuleOffsetVector(x=0, y=0, z=0)
+    )
     decoy.when(
         subject._state_view.geometry.get_well_position(
             labware_id=labware_id, well_name="B1"

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -59,11 +59,11 @@ async def test_calibrate_module_implementation(
     decoy.when(subject._state_view.modules.get_location(module_id)).then_return(
         location
     )
-    decoy.when(subject._state_view.modules.get_raw_module_offset(module_id)).then_return(
-        ModuleOffsetVector(x=0, y=0, z=0)
-    )
     decoy.when(
-        subject._state_view.geometry.get_well_position(
+        subject._state_view.modules.get_module_offset_vector(module_id)
+    ).then_return(ModuleOffsetVector(x=0, y=0, z=0))
+    decoy.when(
+        subject._state_view.geometry.get_nominal_well_position(
             labware_id=labware_id, well_name="B1"
         )
     ).then_return(Point(x=3, y=2, z=1))

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -143,7 +143,7 @@ def test_get_labware_parent_position_on_module(
             module_id="module-id", deck_type=DeckType.OT2_STANDARD
         )
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
-    decoy.when(module_view.get_module_offset_vector("module-id")).then_return(
+    decoy.when(module_view.get_module_calibration_offset("module-id")).then_return(
         ModuleOffsetVector(x=0, y=0, z=0)
     )
 
@@ -254,7 +254,7 @@ def test_get_module_labware_highest_z(
         )
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
     decoy.when(module_view.get_height_over_labware("module-id")).then_return(0.5)
-    decoy.when(module_view.get_module_offset_vector("module-id")).then_return(
+    decoy.when(module_view.get_module_calibration_offset("module-id")).then_return(
         ModuleOffsetVector(x=0, y=0, z=0)
     )
 
@@ -550,7 +550,7 @@ def test_get_module_labware_well_position(
             module_id="module-id", deck_type=DeckType.OT2_STANDARD
         )
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
-    decoy.when(module_view.get_module_offset_vector("module-id")).then_return(
+    decoy.when(module_view.get_module_calibration_offset("module-id")).then_return(
         ModuleOffsetVector(x=0, y=0, z=0)
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -17,6 +17,7 @@ from opentrons.protocol_engine.types import (
     LabwareOffsetVector,
     DeckSlotLocation,
     ModuleLocation,
+    ModuleOffsetVector,
     LoadedLabware,
     LoadedModule,
     WellLocation,
@@ -138,10 +139,13 @@ def test_get_labware_parent_position_on_module(
     )
     decoy.when(labware_view.get_deck_definition()).then_return(standard_deck_def)
     decoy.when(
-        module_view.get_module_offset(
+        module_view.get_nominal_module_offset(
             module_id="module-id", deck_type=DeckType.OT2_STANDARD
         )
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
+    decoy.when(module_view.get_module_offset_vector("module-id")).then_return(
+        ModuleOffsetVector(x=0, y=0, z=0)
+    )
 
     result = subject.get_labware_parent_position("labware-id")
 
@@ -245,11 +249,14 @@ def test_get_module_labware_highest_z(
     )
     decoy.when(labware_view.get_deck_definition()).then_return(standard_deck_def)
     decoy.when(
-        module_view.get_module_offset(
+        module_view.get_nominal_module_offset(
             module_id="module-id", deck_type=DeckType.OT2_STANDARD
         )
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
     decoy.when(module_view.get_height_over_labware("module-id")).then_return(0.5)
+    decoy.when(module_view.get_module_offset_vector("module-id")).then_return(
+        ModuleOffsetVector(x=0, y=0, z=0)
+    )
 
     highest_z = subject.get_labware_highest_z("labware-id")
 
@@ -539,13 +546,15 @@ def test_get_module_labware_well_position(
     )
     decoy.when(labware_view.get_deck_definition()).then_return(standard_deck_def)
     decoy.when(
-        module_view.get_module_offset(
+        module_view.get_nominal_module_offset(
             module_id="module-id", deck_type=DeckType.OT2_STANDARD
         )
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
+    decoy.when(module_view.get_module_offset_vector("module-id")).then_return(
+        ModuleOffsetVector(x=0, y=0, z=0)
+    )
 
     result = subject.get_well_position("labware-id", "B2")
-
     assert result == Point(
         x=slot_pos[0] + 1 + well_def.x + 4,
         y=slot_pos[1] - 2 + well_def.y + 5,

--- a/hardware-testing/hardware_testing/scripts/module_calibration.py
+++ b/hardware-testing/hardware_testing/scripts/module_calibration.py
@@ -1,7 +1,8 @@
 """OT-3 Module Calibration Script."""
 import argparse
+from time import sleep
 from traceback import print_exc
-from typing import Optional
+from typing import Optional, List
 import requests
 
 
@@ -35,69 +36,85 @@ BASE_URL = "http://{}:31950"
 PARAMS = {"waitUntilComplete": "true"}
 
 
-def _home_z(ip_addr: str) -> None:
+def _home(ip_addr: str, axes: Optional[List[str]] = None) -> None:
     """Home the z axis for the instrument."""
-    # Home the instrument axis so we are at a known state
-    print("Homing z axis")
-    home_z = {"data": {"commandType": "home", "params": {"axes": ["leftZ", "rightZ"]}}}
+    axes = axes or list()
+    print(f"Homing {axes} axes")
+    home = {"data": {"commandType": "home", "params": {"axes": axes}}}
     url = f"{BASE_URL.format(ip_addr)}/commands"
-    requests.post(headers=HEADERS, url=url, json=home_z, params=PARAMS)
+    requests.post(headers=HEADERS, url=url, json=home, params=PARAMS)
+
+
+def _get_current_run(ip_addr: str) -> Optional[str]:
+    url = f"{BASE_URL.format(ip_addr)}/runs"
+    res = requests.get(headers=HEADERS, url=url)
+    runs = res.json()["data"]
+    active_run = None
+    for run in runs:
+        if run["current"]:
+            active_run = run["id"]
+            break
+    return active_run
 
 
 def _create_run(ip_addr: str) -> Optional[str]:
     """Create an empty run."""
-    print("Creating new run.")
     url = f"{BASE_URL.format(ip_addr)}/runs"
     res = requests.post(headers=HEADERS, url=url)
     if res.status_code != 201:
         return None
     # get the run id
-    return res.json()["data"]["id"]
+    return res.json()["data"].get("id")
 
 
-def _cancel_run(ip_addr: str, run_id: str) -> bool:
-    """Cancel the run."""
-    print(f"Canceling run {run_id}")
+def _cancel_run(ip_addr: str, run_id: Optional[str] = None) -> bool:
+    run_id = run_id or _get_current_run(ip_addr)
+    print(f"Finishing run {run_id}")
     stop = {"data": {"actionType": "stop"}}
     url = f"{BASE_URL.format(ip_addr)}/runs/{run_id}/actions"
     res = requests.post(headers=HEADERS, params=PARAMS, url=url, json=stop)
-    return res.status_code == 201
+    sleep(1)  # give some time to cancel the run
+    # delete the run
+    url = f"{BASE_URL.format(ip_addr)}/runs/{run_id}"
+    res = requests.delete(headers=HEADERS, params=PARAMS, url=url)
+    return _get_current_run(ip_addr) is None
 
 
 def _main(args: argparse.Namespace) -> None:
     base_url = f"{BASE_URL.format(args.host)}"
-
-    # Collect all runs
-    res = requests.get(headers=HEADERS, url=f"{base_url}/runs")
-    runs = res.json()["data"]
-    active_run = None
-    for run in runs:
-        if run["current"]:
-            active_run = run
-            break
-
-    if active_run:
-        choice = input("There is a run in progress, do you want to cancel it? y/n\n")
+    # check if there is an active run
+    run_id = _get_current_run(args.host)
+    if run_id:
+        choice = input(
+            f"{run_id} There is a run in progress, do you want to cancel it? y/n\n"
+        )
         if choice.lower() in "no":
             print("Not canceling existing run, exiting.\n")
             exit(1)
-
         # Cancel the run
-        run_id = active_run["id"]
         if not _cancel_run(args.host, run_id):
-            print("Could not cancel run.")
-            exit(1)
+            raise RuntimeError("Could not cancel run.")
 
     # Create a new run
     run_id = _create_run(args.host)
     if not run_id:
-        print("Could not create run.")
-        exit(1)
+        raise RuntimeError("Could not create run.")
 
     url = f"{base_url}/runs/{run_id}/commands"
 
-    # Home the instrument axis so we are at a known state
-    _home_z(args.host)
+    # Home all axes so we are at a known state
+    _home(args.host, ["leftZ"])
+
+    # Make sure the module is attached
+    res = requests.get(headers=HEADERS, params=PARAMS, url=f"{base_url}/modules")
+    if res.status_code != 200:
+        raise RuntimeError("Error fetching modules attached.")
+    modules = res.json().get("data", [])
+    for module in modules:
+        if module.get("moduleModel") == args.model:
+            break
+    else:
+        raise RuntimeError(f"Module {args.model} was not detected.")
 
     # load the module based on the model
     print(f"Loading the module {args.model} at slot {args.slot}")
@@ -108,10 +125,13 @@ def _main(args: argparse.Namespace) -> None:
         }
     }
     res = requests.post(headers=HEADERS, params=PARAMS, url=url, json=load_module)
-    if res.status_code != 201:
-        print("Error loading module")
-        exit(1)
-    module_id = res.json()["data"]["result"]["moduleId"]
+    data = res.json().get("data")
+    error = data.get("error")
+    if res.status_code != 201 or error:
+        error_type = error.get("errorType")
+        error_details = error.get("detail")
+        raise RuntimeErrorf("Error loading module: {error_type} - {error_details}")
+    module_id = data["result"]["moduleId"]
 
     # load the calibration labware for the specific module
     print(f"Loading the calibration adapter at slot {args.slot}")
@@ -127,10 +147,14 @@ def _main(args: argparse.Namespace) -> None:
         }
     }
     res = requests.post(headers=HEADERS, params=PARAMS, url=url, json=load_labware)
-    if res.status_code != 201:
-        print("Error loading labware")
-        exit(1)
-    labware_id = res.json()["data"]["result"]["labwareId"]
+    data = res.json().get("data")
+    error = data.get("error")
+    if res.status_code != 201 or error:
+        error_type = error.get("errorType")
+        error_details = error.get("detail")
+        msg = f"Error loading labware: {error_type} - {error_details}"
+        raise RuntimeError(msg)
+    labware_id = data["result"]["labwareId"]
 
     # calibrate the module
     print(f"Calibrating {args.model} at slot {args.slot} with mount {args.mount}")
@@ -146,13 +170,16 @@ def _main(args: argparse.Namespace) -> None:
     }
 
     res = requests.post(headers=HEADERS, params=PARAMS, url=url, json=calibrate_module)
-    if res.status_code != 201 or not res.json()["data"].get("result"):
-        error = res.json()["data"]["error"]
+    data = res.json().get("data")
+    error = data.get("error")
+    if res.status_code != 201 or error:
         error_type = error.get("errorType")
         error_details = error.get("detail")
-        print(f"Failed to calibrate module {args.model} {error_type} - {error_details}")
-        return
+        msg = f"Failed to calibrate module {args.model}: {error_type} - {error_details}"
+        raise RuntimeError(msg)
 
+    # Finish and print result
+    _cancel_run(args.host, run_id)
     calibration_offset = res.json()["data"]["result"]["moduleOffset"]
     print(f"Calibration result {calibration_offset}")
 
@@ -185,7 +212,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     try:
         _main(args)
-    except Exception:
-        print("Unhandled exception")
-        print_exc()
-        _home_z(args.host)
+    except Exception as e:
+        print(e)
+        _cancel_run(args.host)
+    finally:
+        # home the gantry
+        _home(args.host, ["leftZ", "rightZ"])

--- a/hardware-testing/hardware_testing/scripts/module_calibration.py
+++ b/hardware-testing/hardware_testing/scripts/module_calibration.py
@@ -103,7 +103,7 @@ def _main(args: argparse.Namespace) -> None:
     url = f"{base_url}/runs/{run_id}/commands"
 
     # Home all axes so we are at a known state
-    _home(args.host, ["leftZ"])
+    _home(args.host)
 
     # Make sure the module is attached
     res = requests.get(headers=HEADERS, params=PARAMS, url=f"{base_url}/modules")

--- a/hardware-testing/hardware_testing/scripts/module_calibration.py
+++ b/hardware-testing/hardware_testing/scripts/module_calibration.py
@@ -1,7 +1,6 @@
 """OT-3 Module Calibration Script."""
 import argparse
 from time import sleep
-from traceback import print_exc
 from typing import Optional, List
 import requests
 
@@ -72,11 +71,11 @@ def _cancel_run(ip_addr: str, run_id: Optional[str] = None) -> bool:
     print(f"Finishing run {run_id}")
     stop = {"data": {"actionType": "stop"}}
     url = f"{BASE_URL.format(ip_addr)}/runs/{run_id}/actions"
-    res = requests.post(headers=HEADERS, params=PARAMS, url=url, json=stop)
+    requests.post(headers=HEADERS, params=PARAMS, url=url, json=stop)
     sleep(1)  # give some time to cancel the run
     # delete the run
     url = f"{BASE_URL.format(ip_addr)}/runs/{run_id}"
-    res = requests.delete(headers=HEADERS, params=PARAMS, url=url)
+    requests.delete(headers=HEADERS, params=PARAMS, url=url)
     return _get_current_run(ip_addr) is None
 
 
@@ -130,7 +129,7 @@ def _main(args: argparse.Namespace) -> None:
     if res.status_code != 201 or error:
         error_type = error.get("errorType")
         error_details = error.get("detail")
-        raise RuntimeErrorf("Error loading module: {error_type} - {error_details}")
+        raise RuntimeError(f"Error loading module: {error_type} - {error_details}")
     module_id = data["result"]["moduleId"]
 
     # load the calibration labware for the specific module

--- a/shared-data/labware/definitions/2/opentrons_calibration_adapter_thermocycler_module/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibration_adapter_thermocycler_module/1.json
@@ -22,8 +22,8 @@
       "shape": "rectangular",
       "xDimension": 20,
       "yDimension": 20,
-      "x": 97.88,
-      "y": 42.74,
+      "x": 92.88,
+      "y": 40.25,
       "z": 22.75
     },
     "B1": {
@@ -31,8 +31,8 @@
       "totalLiquidVolume": 0,
       "shape": "circular",
       "diameter": 1,
-      "x": 110.88,
-      "y": 55.74,
+      "x": 105.88,
+      "y": 53.25,
       "z": 27.5
     }
   },


### PR DESCRIPTION
# Overview

Module Calibrations were failing because the calibration starting position was being shifted by the previous module calibration value for the given module, which meant that eventually the starting position would be way off-center and would not be able to find the calibration square. This PR addresses this issue and fixes another issue with non-connected modules (magnetic block) where we would throw `ModuleNotConnectedError` when trying to get the labware well position.

Closes: [RCORE-738](https://opentrons.atlassian.net/browse/RCORE-738)

# Test Plan

- [x] Make sure subsequent module calibrations start at the same position for each module type
- [x] Make sure we don't throw `ModuleNotConnectedError` when getting the position for labware on top of the magnetic block.

# Changelog

- Fixed an issue where the starting point for module calibrations would be off by the previous module offset causing subsequent module calibrations to fail.
- Fixed a potential issue in get_module_offset if the module is a non-connected module where just getting the well position would throw ModuleNotConnectedError, instead, we want to return the offset without the calibrated offset value.
- Added get_raw_module_offset so we can get the loaded module offsets without transforms
- Refactored the calibrate_module test script so it handles needing to home after robot-server restart, resetting states, and generally handling failure cases better.

# Review requests

Make sure we are comfortable with the get_module_changes which affect get_well_position

# Risk assessment

medium, while this affects module calibration directly any changes to get_module_offset also affect get_well_position


[RCORE-738]: https://opentrons.atlassian.net/browse/RCORE-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ