### PR TITLE
feat(app): error handling for wrong pip attached

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -61,6 +61,7 @@
   "pipette_failed_to_attach": "unable to detect pipette",
   "pipette_failed_to_detach": "{{pipetteName}} still attached",
   "pipette_heavy": "The 96-Channel Pipette is heavy ({{weight}}). Ask a labmate for help, if needed.",
+  "please_install_correct_pip": "Please install {{pipetteName}}",
   "progress_will_be_lost": "{{flow}} progress will be lost",
   "reattach_carriage": "reattach z-axis carriage",
   "recalibrate_pipette": "recalibrate {{mount}} pipette",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -61,7 +61,7 @@
   "pipette_failed_to_attach": "unable to detect pipette",
   "pipette_failed_to_detach": "{{pipetteName}} still attached",
   "pipette_heavy": "The 96-Channel Pipette is heavy ({{weight}}). Ask a labmate for help, if needed.",
-  "please_install_correct_pip": "Please install {{pipetteName}}",
+  "please_install_correct_pip": "Install {{pipetteName}} instead",
   "progress_will_be_lost": "{{flow}} progress will be lost",
   "reattach_carriage": "reattach z-axis carriage",
   "recalibrate_pipette": "recalibrate {{mount}} pipette",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -25,6 +25,7 @@
   "detach_96_attach_mount": "Detach 96-Channel Pipette and Attach {{mount}} Pipette",
   "detach_96_channel": "Detach 96-Channel Pipette",
   "detach_and_reattach": "Detach and reattach pipette",
+  "detach_and_retry": "detach and retry",
   "detach_mount_attach_96": "Detach {{mount}} Pipette and Attach 96-Channel Pipette",
   "detach_mounting_plate_instructions": "Hold onto the plate so it does not fall. Then remove the pins on the plate from the slots on the gantry carriage.",
   "detach_pipette_to_attach_96": "Detach {{pipetteName}} and attach 96-Channel pipette",
@@ -76,5 +77,6 @@
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",
+  "wrong_pip": "wrong instrument installed",
   "z_axis_still_attached": "z-axis screw still secure"
 }

--- a/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CheckPipetteButton.tsx
@@ -7,8 +7,8 @@ interface CheckPipetteButtonProps {
   proceedButtonText: string
   setFetching: React.Dispatch<React.SetStateAction<boolean>>
   isFetching: boolean
-  proceed: () => void
   isOnDevice: boolean | null
+  proceed?: () => void
 }
 export const CheckPipetteButton = (
   props: CheckPipetteButtonProps
@@ -36,7 +36,7 @@ export const CheckPipetteButton = (
         setFetching(true)
         refetch()
           .then(() => {
-            proceed()
+            proceed?.()
           })
           .catch(() => {})
       }}
@@ -47,7 +47,7 @@ export const CheckPipetteButton = (
       onClick={() => {
         refetch()
           .then(() => {
-            proceed()
+            proceed?.()
           })
           .catch(() => {})
       }}

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -185,8 +185,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
         isOnDevice={isOnDevice}
       />
     )
