### PR TITLE
fix(api): handle absent motor status

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -501,7 +501,7 @@ class OT3Controller:
             # homed since a power cycle)
             motor_ok_latch = (
                 (not ff.stall_detection_enabled())
-                and self._motor_status[axis].motor_ok
+                and ((axis in self._motor_status) and self._motor_status[axis].motor_ok)
                 and self._motor_status[axis].encoder_ok
             )
             self._motor_status.update(


### PR DESCRIPTION
We added a latch to implement disabling stall detection that works by latching in the first time the motors respond OK (aka after they home for the first time). But for that, it has to access the motor status; and we do it in the function where we handle motor status; and so the very first response we get, we don't have a motor status to handle, and we crash.

The fix is to treat a missing motor status equivalently to a bad motor status.

Closes RQA-906
