### PR TITLE
feat(app, shared-data): use new lower position for mounting plate attachment

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -195,6 +195,7 @@ export const BeforeBeginning = (
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
         mount: RIGHT,
+        maintenancePosition: 'attachPlate',
       },
     },
   ]

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -8,7 +8,6 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from '@opentrons/components'
-import { LEFT } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -30,11 +29,6 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
         {
           commandType: 'home' as const,
           params: { axes: ['rightZ'] },
-        },
-        {
-          // @ts-expect-error calibration command types not yet supported
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: { mount: LEFT },
         },
       ],
       false

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { RIGHT } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { Skeleton } from '../../atoms/Skeleton'
@@ -25,6 +26,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     mount,
     isFetching,
     setFetching,
+    chainRunCommands,
     isOnDevice,
     flowType,
   } = props
@@ -36,6 +38,25 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
   }
   const is96ChannelPipette =
     attachedPipettes[mount]?.instrumentName === 'p1000_96'
+  const handle96ChannelProceed = (): void => {
+    chainRunCommands(
+      {
+        // @ts-expect-error calibration type not yet supported
+        commandType: 'calibration/moveToMaintenancePosition' as const,
+        params: {
+          mount: RIGHT,
+          maintenancePosition: 'attachPlate',
+        },
+      },
+      true
+    )
+      .then(() => {
+        proceed()
+      })
+      .catch(() => {
+        proceed()
+      })
+  }
   const channel = attachedPipettes[mount]?.data.channels
   let bodyText: React.ReactNode = <div></div>
   if (isFetching) {
@@ -98,7 +119,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
         <CheckPipetteButton
           isOnDevice={isOnDevice}
           proceedButtonText={i18n.format(t('shared:continue'), 'capitalize')}
-          proceed={proceed}
+          proceed={is96ChannelPipette ? handle96ChannelProceed : proceed}
           setFetching={setFetching}
           isFetching={isFetching}
         />

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -40,15 +40,17 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     attachedPipettes[mount]?.instrumentName === 'p1000_96'
   const handle96ChannelProceed = (): void => {
     chainRunCommands(
-      {
-        // @ts-expect-error calibration type not yet supported
-        commandType: 'calibration/moveToMaintenancePosition' as const,
-        params: {
-          mount: RIGHT,
-          maintenancePosition: 'attachPlate',
+      [
+        {
+          // @ts-expect-error calibration type not yet supported
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: {
+            mount: RIGHT,
+            maintenancePosition: 'attachPlate',
+          },
         },
-      },
-      true
+      ],
+      false
     )
       .then(() => {
         proceed()

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { LEFT } from '@opentrons/shared-data'
 import { SPACING } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -10,8 +11,35 @@ import type { PipetteWizardStepProps } from './types'
 export const MountingPlate = (
   props: PipetteWizardStepProps
 ): JSX.Element | null => {
-  const { goBack, proceed, flowType } = props
+  const {
+    goBack,
+    proceed,
+    flowType,
+    chainRunCommands,
+    setShowErrorMessage,
+  } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
+
+  const handleAttachMountingPlate = (): void => {
+    chainRunCommands(
+      [
+        {
+          // @ts-expect-error calibration type not yet supported
+          commandType: 'calibration/moveToMaintenancePosition' as const,
+          params: {
+            mount: LEFT,
+          },
+        },
+      ],
+      false
+    )
+      .then(() => {
+        proceed()
+      })
+      .catch(error => {
+        setShowErrorMessage(error.message)
+      })
+  }
 
   return (
     <GenericWizardTile
@@ -54,7 +82,7 @@ export const MountingPlate = (
         )
       }
       proceedButtonText={i18n.format(t('shared:continue'), 'capitalize')}
-      proceed={proceed}
+      proceed={flowType === FLOWS.DETACH ? proceed : handleAttachMountingPlate}
       back={goBack}
     />
   )

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { RIGHT } from '@opentrons/shared-data'
 import { SPACING } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -11,35 +10,8 @@ import type { PipetteWizardStepProps } from './types'
 export const MountingPlate = (
   props: PipetteWizardStepProps
 ): JSX.Element | null => {
-  const {
-    goBack,
-    proceed,
-    flowType,
-    chainRunCommands,
-    setShowErrorMessage,
-  } = props
+  const { goBack, proceed, flowType } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
-
-  const handleDetachMountingPlate = (): void => {
-    chainRunCommands(
-      [
-        {
-          // @ts-expect-error calibration type not yet supported
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: RIGHT,
-          },
-        },
-      ],
-      false
-    )
-      .then(() => {
-        proceed()
-      })
-      .catch(error => {
-        setShowErrorMessage(error.message)
-      })
-  }
 
   return (
     <GenericWizardTile
@@ -82,7 +54,7 @@ export const MountingPlate = (
         )
       }
       proceedButtonText={i18n.format(t('shared:continue'), 'capitalize')}
-      proceed={flowType === FLOWS.ATTACH ? proceed : handleDetachMountingPlate}
+      proceed={proceed}
       back={goBack}
     />
   )

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -299,7 +299,7 @@ describe('BeforeBeginning', () => {
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: RIGHT },
+            params: { maintenancePosition: 'attachPlate', mount: RIGHT },
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -79,10 +79,6 @@ describe('Carriage', () => {
             axes: ['rightZ'],
           },
         },
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: { mount: LEFT },
-        },
       ],
       false
     )

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { LEFT, NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
@@ -34,7 +34,7 @@ describe('MountingPlate', () => {
       isOnDevice: false,
     }
   })
-  it('returns the correct information, buttons work as expected for attach flow', () => {
+  it('returns the correct information, buttons work as expected for attach flow', async () => {
     const { getByText, getByAltText, getByRole, getByLabelText } = render(props)
     getByText('Attach Mounting Plate')
     getByText(
@@ -43,6 +43,17 @@ describe('MountingPlate', () => {
     getByAltText('Attach mounting plate')
     const proceedBtn = getByRole('button', { name: 'Continue' })
     fireEvent.click(proceedBtn)
+    await waitFor(() => {
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: LEFT },
+          },
+        ],
+        false
+      )
+    })
     expect(props.proceed).toHaveBeenCalled()
     const backBtn = getByLabelText('back')
     fireEvent.click(backBtn)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
-import { LEFT, NINETY_SIX_CHANNEL, RIGHT } from '@opentrons/shared-data'
+import { LEFT, NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { mockAttachedPipetteInformation } from '../../../redux/pipettes/__fixtures__'
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
@@ -62,20 +62,7 @@ describe('MountingPlate', () => {
     getByAltText('Detach mounting plate')
     const proceedBtn = getByRole('button', { name: 'Continue' })
     fireEvent.click(proceedBtn)
-    expect(props.chainRunCommands).toHaveBeenCalledWith(
-      [
-        {
-          commandType: 'calibration/moveToMaintenancePosition',
-          params: {
-            mount: RIGHT,
-          },
-        },
-      ],
-      false
-    )
-    await waitFor(() => {
-      expect(props.proceed).toHaveBeenCalled()
-    })
+    expect(props.proceed).toHaveBeenCalled()
     const backBtn = getByLabelText('back')
     fireEvent.click(backBtn)
     expect(props.goBack).toHaveBeenCalled()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -393,7 +393,7 @@ describe('PipetteWizardFlows', () => {
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition' as const,
-            params: { mount: RIGHT },
+            params: { maintenancePosition: 'attachPlate', mount: RIGHT },
           },
         ],
         false

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -60,4 +60,5 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: PipetteMount
+  maintenancePosition?: 'attachPlate' | 'attachInstrument'
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Utilize the new `maintenancePosition` that will move both mounts to the bottom of the gantry for unscrewing right mount and attaching/detaching the mounting plate
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Run through the 96-channel attach and detach flows and see that both mounts move to the bottom. The right mount shouldn't fall when unscrewed and you shouldn't have to hold it up to screw in the mounting plate
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Add optional `maintenancePosition` param to `moveToMaintenancePosition` command type
Utilize this command in the 96-channel attach and detach flows
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test this out once Tamar's changes go in
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
