### PR TITLE
feat(shared-data): add 96-Channel to pipette dev types

### DIFF
--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -1056,7 +1056,8 @@
         "p1000_single",
         "p1000_single_gen2",
         "p1000_single_gen3",
-        "p1000_multi_gen3"
+        "p1000_multi_gen3",
+        "p1000_96"
       ],
       "type": "string"
     },

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -58,7 +58,7 @@ class PipetteNameType(str, Enum):
     P1000_SINGLE_GEN2 = "p1000_single_gen2"
     P1000_SINGLE_GEN3 = "p1000_single_gen3"
     P1000_MULTI_GEN3 = "p1000_multi_gen3"
-    P1000_96 = 'p1000_96'
+    P1000_96 = "p1000_96"
 
 
 # Generic NewType for models because we get new ones frequently and theres

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -58,6 +58,7 @@ class PipetteNameType(str, Enum):
     P1000_SINGLE_GEN2 = "p1000_single_gen2"
     P1000_SINGLE_GEN3 = "p1000_single_gen3"
     P1000_MULTI_GEN3 = "p1000_multi_gen3"
+    P1000_96 = 'p1000_96'
 
 
 # Generic NewType for models because we get new ones frequently and theres


### PR DESCRIPTION
# Overview

Upon uploading a JSON protocol with a 96-channel, I ran into an error saying `p1000_96` wasn't a valid `PipetteNameType`. When adding it, the error is gone and the protocol no longer fails protocol analysis.

# Test Plan

upload a 96-channel JSON protocol to the app and verify that it works (ask me for the protocol 😄) 

# Changelog

add `p1000_96` to the `PipetteNameTypes`

# Review requests

do I need to change anything else?

# Risk assessment

low