### PR TITLE
test: fix g-code-testing hanging

### DIFF
--- a/api/src/opentrons/hardware_control/emulation/proxy.py
+++ b/api/src/opentrons/hardware_control/emulation/proxy.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 import asyncio
 import logging
-import socket
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -119,7 +118,7 @@ class Proxy:
         self._cons.append(connection)
         self._event_listener.on_server_connected(
             server_type=self._name,
-            client_uri=f"socket://{socket.gethostname()}:{self._settings.driver_port}",
+            client_uri=f"socket://127.0.0.1:{self._settings.driver_port}",
             identifier=connection.identifier,
         )
 


### PR DESCRIPTION
# Overview

This attempts to fix `g-code-testing` CI workflows that are failing in `edge`.

# Changelog

See investigation in [this Slack thread](https://opentrons.slack.com/archives/CMGV77JP4/p1684250952700519).

Something was failing behind the scenes with this error:

```
Could not open port socket://foo:9997: [Errno 8] nodename nor servname provided, or not known
```

Where `foo` was the name of my laptop.

That appears to come from here: https://github.com/Opentrons/opentrons/blob/528a4960fdc1dcb589d208e54a6201867fdb20e9/api/src/opentrons/hardware_control/emulation/proxy.py#L122

This PR's attempted fix is to replace that `socket.gethostname()` with a hard-coded `"127.0.0.1"`.

# Test plan

* [ ] Make sure all CI is passing **and nothing is timing out.**
  * Note that timed-out workflows are gray in the GitHub UI, not red!
* [ ] Make sure all tests (`api` and `g-code-testing`) are passing locally. Or, at least, the "fast" G-code tests, if you don't want to run the whole thing.
  * **This isn't working for me,** but I think it's because the tests are flaky for unrelated reasons.
  * If I run the normal `make test-g-code-fast` command, I usually get [some failures](https://gist.github.com/SyntaxColoring/d358ad46f963ff7f254e7fc61e56da8b) related to having too many files open, and other times, it hangs.
  * If I run those failing tests individually, [they pass](https://gist.github.com/SyntaxColoring/720df2f478dd5f5992bea8015c012118).
  * I'm ticketing this as RQA-798.

# Review requests

I don't remotely understand what was going on here.

Why did this suddenly start failing? Maybe something changed in the platform's name resolution logic? But we're seeing this across operating systems. Maybe something changed in `socket.gethostname()`? But we haven't updated Python, either.

Is it okay to change this URL? I don't understand its significance, or what uses it. This is a Unix socket, right? But if so, why does it have a port? Aren't ports a UDP and TCP concept that doesn't apply to Unix sockets?

Is it appropriate to use `127.0.0.1` here? I see this pattern elsewhere in our codebase ([1][1], [2][2], [3][3], [4][4]), but it doesn't make sense to me for the same reason the port number doesn't make sense to me.

[1]: https://github.com/Opentrons/opentrons/blob/83542dceecf671f0671e31501c7e8e1f03c42cb6/api/tests/opentrons/hardware_control/integration/build_module.py#L31
[2]: https://github.com/Opentrons/opentrons/blob/83542dceecf671f0671e31501c7e8e1f03c42cb6/api/tests/opentrons/hardware_control/integration/test_controller.py#L17
[3]: https://github.com/Opentrons/opentrons/blob/83542dceecf671f0671e31501c7e8e1f03c42cb6/api/tests/opentrons/hardware_control/integration/test_smoothie.py#L21
[4]: https://github.com/Opentrons/opentrons/blob/83542dceecf671f0671e31501c7e8e1f03c42cb6/g-code-testing/g_code_parsing/g_code_engine.py#L55


# Risk assessment

Medium.

This appears to be emulation-only code, so I don't think it can break actual robots, but it has the potential to cause very confusing failures in CI or in https://github.com/Opentrons/opentrons-emulation setups.
