### PR TITLE
feat(api): randomize tip dropping location in trash

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -325,6 +325,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         location: Optional[Location],
         well_core: WellCore,
         home_after: Optional[bool],
+        randomize_drop_location: Optional[bool] = False,
     ) -> None:
         """Move to and drop a tip into a given well.
 
@@ -333,6 +334,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
                 Used to calculate the relative well offset for the drop command.
             well_core: The well we're dropping into
             home_after: Whether to home the pipette after the tip is dropped.
+            randomize_drop_location: Whether to randomize the exact location to drop tip
+                within the specified well.
         """
         well_name = well_core.get_name()
         labware_id = well_core.labware_id
@@ -359,6 +362,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             well_name=well_name,
             well_location=well_location,
             home_after=home_after,
+            randomize_drop_location=randomize_drop_location,
         )
 
         self._protocol_core.set_last_location(location=location, mount=self.get_mount())

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -116,6 +116,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         location: Optional[types.Location],
         well_core: WellCoreType,
         home_after: Optional[bool],
+        randomize_drop_location: Optional[bool] = False,
     ) -> None:
         """Move to and drop a tip into a given well.
 
@@ -124,6 +125,8 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
                 If unspecified, the default drop location of the well will be used.
             well_core: The well we're dropping into
             home_after: Whether to home the pipette after the tip is dropped.
+            randomize_drop_location: Whether to randomize the exact location to drop tip
+                within the specified well.
         """
         ...
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -14,6 +14,7 @@ from opentrons.protocols.api_support.util import (
     build_edges,
     FlowRates,
     PlungerSpeeds,
+    APIVersionError,
 )
 from opentrons.protocols.geometry import planning
 
@@ -219,6 +220,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         location: Optional[types.Location],
         well_core: LegacyWellCore,
         home_after: Optional[bool],
+        randomize_drop_location: Optional[bool] = False,
     ) -> None:
         """Move to and drop a tip into a given well.
 
@@ -228,6 +230,10 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
             well_core: The well we're dropping into
             home_after: Whether to home the pipette after the tip is dropped.
         """
+        if randomize_drop_location:
+            raise APIVersionError(
+                "Tip drop randomization is not supported in this API version."
+            )
         labware_core = well_core.geometry.parent
 
         if location is None:

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -11,7 +11,11 @@ from opentrons.protocols.api_support import instrument as instrument_support
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds
+from opentrons.protocols.api_support.util import (
+    FlowRates,
+    PlungerSpeeds,
+    APIVersionError,
+)
 from opentrons.protocols.geometry import planning
 
 from ..instrument import AbstractInstrument
@@ -190,7 +194,12 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
         location: Optional[types.Location],
         well_core: LegacyWellCore,
         home_after: Optional[bool],
+        randomize_drop_location: Optional[bool] = False,
     ) -> None:
+        if randomize_drop_location:
+            raise APIVersionError(
+                "Tip drop randomization is not supported in this API version."
+            )
         labware_core = well_core.geometry.parent
 
         if location is None:

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -224,6 +224,7 @@ class SyncClient:
         well_name: str,
         well_location: DropTipWellLocation,
         home_after: Optional[bool],
+        randomize_drop_location: Optional[bool],
     ) -> commands.DropTipResult:
         """Execute a DropTip command and return the result."""
         request = commands.DropTipCreate(
@@ -233,6 +234,7 @@ class SyncClient:
                 wellName=well_name,
                 wellLocation=well_location,
                 homeAfter=home_after,
+                randomizeDropLocation=randomize_drop_location,
             )
         )
         result = self._transport.execute_command(request=request)

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -34,7 +34,7 @@ class DropTipParams(PipetteIdMixin):
             " a safe default depending on its hardware."
         ),
     )
