### PR TITLE
fix(app): check if mixpanel events exist before opting out #12673

### DIFF
--- a/app/src/redux/analytics/mixpanel.ts
+++ b/app/src/redux/analytics/mixpanel.ts
@@ -65,8 +65,11 @@ export function setMixpanelTracking(
       })
     } else {
       log.debug('User has opted out of analytics; stopping tracking')
-      mixpanel.opt_out_tracking()
-      mixpanel.reset()
+      const config = mixpanel?.get_config?.()
+      if (config != null) {
+        mixpanel.opt_out_tracking?.()
+        mixpanel.reset?.()
+      }
     }
   }
 }


### PR DESCRIPTION
# Overview

This PR checks to see if a mixpanel config exists before attempting to invoke the opt out and reset methods. This is because internal testers were getting the error attached below if they opted out of analytics.


![image (1)](https://github.com/Opentrons/opentrons/assets/5788529/75fb1839-81b4-4791-bfd8-bc391ba32cf5)


# Review Requests

Because this issue cant be repro'd using make dev, and because we cant build mac osx versions locally because of python mismatch issues, im honestly not sure how to verify this fixes the issue other than checking the artifact CI generates to make sure the error goes away

