### PR TITLE
test(components): remove getByRoles for each button key

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/__tests__/CustomKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/__tests__/CustomKeyboard.test.tsx
@@ -20,100 +20,110 @@ describe('CustomKeyboard', () => {
   })
 
   it('should render the custom keyboards lower case', () => {
-    const { getByRole } = render(props)
-    // first row
-    getByRole('button', { name: 'q' })
-    getByRole('button', { name: 'w' })
-    getByRole('button', { name: 'e' })
-    getByRole('button', { name: 'r' })
-    getByRole('button', { name: 't' })
-    getByRole('button', { name: 'y' })
-    getByRole('button', { name: 'u' })
-    getByRole('button', { name: 'i' })
-    getByRole('button', { name: 'o' })
-    getByRole('button', { name: 'p' })
-
-    // second row
-    getByRole('button', { name: 'a' })
-    getByRole('button', { name: 's' })
-    getByRole('button', { name: 'd' })
-    getByRole('button', { name: 'f' })
-    getByRole('button', { name: 'g' })
-    getByRole('button', { name: 'h' })
-    getByRole('button', { name: 'j' })
-    getByRole('button', { name: 'k' })
-    getByRole('button', { name: 'l' })
-
-    // third row
-    getByRole('button', { name: 'shift' })
-    getByRole('button', { name: 'z' })
-    getByRole('button', { name: 'x' })
-    getByRole('button', { name: 'c' })
-    getByRole('button', { name: 'v' })
-    getByRole('button', { name: 'b' })
-    getByRole('button', { name: 'n' })
-    getByRole('button', { name: 'm' })
-    getByRole('button', { name: 'del' })
-
-    // fourth row
-    getByRole('button', { name: '123' }) // numbers
+    const { getAllByRole } = render(props)
+    const buttons = getAllByRole('button')
+    const expectedButtonNames = [
+      'q',
+      'w',
+      'e',
+      'r',
+      't',
+      'y',
+      'u',
+      'i',
+      'o',
+      'p',
+      'a',
+      's',
+      'd',
+      'f',
+      'g',
+      'h',
+      'j',
+      'k',
+      'l',
+      'shift',
+      'z',
+      'x',
+      'c',
+      'v',
+      'b',
+      'n',
+      'm',
+      'del',
+      '123',
+    ]
+    buttons.forEach((button, index) => {
+      const expectedName = expectedButtonNames[index]
+      expect(button).toHaveTextContent(expectedName)
+    })
   })
   it('should render the custom keyboards upper case, when clicking shift key', () => {
-    const { getByRole } = render(props)
+    const { getByRole, getAllByRole } = render(props)
     const shiftKey = getByRole('button', { name: 'shift' })
     fireEvent.click(shiftKey)
 
-    // first row
-    getByRole('button', { name: 'Q' })
-    getByRole('button', { name: 'W' })
-    getByRole('button', { name: 'E' })
-    getByRole('button', { name: 'R' })
-    getByRole('button', { name: 'T' })
-    getByRole('button', { name: 'Y' })
-    getByRole('button', { name: 'U' })
-    getByRole('button', { name: 'I' })
-    getByRole('button', { name: 'O' })
-
-    // second row
-    getByRole('button', { name: 'A' })
-    getByRole('button', { name: 'S' })
-    getByRole('button', { name: 'D' })
-    getByRole('button', { name: 'F' })
-    getByRole('button', { name: 'G' })
-    getByRole('button', { name: 'H' })
-    getByRole('button', { name: 'J' })
-    getByRole('button', { name: 'K' })
-    getByRole('button', { name: 'L' })
-
-    // third row
-    getByRole('button', { name: 'shift' })
-    getByRole('button', { name: 'Z' })
-    getByRole('button', { name: 'X' })
-    getByRole('button', { name: 'C' })
-    getByRole('button', { name: 'V' })
-    getByRole('button', { name: 'B' })
-    getByRole('button', { name: 'N' })
-    getByRole('button', { name: 'M' })
-    // fourth row
-    getByRole('button', { name: '123' }) // numbers
+    const buttons = getAllByRole('button')
+    const expectedButtonNames = [
+      'Q',
+      'W',
+      'E',
+      'R',
+      'T',
+      'Y',
+      'U',
+      'I',
+      'O',
+      'P',
+      'A',
+      'S',
+      'D',
+      'F',
+      'G',
+      'H',
+      'J',
+      'K',
+      'L',
+      'shift',
+      'Z',
+      'X',
+      'C',
+      'V',
+      'B',
+      'N',
+      'M',
+      'del',
+      '123',
+    ]
+    buttons.forEach((button, index) => {
+      const expectedName = expectedButtonNames[index]
+      expect(button).toHaveTextContent(expectedName)
+    })
   })
 
   it('should render the custom keyboards numbers, when clicking number key', () => {
-    const { getByRole } = render(props)
+    const { getByRole, getAllByRole } = render(props)
     const numberKey = getByRole('button', { name: '123' })
     fireEvent.click(numberKey)
-    getByRole('button', { name: '1' })
-    getByRole('button', { name: '2' })
-    getByRole('button', { name: '3' })
-    getByRole('button', { name: '4' })
-    getByRole('button', { name: '5' })
-    getByRole('button', { name: '6' })
-    getByRole('button', { name: '7' })
-    getByRole('button', { name: '8' })
-    getByRole('button', { name: '9' })
-    getByRole('button', { name: '0' })
-    getByRole('button', { name: 'ABC' })
-    getByRole('button', { name: 'del' })
+    const buttons = getAllByRole('button')
+    const expectedButtonNames = [
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      'ABC',
+      '0',
+      'del',
+    ]
+    buttons.forEach((button, index) => {
+      const expectedName = expectedButtonNames[index]
+      expect(button).toHaveTextContent(expectedName)
+    })
   })
 
   it('should render the custom keyboards lower case, when clicking number key then abc key', () => {

--- a/app/src/atoms/SoftwareKeyboard/__tests__/NormalKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/__tests__/NormalKeyboard.test.tsx
@@ -19,144 +19,142 @@ describe('SoftwareKeyboard', () => {
     }
   })
   it('should render the software keyboards', () => {
-    const { getByRole, getAllByRole } = render(props)
-    // first row
-    getByRole('button', { name: '`' })
-    getByRole('button', { name: '1' })
-    getByRole('button', { name: '2' })
-    getByRole('button', { name: '3' })
-    getByRole('button', { name: '4' })
-    getByRole('button', { name: '5' })
-    getByRole('button', { name: '6' })
-    getByRole('button', { name: '7' })
-    getByRole('button', { name: '8' })
-    getByRole('button', { name: '9' })
-    getByRole('button', { name: '0' })
-    getByRole('button', { name: '-' })
-    getByRole('button', { name: '=' })
-    getByRole('button', { name: 'backspace' })
+    const { getAllByRole } = render(props)
+    const buttons = getAllByRole('button')
 
-    // second row
-    getByRole('button', { name: 'tab' })
-    getByRole('button', { name: 'q' })
-    getByRole('button', { name: 'w' })
-    getByRole('button', { name: 'e' })
-    getByRole('button', { name: 'r' })
-    getByRole('button', { name: 't' })
-    getByRole('button', { name: 'y' })
-    getByRole('button', { name: 'u' })
-    getByRole('button', { name: 'i' })
-    getByRole('button', { name: 'o' })
-    getByRole('button', { name: 'p' })
-    getByRole('button', { name: '[' })
-    getByRole('button', { name: ']' })
-    getByRole('button', { name: '\\' })
+    const expectedButtonNames = [
+      '`',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '0',
+      '-',
+      '=',
+      'backspace',
+      'tab',
+      'q',
+      'w',
+      'e',
+      'r',
+      't',
+      'y',
+      'u',
+      'i',
+      'o',
+      'p',
+      '[',
+      ']',
+      '\\',
+      'caps',
+      'a',
+      's',
+      'd',
+      'f',
+      'g',
+      'h',
+      'j',
+      'k',
+      'l',
+      ';',
+      "'",
+      '< enter',
+      'shift',
+      'z',
+      'x',
+      'c',
+      'v',
+      'b',
+      'n',
+      'm',
+      ',',
+      '.',
+      '/',
+      'shift',
+      '.com',
+      '@',
+      '', // space keyboard
+    ]
 
-    // third row
-    getByRole('button', { name: 'caps' })
-    getByRole('button', { name: 'a' })
-    getByRole('button', { name: 's' })
-    getByRole('button', { name: 'd' })
-    getByRole('button', { name: 'f' })
-    getByRole('button', { name: 'g' })
-    getByRole('button', { name: 'h' })
-    getByRole('button', { name: 'j' })
-    getByRole('button', { name: 'k' })
-    getByRole('button', { name: 'l' })
-    getByRole('button', { name: ';' })
-    getByRole('button', { name: "'" })
-    getByRole('button', { name: '< enter' })
-
-    // fourth row
-    getByRole('button', { name: 'z' })
-    getByRole('button', { name: 'x' })
-    getByRole('button', { name: 'c' })
-    getByRole('button', { name: 'v' })
-    getByRole('button', { name: 'b' })
-    getByRole('button', { name: 'n' })
-    getByRole('button', { name: 'm' })
-    getByRole('button', { name: ',' })
-    getByRole('button', { name: '.' })
-    getByRole('button', { name: '/' })
-    const shiftButtons = getAllByRole('button', { name: 'shift' })
-    expect(shiftButtons.length).toBe(2)
-
-    // fifth row
-    getByRole('button', { name: '.com' })
-    getByRole('button', { name: '@' })
-    getByRole('button', { name: '' }) // space keyboard
+    buttons.forEach((button, index) => {
+      const expectedName = expectedButtonNames[index]
+      expect(button).toHaveTextContent(expectedName)
+    })
   })
 
   it('should render the software keyboards when hitting shift key', () => {
-    const { getByRole, getAllByRole } = render(props)
+    const { getAllByRole } = render(props)
     const shiftKey = getAllByRole('button', { name: 'shift' })[0]
     fireEvent.click(shiftKey)
+    const buttons = getAllByRole('button')
+    const expectedButtonNames = [
+      '~',
+      '!',
+      '@',
+      '#',
+      '$',
+      '%',
+      '^',
+      '&',
+      '*',
+      '(',
+      ')',
+      '_',
+      '+',
+      'backspace',
+      'tab',
+      'Q',
+      'W',
+      'E',
+      'R',
+      'T',
+      'Y',
+      'U',
+      'I',
+      'O',
+      'P',
+      '{',
+      '}',
+      '|',
+      'caps',
+      'A',
+      'S',
+      'D',
+      'F',
+      'G',
+      'H',
+      'J',
+      'K',
+      'L',
+      ':',
+      '"',
+      '< enter',
+      'shift',
+      'Z',
+      'X',
+      'C',
+      'V',
+      'B',
+      'N',
+      'M',
+      '<',
+      '>',
+      '?',
+      'shift',
+      '.com',
+      '@',
+      '', // space keyboard
+    ]
 
-    // first row
-    getByRole('button', { name: '~' })
-    getByRole('button', { name: '!' })
-    // Note: kj the fifth row also has @
-    const atButtons = getAllByRole('button', { name: '@' })
-    expect(atButtons.length).toBe(2)
-    getByRole('button', { name: '#' })
-    getByRole('button', { name: '$' })
-    getByRole('button', { name: '%' })
-    getByRole('button', { name: '^' })
-    getByRole('button', { name: '&' })
-    getByRole('button', { name: '*' })
-    getByRole('button', { name: '(' })
-    getByRole('button', { name: ')' })
-    getByRole('button', { name: '_' })
-    getByRole('button', { name: '+' })
-    getByRole('button', { name: 'backspace' })
-
-    // second row
-    getByRole('button', { name: 'tab' })
-    getByRole('button', { name: 'Q' })
-    getByRole('button', { name: 'W' })
-    getByRole('button', { name: 'E' })
-    getByRole('button', { name: 'R' })
-    getByRole('button', { name: 'T' })
-    getByRole('button', { name: 'Y' })
-    getByRole('button', { name: 'U' })
-    getByRole('button', { name: 'I' })
-    getByRole('button', { name: 'O' })
-    getByRole('button', { name: 'P' })
-    getByRole('button', { name: '{' })
-    getByRole('button', { name: '}' })
-    getByRole('button', { name: '|' })
-
-    // third row
-    getByRole('button', { name: 'caps' })
-    getByRole('button', { name: 'A' })
-    getByRole('button', { name: 'S' })
-    getByRole('button', { name: 'D' })
-    getByRole('button', { name: 'F' })
-    getByRole('button', { name: 'G' })
-    getByRole('button', { name: 'H' })
-    getByRole('button', { name: 'J' })
-    getByRole('button', { name: 'K' })
-    getByRole('button', { name: 'L' })
-    getByRole('button', { name: ':' })
-    getByRole('button', { name: '"' })
-    getByRole('button', { name: ':' })
-    getByRole('button', { name: '< enter' })
-
-    // fourth row
-    getByRole('button', { name: 'Z' })
-    getByRole('button', { name: 'X' })
-    getByRole('button', { name: 'C' })
-    getByRole('button', { name: 'V' })
-    getByRole('button', { name: 'B' })
-    getByRole('button', { name: 'N' })
-    getByRole('button', { name: 'M' })
-    getByRole('button', { name: '<' })
-    getByRole('button', { name: '>' })
-    getByRole('button', { name: '?' })
-    const shiftButtons = getAllByRole('button', { name: 'shift' })
-    expect(shiftButtons.length).toBe(2)
-
-    // Note: kj fifth row is the same
+    buttons.forEach((button, index) => {
+      const expectedName = expectedButtonNames[index]
+      expect(button).toHaveTextContent(expectedName)
+    })
   })
 
   it('should call mock function when clicking a key', () => {

--- a/app/src/atoms/SoftwareKeyboard/__tests__/Numpad.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/__tests__/Numpad.test.tsx
@@ -19,17 +19,27 @@ describe('Numpad', () => {
     }
   })
   it('should render the numpad keys', () => {
-    const { getByRole } = render(props)
-    getByRole('button', { name: '1' })
-    getByRole('button', { name: '2' })
-    getByRole('button', { name: '3' })
-    getByRole('button', { name: '4' })
-    getByRole('button', { name: '5' })
-    getByRole('button', { name: '6' })
-    getByRole('button', { name: '7' })
-    getByRole('button', { name: '8' })
-    getByRole('button', { name: '9' })
-    getByRole('button', { name: '0' })
+    const { getAllByRole } = render(props)
+    const buttons = getAllByRole('button')
+    const expectedButtonNames = [
+      '7',
+      '8',
+      '9',
+      '4',
+      '5',
+      '6',
+      '1',
+      '2',
+      '3',
+      '0',
+      '.',
+      'backspace',
+    ]
+
+    buttons.forEach((button, index) => {
+      const expectedName = expectedButtonNames[index]
+      expect(button).toHaveTextContent(expectedName)
+    })
   })
 
   it('should call mock function when clicking num key', () => {


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
tests for software keyboard used getByRole for each button key and that slows down the tests. This PR removes most getByRole that used for each button key and check key value with getAllByRole and forEach.

before 
✓ should render the software keyboards (7348 ms)

after
✓ should render the software keyboards (134 ms)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update software keyboard tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
