### PR TITLE
fix(hardware-testing): home the gantry when verifying module calibration offset

### DIFF
--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -138,13 +138,13 @@ async def build_async_ot3_hardware_api(
     config = build_config_ot3({}) if use_defaults else load_ot3_config()
     kwargs = {"config": config}
     if is_simulating:
-        builder = OT3API.build_hardware_simulator
+        builder = OT3API.build_hardware_simulator  # type: ignore
         sim_pips = _create_attached_instruments_dict(
             pipette_left, pipette_right, gripper
         )
         kwargs["attached_instruments"] = sim_pips  # type: ignore[assignment]
     else:
-        builder = OT3API.build_hardware_controller
+        builder = OT3API.build_hardware_controller  # type: ignore
         stop_server_ot3()
         restart_canbus_ot3()
         kwargs["use_usb_bus"] = True  # type: ignore[assignment]

--- a/hardware-testing/hardware_testing/scripts/module_calibration.py
+++ b/hardware-testing/hardware_testing/scripts/module_calibration.py
@@ -81,6 +81,7 @@ def _main(args: argparse.Namespace, opentrons_api: OpentronsHTTPAPI) -> None:
     # Setup the run
     opentrons_api.cancel_run(run_id)
     opentrons_api.create_run()
+    opentrons_api.home()
     module_id = opentrons_api.load_module(args.model, args.slot)
     opentrons_api.load_labware(module_id, args.model)
     opentrons_api.load_pipette(args.mount)


### PR DESCRIPTION
# Overview

Need to home the gantry before verifying the module calibration offset

# Test Plan

# Changelog

# Review requests
