### PR TITLE
refactor(app): show usb connection status in desktop app robot settings

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -24,6 +24,11 @@ import { ExternalLink } from '../../../atoms/Link/ExternalLink'
 import { StyledText } from '../../../atoms/text'
 import { Divider } from '../../../atoms/structure'
 
+import {
+  getRobotAddressesByName,
+  HEALTH_STATUS_OK,
+  OPENTRONS_USB,
+} from '../../../redux/discovery'
 import { fetchStatus, getNetworkInterfaces } from '../../../redux/networking'
 
 import { useIsOT3, useIsRobotBusy } from '../hooks'
@@ -58,8 +63,12 @@ export function RobotSettingsNetworking({
 
   const canDisconnect = useCanDisconnect(robotName)
 
-  // TODO(bh, 2023-1-18): get the real OT-3 USB connection info
-  const isOT3ConnectedViaUSB = false
+  const addresses = useSelector((state: State) =>
+    getRobotAddressesByName(state, robotName)
+  )
+  const usbAddress = addresses.find(addr => addr.ip === OPENTRONS_USB)
+  const isOT3ConnectedViaUSB =
+    usbAddress != null && usbAddress.healthStatus === HEALTH_STATUS_OK
 
   const { wifi, ethernet } = useSelector((state: State) =>
     getNetworkInterfaces(state, robotName)

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -583,6 +583,24 @@ describe('discovery selectors', () => {
       args: ['qux'],
       expected: 'Opentrons Flex',
     },
+    {
+      name: 'getRobotAddressesByName returns addresses by name',
+      selector: discovery.getRobotAddressesByName,
+      state: MOCK_STATE,
+      args: ['qux'],
+      expected: [
+        {
+          ip: '10.0.0.4',
+          port: 31950,
+          seen: true,
+          healthStatus: HEALTH_STATUS_UNREACHABLE,
+          serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
+          healthError: mockHealthFetchErrorResponse,
+          serverHealthError: mockHealthFetchErrorResponse,
+          advertisedModel: ROBOT_MODEL_OT3,
+        },
+      ],
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -25,6 +25,7 @@ import {
 import type { State } from '../types'
 import {
   DiscoveredRobot,
+  DiscoveryClientRobotAddress,
   Robot,
   ReachableRobot,
   UnreachableRobot,
@@ -248,3 +249,16 @@ export const getRobotModelByName = (
     robot != null ? getRobotModel(robot)?.split(/\s/)[0] : null
   return robotModelName === 'OT-3' ? 'Opentrons Flex' : robotModelName
 }
+
+export const getRobotAddressesByName: (
+  state: State,
+  robotName: string
+) => DiscoveryClientRobotAddress[] = createSelector(
+  state => state.discovery.robotsByName,
+  (state: State, robotName: string) => robotName,
+  (robotsMap, robotName) => {
+    const robot = robotsMap[robotName]
+    const { addresses } = robot
+    return addresses
+  }
+)

--- a/app/src/redux/discovery/types.ts
+++ b/app/src/redux/discovery/types.ts
@@ -1,5 +1,6 @@
 import type {
   DiscoveryClientRobot,
+  DiscoveryClientRobotAddress,
   HealthResponse,
   HealthStatus,
 } from '@opentrons/discovery-client'
@@ -13,7 +14,7 @@ import {
   ROBOT_MODEL_OT3,
 } from './constants'
 
-export type { DiscoveryClientRobot, HealthStatus }
+export type { DiscoveryClientRobot, DiscoveryClientRobotAddress, HealthStatus }
 
 export type RobotsMap = Record<string, DiscoveryClientRobot>
 


### PR DESCRIPTION
# Overview

adds a `getRobotAddressesByName` discovery selector and shows an active usb connection when a healthy address with ip 'opentrons-usb' exists for the robot in question

closes RCORE-764

# Test Plan

 - manually tested usb-connected and disconnected dev kit
 - added unit tests for robot settings networking and new selector

# Changelog

 - Shows usb connection status in desktop app robot settings

# Review requests

check for the green checkmark when connected via USB

# Risk assessment

low
