### PR TITLE
fix(api): emulator proxy client uri logic

### DIFF
--- a/api/src/opentrons/hardware_control/emulation/proxy.py
+++ b/api/src/opentrons/hardware_control/emulation/proxy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+import socket
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List
@@ -117,9 +118,7 @@ class Proxy:
         )
 
         client_host = (
-            "127.0.0.1" 
-            if self._settings.use_local_host 
-            else socket.gethostname()
+            "127.0.0.1" if self._settings.use_local_host else socket.gethostname()
         )
 
         self._cons.append(connection)

--- a/api/src/opentrons/hardware_control/emulation/proxy.py
+++ b/api/src/opentrons/hardware_control/emulation/proxy.py
@@ -115,10 +115,17 @@ class Proxy:
         connection = Connection(
             identifier=str(uuid.uuid1()), reader=reader, writer=writer
         )
+
+        client_host = (
+            "127.0.0.1" 
+            if self._settings.use_local_host 
+            else socket.gethostname()
+        )
+
         self._cons.append(connection)
         self._event_listener.on_server_connected(
             server_type=self._name,
-            client_uri=f"socket://127.0.0.1:{self._settings.driver_port}",
+            client_uri=f"socket://{client_host}:{self._settings.driver_port}",
             identifier=connection.identifier,
         )
 

--- a/api/src/opentrons/hardware_control/emulation/proxy.py
+++ b/api/src/opentrons/hardware_control/emulation/proxy.py
@@ -117,6 +117,8 @@ class Proxy:
             identifier=str(uuid.uuid1()), reader=reader, writer=writer
         )
 
+        log.info(f"Using Local Host: {self._settings.use_local_host}")
+
         client_host = (
             "127.0.0.1" if self._settings.use_local_host else socket.gethostname()
         )

--- a/api/src/opentrons/hardware_control/emulation/settings.py
+++ b/api/src/opentrons/hardware_control/emulation/settings.py
@@ -61,6 +61,7 @@ class ProxySettings(BaseModel):
     host: str = "0.0.0.0"
     emulator_port: int
     driver_port: int
+    use_local_host: bool = True
 
 
 class ModuleServerSettings(BaseModel):


### PR DESCRIPTION
# Overview

The emulator proxy was failing when calling `socket.gethostname()` when the proxy was not running inside of Docker.

It was fixed to be hard-coded to `127.0.0.1` but this broke `opentrons-emulation`'s usage of the proxy.

To fix, added `use_local_host` flag to `ProxySettings`. This flag is defaulted to `True`. 
When set to `True` the emulator proxy defaults to using `127.0.0.1` as its host name.
When set to `False` it calls `socket.gethostname()` and it's internal IP address inside of the Docker network

When running the proxy outside of Docker this flag does not need to be changed.
But when running inside of Docker (i.e. opentrons-emulation) it needs to be set to `False`. 

# Test Plan

- [x] Make sure G-Code CI tests pass with no changes to their configuration
- [x] Make sure, inside of opentrons-emulation, that the emulator proxy now resolves it's hostname sucessfully when it sets `OT_EMULATOR_use_local_host="False"`


# Review requests

No

# Risk assessment

Low, not changing any major functionality. Just adding a simple conditional, whose default value only breaks emulation. Therefore, since I am the main dev for emulation, that's on me to handle.
