### PR TITLE
fix(api): add a buffer to tip action home moves to make sure the limit switch is triggered

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -79,6 +79,9 @@ class TipMotorPickUpTipSpec:
     pick_up_distance: float
     speed: float
     currents: Dict[OT3Axis, float]
+    # FIXME we should throw this in a config
+    # file of some sort
+    home_buffer: float = 0
 
 
 @dataclass(frozen=True)
@@ -100,6 +103,9 @@ class DropTipMove:
     home_after_safety_margin: float = 0
     home_axes: Sequence[OT3Axis] = tuple()
     is_ht_tip_action: bool = False
+    # FIXME we should throw this in a config
+    # file of some sort
+    home_buffer: float = 0
 
 
 @dataclass(frozen=True)
@@ -691,6 +697,7 @@ class PipetteHandlerProvider:
                         pick_up_distance=instrument.pick_up_configurations.distance,
                         speed=instrument.pick_up_configurations.speed,
                         currents={OT3Axis.Q: instrument.pick_up_configurations.current},
+                        home_buffer=10,
                     ),
                 ),
                 add_tip_to_instr,
@@ -769,6 +776,7 @@ class PipetteHandlerProvider:
                     home_after_safety_margin=abs(bottom_pos - droptip_pos),
                     home_axes=home_axes,
                     is_ht_tip_action=is_ht_pipette,
+                    home_buffer=10 if is_ht_pipette else 0,
                 ),
                 DropTipMove(  # always finish drop-tip at a known safe plunger position
                     target_position=bottom_pos, current=plunger_currents, speed=None

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1619,7 +1619,7 @@ class OT3API(
             # back clamps off the adapter posts
             await self._backend.tip_action(
                 [OT3Axis.of_main_tool_actuator(mount)],
-                pipette_spec.pick_up_distance,
+                pipette_spec.pick_up_distance + pipette_spec.home_buffer,
                 pipette_spec.speed,
                 "home",
             )
@@ -1703,7 +1703,7 @@ class OT3API(
                 )
                 await self._backend.tip_action(
                     [OT3Axis.of_main_tool_actuator(mount)],
-                    move.target_position,
+                    move.target_position + move.home_buffer,
                     move.speed,
                     "home",
                 )

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -89,6 +89,7 @@ def test_plan_check_pick_up_tip_with_presses_argument(
                 pick_up_distance=0,
                 speed=10,
                 currents={OT3Axis.Q: 1},
+                home_buffer=10,
             ),
         ),
         (None, 3, 8, None),


### PR DESCRIPTION
## Overview

During pick up and drop tip movements on the 96 channel, we move the motor exactly the same distance as we do back to the home position. Strangely, these are also the only moves that seem to not be able to reset their position on a commanded home message.

There was another issue (resolved by https://github.com/Opentrons/ot3-firmware/pull/669) which I think was probably a red herring for the 'resetting from home' position issue.

# Test Plan

- [ ] Run a protocol that executes pickup/drop tip a bunch of times and visually check to make sure it's going to the right distance every time. Also check in the can monitor that on homed moves of the tip motor the position gets reset every time.

# Changelog

- Add a home buffer to the pick up and drop tip moves rather than using the exact same distance to move the motors back to the home position.

# Review requests

Does this solution seem OK for now? Also I know we need to do something with the floating hardcoded values in the `pipette_handler`, but decided to not address that here.

# Risk assessment

Low. Just adding a buffer for homing moves on the tip motors for the 96 channel.