### PR TITLE
fix(api): disable motors during the pipette attach and detach position

### DIFF
--- a/api/src/opentrons/calibration_storage/__init__.py
+++ b/api/src/opentrons/calibration_storage/__init__.py
@@ -12,13 +12,18 @@ from .ot2.tip_length import (
     _save_custom_tiprack_definition,
 )
 from .ot2.pipette_offset import get_all_pipette_offset_calibrations
+from .ot3.deck_attitude import (
+    save_robot_belt_attitude,
+    get_robot_belt_attitude,
+    delete_robot_belt_attitude,
+)
+from .ot2.deck_attitude import (
+    save_robot_deck_attitude,
+    get_robot_deck_attitude,
+    delete_robot_deck_attitude,
+)
 
 if config.feature_flags.enable_ot3_hardware_controller():
-    from .ot3.deck_attitude import (
-        save_robot_deck_attitude,
-        get_robot_deck_attitude,
-        delete_robot_deck_attitude,
-    )
     from .ot3.pipette_offset import (
         save_pipette_calibration,
         clear_pipette_offset_calibrations,
@@ -41,11 +46,6 @@ if config.feature_flags.enable_ot3_hardware_controller():
         delete_module_offset_file,
     )
 else:
-    from .ot2.deck_attitude import (
-        save_robot_deck_attitude,
-        get_robot_deck_attitude,
-        delete_robot_deck_attitude,
-    )
     from .ot2.pipette_offset import (
         save_pipette_calibration,
         clear_pipette_offset_calibrations,
@@ -67,6 +67,9 @@ __all__ = [
     "save_robot_deck_attitude",
     "get_robot_deck_attitude",
     "delete_robot_deck_attitude",
+    "save_robot_belt_attitude",
+    "get_robot_belt_attitude",
+    "delete_robot_belt_attitude",
     # pipette calibration functions
     "save_pipette_calibration",
     "get_pipette_offset",

--- a/api/src/opentrons/calibration_storage/ot2/models/v1.py
+++ b/api/src/opentrons/calibration_storage/ot2/models/v1.py
@@ -49,7 +49,7 @@ class TipLengthModel(BaseModel):
 
 class DeckCalibrationModel(BaseModel):
     attitude: types.AttitudeMatrix = Field(
-        ..., description="Attitude matrix found from calibration."
+        ..., description="Attitude matrix for deck found from calibration."
     )
     last_modified: datetime = Field(
         default=None, description="The last time this deck was calibrated."

--- a/api/src/opentrons/calibration_storage/ot3/deck_attitude.py
+++ b/api/src/opentrons/calibration_storage/ot3/deck_attitude.py
@@ -15,26 +15,26 @@ from .models import v1
 log = logging.getLogger(__name__)
 
 
-# Delete Deck Calibration
+# Delete Belt Calibration
 
 
 @no_type_check
-def delete_robot_deck_attitude() -> None:
+def delete_robot_belt_attitude() -> None:
     """
-    Delete the robot deck attitude calibration.
+    Delete the robot belt attitude calibration.
     """
     gantry_path = (
-        config.get_opentrons_path("robot_calibration_dir") / "deck_calibration.json"
+        config.get_opentrons_path("robot_calibration_dir") / "belt_calibration.json"
     )
 
     io.delete_file(gantry_path)
 
 
-# Save Deck Calibration
+# Save Belt Calibration
 
 
 @no_type_check
-def save_robot_deck_attitude(
+def save_robot_belt_attitude(
     transform: local_types.AttitudeMatrix,
     pip_id: Optional[str],
     source: Optional[local_types.SourceType] = None,
@@ -51,7 +51,7 @@ def save_robot_deck_attitude(
     else:
         cal_status_model = v1.CalibrationStatus()
 
-    gantry_calibration = v1.DeckCalibrationModel(
+    gantry_calibration = v1.BeltCalibrationModel(
         attitude=transform,
         pipetteCalibratedWith=pip_id,
         lastModified=utc_now(),
@@ -59,25 +59,25 @@ def save_robot_deck_attitude(
         status=cal_status_model,
     )
     # convert to schema + validate json conversion
-    io.save_to_file(robot_dir, "deck_calibration", gantry_calibration)
+    io.save_to_file(robot_dir, "belt_calibration", gantry_calibration)
 
 
-# Get Deck Calibration
+# Get Belt Calibration
 
 
 @no_type_check
-def get_robot_deck_attitude() -> Optional[v1.DeckCalibrationModel]:
-    deck_calibration_path = (
-        config.get_opentrons_path("robot_calibration_dir") / "deck_calibration.json"
+def get_robot_belt_attitude() -> Optional[v1.BeltCalibrationModel]:
+    belt_calibration_path = (
+        config.get_opentrons_path("robot_calibration_dir") / "belt_calibration.json"
     )
     try:
-        return v1.DeckCalibrationModel(**io.read_cal_file(deck_calibration_path))
+        return v1.BeltCalibrationModel(**io.read_cal_file(belt_calibration_path))
     except FileNotFoundError:
-        log.warning("Deck calibration not found.")
+        log.warning("Belt calibration not found.")
         pass
     except (json.JSONDecodeError, ValidationError):
         log.warning(
-            "Deck calibration is malformed. Please factory reset your calibrations."
+            "Belt calibration is malformed. Please factory reset your calibrations."
         )
         pass
     return None

--- a/api/src/opentrons/calibration_storage/ot3/models/v1.py
+++ b/api/src/opentrons/calibration_storage/ot3/models/v1.py
@@ -45,9 +45,9 @@ class TipLengthModel(BaseModel):
         json_decoders = {datetime: lambda obj: datetime.fromisoformat(obj)}
 
 
-class DeckCalibrationModel(BaseModel):
+class BeltCalibrationModel(BaseModel):
     attitude: types.AttitudeMatrix = Field(
-        ..., description="Attitude matrix found from calibration."
+        ..., description="Attitude matrix for belts found from calibration."
     )
     lastModified: datetime = Field(
         ..., description="The last time this deck was calibrated."

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -61,10 +61,15 @@ DEFAULT_CALIBRATION_SETTINGS: Final[OT3CalibrationSettings] = OT3CalibrationSett
 
 ROBOT_CONFIG_VERSION: Final = 1
 DEFAULT_LOG_LEVEL: Final = "INFO"
-DEFAULT_DECK_TRANSFORM: Final[OT3Transform] = [
+DEFAULT_MACHINE_TRANSFORM: Final[OT3Transform] = [
     [-1.0, 0.0, 0.0],
     [0.0, -1.0, 0.0],
     [0.0, 0.0, -1.0],
+]
+DEFAULT_BELT_ATTITUDE: Final[OT3Transform] = [
+    [1.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0],
 ]
 DEFAULT_CARRIAGE_OFFSET: Final[Offset] = (477.20, 493.8, 253.475)
 DEFAULT_LEFT_MOUNT_OFFSET: Final[Offset] = (-13.5, -60.5, 255.675)
@@ -382,7 +387,7 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
             "safe_home_distance", DEFAULT_SAFE_HOME_DISTANCE
         ),
         deck_transform=_build_default_transform(
-            robot_settings.get("deck_transform", []), DEFAULT_DECK_TRANSFORM
+            robot_settings.get("deck_transform", []), DEFAULT_MACHINE_TRANSFORM
         ),
         carriage_offset=_build_default_offset(
             robot_settings.get("carriage_offset", []), DEFAULT_CARRIAGE_OFFSET

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -164,11 +164,12 @@ def _save_config_data(data: str, filename: Union[str, Path]) -> None:
         log.exception("Write failed with exception:")
 
 
-def default_deck_calibration() -> List[List[float]]:
-    if ff.enable_ot3_hardware_controller():
-        return defaults_ot3.DEFAULT_DECK_TRANSFORM
-    else:
-        return defaults_ot2.DEFAULT_DECK_CALIBRATION_V2
+def default_ot2_deck_calibration() -> List[List[float]]:
+    return defaults_ot2.DEFAULT_DECK_CALIBRATION_V2
+
+
+def default_ot3_deck_calibration() -> List[List[float]]:
+    return defaults_ot3.DEFAULT_BELT_ATTITUDE
 
 
 def default_pipette_offset() -> List[float]:

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -22,14 +22,20 @@ from .constants import DROP_TIP_RELEASE_DISTANCE
 from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
 from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
-from .protocols import HardwareControlAPI
+from .protocols import HardwareControlInterface
 from .instruments import AbstractInstrument, Gripper
+from typing import Union
+from .ot3_calibration import OT3Transforms
+from .robot_calibration import RobotCalibration
 
 # TODO (lc 12-05-2022) We should 1. figure out if we need
 # to globally export a class that is strictly used in the hardware controller
 # and 2. how to properly export an ot2 and ot3 pipette.
 from .instruments.ot2.pipette import Pipette
 
+OT2HardwareControlAPI = HardwareControlInterface[RobotCalibration]
+OT3HardwareControlAPI = HardwareControlInterface[OT3Transforms]
+HardwareControlAPI = Union[OT2HardwareControlAPI, OT3HardwareControlAPI]
 
 ThreadManagedHardware = ThreadManager[HardwareControlAPI]
 SyncHardwareAPI = SynchronousAdapter[HardwareControlAPI]

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -55,7 +55,7 @@ from .robot_calibration import (
     RobotCalibrationProvider,
     RobotCalibration,
 )
-from .protocols import HardwareControlAPI
+from .protocols import HardwareControlInterface
 from .instruments.ot2.pipette_handler import PipetteHandlerProvider
 from .instruments.ot2.instrument_calibration import load_pipette_offset
 from .motion_utilities import (
@@ -79,7 +79,7 @@ class API(
     # of methods that are present in the protocol will call the (empty,
     # do-nothing) methods in the protocol. This will happily make all the
     # tests fail.
-    HardwareControlAPI,
+    HardwareControlInterface[RobotCalibration],
 ):
     """This API is the primary interface to the hardware controller.
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -312,8 +312,10 @@ class OT3API(
     @classmethod
     async def build_hardware_simulator(
         cls,
-        attached_instruments: Optional[
-            Dict[Union[top_types.Mount, OT3Mount], Dict[str, Optional[str]]]
+        attached_instruments: Union[
+            None,
+            Dict[OT3Mount, Dict[str, Optional[str]]],
+            Dict[top_types.Mount, Dict[str, Optional[str]]],
         ] = None,
         attached_modules: Optional[List[str]] = None,
         config: Union[RobotConfig, OT3Config, None] = None,
@@ -326,7 +328,6 @@ class OT3API(
         Multiple simulating hardware controllers may be active at one time.
         """
 
-        checked_attached = attached_instruments or {}
         checked_modules = attached_modules or []
 
         checked_loop = use_or_initialize_loop(loop)
@@ -335,7 +336,9 @@ class OT3API(
         else:
             checked_config = config
         backend = await OT3Simulator.build(
-            {OT3Mount.from_mount(k): v for k, v in checked_attached.items()},
+            {OT3Mount.from_mount(k): v for k, v in attached_instruments.items()}
+            if attached_instruments
+            else {},
             checked_modules,
             checked_config,
             checked_loop,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -70,7 +70,6 @@ from .backends.ot3utils import (
 from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl
-from .util import DeckTransformState
 from .types import (
     Axis,
     CriticalPoint,
@@ -99,13 +98,9 @@ from .types import (
 )
 from .errors import MustHomeError, GripperNotAttachedError
 from . import modules
-from .robot_calibration import (
-    OT3Transforms,
-    RobotCalibration,
-    build_ot3_transforms,
-)
+from .ot3_calibration import OT3Transforms, OT3RobotCalibrationProvider
 
-from .protocols import HardwareControlAPI
+from .protocols import HardwareControlInterface
 
 # TODO (lc 09/15/2022) We should update our pipette handler to reflect OT-3 properties
 # in a follow-up PR.
@@ -151,12 +146,13 @@ mod_log = logging.getLogger(__name__)
 
 class OT3API(
     ExecutionManagerProvider,
+    OT3RobotCalibrationProvider,
     # This MUST be kept last in the inheritance list so that it is
     # deprioritized in the method resolution order; otherwise, invocations
     # of methods that are present in the protocol will call the (empty,
     # do-nothing) methods in the protocol. This will happily make all the
     # tests fail.
-    HardwareControlAPI,
+    HardwareControlInterface[OT3Transforms],
 ):
     """This API is the primary interface to the hardware controller.
 
@@ -207,7 +203,6 @@ class OT3API(
         self._motion_lock = asyncio.Lock()
         self._door_state = DoorState.CLOSED
         self._pause_manager = PauseManager()
-        self._transforms = build_ot3_transforms(self._config)
         self._gantry_load = GantryLoad.LOW_THROUGHPUT
         self._move_manager = MoveManager(
             constraints=get_system_constraints(
@@ -220,20 +215,8 @@ class OT3API(
 
         self._pipette_handler = OT3PipetteHandler({m: None for m in OT3Mount})
         self._gripper_handler = GripperHandler(gripper=None)
+        OT3RobotCalibrationProvider.__init__(self, self._config)
         ExecutionManagerProvider.__init__(self, isinstance(backend, OT3Simulator))
-
-    def set_robot_calibration(self, robot_calibration: RobotCalibration) -> None:
-        self._transforms.deck_calibration = robot_calibration.deck_calibration
-
-    def reset_robot_calibration(self) -> None:
-        self._transforms = build_ot3_transforms(self._config)
-
-    @property
-    def robot_calibration(self) -> OT3Transforms:
-        return self._transforms
-
-    def validate_calibration(self) -> DeckTransformState:
-        return DeckTransformState.OK
 
     @property
     def door_state(self) -> DoorState:
@@ -273,8 +256,8 @@ class OT3API(
     ) -> Dict[OT3Axis, float]:
         return deck_from_machine(
             machine_pos,
-            self._transforms.deck_calibration.attitude,
-            self._transforms.carriage_offset,
+            self._robot_calibration.deck_calibration.attitude,
+            self._robot_calibration.carriage_offset,
         )
 
     @classmethod
@@ -1101,8 +1084,8 @@ class OT3API(
         """Worker function to apply robot motion."""
         machine_pos = machine_from_deck(
             target_position,
-            self._transforms.deck_calibration.attitude,
-            self._transforms.carriage_offset,
+            self._robot_calibration.deck_calibration.attitude,
+            self._robot_calibration.carriage_offset,
         )
         bounds = self._backend.axis_bounds
         to_check = {
@@ -1319,9 +1302,6 @@ class OT3API(
     async def update_config(self, **kwargs: Any) -> None:
         """Update values of the robot's configuration."""
         self._config = replace(self._config, **kwargs)
-
-    async def update_deck_calibration(self, new_transform: RobotCalibration) -> None:
-        pass
 
     @ExecutionManagerProvider.wait_for_running
     async def _grip(self, duty_cycle: float) -> None:
@@ -2074,7 +2054,7 @@ class OT3API(
         machine_pass_distance = moving_axis.of_point(
             machine_vector_from_deck_vector(
                 moving_axis.set_in_point(top_types.Point(0, 0, 0), pass_distance),
-                self._transforms.deck_calibration.attitude,
+                self._robot_calibration.deck_calibration.attitude,
             )
         )
         pass_start_pos = moving_axis.set_in_point(here, pass_start)
@@ -2127,7 +2107,8 @@ class OT3API(
             )
         sweep_distance = moving_axis.of_point(
             machine_vector_from_deck_vector(
-                end - begin, self._transforms.deck_calibration.attitude
+                end - begin,
+                self._robot_calibration.deck_calibration.attitude,
             )
         )
 

--- a/api/src/opentrons/hardware_control/protocols/__init__.py
+++ b/api/src/opentrons/hardware_control/protocols/__init__.py
@@ -6,7 +6,7 @@ from .hardware_manager import HardwareManager
 from .chassis_accessory_manager import ChassisAccessoryManager
 from .event_sourcer import EventSourcer
 from .liquid_handler import LiquidHandler
-from .calibratable import Calibratable
+from .calibratable import Calibratable, CalibrationType
 from .configurable import Configurable
 from .motion_controller import MotionController
 from .instrument_configurer import InstrumentConfigurer
@@ -16,16 +16,16 @@ from .stoppable import Stoppable
 from .simulatable import Simulatable
 
 
-class HardwareControlAPI(
+class HardwareControlInterface(
     ModuleProvider,
     ExecutionControllable,
-    LiquidHandler,
+    LiquidHandler[CalibrationType],
     ChassisAccessoryManager,
     HardwareManager,
     AsyncioConfigurable,
     Stoppable,
     Simulatable,
-    Protocol,
+    Protocol[CalibrationType],
 ):
     """A mypy protocol for a hardware controller.
 

--- a/api/src/opentrons/hardware_control/protocols/calibratable.py
+++ b/api/src/opentrons/hardware_control/protocols/calibratable.py
@@ -1,14 +1,16 @@
 from typing_extensions import Protocol
+from typing import TypeVar
 
-from ..robot_calibration import RobotCalibration
 from ..util import DeckTransformState
 
+CalibrationType = TypeVar("CalibrationType")
 
-class Calibratable(Protocol):
+
+class Calibratable(Protocol[CalibrationType]):
     """Protocol specifying calibration information"""
 
     @property
-    def robot_calibration(self) -> RobotCalibration:
+    def robot_calibration(self) -> CalibrationType:
         """The currently-active robot calibration of the machine."""
         ...
 
@@ -21,10 +23,25 @@ class Calibratable(Protocol):
         """
         ...
 
-    def set_robot_calibration(self, robot_calibration: RobotCalibration) -> None:
+    def reset_deck_calibration(self) -> None:
+        """Resets only deck calibration data."""
+        ...
+
+    def load_deck_calibration(self) -> None:
+        """Loads only any deck calibration data that is stored."""
+        ...
+
+    def set_robot_calibration(self, robot_calibration: CalibrationType) -> None:
         """Set the current robot calibration from stored data."""
         ...
 
     def validate_calibration(self) -> DeckTransformState:
         """Check whether the current calibration is valid."""
+        ...
+
+    def build_temporary_identity_calibration(self) -> CalibrationType:
+        """
+        Get temporary default calibration data suitable for use during
+        calibration
+        """
         ...

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -6,15 +6,15 @@ from opentrons.types import Mount
 from .instrument_configurer import InstrumentConfigurer
 from .motion_controller import MotionController
 from .configurable import Configurable
-from .calibratable import Calibratable
+from .calibratable import Calibratable, CalibrationType
 
 
 class LiquidHandler(
     InstrumentConfigurer,
     MotionController,
     Configurable,
-    Calibratable,
-    Protocol,
+    Calibratable[CalibrationType],
+    Protocol[CalibrationType],
 ):
     async def prepare_for_aspirate(self, mount: Mount, rate: float = 1.0) -> None:
         """

--- a/api/src/opentrons/hardware_control/scripts/gripper_control.py
+++ b/api/src/opentrons/hardware_control/scripts/gripper_control.py
@@ -8,7 +8,7 @@ sys.path.append("/opt/opentrons-robot-server")
 from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
 from opentrons.hardware_control.ot3api import OT3API  # noqa: E402
 from opentrons.hardware_control.types import OT3Axis, OT3Mount  # noqa: E402
-from opentrons.hardware_control.protocols import HardwareControlAPI  # noqa: E402
+from opentrons.hardware_control import HardwareControlAPI  # noqa: E402
 from opentrons.types import Point  # noqa: E402
 from opentrons_shared_data.deck import load as load_deck_def  # noqa: E402
 

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -45,6 +45,7 @@ from opentrons.hardware_control.types import (  # noqa: E402
 from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
     calibrate_pipette,
     calibrate_belts,
+    delete_belt_calibration_data,
     calibrate_gripper_jaw,
     calibrate_module,
     find_calibration_structure_height,
@@ -53,7 +54,7 @@ from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
     find_axis_center,
     gripper_pin_offsets_mean,
 )
-from opentrons.hardware_control.protocols import HardwareControlAPI  # noqa: E402
+from opentrons.hardware_control import HardwareControlAPI  # noqa: E402
 from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
 
 
@@ -88,6 +89,13 @@ if ff.enable_ot3_hardware_controller():
 
     HCApi: Union[Type[OT3API], Type["API"]] = OT3API
 
+    def build_thread_manager() -> ThreadManager[Union["API", OT3API]]:
+        return ThreadManager(
+            OT3API.build_hardware_controller,
+            use_usb_bus=ff.rear_panel_integration(),
+            update_firmware=update_firmware,
+        )
+
     def wrap_async_util_fn(fn: Any, *bind_args: Any, **bind_kwargs: Any) -> Any:
         @wraps(fn)
         def synchronizer(*args: Any, **kwargs: Any) -> Any:
@@ -101,6 +109,13 @@ else:
     from opentrons.hardware_control.api import API
 
     HCApi = API
+
+    def build_thread_manager() -> ThreadManager[Union[API, OT3API]]:
+        return ThreadManager(
+            API.build_hardware_controller,
+            use_usb_bus=ff.rear_panel_integration(),
+            update_firmware=update_firmware,
+        )
 
 
 logging.basicConfig(level=logging.INFO)
@@ -116,11 +131,7 @@ def build_api() -> ThreadManager[HardwareControlAPI]:
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.INFO)
     logging.getLogger().addHandler(stream_handler)
-    tm = ThreadManager(
-        HCApi.build_hardware_controller,
-        use_usb_bus=ff.rear_panel_integration(),
-        update_firmware=update_firmware,
-    )
+    tm = build_thread_manager()
     logging.getLogger().removeHandler(stream_handler)
     tm.managed_thread_ready_blocking()
     return tm
@@ -148,6 +159,7 @@ def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
             ),
             "calibrate_pipette": wrap_async_util_fn(calibrate_pipette, api),
             "calibrate_belts": wrap_async_util_fn(calibrate_belts, api),
+            "delete_belt_calibration_data": delete_belt_calibration_data,
             "calibrate_gripper": wrap_async_util_fn(calibrate_gripper_jaw, api),
             "calibrate_module": wrap_async_util_fn(calibrate_module, api),
             "gripper_pin_offsets_mean": gripper_pin_offsets_mean,

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -7,7 +7,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType, Point
-from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control.types import CriticalPoint, Axis
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -71,7 +71,7 @@ class MoveToMaintenancePositionImplementation(
             abs_position=calibration_coordinates,
             critical_point=CriticalPoint.MOUNT,
         )
-
+        await self._hardware_api.disengage_axes([Axis.Z, Axis.A])
         return MoveToMaintenancePositionResult()
 
 

--- a/api/src/opentrons/protocol_engine/resources/ot3_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/ot3_validation.py
@@ -6,7 +6,7 @@ from opentrons.protocol_engine.errors import HardwareNotSupportedError
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
-    from opentrons.hardware_control.protocols import HardwareControlAPI
+    from opentrons.hardware_control import HardwareControlAPI
 
 
 def ensure_ot3_hardware(

--- a/api/tests/opentrons/calibration_storage/test_deck_attitude.py
+++ b/api/tests/opentrons/calibration_storage/test_deck_attitude.py
@@ -2,7 +2,24 @@ import pytest
 import importlib
 import opentrons
 from typing import Any, TYPE_CHECKING
+from opentrons.calibration_storage import (
+    save_robot_belt_attitude,
+    get_robot_belt_attitude,
+    delete_robot_belt_attitude,
+)
+from opentrons.calibration_storage import (
+    save_robot_deck_attitude,
+    get_robot_deck_attitude,
+    delete_robot_deck_attitude,
+)
 
+# needed for proper type checking unfortunately
+from opentrons.calibration_storage.ot3.models.v1 import (
+    BeltCalibrationModel as OT3BeltCalModel,
+)
+from opentrons.calibration_storage.ot2.models.v1 import (
+    DeckCalibrationModel as OT2DeckCalModel,
+)
 
 if TYPE_CHECKING:
     from opentrons_shared_data.deck.dev_types import RobotModel
@@ -14,83 +31,83 @@ def reload_module(robot_model: "RobotModel") -> None:
 
 
 @pytest.fixture
-def starting_calibration_data(
-    robot_model: "RobotModel", ot_config_tempdir: Any
-) -> None:
-    """
-    Starting calibration data fixture.
-
-    Adds dummy data to a temporary directory to test delete commands against.
-    """
-    from opentrons.calibration_storage import save_robot_deck_attitude
-
-    if robot_model == "OT-3 Standard":
-        save_robot_deck_attitude([[1, 0, 0], [0, 1, 0], [0, 0, 1]], "pip1")
-    else:
-        save_robot_deck_attitude([[1, 0, 0], [0, 1, 0], [0, 0, 1]], "pip1", "mytiprack")
-
-
-def test_save_deck_attitude(ot_config_tempdir: Any, robot_model: "RobotModel") -> None:
-    """
-    Test saving deck attitude calibrations.
-    """
-    from opentrons.calibration_storage import (
-        get_robot_deck_attitude,
-        save_robot_deck_attitude,
+def starting_ot2_calibration_data(ot_config_tempdir: Any) -> None:
+    """Starting OT-2 deck calibration data fixture."""
+    save_robot_deck_attitude(
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "pip1",
+        "mytiprack",
     )
 
+
+@pytest.fixture
+def starting_ot3_calibration_data(ot_config_tempdir: Any) -> None:
+    """Starting OT-3 belt calibration data fixture."""
+    save_robot_belt_attitude(
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "pip1",
+    )
+
+
+def test_save_ot2_deck_attitude(ot_config_tempdir: Any) -> None:
+    """Test saving an OT-2 deck attitude calibration."""
     assert get_robot_deck_attitude() is None
-    if robot_model == "OT-3 Standard":
-        save_robot_deck_attitude([[1, 0, 0], [0, 1, 0], [0, 0, 1]], "pip1")
-    else:
-        save_robot_deck_attitude([[1, 0, 0], [0, 1, 0], [0, 0, 1]], "pip1", "mytiprack")
+    save_robot_deck_attitude(
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "pip1",
+        "mytiprack",
+    )
     assert get_robot_deck_attitude() != {}
 
 
-def test_get_deck_calibration(
-    starting_calibration_data: Any, robot_model: "RobotModel"
-) -> None:
-    """
-    Test ability to get a deck calibration model.
-    """
-    from opentrons.calibration_storage import get_robot_deck_attitude
-
-    # needed for proper type checking unfortunately
-    from opentrons.calibration_storage.ot3.models.v1 import (
-        DeckCalibrationModel as OT3DeckCalModel,
+def test_save_ot3_deck_attitude(ot_config_tempdir: Any) -> None:
+    """Test saving an OT-3 belt attitude calibration."""
+    assert get_robot_belt_attitude() is None
+    save_robot_belt_attitude(
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        "pip1",
     )
-    from opentrons.calibration_storage.ot2.models.v1 import (
-        DeckCalibrationModel as OT2DeckCalModel,
-    )
+    assert get_robot_belt_attitude() != {}
 
+
+def test_get_ot2_deck_calibration(starting_ot2_calibration_data: Any) -> None:
+    """Test ability to get an OT-2 deck calibration model."""
     robot_deck = get_robot_deck_attitude()
-    if robot_model == "OT-3 Standard":
-        assert robot_deck == OT3DeckCalModel(
-            attitude=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-            lastModified=robot_deck.lastModified,
-            source=robot_deck.source,
-            pipetteCalibratedWith="pip1",
-        )
-    else:
-        assert robot_deck == OT2DeckCalModel(
-            attitude=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-            last_modified=robot_deck.last_modified,
-            source=robot_deck.source,
-            pipette_calibrated_with="pip1",
-            tiprack="mytiprack",
-        )
-
-
-def test_delete_deck_calibration(starting_calibration_data: Any) -> None:
-    """
-    Test delete deck calibration.
-    """
-    from opentrons.calibration_storage import (
-        get_robot_deck_attitude,
-        delete_robot_deck_attitude,
+    assert robot_deck
+    assert robot_deck == OT2DeckCalModel(
+        attitude=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        last_modified=robot_deck.last_modified,
+        source=robot_deck.source,
+        pipette_calibrated_with="pip1",
+        tiprack="mytiprack",
     )
 
-    assert get_robot_deck_attitude() != {}
-    assert get_robot_deck_attitude().attitude == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+
+def test_get_ot3_deck_calibration(starting_ot3_calibration_data: Any) -> None:
+    """Test ability to get an OT-3 belt calibration model."""
+    robot_belt = get_robot_belt_attitude()
+    assert robot_belt
+    assert robot_belt == OT3BeltCalModel(
+        attitude=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        lastModified=robot_belt.lastModified,
+        source=robot_belt.source,
+        pipetteCalibratedWith="pip1",
+    )
+
+
+def test_delete_ot2_deck_calibration(starting_ot2_calibration_data: Any) -> None:
+    """Test delete OT-2 deck calibration data."""
+    robot_deck = get_robot_deck_attitude()
+    assert robot_deck
+    assert robot_deck.attitude == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     delete_robot_deck_attitude()
     assert get_robot_deck_attitude() is None
+
+
+def test_delete_ot3_deck_calibration(starting_ot3_calibration_data: Any) -> None:
+    """Test delete OT-3 belt calibration data."""
+    robot_belt = get_robot_belt_attitude()
+    assert robot_belt
+    assert robot_belt.attitude == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    delete_robot_belt_attitude()
+    assert get_robot_belt_attitude() is None

--- a/api/tests/opentrons/config/test_defaults_ot3.py
+++ b/api/tests/opentrons/config/test_defaults_ot3.py
@@ -115,29 +115,31 @@ def test_load_offset_vals() -> None:
 def test_load_transform_vals() -> None:
     # not list
     assert (
-        defaults_ot3._build_default_transform(None, defaults_ot3.DEFAULT_DECK_TRANSFORM)
-        == defaults_ot3.DEFAULT_DECK_TRANSFORM
+        defaults_ot3._build_default_transform(
+            None, defaults_ot3.DEFAULT_MACHINE_TRANSFORM
+        )
+        == defaults_ot3.DEFAULT_MACHINE_TRANSFORM
     )
     # list of not lists
     assert (
         defaults_ot3._build_default_transform(
-            [1, 2, 3], defaults_ot3.DEFAULT_DECK_TRANSFORM
+            [1, 2, 3], defaults_ot3.DEFAULT_MACHINE_TRANSFORM
         )
-        == defaults_ot3.DEFAULT_DECK_TRANSFORM
+        == defaults_ot3.DEFAULT_MACHINE_TRANSFORM
     )
     # list of wrong number of lists
     assert (
         defaults_ot3._build_default_transform(
-            [[1, 2, 3], [3, 2, 1]], defaults_ot3.DEFAULT_DECK_TRANSFORM
+            [[1, 2, 3], [3, 2, 1]], defaults_ot3.DEFAULT_MACHINE_TRANSFORM
         )
-        == defaults_ot3.DEFAULT_DECK_TRANSFORM
+        == defaults_ot3.DEFAULT_MACHINE_TRANSFORM
     )
     # list of right number of lists of wrong number of elements
     assert (
         defaults_ot3._build_default_transform(
-            [[1, 2, 3], [1, 2, 3], [1, 2, 3, 4]], defaults_ot3.DEFAULT_DECK_TRANSFORM
+            [[1, 2, 3], [1, 2, 3], [1, 2, 3, 4]], defaults_ot3.DEFAULT_MACHINE_TRANSFORM
         )
-        == defaults_ot3.DEFAULT_DECK_TRANSFORM
+        == defaults_ot3.DEFAULT_MACHINE_TRANSFORM
     )
     # list of right number of lists of right number of elements of wrong type
     assert (
@@ -151,13 +153,13 @@ def test_load_transform_vals() -> None:
                 [1, "hi", 3],
                 [1, 2, {}],
             ],
-            defaults_ot3.DEFAULT_DECK_TRANSFORM,
+            defaults_ot3.DEFAULT_MACHINE_TRANSFORM,
         )
-        == defaults_ot3.DEFAULT_DECK_TRANSFORM
+        == defaults_ot3.DEFAULT_MACHINE_TRANSFORM
     )
     # right shape, different data is preserved
     assert defaults_ot3._build_default_transform(
-        [[1, 2, 3], [1, 2, 3], [1, 2, 3]], defaults_ot3.DEFAULT_DECK_TRANSFORM
+        [[1, 2, 3], [1, 2, 3], [1, 2, 3]], defaults_ot3.DEFAULT_MACHINE_TRANSFORM
     ) == [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
 
 

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -8,10 +8,12 @@ from decoy import Decoy
 from numpy import isclose
 
 from opentrons.config import CONFIG, pipette_config, feature_flags as ff
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import API
 from opentrons.hardware_control.dev_types import PipetteSpec
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.pipette.dev_types import PipetteModel
+
+from opentrons.hardware_control.backends import Simulator
 
 defs = json.loads(load_shared_data("pipette/definitions/1/pipetteModelSpecs.json"))
 
@@ -277,9 +279,10 @@ def test_validate_overrides_pass(
 # an effective test of whether anything actually works
 # TODO (lc, 12-05-2022): Re-write these tests when the OT2 pipette
 # configurations are ported over to the new format.
+@pytest.mark.ot2_only
 @pytest.fixture
 async def attached_pipettes(
-    hardware: HardwareControlAPI,
+    hardware: API,
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[Dict[str, PipetteSpec], None]:
     """Fixture the robot to have attached pipettes
@@ -303,16 +306,23 @@ async def attached_pipettes(
     right_name = right_mod.split("_v")[0]
     left_id = marker_with_default("attach_left_id", "abc123")
     right_id = marker_with_default("attach_right_id", "abcd123")
-    mount_type = type(list(hardware._backend._attached_instruments.keys())[0])  # type: ignore[attr-defined]
+    backend = cast(Simulator, hardware._backend)
+    mount_type = type(list(backend._attached_instruments.keys())[0])
 
-    hardware._backend._attached_instruments = {  # type: ignore[attr-defined]
-        mount_type.RIGHT: {"model": right_mod, "id": right_id, "name": right_name},
-        mount_type.LEFT: {"model": left_mod, "id": left_id, "name": left_name},
+    backend._attached_instruments = {
+        mount_type.RIGHT: {  # type: ignore[typeddict-item]
+            "model": right_mod,
+            "id": right_id,
+            "name": right_name,
+        },
+        mount_type.LEFT: {  # type: ignore[typeddict-item]
+            "model": left_mod,
+            "id": left_id,
+            "name": left_name,
+        },
     }
     await hardware.cache_instruments()
-    yield {
-        k.name.lower(): v for k, v in hardware._backend._attached_instruments.items()  # type: ignore[attr-defined]
-    }
+    yield {k.name.lower(): v for k, v in backend._attached_instruments.items()}
 
     # Delete created config files
     (CONFIG["pipette_config_overrides_dir"] / "abc123.json").unlink()

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -93,8 +93,8 @@ async def test_home(ot3_hardware, mock_home):
         assert dfm_mock.call_count == 2
         dfm_mock.assert_called_with(
             mock_home.return_value,
-            ot3_hardware._transforms.deck_calibration.attitude,
-            ot3_hardware._transforms.carriage_offset,
+            ot3_hardware._robot_calibration.deck_calibration.attitude,
+            ot3_hardware._robot_calibration.carriage_offset,
         )
     assert ot3_hardware._current_position[OT3Axis.X] == 20
 

--- a/api/tests/opentrons/hardware_control/test_ot3_transforms.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_transforms.py
@@ -32,7 +32,7 @@ async def test_transforms_roundtrip(pipette_model):
 @pytest.mark.parametrize(
     "pipette_model", ["p1000_single_v3.3", "p50_single_v3.3", "p1000_multi_v3.3"]
 )
-async def test_transform_values(pipette_model):
+async def test_transform_values(pipette_model, enable_ot3_hardware_controller):
     attached = {
         types.Mount.LEFT: {
             "model": pipette_model,

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -17,7 +17,7 @@ from opentrons.protocols.api_support.deck_type import (
 )
 from opentrons.protocol_engine.types import ModuleDefinition
 
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 from opentrons.hardware_control.api import API
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def hardware_api(decoy: Decoy) -> HardwareControlAPI:
     """Get a mocked out HardwareControlAPI of unspecified robot type."""
-    return decoy.mock(cls=HardwareControlAPI)
+    return decoy.mock(cls=OT2HardwareControlAPI)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -7,7 +7,7 @@ import pytest
 from decoy import Decoy, matchers
 from pydantic import BaseModel
 
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.resources import ModelUtils
@@ -41,7 +41,7 @@ from opentrons.protocol_engine.execution import (
 @pytest.fixture
 def hardware_api(decoy: Decoy) -> HardwareControlAPI:
     """Get a mocked out StateStore."""
-    return decoy.mock(cls=HardwareControlAPI)
+    return decoy.mock(cls=OT2HardwareControlAPI)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/execution/test_door_watcher.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_door_watcher.py
@@ -7,7 +7,7 @@ import pytest
 from anyio import to_thread
 from decoy import Decoy, matchers
 
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 from opentrons.hardware_control.types import (
     DoorStateNotification,
     DoorState,
@@ -33,7 +33,7 @@ def hardware_control_api(
     decoy: Decoy,
 ) -> HardwareControlAPI:
     """Return a mock in the shape of a HardwareControlAPI."""
-    return decoy.mock(cls=HardwareControlAPI)
+    return decoy.mock(cls=OT2HardwareControlAPI)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -80,12 +80,6 @@ def state_store(decoy: Decoy) -> StateStore:
 
 
 @pytest.fixture
-def hardware_api(decoy: Decoy) -> HardwareControlAPI:
-    """Get a mocked out HardwareControlAPI instance."""
-    return decoy.mock(cls=HardwareControlAPI)
-
-
-@pytest.fixture
 def action_dispatcher(decoy: Decoy) -> ActionDispatcher:
     """Get a mocked out ActionDispatcher instance."""
     return decoy.mock(cls=ActionDispatcher)

--- a/api/tests/opentrons/protocol_engine/execution/test_rail_lights_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_rail_lights_handler.py
@@ -3,15 +3,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.protocol_engine.execution.rail_lights import RailLightsHandler
-from opentrons.hardware_control import HardwareControlAPI
-
-
-@pytest.fixture
-def hardware_api(
-    decoy: Decoy,
-) -> HardwareControlAPI:
-    """Return a mock in the shape of a HardwareControlAPI."""
-    return decoy.mock(cls=HardwareControlAPI)
+from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 
 
 @pytest.fixture
@@ -26,7 +18,7 @@ def subject(
 async def test_set_rail_lights(
     decoy: Decoy,
     subject: RailLightsHandler,
-    hardware_api: HardwareControlAPI,
+    hardware_api: OT2HardwareControlAPI,
     binary: bool,
 ) -> None:
     """The hardware controller should be called."""

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -6,7 +6,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.types import DeckSlotName
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 from opentrons.hardware_control.modules import MagDeck, TempDeck
 from opentrons.hardware_control.types import PauseType as HardwarePauseType
 
@@ -82,7 +82,7 @@ def model_utils(decoy: Decoy) -> ModelUtils:
 @pytest.fixture
 def hardware_api(decoy: Decoy) -> HardwareControlAPI:
     """Get a mock HardwareControlAPI."""
-    return decoy.mock(cls=HardwareControlAPI)
+    return decoy.mock(cls=OT2HardwareControlAPI)
 
 
 @pytest.fixture

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -73,7 +73,7 @@
   "turn_off_updates": "Turn off software update notifications in App Settings.",
   "up_to_date": "Up to date",
   "update_alerts": "Software Update Alerts",
-  "update_available": "A software update is available. ",
+  "update_available": "update available",
   "update_channel": "Update Channel",
   "update_description": "Stable receives the latest stable releases. Beta allows you to try out new in-progress features before they launch in Stable channel, but they have not completed testing yet.",
   "usb_to_ethernet_adapter_description": "Description",

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/RobotSystemVersion.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/RobotSystemVersion.tsx
@@ -37,7 +37,7 @@ export function RobotSystemVersion({
   isUpdateAvailable,
   setCurrentOption,
 }: RobotSystemVersionProps): JSX.Element {
-  const { t } = useTranslation([
+  const { t, i18n } = useTranslation([
     'device_settings',
     'shared',
     'device_details',
@@ -86,7 +86,7 @@ export function RobotSystemVersion({
                 lineHeight="1.875rem"
                 fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               >
-                {t('app_settings:update_available')}
+                {i18n.format(t('app_settings:update_available'), 'capitalize')}
               </StyledText>
             </Flex>
           ) : null}

--- a/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSystemVersion.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSystemVersion.test.tsx
@@ -53,7 +53,7 @@ describe('RobotSystemVersion', () => {
       isUpdateAvailable: true,
     }
     const [{ getByText, getByRole }] = render(props)
-    getByText('A software update is available.')
+    getByText('Update available')
     getByRole('button', { name: 'View software update' })
   })
 

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
@@ -21,6 +21,7 @@ import {
 } from '@opentrons/components'
 
 import { StyledText } from '../../../atoms/text'
+import { InlineNotification } from '../../../atoms/InlineNotification'
 import { toggleDevtools } from '../../../redux/config'
 
 import type { IconName } from '@opentrons/components'
@@ -72,7 +73,7 @@ export function RobotSettingButton({
   lightsOn,
   toggleLights,
 }: RobotSettingButtonProps): JSX.Element {
-  const { t } = useTranslation(['app_settings', 'shared'])
+  const { t, i18n } = useTranslation(['app_settings', 'shared'])
   const dispatch = useDispatch<Dispatch>()
 
   const handleClick = (): void => {
@@ -112,7 +113,7 @@ export function RobotSettingButton({
           </StyledText>
           {settingInfo != null ? (
             <StyledText
-              color={COLORS.darkGreyEnabled}
+              color={COLORS.darkBlack70}
               as="h4"
               fontWeight={TYPOGRAPHY.fontWeightRegular}
               textAlign={TYPOGRAPHY.textAlignLeft}
@@ -122,22 +123,6 @@ export function RobotSettingButton({
           ) : null}
         </Flex>
       </Flex>
-      {isUpdateAvailable ?? false ? (
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          gridGap={SPACING.spacing12}
-          alignItems={ALIGN_CENTER}
-          backgroundColor={COLORS.warningBackgroundMed}
-          padding={`${SPACING.spacing12} ${SPACING.spacing4}`}
-          borderRadius={BORDERS.size4}
-        >
-          <Icon name="ot-alert" size="1.75rem" color={COLORS.warningEnabled} />
-          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-            {t('update_available')}
-          </StyledText>
-        </Flex>
-      ) : null}
-
       {enabledDevTools != null ? (
         <Flex
           flexDirection={DIRECTION_ROW}
@@ -167,10 +152,18 @@ export function RobotSettingButton({
           </StyledText>
         </Flex>
       ) : null}
-
-      {enabledDevTools == null && ledLights == null ? (
-        <Icon name="chevron-right" size="3rem" />
-      ) : null}
+      <Flex gridGap={SPACING.spacing40} alignItems={ALIGN_CENTER}>
+        {isUpdateAvailable ?? false ? (
+          <InlineNotification
+            type="alert"
+            heading={i18n.format(t('update_available'), 'capitalize')}
+            hug={true}
+          />
+        ) : null}
+        {enabledDevTools == null && ledLights == null ? (
+          <Icon name="more" size="3rem" />
+        ) : null}
+      </Flex>
     </Btn>
   )
 }

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -18,6 +18,7 @@ import {
   TextSize,
   UpdateChannel,
 } from '../../../../organisms/OnDeviceDisplay/RobotSettingsDashboard'
+import { getBuildrootUpdateAvailable } from '../../../../redux/buildroot'
 import { useLights } from '../../../../organisms/Devices/hooks'
 
 import { RobotSettingsDashboard } from '..'
@@ -77,6 +78,9 @@ const mockUpdateChannel = UpdateChannel as jest.MockedFunction<
   typeof UpdateChannel
 >
 const mockUseLights = useLights as jest.MockedFunction<typeof useLights>
+const mockGetBuildrootUpdateAvailable = getBuildrootUpdateAvailable as jest.MockedFunction<
+  typeof getBuildrootUpdateAvailable
+>
 
 const render = () => {
   return renderWithProviders(
@@ -212,6 +216,12 @@ describe('RobotSettingsDashboard', () => {
     const button = getByText('Enable Developer Tools')
     fireEvent.click(button)
     expect(mockToggleDevtools).toHaveBeenCalled()
+  })
+
+  it('should return an update available with correct text', () => {
+    mockGetBuildrootUpdateAvailable.mockReturnValue('upgrade')
+    const [{ getByText }] = render()
+    getByText('Update available')
   })
 
   // The following cases will be activate when RobotSettings PRs are ready

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -478,7 +478,7 @@ async def move_gripper_jaw_relative_ot3(api: OT3API, delta: float) -> None:
 
 def get_endstop_position_ot3(api: OT3API, mount: OT3Mount) -> Dict[OT3Axis, float]:
     """Get the endstop's position per mount."""
-    transforms = api._transforms
+    transforms = api._robot_calibration
     machine_pos_per_axis = api._backend.home_position()
     deck_pos_per_axis = deck_from_machine(
         machine_pos_per_axis,

--- a/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_alignment.py
+++ b/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_alignment.py
@@ -2,7 +2,7 @@
 from typing import List, Union
 from typing_extensions import Final
 
-from opentrons.config.defaults_ot3 import DEFAULT_DECK_TRANSFORM
+from opentrons.config.defaults_ot3 import DEFAULT_MACHINE_TRANSFORM
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.ot3_calibration import (
     find_calibration_structure_height,
@@ -65,7 +65,7 @@ async def _find_slot(api: OT3API, mount: OT3Mount, expected: Point) -> Point:
 
 def _assert_deck_transform_is_default(api: OT3API) -> None:
     att_matrix = api.config.deck_transform
-    for def_row, att_row in zip(DEFAULT_DECK_TRANSFORM, att_matrix):
+    for def_row, att_row in zip(DEFAULT_MACHINE_TRANSFORM, att_matrix):
         for default_val, current_val in zip(def_row, att_row):
             assert (
                 current_val == default_val

--- a/robot-server/dev-flex.env
+++ b/robot-server/dev-flex.env
@@ -1,0 +1,7 @@
+# Environment for Flex development
+
+ENABLE_VIRTUAL_SMOOTHIE=true
+OT_ROBOT_SERVER_persistence_directory=automatically_make_temporary
+OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test-flex.json
+OT_API_FF_enableOT3HardwareController=true
+DEV_ROBOT_NAME=opentrons-dev

--- a/robot-server/simulators/.gitignore
+++ b/robot-server/simulators/.gitignore
@@ -2,3 +2,4 @@
 *.json
 # ...unless specifically allowed.
 !test.json
+!test-flex.json

--- a/robot-server/simulators/README.md
+++ b/robot-server/simulators/README.md
@@ -10,6 +10,7 @@ The file is made up of the following keys:values which are all optional.
 
 ```
 {
+  "machine": "OT-2 Standard" # or "OT-3 Standard"; OT-2 is the default
   "attached_instruments": {
     "right": {
         # Definition of right pipette
@@ -18,6 +19,9 @@ The file is made up of the following keys:values which are all optional.
     "left": {
         # Definition of left pipette
         ...
+    },
+    "gripper": {
+        # Definition of gripper, if machine is OT-3 Standard
     }
   },
 }
@@ -74,7 +78,7 @@ See [pipette](../../api/src/opentrons/config/pipette_config.py) for available fi
 
 ### Configs
 
-This is the same format as `robot_settings.json` as defined in [robot_configs](../../api/src/opentrons/config/robot_configs.py).
+This is the same format as `robot_settings.json` as defined in [robot_configs](../../api/src/opentrons/config/robot_configs.py) if this is an OT-2. If this is an OT-3, it is the OT-3 variant.
 
 ```
 {

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -1,0 +1,64 @@
+{
+  "machine": "OT-3 Standard",
+  "attached_instruments": {
+    "right": {
+      "model": "p1000_single_v3.4",
+      "id": "321",
+      "max_volume": 1000,
+      "name": "p1000_single",
+      "tip_length": 0,
+      "channels": 1
+    },
+    "left": {
+      "model": "p50_single_v3.4",
+      "id": "123",
+      "max_volume": 50,
+      "name": "p50_single",
+      "tip_length": 0,
+      "channels": 1
+    }
+  },
+  "attached_modules": {
+    "thermocycler": [
+      {
+        "function_name": "set_temperature",
+        "kwargs": {
+          "temperature": 3,
+          "hold_time_seconds": 1,
+          "hold_time_minutes": 2,
+          "ramp_rate": 4,
+          "volume": 5
+        }
+      },
+      {
+        "function_name": "set_lid_temperature",
+        "kwargs": {
+          "temperature": 4
+        }
+      }
+    ],
+    "heatershaker": [],
+    "tempdeck": [
+      {
+        "function_name": "start_set_temperature",
+        "kwargs": {
+          "celsius": 3
+        }
+      },
+      {
+        "function_name": "await_temperature",
+        "kwargs": {
+          "awaiting_temperature": null
+        }
+      }
+    ],
+    "magdeck": [
+      {
+        "function_name": "engage",
+        "kwargs": {
+          "height": 4
+        }
+      }
+    ]
+  }
+}

--- a/robot-server/tests/commands/test_get_default_engine.py
+++ b/robot-server/tests/commands/test_get_default_engine.py
@@ -13,12 +13,6 @@ from robot_server.commands.get_default_engine import get_default_engine
 
 
 @pytest.fixture()
-def hardware_api(decoy: Decoy) -> HardwareControlAPI:
-    """Get a mocked out HardwareControlAPI."""
-    return decoy.mock(cls=HardwareControlAPI)
-
-
-@pytest.fixture()
 def protocol_engine(decoy: Decoy) -> ProtocolEngine:
     """Get a mocked out ProtocolEngine."""
     return decoy.mock(cls=ProtocolEngine)

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -13,6 +13,7 @@ from mock import MagicMock
 from pathlib import Path
 from typing import Any, Callable, Generator, Iterator, cast
 from typing_extensions import NoReturn
+from decoy import Decoy
 
 from sqlalchemy.engine import Engine as SQLEngine
 
@@ -51,6 +52,14 @@ async def always_raise() -> NoReturn:
 
 
 app.include_router(test_router)
+
+
+@pytest.fixture()
+def hardware_api(decoy: Decoy) -> HardwareControlAPI:
+    """Return a mock in the shape of a HardwareControlAPI."""
+    # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
+    # should pass in some sort of actual, valid HardwareAPI instead of a mock
+    return decoy.mock(cls=API)
 
 
 @pytest.fixture(autouse=True)

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -34,12 +34,6 @@ if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
 
 
-@pytest.fixture()
-def hardware_api(decoy: Decoy) -> HardwareControlAPI:
-    """Get a mock hardware control API."""
-    return decoy.mock(cls=HardwareControlAPI)
-
-
 def get_sample_pipette_dict(
     name: PipetteName,
     model: PipetteModel,

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -55,7 +55,6 @@ class DevServer:
             "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev-flex.env"
             if self.is_ot3
             else "dev.env",
-            "OT_API_FF_enableOT3HardwareController": "true" if self.is_ot3 else "false",
             "OT_API_CONFIG_DIR": str(self.ot_api_config_dir),
             "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),
         }

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -52,7 +52,9 @@ class DevServer:
         # This environment is only for the subprocess so it should
         # not have any side effects.
         env = {
-            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev.env",
+            "OT_ROBOT_SERVER_DOT_ENV_PATH": "dev-flex.env"
+            if self.is_ot3
+            else "dev.env",
             "OT_API_FF_enableOT3HardwareController": "true" if self.is_ot3 else "false",
             "OT_API_CONFIG_DIR": str(self.ot_api_config_dir),
             "OT_ROBOT_SERVER_persistence_directory": str(self.persistence_directory),

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -7,7 +7,7 @@ from decoy import Decoy, matchers
 from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.types import DeckSlotName
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import API
 from opentrons.protocol_engine import (
     ProtocolEngine,
     StateSummary,
@@ -26,7 +26,7 @@ def subject(decoy: Decoy) -> MaintenanceEngineStore:
     """Get a MaintenanceEngineStore test subject."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
-    hardware_api = decoy.mock(cls=HardwareControlAPI)
+    hardware_api = decoy.mock(cls=API)
     return MaintenanceEngineStore(
         hardware_api=hardware_api,
         # Arbitrary choice of robot and deck type. Tests where these matter should
@@ -56,7 +56,7 @@ async def test_create_engine_uses_robot_and_deck_type(
     """It should create ProtocolEngines with the given robot and deck type."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
-    hardware_api = decoy.mock(cls=HardwareControlAPI)
+    hardware_api = decoy.mock(cls=API)
     subject = MaintenanceEngineStore(
         hardware_api=hardware_api,
         robot_type=robot_type,

--- a/robot-server/tests/modules/test_router.py
+++ b/robot-server/tests/modules/test_router.py
@@ -23,12 +23,6 @@ _HTTP_API_VERSION: Final = 3
 
 
 @pytest.fixture()
-def hardware_api(decoy: Decoy) -> HardwareControlAPI:
-    """Get a mock hardware control API."""
-    return decoy.mock(cls=HardwareControlAPI)
-
-
-@pytest.fixture()
 def magnetic_module(decoy: Decoy) -> MagDeck:
     """Get a mock magnetic module control interface."""
     return decoy.mock(cls=MagDeck)

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -8,7 +8,7 @@ from opentrons_shared_data import get_shared_data_root
 from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.types import DeckSlotName
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI, API
 from opentrons.protocol_engine import ProtocolEngine, StateSummary, types as pe_types
 from opentrons.protocol_runner import (
     RunResult,
@@ -19,16 +19,6 @@ from opentrons.protocol_reader import ProtocolReader, ProtocolSource
 
 from robot_server.protocols import ProtocolResource
 from robot_server.runs.engine_store import EngineStore, EngineConflictError
-
-
-@pytest.fixture
-def hardware_api(
-    decoy: Decoy,
-) -> HardwareControlAPI:
-    """Return a mock in the shape of a HardwareControlAPI."""
-    # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
-    # should pass in some sort of actual, valid HardwareAPI instead of a mock
-    return decoy.mock(cls=HardwareControlAPI)
 
 
 @pytest.fixture
@@ -98,7 +88,7 @@ async def test_create_engine_uses_robot_type(
     """It should create ProtocolEngines with the given robot and deck type."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
-    hardware_api = decoy.mock(cls=HardwareControlAPI)
+    hardware_api = decoy.mock(cls=API)
     subject = EngineStore(
         hardware_api=hardware_api, robot_type=robot_type, deck_type=deck_type
     )
@@ -202,7 +192,7 @@ async def test_get_default_engine_robot_type(
     """It should create default ProtocolEngines with the given robot and deck type."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
-    hardware_api = decoy.mock(cls=HardwareControlAPI)
+    hardware_api = decoy.mock(cls=API)
     subject = EngineStore(
         hardware_api=hardware_api, robot_type=robot_type, deck_type=deck_type
     )


### PR DESCRIPTION
## Overview

We don't know what pipettes are attached on the hardware controller side until we actually detect the pipette. This means that when the 96 channel gets attached for the first time the mount falls because there isn't enough current on the head motors to support it. We should instead auto-disengage all the ZA motors which will trigger the ebrake on the head board.

The motors will get re-enabled as soon as any movement is issued.