### PR TITLE
fix(hardware, api): recoverable error handling

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -394,7 +394,7 @@ class MoveScheduler:
         log.error(f"Error during move group: {message}")
         if severity == ErrorSeverity.unrecoverable:
             self._should_stop = True
-        self._event.set()
+            self._event.set()
 
     def _handle_move_completed(
         self, message: _AcceptableMoves, arbitration_id: ArbitrationId


### PR DESCRIPTION

# Overview

We have a feature flag to disable stall detection to reduce errors during protocol testing. The way this is handled is by setting a flag "ignore_stalls" to the axis controllers. However, they don't _really_ ignore the stalls; instead they will send a "recoverable" error when a stall is detected and continue running a move group as instructed. The hardware controller was still handling these recoverable errors the same as unrecoverable ones, which results in the robot starting a new move group before the old move group finishes, miscalculating move deltas, etc.

This PR changes the behavior to mask stall errors if the feature flag is set. This means that the hardware controller will run the rest of a move group even if there's a stall, and it will "latch" the value of the `motor_ok` flag from each axis controller.

# Test Plan

Run a protocol with the feature flag set to "disable" stall detection, and forcibly stall a motor during a movement. Check the logs after and make sure that the hardware controller waits for all of the responses to come back, and that it continues to keep doing the protocol steps as expected (with the exception that it stalled and lost position).

Tested on a robot and the change works as expected.


# Changelog

- Don't set the move group completion event from a recoverable error
- Don't clear the `motor_ok` flag if the feature flag to ignore stalls is set


# Review requests


# Risk assessment

Only affects error handling cases that were already kind of not working.
