### PR TITLE
fix(app-shell-odd): do not access odd dir before initialization

### DIFF
--- a/app-shell-odd/src/config/index.ts
+++ b/app-shell-odd/src/config/index.ts
@@ -23,7 +23,7 @@ import type { Config, Overrides } from './types'
 
 export * from './types'
 
-export const ODD_DIR = '/data/ODD'
+const ODD_DIR = '/data/ODD'
 
 // Note (kj:03/02/2023) this file path will be updated when the embed team cleans up
 const BRIGHTNESS_FILE =

--- a/app-shell-odd/src/log.ts
+++ b/app-shell-odd/src/log.ts
@@ -5,11 +5,12 @@ import path from 'path'
 import dateFormat from 'dateformat'
 import winston from 'winston'
 
-import { ODD_DIR, getConfig } from './config'
+import { getConfig } from './config'
 
 import type Transport from 'winston-transport'
 import type { Config } from './config'
 
+const ODD_DIR = '/data/ODD'
 const LOG_DIR = path.join(ODD_DIR, 'logs')
 const ERROR_LOG = path.join(LOG_DIR, 'error.log')
 const COMBINED_LOG = path.join(LOG_DIR, 'combined.log')


### PR DESCRIPTION
# Overview

CI broke because the app-shell-odd's main file was trying to access a variable in another file before it actually initialized. This PR just copies the dir name so the app can build. 

# Review requests

run `make -C app dev-odd` and make sure the app starts on ODD mode.

# Risk assessment

Low
