### PR TITLE
fix(app): render correct deck in LPC

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolMetadata.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolMetadata.test.tsx
@@ -24,6 +24,7 @@ describe('useProtocolMetadata', () => {
     .mockReturnValue({
       data: {
         protocolType: 'json',
+        robotType: 'OT-3 Standard',
         metadata: {
           author: 'AUTHOR',
           description: 'DESCRIPTION',
@@ -40,16 +41,17 @@ describe('useProtocolMetadata', () => {
     jest.restoreAllMocks()
   })
 
-  it('should return author, lastUpdated, method, and description from redux selectors', () => {
+  it('should return author, lastUpdated, method, description, and robot type', () => {
     const wrapper: React.FunctionComponent<{}> = ({ children }) => (
       <Provider store={store}>{children}</Provider>
     )
     const { result } = renderHook(useProtocolMetadata, { wrapper })
-    const { author, lastUpdated, creationMethod, description } = result.current
+    const { author, lastUpdated, creationMethod, description, robotType } = result.current
 
     expect(author).toBe('AUTHOR')
     expect(lastUpdated).toBe(123456)
     expect(creationMethod).toBe('json')
     expect(description).toBe('DESCRIPTION')
+    expect(robotType).toBe('OT-3 Standard')
   })
 })

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolMetadata.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolMetadata.test.tsx
@@ -46,7 +46,13 @@ describe('useProtocolMetadata', () => {
       <Provider store={store}>{children}</Provider>
     )
     const { result } = renderHook(useProtocolMetadata, { wrapper })
-    const { author, lastUpdated, creationMethod, description, robotType } = result.current
+    const {
+      author,
+      lastUpdated,
+      creationMethod,
+      description,
+      robotType,
+    } = result.current
 
     expect(author).toBe('AUTHOR')
     expect(lastUpdated).toBe(123456)

--- a/app/src/organisms/Devices/hooks/useProtocolMetadata.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolMetadata.ts
@@ -16,6 +16,8 @@ export function useProtocolMetadata(): ProtocolMetadata {
   const author = protocolMetadata?.author
   const description = protocolMetadata?.description
   const lastUpdated = protocolMetadata?.lastModified
+  // TODO: remove robot type from this hook to align on server definition of metadata
+  // see https://github.com/Opentrons/opentrons/pull/12815#discussion_r1210780976
   const robotType = protocolRecord?.data.robotType
 
   return {

--- a/app/src/organisms/Devices/hooks/useProtocolMetadata.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolMetadata.ts
@@ -1,10 +1,11 @@
 import { useCurrentProtocol } from '../../ProtocolUpload/hooks'
-
+import type { RobotType } from '@opentrons/shared-data'
 interface ProtocolMetadata {
   author?: string
   lastUpdated?: number | null
   description?: string | null
   creationMethod?: 'json' | 'python'
+  robotType?: RobotType
   [key: string]: any
 }
 
@@ -15,6 +16,7 @@ export function useProtocolMetadata(): ProtocolMetadata {
   const author = protocolMetadata?.author
   const description = protocolMetadata?.description
   const lastUpdated = protocolMetadata?.lastModified
+  const robotType = protocolRecord?.data.robotType
 
   return {
     ...protocolMetadata,
@@ -22,5 +24,6 @@ export function useProtocolMetadata(): ProtocolMetadata {
     lastUpdated,
     description,
     creationMethod,
+    robotType,
   }
 }

--- a/app/src/organisms/LabwarePositionCheck/PrepareSpace.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PrepareSpace.tsx
@@ -15,6 +15,7 @@ import ot3DeckDef from '@opentrons/shared-data/deck/definitions/3/ot3_standard.j
 
 import { getIsOnDevice } from '../../redux/config'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
+import { useProtocolMetadata } from '../Devices/hooks'
 
 import type { CheckLabwareStep } from './types'
 
@@ -42,9 +43,12 @@ interface PrepareSpaceProps extends Omit<CheckLabwareStep, 'section'> {
 export const PrepareSpace = (props: PrepareSpaceProps): JSX.Element | null => {
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const { location, moduleId, labwareDef, protocolData, header, body } = props
+
+  const { robotType } = useProtocolMetadata()
   const isOnDevice = useSelector(getIsOnDevice)
 
-  if (protocolData == null) return null
+  if (protocolData == null || robotType == null) return null
+  const deckDef = robotType === 'OT-3 Standard' ? ot3DeckDef : ot2DeckDef
   return (
     <GenericWizardTile
       header={header}
@@ -52,15 +56,7 @@ export const PrepareSpace = (props: PrepareSpaceProps): JSX.Element | null => {
       rightHandBody={
         <RobotWorkSpace
           height={isOnDevice ? '80%' : '100%'}
-          deckDef={
-            protocolData.labware.some(
-              l =>
-                l.loadName === 'opentrons_1_trash_850ml_fixed' ||
-                l.loadName === 'opentrons_1_trash_1100ml_fixed'
-            )
-              ? (ot3DeckDef as any)
-              : (ot2DeckDef as any)
-          }
+          deckDef={deckDef as any}
           viewBox={DECK_MAP_VIEWBOX}
           deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
           id="LabwarePositionCheck_deckMap"

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -1,18 +1,25 @@
 import * as React from 'react'
+import { resetAllWhenMocks, when } from 'jest-when'
 import type { MatcherFunction } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
-import { i18n } from '../../../i18n'
-import { CheckItem } from '../CheckItem'
-import { SECTIONS } from '../constants'
-import { mockCompletedAnalysis, mockExistingOffsets } from '../__fixtures__'
 import {
   HEATERSHAKER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
-import { resetAllWhenMocks, when } from 'jest-when'
+import { i18n } from '../../../i18n'
+import { useProtocolMetadata } from '../../Devices/hooks'
+import { CheckItem } from '../CheckItem'
+import { SECTIONS } from '../constants'
+import { mockCompletedAnalysis, mockExistingOffsets } from '../__fixtures__'
+
+jest.mock('../../Devices/hooks')
 
 const mockStartPosition = { x: 10, y: 20, z: 30 }
 const mockEndPosition = { x: 9, y: 19, z: 29 }
+
+const mockUseProtocolMetaData = useProtocolMetadata as jest.MockedFunction<
+  typeof useProtocolMetadata
+>
 
 const matchTextWithSpans: (text: string) => MatcherFunction = (
   text: string
@@ -54,6 +61,7 @@ describe('CheckItem', () => {
       existingOffsets: mockExistingOffsets,
       isRobotMoving: false,
     }
+    mockUseProtocolMetaData.mockReturnValue({ robotType: 'OT-3 Standard' })
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -1,15 +1,22 @@
 import * as React from 'react'
+import { resetAllWhenMocks, when } from 'jest-when'
 import type { MatcherFunction } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
+import { HEATERSHAKER_MODULE_V1 } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
+import { useProtocolMetadata } from '../../Devices/hooks'
 import { PickUpTip } from '../PickUpTip'
 import { SECTIONS } from '../constants'
 import { mockCompletedAnalysis, mockExistingOffsets } from '../__fixtures__'
-import { HEATERSHAKER_MODULE_V1 } from '@opentrons/shared-data'
-import { CommandData } from '@opentrons/api-client'
-import { resetAllWhenMocks, when } from 'jest-when'
+import type { CommandData } from '@opentrons/api-client'
+
+jest.mock('../../Devices/hooks')
 
 const mockStartPosition = { x: 10, y: 20, z: 30 }
+
+const mockUseProtocolMetaData = useProtocolMetadata as jest.MockedFunction<
+  typeof useProtocolMetadata
+>
 
 const matchTextWithSpans: (text: string) => MatcherFunction = (
   text: string
@@ -49,6 +56,7 @@ describe('PickUpTip', () => {
       existingOffsets: mockExistingOffsets,
       isRobotMoving: false,
     }
+    mockUseProtocolMetaData.mockReturnValue({ robotType: 'OT-3 Standard' })
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react'
 import type { MatcherFunction } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
+import { HEATERSHAKER_MODULE_V1 } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { ReturnTip } from '../ReturnTip'
 import { SECTIONS } from '../constants'
 import { mockCompletedAnalysis } from '../__fixtures__'
-import { HEATERSHAKER_MODULE_V1 } from '@opentrons/shared-data'
+import { useProtocolMetadata } from '../../Devices/hooks'
+
+jest.mock('../../Devices/hooks')
+
+const mockUseProtocolMetaData = useProtocolMetadata as jest.MockedFunction<
+  typeof useProtocolMetadata
+>
 
 const matchTextWithSpans: (text: string) => MatcherFunction = (
   text: string
@@ -42,6 +49,7 @@ describe('ReturnTip', () => {
       tipPickUpOffset: null,
       isRobotMoving: false,
     }
+    mockUseProtocolMetaData.mockReturnValue({ robotType: 'OT-3 Standard' })
   })
   afterEach(() => {
     jest.restoreAllMocks()

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCarousel.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCarousel.test.tsx
@@ -27,6 +27,7 @@ const mockSortedProtocol = [
       description: 'mock protocol',
       name: 'Mock Protocol',
     },
+    robotType: 'OT-3 Standard',
     protocolType: 'python',
   },
 ] as ProtocolResource[]

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/PinnedProtocol.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/PinnedProtocol.test.tsx
@@ -21,6 +21,7 @@ jest.mock('react-router-dom', () => {
 const mockProtocol: ProtocolResource = {
   id: 'mockProtocol1',
   createdAt: '2022-05-03T21:36:12.494778+00:00',
+  robotType: 'OT-3 Standard',
   protocolType: 'json',
   metadata: {
     protocolName: 'yay mock protocol',

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -22,6 +22,7 @@ const mockProtocol: ProtocolResource = {
   id: 'mockProtocol1',
   createdAt: '2022-05-03T21:36:12.494778+00:00',
   protocolType: 'json',
+  robotType: 'OT-3 Standard',
   metadata: {
     protocolName: 'yay mock protocol',
     author: 'engineering',

--- a/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/utils.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDashboard/__tests__/utils.test.tsx
@@ -7,6 +7,7 @@ const mockProtocols = [
   {
     id: 'mockProtocol1',
     createdAt: '2022-05-03T21:36:12.494778+00:00',
+    robotType: 'OT-3 Standard',
     protocolType: 'json',
     metadata: {
       protocolName: 'yay mock protocol',
@@ -23,6 +24,7 @@ const mockProtocols = [
     id: 'mockProtocol2',
     createdAt: '2022-05-10T17:04:43.132768+00:00',
     protocolType: 'json',
+    robotType: 'OT-3 Standard',
     metadata: {
       protocolName: 'hello mock protocol',
       author: 'engineering',
@@ -37,6 +39,7 @@ const mockProtocols = [
   {
     id: 'mockProtocol3',
     createdAt: '2022-06-04T18:20:21.526508+00:00',
+    robotType: 'OT-3 Standard',
     protocolType: 'json',
     metadata: {
       protocolName: 'mock protocol',

--- a/app/src/pages/OnDeviceDisplay/RobotDashboard/__tests__/RobotDashboard.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotDashboard/__tests__/RobotDashboard.test.tsx
@@ -74,6 +74,7 @@ const mockProtocol: ProtocolResource = {
   id: 'mockProtocol1',
   createdAt: '2022-05-03T21:36:12.494778+00:00',
   protocolType: 'json',
+  robotType: 'OT-3 Standard',
   metadata: {
     protocolName: 'yay mock protocol',
     author: 'engineering',

--- a/react-api-client/src/protocols/__tests__/useCreateProtocolMutation.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useCreateProtocolMutation.test.tsx
@@ -34,6 +34,7 @@ const PROTOCOL_RESPONSE = {
   data: {
     id: '1',
     createdAt: 'now',
+    robotType: 'OT-3 Standard',
     protocolType: 'json',
     metadata: {},
     analysisSummaries: [],

--- a/react-api-client/src/protocols/__tests__/useProtocolQuery.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useProtocolQuery.test.tsx
@@ -24,6 +24,7 @@ const PROTOCOL_RESPONSE = {
     metadata: {},
     analysisSummaries: [],
     files: [],
+    robotType: 'OT-3 Standard',
   },
 } as Protocol
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -454,6 +454,7 @@ export interface ProtocolResource {
   id: string
   createdAt: string
   protocolType: 'json' | 'python'
+  robotType: RobotType
   metadata: ProtocolMetadata
   analysisSummaries: ProtocolAnalysisSummary[]
   files: ResourceFile[]


### PR DESCRIPTION
# Overview

This PR changes LPC to use the deck definition for the robot type provided by the robot server's protocol endpoint. This fixes a bug where we were accessing deck slot names that don't exist during LPC.

closes RAUT-456

# Test Plan

Verified that LPC works for Flex protocols on a Flex.

# Changelog

- Render correct deck in LPC


# Risk assessment

Low