### PR TITLE
feat(hardware): add limit switch backoff to home sequence

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from functools import wraps
 import logging
 from copy import deepcopy
-from math import isclose
 from typing import (
     Any,
     Awaitable,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from functools import wraps
 import logging
 from copy import deepcopy
+from math import isclose
 from typing import (
     Any,
     Awaitable,
@@ -47,6 +48,7 @@ from .ot3utils import (
     USBTARGET_SUBSYSTEM,
     filter_probed_core_nodes,
     motor_nodes,
+    LIMIT_SWITCH_OVERTRAVEL_DISTANCE,
 )
 
 try:
@@ -524,6 +526,14 @@ class OT3Controller:
         positions = await runner.run(can_messenger=self._messenger)
         self._handle_motor_status_response(positions)
 
+    def _get_axis_home_distance(self, axis: OT3Axis) -> float:
+        if self.check_motor_status([axis]):
+            return -1 * (
+                self._position[axis_to_node(axis)] + LIMIT_SWITCH_OVERTRAVEL_DISTANCE
+            )
+        else:
+            return -1 * self.axis_bounds[axis][1] - self.axis_bounds[axis][0]
+
     def _build_home_pipettes_runner(
         self,
         axes: Sequence[OT3Axis],
@@ -534,7 +544,7 @@ class OT3Controller:
         ]
 
         distances_pipette = {
-            ax: -1 * self.axis_bounds[ax][1] - self.axis_bounds[ax][0]
+            ax: self._get_axis_home_distance(ax)
             for ax in axes
             if ax in OT3Axis.pipette_axes()
         }
@@ -565,7 +575,7 @@ class OT3Controller:
         ]
 
         distances_gantry = {
-            ax: -1 * self.axis_bounds[ax][1] - self.axis_bounds[ax][0]
+            ax: self._get_axis_home_distance(ax)
             for ax in axes
             if ax in OT3Axis.gantry_axes() and ax not in OT3Axis.mount_axes()
         }
@@ -575,7 +585,7 @@ class OT3Controller:
             if ax in OT3Axis.gantry_axes() and ax not in OT3Axis.mount_axes()
         }
         distances_z = {
-            ax: -1 * self.axis_bounds[ax][1] - self.axis_bounds[ax][0]
+            ax: self._get_axis_home_distance(ax)
             for ax in axes
             if ax in OT3Axis.mount_axes()
         }

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -40,6 +40,7 @@ from opentrons_hardware.hardware_control.motion import (
     create_step,
     NodeIdMotionValues,
     create_home_step,
+    create_backoff_step,
     MoveGroup,
     MoveType,
     MoveStopCondition,
@@ -329,11 +330,15 @@ def create_home_group(
 ) -> MoveGroup:
     node_id_distances = _convert_to_node_id_dict(distance)
     node_id_velocities = _convert_to_node_id_dict(velocity)
-    step = create_home_step(
+    home = create_home_step(
         distance=node_id_distances,
         velocity=node_id_velocities,
     )
-    move_group: MoveGroup = [step]
+    # halve the homing speed for backoff
+    backoff_velocities = {k: v / 2 for k, v in node_id_velocities.items()}
+    backoff = create_backoff_step(backoff_velocities)
+
+    move_group: MoveGroup = [home, backoff]
     return move_group
 
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -51,6 +51,8 @@ from opentrons_hardware.hardware_control.motion import (
 GRIPPER_JAW_HOME_TIME: float = 10
 GRIPPER_JAW_GRIP_TIME: float = 10
 
+LIMIT_SWITCH_OVERTRAVEL_DISTANCE: float = 1
+
 PipetteAction = Literal["clamp", "home"]
 
 # TODO: These methods exist to defer uses of NodeId to inside
@@ -335,7 +337,7 @@ def create_home_group(
         velocity=node_id_velocities,
     )
     # halve the homing speed for backoff
-    backoff_velocities = {k: v for k, v in node_id_velocities.items()}
+    backoff_velocities = {k: v / 2 for k, v in node_id_velocities.items()}
     backoff = create_backoff_step(backoff_velocities)
 
     move_group: MoveGroup = [home, backoff]

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -335,7 +335,7 @@ def create_home_group(
         velocity=node_id_velocities,
     )
     # halve the homing speed for backoff
-    backoff_velocities = {k: v / 2 for k, v in node_id_velocities.items()}
+    backoff_velocities = {k: v for k, v in node_id_velocities.items()}
     backoff = create_backoff_step(backoff_velocities)
 
     move_group: MoveGroup = [home, backoff]

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -341,7 +341,7 @@ class MoveStopCondition(int, Enum):
     gripper_force = 0x8
     stall = 0x10
     ignore_stalls = 0x20
-    limit_switch_backoff = 0x4C0
+    limit_switch_backoff = 0x40
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -341,7 +341,7 @@ class MoveStopCondition(int, Enum):
     gripper_force = 0x8
     stall = 0x10
     ignore_stalls = 0x20
-    limit_switch_backoff = 0x30
+    limit_switch_backoff = 0x40
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -341,6 +341,7 @@ class MoveStopCondition(int, Enum):
     gripper_force = 0x8
     stall = 0x10
     ignore_stalls = 0x20
+    limit_switch_backoff = 0x30
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -341,7 +341,7 @@ class MoveStopCondition(int, Enum):
     gripper_force = 0x8
     stall = 0x10
     ignore_stalls = 0x20
-    limit_switch_backoff = 0x40
+    limit_switch_backoff = 0x4C0
 
 
 @unique

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -1,5 +1,5 @@
 """A collection of motions that define a single move."""
-from typing import List, Dict, Iterable, Union, Tuple
+from typing import List, Dict, Iterable, Union
 from dataclasses import dataclass
 import numpy as np
 from logging import getLogger

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -146,7 +146,7 @@ def create_backoff_step(velocity: Dict[NodeId, np.float64]) -> MoveGroupStep:
             distance_mm=np.float64(BACKOFF_MAX_MM),
             acceleration_mm_sec_sq=np.float64(0),
             velocity_mm_sec=abs(v),
-            duration_sec=np.float64(BACKOFF_MAX_MM)/abs(v),
+            duration_sec=np.float64(BACKOFF_MAX_MM) / abs(v),
             stop_condition=MoveStopCondition.limit_switch_backoff,
             move_type=MoveType.linear,
         )

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -1,5 +1,5 @@
 """A collection of motions that define a single move."""
-from typing import List, Dict, Iterable, Union
+from typing import List, Dict, Iterable, Union, Tuple
 from dataclasses import dataclass
 import numpy as np
 from logging import getLogger
@@ -35,6 +35,7 @@ class MoveType(int, Enum):
             MoveStopCondition.encoder_position: cls.linear,
             MoveStopCondition.gripper_force: cls.grip,
             MoveStopCondition.stall: cls.linear,
+            MoveStopCondition.limit_switch_backoff: cls.linear,
         }
         return mapping[condition]
 
@@ -95,6 +96,8 @@ MAX_SPEEDS = {
     NodeId.pipette_right: 2,
 }
 
+BACKOFF_MAX_MM = 5
+
 
 def create_step(
     distance: Dict[NodeId, np.float64],
@@ -132,6 +135,22 @@ def create_step(
             move_type=MoveType.get_move_type(stop_condition),
         )
     return step
+
+
+def create_backoff_step(velocity: Dict[NodeId, np.float64]) -> MoveGroupStep:
+    """Create a sequence to back away from the limit switch and re-home."""
+    backoff: MoveGroupStep = {}
+
+    for axis, v in velocity.items():
+        backoff[axis] = MoveGroupSingleAxisStep(
+            distance_mm=np.float64(BACKOFF_MAX_MM),
+            acceleration_mm_sec_sq=np.float64(0),
+            velocity_mm_sec=abs(v),
+            duration_sec=np.float64(BACKOFF_MAX_MM)/abs(v),
+            stop_condition=MoveStopCondition.limit_switch_backoff,
+            move_type=MoveType.linear,
+        )
+    return backoff
 
 
 def create_home_step(

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -332,13 +332,14 @@ class MoveScheduler:
         # For each move group create a set identifying the node and seq id.
         self._moves: List[Set[Tuple[int, int]]] = []
         self._durations: List[float] = []
-        self._stop_condition: List[MoveStopCondition] = []
+        self._stop_condition: List[List[MoveStopCondition]] = []
         self._start_at_index = start_at_index
         self._expected_tip_action_motors = []
 
         for move_group in move_groups:
             move_set = set()
             duration = 0.0
+            stop_cond = []
             for seq_id, move in enumerate(move_group):
                 movesteps = list(move.values())
                 move_set.update(set((k.value, seq_id) for k in move.keys()))
@@ -349,9 +350,10 @@ class MoveScheduler:
                         GearMotorId.right,
                     ]
                 for step in move_group[seq_id]:
-                    self._stop_condition.append(move_group[seq_id][step].stop_condition)
+                    stop_cond.append(move_group[seq_id][step].stop_condition)
 
             self._moves.append(move_set)
+            self._stop_condition.append(stop_cond)
             self._durations.append(duration)
         log.debug(f"Move scheduler running for groups {move_groups}")
         self._completion_queue: asyncio.Queue[_CompletionPacket] = asyncio.Queue()
@@ -401,15 +403,22 @@ class MoveScheduler:
         self, message: _AcceptableMoves, arbitration_id: ArbitrationId
     ) -> None:
         group_id = message.payload.group_id.value - self._start_at_index
+        seq_id = message.payload.seq_id.value
         ack_id = message.payload.ack_id.value
         node_id = arbitration_id.parts.originating_node_id
         try:
-            stop_cond = self._stop_condition[group_id]
+            stop_cond = self._stop_condition[group_id][seq_id]
             if (
-                stop_cond == MoveStopCondition.limit_switch
+                stop_cond
+                in [
+                    MoveStopCondition.limit_switch,
+                    MoveStopCondition.limit_switch_backoff,
+                ]
                 and ack_id != MoveAckId.stopped_by_condition
             ):
-                log.warning(f"Homing time out for {node_id}")
+                log.error(
+                    f"Homing move from node {node_id} completed without meeting condition {stop_cond}"
+                )
                 self._should_stop = True
                 self._event.set()
         except IndexError:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -118,7 +118,7 @@ def test_build_linear_home_step() -> None:
             duration_sec=float64(20.0),
             acceleration_mm_sec_sq=float64(0),
             stop_condition=MoveStopCondition.limit_switch,
-            move_type=MoveType.home
+            move_type=MoveType.home,
         ),
         NodeId.head_l: MoveGroupSingleAxisStep(
             distance_mm=float64(4),
@@ -126,7 +126,7 @@ def test_build_linear_home_step() -> None:
             duration_sec=float64(40),
             acceleration_mm_sec_sq=float64(0),
             stop_condition=MoveStopCondition.limit_switch,
-            move_type=MoveType.home
+            move_type=MoveType.home,
         ),
     }
     distance = {NodeId.head_l: float64(4), NodeId.pipette_right: float64(10)}