-    randomizeDropLocation: bool = Field(
+    randomizeDropLocation: Optional[bool] = Field(
         False,
         description=(
             "Whether to randomize the location where tip is dropped within the labware."
@@ -73,6 +73,9 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
         home_after = params.homeAfter
 
         if params.randomizeDropLocation:
+            # TODO (spp, 2023-05-30): we might make this cycle through pre-defined
+            #  locations to drop tip instead of a completely random location.
+            #  That would make sw as well as hw testing more robust.
             drop_tip_well_location = (
                 self._state_view.labware.get_random_drop_tip_location(
                     labware_id=labware_id,

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -1,5 +1,6 @@
 """Drop tip command request, result, and implementation models."""
 from __future__ import annotations
+
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
@@ -33,6 +34,15 @@ class DropTipParams(PipetteIdMixin):
             " a safe default depending on its hardware."
         ),
     )
+    randomizeDropLocation: bool = Field(
+        False,
+        description=(
+            "Whether to randomize the location where tip is dropped within the labware."
+            " If True, this command will ignore the wellLocation provided and"
+            " drop tip at a random location within a set area of the specified labware well."
+            " If False, the tip will be dropped at the top center of the well."
+        ),
+    )
 
 
 class DropTipResult(DestinationPositionResult):
@@ -60,8 +70,17 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, DropTipResult]):
         pipette_id = params.pipetteId
         labware_id = params.labwareId
         well_name = params.wellName
-        drop_tip_well_location = params.wellLocation
         home_after = params.homeAfter
+
+        if params.randomizeDropLocation:
+            drop_tip_well_location = (
+                self._state_view.labware.get_random_drop_tip_location(
+                    labware_id=labware_id,
+                    well_name=well_name,
+                )
+            )
+        else:
+            drop_tip_well_location = params.wellLocation
 
         well_location = self._state_view.geometry.get_tip_drop_location(
             pipette_id=pipette_id,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -623,7 +623,7 @@ class LabwareView(HasState[LabwareState]):
     def get_random_drop_tip_location(
         self, labware_id: str, well_name: str
     ) -> DropTipWellLocation:
-        """Get a random x, y location within 3/4th area of the well top center plane."""
+        """Get a random location along the x-axis within 3/4th length of the well top plane."""
         well_dims = self.get_well_size(labware_id=labware_id, well_name=well_name)
         random_offset_in_well = WellOffset(
             x=random.randrange(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1,6 +1,7 @@
 """Basic labware data state and store."""
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -40,6 +41,9 @@ from ..types import (
     LabwareLocation,
     LoadedLabware,
     ModuleLocation,
+    DropTipWellLocation,
+    DropTipWellOrigin,
+    WellOffset,
 )
 from ..actions import (
     Action,
@@ -614,6 +618,22 @@ class LabwareView(HasState[LabwareState]):
             x=target_center.x,
             y=target_center.y + offset.y,
             z=offset.z,
+        )
+
+    def get_random_drop_tip_location(
+        self, labware_id: str, well_name: str
+    ) -> DropTipWellLocation:
+        """Get a random x, y location within 3/4th area of the well top center plane."""
+        well_dims = self.get_well_size(labware_id=labware_id, well_name=well_name)
+        random_offset_in_well = WellOffset(
+            x=random.randrange(
+                start=int(well_dims[0] * -3 / 8), stop=int(well_dims[0] * 3 / 8), step=1
+            ),
+            y=0,
+            z=0,
+        )
+        return DropTipWellLocation(
+            origin=DropTipWellOrigin.DEFAULT, offset=random_offset_in_well
         )
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -265,7 +265,12 @@ def test_drop_tip_no_location(
         engine_client=mock_engine_client,
     )
 
-    subject.drop_tip(location=None, well_core=well_core, home_after=True)
+    subject.drop_tip(
+        location=None,
+        well_core=well_core,
+        home_after=True,
+        randomize_drop_location=False,
+    )
 
     decoy.verify(
         mock_engine_client.drop_tip(
@@ -277,6 +282,7 @@ def test_drop_tip_no_location(
                 offset=WellOffset(x=0, y=0, z=0),
             ),
             home_after=True,
+            randomize_drop_location=False,
         ),
         times=1,
     )
@@ -301,7 +307,12 @@ def test_drop_tip_with_location(
         )
     ).then_return(WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)))
 
-    subject.drop_tip(location=location, well_core=well_core, home_after=True)
+    subject.drop_tip(
+        location=location,
+        well_core=well_core,
+        home_after=True,
+        randomize_drop_location=True,
+    )
 
     decoy.verify(
         mock_engine_client.drop_tip(
@@ -312,6 +323,7 @@ def test_drop_tip_with_location(
                 origin=DropTipWellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
             ),
             home_after=True,
+            randomize_drop_location=True,
         ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -596,12 +596,16 @@ def test_drop_tip_to_well(
 
     decoy.verify(
         mock_instrument_core.drop_tip(
-            location=None, well_core=mock_well._core, home_after=False
+            location=None,
+            well_core=mock_well._core,
+            home_after=False,
+            randomize_drop_location=False,
         ),
         times=1,
     )
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
 def test_drop_tip_to_trash(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
@@ -617,7 +621,35 @@ def test_drop_tip_to_trash(
 
     decoy.verify(
         mock_instrument_core.drop_tip(
-            location=None, well_core=mock_well._core, home_after=None
+            location=None,
+            well_core=mock_well._core,
+            home_after=None,
+            randomize_drop_location=False,
+        ),
+        times=1,
+    )
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 15)])
+def test_drop_tip_to_randomized_trash_location(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    mock_trash: Labware,
+    subject: InstrumentContext,
+) -> None:
+    """It should drop a tip in the trash if not given a location ."""
+    mock_well = decoy.mock(cls=Well)
+
+    decoy.when(mock_trash.wells()).then_return([mock_well])
+
+    subject.drop_tip()
+
+    decoy.verify(
+        mock_instrument_core.drop_tip(
+            location=None,
+            well_core=mock_well._core,
+            home_after=None,
+            randomize_drop_location=True,
         ),
         times=1,
     )
@@ -643,7 +675,10 @@ def test_return_tip(
             prep_after=True,
         ),
         mock_instrument_core.drop_tip(
-            location=None, well_core=mock_well._core, home_after=None
+            location=None,
+            well_core=mock_well._core,
+            home_after=None,
+            randomize_drop_location=False,
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -303,6 +303,7 @@ def test_drop_tip(
             wellName="A2",
             wellLocation=DropTipWellLocation(),
             homeAfter=True,
+            randomizeDropLocation=True,
         )
     )
     response = commands.DropTipResult(position=DeckPoint(x=4, y=5, z=6))
@@ -315,6 +316,7 @@ def test_drop_tip(
         well_name="A2",
         well_location=DropTipWellLocation(),
         home_after=True,
+        randomize_drop_location=True,
     )
 
     assert result == response

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -111,3 +111,53 @@ async def test_drop_tip_implementation(
         await mock_tip_handler.drop_tip(pipette_id="abc", home_after=True),
         times=1,
     )
+
+
+async def test_drop_tip_with_randomization(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    mock_movement_handler: MovementHandler,
+    mock_tip_handler: TipHandler,
+) -> None:
+    """It should drop tip at random location within the labware every time."""
+    subject = DropTipImplementation(
+        state_view=mock_state_view,
+        movement=mock_movement_handler,
+        tip_handler=mock_tip_handler,
+    )
+    params = DropTipParams(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+        wellLocation=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
+        homeAfter=True,
+        randomizeDropLocation=True,
+    )
+    drop_location = DropTipWellLocation(
+        origin=DropTipWellOrigin.DEFAULT, offset=WellOffset(x=10, y=20, z=30)
+    )
+    decoy.when(
+        mock_state_view.labware.get_random_drop_tip_location(
+            labware_id="123", well_name="A3"
+        )
+    ).then_return(drop_location)
+
+    decoy.when(
+        mock_state_view.geometry.get_tip_drop_location(
+            pipette_id="abc",
+            labware_id="123",
+            well_location=drop_location,
+        )
+    ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
+
+    decoy.when(
+        await mock_movement_handler.move_to_well(
+            pipette_id="abc",
+            labware_id="123",
+            well_name="A3",
+            well_location=WellLocation(offset=WellOffset(x=4, y=5, z=6)),
+        )
+    ).then_return(Point(x=111, y=222, z=333))
+
+    result = await subject.execute(params)
+    assert result == DropTipResult(position=DeckPoint(x=111, y=222, z=333))

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -997,7 +997,6 @@ def test_get_random_drop_tip_location(
         print(drop_location[i])
         assert not all(drop_location[i] == another_loc for another_loc in drop_location)
         # trash's well A1 dimensions:
-        # "yDimension": 78
         # "xDimension": 225
         assert -84 <= drop_location[i].offset.x < 84
         assert drop_location[i].offset.y == 0

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -1,7 +1,7 @@
 """Labware state store tests."""
 import pytest
 from datetime import datetime
-from typing import Dict, Optional, cast, ContextManager, Any, Union
+from typing import Dict, Optional, cast, ContextManager, Any, Union, List
 from contextlib import nullcontext as does_not_raise
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
@@ -20,6 +20,7 @@ from opentrons.protocol_engine.types import (
     LoadedLabware,
     ModuleModel,
     ModuleLocation,
+    DropTipWellLocation,
 )
 from opentrons.protocol_engine.state.move_types import EdgePathType
 from opentrons.protocol_engine.state.labware import (
@@ -43,6 +44,14 @@ reservoir = LoadedLabware(
     loadName="reservoir-load-name",
     location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
     definitionUri="some-reservoir-uri",
+    offsetId=None,
+)
+
+trash = LoadedLabware(
+    id="trash-id",
+    loadName="trash-load-name",
+    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
+    definitionUri="some-trash-uri",
     offsetId=None,
 )
 
@@ -964,3 +973,32 @@ def test_get_all_labware_definition_empty() -> None:
     result = subject.get_loaded_labware_definitions()
 
     assert result == []
+
+
+def test_get_random_drop_tip_location(
+    ot3_fixed_trash_def: LabwareDefinition,
+) -> None:
+    """It should provide a random location within 3/4th of well top center every time."""
+    subject = get_labware_view(
+        labware_by_id={
+            "trash-id": trash,
+        },
+        definitions_by_uri={
+            "some-trash-uri": ot3_fixed_trash_def,
+        },
+    )
+    drop_location: List[DropTipWellLocation] = []
+    for i in range(50):
+        drop_location.append(
+            subject.get_random_drop_tip_location(labware_id="trash-id", well_name="A1")
+        )
+
+    for i in range(50):
+        print(drop_location[i])
+        assert not all(drop_location[i] == another_loc for another_loc in drop_location)
+        # trash's well A1 dimensions:
+        # "yDimension": 78
+        # "xDimension": 225
+        assert -84 <= drop_location[i].offset.x < 84
+        assert drop_location[i].offset.y == 0
+        assert drop_location[i].offset.z == 0

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -444,6 +444,7 @@ stages:
                       x: 0
                       y: 0
                       z: 0
+                  randomizeDropLocation: false
                 result:
                   position: { 'x': 347.84000000000003, 'y': 325.06, 'z': 82.0 }
                 startedAt: !anystr

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -288,6 +288,7 @@ stages:
                   x: 0
                   y: 0
                   z: 0
+              randomizeDropLocation: false
           - id: '{setup_command_id}'
             key: '{setup_command_key}'
             intent: setup
@@ -558,6 +559,7 @@ stages:
                   x: 0
                   y: 0
                   z: 0
+              randomizeDropLocation: false
           - id: '{setup_command_id}'
             key: '{setup_command_key}'
             intent: setup

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -121,6 +121,7 @@ stages:
                   x: 0
                   y: 0
                   z: 0
+              randomizeDropLocation: false
           - id: !anystr
             key: !anystr
             commandType: pickUpTip

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -119,3 +119,4 @@ stages:
                   x: 0
                   y: 0
                   z: 0
+              randomizeDropLocation: false

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -717,6 +717,12 @@
           "title": "Homeafter",
           "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
           "type": "boolean"
+        },
+        "randomizeDropLocation": {
+          "title": "Randomizedroplocation",
+          "description": "Whether to randomize the location where tip is dropped within the labware. If True, this command will ignore the wellLocation provided and drop tip at a random location within a set area of the specified labware well. If False, the tip will be dropped at the top center of the well.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "required": ["pipetteId", "labwareId", "wellName"]


### PR DESCRIPTION
Closes RQA-822

# Overview

Adds tip drop randomization to protocol engine `dropTip` command and wires up PAPI v2.15+ to use randomization when dropping tips without a location specified.

# Test Plan

- Run a v2.15 protocol with a few `instrument_context.drop_tip()` methods on both Flex & OT2. The pipette should drop tips at different, random locations in the trash well every time. This location should always be along the center line of the well in x-direction and should be within 3/4th area of the well from its center.
- Also run a v2.15 protocol with a drop_tip location specified. Verify that this does NOT randomize the drop location

# Changelog

- added `randomizeDropLocation` param to engine's `dropTip` command, which when true, drops tip in random trash location
- added a `get_random_drop_tip_location` getter to labware state
- added `randomize_drop_locatoin` arg to `core.drop_tip`
- updated `instrument_context.drop_tip` to set `core.random_drop_location` to True if API >= 2.15 & location is not specified.

# Review requests

- Is this a good approach? I've talked with people from SW and science about the best approach for both PAPI users as well as for engine and landed on this implementation. It avoids the problem of versioning in engine by making `randomizeDropLocation` an optional param.
- The PAPI method also still allows for overriding randomization by specifying a drop location so protocol authors will still have an option.

# Risk assessment

Medium. It changes the default behavior of `drop_tip()` when no location is specified. But after talking to science, this sounds like a welcome change.
