### PR TITLE
fix(app, react-api-client): fix tests after weird merges

### DIFF
--- a/app/src/pages/OnDeviceDisplay/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/ProtocolSetup.test.tsx
@@ -239,7 +239,7 @@ describe('ProtocolSetup', () => {
       missingModuleIds: ['missingMod'],
       remainingAttachedModules: [],
     })
-    const [{ getByRole, getByText }] = render(`/protocols/${RUN_ID}/setup/`)
+    const [{ getByRole, getByText }] = render(`/runs/${RUN_ID}/setup/`)
     getByRole('button', { name: 'play' }).click()
     expect(mockPlay).toBeCalledTimes(0)
     getByText('Mock Snackbar')

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceRunMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceRunMutation.test.tsx
@@ -44,19 +44,15 @@ describe('useCreateMaintenanceRunMutation hook', () => {
       .calledWith(HOST_CONFIG, {})
       .mockRejectedValue('oh no')
 
-    const { result, waitFor } = renderHook(
-      () => useCreateMaintenanceRunMutation(),
-      {
-        wrapper,
-      }
-    )
+    const { result } = renderHook(() => useCreateMaintenanceRunMutation(), {
+      wrapper,
+    })
 
     expect(result.current.data).toBeUndefined()
-    result.current.createMaintenanceRun({})
-    await waitFor(() => {
-      console.log(result.current.status)
-      return result.current.status !== 'loading'
-    })
+
+    await expect(() => result.current.createMaintenanceRun({})).rejects.toBe(
+      'oh no'
+    )
     expect(result.current.data).toBeUndefined()
   })
 


### PR DESCRIPTION
# Overview

At the end of the day yesterday we merged in a flurry of PRs that resulted in some frontend test failures. This PR should fix those failures and make edge green again.

# Review Requests
Make sure all frontend tests pass on this PR

# Risk assessment

Low
