### PR TITLE
chore: Regex fixup

### DIFF
--- a/hardware/opentrons_hardware/instruments/gripper/serials.py
+++ b/hardware/opentrons_hardware/instruments/gripper/serials.py
@@ -5,7 +5,20 @@ import struct
 
 from opentrons_hardware.instruments.serial_utils import ensure_serial_length
 
-SERIAL_RE = re.compile("^(?:GRPV)(?P<model>[0-9]{2,2})(?P<code>.{,12})$")
+# Separate string into 2 groups
+#  - model
+#  - code
+
+GRIPPER_REGEX_STRING = (
+    "^"  # start of string
+    "GRPV"  # The characters GRPV
+    "(?P<model>\d{2})"  # "model" group contains exactly 2 digits
+    "(?P<code>[\w\d]{0,12})"  # "code" group contains 0 to 12 inclusive alphanumeric characters
+    "$"  # end of string
+
+)
+
+SERIAL_RE = re.compile(GRIPPER_REGEX_STRING)
 
 SERIAL_FORMAT_MSG = (
     "Serial numbers must have the format GRPVMMXXXXXX... where"

--- a/hardware/opentrons_hardware/instruments/gripper/serials.py
+++ b/hardware/opentrons_hardware/instruments/gripper/serials.py
@@ -12,10 +12,9 @@ from opentrons_hardware.instruments.serial_utils import ensure_serial_length
 GRIPPER_REGEX_STRING = (
     "^"  # start of string
     "GRPV"  # The characters GRPV
-    "(?P<model>\d{2})"  # "model" group contains exactly 2 digits
-    "(?P<code>[\w\d]{0,12})"  # "code" group contains 0 to 12 inclusive alphanumeric characters
+    r"(?P<model>\d{2})"  # "model" group contains exactly 2 digits
+    r"(?P<code>[\w\d]{0,12})"  # "code" group contains 0 to 12 inclusive alphanumeric characters
     "$"  # end of string
-
 )
 
 SERIAL_RE = re.compile(GRIPPER_REGEX_STRING)

--- a/hardware/opentrons_hardware/instruments/pipettes/serials.py
+++ b/hardware/opentrons_hardware/instruments/pipettes/serials.py
@@ -5,7 +5,21 @@ import struct
 from opentrons_hardware.firmware_bindings.constants import PipetteName
 from opentrons_hardware.instruments.serial_utils import ensure_serial_length
 
-SERIAL_RE = re.compile("^(?P<name>P.{3,3})V(?P<model>[0-9]{2,2})(?P<code>.{,12})$")
+# Separate string into 3 named groups:
+#   - name P any
+#   - model
+#   - code
+
+RAW_SERIAL_STRING = (
+    "^"  # start of string
+    "(?P<name>P[\w\d]{3}"  # "name" group starts with P and contains exactly 3 alphanumeric characters
+    "V" # The character V
+    "(?P<model>\d{2})" # "model" group contains exactly 2 digits
+    "(?P<code>[\w\d]{0,12})" # "code" group contains 0 to 12 inclusive alphanumeric characters
+    "$"  # end of string
+)
+
+SERIAL_RE = re.compile(RAW_SERIAL_STRING)
 
 NAME_LOOKUP: Dict[str, PipetteName] = {
     "P1KS": PipetteName.p1000_single,

--- a/hardware/opentrons_hardware/instruments/pipettes/serials.py
+++ b/hardware/opentrons_hardware/instruments/pipettes/serials.py
@@ -12,13 +12,12 @@ from opentrons_hardware.instruments.serial_utils import ensure_serial_length
 
 RAW_SERIAL_STRING = (
     "^"  # start of string
-    r"(?P<name>P[\w\d]{3}"  # "name" group starts with P and contains exactly 3 alphanumeric characters
+    r"(?P<name>P[\w\d]{3})"  # "name" group starts with P and contains exactly 3 alphanumeric characters
     "V"  # The character V
     r"(?P<model>\d{2})"  # "model" group contains exactly 2 digits
     r"(?P<code>[\w\d]{0,12})"  # "code" group contains 0 to 12 inclusive alphanumeric characters
     "$"  # end of string
 )
-
 SERIAL_RE = re.compile(RAW_SERIAL_STRING)
 
 NAME_LOOKUP: Dict[str, PipetteName] = {

--- a/hardware/opentrons_hardware/instruments/pipettes/serials.py
+++ b/hardware/opentrons_hardware/instruments/pipettes/serials.py
@@ -12,10 +12,10 @@ from opentrons_hardware.instruments.serial_utils import ensure_serial_length
 
 RAW_SERIAL_STRING = (
     "^"  # start of string
-    "(?P<name>P[\w\d]{3}"  # "name" group starts with P and contains exactly 3 alphanumeric characters
-    "V" # The character V
-    "(?P<model>\d{2})" # "model" group contains exactly 2 digits
-    "(?P<code>[\w\d]{0,12})" # "code" group contains 0 to 12 inclusive alphanumeric characters
+    r"(?P<name>P[\w\d]{3}"  # "name" group starts with P and contains exactly 3 alphanumeric characters
+    "V"  # The character V
+    r"(?P<model>\d{2})"  # "model" group contains exactly 2 digits
+    r"(?P<code>[\w\d]{0,12})"  # "code" group contains 0 to 12 inclusive alphanumeric characters
     "$"  # end of string
 )
 

--- a/hardware/tests/opentrons_hardware/instruments/test_serials.py
+++ b/hardware/tests/opentrons_hardware/instruments/test_serials.py
@@ -69,6 +69,8 @@ def test_pipette_name_validity(scannedval: str) -> None:
         "P1KSVVV",
         "P1KSV0A",
         "P1KSV0102022022123123123",
+        "P,KSV01abc123",
+        "P1KSV01,abc123",
     ],
 )
 def test_pipette_serial_validity(scannedval: str) -> None:
@@ -127,14 +129,7 @@ def test_scan_valid_gripper_serials(
 
 @pytest.mark.parametrize(
     "scannedval",
-    [
-        "",
-        "G",
-        "GR",
-        "GRVVV",
-        "GRV0A",
-        "GRVV0102022022123123123",
-    ],
+    ["", "G", "GR", "GRVVV", "GRV0A", "GRVV0102022022123123123", "GRPV01,abc123"],
 )
 def test_gripper_serial_validity(scannedval: str) -> None:
     """Various regex failures for gripper."""


### PR DESCRIPTION
# Overview

There were some issues with our serial number regexes (regexs?) (regi?) (who knows). Fixed them.
Specifically,

- Our character matches were not strict enough is some areas, allowing matches on special characters
- Over-defined quantifiers which, although they worked, were confusing
- Unnecessary non-matching group

Also broke down the Python regex string itself and commented on what it does. 
Reading regex from scratch usually sucks

# Test Plan

- [x] Make sure tests still pass


# Changelog

- Change `{2,2}` and `{3,3}` quantifiers to `{2}` and `{3}` respectively. They mean the same thing but took some searching to make sure I wasn't missing anything. 
- Change usage of `.` to `[\w\d]`. The `.` character allows all characters except newlines to be matched. Going off the `SERIAL_FORMAT_MSG` inside the files, we want everything to be alphanumeric. The only one I am not %100 sure about is the `code` portion. I think we would want to only support alphanumeric but could use confirmation.
- Change usage of `[0-9]` to `\d`. Both function same but `\d` is specifically meant to replace `[0-9]`. 
- Use a multi-line string to break up regex into its logical parts and comment what each one is doing.
- Add test cases to cover fixed cases
- Remove non-capturing group. You only need to use non-capturing groups when you want to use quantifiers. So for instance, `(?:C){3}(something)` would match `cccsomething` but only capture something.

# Review requests

- [x] Can someone confirm that we want the `code` portion to be alphanumeric?

Confirmed by @sfoster1 

# Risk assessment

Low, tested with regex validation software, also tests will cover this
