### PR TITLE
refactor(app): instrument dashboard and details design qa 1

### DIFF
--- a/app/src/atoms/buttons/BackButton.tsx
+++ b/app/src/atoms/buttons/BackButton.tsx
@@ -20,7 +20,7 @@ export function BackButton({
       onClick={onClick != null ? onClick : () => history.goBack()}
     >
       <Flex alignItems={ALIGN_CENTER}>
-        <Icon name="chevron-left" height="3rem" />
+        <Icon name="back" height="3rem" />
         <Box fontSize="2rem" fontWeight="700">
           {/* render "Back" if no children given */}
           {children != null ? children : t('back')}

--- a/app/src/organisms/InstrumentInfo/index.tsx
+++ b/app/src/organisms/InstrumentInfo/index.tsx
@@ -34,7 +34,7 @@ interface InstrumentInfoProps {
   instrument: InstrumentData | null
 }
 export const InstrumentInfo = (props: InstrumentInfoProps): JSX.Element => {
-  const { t } = useTranslation('instruments_dashboard')
+  const { t, i18n } = useTranslation('instruments_dashboard')
   const { instrument } = props
   const history = useHistory()
   const [wizardProps, setWizardProps] = React.useState<
@@ -115,7 +115,7 @@ export const InstrumentInfo = (props: InstrumentInfoProps): JSX.Element => {
                 ? formatTimestamp(
                     instrument.data.calibratedOffset?.last_modified
                   )
-                : t('no_cal_data')
+                : i18n.format(t('no_cal_data'), 'capitalize')
             }
           />
           <InfoItem label={t('firmware_version')} value="TODO" />

--- a/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
@@ -2,8 +2,12 @@ import * as React from 'react'
 import { useHistory } from 'react-router-dom'
 
 import {
+  getGripperDisplayName,
+  getPipetteModelSpecs,
+  GripperModel,
   LEFT,
   NINETY_SIX_CHANNEL,
+  PipetteModel,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 import { ChoosePipette } from '../PipetteWizardFlows/ChoosePipette'
@@ -54,11 +58,20 @@ export function AttachedInstrumentMountItem(
       history.push(`/instruments/${mount}`)
     }
   }
+
+  const displayName =
+    attachedInstrument?.mount !== 'extension'
+      ? getPipetteModelSpecs(
+          attachedInstrument?.instrumentModel as PipetteModel
+        )?.displayName
+      : getGripperDisplayName(
+          attachedInstrument?.instrumentModel as GripperModel
+        )
   return (
     <>
       <LabeledMount
         mount={mount}
-        instrumentName={attachedInstrument?.instrumentModel ?? null}
+        instrumentName={displayName ?? null}
         handleClick={handleClick}
       />
       {showChoosePipetteModal ? (

--- a/app/src/pages/OnDeviceDisplay/InstrumentDetail.tsx
+++ b/app/src/pages/OnDeviceDisplay/InstrumentDetail.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
+import {
+  getGripperDisplayName,
+  getPipetteModelSpecs,
+  GripperModel,
+  PipetteModel,
+} from '@opentrons/shared-data'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
 import { BackButton } from '../../atoms/buttons/BackButton'
@@ -12,13 +18,20 @@ export const InstrumentDetail = (): JSX.Element => {
   const { data: attachedInstruments } = useInstrumentsQuery()
   const instrument =
     (attachedInstruments?.data ?? []).find(i => i.mount === mount) ?? null
+
+  const displayName =
+    instrument?.mount !== 'extension'
+      ? getPipetteModelSpecs(instrument?.instrumentModel as PipetteModel)
+          ?.displayName
+      : getGripperDisplayName(instrument?.instrumentModel as GripperModel)
+
   return (
     <Flex
       padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`}
       flexDirection={DIRECTION_COLUMN}
       height="100%"
     >
-      <BackButton>{instrument?.instrumentModel}</BackButton>
+      <BackButton>{displayName}</BackButton>
       <InstrumentInfo instrument={instrument} />
     </Flex>
   )

--- a/app/src/pages/OnDeviceDisplay/__tests__/InstrumentsDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/InstrumentsDashboard.test.tsx
@@ -63,8 +63,8 @@ const mockGripperData = {
   },
 }
 const mockRightPipetteData = {
-  instrumentModel: 'p300_single_v2',
-  instrumentType: 'p300',
+  instrumentModel: 'p50_single_v3.0',
+  instrumentType: 'p50',
   mount: 'right',
   serialNumber: 'abc123',
   data: {
@@ -76,7 +76,7 @@ const mockRightPipetteData = {
   },
 }
 const mockLeftPipetteData = {
-  instrumentModel: 'p1000_single_v2',
+  instrumentModel: 'p1000_single_v3.0',
   instrumentType: 'p1000',
   mount: 'left',
   serialNumber: 'def456',
@@ -106,11 +106,11 @@ describe('InstrumentsDashboard', () => {
   it('should render mount info for all attached mounts', () => {
     const [{ getByText }] = render()
     getByText('left Mount')
-    getByText(mockLeftPipetteData.instrumentModel)
+    getByText('Flex 1-Channel 1000 μL')
     getByText('right Mount')
-    getByText(mockRightPipetteData.instrumentModel)
+    getByText('Flex 1-Channel 50 μL')
     getByText('extension Mount')
-    getByText(mockGripperData.instrumentModel)
+    getByText('Flex Gripper')
   })
   it('should route to left mount detail when instrument attached and clicked', async () => {
     const [{ getByText }] = render()


### PR DESCRIPTION
closes RAUT-444

# Overview

Addresses design QA Round 1 for instruments dashboard and details.

# Test Plan

Test the instruments dashboard on the touchscreen. should match the designs! 

# Changelog

- instead of displaying instrument model, display the displayName
- capitalize the no instruments available string
- change the back icon from `chevron-left` to `back`

# Review requests

see test plan

# Risk assessment

low