### PR TITLE
fix(app): fix temperature module wait for temp text

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -9,6 +9,7 @@
   "deactivating_hs_heater": "Deactivating heater",
   "deactivating_tc_block": "Deactivating Thermocycler block",
   "deactivating_tc_lid": "Deactivating Thermocycler lid",
+  "degrees_c": "{{temp}}°C",
   "disengaging_magnetic_module": "Disengaging Magnetic Module",
   "dispense": "Dispensing {{volume}} µL into well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
   "drop_tip": "Dropping tip in {{well_name}} of {{labware}}",
@@ -35,11 +36,12 @@
   "pickup_tip": "Picking up tip from {{well_name}} of {{labware}} in {{labware_location}}",
   "save_position": "Saving position",
   "set_and_await_hs_shake": "Setting Heater-Shaker to shake at {{rpm}} rpm and waiting until reached",
-  "setting_hs_temp": "Setting Target Temperature of Heater-Shaker to {{temp}}°C",
-  "setting_temperature_module_temp": "Setting Temperature Module to {{temp}}°C (rounded to nearest integer)",
-  "setting_thermocycler_block_temp": "Setting Thermocycler block temperature to {{temp}}°C with hold time of {{hold_time_seconds}} seconds after target reached",
-  "setting_thermocycler_lid_temp": "Setting Thermocycler lid temperature to {{temp}}°C",
+  "setting_hs_temp": "Setting Target Temperature of Heater-Shaker to {{temp}}",
+  "setting_temperature_module_temp": "Setting Temperature Module to {{temp}} (rounded to nearest integer)",
+  "setting_thermocycler_block_temp": "Setting Thermocycler block temperature to {{temp}} with hold time of {{hold_time_seconds}} seconds after target reached",
+  "setting_thermocycler_lid_temp": "Setting Thermocycler lid temperature to {{temp}}",
   "slot": "Slot {{slot_name}}",
+  "target_temperature": "target temperature",
   "tc_awaiting_for_duration": "Waiting for Thermocycler profile to complete",
   "tc_run_profile_steps": "temperature: {{celsius}}°C, seconds: {{seconds}}",
   "tc_starting_profile": "Thermocycler starting {{repetitions}} repetitions of cycle composed of the following steps:",
@@ -50,5 +52,5 @@
   "waiting_for_hs_to_reach": "Waiting for Heater-Shaker to reach target temperature",
   "waiting_for_tc_block_to_reach": "Waiting for Thermocycler block to reach target temperature and holding for specified time",
   "waiting_for_tc_lid_to_reach": "Waiting for Thermocycler lid to reach target temperature",
-  "waiting_to_reach_temp_module": "Waiting for Temperature Module to reach target temperature"
+  "waiting_to_reach_temp_module": "Waiting for Temperature Module to reach {{temp}}"
 }

--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -50,5 +50,5 @@
   "waiting_for_hs_to_reach": "Waiting for Heater-Shaker to reach target temperature",
   "waiting_for_tc_block_to_reach": "Waiting for Thermocycler block to reach target temperature and holding for specified time",
   "waiting_for_tc_lid_to_reach": "Waiting for Thermocycler lid to reach target temperature",
-  "waiting_to_reach_temp_module": "Waiting for Temperature Module to reach {{temp}}°C (rounded to nearest integer)"
+  "waiting_to_reach_temp_module": "Waiting for Temperature Module to reach target temperature"
 }

