### PR TITLE
chore(api,robot-server): allow OT-3 sim configs

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -329,8 +329,10 @@ class OT3API(
     @classmethod
     async def build_hardware_simulator(
         cls,
-        attached_instruments: Optional[
-            Dict[Union[top_types.Mount, OT3Mount], Dict[str, Optional[str]]]
+        attached_instruments: Union[
+            None,
+            Dict[OT3Mount, Dict[str, Optional[str]]],
+            Dict[top_types.Mount, Dict[str, Optional[str]]],
         ] = None,
         attached_modules: Optional[List[str]] = None,
         config: Union[RobotConfig, OT3Config, None] = None,
@@ -343,7 +345,6 @@ class OT3API(
         Multiple simulating hardware controllers may be active at one time.
         """
 
-        checked_attached = attached_instruments or {}
         checked_modules = attached_modules or []
 
         checked_loop = use_or_initialize_loop(loop)
@@ -352,7 +353,9 @@ class OT3API(
         else:
             checked_config = config
         backend = await OT3Simulator.build(
-            {OT3Mount.from_mount(k): v for k, v in checked_attached.items()},
+            {OT3Mount.from_mount(k): v for k, v in attached_instruments.items()}
+            if attached_instruments
+            else {},
             checked_modules,
             checked_config,
             checked_loop,

--- a/api/src/opentrons/hardware_control/simulator_setup.py
+++ b/api/src/opentrons/hardware_control/simulator_setup.py
@@ -1,13 +1,17 @@
 import asyncio
-from typing import Dict, Optional, Any, List, cast
-from dataclasses import dataclass, asdict, field
+from typing import Dict, Optional, Any, List, Union
+from typing_extensions import Literal
+from dataclasses import dataclass, asdict, field, replace
 import json
 from pathlib import Path
+from warnings import warn
 
 from opentrons.config import robot_configs
-from opentrons.config.types import RobotConfig
+from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.types import Mount
 from opentrons.hardware_control import API, HardwareControlAPI, ThreadManager
+from opentrons.hardware_control.ot3api import OT3API
+from opentrons.hardware_control.types import OT3Mount
 
 
 # Name and kwargs for a module function
@@ -19,7 +23,8 @@ class ModuleCall:
 
 
 @dataclass(frozen=True)
-class SimulatorSetup:
+class OT2SimulatorSetup:
+    machine: Literal["OT-2 Standard"] = "OT-2 Standard"
     attached_instruments: Dict[Mount, Dict[str, Optional[str]]] = field(
         default_factory=dict
     )
@@ -28,18 +33,46 @@ class SimulatorSetup:
     strict_attached_instruments: bool = True
 
 
+@dataclass(frozen=True)
+class OT3SimulatorSetup:
+    machine: Literal["OT-3 Standard"] = "OT-3 Standard"
+    attached_instruments: Dict[OT3Mount, Dict[str, Optional[str]]] = field(
+        default_factory=dict
+    )
+    attached_modules: Dict[str, List[ModuleCall]] = field(default_factory=dict)
+    config: Optional[OT3Config] = None
+    strict_attached_instruments: bool = True
+
+
+SimulatorSetup = Union[OT2SimulatorSetup, OT3SimulatorSetup]
+
+
+async def _simulator_for_setup(
+    setup: SimulatorSetup, loop: Optional[asyncio.AbstractEventLoop]
+) -> HardwareControlAPI:
+    if setup.machine == "OT-2 Standard":
+        return await API.build_hardware_simulator(
+            attached_instruments=setup.attached_instruments,
+            attached_modules=list(setup.attached_modules.keys()),
+            config=setup.config,
+            strict_attached_instruments=setup.strict_attached_instruments,
+            loop=loop,
+        )
+    else:
+        return await OT3API.build_hardware_simulator(
+            attached_instruments=setup.attached_instruments,
+            attached_modules=list(setup.attached_modules.keys()),
+            config=setup.config,
+            strict_attached_instruments=setup.strict_attached_instruments,
+            loop=loop,
+        )
+
+
 async def create_simulator(
     setup: SimulatorSetup, loop: Optional[asyncio.AbstractEventLoop] = None
 ) -> HardwareControlAPI:
     """Create a simulator"""
-    simulator = await API.build_hardware_simulator(
-        attached_instruments=setup.attached_instruments,
-        attached_modules=list(setup.attached_modules.keys()),
-        config=setup.config,
-        strict_attached_instruments=setup.strict_attached_instruments,
-        loop=loop,
-    )
-
+    simulator = await _simulator_for_setup(setup, loop)
     for attached_module in simulator.attached_modules:
         calls = setup.attached_modules[attached_module.name()]
         for call in calls:
@@ -56,18 +89,32 @@ async def load_simulator(
     return await create_simulator(setup=load_simulator_setup(path), loop=loop)
 
 
-async def load_simulator_thread_manager(
-    path: Path,
+def _thread_manager_for_setup(
+    setup: SimulatorSetup,
 ) -> ThreadManager[HardwareControlAPI]:
-    """Create a simulator wrapped in a ThreadManager from a JSON file."""
-    setup = load_simulator_setup(path)
-    thread_manager: ThreadManager[HardwareControlAPI] = ThreadManager(
-        API.build_hardware_simulator,
-        attached_instruments=setup.attached_instruments,
-        attached_modules=list(setup.attached_modules.keys()),
-        config=setup.config,
-        strict_attached_instruments=setup.strict_attached_instruments,
-    )
+    if setup.machine == "OT-2 Standard":
+        return ThreadManager(
+            API.build_hardware_simulator,
+            attached_instruments=setup.attached_instruments,
+            attached_modules=list(setup.attached_modules.keys()),
+            config=setup.config,
+            strict_attached_instruments=setup.strict_attached_instruments,
+        )
+    else:
+        return ThreadManager(
+            OT3API.build_hardware_simulator,
+            attached_instruments=setup.attached_instruments,
+            attached_modules=list(setup.attached_modules.keys()),
+            config=setup.config,
+            strict_attached_instruments=setup.strict_attached_instruments,
+        )
+
+
+async def create_simulator_thread_manager(
+    setup: SimulatorSetup,
+) -> ThreadManager[HardwareControlAPI]:
+    """Create a simulator thread manager from a loaded config."""
+    thread_manager = _thread_manager_for_setup(setup)
     await thread_manager.managed_thread_ready_async()
 
     for attached_module in thread_manager.wrapped().attached_modules:
@@ -79,10 +126,30 @@ async def load_simulator_thread_manager(
     return thread_manager
 
 
+async def load_simulator_thread_manager(
+    path: Path,
+) -> ThreadManager[HardwareControlAPI]:
+    """Create a simulator wrapped in a ThreadManager from a JSON file."""
+    return await create_simulator_thread_manager(load_simulator_setup(path))
+
+
 def save_simulator_setup(simulator_setup: SimulatorSetup, path: Path) -> None:
     """Write a simulator setup to a file."""
-    as_dict = asdict(simulator_setup)
-    as_dict = {k: _prepare_for_dict(k, v) for (k, v) in as_dict.items()}
+    no_config = replace(simulator_setup, config=None)
+    as_dict = asdict(no_config)
+
+    as_dict["config"] = (
+        robot_configs.config_to_save(simulator_setup.config)
+        if simulator_setup.config
+        else None
+    )
+
+    if as_dict.get("attached_instruments", None):
+        as_dict["attached_instruments"] = {
+            mount.name.lower(): data
+            for mount, data in as_dict["attached_instruments"].items()
+        }
+
     with path.open("w") as f:
         json.dump(as_dict, f)
 
@@ -91,19 +158,20 @@ def load_simulator_setup(path: Path) -> SimulatorSetup:
     """Load a simulator setup from a file."""
     with path.open() as f:
         obj = json.load(f)
-        return SimulatorSetup(
+
+    if "machine" not in obj:
+        warn(
+            "Simulator configuration does not name a machine, defaulting to OT-2 Standard"
+        )
+    machine_type = obj.get("machine", "OT-2 Standard")
+    if machine_type == "OT-2 Standard":
+        return OT2SimulatorSetup(
             **{k: _prepare_for_simulator_setup(k, v) for (k, v) in obj.items()}
         )
-
-
-def _prepare_for_dict(key: str, value: Dict[str, Any]) -> Dict[str, Any]:
-    """Convert an element in SimulatorSetup to be a serializable dict"""
-    if key == "attached_instruments" and value:
-        return {
-            mount.name.lower(): data
-            for (mount, data) in cast(Dict[Mount, Any], value).items()
-        }
-    return value
+    else:
+        return OT3SimulatorSetup(
+            **{k: _prepare_for_ot3_simulator_setup(k, v) for (k, v) in obj.items()}
+        )
 
 
 def _prepare_for_simulator_setup(key: str, value: Dict[str, Any]) -> Any:
@@ -112,6 +180,16 @@ def _prepare_for_simulator_setup(key: str, value: Dict[str, Any]) -> Any:
         return {Mount[mount.upper()]: data for (mount, data) in value.items()}
     if key == "config" and value:
         return robot_configs.build_config_ot2(value)
+    if key == "attached_modules" and value:
+        return {k: [ModuleCall(**data) for data in v] for (k, v) in value.items()}
+    return value
+
+
+def _prepare_for_ot3_simulator_setup(key: str, value: Dict[str, Any]) -> Any:
+    if key == "attached_instruments" and value:
+        return {OT3Mount[mount.upper()]: data for (mount, data) in value.items()}
+    if key == "config" and value:
+        return robot_configs.build_config_ot3(value)
     if key == "attached_modules" and value:
         return {k: [ModuleCall(**data) for data in v] for (k, v) in value.items()}
     return value

--- a/api/src/opentrons/hardware_control/simulator_setup.py
+++ b/api/src/opentrons/hardware_control/simulator_setup.py
@@ -10,7 +10,6 @@ from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig, OT3Config
 from opentrons.types import Mount
 from opentrons.hardware_control import API, HardwareControlAPI, ThreadManager
-from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.types import OT3Mount
 
 
@@ -59,6 +58,8 @@ async def _simulator_for_setup(
             loop=loop,
         )
     else:
+        from opentrons.hardware_control.ot3api import OT3API
+
         return await OT3API.build_hardware_simulator(
             attached_instruments=setup.attached_instruments,
             attached_modules=list(setup.attached_modules.keys()),
@@ -101,6 +102,8 @@ def _thread_manager_for_setup(
             strict_attached_instruments=setup.strict_attached_instruments,
         )
     else:
+        from opentrons.hardware_control.ot3api import OT3API
+
         return ThreadManager(
             OT3API.build_hardware_simulator,
             attached_instruments=setup.attached_instruments,

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -1,13 +1,62 @@
 from pathlib import Path
+from typing import Type, Union, cast
+
+import pytest
 
 from opentrons.config import robot_configs
 from opentrons.hardware_control.modules import MagDeck, Thermocycler, TempDeck
-from opentrons.hardware_control import simulator_setup
+from opentrons.hardware_control import simulator_setup, API
 from opentrons.types import Mount
+from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons.hardware_control.ot3api import OT3API
+from opentrons.hardware_control.types import OT3Mount
 
 
-async def test_with_magdeck():
-    setup = simulator_setup.SimulatorSetup(
+@pytest.fixture(params=["OT-2 Standard", "OT-3 Standard"])
+def machine_type(request: pytest.FixtureRequest) -> RobotType:
+    """Get both kinds of machine type."""
+    return cast(RobotType, request.param)
+
+
+@pytest.fixture
+def setup_klass(machine_type: RobotType) -> Type[simulator_setup.SimulatorSetup]:
+    """Get the appropriate setup class for the machine type."""
+    if machine_type == "OT-2 Standard":
+        return simulator_setup.OT2SimulatorSetup
+    else:
+        return simulator_setup.OT3SimulatorSetup
+
+
+@pytest.fixture
+def simulator_type(machine_type: RobotType) -> Union[Type[API], Type[OT3API]]:
+    """Get the appropriate simulated hardware controller instance type."""
+    if machine_type == "OT-2 Standard":
+        return API
+    else:
+        return OT3API
+
+
+async def assure_simulator_type(
+    setup_klass: Type[simulator_setup.SimulatorSetup],
+    simulator_type: Union[Type[API], Type[OT3API]],
+) -> None:
+    """It should create the appropriate kind of direct simulator."""
+    simulator = await simulator_setup.create_simulator(setup_klass())
+    assert isinstance(simulator, simulator_type)
+
+
+async def assure_thread_manager_type(
+    setup_klass: Type[simulator_setup.SimulatorSetup],
+    simulator_type: Union[Type[API], Type[OT3API]],
+) -> None:
+    """It should create the appropriate kind of thread manager simulator."""
+    manager = await simulator_setup.create_simulator_thread_manager(setup_klass())
+    assert isinstance(object.__getattribute__(manager, "managed_obj"), simulator_type)
+
+
+async def test_with_magdeck(setup_klass: Type[simulator_setup.SimulatorSetup]) -> None:
+    """It should work to build a magdeck."""
+    setup = setup_klass(
         attached_modules={
             "magdeck": [simulator_setup.ModuleCall("engage", kwargs={"height": 3})]
         }
@@ -21,8 +70,11 @@ async def test_with_magdeck():
     }
 
 
-async def test_with_thermocycler():
-    setup = simulator_setup.SimulatorSetup(
+async def test_with_thermocycler(
+    setup_klass: Type[simulator_setup.SimulatorSetup],
+) -> None:
+    """It should work to build a thermocycler."""
+    setup = setup_klass(
         attached_modules={
             "thermocycler": [
                 simulator_setup.ModuleCall(
@@ -59,8 +111,9 @@ async def test_with_thermocycler():
     }
 
 
-async def test_with_tempdeck():
-    setup = simulator_setup.SimulatorSetup(
+async def test_with_tempdeck(setup_klass: Type[simulator_setup.SimulatorSetup]) -> None:
+    """It should work to build a tempdeck."""
+    setup = setup_klass(
         attached_modules={
             "tempdeck": [
                 simulator_setup.ModuleCall(
@@ -81,10 +134,10 @@ async def test_with_tempdeck():
     }
 
 
-def test_persistance(tmpdir):
-    sim = simulator_setup.SimulatorSetup(
+def test_persistence_ot2(tmpdir: str) -> None:
+    sim = simulator_setup.OT2SimulatorSetup(
         attached_instruments={
-            Mount.LEFT: {"max_volume": 300},
+            Mount.LEFT: {"id": "an id"},
             Mount.RIGHT: {"id": "some id"},
         },
         attached_modules={
@@ -94,7 +147,30 @@ def test_persistance(tmpdir):
                 simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 24}),
             ],
         },
-        config=robot_configs.build_config({}),
+        config=robot_configs.build_config_ot2({}),
+    )
+    file = Path(tmpdir) / "sim_setup.json"
+    simulator_setup.save_simulator_setup(sim, file)
+    test_sim = simulator_setup.load_simulator_setup(file)
+
+    assert test_sim == sim
+
+
+def test_persistence_ot3(tmpdir: str) -> None:
+    sim = simulator_setup.OT3SimulatorSetup(
+        attached_instruments={
+            OT3Mount.LEFT: {"id": "an id"},
+            OT3Mount.RIGHT: {"id": "some id"},
+            OT3Mount.GRIPPER: {"id": "some-other-id"},
+        },
+        attached_modules={
+            "magdeck": [simulator_setup.ModuleCall("engage", kwargs={"height": 3})],
+            "tempdeck": [
+                simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 23}),
+                simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 24}),
+            ],
+        },
+        config=robot_configs.build_config_ot3({}),
     )
     file = Path(tmpdir) / "sim_setup.json"
     simulator_setup.save_simulator_setup(sim, file)

--- a/robot-server/dev-flex.env
+++ b/robot-server/dev-flex.env
@@ -1,0 +1,7 @@
+# Environment for Flex development
+
+ENABLE_VIRTUAL_SMOOTHIE=true
+OT_ROBOT_SERVER_persistence_directory=automatically_make_temporary
+OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test-flex.json
+OT_API_FF_enableOT3HardwareController=true
+DEV_ROBOT_NAME=opentrons-dev

--- a/robot-server/simulators/.gitignore
+++ b/robot-server/simulators/.gitignore
@@ -2,3 +2,4 @@
 *.json
 # ...unless specifically allowed.
 !test.json
+!test-flex.json

--- a/robot-server/simulators/README.md
+++ b/robot-server/simulators/README.md
@@ -10,6 +10,7 @@ The file is made up of the following keys:values which are all optional.
 
 ```
 {
+  "machine": "OT-2 Standard" # or "OT-3 Standard"; OT-2 is the default
   "attached_instruments": {
     "right": {
         # Definition of right pipette
@@ -18,6 +19,9 @@ The file is made up of the following keys:values which are all optional.
     "left": {
         # Definition of left pipette
         ...
+    },
+    "gripper": {
+        # Definition of gripper, if machine is OT-3 Standard
     }
   },
 }
@@ -74,7 +78,7 @@ See [pipette](../../api/src/opentrons/config/pipette_config.py) for available fi
 
 ### Configs
 
-This is the same format as `robot_settings.json` as defined in [robot_configs](../../api/src/opentrons/config/robot_configs.py).
+This is the same format as `robot_settings.json` as defined in [robot_configs](../../api/src/opentrons/config/robot_configs.py) if this is an OT-2. If this is an OT-3, it is the OT-3 variant.
 
 ```
 {

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -2,10 +2,10 @@
   "machine": "OT-3 Standard",
   "attached_instruments": {
     "right": {
-      "model": "p300_single_v3.4",
+      "model": "p1000_single_v3.4",
       "id": "321",
-      "max_volume": 300,
-      "name": "p300_single",
+      "max_volume": 1000,
+      "name": "p1000_single",
       "tip_length": 0,
       "channels": 1
     },

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -1,0 +1,64 @@
+{
+  "machine": "OT-3 Standard",
+  "attached_instruments": {
+    "right": {
+      "model": "p300_single_v3.4",
+      "id": "321",
+      "max_volume": 300,
+      "name": "p300_single",
+      "tip_length": 0,
+      "channels": 1
+    },
+    "left": {
+      "model": "p50_single_v3.4",
+      "id": "123",
+      "max_volume": 50,
+      "name": "p50_single",
+      "tip_length": 0,
+      "channels": 1
+    }
+  },
+  "attached_modules": {
+    "thermocycler": [
+      {
+        "function_name": "set_temperature",
+        "kwargs": {
+          "temperature": 3,
+          "hold_time_seconds": 1,
+          "hold_time_minutes": 2,
+          "ramp_rate": 4,
+          "volume": 5
+        }
+      },
+      {
+        "function_name": "set_lid_temperature",
+        "kwargs": {
+          "temperature": 4
+        }
+      }
+    ],
+    "heatershaker": [],
+    "tempdeck": [
+      {
+        "function_name": "start_set_temperature",
+        "kwargs": {
+          "celsius": 3
+        }
+      },
+      {
+        "function_name": "await_temperature",
+        "kwargs": {
+          "awaiting_temperature": null
+        }
+      }
+    ],
+    "magdeck": [
+      {
+        "function_name": "engage",
+        "kwargs": {
+          "height": 4
+        }
+      }
+    ]
+  }
+}

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -52,7 +52,7 @@ class DevServer:
         # This environment is only for the subprocess so it should
         # not have any side effects.
         env = {
-            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
+            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev-flex.env" if self.is_ot3 else "dev.env",
             "OT_API_FF_enableOT3HardwareController": "true" if self.is_ot3 else "false",
             "OT_API_CONFIG_DIR": str(self.ot_api_config_dir),
             "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -52,7 +52,9 @@ class DevServer:
         # This environment is only for the subprocess so it should
         # not have any side effects.
         env = {
-            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev-flex.env" if self.is_ot3 else "dev.env",
+            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev-flex.env"
+            if self.is_ot3
+            else "dev.env",
             "OT_API_FF_enableOT3HardwareController": "true" if self.is_ot3 else "false",
             "OT_API_CONFIG_DIR": str(self.ot_api_config_dir),
             "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),


### PR DESCRIPTION
We have a lovely submodule for creating simulated hardware controllers based on json config files, which is great, but that was never extended to handle the OT-3. This PR does that by
- Splitting the config into types since the configurations are slightly different
- Making the appropriate controller class get loaded based on the machine type from the configuration
- Adding a configuration file for the robot server integration tests that use an OT-3

I don't believe any integration tests actually use this server right now, but they will in #12731 which I'm going to rebase on top of this.