-  }
-  if (
+  } else if (
     !isSuccess &&
     requiredPipette == null &&
     requiredPipDisplayName == null &&

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CheckPipetteButton.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { CheckPipetteButton } from '../CheckPipetteButton'
+import { waitFor } from '@testing-library/react'
 
 const render = (props: React.ComponentProps<typeof CheckPipetteButton>) => {
   return renderWithProviders(<CheckPipetteButton {...props} />)[0]
@@ -31,10 +32,11 @@ describe('CheckPipetteButton', () => {
   afterEach(() => {
     jest.resetAllMocks()
   })
-  it('clicking on the button calls refetch', () => {
+  it('clicking on the button calls refetch and proceed', async () => {
     const { getByRole } = render(props)
     getByRole('button', { name: 'continue' }).click()
     expect(refetch).toHaveBeenCalled()
+    await waitFor(() => expect(props.proceed).toHaveBeenCalled())
   })
   it('button is disabled when fetching is true', () => {
     const { getByRole } = render({ ...props, isFetching: true })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -293,7 +293,7 @@ describe('Results', () => {
     }
     const { getByText, getByRole } = render(props)
     getByText('Wrong instrument installed')
-    getByText('Please install Flex 8-Channel 50 μL')
+    getByText('Install Flex 8-Channel 50 μL instead')
     getByRole('button', { name: 'Detach and retry' }).click()
     await act(() => pipettePromise)
     expect(mockRefetchInstruments).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -268,4 +268,33 @@ describe('Results', () => {
     await act(() => pipettePromise)
     expect(mockRefetchInstruments).toHaveBeenCalled()
   })
+  it('renders the correct information when pipette succceeds to attach during run setup', () => {
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      requiredPipette: {
+        id: 'mockId',
+        pipetteName: 'p1000_single_gen3',
+        mount: LEFT,
+      },
+    }
+    const { getByText } = render(props)
+    getByText('Flex 1-Channel 1000 μL successfully attached')
+  })
+  it('renders the correct information when attaching wrong pipette for run setup', () => {
+    props = {
+      ...props,
+      flowType: FLOWS.ATTACH,
+      requiredPipette: {
+        id: 'mockId',
+        pipetteName: 'p50_multi_gen3',
+        mount: LEFT,
+      },
+    }
+    const { getByText, getByLabelText } = render(props)
+    getByText('Wrong instrument installed')
+    getByText('Detach and retry')
+    getByLabelText('Results_exit').click()
+    expect(props.goBack).toHaveBeenCalled()
+  })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -281,7 +281,7 @@ describe('Results', () => {
     const { getByText } = render(props)
     getByText('Flex 1-Channel 1000 μL successfully attached')
   })
-  it('renders the correct information when attaching wrong pipette for run setup', () => {
+  it('renders the correct information when attaching wrong pipette for run setup', async () => {
     props = {
       ...props,
       flowType: FLOWS.ATTACH,
@@ -291,10 +291,11 @@ describe('Results', () => {
         mount: LEFT,
       },
     }
-    const { getByText, getByLabelText } = render(props)
+    const { getByText, getByRole } = render(props)
     getByText('Wrong instrument installed')
-    getByText('Detach and retry')
-    getByLabelText('Results_exit').click()
-    expect(props.goBack).toHaveBeenCalled()
+    getByText('Please install Flex 8-Channel 50 μL')
+    getByRole('button', { name: 'Detach and retry' }).click()
+    await act(() => pipettePromise)
+    expect(mockRefetchInstruments).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -75,7 +75,9 @@ export const PipetteWizardFlows = (
           ),
     []
   )
-
+  const requiredPipette = props.pipetteInfo?.find(
+    pipette => pipette.mount === mount
+  )
   const host = useHost()
   const [maintenanceRunId, setMaintenanceRunId] = React.useState<string>('')
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
@@ -253,6 +255,7 @@ export const PipetteWizardFlows = (
         isFetching={isFetchingPipettes}
         setFetching={setIsFetchingPipettes}
         hasCalData={hasCalData}
+        requiredPipette={requiredPipette}
       />
     )
   } else if (currentStep.section === SECTIONS.MOUNT_PIPETTE) {


### PR DESCRIPTION
closes RLIQ-393

# Overview

When attaching a pipette in run setup, if you attach the wrong pipette, the results page now renders the error modal ([designs](https://www.figma.com/file/0hYQ4lFJbAAI33jQMRt1Di/Release%3A-Opentrons-App-w-Flex?type=design&node-id=4244-89424&t=puyJ3UtUhsrZYz3V-0)). When you click `detach and retry` it goes back to detach and reattach the correct pipette.

# Test Plan

test this flow on a robot to make sure it works as expected

# Changelog

- add error logic to `Results` page and add test cases

# Review requests

see test plan

# Risk assessment

low