### PR TITLE
feat(motor-control): use um/tick/tick for acceleration

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -184,8 +184,8 @@ class AddToMoveGroupRequestPayload(MoveGroupRequestPayload):
 class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
     """Add a linear move request to a message group."""
 
-    acceleration: utils.Int32Field
-    velocity: utils.Int32Field
+    acceleration_um: utils.Int32Field
+    velocity_mm: utils.Int32Field
     request_stop_condition: MoveStopConditionField
 
 
@@ -193,7 +193,7 @@ class AddLinearMoveRequestPayload(AddToMoveGroupRequestPayload):
 class HomeRequestPayload(AddToMoveGroupRequestPayload):
     """Request to home."""
 
-    velocity: utils.Int32Field
+    velocity_mm: utils.Int32Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -282,7 +282,8 @@ class MoveGroupRunner:
                 acceleration_um=Int32Field(
                     int(
                         (
-                            step.acceleration_mm_sec_sq * 1000.0
+                            step.acceleration_mm_sec_sq
+                            * 1000.0
                             / interrupts_per_sec
                             / interrupts_per_sec
                         )

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -265,7 +265,7 @@ class MoveGroupRunner:
                 group_id=UInt8Field(group),
                 seq_id=UInt8Field(seq),
                 duration=UInt32Field(int(step.duration_sec * interrupts_per_sec)),
-                velocity=self._convert_velocity(
+                velocity_mm=self._convert_velocity(
                     step.velocity_mm_sec, interrupts_per_sec
                 ),
             )
@@ -279,17 +279,17 @@ class MoveGroupRunner:
                 group_id=UInt8Field(group),
                 seq_id=UInt8Field(seq),
                 duration=UInt32Field(int(step.duration_sec * interrupts_per_sec)),
-                acceleration=Int32Field(
+                acceleration_um=Int32Field(
                     int(
                         (
-                            step.acceleration_mm_sec_sq
+                            step.acceleration_mm_sec_sq * 1000.0
                             / interrupts_per_sec
                             / interrupts_per_sec
                         )
                         * (2**31)
                     )
                 ),
-                velocity=Int32Field(
+                velocity_mm=Int32Field(
                     int((step.velocity_mm_sec / interrupts_per_sec) * (2**31))
                 ),
             )

--- a/hardware/opentrons_hardware/scripts/update_fws.py
+++ b/hardware/opentrons_hardware/scripts/update_fws.py
@@ -51,12 +51,13 @@ async def run(args: argparse.Namespace) -> None:
     with open(args.dict) as fp:
         update_dict = json.load(fp)
     update_details: Dict[FirmwareTarget, str] = dict()
-    for name, filepath in update_dict.items():
+    for name, filepath in update_dict["subsystems"].items():
         try:
             name = name.replace("-", "_")
             target: FirmwareTarget = (
                 NodeId[name] if name in NodeId.__members__ else USBTarget[name]
             )
+            print(target)
             update_details[target] = filepath
         except KeyError:
             logger.warning(f"Invalid target {name}")

--- a/hardware/opentrons_hardware/scripts/update_fws.py
+++ b/hardware/opentrons_hardware/scripts/update_fws.py
@@ -51,13 +51,12 @@ async def run(args: argparse.Namespace) -> None:
     with open(args.dict) as fp:
         update_dict = json.load(fp)
     update_details: Dict[FirmwareTarget, str] = dict()
-    for name, filepath in update_dict["subsystems"].items():
+    for name, filepath in update_dict.items():
         try:
             name = name.replace("-", "_")
             target: FirmwareTarget = (
                 NodeId[name] if name in NodeId.__members__ else USBTarget[name]
             )
-            print(target)
             update_details[target] = filepath
         except KeyError:
             logger.warning(f"Invalid target {name}")

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -59,8 +59,8 @@ async def test_add_moves(
                 seq_id=UInt8Field(i),
                 duration=UInt32Field(duration),
                 request_stop_condition=MoveStopConditionField(0),
-                acceleration=Int32Field(0),
-                velocity=Int32Field(0),
+                acceleration_um=Int32Field(0),
+                velocity_mm=Int32Field(0),
             )
         )
         for i, duration in enumerate(durations)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -83,6 +83,7 @@ def calc_acceleration(step: MoveGroupSingleAxisStep) -> int:
     """Calculate acceleration."""
     return int(
         step.acceleration_mm_sec_sq
+        * 1000
         / interrupts_per_sec
         / interrupts_per_sec
         * (2**31)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -289,7 +289,7 @@ async def test_home(
             payload=HomeRequestPayload(
                 group_id=UInt8Field(0),
                 seq_id=UInt8Field(0),
-                velocity=Int32Field(calc_velocity(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -311,8 +311,8 @@ async def test_single_send_setup_commands(
                 group_id=UInt8Field(0),
                 seq_id=UInt8Field(0),
                 request_stop_condition=MoveStopConditionField(0),
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -359,8 +359,8 @@ async def test_send_ignore_stalls_requests(
                 group_id=UInt8Field(0),
                 seq_id=UInt8Field(0),
                 request_stop_condition=request_stop_condition,
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -384,8 +384,8 @@ async def test_multi_send_setup_commands(
                 group_id=UInt8Field(0),
                 seq_id=UInt8Field(0),
                 request_stop_condition=MoveStopConditionField(0),
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -401,8 +401,8 @@ async def test_multi_send_setup_commands(
                 group_id=UInt8Field(1),
                 seq_id=UInt8Field(0),
                 request_stop_condition=MoveStopConditionField(0),
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -417,8 +417,8 @@ async def test_multi_send_setup_commands(
                 group_id=UInt8Field(1),
                 seq_id=UInt8Field(0),
                 request_stop_condition=MoveStopConditionField(0),
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -434,8 +434,8 @@ async def test_multi_send_setup_commands(
                 group_id=UInt8Field(2),
                 seq_id=UInt8Field(0),
                 request_stop_condition=MoveStopConditionField(0),
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),
@@ -450,8 +450,8 @@ async def test_multi_send_setup_commands(
                 group_id=UInt8Field(2),
                 seq_id=UInt8Field(1),
                 request_stop_condition=MoveStopConditionField(0),
-                velocity=Int32Field(calc_velocity(step)),
-                acceleration=Int32Field(calc_acceleration(step)),
+                velocity_mm=Int32Field(calc_velocity(step)),
+                acceleration_um=Int32Field(calc_acceleration(step)),
                 duration=UInt32Field(calc_duration(step)),
             )
         ),


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We want to increase the resolution of the stepper motor acceleration so we can work with much slower acceleration. So instead of passing values as mm/tick/tick to the firmware, we're using um/tick/tick so we don't lose precision for small values.

Firmware-side changes https://github.com/Opentrons/ot3-firmware/pull/678
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
