### PR TITLE
fix(app): toast styling fixes

### DIFF
--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -268,7 +268,7 @@ export function Toast(props: ToastProps): JSX.Element {
         </Flex>
       </Flex>
       {closeText.length > 0 && (
-        <Link role="button" height={SPACING.spacing24}>
+        <Link role="button">
           <StyledText
             color={COLORS.darkBlackEnabled}
             fontSize={
@@ -281,6 +281,9 @@ export function Toast(props: ToastProps): JSX.Element {
             }
             lineHeight={
               showODDStyle ? TYPOGRAPHY.lineHeight28 : TYPOGRAPHY.lineHeight20
+            }
+            textDecoration={
+              showODDStyle ? 'none' : TYPOGRAPHY.textDecorationUnderline
             }
             textTransform={TYPOGRAPHY.textTransformCapitalize}
             whiteSpace="nowrap"

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -215,7 +215,8 @@ export function Toast(props: ToastProps): JSX.Element {
         <Icon
           name={icon?.name ?? toastStyleByType[type].iconName}
           color={toastStyleByType[type].color}
-          width={showODDStyle ? SPACING.spacing32 : SPACING.spacing16}
+          maxWidth={showODDStyle ? SPACING.spacing32 : SPACING.spacing16}
+          minWidth={showODDStyle ? SPACING.spacing32 : SPACING.spacing16}
           marginRight={SPACING.spacing8}
           spin={icon?.spin != null ? icon.spin : false}
           aria-label={`icon_${type}`}
@@ -261,6 +262,8 @@ export function Toast(props: ToastProps): JSX.Element {
             lineHeight={
               showODDStyle ? TYPOGRAPHY.lineHeight28 : TYPOGRAPHY.lineHeight20
             }
+            overflow="hidden"
+            textOverflow="ellipsis"
             whiteSpace="nowrap"
           >
             {message}

--- a/app/src/organisms/ToasterOven/ToasterOven.tsx
+++ b/app/src/organisms/ToasterOven/ToasterOven.tsx
@@ -91,6 +91,7 @@ export function ToasterOven({ children }: ToasterOvenProps): JSX.Element {
           right={SPACING.spacing32}
           bottom={SPACING.spacing16}
           zIndex={1000}
+          width="100%"
         >
           {toasts.map(toast => (
             <Toast


### PR DESCRIPTION
# Overview

This PR fixes text overflow and alignment issues in the desktop and ODD toasts

Closes both RAUT-412 and RAUT-379

# Test Plan

Manually verified close text placement and styling and long message overflow truncation in storybook

# Changelog

- Fixed close text vertical alignment
- Added underline to close text on desktop
- Truncate message with ellipses
- Keep icon from resizing by setting both max and min size the same
- Constrain the ToasterOven to 100% of the screen width.

# Review requests

In storybook, set the toast message and optional header to be absurdly long. Verify it is truncated and not stretching the toast off the edge of the screen. Verify the close text is centered vertically. Verify close text is underlined on desktop.

# Risk assessment

None.
