### PR TITLE
refactor(app-shell): make upload system file aware of opentrons-usb hostname

### DIFF
--- a/app-shell/src/buildroot/update.ts
+++ b/app-shell/src/buildroot/update.ts
@@ -3,6 +3,8 @@
 
 import path from 'path'
 
+import { OPENTRONS_USB } from '@opentrons/app/src/redux/discovery/constants'
+
 import { fetch, postFile } from '../http'
 import { getSerialPortHttpAgent } from '../usb'
 
@@ -62,10 +64,19 @@ export function uploadSystemFile(
   urlPath: string,
   file: string
 ): Promise<unknown> {
+  const isUsbUpload = robot.ip === OPENTRONS_USB
+
   const serialPortHttpAgent = getSerialPortHttpAgent()
   const url = `http://${robot.ip}:${robot.port}${urlPath}`
 
-  return postFile(url, getSystemFileName(robot.robotModel), file, {
-    agent: serialPortHttpAgent,
-  })
+  return postFile(
+    url,
+    getSystemFileName(robot.robotModel),
+    file,
+    isUsbUpload
+      ? {
+          agent: serialPortHttpAgent,
+        }
+      : {}
+  )
 }


### PR DESCRIPTION
# Overview

only pass the serial port http agent to upload system file for opentrons-usb hostname.

otherwise, as noted by @shlokamin, regular wifi/ethernet http system file uploads will fail if the client is also connected via usb.

closes RCORE-765

# Test Plan

manually checked that app can upload a system update to an OT-3 when:
 - connected by both wifi/ethernet and usb
 - connected only by wifi/ethernet
 - connected only by usb

# Changelog

 -  Makes upload system file aware of opentrons-usb hostname

# Review requests

verify the above test cases

# Risk assessment

low
