### PR TITLE
fix(app): unblock 96-Channel detach flow and calibration error flow

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -127,6 +127,8 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       proceed={proceed}
       isOnDevice={isOnDevice}
       errorMessage={errorMessage}
+      chainRunCommands={chainRunCommands}
+      mount={mount}
     />
   ) : (
     <GenericWizardTile

--- a/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { COLORS, PrimaryButton } from '@opentrons/components'
+import { CreateCommand, PipetteMount } from '@opentrons/shared-data'
 import { SmallButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 
@@ -8,13 +9,34 @@ interface CalibrationErrorModalProps {
   proceed: () => void
   isOnDevice: boolean | null
   errorMessage: string
+  chainRunCommands: (
+    commands: CreateCommand[],
+    continuePastCommandFailure: boolean
+  ) => Promise<any>
+  mount: PipetteMount
 }
 
 export function CalibrationErrorModal(
   props: CalibrationErrorModalProps
 ): JSX.Element {
-  const { proceed, isOnDevice, errorMessage } = props
+  const { proceed, isOnDevice, errorMessage, chainRunCommands, mount } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
+  const handleProceed = (): void => {
+    chainRunCommands(
+      [
+        {
+          // @ts-expect-error calibration type not yet supported
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: {
+            mount: mount,
+          },
+        },
+      ],
+      false
+    ).then(() => {
+      proceed()
+    })
+  }
   return (
     <SimpleWizardBody
       iconColor={COLORS.errorEnabled}
@@ -24,12 +46,12 @@ export function CalibrationErrorModal(
     >
       {isOnDevice ? (
         <SmallButton
-          onClick={proceed}
+          onClick={handleProceed}
           buttonText={i18n.format(t('next'), 'capitalize')}
           buttonType="primary"
         />
       ) : (
-        <PrimaryButton onClick={proceed}>
+        <PrimaryButton onClick={handleProceed}>
           {i18n.format(t('next'), 'capitalize')}
         </PrimaryButton>
       )}

--- a/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { COLORS, PrimaryButton } from '@opentrons/components'
-import { CreateCommand, PipetteMount } from '@opentrons/shared-data'
 import { SmallButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import type { CreateCommand, PipetteMount } from '@opentrons/shared-data'
 
 interface CalibrationErrorModalProps {
   proceed: () => void

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -8,7 +8,7 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from '@opentrons/components'
-import { SINGLE_MOUNT_PIPETTES, LEFT } from '@opentrons/shared-data'
+import { LEFT } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -19,14 +19,7 @@ import { BODY_STYLE, FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
 
 export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
-  const {
-    goBack,
-    proceed,
-    flowType,
-    selectedPipette,
-    chainRunCommands,
-    isOnDevice,
-  } = props
+  const { goBack, proceed, flowType, chainRunCommands, isOnDevice } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   const [errorMessage, setErrorMessage] = React.useState<boolean>(false)
   const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
@@ -54,9 +47,6 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
         setErrorMessage(true)
       })
   }
-  //  this should never happen but to be safe
-  if (selectedPipette === SINGLE_MOUNT_PIPETTES || flowType === FLOWS.CALIBRATE)
-    return null
 
   return errorMessage ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { RIGHT, SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
+import { RIGHT } from '@opentrons/shared-data'
 import { SPACING } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -15,15 +15,10 @@ export const MountingPlate = (
     goBack,
     proceed,
     flowType,
-    selectedPipette,
     chainRunCommands,
     setShowErrorMessage,
   } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
-
-  //  this should never happen but to be safe
-  if (selectedPipette === SINGLE_MOUNT_PIPETTES || flowType === FLOWS.CALIBRATE)
-    return null
 
   const handleDetachMountingPlate = (): void => {
     chainRunCommands(

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CalibrationErrorModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CalibrationErrorModal.test.tsx
@@ -16,23 +16,27 @@ describe('CalibrationErrorModal', () => {
       proceed: jest.fn(),
       errorMessage: 'error shmerror',
       isOnDevice: false,
+      chainRunCommands: jest.fn(() => Promise.resolve()),
+      mount: 'left',
     }
     const { getByText, getByRole } = render(props)
     getByText('Pipette calibration failed')
     getByText('error shmerror')
     getByRole('button', { name: 'Next' }).click()
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.chainRunCommands).toHaveBeenCalled()
   })
   it('renders the on device button with correct text', () => {
     props = {
       proceed: jest.fn(),
       errorMessage: 'error shmerror',
       isOnDevice: true,
+      chainRunCommands: jest.fn(() => Promise.resolve()),
+      mount: 'left',
     }
     const { getByText, getByLabelText } = render(props)
     getByText('Pipette calibration failed')
     getByText('error shmerror')
     getByLabelText('SmallButton_primary').click()
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.chainRunCommands).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
-import {
-  LEFT,
-  NINETY_SIX_CHANNEL,
-  SINGLE_MOUNT_PIPETTES,
-} from '@opentrons/shared-data'
+import { LEFT, NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { mockAttachedPipetteInformation } from '../../../redux/pipettes/__fixtures__'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
@@ -70,22 +66,6 @@ describe('Carriage', () => {
     getByRole('button', { name: 'Continue' })
     getByLabelText('back').click()
     expect(props.goBack).toHaveBeenCalled()
-  })
-  it('renders null if a single mount pipette is attached', () => {
-    props = {
-      ...props,
-      selectedPipette: SINGLE_MOUNT_PIPETTES,
-    }
-    const { container } = render(props)
-    expect(container.firstChild).toBeNull()
-  })
-  it('renders null if flow is calibrate is attached', () => {
-    props = {
-      ...props,
-      flowType: FLOWS.CALIBRATE,
-    }
-    const { container } = render(props)
-    expect(container.firstChild).toBeNull()
   })
   it('clicking on continue button executes the commands correctly', async () => {
     const { getByRole } = render(props)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
-import {
-  LEFT,
-  NINETY_SIX_CHANNEL,
-  RIGHT,
-  SINGLE_MOUNT_PIPETTES,
-} from '@opentrons/shared-data'
+import { LEFT, NINETY_SIX_CHANNEL, RIGHT } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { mockAttachedPipetteInformation } from '../../../redux/pipettes/__fixtures__'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
@@ -84,22 +79,5 @@ describe('MountingPlate', () => {
     const backBtn = getByLabelText('back')
     fireEvent.click(backBtn)
     expect(props.goBack).toHaveBeenCalled()
-  })
-  it('renders null if a single mount pipette is attached', () => {
-    props = {
-      ...props,
-      selectedPipette: SINGLE_MOUNT_PIPETTES,
-    }
-    const { container } = render(props)
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('renders null if flow is calibrate is attached', () => {
-    props = {
-      ...props,
-      flowType: FLOWS.CALIBRATE,
-    }
-    const { container } = render(props)
-    expect(container.firstChild).toBeNull()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -142,18 +142,21 @@ export const PipetteWizardFlows = (
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
     onSuccess: () => handleClose(),
+    onError: () => handleClose(),
   })
 
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
     if (maintenanceRunId == null) handleClose()
     else {
-      chainRunCommands(
-        [{ commandType: 'home' as const, params: {} }],
-        true
-      ).then(() => {
-        deleteMaintenanceRun(maintenanceRunId)
-      })
+      chainRunCommands([{ commandType: 'home' as const, params: {} }], false)
+        .then(() => {
+          deleteMaintenanceRun(maintenanceRunId)
+        })
+        .catch(error => {
+          console.error(error)
+          handleClose()
+        })
     }
   }
   const {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
A few pipette flow fixes to unblock 96-channel detach flow and various failures
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
I tested the following on Friday:
1. Successful 96-channel detach flow
2. 96-Channel attach flow with failed calibration and successful detach probe
3. Failed home command at end of flow doesn't get stuck on open modal spinner anymore

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Remove early null returns from 96-channel screens as they are getting triggered for 96-channel detach flow
4. Add in `moveToMaintenancePosition` command for detach probe step after calibration failure
5. Close modal and log error if final home or run deletion fail

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over the code changes
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
