### PR TITLE
build(api,shared-data): replace static versioning with intervals

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -60,12 +60,12 @@ DESCRIPTION = (
 PACKAGES = find_packages(where="src")
 INSTALL_REQUIRES = [
     f"opentrons-shared-data=={VERSION}",
-    "aionotify==0.2.0",
-    "anyio==3.3.0",
-    "jsonschema==3.0.2",
+    "aionotify>=0.2.0,<1",
+    "anyio>=3.3.0,<4",
+    "jsonschema>=3.0.2,<5",
     "numpy>=1.15.1,<2",
-    "pydantic==1.8.2",
-    "pyserial==3.5",
+    "pydantic>=1.8.2,<2",
+    "pyserial>=3.5,<4",
     "typing-extensions>=4.0.0,<5",
     "click>=8.0.0,<9",
     'importlib-metadata >= 1.0 ; python_version < "3.8"',

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -132,9 +132,9 @@ DESCRIPTION = (
 )
 PACKAGES = find_packages(where=".", exclude=["tests"])
 INSTALL_REQUIRES = [
-    "jsonschema==3.0.2",
+    "jsonschema>=3.0.2,<5",
     "typing-extensions>=4.0.0,<5",
-    "pydantic==1.8.2",
+    "pydantic>=1.8.2,<2",
 ]
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Change static dependencies versioning with intervals. This allows opentrons to be compatible with third-party software. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

We are waiting for the OT-2 to arrive and therefore we could not test it on the hardware yet.  On the other hand, test will be run on the CI when creating the pull request.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
- Replace static dependencies versions with intervals 
# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

The dependency jsonschema follows semantic versioning and not breaking changes were introduced in 4.X.X. Hereby we included up until version 5 in `jsonschema>=3.0.2,<5`

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
