### PR TITLE
fix(app): home before all gripper maintenance

### DIFF
--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -70,7 +70,11 @@ export const BeforeBeginning = (
     createMaintenanceRun({})
   }, [])
 
-  let commandsOnProceed: CreateCommand[] = [
+  const commandsOnProceed: CreateCommand[] = [
+    // TODO: this needs to go once we're properly handling the axes for the commands
+    // below instead of using the left pipette axis as a proxy, but until then we need
+    // to make sure that proxy axis is homed.
+    { commandType: 'home' as const, params: {} },
     {
       // @ts-expect-error(BC, 2022-03-10): this will pass type checks when we update command types from V6 to V7 in shared-data
       commandType: 'calibration/moveToMaintenancePosition' as const,
@@ -79,15 +83,6 @@ export const BeforeBeginning = (
       },
     },
   ]
-  if (
-    flowType === GRIPPER_FLOW_TYPES.ATTACH ||
-    flowType === GRIPPER_FLOW_TYPES.RECALIBRATE
-  ) {
-    commandsOnProceed = [
-      { commandType: 'home' as const, params: {} },
-      ...commandsOnProceed,
-    ]
-  }
 
   const handleOnClick = (): void => {
     chainRunCommands(commandsOnProceed, true)

--- a/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -94,6 +94,7 @@ describe('BeforeBeginning', () => {
     getByRole('button', { name: 'Move gantry to front' }).click()
     expect(props.chainRunCommands).toHaveBeenCalledWith(
       [
+        { commandType: 'home', params: {} },
         {
           commandType: 'calibration/moveToMaintenancePosition',
           params: { mount: 'left' },


### PR DESCRIPTION
We were homing before some gripper maintenance flows but not all of them, and we do need to home before all of them at least while we're using the left pipette as a proxy for the gripper.
