### PR TITLE
fix(api): Home pipette used correct gantry load settings

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -539,6 +539,8 @@ class OT3Controller:
     def _build_home_pipettes_runner(
         self, axes: Sequence[OT3Axis]
     ) -> Optional[MoveGroupRunner]:
+        # FIXME: this should switch between using low-throughput vs high-throughput
+        #        depending on what is attached
         speed_settings = (
             self._configuration.motion_settings.max_speed_discontinuity.low_throughput
         )
@@ -568,6 +570,8 @@ class OT3Controller:
     def _build_home_gantry_z_runner(
         self, axes: Sequence[OT3Axis]
     ) -> Optional[MoveGroupRunner]:
+        # FIXME: this should switch between using low-throughput vs high-throughput
+        #        depending on what is attached
         speed_settings = (
             self._configuration.motion_settings.max_speed_discontinuity.low_throughput
         )

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -300,7 +300,9 @@ class OT3Simulator:
         self._encoder_position.update(final_positions)
 
     @ensure_yield
-    async def home(self, axes: Optional[List[OT3Axis]] = None) -> OT3AxisMap[float]:
+    async def home(
+        self, axes: Sequence[OT3Axis], gantry_load: GantryLoad
+    ) -> OT3AxisMap[float]:
         """Home axes.
 
         Args:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1202,10 +1202,10 @@ class OT3API(
                     moves[0],
                     MoveStopCondition.none,
                 )
-            await self._backend.home([axis])
+            await self._backend.home([axis], self.gantry_load)
         else:
             # both stepper and encoder positions are invalid, must home
-            await self._backend.home([axis])
+            await self._backend.home([axis], self.gantry_load)
 
     async def _home(self, axes: Sequence[OT3Axis]) -> None:
         """Home one axis at a time."""
@@ -1215,7 +1215,7 @@ class OT3API(
                     if axis == OT3Axis.G:
                         await self.home_gripper_jaw()
                     elif axis == OT3Axis.Q:
-                        await self._backend.home([axis])
+                        await self._backend.home([axis], self.gantry_load)
                     else:
                         await self._home_axis(axis)
                 except ZeroLengthMoveError:

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -253,7 +253,7 @@ async def test_home_execute(
     assert not controller._motor_status
 
     commanded_homes = set(axes)
-    await controller.home(axes)
+    await controller.home(axes, GantryLoad.LOW_THROUGHPUT)
     all_calls = list(chain([args[0][0] for args in mock_move_group_run.call_args_list]))
     for command in all_calls:
         for group in command._move_groups:
@@ -277,7 +277,7 @@ async def test_home_prioritize_mount(
     # nothing has been homed
     assert not controller._motor_status
 
-    await controller.home(axes)
+    await controller.home(axes, GantryLoad.LOW_THROUGHPUT)
     has_xy = len({OT3Axis.X, OT3Axis.Y} & set(axes)) > 0
     has_mount = len(set(OT3Axis.mount_axes()) & set(axes)) > 0
     run = mock_move_group_run.call_args_list[0][0][0]._move_groups
@@ -302,7 +302,7 @@ async def test_home_build_runners(
     mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
     assert not controller._motor_status
 
-    await controller.home(axes)
+    await controller.home(axes, GantryLoad.LOW_THROUGHPUT)
     has_pipette = len(set(OT3Axis.pipette_axes()) & set(axes)) > 0
     has_gantry = len(set(OT3Axis.gantry_axes()) & set(axes)) > 0
 
@@ -348,7 +348,7 @@ async def test_home_only_present_devices(
 
     # nothing has been homed
     assert not controller._motor_status
-    await controller.home(axes)
+    await controller.home(axes, GantryLoad.LOW_THROUGHPUT)
 
     for call in mock_move_group_run.call_args_list:
         # pull the bound-self argument that is the runner instance out of
@@ -845,7 +845,7 @@ async def test_update_required_flag(
         controller._initialized = True
         controller._check_updates = True
         with pytest.raises(FirmwareUpdateRequired):
-            await controller.home(axes)
+            await controller.home(axes, GantryLoad.LOW_THROUGHPUT)
 
 
 async def test_update_required_bypass_firmware_update(controller: OT3Controller):

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -10,6 +10,7 @@ from opentrons.calibration_storage.types import (
     SourceType,
     CalibrationStatus,
 )
+from opentrons.config.types import GantryLoad
 from opentrons.hardware_control.types import (
     Axis,
     CriticalPoint,
@@ -87,8 +88,8 @@ async def test_home(ot3_hardware, mock_home):
     with mock.patch("opentrons.hardware_control.ot3api.deck_from_machine") as dfm_mock:
         dfm_mock.return_value = {OT3Axis.X: 20}
         await ot3_hardware._home([OT3Axis.X])
-
-        mock_home.assert_called_once_with([OT3Axis.X])
+        assert ot3_hardware.gantry_load == GantryLoad.LOW_THROUGHPUT
+        mock_home.assert_called_once_with([OT3Axis.X], GantryLoad.LOW_THROUGHPUT)
         assert dfm_mock.call_count == 2
         dfm_mock.assert_called_with(
             mock_home.return_value,
@@ -106,7 +107,8 @@ async def test_home_unmet(ot3_hardware, mock_home):
     mock_home.side_effect = MoveConditionNotMet()
     with pytest.raises(MoveConditionNotMet):
         await ot3_hardware.home([OT3Axis.X])
-    mock_home.assert_called_once_with([OT3Axis.X])
+    assert ot3_hardware.gantry_load == GantryLoad.LOW_THROUGHPUT
+    mock_home.assert_called_once_with([OT3Axis.X], GantryLoad.LOW_THROUGHPUT)
     assert ot3_hardware._current_position == {}
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

`OT3API` passes in the currently active `GantryLoad` when calling `OT3Controller.home()`, so that correct homing speeds are used.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
