### PR TITLE
Revert "fix(api): disable motors during the pipette attach and detach position"

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -7,7 +7,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType, Point
-from opentrons.hardware_control.types import CriticalPoint, Axis
+from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocol_engine.commands.command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -72,7 +72,6 @@ class MoveToMaintenancePositionImplementation(
             critical_point=CriticalPoint.MOUNT,
         )
 
-        await self._hardware_api.disengage_axes([Axis.Z, Axis.A])
         return MoveToMaintenancePositionResult()
 
 


### PR DESCRIPTION
Gotta figure out what to do about safely disabling the ZA motors. Currently the firmware (correctly) sets the motor status as not OK as soon as the motors get disabled so doing this causes the hardware controller to think that the disabled axes need to be homed :(.

Reverts Opentrons/opentrons#12772