### PR TITLE
fix(app): allow OT-3 wifi disconnect

### DIFF
--- a/app/src/resources/networking/hooks/useCanDisconnect.ts
+++ b/app/src/resources/networking/hooks/useCanDisconnect.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import Semver from 'semver'
+import { useIsOT3 } from '../../../organisms/Devices/hooks'
 import { getRobotApiVersionByName } from '../../../redux/discovery'
 import { useWifiList } from './useWifiList'
 
@@ -8,6 +9,7 @@ import type { State } from '../../../redux/types'
 const API_MIN_DISCONNECT_VERSION = '3.17.0-alpha.0'
 
 export const useCanDisconnect = (robotName: string): boolean => {
+  const isOT3 = useIsOT3(robotName)
   const wifiList = useWifiList(robotName)
   const apiVersion = useSelector((state: State) => {
     return getRobotApiVersionByName(state, robotName)
@@ -15,7 +17,7 @@ export const useCanDisconnect = (robotName: string): boolean => {
 
   const active = wifiList.some(nw => nw.active)
   const supportsDisconnect = Semver.valid(apiVersion)
-    ? Semver.gte(apiVersion as string, API_MIN_DISCONNECT_VERSION)
+    ? isOT3 || Semver.gte(apiVersion as string, API_MIN_DISCONNECT_VERSION)
     : false
 
   return Boolean(active && supportsDisconnect)


### PR DESCRIPTION
# Overview

useCanDisconnect does a legacy semver check for robot api versions greater than 3.17.0-alpha.0, but at this time OT-3 internal releases are versioned 0.x.x. This change allows all robot api versions on an OT-3 to support disconnect.

closes RQA-817

# Test Plan

 - manually verified disconnect for OT-3s versioned 0.x.x
 - updated hook unit tests

# Changelog

 - Allows OT-3 wifi disconnect

# Review requests

confirm OT-3s can be disconnected from wifi

# Risk assessment

low
