### PR TITLE
fix(app): Make labware filtering in Labware Position Check robust to different deck types

### DIFF
--- a/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
@@ -20,7 +20,7 @@ export function getLabwareLocationCombos(
   return commands.reduce<LabwareLocationCombo[]>((acc, command) => {
     if (command.commandType === 'loadLabware') {
       if (command.result?.definition == null) return acc
-      if (command.result.definition.parameters.format === ‘trash’) return acc
+      if (command.result.definition.parameters.format === 'trash') return acc
       const definitionUri = getLabwareDefURI(command.result.definition)
       if (command.params.location === 'offDeck') {
         return acc

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
@@ -20,6 +20,7 @@ export function getLabwareLocationCombos(
   return commands.reduce<LabwareLocationCombo[]>((acc, command) => {
     if (command.commandType === 'loadLabware') {
       if (command.result?.definition == null) return acc
+      if (command.result.definition.parameters.format === ‘trash’) return acc
       const definitionUri = getLabwareDefURI(command.result.definition)
       if (command.params.location === 'offDeck') {
         return acc

--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -155,10 +155,6 @@ function getCheckLabwareSectionSteps(args: LPCArgs): CheckLabwareStep[] {
       ...labwareLocationCombos.reduce<CheckLabwareStep[]>(
         (innerAcc, { location, labwareId, moduleId }) => {
           if (
-            !getSlotHasMatingSurfaceUnitVector(
-              OT2_STANDARD_DECK_DEF,
-              location.slotName
-            ) ||
             labwareId !== currentLabware.id
           ) {
             return innerAcc

--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -1,10 +1,8 @@
-import standardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
 import { SECTIONS } from '../constants'
 import { getLabwareDefinitionsFromCommands } from './labware'
 import {
   getLabwareDefURI,
   getIsTiprack,
-  getSlotHasMatingSurfaceUnitVector,
   FIXED_TRASH_ID,
 } from '@opentrons/shared-data'
 import { getLabwareLocationCombos } from '../../ApplyHistoricOffsets/hooks/getLabwareLocationCombos'
@@ -29,8 +27,6 @@ interface LPCArgs {
   modules: ProtocolAnalysisOutput['modules']
   commands: RunTimeCommand[]
 }
-
-const OT2_STANDARD_DECK_DEF = standardDeckDef as any
 
 export const getCheckSteps = (args: LPCArgs): LabwarePositionCheckStep[] => {
   const checkTipRacksSectionSteps = getCheckTipRackSectionSteps(args)

--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -150,9 +150,7 @@ function getCheckLabwareSectionSteps(args: LPCArgs): CheckLabwareStep[] {
       ...acc,
       ...labwareLocationCombos.reduce<CheckLabwareStep[]>(
         (innerAcc, { location, labwareId, moduleId }) => {
-          if (
-            labwareId !== currentLabware.id
-          ) {
+          if (labwareId !== currentLabware.id) {
             return innerAcc
           }
 

--- a/app/src/organisms/LabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/labware.ts
@@ -4,11 +4,9 @@ import {
   getTiprackVolume,
   ProtocolFile,
   LabwareDefinition2,
-  getSlotHasMatingSurfaceUnitVector,
   getLabwareDefURI,
   CompletedProtocolAnalysis,
 } from '@opentrons/shared-data'
-import standardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
 import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
 import type {
   ProtocolAnalysisOutput,
@@ -17,8 +15,6 @@ import type {
 import type { LabwareToOrder } from '../types'
 import { getModuleInitialLoadInfo } from '../../Devices/ProtocolRun/utils/getModuleInitialLoadInfo'
 import { LabwareLocation } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
-
-const OT2_STANDARD_DECK_DEF = standardDeckDef as any
 
 export const tipRackOrderSort = (
   tiprack1: LabwareToOrder,

--- a/app/src/organisms/LabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/labware.ts
@@ -159,14 +159,7 @@ export const getLabwareIdsInOrder = (
       return [
         ...acc,
         ...labwareLocations.reduce<LabwareToOrder[]>((innerAcc, loc) => {
-          if (
-            !getSlotHasMatingSurfaceUnitVector(
-              OT2_STANDARD_DECK_DEF,
-              loc !== 'offDeck' && 'slotName' in loc ? loc.slotName : ''
-            )
-          ) {
-            return innerAcc
-          }
+          if (labwareDef.parameters.format === 'trash') return innerAcc
           let slot = ''
           if (loc === 'offDeck') {
             slot = 'offDeck'
@@ -222,6 +215,7 @@ export const getAllUniqLocationsForLabware = (
   const labwareLocation = commands.reduce<LabwareLocation[]>(
     (acc, command: RunTimeCommand) =>
       command.commandType === 'loadLabware' &&
+      command.result?.definition.parameters.format !== 'trash' &&
       command.result?.labwareId === labwareId
         ? [...acc, command.params.location]
         : acc,

--- a/app/src/organisms/LabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/labware.ts
@@ -145,8 +145,10 @@ export const getLabwareIdsInOrder = (
           `could not find labware definition within protocol with uri: ${currentLabware.definitionUri}`
         )
       }
+      // skip any labware that is a tip rack or trash
       const isTiprack = getIsTiprack(labwareDef)
-      if (isTiprack) return acc // skip any labware that is a tiprack
+      const isTrash = labwareDef.parameters.format === 'trash'
+      if (isTiprack || isTrash) return acc
 
       const labwareLocations = getAllUniqLocationsForLabware(
         currentLabware.id,
@@ -155,7 +157,6 @@ export const getLabwareIdsInOrder = (
       return [
         ...acc,
         ...labwareLocations.reduce<LabwareToOrder[]>((innerAcc, loc) => {
-          if (labwareDef.parameters.format === 'trash') return innerAcc
           let slot = ''
           if (loc === 'offDeck') {
             slot = 'offDeck'


### PR DESCRIPTION
# Overview

The app has some code to filter out the trash bin from the labware to visit during Labware Position Check. This code was implemented in a way that depended on details of the deck definition.

This was a latent bug that manifests now that the OT-2 and OT-3 deck definitions are going to have different slot IDs. To fix it, we now bypass deck definitions entirely for this logic. Instead, we look at the labware definition's `params.format` and filter it out if it's equal to `"trash"`.

This fixes RLAB-350.

# Test plan

I've tested this as part of #12781. I clicked through Labware Position Check and made sure it visited all labware, and that it didn't visit the trash.

# Review requests

Is `format === 'trash'` a good way to implement this?

# Risk assessment

I'm gonna go with a pessimistic "medium" because I'm unfamiliar with the app code and there might be deeper implications that I'm missing.