### PR TITLE
feat(engine): drop tip in place for Protocol Engine

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -94,6 +94,14 @@ from .drop_tip import (
     DropTipCommandType,
 )
 
+from .drop_tip_in_place import (
+    DropTipInPlace,
+    DropTipInPlaceParams,
+    DropTipInPlaceCreate,
+    DropTipInPlaceResult,
+    DropTipInPlaceCommandType,
+)
+
 from .home import (
     Home,
     HomeParams,
@@ -290,6 +298,12 @@ __all__ = [
     "DropTipParams",
     "DropTipResult",
     "DropTipCommandType",
+    # drop tip in place command models
+    "DropTipInPlace",
+    "DropTipInPlaceCreate",
+    "DropTipInPlaceParams",
+    "DropTipInPlaceResult",
+    "DropTipInPlaceCommandType",
     # home command models
     "Home",
     "HomeParams",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -73,6 +73,14 @@ from .drop_tip import (
     DropTipCommandType,
 )
 
+from .drop_tip_in_place import (
+    DropTipInPlace,
+    DropTipInPlaceParams,
+    DropTipInPlaceCreate,
+    DropTipInPlaceResult,
+    DropTipInPlaceCommandType,
+)
+
 from .home import (
     Home,
     HomeParams,
@@ -211,6 +219,7 @@ Command = Union[
     BlowOut,
     BlowOutInPlace,
     DropTip,
+    DropTipInPlace,
     Home,
     LoadLabware,
     LoadLiquid,
@@ -263,6 +272,7 @@ CommandParams = Union[
     BlowOutParams,
     BlowOutInPlaceParams,
     DropTipParams,
+    DropTipInPlaceParams,
     HomeParams,
     LoadLabwareParams,
     LoadLiquidParams,
@@ -316,6 +326,7 @@ CommandType = Union[
     BlowOutCommandType,
     BlowOutInPlaceCommandType,
     DropTipCommandType,
+    DropTipInPlaceCommandType,
     HomeCommandType,
     LoadLabwareCommandType,
     LoadLiquidCommandType,
@@ -368,6 +379,7 @@ CommandCreate = Union[
     BlowOutCreate,
     BlowOutInPlaceCreate,
     DropTipCreate,
+    DropTipInPlaceCreate,
     HomeCreate,
     LoadLabwareCreate,
     LoadLiquidCreate,
@@ -420,6 +432,7 @@ CommandResult = Union[
     BlowOutResult,
     BlowOutInPlaceResult,
     DropTipResult,
+    DropTipInPlaceResult,
     HomeResult,
     LoadLabwareResult,
     LoadLiquidResult,

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -1,8 +1,5 @@
 """Dispense-in-place command request, result, and implementation models."""
 
-# TODO(mm, 2022-08-15): This command is not yet in the JSON protocol schema.
-# Before our production code emits this command, we must add it to the schema,
-# and probably bump the schema version.
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -1,0 +1,75 @@
+"""Drop tip in place command request, result, and implementation models."""
+from __future__ import annotations
+from pydantic import Field, BaseModel
+from typing import TYPE_CHECKING, Optional, Type
+from typing_extensions import Literal
+
+from .pipetting_common import PipetteIdMixin
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import TipHandler
+
+
+DropTipInPlaceCommandType = Literal["dropTipInPlace"]
+
+
+class DropTipInPlaceParams(PipetteIdMixin):
+    """Payload required to drop a tip in place."""
+
+    homeAfter: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether to home this pipette's plunger after dropping the tip."
+            " You should normally leave this unspecified to let the robot choose"
+            " a safe default depending on its hardware."
+        ),
+    )
+
+
+class DropTipInPlaceResult(BaseModel):
+    """Result data from the execution of a DropTipInPlace command."""
+
+    pass
+
+
+class DropTipInPlaceImplementation(
+    AbstractCommandImpl[DropTipInPlaceParams, DropTipInPlaceResult]
+):
+    """Drop tip in place command implementation."""
+
+    def __init__(
+        self,
+        tip_handler: TipHandler,
+        **kwargs: object,
+    ) -> None:
+        self._tip_handler = tip_handler
+
+    async def execute(self, params: DropTipInPlaceParams) -> DropTipInPlaceResult:
+        """Drop a tip using the requested pipette."""
+        await self._tip_handler.drop_tip(
+            pipette_id=params.pipetteId, home_after=params.homeAfter
+        )
+
+        return DropTipInPlaceResult()
+
+
+class DropTipInPlace(BaseCommand[DropTipInPlaceParams, DropTipInPlaceResult]):
+    """Drop tip in place command model."""
+
+    commandType: DropTipInPlaceCommandType = "dropTipInPlace"
+    params: DropTipInPlaceParams
+    result: Optional[DropTipInPlaceResult]
+
+    _ImplementationCls: Type[
+        DropTipInPlaceImplementation
+    ] = DropTipInPlaceImplementation
+
+
+class DropTipInPlaceCreate(BaseCommandCreate[DropTipInPlaceParams]):
+    """Drop tip in place command creation request model."""
+
+    commandType: DropTipInPlaceCommandType = "dropTipInPlace"
+    params: DropTipInPlaceParams
+
+    _CommandCls: Type[DropTipInPlace] = DropTipInPlace

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -28,6 +28,7 @@ from ..commands import (
     MoveRelativeResult,
     PickUpTipResult,
     DropTipResult,
+    DropTipInPlaceResult,
     HomeResult,
     BlowOutResult,
     TouchTipResult,
@@ -167,7 +168,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.attached_tip_by_id[pipette_id] = attached_tip
             self._state.aspirated_volume_by_id[pipette_id] = 0
 
-        elif isinstance(command.result, DropTipResult):
+        elif isinstance(command.result, (DropTipResult, DropTipInPlaceResult)):
             pipette_id = command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -10,7 +10,13 @@ from ..actions import (
     ResetTipsAction,
     AddPipetteConfigAction,
 )
-from ..commands import Command, LoadLabwareResult, PickUpTipResult, DropTipResult
+from ..commands import (
+    Command,
+    LoadLabwareResult,
+    PickUpTipResult,
+    DropTipResult,
+    DropTipInPlaceResult,
+)
 
 
 class TipRackWellState(Enum):
@@ -91,7 +97,7 @@ class TipStore(HasState[TipState], HandlesActions):
             )
             self._state.length_by_pipette_id[pipette_id] = length
 
-        elif isinstance(command.result, DropTipResult):
+        elif isinstance(command.result, (DropTipResult, DropTipInPlaceResult)):
             pipette_id = command.params.pipetteId
             self._state.length_by_pipette_id.pop(pipette_id, None)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -1,4 +1,4 @@
-"""Test pick up tip commands."""
+"""Test drop tip commands."""
 import pytest
 from decoy import Decoy
 

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -1,0 +1,36 @@
+"""Test drop tip in place commands."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.execution import TipHandler
+
+from opentrons.protocol_engine.commands.drop_tip_in_place import (
+    DropTipInPlaceParams,
+    DropTipInPlaceResult,
+    DropTipInPlaceImplementation,
+)
+
+
+@pytest.fixture
+def mock_tip_handler(decoy: Decoy) -> TipHandler:
+    """Get a mock TipHandler."""
+    return decoy.mock(cls=TipHandler)
+
+
+async def test_drop_tip_implementation(
+    decoy: Decoy,
+    mock_tip_handler: TipHandler,
+) -> None:
+    """A DropTip command should have an execution implementation."""
+    subject = DropTipInPlaceImplementation(tip_handler=mock_tip_handler)
+
+    params = DropTipInPlaceParams(pipetteId="abc", homeAfter=False)
+
+    result = await subject.execute(params)
+
+    assert result == DropTipInPlaceResult()
+
+    decoy.verify(
+        await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),
+        times=1,
+    )

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -300,6 +300,24 @@ def create_drop_tip_command(
     )
 
 
+def create_drop_tip_in_place_command(
+    pipette_id: str,
+) -> cmd.DropTipInPlace:
+    """Get a completed DropTip command."""
+    params = cmd.DropTipInPlaceParams(pipetteId=pipette_id)
+
+    result = cmd.DropTipInPlaceResult()
+
+    return cmd.DropTipInPlace(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime.now(),
+        params=params,
+        result=result,
+    )
+
+
 def create_move_to_well_command(
     pipette_id: str,
     labware_id: str = "labware-id",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -39,6 +39,7 @@ from .command_fixtures import (
     create_dispense_in_place_command,
     create_pick_up_tip_command,
     create_drop_tip_command,
+    create_drop_tip_in_place_command,
     create_touch_tip_command,
     create_move_to_well_command,
     create_blow_out_command,
@@ -118,6 +119,34 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
     subject.handle_action(UpdateCommandAction(command=drop_tip_command))
     assert subject.state.attached_tip_by_id["abc"] is None
     assert subject.state.aspirated_volume_by_id["abc"] is None
+
+
+def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
+    """It should clear tip and volume details after a drop tip in place."""
+    load_pipette_command = create_load_pipette_command(
+        pipette_id="xyz",
+        pipette_name=PipetteNameType.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+
+    pick_up_tip_command = create_pick_up_tip_command(
+        pipette_id="xyz", tip_volume=42, tip_length=101, tip_diameter=8.0
+    )
+
+    drop_tip_in_place_command = create_drop_tip_in_place_command(
+        pipette_id="xyz",
+    )
+
+    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
+    subject.handle_action(UpdateCommandAction(command=pick_up_tip_command))
+    assert subject.state.attached_tip_by_id["xyz"] == TipGeometry(
+        volume=42, length=101, diameter=8.0
+    )
+    assert subject.state.aspirated_volume_by_id["xyz"] == 0
+
+    subject.handle_action(UpdateCommandAction(command=drop_tip_in_place_command))
+    assert subject.state.attached_tip_by_id["xyz"] is None
+    assert subject.state.aspirated_volume_by_id["xyz"] is None
 
 
 def test_pipette_volume_adds_aspirate(subject: PipetteStore) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -59,26 +59,40 @@ def load_labware_command(labware_definition: LabwareDefinition) -> commands.Load
 
 @pytest.fixture
 def pick_up_tip_command() -> commands.PickUpTip:
-    """Get a load labware command value object."""
+    """Get a pick-up tip command value object."""
     return commands.PickUpTip.construct(  # type: ignore[call-arg]
         params=commands.PickUpTipParams.construct(
             pipetteId="pipette-id",
             labwareId="cool-labware",
             wellName="A1",
         ),
-        result=commands.PickUpTipResult.construct(position=DeckPoint(x=0, y=0, z=0)),
+        result=commands.PickUpTipResult.construct(
+            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
+        ),
     )
 
 
 @pytest.fixture
 def drop_tip_command() -> commands.DropTip:
-    """Get a load labware command value object."""
+    """Get a drop tip command value object."""
     return commands.DropTip.construct(  # type: ignore[call-arg]
-        params=commands.DropTipParams.construct(  # type: ignore[call-arg]
+        params=commands.DropTipParams.construct(
+            pipetteId="pipette-id",
             labwareId="cool-labware",
             wellName="A1",
         ),
         result=commands.DropTipResult.construct(position=DeckPoint(x=0, y=0, z=0)),
+    )
+
+
+@pytest.fixture
+def drop_tip_in_place_command() -> commands.DropTipInPlace:
+    """Get a drop tip in place command object."""
+    return commands.DropTipInPlace.construct(  # type: ignore[call-arg]
+        params=commands.DropTipInPlaceParams.construct(
+            pipetteId="pipette-id",
+        ),
+        result=commands.DropTipInPlaceResult.construct(),
     )
 
 
@@ -310,3 +324,53 @@ def test_has_tip_tip_rack(
     result = TipView(state=subject.state).has_clean_tip("cool-labware", "A1")
 
     assert result is True
+
+
+def test_drop_tip(
+    subject: TipStore,
+    load_labware_command: commands.LoadLabware,
+    pick_up_tip_command: commands.PickUpTip,
+    drop_tip_command: commands.DropTip,
+    drop_tip_in_place_command: commands.DropTipInPlace,
+) -> None:
+    """It should be able to reset tip tracking state."""
+    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.AddPipetteConfigAction(
+            pipette_id="pipette-id",
+            serial_number="pipette-serial",
+            config=LoadedStaticPipetteData(
+                channels=8,
+                max_volume=15,
+                min_volume=3,
+                model="gen a",
+                display_name="display name",
+                flow_rates=FlowRates(
+                    default_aspirate={},
+                    default_dispense={},
+                    default_blow_out={},
+                ),
+                return_tip_scale=0,
+                nominal_tip_overlap={},
+                nozzle_offset_z=1.23,
+                home_position=4.56,
+            ),
+        )
+    )
+    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+    result = TipView(subject.state).get_tip_length("pipette-id")
+    assert result == 1.23
+
+    subject.handle_action(actions.UpdateCommandAction(command=drop_tip_command))
+    result = TipView(subject.state).get_tip_length("pipette-id")
+    assert result == 0
+
+    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+    result = TipView(subject.state).get_tip_length("pipette-id")
+    assert result == 1.23
+
+    subject.handle_action(
+        actions.UpdateCommandAction(command=drop_tip_in_place_command)
+    )
+    result = TipView(subject.state).get_tip_length("pipette-id")
+    assert result == 0

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -333,7 +333,7 @@ def test_drop_tip(
     drop_tip_command: commands.DropTip,
     drop_tip_in_place_command: commands.DropTipInPlace,
 ) -> None:
-    """It should be able to reset tip tracking state."""
+    """It should be clear tip length when a tip is dropped."""
     subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
     subject.handle_action(
         actions.AddPipetteConfigAction(

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -30,6 +30,9 @@
       "$ref": "#/definitions/DropTipCreate"
     },
     {
+      "$ref": "#/definitions/DropTipInPlaceCreate"
+    },
+    {
       "$ref": "#/definitions/HomeCreate"
     },
     {
@@ -731,6 +734,54 @@
         },
         "params": {
           "$ref": "#/definitions/DropTipParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "DropTipInPlaceParams": {
+      "title": "DropTipInPlaceParams",
+      "description": "Payload required to drop a tip in place.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "homeAfter": {
+          "title": "Homeafter",
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "type": "boolean"
+        }
+      },
+      "required": ["pipetteId"]
+    },
+    "DropTipInPlaceCreate": {
+      "title": "DropTipInPlaceCreate",
+      "description": "Drop tip in place command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "dropTipInPlace",
+          "enum": ["dropTipInPlace"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DropTipInPlaceParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",


### PR DESCRIPTION
# Overview

Addresses the `dropTipInPlace` implementation part of RSS-238.

This PR adds a `dropTipInPlace` command to the Protocol Engine. It uses the same `tip_handler` collobrator as `dropTip`, but without any of the associated movement parameters or actions. This PR does not change how the hardware api `drop_tip` implementation works, meaning this will fail if the robot does not think there is a tip attached.

# Test Plan

This command was tested on a robot using postman to ensure it functions as expected, purely dropping the tip in place without moving the gantry.

# Changelog

- added `dropTipInPlace` implementation to protocol engine

# Review requests

Do people have opinions on the `home_after` parameter? I took it straight from the original `dropTip` but open to removing it if we don't deem in necessary or useful.

# Risk assessment

Low, just adds a new command to the protocol engine.