### PR TITLE
fix(app): fix calibration data source for run setup pipette flows

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -75,7 +75,7 @@ export function SetupPipetteCalibrationItem({
 
   if (pipetteInfo == null) return null
   const pipetteCalDate = isOT3
-    ? attachedPipettesForFlex[mount]?.data?.calibratedOffset.last_modified
+    ? attachedPipettesForFlex[mount]?.data?.calibratedOffset?.last_modified
     : pipetteInfo.pipetteCalDate
 
   const attached =
@@ -149,7 +149,6 @@ export function SetupPipetteCalibrationItem({
           <Flex>{pipetteMismatchInfo}</Flex>
           {isOT3 ? (
             <TertiaryButton
-              disabled={!isDeckCalibrated}
               id="PipetteCalibration_calibratePipetteButton"
               {...targetProps}
               onClick={() => setShowFlexPipetteFlow(true)}

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -28,7 +28,11 @@ import * as PipetteConstants from '../../../redux/pipettes/constants'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { PipetteWizardFlows } from '../../PipetteWizardFlows'
 import { FLOWS } from '../../PipetteWizardFlows/constants'
-import { useDeckCalibrationData, useIsOT3 } from '../hooks'
+import {
+  useDeckCalibrationData,
+  useAttachedPipettesFromInstrumentsQuery,
+  useIsOT3,
+} from '../hooks'
 import { SetupCalibrationItem } from './SetupCalibrationItem'
 
 import type { Mount } from '../../../redux/pipettes/types'
@@ -56,6 +60,7 @@ export function SetupPipetteCalibrationItem({
     false
   )
   const { isDeckCalibrated } = useDeckCalibrationData(robotName)
+  const attachedPipettesForFlex = useAttachedPipettesFromInstrumentsQuery()
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
 
   const isOT3 = useIsOT3(robotName)
@@ -69,6 +74,9 @@ export function SetupPipetteCalibrationItem({
   let pipetteMismatchInfo
 
   if (pipetteInfo == null) return null
+  const pipetteCalDate = isOT3
+    ? attachedPipettesForFlex[mount]?.data?.calibratedOffset.last_modified
+    : pipetteInfo.pipetteCalDate
 
   const attached =
     pipetteInfo.requestedPipetteMatch === PipetteConstants.INEXACT_MATCH ||
@@ -98,7 +106,7 @@ export function SetupPipetteCalibrationItem({
   }
 
   let flowType = ''
-  if (pipetteInfo.pipetteCalDate != null && attached) {
+  if (pipetteCalDate != null && attached) {
     button = pipetteMismatchInfo
   } else if (!attached) {
     subText = t('attach_pipette_calibration')
@@ -173,7 +181,7 @@ export function SetupPipetteCalibrationItem({
     )
   }
 
-  const attachedCalibratedDate = pipetteInfo.pipetteCalDate
+  const attachedCalibratedDate = pipetteCalDate ?? null
 
   return (
     <>

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -131,19 +131,21 @@ export function ProtocolInstrumentMountItem(
               )}
             </CalibrationStatus>
           </Flex>
-          <Flex flex="1">
-            <SmallButton
-              onClick={
-                attachedInstrument != null ? handleCalibrate : handleAttach
-              }
-              buttonText={i18n.format(
-                t(attachedInstrument != null ? 'calibrate' : 'attach'),
-                'capitalize'
-              )}
-              buttonType="primary"
-              buttonCategory="rounded"
-            />
-          </Flex>
+          {!isAttachedWithCal && (
+            <Flex flex="1">
+              <SmallButton
+                onClick={
+                  attachedInstrument != null ? handleCalibrate : handleAttach
+                }
+                buttonText={i18n.format(
+                  t(attachedInstrument != null ? 'calibrate' : 'attach'),
+                  'capitalize'
+                )}
+                buttonType="primary"
+                buttonCategory="rounded"
+              />
+            </Flex>
+          )}
         </Flex>
       </MountItem>
       {showPipetteWizardFlow ? (

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -94,7 +94,6 @@ describe('ProtocolInstrumentMountItem', () => {
     getByText('Left mount')
     getByText('Calibrated')
     getByText('Flex 8-Channel 1000 μL')
-    getByText('Calibrate')
   })
   it('renders the pipette with no cal data and the calibration button and clicking on it launches the correct flow ', () => {
     props = {

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -17,14 +17,14 @@ export const getPipetteWizardStepsForProtocol = (
   //  no pipette is required in the protocol
   if (
     (requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName &&
-      attachedPipettes[mount]?.data.calibratedOffset != null) ||
+      attachedPipettes[mount]?.data?.calibratedOffset?.last_modified != null) ||
     requiredPipette == null
   ) {
     return []
     //    return calibration flow only if correct pipette is attached and pipette cal null
   } else if (
     requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName &&
-    attachedPipettes[mount]?.data.calibratedOffset == null
+    attachedPipettes[mount]?.data?.calibratedOffset?.last_modified == null
   ) {
     return [
       {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fine tunes and fixes a few things I noticed while testing protocol setup pipette flows
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Test plan I executed:
1. View attached and calibrated pipette on desktop and ODD, see that this is properly reflected
2. View attached but not calibrated pipette on desktop and ODD, see that you are prompted to calibrate. Upon completing calibration, data should now be present

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Remove "calibrate" button from pipette mount item on ODD if the pipette is already calibrated
4. Grab calibration date from `/instruments` endpoint instead of `/pipettes` on desktop

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Ensure changes look sound

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
