### PR TITLE
fix(docs): note that 2.14 doesn't work with Jupyter

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -17,10 +17,10 @@ The OT-2 runs a `Jupyter Notebook <https://jupyter.org>`_ server on port 48888, 
 .. note::
     The Jupyter Notebook server only supports versions 2.13 and earlier of the Python API. Use the Opentrons App to run protocols that require functionality added in newer versions.
 
-To access the OT-2’s Jupyter Notebook, either:
+Access the OT-2’s Jupyter Notebook one of two ways:
 
-- go to the **Advanced** tab of Robot Settings and click the **Launch Jupyter Notebook** button, or
-- if you know your robot's IP address, navigate directly to ``http://<robot-ip>:48888`` in your web browser.
+- Go to the **Advanced** tab of Robot Settings and click the **Launch Jupyter Notebook** button.
+- If you know your robot's IP address, navigate directly to ``http://<robot-ip>:48888`` in your web browser.
 
 Once you've launched Jupyter Notebook, you can create a notebook file or edit an existing one. These notebook files are stored on the OT-2 itself. If you want to save code from a notebook to your computer, go to **File > Download As** in the notebook interface.
 

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -14,6 +14,9 @@ Jupyter Notebook
 
 The OT-2 runs a `Jupyter Notebook <https://jupyter.org>`_ server on port 48888, which you can connect to with your web browser. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells and run a single cell at a time.
 
+.. note::
+    The Jupyter Notebook server only supports versions 2.13 and earlier of the Python API. Use the Opentrons App to run protocols that require functionality added in newer versions.
+
 To access the OT-2’s Jupyter Notebook, either:
 
 - go to the **Advanced** tab of Robot Settings and click the **Launch Jupyter Notebook** button, or
@@ -32,7 +35,7 @@ Rather than writing a  ``run`` function and embedding commands within it, start 
     :substitutions:
 
     import opentrons.execute
-    protocol = opentrons.execute.get_protocol_api('|apiLevel|')
+    protocol = opentrons.execute.get_protocol_api('2.13')
     protocol.home()
 
 The first command you execute should always be :py:meth:`~opentrons.protocol_api.ProtocolContext.home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Jupyter notebook relies on tools, especially `opentrons.simulate.get_protocol_api()`, that aren't supported in version 2.14 and later of the Python API. We noted this on the Versioning page but didn't mention it on the Advanced Control page. This PR updates the Advanced Control page.

# Test and Deployment Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

This is a _docs hotfix_ and requires a slightly different process than most PRs. `edge` has diverged significantly from the previous docs deployment, and we don't want to include updates from edge in this small docs change.

1. Get approving reviews based on the content in the [branch sandbox](http://sandbox.docs.opentrons.com/docs-hotfix-jupyter-api-version/v2/new_advanced_running.html).
  a. Approve the additions to Advanced Control.
  b. Check that the API Reference and other pages don't have any extra new stuff in them.
2. I'll tag and deploy the docs _before_ merging this PR.
3. I'll merge this PR so the changes carry forward in future docs.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- New note about Jupyter version support.
- Changed version in code snippet from variable (latest version) to static `2.13`

# Review requests

<!--
Describe any requests for your reviewers here.
-->

- Check out the sandbox. Please double check the API reference and other snippets that have variable API levels! They should all reflect 2.14 as of its release.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

V low, it's docs.