### PR TITLE
refactor(app-shell,app): add status and statusText to IPC usb:request handler response

### DIFF
--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -99,7 +99,11 @@ async function usbListener(
       data,
       headers: { ...config.headers, ...formHeaders },
     })
-    return { data: response.data }
+    return {
+      data: response.data,
+      status: response.status,
+      statusText: response.statusText,
+    }
   } catch (e) {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     usbLog.debug(`usbListener error ${e?.message ?? 'unknown'}`)

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -66,9 +66,9 @@ export function fetchRobotApi(
           path,
           method,
           body: response?.data,
-          ok: response?.data != null,
-          // TODO(bh, 2023-04-25): until all response info forwarded (including unsuccessful requests), presume success here to quiet TS
-          status: 200,
+          status: response?.status,
+          // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
+          ok: response?.statusText === 'OK',
         }))
       )
     : from(fetch(url, options)).pipe(


### PR DESCRIPTION
# Overview

adds the status and statusText axios response props to the IPC usb:request handler for use by the remaining rxjs robot-api fetch calls

closes RCORE-767

# Test Plan

manually tested the remaining robot-api http calls: /networking/status, /system/time, etc

# Changelog

 - Adds status and statusText to IPC usb:request handler response

# Review requests

 smoke test device pages for a usb-connected robot, look for unexpected errors

# Risk assessment

low
