### PR TITLE
fix(app): exclude magnetic block from run setup module matching

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useUnmatchedModulesForProtocol.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useUnmatchedModulesForProtocol.test.tsx
@@ -24,6 +24,13 @@ const mockUseAttachedModules = useAttachedModules as jest.MockedFunction<
 >
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 
+const mockMagneticBlockDef = {
+  labwareOffset: { x: 5, y: 5, z: 5 },
+  moduleId: 'someMagneticBlock',
+  model: 'magneticBlockV1' as ModuleModel,
+  type: 'magneticBlockType' as ModuleType,
+  compatibleWith: [],
+}
 const mockMagneticModuleDef = {
   labwareOffset: { x: 5, y: 5, z: 5 },
   moduleId: 'someMagneticModule',
@@ -56,8 +63,26 @@ describe('useModuleMatchResults', () => {
     resetAllWhenMocks()
   })
 
-  it('should return no missing Module Ids if all modules present', () => {
+  it('should return no missing Module Ids if all connecting modules are present', () => {
     when(mockUseAttachedModules).calledWith().mockReturnValue([])
+    const moduleId = 'fakeMagBlockId'
+    when(mockUseModuleRenderInfoForProtocolById)
+      .calledWith(mockConnectedRobot.name, '1')
+      .mockReturnValue({
+        [moduleId]: {
+          moduleId: moduleId,
+          x: 0,
+          y: 0,
+          z: 0,
+          moduleDef: mockMagneticBlockDef as any,
+          nestedLabwareDef: null,
+          nestedLabwareId: null,
+          nestedLabwareDisplayName: null,
+          protocolLoadOrder: 0,
+          attachedModuleMatch: null,
+          slotName: '1',
+        },
+      })
 
     const { result } = renderHook(() =>
       useUnmatchedModulesForProtocol(mockConnectedRobot.name, '1')

--- a/app/src/organisms/Devices/hooks/useUnmatchedModulesForProtocol.ts
+++ b/app/src/organisms/Devices/hooks/useUnmatchedModulesForProtocol.ts
@@ -7,6 +7,13 @@ import {
   useModuleRenderInfoForProtocolById,
   useRobot,
 } from '.'
+import {
+  MAGNETIC_BLOCK_TYPE,
+  ModuleType,
+  getModuleType,
+} from '@opentrons/shared-data'
+
+const NON_CONNECTING_MODULE_TYPES: ModuleType[] = [MAGNETIC_BLOCK_TYPE]
 
 interface UnmatchedModuleResults {
   missingModuleIds: string[]
@@ -35,6 +42,8 @@ export function useUnmatchedModulesForProtocol(
     moduleRenderInfoById,
     (acc, { moduleDef }, id) => {
       const { model, compatibleWith } = moduleDef
+      // Skip matching any modules that don't require an electronic robot connection
+      if (NON_CONNECTING_MODULE_TYPES.includes(getModuleType(model))) return acc
       // for this required module, find a remaining (unmatched) attached module of the requested model
       const moduleTypeMatchIndex = acc.remainingAttachedModules.findIndex(
         attachedModule => {


### PR DESCRIPTION
# Overview

Because the magnetic block doesn't require a matched attached module in order to complete LPC or a protocol run, exclude it from the specced to attached module matching process during protocol setup.

Closes RQA-787


# Review requests

 - load -> do LPC -> start run of protocol with mag block 

# Risk assessment
low