--- a/app/src/organisms/CommandText/TemperatureCommandText.tsx
+++ b/app/src/organisms/CommandText/TemperatureCommandText.tsx
@@ -34,7 +34,10 @@ export const TemperatureCommandText = ({
   const { t } = useTranslation('protocol_command_text')
 
   return t(T_KEYS_BY_COMMAND_TYPE[command.commandType], {
-    temp: command.params.celsius,
+    temp:
+      command.params?.celsius != null
+        ? t('degrees_c', { temp: command.params.celsius })
+        : t('target_temperature'),
     hold_time_seconds:
       'holdTimeSeconds' in command.params
         ? command.params.holdTimeSeconds ?? '0'

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -322,13 +322,35 @@ describe('CommandText', () => {
     )[0]
     getByText('Setting Temperature Module to 20°C (rounded to nearest integer)')
   })
-  it('renders correct text for temperatureModule/waitForTemperature', () => {
+  it('renders correct text for temperatureModule/waitForTemperature with target temp', () => {
     const mockTemp = 20
     const { getByText } = renderWithProviders(
       <CommandText
         command={{
           commandType: 'temperatureModule/waitForTemperature',
           params: { celsius: mockTemp, moduleId: 'abc123' },
+          id: 'def456',
+          result: {},
+          status: 'queued',
+          error: null,
+          createdAt: 'fake_timestamp',
+          startedAt: null,
+          completedAt: null,
+        }}
+        robotSideAnalysis={mockRobotSideAnalysis}
+      />,
+      {
+        i18nInstance: i18n,
+      }
+    )[0]
+    getByText('Waiting for Temperature Module to reach 20°C')
+  })
+  it('renders correct text for temperatureModule/waitForTemperature with no specified temp', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        command={{
+          commandType: 'temperatureModule/waitForTemperature',
+          params: { moduleId: 'abc123' },
           id: 'def456',
           result: {},
           status: 'queued',

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -343,9 +343,7 @@ describe('CommandText', () => {
         i18nInstance: i18n,
       }
     )[0]
-    getByText(
-      'Waiting for Temperature Module to reach 20°C (rounded to nearest integer)'
-    )
+    getByText('Waiting for Temperature Module to reach target temperature')
   })
   it('renders correct text for thermocycler/setTargetBlockTemperature', () => {
     const mockTemp = 20

--- a/shared-data/protocol/types/schemaV7/command/module.ts
+++ b/shared-data/protocol/types/schemaV7/command/module.ts
@@ -55,7 +55,7 @@ export interface MagneticModuleEngageMagnetCreateCommand
 }
 export interface MagneticModuleEngageMagnetRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    MagneticModuleEngageMagnetCreateCommand {
+  MagneticModuleEngageMagnetCreateCommand {
   result?: any
 }
 export interface MagneticModuleDisengageCreateCommand
@@ -65,7 +65,7 @@ export interface MagneticModuleDisengageCreateCommand
 }
 export interface MagneticModuleDisengageRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    MagneticModuleDisengageCreateCommand {
+  MagneticModuleDisengageCreateCommand {
   result?: any
 }
 export interface TemperatureModuleSetTargetTemperatureCreateCommand
@@ -75,7 +75,7 @@ export interface TemperatureModuleSetTargetTemperatureCreateCommand
 }
 export interface TemperatureModuleSetTargetTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TemperatureModuleSetTargetTemperatureCreateCommand {
+  TemperatureModuleSetTargetTemperatureCreateCommand {
   result?: any
 }
 export interface TemperatureModuleDeactivateCreateCommand
@@ -85,21 +85,22 @@ export interface TemperatureModuleDeactivateCreateCommand
 }
 export interface TemperatureModuleDeactivateRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TemperatureModuleDeactivateCreateCommand {
+  TemperatureModuleDeactivateCreateCommand {
   result?: any
+}
+export interface TemperatureModuleAwaitTemperatureParams {
+  // same params as TemperatureParams except celsius is optional
+  moduleId: string
+  celsius?: number
 }
 export interface TemperatureModuleAwaitTemperatureCreateCommand
   extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/waitForTemperature'
-  params: {
-    // same params as TemperatureParams except celsius is optional
-    moduleId: string
-    celsius?: number
-  }
+  params: TemperatureModuleAwaitTemperatureParams
 }
 export interface TemperatureModuleAwaitTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TemperatureModuleAwaitTemperatureCreateCommand {
+  TemperatureModuleAwaitTemperatureCreateCommand {
   result?: any
 }
 export interface TCSetTargetBlockTemperatureCreateCommand
@@ -109,7 +110,7 @@ export interface TCSetTargetBlockTemperatureCreateCommand
 }
 export interface TCSetTargetBlockTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCSetTargetBlockTemperatureCreateCommand {
+  TCSetTargetBlockTemperatureCreateCommand {
   result?: any
 }
 export interface TCSetTargetLidTemperatureCreateCommand
@@ -119,7 +120,7 @@ export interface TCSetTargetLidTemperatureCreateCommand
 }
 export interface TCSetTargetLidTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCSetTargetLidTemperatureCreateCommand {
+  TCSetTargetLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCWaitForBlockTemperatureCreateCommand
@@ -129,7 +130,7 @@ export interface TCWaitForBlockTemperatureCreateCommand
 }
 export interface TCWaitForBlockTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCWaitForBlockTemperatureCreateCommand {
+  TCWaitForBlockTemperatureCreateCommand {
   result?: any
 }
 export interface TCWaitForLidTemperatureCreateCommand
@@ -139,7 +140,7 @@ export interface TCWaitForLidTemperatureCreateCommand
 }
 export interface TCWaitForLidTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCWaitForLidTemperatureCreateCommand {
+  TCWaitForLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
@@ -148,7 +149,7 @@ export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCOpenLidRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCOpenLidCreateCommand {
+  TCOpenLidCreateCommand {
   result?: any
 }
 export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
@@ -157,7 +158,7 @@ export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCCloseLidRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCCloseLidCreateCommand {
+  TCCloseLidCreateCommand {
   result?: any
 }
 export interface TCDeactivateBlockCreateCommand
@@ -167,7 +168,7 @@ export interface TCDeactivateBlockCreateCommand
 }
 export interface TCDeactivateBlockRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCDeactivateBlockCreateCommand {
+  TCDeactivateBlockCreateCommand {
   result?: any
 }
 export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
@@ -176,7 +177,7 @@ export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCDeactivateLidRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCDeactivateLidCreateCommand {
+  TCDeactivateLidCreateCommand {
   result?: any
 }
 export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
@@ -185,7 +186,7 @@ export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCRunProfileRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCRunProfileCreateCommand {
+  TCRunProfileCreateCommand {
   result?: any
 }
 export interface TCAwaitProfileCompleteCreateCommand
@@ -195,7 +196,7 @@ export interface TCAwaitProfileCompleteCreateCommand
 }
 export interface TCAwaitProfileCompleteRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TCAwaitProfileCompleteCreateCommand {
+  TCAwaitProfileCompleteCreateCommand {
   result?: any
 }
 export interface HeaterShakerSetTargetTemperatureCreateCommand
@@ -205,7 +206,7 @@ export interface HeaterShakerSetTargetTemperatureCreateCommand
 }
 export interface HeaterShakerSetTargetTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerSetTargetTemperatureCreateCommand {
+  HeaterShakerSetTargetTemperatureCreateCommand {
   result?: any
 }
 export interface HeaterShakerWaitForTemperatureCreateCommand
@@ -215,7 +216,7 @@ export interface HeaterShakerWaitForTemperatureCreateCommand
 }
 export interface HeaterShakerWaitForTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerWaitForTemperatureCreateCommand {
+  HeaterShakerWaitForTemperatureCreateCommand {
   result?: any
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
@@ -225,7 +226,7 @@ export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
+  HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
   result?: any
 }
 export interface HeaterShakerDeactivateHeaterCreateCommand
@@ -235,7 +236,7 @@ export interface HeaterShakerDeactivateHeaterCreateCommand
 }
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateHeaterCreateCommand {
+  HeaterShakerDeactivateHeaterCreateCommand {
   result?: any
 }
 export interface HeaterShakerOpenLatchCreateCommand
@@ -245,7 +246,7 @@ export interface HeaterShakerOpenLatchCreateCommand
 }
 export interface HeaterShakerOpenLatchRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerOpenLatchCreateCommand {
+  HeaterShakerOpenLatchCreateCommand {
   result?: any
 }
 export interface HeaterShakerCloseLatchCreateCommand
@@ -255,7 +256,7 @@ export interface HeaterShakerCloseLatchCreateCommand
 }
 export interface HeaterShakerCloseLatchRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerCloseLatchCreateCommand {
+  HeaterShakerCloseLatchCreateCommand {
   result?: any
 }
 export interface HeaterShakerDeactivateShakerCreateCommand
@@ -265,7 +266,7 @@ export interface HeaterShakerDeactivateShakerCreateCommand
 }
 export interface HeaterShakerDeactivateShakerRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateShakerCreateCommand {
+  HeaterShakerDeactivateShakerCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV7/command/module.ts
+++ b/shared-data/protocol/types/schemaV7/command/module.ts
@@ -55,7 +55,7 @@ export interface MagneticModuleEngageMagnetCreateCommand
 }
 export interface MagneticModuleEngageMagnetRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  MagneticModuleEngageMagnetCreateCommand {
+    MagneticModuleEngageMagnetCreateCommand {
   result?: any
 }
 export interface MagneticModuleDisengageCreateCommand
@@ -65,7 +65,7 @@ export interface MagneticModuleDisengageCreateCommand
 }
 export interface MagneticModuleDisengageRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  MagneticModuleDisengageCreateCommand {
+    MagneticModuleDisengageCreateCommand {
   result?: any
 }
 export interface TemperatureModuleSetTargetTemperatureCreateCommand
@@ -75,7 +75,7 @@ export interface TemperatureModuleSetTargetTemperatureCreateCommand
 }
 export interface TemperatureModuleSetTargetTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TemperatureModuleSetTargetTemperatureCreateCommand {
+    TemperatureModuleSetTargetTemperatureCreateCommand {
   result?: any
 }
 export interface TemperatureModuleDeactivateCreateCommand
@@ -85,7 +85,7 @@ export interface TemperatureModuleDeactivateCreateCommand
 }
 export interface TemperatureModuleDeactivateRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TemperatureModuleDeactivateCreateCommand {
+    TemperatureModuleDeactivateCreateCommand {
   result?: any
 }
 export interface TemperatureModuleAwaitTemperatureParams {
@@ -100,7 +100,7 @@ export interface TemperatureModuleAwaitTemperatureCreateCommand
 }
 export interface TemperatureModuleAwaitTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TemperatureModuleAwaitTemperatureCreateCommand {
+    TemperatureModuleAwaitTemperatureCreateCommand {
   result?: any
 }
 export interface TCSetTargetBlockTemperatureCreateCommand
@@ -110,7 +110,7 @@ export interface TCSetTargetBlockTemperatureCreateCommand
 }
 export interface TCSetTargetBlockTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCSetTargetBlockTemperatureCreateCommand {
+    TCSetTargetBlockTemperatureCreateCommand {
   result?: any
 }
 export interface TCSetTargetLidTemperatureCreateCommand
@@ -120,7 +120,7 @@ export interface TCSetTargetLidTemperatureCreateCommand
 }
 export interface TCSetTargetLidTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCSetTargetLidTemperatureCreateCommand {
+    TCSetTargetLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCWaitForBlockTemperatureCreateCommand
@@ -130,7 +130,7 @@ export interface TCWaitForBlockTemperatureCreateCommand
 }
 export interface TCWaitForBlockTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCWaitForBlockTemperatureCreateCommand {
+    TCWaitForBlockTemperatureCreateCommand {
   result?: any
 }
 export interface TCWaitForLidTemperatureCreateCommand
@@ -140,7 +140,7 @@ export interface TCWaitForLidTemperatureCreateCommand
 }
 export interface TCWaitForLidTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCWaitForLidTemperatureCreateCommand {
+    TCWaitForLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
@@ -149,7 +149,7 @@ export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCOpenLidRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCOpenLidCreateCommand {
+    TCOpenLidCreateCommand {
   result?: any
 }
 export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
@@ -158,7 +158,7 @@ export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCCloseLidRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCCloseLidCreateCommand {
+    TCCloseLidCreateCommand {
   result?: any
 }
 export interface TCDeactivateBlockCreateCommand
@@ -168,7 +168,7 @@ export interface TCDeactivateBlockCreateCommand
 }
 export interface TCDeactivateBlockRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCDeactivateBlockCreateCommand {
+    TCDeactivateBlockCreateCommand {
   result?: any
 }
 export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
@@ -177,7 +177,7 @@ export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCDeactivateLidRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCDeactivateLidCreateCommand {
+    TCDeactivateLidCreateCommand {
   result?: any
 }
 export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
@@ -186,7 +186,7 @@ export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TCRunProfileRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCRunProfileCreateCommand {
+    TCRunProfileCreateCommand {
   result?: any
 }
 export interface TCAwaitProfileCompleteCreateCommand
@@ -196,7 +196,7 @@ export interface TCAwaitProfileCompleteCreateCommand
 }
 export interface TCAwaitProfileCompleteRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TCAwaitProfileCompleteCreateCommand {
+    TCAwaitProfileCompleteCreateCommand {
   result?: any
 }
 export interface HeaterShakerSetTargetTemperatureCreateCommand
@@ -206,7 +206,7 @@ export interface HeaterShakerSetTargetTemperatureCreateCommand
 }
 export interface HeaterShakerSetTargetTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerSetTargetTemperatureCreateCommand {
+    HeaterShakerSetTargetTemperatureCreateCommand {
   result?: any
 }
 export interface HeaterShakerWaitForTemperatureCreateCommand
@@ -216,7 +216,7 @@ export interface HeaterShakerWaitForTemperatureCreateCommand
 }
 export interface HeaterShakerWaitForTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerWaitForTemperatureCreateCommand {
+    HeaterShakerWaitForTemperatureCreateCommand {
   result?: any
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
@@ -226,7 +226,7 @@ export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
+    HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
   result?: any
 }
 export interface HeaterShakerDeactivateHeaterCreateCommand
@@ -236,7 +236,7 @@ export interface HeaterShakerDeactivateHeaterCreateCommand
 }
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerDeactivateHeaterCreateCommand {
+    HeaterShakerDeactivateHeaterCreateCommand {
   result?: any
 }
 export interface HeaterShakerOpenLatchCreateCommand
@@ -246,7 +246,7 @@ export interface HeaterShakerOpenLatchCreateCommand
 }
 export interface HeaterShakerOpenLatchRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerOpenLatchCreateCommand {
+    HeaterShakerOpenLatchCreateCommand {
   result?: any
 }
 export interface HeaterShakerCloseLatchCreateCommand
@@ -256,7 +256,7 @@ export interface HeaterShakerCloseLatchCreateCommand
 }
 export interface HeaterShakerCloseLatchRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerCloseLatchCreateCommand {
+    HeaterShakerCloseLatchCreateCommand {
   result?: any
 }
 export interface HeaterShakerDeactivateShakerCreateCommand
@@ -266,7 +266,7 @@ export interface HeaterShakerDeactivateShakerCreateCommand
 }
 export interface HeaterShakerDeactivateShakerRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  HeaterShakerDeactivateShakerCreateCommand {
+    HeaterShakerDeactivateShakerCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV7/command/module.ts
+++ b/shared-data/protocol/types/schemaV7/command/module.ts
@@ -91,7 +91,11 @@ export interface TemperatureModuleDeactivateRunTimeCommand
 export interface TemperatureModuleAwaitTemperatureCreateCommand
   extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/waitForTemperature'
-  params: TemperatureParams
+  params: {
+    // same params as TemperatureParams except celsius is optional
+    moduleId: string
+    celsius?: number
+  }
 }
 export interface TemperatureModuleAwaitTemperatureRunTimeCommand
   extends CommonCommandRunTimeInfo,

--- a/step-generation/src/getNextRobotStateAndWarnings/temperatureUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/temperatureUpdates.ts
@@ -6,9 +6,10 @@ import {
   TEMPERATURE_AT_TARGET,
 } from '../constants'
 import type {
+  TemperatureModuleAwaitTemperatureParams,
   TemperatureParams,
   ModuleOnlyParams,
-} from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
+} from '@opentrons/shared-data/protocol/types/schemaV7/command/module'
 import type {
   InvariantContext,
   RobotStateAndWarnings,
@@ -39,7 +40,7 @@ export function forSetTemperature(
   _setTemperatureAndStatus(moduleState, celsius, TEMPERATURE_APPROACHING_TARGET)
 }
 export function forAwaitTemperature(
-  params: TemperatureParams,
+  params: TemperatureModuleAwaitTemperatureParams,
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings
 ): void {


### PR DESCRIPTION
# Overview

The wait for target temperature command for the temperature module improperly interpolates a temperature value, despite the fact that only the target temperature previously set will be awaited

Closes RQA-749

