### PR TITLE
build(app-shell): do not force mac code signing when in dev mode

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -72,7 +72,7 @@ module.exports = async () => ({
     category: 'public.app-category.productivity',
     type: DEV_MODE ? 'development' : 'distribution',
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
-    forceCodeSigning: true,
+    forceCodeSigning: !DEV_MODE,
     gatekeeperAssess: true,
   },
   dmg: {


### PR DESCRIPTION
# Overview

When building the app locally for mac osx we currently get a code signing error. This PR updates our electron builder config to only force code signing when not in dev mode. 


# Changelog

- Do not force mac code signing when in dev mode

# Risk assessment

Low
