### PR TITLE
chore(hardware-testing): Fix linting error from OT3API builder changes

### DIFF
--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from math import pi
 from subprocess import run
 from time import time
-from typing import List, Optional, Dict, Tuple, Union
+from typing import Callable, Coroutine, Dict, List, Optional, Tuple, Union
 
 from opentrons_hardware.drivers.can_bus import DriverSettings, build, CanMessenger
 from opentrons_hardware.drivers.can_bus import settings as can_bus_settings
@@ -138,7 +138,11 @@ async def build_async_ot3_hardware_api(
     config = build_config_ot3({}) if use_defaults else load_ot3_config()
     kwargs = {"config": config}
     if is_simulating:
-        builder = OT3API.build_hardware_simulator
+        # This Callable type annotation works around mypy complaining about slight mismatches
+        # between the signatures of build_hardware_simulator() and build_hardware_controller().
+        builder: Callable[
+            ..., Coroutine[None, None, OT3API]
+        ] = OT3API.build_hardware_simulator
         sim_pips = _create_attached_instruments_dict(
             pipette_left, pipette_right, gripper
         )


### PR DESCRIPTION
# Overview

PR #12754 slightly changed the signature of `OT3API.build_hardware_simulator()` in a way that `OT3API.build_hardware_controller` is no longer substitutable for it.

In `build_hardware_controller()`, `attached_instruments`'s keys can be a mixture of `OT3Mount` and `Mount`, but in `build_hardware_simulator()`, they now have to all be one or the other.

This is causing `hardware-testing` type-checking failures in `edge` ([example](https://github.com/Opentrons/opentrons/actions/runs/5084304156/jobs/9136423681)). For some reason, this workflow didn't run on PR #12754, so it wasn't caught then.

# Review requests

The other ways to fix this would be to change `build_hardware_controller()` to match `build_hardware_simulator()`, or the other way around. That seems probably better? But which one should win?