### PR TITLE
fix(shared-data): return heights for v3 pipettes

### DIFF
--- a/shared-data/pipette/definitions/1/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteModelSpecs.json
@@ -5735,7 +5735,7 @@
         "max": 100
       },
       "quirks": ["pickupTipShake"],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.71,
       "idleCurrent": 0.3
     },
     "p1000_single_v3.1": {
@@ -5930,7 +5930,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.71,
       "idleCurrent": 0.3
     },
     "p1000_single_v3.3": {
@@ -6125,7 +6125,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.71,
       "idleCurrent": 0.3
     },
     "p1000_single_v3.4": {
@@ -6320,7 +6320,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.71,
       "idleCurrent": 0.3
     },
     "p50_single_v3.0": {
@@ -6486,7 +6486,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_single_v3.1": {
@@ -6653,7 +6653,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_single_v3.3": {
@@ -6822,7 +6822,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_single_v3.4": {
@@ -6991,7 +6991,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_single_v4.3": {
@@ -7160,7 +7160,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.83,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p1000_multi_v3.0": {
@@ -7355,7 +7355,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.82,
       "idleCurrent": 0.3
     },
     "p1000_multi_v3.1": {
@@ -7550,7 +7550,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.82,
       "idleCurrent": 0.3
     },
     "p1000_multi_v3.3": {
@@ -7745,7 +7745,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.82,
       "idleCurrent": 0.3
     },
     "p1000_multi_v3.4": {
@@ -7940,7 +7940,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.82,
       "idleCurrent": 0.3
     },
     "p50_multi_v3.0": {
@@ -8107,7 +8107,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_multi_v3.1": {
@@ -8274,7 +8274,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_multi_v3.3": {
@@ -8443,7 +8443,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p50_multi_v3.4": {
@@ -8612,7 +8612,7 @@
         "max": 100
       },
       "quirks": [],
-      "returnTipHeight": 0.5,
+      "returnTipHeight": 0.78,
       "idleCurrent": 0.3
     },
     "p1000_96_v1": {

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_0.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.5,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.4148, -1705.1015, 20.5455],
@@ -108,7 +108,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.8314, -2.9322, 24.0741],
@@ -207,7 +207,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.82,
       "aspirate": {
         "default": [
           [0.7511, 3.9556, 6.455],

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_3.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.5,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.4148, -1705.1015, 20.5455],
@@ -108,7 +108,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.8314, -2.9322, 24.0741],
@@ -207,7 +207,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.82,
       "aspirate": {
         "default": [
           [0.7511, 3.9556, 6.455],

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_4.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.5,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.4148, -1705.1015, 20.5455],
@@ -108,7 +108,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.8314, -2.9322, 24.0741],
@@ -207,7 +207,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.82,
       "aspirate": {
         "default": [
           [0.7511, 3.9556, 6.455],

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_0.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 4,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.5,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.6464, 0.4817, 0.0427],

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_3.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 4,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.5,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.6464, 0.4817, 0.0427],

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_4.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 4,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.5,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.6464, 0.4817, 0.0427],

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_0.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.4148, -1705.1015, 20.5455],
@@ -108,7 +108,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.8314, -2.9322, 24.0741],
@@ -207,7 +207,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.82,
       "aspirate": {
         "default": [
           [0.7511, 3.9556, 6.455],

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_3.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.4148, -1705.1015, 20.5455],
@@ -108,7 +108,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.8314, -2.9322, 24.0741],
@@ -207,7 +207,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.82,
       "aspirate": {
         "default": [
           [0.7511, 3.9556, 6.455],

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_4.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.0671, 16.2577, -0.617],
@@ -82,7 +82,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 58.35,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.1983, -15.5377, 4.4239],
@@ -157,7 +157,7 @@
       "defaultBlowOutFlowRate": 80,
       "defaultTipLength": 95.6,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.82,
       "aspirate": {
         "default": [
           [4.1286, 0.3769, 9.3332],

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_0.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 4,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.6464, 0.4817, 0.0427],

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_3.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 4,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.6464, 0.4817, 0.0427],

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_4.json
@@ -7,7 +7,7 @@
       "defaultBlowOutFlowRate": 4,
       "defaultTipLength": 57.9,
       "defaultTipOverlap": 10.5,
-      "defaultReturnTipHeight": 0.83,
+      "defaultReturnTipHeight": 0.71,
       "aspirate": {
         "default": [
           [0.45, 0.4702, 0.0464],


### PR DESCRIPTION
Update the return tip multipliers for the v3 pipettes to values from hardware life testing... mostly.

This commit alters the v2 configs to have the proper values for all tips, _but_ the protocol engine - which implements return tip - does not use the v2 configs. It uses the v1 configs, which do not have separate values for different tips.

For the pipettes that use multiple tips, we need to select just one value. We want the distance from the bottom of each tip's ribs (and top) to be the same, which means the multipliers are different. We select the smallest multiplier; this makes larger tips too high; but that's better than too low.

Since the numbers in the v2 configs are correct, whenever PE loads the v2 configs everything will get fixed.
