### PR TITLE
refactor(discovery-client,app-shell): prefer manual address entries in health poller

### DIFF
--- a/app-shell/src/discovery.ts
+++ b/app-shell/src/discovery.ts
@@ -145,21 +145,6 @@ export function registerDiscovery(
     client.stop()
   })
 
-  function removeCachedUsbRobot(): void {
-    const cachedUsbRobotName = client
-      .getRobots()
-      .find(robot =>
-        robot.addresses.some(address => address.ip === OPENTRONS_USB)
-      )?.name
-
-    if (cachedUsbRobotName != null) {
-      log.debug(
-        `deleting old opentrons-usb entry with name ${cachedUsbRobotName}`
-      )
-      client.removeRobot(cachedUsbRobotName)
-    }
-  }
-
   return function handleIncomingAction(action: Action) {
     log.debug('handling action in discovery', { action })
 
@@ -185,8 +170,6 @@ export function registerDiscovery(
         return clearCache()
       }
       case USB_HTTP_REQUESTS_START: {
-        removeCachedUsbRobot()
-
         const usbHttpAgent = getSerialPortHttpAgent()
 
         client.start({

--- a/app-shell/src/discovery.ts
+++ b/app-shell/src/discovery.ts
@@ -202,12 +202,14 @@ export function registerDiscovery(
         break
       }
       case USB_HTTP_REQUESTS_STOP: {
-        // TODO(bh, 2023-05-05): we actually still want this robot to show up in the not available list
-        removeCachedUsbRobot()
-
         client.start({
           healthPollInterval: FAST_POLL_INTERVAL_MS,
-          manualAddresses: [],
+          manualAddresses: [
+            {
+              ip: OPENTRONS_USB,
+              port: DEFAULT_PORT,
+            },
+          ],
         })
         break
       }

--- a/discovery-client/src/__tests__/health-poller.test.ts
+++ b/discovery-client/src/__tests__/health-poller.test.ts
@@ -13,7 +13,6 @@ jest.mock('node-fetch', () => ({ __esModule: true, default: jest.fn() }))
 const fetch = nodeFetch as jest.MockedFunction<typeof nodeFetch>
 
 const EXPECTED_FETCH_OPTS = {
-  agent: undefined,
   timeout: 10000,
   headers: { 'Opentrons-Version': '2' },
 }

--- a/discovery-client/src/health-poller.ts
+++ b/discovery-client/src/health-poller.ts
@@ -1,8 +1,9 @@
 import net from 'net'
 import fetch from 'node-fetch'
 import intersectionBy from 'lodash/intersectionBy'
+import isEqual from 'lodash/isEqual'
 import unionBy from 'lodash/unionBy'
-import xorBy from 'lodash/xorBy'
+import xorWith from 'lodash/xorWith'
 
 import {
   ROBOT_SERVER_HEALTH_PATH,
@@ -91,11 +92,12 @@ export function createHealthPoller(options: HealthPollerOptions): HealthPoller {
     // if xor (symmetric difference) returns values, then elements exist in
     // one list and not the other and need to be added to and/or removed from the queue
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (nextList && xorBy(pollQueue, nextList, 'ip').length > 0) {
+    if (nextList && xorWith(pollQueue, nextList, isEqual).length > 0) {
       // keeping the order of `pollQueue`, remove all elements that aren't
       // in the new list via `intersection`, then add new elements via `union`
       pollQueue = unionBy(
-        intersectionBy(pollQueue, nextList, 'ip'),
+        // prefer reference from nextList
+        intersectionBy(nextList, pollQueue, 'ip'),
         nextList,
         'ip'
       )

--- a/discovery-client/src/store/__tests__/selectors.test.ts
+++ b/discovery-client/src/store/__tests__/selectors.test.ts
@@ -1,3 +1,5 @@
+import type { Agent } from 'http'
+
 import {
   mockLegacyHealthResponse,
   mockLegacyServerHealthResponse,
@@ -189,13 +191,32 @@ describe('discovery client state selectors', () => {
     ])
   })
 
-  it('should be able to get a list addresses to poll', () => {
+  it('should to get a list addresses to poll', () => {
     expect(Selectors.getAddresses(STATE)).toEqual([
-      { ip: '127.0.0.2', port: 31950 },
-      { ip: '127.0.0.3', port: 31950 },
       { ip: '127.0.0.4', port: 31950 },
       { ip: '127.0.0.5', port: 31950 },
       { ip: '127.0.0.6', port: 31950 },
+      { ip: '127.0.0.2', port: 31950 },
+      { ip: '127.0.0.3', port: 31950 },
+    ])
+  })
+
+  it('should prefer manual address entries', () => {
+    expect(
+      Selectors.getAddresses({
+        ...STATE,
+        manualAddresses: [
+          { ip: '127.0.0.4', port: 31950, agent: {} as Agent },
+          { ip: '127.0.0.5', port: 31950 },
+          { ip: '127.0.0.6', port: 31950 },
+        ],
+      })
+    ).toEqual([
+      { agent: {}, ip: '127.0.0.4', port: 31950 },
+      { ip: '127.0.0.5', port: 31950 },
+      { ip: '127.0.0.6', port: 31950 },
+      { ip: '127.0.0.2', port: 31950 },
+      { ip: '127.0.0.3', port: 31950 },
     ])
   })
 

--- a/discovery-client/src/store/selectors.ts
+++ b/discovery-client/src/store/selectors.ts
@@ -34,12 +34,17 @@ export const getAddresses: (state: State) => Address[] = createSelector(
   state => state.manualAddresses,
   getHostStates,
   (manualAddresses, hosts) => {
-    const trackedAddresses = hosts.map(({ ip, port, agent }) => ({
-      ip,
-      port,
-      agent,
-    }))
-    return unionBy(trackedAddresses, manualAddresses, 'ip')
+    const trackedAddresses = hosts.map(({ ip, port, agent }) =>
+      agent != null
+        ? {
+            ip,
+            port,
+            agent,
+          }
+        : { ip, port }
+    )
+    // prefer reference from manualAddresses
+    return unionBy(manualAddresses, trackedAddresses, 'ip')
   }
 )
 


### PR DESCRIPTION
# Overview

to allow updating existing address entries in the health poller manually, the getAddresses selector and discovery-client health poller are updated to prefer manual address entries

closes RCORE-763

# Test Plan

 - manually confirmed discovery-client registers robots as available and unavailable to usb attach and detach

# Changelog

 - Updates discovery-client to prefer manual address entries in health poller

# Review requests

 - confirm soundness of set logic changes
 - confirm discovery still works as intended

# Risk assessment

medium-ish, changes health poller logic
