### PR TITLE
fix(g-code-testing): Fix missing deck type

### DIFF
--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -8,6 +8,7 @@ on:
   push:
     paths:
       - 'Makefile'
+      - 'api/**'
       - 'g-code-testing/**'
       - 'scripts/**/*.mk'
       - 'scripts/**/*.py'
@@ -21,6 +22,7 @@ on:
     paths:
       - 'Makefile'
       - 'g-code-testing/**'
+      - 'api/**'
       - 'scripts/**/*.mk'
       - 'scripts/**/*.py'
       - '.github/workflows/g-code-testing-lint-test.yaml'

--- a/g-code-testing/g_code_parsing/g_code_engine.py
+++ b/g-code-testing/g_code_parsing/g_code_engine.py
@@ -18,6 +18,7 @@ from opentrons.protocol_reader.protocol_source import (
 from opentrons.protocol_runner.protocol_runner import create_protocol_runner
 from opentrons.protocols.parse import parse
 from opentrons.protocols.execution import execute
+from opentrons.protocols.api_support import deck_type
 from contextlib import asynccontextmanager, contextmanager
 from opentrons.protocol_api import create_protocol_context
 from opentrons.config.robot_configs import build_config
@@ -119,7 +120,10 @@ class GCodeEngine:
 
     @asynccontextmanager
     async def run_protocol(
-        self, path: str, version: Union[APIVersion, int]
+        self,
+        path: str,
+        # TODO(mm, 2023-05-16): version should be automatically derived from the protocol file.
+        version: Union[APIVersion, int],
     ) -> AsyncGenerator:
         """
         Runs passed protocol file and collects all G-Code I/O from it.
@@ -129,6 +133,8 @@ class GCodeEngine:
         :return: GCodeProgram with all the parsed data
         """
         file_path = Path(get_configuration_dir(), path)
+
+        # TODO(mm, 2023-05-16): robot_type should be automatically derived from the protocol file.
         robot_type: RobotType = "OT-2 Standard"
 
         with self._emulate() as hardware:
@@ -172,6 +178,8 @@ class GCodeEngine:
                 context = create_protocol_context(
                     api_version=version,
                     hardware_api=hardware,
+                    # TODO(mm, 2023-05-16): deck_type should follow the robot type.
+                    deck_type=deck_type.guess_from_global_config(),
                 )
                 parsed_protocol = parse(protocol.text, protocol.filename)
                 with GCodeWatcher(emulator_settings=self._config) as watcher:


### PR DESCRIPTION
# Overview

This fixes a type-checking error that I introduced in #11812 (RSS-156).

`g-code-testing` uses a function from `api`. I changed the `api` function signature. This wasn't caught in CI because `g-code-testing`'s lint workflow wasn't configured to re-run on `api` changes.

Separately, `g-code-testing` is hanging. That's *not* fixed in this PR. It appears unrelated—something to do with module connections.

# Test Plan

* Make sure "G-Code Testing Lint & Test" passes on this PR.
* On future `api/` changes, we should make sure `g-code-testing`'s lint workflow shows up in those PRs.
* We're *not* expecting "G-Code-Confirm" to pass on this PR, because there are unrelated issues causing it to hang.

# Review requests

None in particular.

# Risk assessment

Low.
