### PR TITLE
fix(api): disable motors during the pipette attach and detach position

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -7,7 +7,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType, Point
-from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control.types import CriticalPoint, Axis
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -72,6 +72,7 @@ class MoveToMaintenancePositionImplementation(
             critical_point=CriticalPoint.MOUNT,
         )
 
+        await self._hardware_api.disengage_axes([Axis.Z, Axis.A])
         return MoveToMaintenancePositionResult()
 
 


### PR DESCRIPTION
## Overview

We don't know what pipettes are attached on the hardware controller side until we actually detect
the pipette. This means that when the 96 channel gets attached for the first time the mount falls
because there isn't enough current on the head motors to support it. We should instead
auto-disengage all the ZA motors which will trigger the ebrake on the head board.

The motors will get re-enabled as soon as any movement is issued.