### PR TITLE
refactor(app): derive device connectivity status icon type from network status

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -125,8 +125,7 @@ export function AvailableRobotOption(
             >
               {robotName}
               <Icon
-                // local boolean corresponds to a wired usb connection
-                aria-label={local ?? false ? 'usb' : 'wifi'}
+                aria-label={iconName}
                 marginBottom={`-${SPACING.spacing4}`}
                 marginLeft={SPACING.spacing8}
                 name={iconName ?? 'wifi'}

--- a/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
 import { NavLink } from 'react-router-dom'
@@ -19,13 +19,15 @@ import { useAllRunsQuery } from '@opentrons/react-api-client'
 import { StyledText } from '../../atoms/text'
 import { MiniCard } from '../../molecules/MiniCard'
 import { getRobotModelByName, OPENTRONS_USB } from '../../redux/discovery'
+import { getNetworkInterfaces, fetchStatus } from '../../redux/networking'
 import { appShellRequestor } from '../../redux/shell/remote'
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import FLEX_PNG from '../../assets/images/FLEX.png'
 import { RobotBusyStatusAction } from '.'
 
+import type { IconName } from '@opentrons/components'
 import type { Robot } from '../../redux/discovery/types'
-import type { State } from '../../redux/types'
+import type { Dispatch, State } from '../../redux/types'
 
 interface AvailableRobotOptionProps {
   robot: Robot
@@ -51,6 +53,7 @@ export function AvailableRobotOption(
   } = props
   const { ip, local, name: robotName } = robot ?? {}
   const { t } = useTranslation('protocol_list')
+  const dispatch = useDispatch<Dispatch>()
   const robotModel = useSelector((state: State) =>
     getRobotModelByName(state, robotName)
   )
@@ -72,6 +75,24 @@ export function AvailableRobotOption(
     }
   )
   const robotHasCurrentRun = runsData?.links?.current != null
+
+  const { ethernet, wifi } = useSelector((state: State) =>
+    getNetworkInterfaces(state, robotName)
+  )
+
+  let iconName: IconName | null = null
+  if (wifi?.ipAddress != null) {
+    iconName = 'wifi'
+  } else if (ethernet?.ipAddress != null) {
+    iconName = 'ethernet'
+  } else if (local != null && local) {
+    iconName = 'usb'
+  }
+
+  React.useEffect(() => {
+    dispatch(fetchStatus(robotName))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return showIdleOnly && robotHasCurrentRun ? null : (
     <>
@@ -108,7 +129,7 @@ export function AvailableRobotOption(
                 aria-label={local ?? false ? 'usb' : 'wifi'}
                 marginBottom={`-${SPACING.spacing4}`}
                 marginLeft={SPACING.spacing8}
-                name={local ?? false ? 'usb' : 'wifi'}
+                name={iconName ?? 'wifi'}
                 size={SIZE_1}
               />
             </StyledText>

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -17,10 +17,12 @@ import {
   mockReachableRobot,
   mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
+import { getNetworkInterfaces } from '../../../redux/networking'
 import { ChooseRobotSlideout } from '..'
 
 jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/buildroot')
+jest.mock('../../../redux/networking')
 
 const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
   typeof getBuildrootUpdateDisplayInfo
@@ -37,6 +39,9 @@ const mockGetUnreachableRobots = getUnreachableRobots as jest.MockedFunction<
 const mockGetScanning = getScanning as jest.MockedFunction<typeof getScanning>
 const mockStartDiscovery = startDiscovery as jest.MockedFunction<
   typeof startDiscovery
+>
+const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
+  typeof getNetworkInterfaces
 >
 
 const render = (props: React.ComponentProps<typeof ChooseRobotSlideout>) => {
@@ -64,6 +69,7 @@ describe('ChooseRobotSlideout', () => {
     mockGetReachableRobots.mockReturnValue([mockReachableRobot])
     mockGetScanning.mockReturnValue(false)
     mockStartDiscovery.mockReturnValue({ type: 'mockStartDiscovery' } as any)
+    mockGetNetworkInterfaces.mockReturnValue({ wifi: null, ethernet: null })
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -27,6 +27,7 @@ import {
   mockReachableRobot,
   mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
+import { getNetworkInterfaces } from '../../../redux/networking'
 import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/protocol-storage/__fixtures__'
 import { useCreateRunFromProtocol } from '../useCreateRunFromProtocol'
 import { useOffsetCandidatesForAnalysis } from '../../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
@@ -40,6 +41,7 @@ jest.mock('../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../organisms/RunTimeControl/hooks')
 jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/buildroot')
+jest.mock('../../../redux/networking')
 jest.mock('../../../redux/config')
 jest.mock('../useCreateRunFromProtocol')
 jest.mock('../../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis')
@@ -83,6 +85,9 @@ const mockUseCreateRunFromProtocol = useCreateRunFromProtocol as jest.MockedFunc
 >
 const mockUseTrackCreateProtocolRunEvent = useTrackCreateProtocolRunEvent as jest.MockedFunction<
   typeof useTrackCreateProtocolRunEvent
+>
+const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
+  typeof getNetworkInterfaces
 >
 
 const render = (
@@ -158,6 +163,9 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
         expect.any(String)
       )
       .mockReturnValue([])
+    when(mockGetNetworkInterfaces)
+      .calledWith({} as State, expect.any(String))
+      .mockReturnValue({ wifi: null, ethernet: null })
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector, useDispatch } from 'react-redux'
 import { Link, useHistory } from 'react-router-dom'
 
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
@@ -23,9 +24,11 @@ import { StyledText } from '../../atoms/text'
 import { Tooltip } from '../../atoms/Tooltip'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
+import { getNetworkInterfaces, fetchStatus } from '../../redux/networking'
 
-import type { StyleProps } from '@opentrons/components'
+import type { IconName, StyleProps } from '@opentrons/components'
 import type { DiscoveredRobot } from '../../redux/discovery/types'
+import type { Dispatch, State } from '../../redux/types'
 
 type RobotStatusHeaderProps = StyleProps &
   Pick<DiscoveredRobot, 'name' | 'local'> & {
@@ -41,6 +44,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   ])
   const history = useHistory()
   const [targetProps, tooltipProps] = useHoverTooltip()
+  const dispatch = useDispatch<Dispatch>()
 
   const currentRunId = useCurrentRunId()
   const currentRunStatus = useCurrentRunStatus()
@@ -76,6 +80,28 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
       </Flex>
     ) : null
 
+  const { ethernet, wifi } = useSelector((state: State) =>
+    getNetworkInterfaces(state, name)
+  )
+
+  let iconName: IconName | null = null
+  let tooltipTranslationKey = ''
+  if (wifi?.ipAddress != null) {
+    iconName = 'wifi'
+    tooltipTranslationKey = 'device_settings:wifi'
+  } else if (ethernet?.ipAddress != null) {
+    iconName = 'ethernet'
+    tooltipTranslationKey = 'device_settings:ethernet'
+  } else if (local != null && local) {
+    iconName = 'usb'
+    tooltipTranslationKey = 'device_settings:wired_usb'
+  }
+
+  React.useEffect(() => {
+    dispatch(fetchStatus(name))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} {...styleProps}>
       <Flex flexDirection={DIRECTION_COLUMN}>
@@ -84,6 +110,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
           color={COLORS.darkGreyEnabled}
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           paddingBottom={SPACING.spacing2}
+          textTransform={TYPOGRAPHY.textTransformUppercase}
           id={`RobotStatusHeader_${String(name)}_robotModel`}
         >
           {robotModel}
@@ -97,25 +124,25 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
             >
               {name}
             </StyledText>
-            <Btn
-              {...targetProps}
-              marginRight={SPACING.spacing8}
-              onClick={() =>
-                history.push(`/devices/${name}/robot-settings/networking`)
-              }
-            >
-              <Icon
-                // local boolean corresponds to a wired usb connection for OT-2
-                // TODO(bh, 2022-10-19): for OT-3, determine what robot data looks like for wired usb and ethernet connections
-                name={local != null && local ? 'usb' : 'wifi'}
-                color={COLORS.darkGreyEnabled}
-                size="1.25rem"
-              />
-            </Btn>
+            {iconName != null ? (
+              <Btn
+                {...targetProps}
+                marginRight={SPACING.spacing8}
+                onClick={() =>
+                  history.push(`/devices/${name}/robot-settings/networking`)
+                }
+              >
+                <Icon
+                  aria-label={iconName}
+                  paddingTop={SPACING.spacing4}
+                  name={iconName}
+                  color={COLORS.darkGreyEnabled}
+                  size="1.25rem"
+                />
+              </Btn>
+            ) : null}
             <Tooltip tooltipProps={tooltipProps} width="auto">
-              {local != null && local
-                ? t('device_settings:wired_usb')
-                : t('device_settings:wifi')}
+              {t(tooltipTranslationKey)}
             </Tooltip>
           </Flex>
         </Flex>

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -85,7 +85,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   )
 
   let iconName: IconName | null = null
-  let tooltipTranslationKey = ''
+  let tooltipTranslationKey = null
   if (wifi?.ipAddress != null) {
     iconName = 'wifi'
     tooltipTranslationKey = 'device_settings:wifi'
@@ -142,7 +142,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
               </Btn>
             ) : null}
             <Tooltip tooltipProps={tooltipProps} width="auto">
-              {t(tooltipTranslationKey)}
+              {tooltipTranslationKey != null ? t(tooltipTranslationKey) : ''}
             </Tooltip>
           </Flex>
         </Flex>

--- a/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
@@ -30,14 +30,18 @@ import {
   mockReachableRobot,
   mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
+import { getNetworkInterfaces } from '../../../redux/networking'
 import { getIsProtocolAnalysisInProgress } from '../../../redux/protocol-storage/selectors'
 import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/protocol-storage/__fixtures__'
 import { SendProtocolToOT3Slideout } from '..'
+
+import type { State } from '../../../redux/types'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../organisms/ToasterOven')
 jest.mock('../../../redux/buildroot')
 jest.mock('../../../redux/discovery')
+jest.mock('../../../redux/networking')
 jest.mock('../../../redux/protocol-storage/selectors')
 
 const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
@@ -65,6 +69,9 @@ const mockUseCreateProtocolMutation = useCreateProtocolMutation as jest.MockedFu
 >
 const mockGetIsProtocolAnalysisInProgress = getIsProtocolAnalysisInProgress as jest.MockedFunction<
   typeof getIsProtocolAnalysisInProgress
+>
+const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
+  typeof getNetworkInterfaces
 >
 
 const render = (
@@ -134,6 +141,9 @@ describe('SendProtocolToOT3Slideout', () => {
       .calledWith(expect.any(Object), expect.any(Object))
       .mockReturnValue({ mutateAsync: mockMutateAsync } as any)
     when(mockMutateAsync).mockImplementation(() => Promise.resolve())
+    when(mockGetNetworkInterfaces)
+      .calledWith({} as State, expect.any(String))
+      .mockReturnValue({ wifi: null, ethernet: null })
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -372,6 +372,41 @@ describe('discovery selectors', () => {
       ],
     },
     {
+      name: 'handles opentrons-usb robots by setting as local',
+      selector: discovery.getDiscoveredRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            'opentrons-foo': {
+              name: 'opentrons-foo',
+              health: mockLegacyHealthResponse,
+              serverHealth: mockLegacyServerHealthResponse,
+              addresses: [
+                {
+                  ip: 'opentrons-usb',
+                  port: 31950,
+                  seen: true,
+                  healthStatus: HEALTH_STATUS_OK,
+                  serverHealthStatus: HEALTH_STATUS_UNREACHABLE,
+                  healthError: null,
+                  serverHealthError: mockHealthFetchErrorResponse,
+                  advertisedModel: null,
+                },
+              ],
+            },
+          },
+        },
+        robot: { connection: { connectedTo: '' } },
+      },
+      expected: [
+        expect.objectContaining({
+          name: 'opentrons-foo',
+          ip: 'opentrons-usb',
+          local: true,
+        }),
+      ],
+    },
+    {
       name: 'getViewableRobots returns connectable and reachable robots',
       selector: discovery.getViewableRobots,
       state: MOCK_STATE,

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -20,6 +20,7 @@ import {
   RE_ROBOT_MODEL_OT2,
   ROBOT_MODEL_OT2,
   ROBOT_MODEL_OT3,
+  OPENTRONS_USB,
 } from './constants'
 
 import type { State } from '../types'
@@ -50,7 +51,8 @@ const isLocal = (ip: string): boolean => {
     RE_HOSTNAME_IPV6_LL.test(ip) ||
     RE_HOSTNAME_IPV4_LL.test(ip) ||
     RE_HOSTNAME_LOCALHOST.test(ip) ||
-    RE_HOSTNAME_LOOPBACK.test(ip)
+    RE_HOSTNAME_LOOPBACK.test(ip) ||
+    ip === OPENTRONS_USB
   )
 }
 


### PR DESCRIPTION
# Overview

calls network status endpoint in robot status header to determine whether robot is connected by wifi or ethernet. adds the `opentrons-usb` ip to the list of conditions that determine the local boolean for a discovered robot. chooses a connectivity status icon based on wifi, ethernet, and usb connection status.

fixes a couple minor styling issues while in the file: icon spacing and uppercase robot model

# Test Plan

 - updated unit tests
 - manually confirmed desired behavior

# Changelog

 - Derives device connectivity status icon type from network status

# Review requests

open the app and check the icon types

# Risk assessment

low
