### PR TITLE
fix(step-generation): modify curried command order for heater-shaker

### DIFF
--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -4,10 +4,10 @@ import {
 } from '@opentrons/shared-data'
 import { heaterShaker } from '../commandCreators'
 import { getModuleState } from '../robotStateSelectors'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 import { getErrorResult, getSuccessResult } from '../fixtures/commandFixtures'
 
 import type { InvariantContext, RobotState, HeaterShakerArgs } from '../types'
-import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 
 jest.mock('../robotStateSelectors')
 
@@ -159,6 +159,86 @@ describe('heaterShaker compound command creator', () => {
         params: {
           moduleId: 'heaterShakerId',
           rpm: 444,
+        },
+      },
+    ])
+  })
+  it('should not call deactivateShaker when it is not shaking but call activate temperature when setting target temp', () => {
+    heaterShakerArgs = {
+      ...heaterShakerArgs,
+      rpm: null,
+      targetTemperature: 80,
+    }
+
+    const state = getInitialRobotStateStandard(invariantContext)
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [HEATER_SHAKER_ID]: {
+          slot: HEATER_SHAKER_SLOT,
+          moduleState: {
+            type: 'heaterShakerModuleType',
+            targetSpeed: null,
+          },
+        } as any,
+      },
+    }
+
+    const result = heaterShaker(heaterShakerArgs, invariantContext, robotState)
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'heaterShaker/closeLabwareLatch',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/setTargetTemperature',
+        key: expect.any(String),
+        params: {
+          celsius: 80,
+          moduleId: 'heaterShakerId',
+        },
+      },
+    ])
+  })
+  it('should call to open latch last', () => {
+    heaterShakerArgs = {
+      ...heaterShakerArgs,
+      latchOpen: true,
+    }
+
+    const state = getInitialRobotStateStandard(invariantContext)
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [HEATER_SHAKER_ID]: {
+          slot: HEATER_SHAKER_SLOT,
+        } as any,
+      },
+    }
+
+    const result = heaterShaker(heaterShakerArgs, invariantContext, robotState)
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'heaterShaker/deactivateHeater',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/openLabwareLatch',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
         },
       },
     ])

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -34,6 +34,14 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
 
   const commandCreators: CurriedCommandCreator[] = []
 
+  if (!args.latchOpen) {
+    commandCreators.push(
+      curryCommandCreator(heaterShakerCloseLatch, {
+        moduleId: args.module,
+      })
+    )
+  }
+
   if (args.targetTemperature === null) {
     commandCreators.push(
       curryCommandCreator(heaterShakerDeactivateHeater, {
@@ -73,12 +81,6 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
   if (args.latchOpen) {
     commandCreators.push(
       curryCommandCreator(heaterShakerOpenLatch, {
-        moduleId: args.module,
-      })
-    )
-  } else {
-    commandCreators.push(
-      curryCommandCreator(heaterShakerCloseLatch, {
         moduleId: args.module,
       })
     )

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -34,20 +34,6 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
 
   const commandCreators: CurriedCommandCreator[] = []
 
-  if (args.latchOpen) {
-    commandCreators.push(
-      curryCommandCreator(heaterShakerOpenLatch, {
-        moduleId: args.module,
-      })
-    )
-  } else {
-    commandCreators.push(
-      curryCommandCreator(heaterShakerCloseLatch, {
-        moduleId: args.module,
-      })
-    )
-  }
-
   if (args.targetTemperature === null) {
     commandCreators.push(
       curryCommandCreator(heaterShakerDeactivateHeater, {
@@ -64,18 +50,36 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
     )
   }
 
-  if (args.rpm === null) {
+  if (
+    args.rpm === null &&
+    'targetSpeed' in heaterShakerState &&
+    heaterShakerState.targetSpeed !== null
+  ) {
     commandCreators.push(
       curryCommandCreator(heaterShakerStopShake, {
         moduleId: args.module,
       })
     )
-  } else {
+  } else if (args.rpm !== null) {
     commandCreators.push(
       curryCommandCreator(heaterShakerSetTargetShakeSpeed, {
         moduleId: args.module,
         commandCreatorFnName: 'setShakeSpeed',
         rpm: args.rpm,
+      })
+    )
+  }
+
+  if (args.latchOpen) {
+    commandCreators.push(
+      curryCommandCreator(heaterShakerOpenLatch, {
+        moduleId: args.module,
+      })
+    )
+  } else {
+    commandCreators.push(
+      curryCommandCreator(heaterShakerCloseLatch, {
+        moduleId: args.module,
       })
     )
   }


### PR DESCRIPTION
closes RAUT-453

bug somewhat outlined here: https://opentrons.atlassian.net/browse/RESC-134

# Overview

Change curried command order for heater-shaker so that the open latch command occurs at the end of the sequence, after the shake and heat commands. And only deactivate the shake if the H-S is already in motion

# Test Plan

Test this on a heater-shaker. I also confirmed that the protocol in the support ticket passed protocol analysis in the app after reimporting and exporting to PD with this change.

# Changelog

changed the order of curried command creator in `heaterShaker` and add some logic so deactivating the shaker only occurs when the heater shaker is already in motion.

# Review requests

see test plan

# Risk assessment

low