### PR TITLE
fix(app): update home param for rightZ axis

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { UseMutateFunction } from 'react-query'
 import { COLORS, SIZE_1, SPACING } from '@opentrons/components'
 import {
-  LEFT,
   NINETY_SIX_CHANNEL,
   RIGHT,
   SINGLE_MOUNT_PIPETTES,

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -156,13 +156,6 @@ export const BeforeBeginning = (
       // @ts-expect-error calibration type not yet supported
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
-        mount: LEFT,
-      },
-    },
-    {
-      // @ts-expect-error calibration type not yet supported
-      commandType: 'calibration/moveToMaintenancePosition' as const,
-      params: {
         mount: RIGHT,
       },
     },

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -38,6 +38,11 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
           commandType: 'home' as const,
           params: { axes: ['rightZ'] },
         },
+        {
+          // @ts-expect-error calibration command types not yet supported
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: { mount: 'left' },
+        },
       ],
       false
     )

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -37,7 +37,7 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
       [
         {
           commandType: 'home' as const,
-          params: { axes: ('rightZ' as unknown) as MotorAxis },
+          params: { axes: ['rightZ'] },
         },
       ],
       false

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -8,7 +8,7 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from '@opentrons/components'
-import { SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
+import { SINGLE_MOUNT_PIPETTES, LEFT } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -41,7 +41,7 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
         {
           // @ts-expect-error calibration command types not yet supported
           commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: { mount: 'left' },
+          params: { mount: LEFT },
         },
       ],
       false

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -16,7 +16,6 @@ import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import unscrewCarriage from '../../assets/images/change-pip/unscrew-carriage.png'
 import { BODY_STYLE, FLOWS } from './constants'
 
-import type { MotorAxis } from '@opentrons/shared-data'
 import type { PipetteWizardStepProps } from './types'
 
 export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -248,10 +248,6 @@ describe('BeforeBeginning', () => {
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT },
-          },
-          {
-            commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: RIGHT },
           },
         ],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -96,7 +96,7 @@ describe('Carriage', () => {
         {
           commandType: 'home',
           params: {
-            axes: 'rightZ',
+            axes: ['rightZ'],
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -101,7 +101,7 @@ describe('Carriage', () => {
         },
         {
           commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: { mount: 'left' },
+          params: { mount: LEFT },
         },
       ],
       false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -99,6 +99,10 @@ describe('Carriage', () => {
             axes: ['rightZ'],
           },
         },
+        {
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: { mount: 'left' },
+        },
       ],
       false
     )

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -392,10 +392,6 @@ describe('PipetteWizardFlows', () => {
         [
           { commandType: 'home' as const, params: {} },
           {
-            commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT },
-          },
-          {
             commandType: 'calibration/moveToMaintenancePosition' as const,
             params: { mount: RIGHT },
           },


### PR DESCRIPTION
Fix RLIQ-373

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
The command to home the `rightZ` axis after the unscrew step was always failing because we were sending the axes param as a string when it expects an array of strings

# Test Plan
Begin the 96-Channel attach flow, notice that the command to home the `rightZ` is no longer failing
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Update the `axes` param for the `home` command to an array from a string
Move the `moveToMaintenancePosition` command for the LEFT mount to after we home the leftX
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Ensure param is now in the correct format
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
