### PR TITLE
refactor(api): fix failing gripper api test

### DIFF
--- a/api/tests/opentrons/config/test_gripper_config.py
+++ b/api/tests/opentrons/config/test_gripper_config.py
@@ -5,7 +5,7 @@ from opentrons_shared_data.gripper.gripper_definition import GripperModel
 
 def test_load_gripper_config() -> None:
     loaded_config = gc.load(GripperModel.v1)
-    assert loaded_config.display_name == "Gripper V1"
+    assert loaded_config.display_name == "Flex Gripper"
 
 
 def test_gripper_force_conversion() -> None:

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -436,7 +436,7 @@ async def test_probing(
             ),
             "P1KSV33hello",
             "GRPV00fake_serial",
-            "Gripper V1",
+            "Flex Gripper",
         ),
     ],
 )


### PR DESCRIPTION
# Overview

Oops I accidentally merged a PR that [broke api tests](https://github.com/Opentrons/opentrons/actions/runs/5049458583/jobs/9059099885) because I didn't update the gripper name. This PR updates the expected gripper name in two api tests

# Risk assessment

Low