### PR TITLE
refactor(app): update connection result success case

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -244,7 +244,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   }, [dispatch, isIdle, usersBrightness])
 
   return (
-    <ApiHostProvider hostname="localhost">
+    <ApiHostProvider hostname="192.168.0.107">
       <Box width="100%" css="user-select: none;">
         {Boolean(isIdle) ? (
           <SleepScreen />

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -244,7 +244,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   }, [dispatch, isIdle, usersBrightness])
 
   return (
-    <ApiHostProvider hostname="192.168.0.107">
+    <ApiHostProvider hostname="localhost">
       <Box width="100%" css="user-select: none;">
         {Boolean(isIdle) ? (
           <SleepScreen />

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -213,6 +213,7 @@
   "software_update_error": "Software update error",
   "some_robot_controls_are_not_available": "Some robot controls are not available when run is in progress",
   "subnet_mask": "Subnet Mask",
+  "successfully_connected_to_network": "Successfully connected to {{ssid}}!",
   "successfully_connected": "Successfully connected!",
   "supported_protocol_api_versions": "Supported Protocol API Versions",
   "switch_to_usb_description": "If your network uses a different authentication method, connect to the Opentrons App and finish Wi-Fi setup there.",

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/WifiConnectionDetails.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/WifiConnectionDetails.tsx
@@ -18,9 +18,9 @@ import {
 
 import { StyledText } from '../../../atoms/text'
 import { MediumButton } from '../../../atoms/buttons'
-import { NetworkDetailsModal } from '../RobotSettingsDashboard/NetworkSettings/NetworkDetailsModal'
 import { getLocalRobot } from '../../../redux/discovery'
 import { getNetworkInterfaces } from '../../../redux/networking'
+import { NetworkDetailsModal } from '../RobotSettingsDashboard/NetworkSettings/NetworkDetailsModal'
 
 import type { WifiSecurityType } from '@opentrons/api-client'
 import type { State } from '../../../redux/types'

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/WifiConnectionDetails.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/WifiConnectionDetails.tsx
@@ -1,73 +1,91 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 
 import {
   Flex,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
-  JUSTIFY_SPACE_BETWEEN,
   SPACING,
   Icon,
   COLORS,
   TYPOGRAPHY,
   ALIGN_CENTER,
   JUSTIFY_CENTER,
-  PrimaryButton,
   BORDERS,
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
-import { getNetworkInterfaces, fetchStatus } from '../../../redux/networking'
+import { MediumButton } from '../../../atoms/buttons'
+import { NetworkDetailsModal } from '../RobotSettingsDashboard/NetworkSettings/NetworkDetailsModal'
 import { getLocalRobot } from '../../../redux/discovery'
+import { getNetworkInterfaces } from '../../../redux/networking'
 
-import type { State, Dispatch } from '../../../redux/types'
-import type {
-  SimpleInterfaceStatus,
-  WifiSecurityType,
-} from '../../../redux/networking/types'
+import type { WifiSecurityType } from '@opentrons/api-client'
+import type { State } from '../../../redux/types'
 
 interface WifiConnectionDetailsProps {
   ssid?: string
   authType?: WifiSecurityType
   showHeader?: boolean
-  showWifiListButton?: boolean
 }
 
 export function WifiConnectionDetails({
   ssid,
   authType,
-  showHeader = true,
-  showWifiListButton = false,
 }: WifiConnectionDetailsProps): JSX.Element {
-  const dispatch = useDispatch<Dispatch>()
+  const { i18n, t } = useTranslation(['device_settings', 'shared'])
+  const history = useHistory()
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
   const { wifi } = useSelector((state: State) =>
     getNetworkInterfaces(state, robotName)
   )
 
-  React.useEffect(() => {
-    dispatch(fetchStatus(robotName))
-  }, [robotName, dispatch])
+  const noData = i18n.format(t('shared:no_data'), 'titleCase')
+  const ipAddress = wifi?.ipAddress != null ? wifi.ipAddress : noData
+  const subnetMask = wifi?.subnetMask != null ? wifi.subnetMask : noData
+  const macAddress = wifi?.macAddress != null ? wifi.macAddress : noData
+
+  const [
+    showNetworkDetailsModal,
+    setShowNetworkDetailsModal,
+  ] = React.useState<boolean>(false)
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
-      {showHeader && <TitleHeader />}
-      <DisplayConnectionStatus connected={wifi != null} />
-      <DisplayConnectedNetworkInfo
-        wifi={wifi}
-        ssid={ssid}
-        authType={authType ?? 'none'}
-      />
-      <DisplayButtons showWifiListButton={showWifiListButton} />
-    </Flex>
+    <>
+      {showNetworkDetailsModal ? (
+        <NetworkDetailsModal
+          ssid={ssid}
+          setShowNetworkDetailModal={setShowNetworkDetailsModal}
+          ipAddress={ipAddress}
+          subnetMask={subnetMask}
+          macAddress={macAddress}
+          securityType={authType}
+        />
+      ) : null}
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
+        <TitleHeader />
+        <DisplayConnectionStatus ssid={ssid} />
+        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
+          <MediumButton
+            flex="1"
+            buttonType="secondary"
+            buttonText={t('view_network_details')}
+            onClick={() => setShowNetworkDetailsModal(true)}
+          />
+          <MediumButton
+            flex="1"
+            buttonText={i18n.format(t('continue'), 'capitalize')}
+            onClick={() => history.push('/robot-settings/update-robot')}
+          />
+        </Flex>
+      </Flex>
+    </>
   )
 }
 
-// Note: kj 12/22/2022 the followings might be a component for network setup process
-// but still the design is the mid-fi
 const TitleHeader = (): JSX.Element => {
   const { t } = useTranslation('device_settings')
   return (
@@ -75,161 +93,38 @@ const TitleHeader = (): JSX.Element => {
       flexDirection={DIRECTION_ROW}
       justifyContent={JUSTIFY_CENTER}
       alignItems={ALIGN_CENTER}
-      marginBottom="1.5625rem"
+      marginBottom={SPACING.spacing32}
     >
-      <StyledText fontSize="2rem" lineHeight="2.75rem" fontWeight="700">
-        {t('connect_via', { type: t('wifi') })}
+      <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightBold}>
+        {t('wifi')}
       </StyledText>
     </Flex>
   )
 }
 
 interface DisplayConnectionStatusProps {
-  connected: boolean
+  ssid?: string
 }
 
 const DisplayConnectionStatus = ({
-  connected,
+  ssid,
 }: DisplayConnectionStatusProps): JSX.Element => {
   const { t } = useTranslation('device_settings')
   return (
     <Flex
-      flexDirection={DIRECTION_ROW}
-      padding={`${SPACING.spacing24} ${SPACING.spacing40}`}
-      backgroundColor={connected ? COLORS.successBackgroundMed : COLORS.light2}
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing32}
+      padding={`${SPACING.spacing40} ${SPACING.spacing80}`}
+      backgroundColor={COLORS.green3}
+      borderRadius={BORDERS.size3}
+      height="18.5rem"
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_CENTER}
-      borderRadius={BORDERS.size3}
     >
-      <Icon
-        name="ot-check"
-        size="2.5rem"
-        color={connected ? COLORS.successEnabled : COLORS.light2}
-      />
-      <StyledText
-        marginLeft={SPACING.spacing24}
-        fontSize="1.625rem"
-        fontWeight="700"
-        lineHeight="2.1875rem"
-        color={COLORS.black}
-      >
-        {t('connection_status')}
+      <Icon size="3rem" name="ot-check" color={COLORS.green2} />
+      <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+        {t('successfully_connected_to_network', { ssid })}
       </StyledText>
-      <StyledText
-        marginLeft="0.625rem"
-        fontSize="1.625rem"
-        fontWeight={TYPOGRAPHY.fontWeightRegular}
-        lineHeight="2.1875rem"
-        color={COLORS.black}
-      >
-        {t(connected ? 'connected' : 'not_connected')}
-      </StyledText>
-    </Flex>
-  )
-}
-
-interface DisplayConnectedNetworkInfoProps {
-  ssid?: string
-  wifi: SimpleInterfaceStatus | null
-  authType: WifiSecurityType
-}
-
-const DisplayConnectedNetworkInfo = ({
-  wifi,
-  ssid,
-  authType,
-}: DisplayConnectedNetworkInfoProps): JSX.Element => {
-  const { t } = useTranslation(['device_settings', 'shared'])
-  return (
-    <Flex
-      flexDirection={DIRECTION_ROW}
-      paddingX={SPACING.spacing32}
-      paddingY={SPACING.spacing24}
-      justifyContent={JUSTIFY_SPACE_BETWEEN}
-      backgroundColor={COLORS.darkGreyDisabled}
-      borderRadius={BORDERS.size3}
-    >
-      <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
-        <Icon name="wifi" size="2.4rem" />
-        <StyledText
-          marginLeft={SPACING.spacing4}
-          fontSize="1.5rem"
-          lineHeight="1.8rem"
-          fontWeight="700"
-        >
-          {ssid ?? t('shared:no_data')}
-        </StyledText>
-      </Flex>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        textAlign={TYPOGRAPHY.textAlignRight}
-        gridGap={SPACING.spacing4}
-      >
-        <StyledText fontSize="1.5rem" lineHeight="2.0625rem" fontWeight="400">
-          {/* ToDo: if wifi is undefined no data or empty */}
-          {`${t('ip_address')}:  ${wifi?.ipAddress ?? 'No data'}`}
-        </StyledText>
-        <StyledText fontSize="1.5rem" lineHeight="2.0625rem" fontWeight="400">
-          {`Authentication: ${String(
-            authType === 'wpa-psk' ? 'WPA2' : 'None'
-          )}`}
-        </StyledText>
-        <StyledText fontSize="1.5rem" lineHeight="2.0625rem" fontWeight="400">
-          {`${t('subnet_mask')}: ${wifi?.subnetMask ?? 'No data'}`}
-        </StyledText>
-        <StyledText fontSize="1.5rem" lineHeight="2.0625rem" fontWeight="400">
-          {`${t('mac_address')}: ${wifi?.macAddress ?? 'No data'}`}
-        </StyledText>
-      </Flex>
-    </Flex>
-  )
-}
-
-interface DisplayButtonsProps {
-  showWifiListButton: boolean
-}
-
-const DisplayButtons = ({
-  showWifiListButton,
-}: DisplayButtonsProps): JSX.Element => {
-  const { t } = useTranslation('device_settings')
-  const history = useHistory()
-  return (
-    <Flex
-      flexDirection={DIRECTION_ROW}
-      gridGap={SPACING.spacing12}
-      height="4.375rem"
-      marginTop="1.4375rem"
-    >
-      {showWifiListButton ? (
-        <PrimaryButton
-          onClick={() => console.log('Not implemented')}
-          width="100%"
-        >
-          <StyledText
-            fontSize="1.5rem"
-            lineHeight="1.375rem"
-            fontWeight="500"
-            color={COLORS.white}
-          >
-            {t('change_network')}
-          </StyledText>
-        </PrimaryButton>
-      ) : (
-        <PrimaryButton
-          onClick={() => history.push('/robot-settings/update-robot')}
-          width="100%"
-        >
-          <StyledText
-            fontSize="1.5rem"
-            lineHeight="1.375rem"
-            fontWeight="500"
-            color={COLORS.white}
-          >
-            {t('check_for_updates')}
-          </StyledText>
-        </PrimaryButton>
-      )}
     </Flex>
   )
 }

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/SelectAuthenticationType.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/SelectAuthenticationType.test.tsx
@@ -94,22 +94,19 @@ describe('SelectAuthenticationType', () => {
   it('when tapping back button, call a mock function - fromWifiList', () => {
     props.fromWifiList = true
     const [{ getAllByRole }] = render(props)
-    const button = getAllByRole('button')[0]
-    button.click()
+    getAllByRole('button')[0].click()
     expect(props.setChangeState).toHaveBeenCalled()
   })
 
   it('should call call a mock function - wpa when tapping continue button', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('Continue')
-    button.click()
+    getByText('Continue').click()
     expect(mockSetShowSelectAuthenticationType).toHaveBeenCalled()
   })
 
   it('should render AlternativeSecurityTypeModal when tapping need another security type? button', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('Need another security type?')
-    button.click()
+    getByText('Need another security type?').click()
     getByText('mock AlternativeSecurityTypeModal')
   })
 })

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/WifiConnectionDetails.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/WifiConnectionDetails.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 
@@ -8,18 +7,15 @@ import { i18n } from '../../../../i18n'
 import { useWifiList } from '../../../../resources/networking/hooks'
 import * as Networking from '../../../../redux/networking'
 import * as Fixtures from '../../../../redux/networking/__fixtures__'
+import { NetworkDetailsModal } from '../../RobotSettingsDashboard/NetworkSettings/NetworkDetailsModal'
 import { WifiConnectionDetails } from '../WifiConnectionDetails'
-
-const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
-  typeof Networking.getNetworkInterfaces
->
-
-const mockUseWifiList = useWifiList as jest.MockedFunction<typeof useWifiList>
-const mockPush = jest.fn()
 
 jest.mock('../../../../resources/networking/hooks')
 jest.mock('../../../../redux/networking')
 jest.mock('../../../../redux/discovery/selectors')
+jest.mock('../../RobotSettingsDashboard/NetworkSettings/NetworkDetailsModal')
+
+const mockPush = jest.fn()
 jest.mock('react-router-dom', () => {
   const reactRouterDom = jest.requireActual('react-router-dom')
   return {
@@ -27,6 +23,14 @@ jest.mock('react-router-dom', () => {
     useHistory: () => ({ push: mockPush } as any),
   }
 })
+
+const mockGetNetworkInterfaces = Networking.getNetworkInterfaces as jest.MockedFunction<
+  typeof Networking.getNetworkInterfaces
+>
+const mockUseWifiList = useWifiList as jest.MockedFunction<typeof useWifiList>
+const mokcNetworkDetailsModal = NetworkDetailsModal as jest.MockedFunction<
+  typeof NetworkDetailsModal
+>
 
 const render = (props: React.ComponentProps<typeof WifiConnectionDetails>) => {
   return renderWithProviders(
@@ -63,6 +67,7 @@ describe('WifiConnectionDetails', () => {
       ethernet: null,
     })
     mockUseWifiList.mockReturnValue(mockWifiList)
+    mokcNetworkDetailsModal.mockReturnValue(<div>mock NetworkDetailsModal</div>)
   })
 
   afterEach(() => {
@@ -70,20 +75,24 @@ describe('WifiConnectionDetails', () => {
   })
 
   it('should render title and description', () => {
-    const [{ getByText, getByRole }] = render(props)
-    getByText('Connect via Wi-Fi')
-    getByText('Connected')
-    getByText('mockWifi')
-    getByText('IP Address: 127.0.0.100')
-    getByText('Subnet Mask: 255.255.255.230')
-    getByText('MAC Address: WI:FI:00:00:00:00')
-    getByRole('button', { name: 'Check for updates' })
+    const [{ getByText }] = render(props)
+    getByText('Wi-Fi')
+    getByText('Successfully connected to mockWifi!')
+    getByText('View network details')
+    getByText('Continue')
+  })
+
+  it('should render network details when tapping view network details', () => {
+    const [{ getByText }] = render(props)
+    const button = getByText('View network details')
+    button.click()
+    getByText('mock NetworkDetailsModal')
   })
 
   it('when clicking Check for updates button, should call mock function', () => {
-    const [{ getByRole }] = render(props)
-    const button = getByRole('button', { name: 'Check for updates' })
-    fireEvent.click(button)
+    const [{ getByText }] = render(props)
+    const button = getByText('Continue')
+    button.click()
     expect(mockPush).toHaveBeenCalledWith('/robot-settings/update-robot')
   })
 })

--- a/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/WifiConnectionDetails.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/SetupNetwork/__tests__/WifiConnectionDetails.test.tsx
@@ -84,15 +84,13 @@ describe('WifiConnectionDetails', () => {
 
   it('should render network details when tapping view network details', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('View network details')
-    button.click()
+    getByText('View network details').click()
     getByText('mock NetworkDetailsModal')
   })
 
   it('when clicking Check for updates button, should call mock function', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('Continue')
-    button.click()
+    getByText('Continue').click()
     expect(mockPush).toHaveBeenCalledWith('/robot-settings/update-robot')
   })
 })

--- a/app/src/organisms/UpdateRobotSoftware/__tests__/ErrorUpdateSoftware.test.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/__tests__/ErrorUpdateSoftware.test.tsx
@@ -40,15 +40,13 @@ describe('ErrorUpdateSoftware', () => {
 
   it('call mockPush when tapping Proceed without updating', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('Proceed without updating')
-    button.click()
+    getByText('Proceed without updating').click()
     expect(mockPush).toBeCalledWith('/robot-settings/rename-robot')
   })
 
   it('call mock function when tapping Try again', () => {
     const [{ getByText }, store] = render(props)
-    const button = getByText('Try again')
-    button.click()
+    getByText('Try again').click()
     expect(store.dispatch).toHaveBeenCalledWith(
       startBuildrootUpdate(props.robotName)
     )

--- a/app/src/organisms/UpdateRobotSoftware/__tests__/NoUpdateFound.test.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/__tests__/NoUpdateFound.test.tsx
@@ -31,8 +31,7 @@ describe('NoUpdateFound', () => {
 
   it('should call mock function when tapping next button', () => {
     const [{ getByText }] = render()
-    const button = getByText('Continue')
-    fireEvent.click(button)
+    getByText('Continue').click()
     expect(mockPush).toBeCalledWith('/robot-settings/rename-robot')
   })
 })

--- a/app/src/organisms/UpdateRobotSoftware/__tests__/NoUpdateFound.test.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/__tests__/NoUpdateFound.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'

--- a/app/src/pages/OnDeviceDisplay/ConnectViaEthernet/__tests__/DisplayConnectionStatus.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ConnectViaEthernet/__tests__/DisplayConnectionStatus.test.tsx
@@ -54,22 +54,19 @@ describe('DisplayConnectionStatus', () => {
 
   it('should call a mock function when tapping view network details button when the connection status is connected', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('View network details')
-    button.click()
+    getByText('View network details').click()
     expect(mockFunc).toHaveBeenCalled()
   })
 
   it('should call a mock function when tapping view network details button when the connection status is not connected', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('View network details')
-    button.click()
+    getByText('View network details').click()
     expect(mockFunc).toHaveBeenCalled()
   })
 
   it('should call a mock push when tapping continue button', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('Continue')
-    button.click()
+    getByText('Continue').click()
     expect(mockPush).toHaveBeenCalledWith('/robot-settings/update-robot')
   })
 })

--- a/app/src/pages/OnDeviceDisplay/ConnectViaEthernet/__tests__/TitleHeader.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ConnectViaEthernet/__tests__/TitleHeader.test.tsx
@@ -34,8 +34,7 @@ describe('TitleHeader', () => {
 
   it('should call a mock function when tapping back button', () => {
     const [{ getByTestId }] = render(props)
-    const button = getByTestId('Ethernet_header_back_button')
-    button.click()
+    getByTestId('Ethernet_header_back_button').click()
     expect(mockPush).toHaveBeenCalledWith('/network-setup')
   })
 })

--- a/app/src/pages/OnDeviceDisplay/RobotDashboard/__tests__/WelcomeModal.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotDashboard/__tests__/WelcomeModal.test.tsx
@@ -44,8 +44,7 @@ describe('WelcomeModal', () => {
 
   it('should call a mock function when tapping got it button', () => {
     const [{ getByText }] = render(props)
-    const button = getByText('Got it')
-    button.click()
+    getByText('Got it').click()
     expect(mockUpdateConfigValue).toHaveBeenCalled()
     expect(props.setShowWelcomeModal).toHaveBeenCalled()
   })

--- a/app/src/pages/OnDeviceDisplay/__tests__/ConnectedViaUSB.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/ConnectedViaUSB.test.tsx
@@ -39,8 +39,7 @@ describe('ConnectViaUSB', () => {
 
   it('should call a mock function when tapping back button', () => {
     const [{ getByRole }] = render()
-    const button = getByRole('button')
-    button.click()
+    getByRole('button').click()
     expect(mockPush).toHaveBeenCalledWith('/network-setup')
   })
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update connection result success case and test

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Go to `Network setup menu` from ODD menu / Unboxing flow 
- Tap `Wi-Fi`
- Select a ssid / `Join other network` and try to connect to a network
- Tap `View network details` -> shows Network details modals
- Tap Continue -> go to RobotSoftware update 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update WifiConnection Details and modify its test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
