### PR TITLE
chore: do not build the app xplatform all the time

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -98,6 +98,10 @@ jobs:
     strategy:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
+        exclude:
+          - os: 'macos-11'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
+          - os: 'windows-2022'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
+
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
     steps:
@@ -193,6 +197,10 @@ jobs:
     strategy:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
+        exclude:
+          - os: 'macos-11'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
+          - os: 'windows-2022'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
+
     name: 'opentrons app backend unit tests and build for OT3'
     runs-on: ${{ matrix.os }}
     steps:
@@ -272,7 +280,7 @@ jobs:
     name: 'Deploy built app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-test-backend']
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release'))
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'
@@ -293,7 +301,7 @@ jobs:
     name: 'Deploy built OT3 app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-ot3']
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release'))
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -301,7 +301,7 @@ jobs:
     name: 'Deploy built OT3 app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-ot3']
-    if: (github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge')  !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
+    if: (github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -98,9 +98,6 @@ jobs:
     strategy:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
-        exclude:
-          - os: format('macos-11{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
-          - os: format('windows-2022{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
 
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
@@ -108,14 +105,6 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
-      - name: 'debug'
-        run: |
-          echo ${{ github.ref }}
-          echo ${{ startsWith(github.ref, 'refs/tags') }}
-          echo ${{ startsWith(github.ref, 'refs/heads/edge') }}
-          echo ${{ startsWith(github.ref, 'refs/heads/internal-release') }}
-          echo ${{ startsWith(github.ref, 'refs/heads/release') }}
-          echo ${{ endsWith(github.ref, 'app-build') }}
       # https://github.com/actions/checkout/issues/290
       - name: 'Fix actions/checkout odd handling of tags'
         if: startsWith(github.ref, 'refs/tags')
@@ -166,7 +155,7 @@ jobs:
           flags: app
 
       # build the desktop app and deploy it
-      - if: github.event_name != 'pull_request'
+      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
         name: 'build app for ${{ matrix.os }}'
         timeout-minutes: 60
         env:
@@ -187,7 +176,7 @@ jobs:
         run: |
           make -C app-shell dist-${{ matrix.os }}
 
-      - if: github.event_name != 'pull_request'
+      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
         name: 'upload github artifact'
         uses: actions/upload-artifact@v3
         with:
@@ -255,7 +244,7 @@ jobs:
           make setup-js
 
       # build the app and deploy it
-      - if: github.event_name != 'pull_request'
+      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
         name: 'build app for ${{ matrix.os }}'
         timeout-minutes: 60
         env:
@@ -276,7 +265,7 @@ jobs:
         run: |
           make -C app-shell dist-${{ matrix.os }}
 
-      - if: github.event_name != 'pull_request'
+      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
         name: 'upload github artifact'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -99,8 +99,8 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
         exclude:
-          - os: format('macos-11{0}', (!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
-          - os: format('windows-2022{0}', (!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
+          - os: format('macos-11{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
+          - os: format('windows-2022{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
 
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
@@ -198,8 +198,8 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
         exclude:
-          - os: format('macos-11{0}',(!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
-          - os: format('windows-2022{0}', (!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
+          - os: format('macos-latest{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
+          - os: format('windows-2022{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
 
     name: 'opentrons app backend unit tests and build for OT3'
     runs-on: ${{ matrix.os }}
@@ -280,7 +280,7 @@ jobs:
     name: 'Deploy built app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-test-backend']
-    if: (github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
+    if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || !endsWith(github.ref, 'app-build'))
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'
@@ -301,7 +301,7 @@ jobs:
     name: 'Deploy built OT3 app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-ot3']
-    if: (github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
+    if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -99,8 +99,8 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
         exclude:
-          - os: 'macos-11'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
-          - os: 'windows-2022'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
+          - os: format('macos-11{0}', ${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
+          - os: format('windows-2022{0}'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
 
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
@@ -198,8 +198,8 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
         exclude:
-          - os: 'macos-11'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
-          - os: 'windows-2022'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}}
+          - os: format('macos-11{0}',${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
+          - os: format('windows-2022{0}', ${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
 
     name: 'opentrons app backend unit tests and build for OT3'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -108,6 +108,14 @@ jobs:
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
+      - name: 'debug'
+        run: |
+          echo ${{ github.ref }}
+          echo ${{ startsWith(github.ref, 'refs/tags') }}
+          echo ${{ startsWith(github.ref, 'refs/heads/edge') }}
+          echo ${{ startsWith(github.ref, 'refs/heads/internal-release') }}
+          echo ${{ startsWith(github.ref, 'refs/heads/release') }}
+          echo ${{ endsWith(github.ref, 'app-build') }}
       # https://github.com/actions/checkout/issues/290
       - name: 'Fix actions/checkout odd handling of tags'
         if: startsWith(github.ref, 'refs/tags')
@@ -280,7 +288,7 @@ jobs:
     name: 'Deploy built app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-test-backend']
-    if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || !endsWith(github.ref, 'app-build'))
+    if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -280,7 +280,7 @@ jobs:
     name: 'Deploy built app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-test-backend']
-    if: github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
+    if: (github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -99,8 +99,8 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
         exclude:
-          - os: format('macos-11{0}', ${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
-          - os: format('windows-2022{0}'${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
+          - os: format('macos-11{0}', (!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
+          - os: format('windows-2022{0}', (!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
 
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
@@ -198,8 +198,8 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
         exclude:
-          - os: format('macos-11{0}',${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
-          - os: format('windows-2022{0}', ${{!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release') || null}})
+          - os: format('macos-11{0}',(!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
+          - os: format('windows-2022{0}', (!startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')) || null)
 
     name: 'opentrons app backend unit tests and build for OT3'
     runs-on: ${{ matrix.os }}
@@ -280,7 +280,7 @@ jobs:
     name: 'Deploy built app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-test-backend']
-    if: github.event_name != 'pull_request' && (!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release'))
+    if: github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge') && !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'
@@ -301,7 +301,7 @@ jobs:
     name: 'Deploy built OT3 app artifacts to S3'
     runs-on: 'ubuntu-22.04'
     needs: ['js-unit-test', 'build-app-ot3']
-    if: github.event_name != 'pull_request' && (!startsWith(github.ref, 'refs/tags') || !startsWith(github.ref, 'refs/heads/edge') || !startsWith(github.ref, 'refs/heads/internal-release') || !startsWith(github.ref, 'refs/heads/release'))
+    if: (github.event_name != 'pull_request') && !startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/heads/edge')  !startsWith(github.ref, 'refs/heads/internal-release') && !startsWith(github.ref, 'refs/heads/release') && !endsWith(github.ref, 'app-build')
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'


### PR DESCRIPTION
It's good to run app builds to test if peoples' PRs work, but it's bad if those app builds sporadically fail or take an hour even if they succeed. Let's cut the number of times we do a full cross-platform app build down by only doing the build if
- This is a tag
- This is edge
- This is release
- This is internal-release
- This push was to a branch that ends in `app-build`

In other cases, we'll only do a linux build. On Linux, we don't have any signing or attestation, so the builds are reliable and fast. That lets us get the benefit (be sure we didn't break something obvious) and still have the builds not take forever.

## Note
This may not be a good idea! It means we won't be getting many app builds, and something breaking could surprise us. It also means we might have a rough first couple alphas since we can't really test the "we get builds on tags" part without pushing a matching tag. But then again, that's what the alphas are for.