### PR TITLE
fix(api): change slots used to calibrate belts

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -661,7 +661,7 @@ async def _determine_transform_matrix(
     -------
     A listed matrix of the linear transform in the x and y dimensions that accounts for the stretch of the gantry x and y belts.
     """
-    slot_a, slot_b, slot_c = 12, 3, 10
+    slot_a, slot_b, slot_c = 1, 10, 3
     point_a, nominal_point_a = await find_slot_center_binary_from_nominal_center(
         hcapi, mount, slot_a
     )


### PR DESCRIPTION
# Overview

Currently, we use deck slots 12, 3, and 10 to calibrate the x and y gantry belts. With 12 being the designated garbage slot, it would be more user-friendly to not use this slot. The same calibration results (attitude matrix with same orientation) can be achieved using deck slots 1, 10, and 3.

# Test Plan

Below are the belt calibration results achieved using these two sets of deck slots. The `calibrate_belts` api method was used.

Slots (12, 3, 10) Belt Calibration Attitude Matrix:
[[0.9979, -0.0001, 0.0], [0.0007, 0.9984, 0.0], [0.0, 0.0, 1.0]]

Slots (1, 10, 3) Belt Calibration Attitude Matrix:
[[0.9983, -0.0, 0.0], [0.0007, 0.9985, 0.0], [0.0, 0.0, 1.0]]

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->



<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
