### PR TITLE
chore(robot-server): Remove redundant enableOT3HardwareController config

### DIFF
--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -55,7 +55,6 @@ class DevServer:
             "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev-flex.env"
             if self.is_ot3
             else "dev.env",
-            "OT_API_FF_enableOT3HardwareController": "true" if self.is_ot3 else "false",
             "OT_API_CONFIG_DIR": str(self.ot_api_config_dir),
             "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),
         }


### PR DESCRIPTION
# Overview

This is a tiny refactor to take advantage of changes in #12754.

We now have a real `.env` file for simulating OT-3s. Therefore, it's now redundant for `DevServer` to specify `"OT_API_FF_enableOT3HardwareController": "true"`, because the `.env` file already has that.

# Test Plan

We should be good as long as existing tests, especially `test_deck_coordinate_load.tavern.yaml`, continue to pass.

# Risk assessment

Low.
