### PR TITLE
fix(app): home leftZ for 96 channel attach flow in case mount falls

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -9,7 +9,9 @@ import {
 } from '@opentrons/components'
 import {
   getPipetteNameSpecs,
+  LEFT,
   LoadedPipette,
+  MotorAxis,
   NINETY_SIX_CHANNEL,
 } from '@opentrons/shared-data'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
@@ -131,7 +133,11 @@ export const Results = (props: ResultsProps): JSX.Element => {
       flowType === FLOWS.ATTACH &&
       currentStepIndex !== totalStepCount
     ) {
-      const axis = mount === 'left' ? 'leftPlunger' : 'rightPlunger'
+      let axes: MotorAxis = mount === LEFT ? ['leftPlunger'] : ['rightPlunger']
+      // TODO: (sb)5/25/23 Stop homing leftZ for 96 once motor is disabled
+      if (attachedPipettes[mount]?.instrumentName === 'p1000_96') {
+        axes = ['leftPlunger', 'leftZ']
+      }
       chainRunCommands(
         [
           {
@@ -146,7 +152,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
           {
             commandType: 'home' as const,
             params: {
-              axes: [axis],
+              axes: axes,
             },
           },
           {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
The 96-Channel pipette is causing the mount to fall during attach. This causes the `moveToMaintenancePosition` command we call before attaching the calibration probe to fail. To unblock this flow we need to home the `leftZ` after attaching a 96-channel.

This will be a temporary fix until we prevent the mount from dropping during attach.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
Run through attaching a 96-channel via desktop, see that you should now be able to continue to calibration within the attach flow
# Changelog
Add home of `leftZ` after 96-channel attach
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over code change
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
