### PR TITLE
feat(robot-server): status bar responds to runs in progress

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -347,7 +347,7 @@ class API(
             await asyncio.sleep(max(0, 0.25 - (now - then)))
         await self.set_lights(button=True)
 
-    async def set_status_bar_state(self, _: StatusBarState) -> None:
+    async def set_status_bar_state(self, state: StatusBarState) -> None:
         """The status bar does not exist on OT-2!"""
         return None
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -351,6 +351,10 @@ class API(
         """The status bar does not exist on OT-2!"""
         return None
 
+    def get_status_bar_state(self) -> StatusBarState:
+        """There is no status bar on OT-2, return IDLE at all times."""
+        return StatusBarState.IDLE
+
     @ExecutionManagerProvider.wait_for_running
     async def delay(self, duration_s: float) -> None:
         """Delay execution by pausing and sleeping."""

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -498,6 +498,9 @@ class OT3API(
     async def set_status_bar_state(self, state: StatusBarState) -> None:
         await self._status_bar_controller.set_status_bar_state(state)
 
+    def get_status_bar_state(self) -> StatusBarState:
+        return self._status_bar_controller.get_current_state()
+
     @ExecutionManagerProvider.wait_for_running
     async def delay(self, duration_s: float) -> None:
         """Delay execution by pausing and sleeping."""

--- a/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
+++ b/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
@@ -49,3 +49,9 @@ class ChassisAccessoryManager(EventSourcer, Protocol):
         and will implicitly revert back to the previous state after a short
         action, while others"""
         ...
+
+    def get_status_bar_state(self) -> StatusBarState:
+        """Get the current status bar state.
+
+        :returns: The current status bar state enumeration."""
+        ...

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -22,9 +22,11 @@ from .run_auto_deleter import RunAutoDeleter
 from .engine_store import EngineStore
 from .run_store import RunStore
 from .run_data_manager import RunDataManager
+from .light_control_task import LightController, run_light_task
 
 _run_store_accessor = AppStateAccessor[RunStore]("run_store")
 _engine_store_accessor = AppStateAccessor[EngineStore]("engine_store")
+_light_control_accessor = AppStateAccessor[LightController]("light_controller")
 
 
 async def get_run_store(
@@ -70,10 +72,28 @@ async def get_protocol_run_has_been_played(
     return protocol_run_state.commands.has_been_played()
 
 
+async def ensure_light_control_task(
+    app_state: AppState = Depends(get_app_state),
+    engine_store: EngineStore = Depends(get_engine_store),
+    task_runner: TaskRunner = Depends(get_task_runner),
+    api: HardwareControlAPI = Depends(get_hardware),
+) -> None:
+    """Ensure the light control task is running."""
+    light_controller = _light_control_accessor.get_from(app_state)
+
+    if light_controller is None:
+        light_controller = LightController(api=api, engine_store=engine_store)
+        task_runner.run(run_light_task, driver=light_controller)
+        _light_control_accessor.set_on(app_state, light_controller)
+
+    return None
+
+
 async def get_run_data_manager(
     task_runner: TaskRunner = Depends(get_task_runner),
     engine_store: EngineStore = Depends(get_engine_store),
     run_store: RunStore = Depends(get_run_store),
+    light_control: None = Depends(ensure_light_control_task),
 ) -> RunDataManager:
     """Get a run data manager to keep track of current/historical run data."""
     return RunDataManager(

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -1,0 +1,71 @@
+"""Background task to drive the status bar."""
+from typing import Optional
+from logging import getLogger
+import asyncio
+
+from .engine_store import EngineStore
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.protocol_engine.types import EngineStatus
+from opentrons.hardware_control.types import StatusBarState
+
+log = getLogger(__name__)
+
+
+def _engine_status_to_status_bar(status: Optional[EngineStatus]) -> StatusBarState:
+    """Convert an engine status into a status bar status."""
+    if status is None:
+        return StatusBarState.IDLE
+
+    return {
+        EngineStatus.IDLE: StatusBarState.IDLE,
+        EngineStatus.RUNNING: StatusBarState.RUNNING,
+        EngineStatus.PAUSED: StatusBarState.PAUSED,
+        EngineStatus.BLOCKED_BY_OPEN_DOOR: StatusBarState.PAUSED,
+        EngineStatus.STOP_REQUESTED: StatusBarState.RUNNING,
+        EngineStatus.STOPPED: StatusBarState.RUNNING,
+        EngineStatus.FINISHING: StatusBarState.RUNNING,
+        EngineStatus.FAILED: StatusBarState.HARDWARE_ERROR,
+        EngineStatus.SUCCEEDED: StatusBarState.RUN_COMPLETED,
+    }[status]
+
+
+class LightController:
+    """LightController sets the status bar to match the protocol status."""
+
+    def __init__(self, api: HardwareControlAPI, engine_store: EngineStore) -> None:
+        """Create a new LightController."""
+        self._api = api
+        self._engine_store = engine_store
+
+    async def update(
+        self, prev_status: Optional[EngineStatus], new_status: Optional[EngineStatus]
+    ) -> None:
+        """Update the status bar if the current run status has changed."""
+        if prev_status == new_status:
+            # No change, don't try to set anything.
+            return
+
+        await self._api.set_status_bar_state(
+            state=_engine_status_to_status_bar(status=new_status)
+        )
+
+    def get_current_status(self) -> Optional[EngineStatus]:
+        """Get the `status` value from the engine's active run engine."""
+        current_id = self._engine_store.current_run_id
+        if current_id is not None:
+            return self._engine_store.engine.state_view.commands.get_status()
+
+        return None
+
+
+async def run_light_task(driver: LightController) -> None:
+    """Run the light control task.
+
+    This is intended to be run as a background task once the EngineStore has been created.
+    """
+    prev_status = driver.get_current_status()
+    while True:
+        await asyncio.sleep(0.1)
+        new_status = driver.get_current_status()
+        await driver.update(prev_status=prev_status, new_status=new_status)
+        prev_status = new_status

--- a/robot-server/tests/runs/test_light_control_task.py
+++ b/robot-server/tests/runs/test_light_control_task.py
@@ -1,0 +1,89 @@
+"""Unit tests for `runs.light_control_task`."""
+
+import pytest
+from typing import Optional
+from decoy import Decoy
+
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import StatusBarState
+from opentrons.protocol_engine.types import EngineStatus
+from robot_server.runs.engine_store import EngineStore
+from robot_server.runs.light_control_task import LightController
+
+
+@pytest.fixture
+def engine_store(decoy: Decoy) -> EngineStore:
+    """Mock out the EngineStore."""
+    return decoy.mock(cls=EngineStore)
+
+
+@pytest.fixture
+def subject(
+    hardware_api: HardwareControlAPI, engine_store: EngineStore
+) -> LightController:
+    """Test subject - LightController."""
+    return LightController(api=hardware_api, engine_store=engine_store)
+
+
+@pytest.mark.parametrize(
+    ["active", "status"],
+    [
+        [False, EngineStatus.IDLE],
+        [True, EngineStatus.IDLE],
+        [True, EngineStatus.RUNNING],
+        [False, EngineStatus.FAILED],
+    ],
+)
+async def test_get_current_status(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    subject: LightController,
+    active: bool,
+    status: EngineStatus,
+) -> None:
+    """Test LightController.get_current_status."""
+    decoy.when(engine_store.current_run_id).then_return("fake_id" if active else None)
+    decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(status)
+
+    expected = status if active else None
+
+    assert subject.get_current_status() == expected
+
+
+@pytest.mark.parametrize(
+    ["prev_state", "new_state", "expected"],
+    [
+        [None, None, StatusBarState.IDLE],
+        [EngineStatus.IDLE, None, StatusBarState.IDLE],
+        [EngineStatus.IDLE, EngineStatus.IDLE, None],
+        [None, EngineStatus.IDLE, StatusBarState.IDLE],
+        [None, EngineStatus.PAUSED, StatusBarState.PAUSED],
+        [
+            EngineStatus.RUNNING,
+            EngineStatus.BLOCKED_BY_OPEN_DOOR,
+            StatusBarState.PAUSED,
+        ],
+        [EngineStatus.RUNNING, EngineStatus.FAILED, StatusBarState.HARDWARE_ERROR],
+        [EngineStatus.RUNNING, EngineStatus.SUCCEEDED, StatusBarState.RUN_COMPLETED],
+    ],
+)
+async def test_light_controller_update(
+    decoy: Decoy,
+    hardware_api: HardwareControlAPI,
+    subject: LightController,
+    prev_state: Optional[EngineStatus],
+    new_state: Optional[EngineStatus],
+    expected: StatusBarState,
+) -> None:
+    """Test LightController.update.
+
+    Verifies that the status bar is NOT updated if the state is the same, and
+    checks that state mapping is correct.
+    """
+    await subject.update(prev_status=prev_state, new_status=new_state)
+
+    call_count = 0 if prev_state == new_state else 1
+
+    decoy.verify(
+        await hardware_api.set_status_bar_state(state=expected), times=call_count
+    )


### PR DESCRIPTION

# Overview

This PR adds a background task to the robot-server that monitors the `engine_store` singleton and updates the status bar correspondingly.

The background task polls at 10Hz and checks 1) if there is a current run 2) what the status of the current run is. Anytime one of these conditions changes, the task will update the light bar with a new setting.

As of now, the settings that the light bar sets include:
* Static white when there is no active protocol _or_ the active protocol is "idle"
* Static blue while a run is in progress
* Blue pulsing while a run is paused (either due to the door, a manual pause, or a `protocol.pause()` call)
* Red blinking if a protocol is failed
* Static green if a protocol is completed successfully 

# Test Plan

Pushed this to a Flex and ran a simple protocol that includes pauses. Verified that the light bar changes to all of the above settings correctly.
* The light turns blue once a run starts
* To induce an error, I knocked the plate out of the gripper during a gripper movement
* Tested both manual pausing and `protocol.pause`, both make the lights pulse blue
* When the run result is acknowledged by either the ODD or desktop app, the light goes from green/red back to white

# Changelog

- Added a `get_status_bar_state` to the API ABC. _This isn't strictly needed by this PR anymore but it's a few-line change with no risk involved._
- Fixed improper renaming of a parameter in the OT2 API implementation of `set_status_bar_state` - this was causing issues with the new unit tests
- Added a `LightController` class to help with transitions between states on the status bar
- Added unit tests for `LightController`
- Added a dependency to set up a background task in the robot-server to poll the `LightController` periodically

# Review requests

- Is there a better way to inject the dependency for the light controller background task? The main alternative I thought of was to just start it when the `engine_store` singleton is initialized.

# Risk assessment

Low. Only adds functionality for OT-3, the API calls on OT-2 are no-op.