@@ -154,4 +154,3 @@ def test_build_limit_switch_backoff_step() -> None:
     }
     velocity = {NodeId.head_l: float64(-0.1), NodeId.pipette_right: float64(-0.5)}
     assert expected == create_backoff_step(velocity)
-

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion.py
@@ -1,8 +1,12 @@
 """Tests for motion methods."""
 from numpy import float64
 from opentrons_hardware.drivers.can_bus import NodeId
+from opentrons_hardware.firmware_bindings.constants import MoveStopCondition
 from opentrons_hardware.hardware_control.motion import (
+    MoveType,
     create_step,
+    create_home_step,
+    create_backoff_step,
     MoveGroupSingleAxisStep,
 )
 
@@ -103,3 +107,51 @@ def test_build_move_with_jaw_node() -> None:
             )
         ),
     )
+
+
+def test_build_linear_home_step() -> None:
+    """It should build linear home step."""
+    expected = {
+        NodeId.pipette_right: MoveGroupSingleAxisStep(
+            distance_mm=float64(10.0),
+            velocity_mm_sec=float64(-0.5),
+            duration_sec=float64(20.0),
+            acceleration_mm_sec_sq=float64(0),
+            stop_condition=MoveStopCondition.limit_switch,
+            move_type=MoveType.home
+        ),
+        NodeId.head_l: MoveGroupSingleAxisStep(
+            distance_mm=float64(4),
+            velocity_mm_sec=float64(-0.1),
+            duration_sec=float64(40),
+            acceleration_mm_sec_sq=float64(0),
+            stop_condition=MoveStopCondition.limit_switch,
+            move_type=MoveType.home
+        ),
+    }
+    distance = {NodeId.head_l: float64(4), NodeId.pipette_right: float64(10)}
+    velocity = {NodeId.head_l: float64(-0.1), NodeId.pipette_right: float64(-0.5)}
+    assert expected == create_home_step(distance, velocity)
+
+
+def test_build_limit_switch_backoff_step() -> None:
+    """It should build linear limit switch backoff step."""
+    expected = {
+        NodeId.pipette_right: MoveGroupSingleAxisStep(
+            distance_mm=float64(5.0),
+            velocity_mm_sec=float64(0.5),
+            duration_sec=float64(10.0),
+            acceleration_mm_sec_sq=float64(0),
+            stop_condition=MoveStopCondition.limit_switch_backoff,
+        ),
+        NodeId.head_l: MoveGroupSingleAxisStep(
+            distance_mm=float64(5.0),
+            velocity_mm_sec=float64(0.1),
+            duration_sec=float64(50),
+            acceleration_mm_sec_sq=float64(0),
+            stop_condition=MoveStopCondition.limit_switch_backoff,
+        ),
+    }
+    velocity = {NodeId.head_l: float64(-0.1), NodeId.pipette_right: float64(-0.5)}
+    assert expected == create_backoff_step(velocity)
+


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
This PR implements backing off away from the limit switch right after a home request to ensure the origins of the stepper motor axes are consistent every time we home. 

See firmware-side changes https://github.com/Opentrons/ot3-firmware/pull/676 

# Test Plan
Test on all stepper motor axes and verify the stepper and encoder positions

# Changelog
* Adding a backoff step to the stepper motor home move group
* Halving the homing velocity to backoff to increase precision
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

# Changes from last review
* we only use the axis boundary distance as the home request distance if the stepper position status is not okay
* add 1.0 mm as the over-travel distance so we don't pass in a home request with 0 duration if we home an axis that's already in its home position 

