### PR TITLE
fix(app): replace pipette flow updates and cleanup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
@@ -33,7 +33,7 @@ export function SetupInstrumentCalibration({
   const { t } = useTranslation('protocol_setup')
   const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
 
-  const { data: instrumentsQueryData } = useInstrumentsQuery()
+  const { data: instrumentsQueryData, refetch } = useInstrumentsQuery()
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const usesGripper = isGripperInCommands(
@@ -62,6 +62,7 @@ export function SetupInstrumentCalibration({
             mount={mount}
             robotName={robotName}
             runId={runId}
+            instrumentsRefetch={refetch}
           />
         ) : null
       })}

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -45,7 +45,7 @@ interface SetupInstrumentCalibrationItemProps {
   mount: Mount
   robotName: string
   runId: string
-  instrumentsRefetch: () => void
+  instrumentsRefetch?: () => void
 }
 
 export function SetupPipetteCalibrationItem({

--- a/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupPipetteCalibrationItem.tsx
@@ -45,6 +45,7 @@ interface SetupInstrumentCalibrationItemProps {
   mount: Mount
   robotName: string
   runId: string
+  instrumentsRefetch: () => void
 }
 
 export function SetupPipetteCalibrationItem({
@@ -52,6 +53,7 @@ export function SetupPipetteCalibrationItem({
   mount,
   robotName,
   runId,
+  instrumentsRefetch,
 }: SetupInstrumentCalibrationItemProps): JSX.Element | null {
   const { t } = useTranslation(['protocol_setup', 'devices_landing'])
   const deviceDetailsUrl = `/devices/${robotName}`
@@ -194,6 +196,7 @@ export function SetupPipetteCalibrationItem({
               : SINGLE_MOUNT_PIPETTES
           }
           pipetteInfo={mostRecentAnalysis?.pipettes}
+          onComplete={instrumentsRefetch}
         />
       )}
       <SetupCalibrationItem

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -59,6 +59,7 @@ interface ProtocolInstrumentMountItemProps {
     | GripperData['data']['calibratedOffset']
     | null
   speccedName: PipetteName | GripperModel
+  instrumentsRefetch?: () => void
 }
 export function ProtocolInstrumentMountItem(
   props: ProtocolInstrumentMountItemProps
@@ -155,6 +156,7 @@ export function ProtocolInstrumentMountItem(
           selectedPipette={selectedPipette}
           mount={mount as Mount}
           pipetteInfo={mostRecentAnalysis?.pipettes}
+          onComplete={props.instrumentsRefetch}
         />
       ) : null}
     </>

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -129,6 +129,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       errorMessage={errorMessage}
       chainRunCommands={chainRunCommands}
       mount={mount}
+      setShowErrorMessage={setShowErrorMessage}
     />
   ) : (
     <GenericWizardTile

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -6,6 +6,8 @@ import {
   RIGHT,
   SINGLE_MOUNT_PIPETTES,
   WEIGHT_OF_96_CHANNEL,
+  LoadedPipette,
+  getPipetteNameSpecs,
 } from '@opentrons/shared-data'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
@@ -40,6 +42,7 @@ interface BeforeBeginningProps extends PipetteWizardStepProps {
     unknown
   >
   isCreateLoading: boolean
+  requiredPipette?: LoadedPipette
 }
 export const BeforeBeginning = (
   props: BeforeBeginningProps
@@ -57,6 +60,7 @@ export const BeforeBeginning = (
     setShowErrorMessage,
     selectedPipette,
     isOnDevice,
+    requiredPipette,
   } = props
   const { t } = useTranslation('pipette_wizard_flows')
   React.useEffect(() => {
@@ -99,8 +103,30 @@ export const BeforeBeginning = (
       break
     }
     case FLOWS.DETACH: {
-      bodyTranslationKey = 'get_started_detach'
-      equipmentList = [HEX_SCREWDRIVER]
+      if (requiredPipette != null) {
+        const displayName =
+          getPipetteNameSpecs(requiredPipette.pipetteName)?.displayName ??
+          requiredPipette.pipetteName
+        bodyTranslationKey = 'remove_labware'
+
+        if (requiredPipette.pipetteName === 'p1000_96') {
+          equipmentList = [
+            { ...NINETY_SIX_CHANNEL_PIPETTE, displayName: displayName },
+            CALIBRATION_PROBE,
+            HEX_SCREWDRIVER,
+            NINETY_SIX_CHANNEL_MOUNTING_PLATE,
+          ]
+        } else {
+          equipmentList = [
+            { ...PIPETTE, displayName: displayName },
+            CALIBRATION_PROBE,
+            HEX_SCREWDRIVER,
+          ]
+        }
+      } else {
+        bodyTranslationKey = 'get_started_detach'
+        equipmentList = [HEX_SCREWDRIVER]
+      }
       break
     }
   }

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -90,11 +90,24 @@ export const BeforeBeginning = (
     }
     case FLOWS.ATTACH: {
       bodyTranslationKey = 'remove_labware'
+      let displayName: string | undefined
+      if (requiredPipette != null) {
+        displayName =
+          getPipetteNameSpecs(requiredPipette.pipetteName)?.displayName ??
+          requiredPipette.pipetteName
+      }
       if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        equipmentList = [PIPETTE, CALIBRATION_PROBE, HEX_SCREWDRIVER]
+        equipmentList = [
+          { ...PIPETTE, displayName: displayName ?? PIPETTE.displayName },
+          CALIBRATION_PROBE,
+          HEX_SCREWDRIVER,
+        ]
       } else {
         equipmentList = [
-          NINETY_SIX_CHANNEL_PIPETTE,
+          {
+            ...NINETY_SIX_CHANNEL_PIPETTE,
+            displayName: displayName ?? NINETY_SIX_CHANNEL_PIPETTE.displayName,
+          },
           CALIBRATION_PROBE,
           HEX_SCREWDRIVER,
           NINETY_SIX_CHANNEL_MOUNTING_PLATE,

--- a/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
@@ -14,12 +14,20 @@ interface CalibrationErrorModalProps {
     continuePastCommandFailure: boolean
   ) => Promise<any>
   mount: PipetteMount
+  setShowErrorMessage: (message: string) => void
 }
 
 export function CalibrationErrorModal(
   props: CalibrationErrorModalProps
 ): JSX.Element {
-  const { proceed, isOnDevice, errorMessage, chainRunCommands, mount } = props
+  const {
+    proceed,
+    isOnDevice,
+    errorMessage,
+    chainRunCommands,
+    mount,
+    setShowErrorMessage,
+  } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   const handleProceed = (): void => {
     chainRunCommands(
@@ -33,9 +41,11 @@ export function CalibrationErrorModal(
         },
       ],
       false
-    ).then(() => {
-      proceed()
-    })
+    )
+      .then(() => {
+        proceed()
+      })
+      .catch(error => setShowErrorMessage(error.message))
   }
   return (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -46,6 +46,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
     hasCalData,
     isRobotMoving,
     requiredPipette,
+    setShowErrorMessage,
   } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   const pipetteName =
@@ -134,6 +135,15 @@ export const Results = (props: ResultsProps): JSX.Element => {
       chainRunCommands(
         [
           {
+            commandType: 'loadPipette' as const,
+            params: {
+              // @ts-expect-error pipetteName is required but missing in schema v6 type
+              pipetteName: attachedPipettes[mount]?.instrumentName,
+              pipetteId: attachedPipettes[mount]?.serialNumber,
+              mount: mount,
+            },
+          },
+          {
             commandType: 'home' as const,
             params: {
               axes: [axis],
@@ -147,10 +157,14 @@ export const Results = (props: ResultsProps): JSX.Element => {
             },
           },
         ],
-        true
-      ).then(() => {
-        proceed()
-      })
+        false
+      )
+        .then(() => {
+          proceed()
+        })
+        .catch(error => {
+          setShowErrorMessage(error.message)
+        })
     } else if (
       isSuccess &&
       flowType === FLOWS.DETACH &&
@@ -166,10 +180,14 @@ export const Results = (props: ResultsProps): JSX.Element => {
             },
           },
         ],
-        true
-      ).then(() => {
-        proceed()
-      })
+        false
+      )
+        .then(() => {
+          proceed()
+        })
+        .catch(error => {
+          setShowErrorMessage(error.message)
+        })
     } else {
       proceed()
     }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -103,6 +103,9 @@ export const Results = (props: ResultsProps): JSX.Element => {
         isSuccess = false
       } else {
         header = i18n.format(t('pipette_detached'), 'capitalize')
+        if (requiredPipette != null) {
+          buttonText = t('attach_pip')
+        }
         if (selectedPipette === NINETY_SIX_CHANNEL) {
           if (currentStepIndex === totalStepCount) {
             header = t('ninety_six_detached_success', {
@@ -136,6 +139,25 @@ export const Results = (props: ResultsProps): JSX.Element => {
               axes: [axis],
             },
           },
+          {
+            // @ts-expect-error calibration type not yet supported
+            commandType: 'calibration/moveToMaintenancePosition' as const,
+            params: {
+              mount: mount,
+            },
+          },
+        ],
+        true
+      ).then(() => {
+        proceed()
+      })
+    } else if (
+      isSuccess &&
+      flowType === FLOWS.DETACH &&
+      currentStepIndex !== totalStepCount
+    ) {
+      chainRunCommands(
+        [
           {
             // @ts-expect-error calibration type not yet supported
             commandType: 'calibration/moveToMaintenancePosition' as const,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -58,6 +58,7 @@ describe('BeforeBeginning', () => {
       isCreateLoading: false,
       isRobotMoving: false,
       isOnDevice: false,
+      requiredPipette: undefined,
     }
     // mockNeedHelpLink.mockReturnValue(<div>mock need help link</div>)
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
@@ -158,6 +159,56 @@ describe('BeforeBeginning', () => {
       fireEvent.click(proceedBtn)
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
+          { commandType: 'home' as const, params: {} },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
+    it('renders the attach flow when swapping pipettes is needed', async () => {
+      props = {
+        ...props,
+        attachedPipettes: { left: mockAttachedPipetteInformation, right: null },
+        flowType: FLOWS.DETACH,
+        requiredPipette: {
+          mount: LEFT,
+          id: 'abc',
+          pipetteName: 'p1000_single_gen3',
+        },
+      }
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.'
+      )
+      getByText(
+        'The calibration probe is included with the robot and should be stored on the front pillar of the robot.'
+      )
+      getByAltText('Flex 1-Channel 1000 μL')
+      getByText('You will need:')
+      getByAltText('Calibration Probe')
+      getByAltText('2.5 mm Hex Screwdriver')
+      getByText(
+        'Provided with the robot. Using another size can strip the instruments’s screws.'
+      )
+      const proceedBtn = getByRole('button', { name: 'Move gantry to front' })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
@@ -317,6 +368,63 @@ describe('BeforeBeginning', () => {
         attachedPipettes: { left: mockAttachedPipetteInformation, right: null },
         flowType: FLOWS.ATTACH,
         selectedPipette: NINETY_SIX_CHANNEL,
+      }
+      const { getByText, getByAltText, getByRole } = render(props)
+      getByText('Before you begin')
+      getByText(
+        'To get started, remove labware from the deck and clean up the working area to make attachment and calibration easier. Also gather the needed equipment shown to the right.'
+      )
+      getByText(
+        'The calibration probe is included with the robot and should be stored on the front pillar of the robot.'
+      )
+      getByText(
+        'The 96-Channel Pipette is heavy (~10kg). Ask a labmate for help, if needed.'
+      )
+      getByAltText('2.5 mm Hex Screwdriver')
+      getByAltText('Calibration Probe')
+      getByAltText('96-Channel Pipette')
+      getByAltText('96-Channel Mounting Plate')
+      getByText(
+        'Provided with the robot. Using another size can strip the instruments’s screws.'
+      )
+      const proceedBtn = getByRole('button', {
+        name: 'Move gantry to front',
+      })
+      fireEvent.click(proceedBtn)
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'loadPipette',
+            params: {
+              mount: LEFT,
+              pipetteId: 'abc',
+              pipetteName: 'p1000_single_gen3',
+            },
+          },
+          { commandType: 'home' as const, params: {} },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+      await waitFor(() => {
+        expect(props.proceed).toHaveBeenCalled()
+      })
+    })
+    it('renders the detach and attach 96 channel flow when there is a required 96-channel', async () => {
+      mockGetIsGantryEmpty.mockReturnValue(false)
+      props = {
+        ...props,
+        attachedPipettes: { left: mockAttachedPipetteInformation, right: null },
+        flowType: FLOWS.ATTACH,
+        selectedPipette: NINETY_SIX_CHANNEL,
+        requiredPipette: {
+          id: '123',
+          pipetteName: 'p1000_96',
+          mount: 'left',
+        },
       }
       const { getByText, getByAltText, getByRole } = render(props)
       getByText('Before you begin')

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -439,7 +439,7 @@ describe('BeforeBeginning', () => {
       )
       getByAltText('2.5 mm Hex Screwdriver')
       getByAltText('Calibration Probe')
-      getByAltText('96-Channel Pipette')
+      getByAltText('Flex 96-Channel 1000 μL')
       getByAltText('96-Channel Mounting Plate')
       getByText(
         'Provided with the robot. Using another size can strip the instruments’s screws.'

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CalibrationErrorModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CalibrationErrorModal.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
+import { waitFor } from '@testing-library/dom'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { CalibrationErrorModal } from '../CalibrationErrorModal'
-import { waitFor } from '@testing-library/dom'
 
 const render = (props: React.ComponentProps<typeof CalibrationErrorModal>) => {
   return renderWithProviders(<CalibrationErrorModal {...props} />, {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/CalibrationErrorModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/CalibrationErrorModal.test.tsx
@@ -18,6 +18,7 @@ describe('CalibrationErrorModal', () => {
       isOnDevice: false,
       chainRunCommands: jest.fn(() => Promise.resolve()),
       mount: 'left',
+      setShowErrorMessage: jest.fn(),
     }
     const { getByText, getByRole } = render(props)
     getByText('Pipette calibration failed')
@@ -32,6 +33,7 @@ describe('CalibrationErrorModal', () => {
       isOnDevice: true,
       chainRunCommands: jest.fn(() => Promise.resolve()),
       mount: 'left',
+      setShowErrorMessage: jest.fn(),
     }
     const { getByText, getByLabelText } = render(props)
     getByText('Pipette calibration failed')

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -168,7 +168,7 @@ describe('Results', () => {
       screen.queryByRole('button', { name: 'Results_errorExit' })
     ).not.toBeInTheDocument()
   })
-  it('renders the correct information when pipette wizard is a fail for 96 channel attach flow and gantry not empty', async () => {
+  it('renders the correct information when pipette wizard is a failing to detach before 96 channel attach flow', async () => {
     props = {
       ...props,
       flowType: FLOWS.DETACH,
@@ -182,7 +182,7 @@ describe('Results', () => {
     getByRole('button', { name: 'Try again' }).click()
     await act(() => pipettePromise)
   })
-  it('renders the correct information when pipette wizard is a success for 96 channel attach flow and gantry not empty', () => {
+  it('renders the correct information when pipette wizard is a success for detaching before 96 channel attach flow', () => {
     props = {
       ...props,
       flowType: FLOWS.DETACH,
@@ -196,7 +196,17 @@ describe('Results', () => {
     )
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.chainRunCommands).toHaveBeenCalledWith(
+      [
+        {
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: {
+            mount: 'left',
+          },
+        },
+      ],
+      true
+    )
   })
   it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel', () => {
     props = {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -90,6 +90,14 @@ describe('Results', () => {
     expect(props.chainRunCommands).toHaveBeenCalledWith(
       [
         {
+          commandType: 'loadPipette' as const,
+          params: {
+            pipetteName: 'p1000_single_gen3',
+            pipetteId: 'abc',
+            mount: 'left',
+          },
+        },
+        {
           commandType: 'home' as const,
           params: {
             axes: ['leftPlunger'],
@@ -102,7 +110,7 @@ describe('Results', () => {
           },
         },
       ],
-      true
+      false
     )
   })
   it('renders the correct information when pipette wizard is a fail for attach flow', async () => {
@@ -205,7 +213,7 @@ describe('Results', () => {
           },
         },
       ],
-      true
+      false
     )
   })
   it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel', () => {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -1,22 +1,12 @@
 import {
   LEFT,
+  RIGHT,
   SINGLE_MOUNT_PIPETTES,
   NINETY_SIX_CHANNEL,
 } from '@opentrons/shared-data'
-import { mockAttachedPipetteInformation } from '../../../redux/pipettes/__fixtures__'
 import { FLOWS, SECTIONS } from '../constants'
 import { getPipetteWizardSteps } from '../getPipetteWizardSteps'
 import type { PipetteWizardStep } from '../types'
-import type { AttachedPipettesFromInstrumentsQuery } from '../../Devices/hooks'
-
-const mockAttachedPipettesEmpty: AttachedPipettesFromInstrumentsQuery = {
-  left: null,
-  right: null,
-}
-const mockAttachedPipettesNotEmpty: AttachedPipettesFromInstrumentsQuery = {
-  left: mockAttachedPipetteInformation,
-  right: null,
-}
 
 describe('getPipetteWizardSteps', () => {
   it('returns the correct array of info when the flow is calibrate single channel', () => {
@@ -44,13 +34,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.CALIBRATE,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        mockAttachedPipettesNotEmpty
-      )
+      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
   it('returns the correct array of info for attach pipette flow single channel', () => {
@@ -88,13 +72,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.ATTACH,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        mockAttachedPipettesEmpty
-      )
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -118,13 +96,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.DETACH,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        mockAttachedPipettesNotEmpty
-      )
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 
@@ -173,13 +145,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.ATTACH,
-        LEFT,
-        NINETY_SIX_CHANNEL,
-        true,
-        mockAttachedPipettesEmpty
-      )
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -213,28 +179,22 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.DETACH,
-        LEFT,
-        NINETY_SIX_CHANNEL,
-        true,
-        mockAttachedPipettesNotEmpty
-      )
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
   it('returns the correct array when 96-channel is going to be attached and there is a pipette already on the mount', () => {
     const mockAttachPipetteFlowSteps = [
       {
         section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
+        mount: RIGHT,
         flowType: FLOWS.ATTACH,
       },
       {
         section: SECTIONS.DETACH_PIPETTE,
-        mount: LEFT,
+        mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -273,13 +233,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.ATTACH,
-        LEFT,
-        NINETY_SIX_CHANNEL,
-        false,
-        mockAttachedPipettesNotEmpty
-      )
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
   it('returns the corect array of info for calibrate pipette 96 channel', () => {
@@ -307,13 +261,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.CALIBRATE,
-        LEFT,
-        NINETY_SIX_CHANNEL,
-        false,
-        mockAttachedPipettesNotEmpty
-      )
+      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, NINETY_SIX_CHANNEL, false)
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -93,11 +93,6 @@ describe('getPipetteWizardStepsForProtocol', () => {
       },
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
         section: SECTIONS.MOUNT_PIPETTE,
         mount: LEFT,
         flowType: FLOWS.ATTACH,
@@ -151,11 +146,6 @@ describe('getPipetteWizardStepsForProtocol', () => {
       },
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
         section: SECTIONS.MOUNT_PIPETTE,
         mount: LEFT,
         flowType: FLOWS.ATTACH,
@@ -198,11 +188,6 @@ describe('getPipetteWizardStepsForProtocol', () => {
         flowType: FLOWS.DETACH,
       },
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -257,11 +242,6 @@ describe('getPipetteWizardStepsForProtocol', () => {
       },
       { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
       {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
         flowType: FLOWS.ATTACH,
@@ -315,21 +295,11 @@ describe('getPipetteWizardStepsForProtocol', () => {
       },
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-      },
-      {
         section: SECTIONS.DETACH_PIPETTE,
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
       { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -51,20 +51,24 @@ export const getPipetteWizardSteps = (
       } else {
         //  pipette needs to be detached before attached 96 channel
         if (!isGantryEmpty) {
+          let detachMount: PipetteMount = LEFT
+          if (mount === LEFT) {
+            detachMount = RIGHT
+          }
           return [
             {
               section: SECTIONS.BEFORE_BEGINNING,
-              mount: RIGHT,
+              mount: detachMount,
               flowType: flowType,
             },
             {
               section: SECTIONS.DETACH_PIPETTE,
-              mount: RIGHT,
+              mount: detachMount,
               flowType: FLOWS.DETACH,
             },
             {
               section: SECTIONS.RESULTS,
-              mount: RIGHT,
+              mount: detachMount,
               flowType: FLOWS.DETACH,
             },
             {

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -6,14 +6,12 @@ import type {
   SelectablePipettes,
 } from './types'
 import type { PipetteMount } from '@opentrons/shared-data'
-import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 
 export const getPipetteWizardSteps = (
   flowType: PipetteWizardFlow,
   mount: PipetteMount,
   selectedPipette: SelectablePipettes,
-  isGantryEmpty: boolean,
-  attachedPipettes: AttachedPipettesFromInstrumentsQuery
+  isGantryEmpty: boolean
 ): PipetteWizardStep[] => {
   switch (flowType) {
     case FLOWS.CALIBRATE: {
@@ -51,28 +49,22 @@ export const getPipetteWizardSteps = (
           },
         ]
       } else {
-        let detachMount = mount
-        if (attachedPipettes[LEFT] == null) {
-          detachMount = RIGHT
-        } else if (attachedPipettes[RIGHT] == null) {
-          detachMount = LEFT
-        }
         //  pipette needs to be detached before attached 96 channel
         if (!isGantryEmpty) {
           return [
             {
               section: SECTIONS.BEFORE_BEGINNING,
-              mount: detachMount,
+              mount: RIGHT,
               flowType: flowType,
             },
             {
               section: SECTIONS.DETACH_PIPETTE,
-              mount: detachMount,
+              mount: RIGHT,
               flowType: FLOWS.DETACH,
             },
             {
               section: SECTIONS.RESULTS,
-              mount: detachMount,
+              mount: RIGHT,
               flowType: FLOWS.DETACH,
             },
             {

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -73,11 +73,6 @@ export const getPipetteWizardStepsForProtocol = (
         },
         { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
         {
-          section: SECTIONS.BEFORE_BEGINNING,
-          mount: mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
           section: SECTIONS.MOUNT_PIPETTE,
           mount: mount,
           flowType: FLOWS.ATTACH,
@@ -113,11 +108,6 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.DETACH,
         },
         { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.DETACH },
-        {
-          section: SECTIONS.BEFORE_BEGINNING,
-          mount: mount,
-          flowType: FLOWS.ATTACH,
-        },
         {
           section: SECTIONS.MOUNT_PIPETTE,
           mount: mount,
@@ -160,21 +150,11 @@ export const getPipetteWizardStepsForProtocol = (
       },
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-      },
-      {
         section: SECTIONS.DETACH_PIPETTE,
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
       { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -226,11 +206,6 @@ export const getPipetteWizardStepsForProtocol = (
       },
       { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
       {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
         flowType: FLOWS.ATTACH,
@@ -280,11 +255,6 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.DETACH,
       },
       { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -83,14 +83,14 @@ export const PipetteWizardFlows = (
   )
   const hasCalData =
     attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
-
+  const memoizedAttachedPipettes = React.useMemo(() => attachedPipettes, [])
   const wizardTitle = usePipetteFlowWizardHeaderText({
     flowType,
     mount,
     selectedPipette,
     hasCalData,
     isGantryEmpty,
-    attachedPipettes,
+    attachedPipettes: memoizedAttachedPipettes,
     pipetteInfo: memoizedPipetteInfo,
   })
 
@@ -132,7 +132,7 @@ export const PipetteWizardFlows = (
   const handleClose = (): void => {
     setIsExiting(false)
     closeFlow()
-    if (currentStepIndex === totalStepCount && onComplete != null) onComplete()
+    if (onComplete != null) onComplete()
   }
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -56,26 +56,21 @@ export const PipetteWizardFlows = (
   const { t } = useTranslation('pipette_wizard_flows')
 
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
+  const memoizedPipetteInfo = React.useMemo(() => props.pipetteInfo ?? null, [])
   const isGantryEmpty =
     attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null
   const pipetteWizardSteps = React.useMemo(
     () =>
-      props.pipetteInfo == null
-        ? getPipetteWizardSteps(
-            flowType,
-            mount,
-            selectedPipette,
-            isGantryEmpty,
-            attachedPipettes
-          )
+      memoizedPipetteInfo == null
+        ? getPipetteWizardSteps(flowType, mount, selectedPipette, isGantryEmpty)
         : getPipetteWizardStepsForProtocol(
             attachedPipettes,
-            props.pipetteInfo,
+            memoizedPipetteInfo,
             mount
           ),
     []
   )
-  const requiredPipette = props.pipetteInfo?.find(
+  const requiredPipette = memoizedPipetteInfo?.find(
     pipette => pipette.mount === mount
   )
   const host = useHost()
@@ -96,7 +91,7 @@ export const PipetteWizardFlows = (
     hasCalData,
     isGantryEmpty,
     attachedPipettes,
-    pipetteInfo: props.pipetteInfo ?? null,
+    pipetteInfo: memoizedPipetteInfo,
   })
 
   const goBack = (): void => {
@@ -220,6 +215,7 @@ export const PipetteWizardFlows = (
         {...calibrateBaseProps}
         createMaintenanceRun={createMaintenanceRun}
         isCreateLoading={isCreateLoading}
+        requiredPipette={requiredPipette}
       />
     )
   } else if (currentStep.section === SECTIONS.ATTACH_PROBE) {

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -33,7 +33,7 @@ export function ProtocolSetupInstruments({
   setSetupScreen,
 }: ProtocolSetupInstrumentsProps): JSX.Element {
   const { t, i18n } = useTranslation('protocol_setup')
-  const { data: attachedInstruments } = useInstrumentsQuery()
+  const { data: attachedInstruments, refetch } = useInstrumentsQuery()
   const {
     data: allPipettesCalibrationData,
   } = useAllPipetteOffsetCalibrationsQuery()
@@ -93,6 +93,7 @@ export function ProtocolSetupInstruments({
                   ) ?? null
                 : null
             }
+            instrumentsRefetch={refetch}
           />
         )
       })}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->


# Overview
This PR fixes the items I found while dev testing single and 8-channel run setup flows: RLIQ-396, RLIQ-395, and RLIQ-394
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
I ran through a few replace pipette flows to make sure this works as expected
https://github.com/Opentrons/opentrons/assets/14302493/63caaa6e-3c0c-476c-b910-e633456b0be5
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

1. Only show before beginning screen once for replace flows
3. If there is a required pipette, show that pipettes name on the before beginning screen instead of a generic pipette item
6. Memoize props for usePipetteFlowWizardHeaderText  so the title doesn’t change during the flow
2. Refetch instruments when you close a flow from run setup on both desktop and odd
4. Add error handling to a few places we were calling chainRunCommands without it
5. Add functionality to the results page to ensure CTA copy and command called is correct when moving from results into a different detach or attach flow

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->
Look over the code
# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
