### PR TITLE
fix(app): modal tweaks

### DIFF
--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {
+  ALIGN_CENTER,
   BORDERS,
   COLORS,
   Flex,
@@ -51,6 +52,7 @@ export function Modal(props: ModalProps): JSX.Element {
         e.stopPropagation()
         onOutsideClick(e)
       }}
+      alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_CENTER}
       alignItems={ALIGN_CENTER}
     >

--- a/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
+++ b/app/src/molecules/Modal/OnDeviceDisplay/Modal.tsx
@@ -7,7 +7,6 @@ import {
   SPACING,
   DIRECTION_COLUMN,
   JUSTIFY_CENTER,
-  ALIGN_CENTER,
 } from '@opentrons/components'
 import { BackgroundOverlay } from '../../BackgroundOverlay'
 import { ModalHeader } from './ModalHeader'
@@ -54,7 +53,6 @@ export function Modal(props: ModalProps): JSX.Element {
       }}
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_CENTER}
-      alignItems={ALIGN_CENTER}
     >
       <Flex
         backgroundColor={isError ? COLORS.red2 : COLORS.white}

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -7,7 +7,6 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
-  TYPOGRAPHY,
   SPACING,
 } from '@opentrons/components'
 import {
@@ -83,23 +82,12 @@ export function ConfirmCancelRunModal({
       <Flex flexDirection={DIRECTION_COLUMN}>
         <Flex
           flexDirection={DIRECTION_COLUMN}
-          padding={SPACING.spacing32}
           gridGap={SPACING.spacing12}
+          paddingBottom={SPACING.spacing40}
+          paddingTop={`${isActiveRun ? SPACING.spacing32 : '0'}`}
         >
-          <StyledText
-            fontSize={TYPOGRAPHY.fontSize22}
-            lineHeight={TYPOGRAPHY.lineHeight28}
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-          >
-            {t('cancel_run_alert_info')}
-          </StyledText>
-          <StyledText
-            fontSize={TYPOGRAPHY.fontSize22}
-            lineHeight={TYPOGRAPHY.lineHeight28}
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-          >
-            {t('cancel_run_module_info')}
-          </StyledText>
+          <StyledText as="p">{t('cancel_run_alert_info')}</StyledText>
+          <StyledText as="p">{t('cancel_run_module_info')}</StyledText>
         </Flex>
         <Flex
           flexDirection={DIRECTION_ROW}


### PR DESCRIPTION

# Overview

This PR addresses round one of DQA feedback for the modal component.

Closes RAUT-432

# Test Plan

Manually verified modal placement and content spacing on both ODD and simulated app.

# Changelog

- Centered modal component on ODD screen
- Adjusted padding and typography for run cancellation model

# Review requests

Verify modals are now centered. Verify both varieties of run cancellation modals now match designs.

# Risk assessment

Low
