### PR TITLE
fix(api, engine): raise exception in analysis if deactivate shaker is called while heater-shaker's latch is open

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
@@ -45,6 +45,8 @@ class DeactivateShakerImpl(
             module_id=params.moduleId
         )
 
+        hs_module_substate.raise_if_labware_latch_not_closed()
+
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
             hs_module_substate.module_id

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -76,11 +76,11 @@ class HeaterShakerModuleSubState:
         """Raise an error if labware is not latched on the heater-shaker."""
         if self.labware_latch_status == HeaterShakerLatchStatus.UNKNOWN:
             raise CannotPerformModuleAction(
-                "Heater-Shaker cannot start shaking if the labware latch status has not been set to closed."
+                "Heater-Shaker cannot start or deactivate shaking if the labware latch has not been set to closed."
             )
         elif self.labware_latch_status == HeaterShakerLatchStatus.OPEN:
             raise CannotPerformModuleAction(
-                "Heater-Shaker cannot start shaking while the labware latch is open."
+                "Heater-Shaker cannot start or deactivate shaking while the labware latch is open."
             )
 
     def raise_if_shaking(self) -> None:


### PR DESCRIPTION
# Overview

Closes RSS-241.

This PR fixes a bug in analysis where calling `deactivateShaker` would not raise an exception if the labware latch was open (or its status is unknown due to not being set explicitly to open or closed). This action is illegal as `deactivateShaker`, in addition to stopping shaking, also homes the plate. Since any movement of the plate should not happen if the latch is open, an exception will now be raised if the latch is not closed. 

# Test Plan

Confirmed that the following protocol correctly raises an error, when latch status is set to open or not set at all.

```
metadata = {
    'protocolName': 'Heater shaker deactivate raises',
}

requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.14"
}



def run(context):
    heater_shaker = context.load_module("heaterShakerModuleV1", "3")

    # Protocol will fail with open_labware_latch called or commented out
    heater_shaker.open_labware_latch()
    heater_shaker.deactivate_shaker()
```

# Changelog

- Added check for latch status before executing a `deactivateShaker` command
- Updated exception string to communicate deactivate shaking may have caused this exception

# Review requests

# Risk assessment
Low, fixes illegal action that shouldn't have been allowed in the first place.