### PR TITLE
fix(app): render empty state in robot dashboard if no protocols have been ran

### DIFF
--- a/app/src/pages/OnDeviceDisplay/RobotDashboard/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotDashboard/index.tsx
@@ -41,10 +41,14 @@ export function RobotDashboard(): JSX.Element {
     unfinishedUnboxingFlowRoute === '/robot-settings/rename-robot'
   )
 
+  const recentlyRunProtocols = protocolsData.filter(protocol =>
+    runData.some(run => run.protocolId === protocol.id)
+  )
+
   /** Currently the max number of displaying recent run protocol is 8 */
   const sortedProtocols =
-    protocolsData.length > 0
-      ? sortProtocols(SORT_KEY, protocolsData, runData).slice(
+    recentlyRunProtocols.length > 0
+      ? sortProtocols(SORT_KEY, recentlyRunProtocols, runData).slice(
           0,
           MAXIMUM_RECENT_RUN_PROTOCOLS
         )


### PR DESCRIPTION
# Overview

Currently we do not render the empty state in the robot dashboard even if no protocols have been ran. This PR explicitly checks if a protocol has been run before rendering the non empty state

# Test Plan

# Changelog

- Render empty state in recent protocol run cards if no protocols have been ran


# Review requests

Send a protocol to an ODD but don't run it. The empty state should show on the robot dashboard.

# Risk assessment

Low
