### PR TITLE
fix(api): always move to maintenance position with mount critical point

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -7,6 +7,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType, Point
+from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -66,6 +67,7 @@ class MoveToMaintenancePositionImplementation(
         await self._hardware_api.move_to(
             mount=hardware_mount,
             abs_position=calibration_coordinates,
+            critical_point=CriticalPoint.MOUNT,
         )
 
         return MoveToMaintenancePositionResult()

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -64,6 +64,7 @@ class MoveToMaintenancePositionImplementation(
             offset=_INSTRUMENT_ATTACH_OFFSET
         )
 
+        # NOTE(bc, 2023-05-10): this is a direct diagonal movement, an arc movement would be safer
         await self._hardware_api.move_to(
             mount=hardware_mount,
             abs_position=calibration_coordinates,

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import Point, MountType, Mount
+from opentrons.hardware_control.types import CriticalPoint
 
 
 @pytest.fixture
@@ -40,6 +41,10 @@ async def test_calibration_move_to_location_implementation(
     assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
-        await hardware_api.move_to(mount=Mount.LEFT, abs_position=Point(x=1, y=2, z=3)),
+        await hardware_api.move_to(
+            mount=Mount.LEFT,
+            abs_position=Point(x=1, y=2, z=3),
+            critical_point=CriticalPoint.MOUNT,
+        ),
         times=1,
     )


### PR DESCRIPTION
# Overview

Instead of applying the maintenance position offset to the default critical point in the move_to_maintenance_position command, always use the MOUNT critical point.

Closes RQA-778

# Review requests

- Perform "Detach Pipette" Flow, the mount should descend as it does for "Attach Pipette"

# Risk assessment
low
