### PR TITLE
refactor(app-shell): add usb bad request handler on detach

### DIFF
--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -161,7 +161,7 @@ export function registerUsb(dispatch: Dispatch): (action: Action) => unknown {
           ipcMain.handle('usb:request', () =>
             Promise.resolve({
               status: 400,
-              statusText: 'Bad Request',
+              statusText: 'USB robot disconnected',
             })
           )
         }

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -127,7 +127,8 @@ function startUsbHttpRequests(dispatch: Dispatch): void {
       }
 
       createSerialPortHttpAgent(ot3UsbSerialPort.path)
-
+      // remove any existing handler
+      ipcMain.removeHandler('usb:request')
       ipcMain.handle('usb:request', usbListener)
 
       dispatch(usbRequestsStart())
@@ -156,6 +157,13 @@ export function registerUsb(dispatch: Dispatch): (action: Action) => unknown {
           destroyUsbHttpAgent()
           ipcMain.removeHandler('usb:request')
           dispatch(usbRequestsStop())
+          // handle any additional invocations of usb:request
+          ipcMain.handle('usb:request', () =>
+            Promise.resolve({
+              status: 400,
+              statusText: 'Bad Request',
+            })
+          )
         }
         break
     }

--- a/react-api-client/src/modules/useModulesQuery.ts
+++ b/react-api-client/src/modules/useModulesQuery.ts
@@ -12,7 +12,7 @@ export function useModulesQuery(
     [host, 'modules'],
     () =>
       getModules(host as HostConfig).then(response => {
-        const modules = response.data.data
+        const modules = response.data?.data ?? []
         // this check will determine if the module response is v3 or v2
         // if v2, we will return an empty array
         if (modules.length > 0 && 'id' in modules[0]) {


### PR DESCRIPTION
# Overview

after detaching a usb-connected robot, the device details page will continue making a handful of requests via `appShellRequestor`. without a handler, these requests log errors in both the renderer and main processes. this adds a "bad request" handler to handle those requests. removing any existing handler on usb attach is required to allow re-adding a handler on usb re-attach. 

the "bad request" status code is only relevant for the remaining robot-api rxjs requests.

re RCORE-763

# Test Plan

 - manually confirmed usb attach/detach adds and removes handlers.

# Changelog

 - Adds usb bad request handler on detach

# Review requests

is this a reasonable approach?

# Risk assessment

low
