### PR TITLE
feat(api): Monitor for overpressure on pipetting commands

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -577,6 +577,16 @@ def _migrate25to26(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate26to27(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 27 of the feature flags file.
+
+    - Adds the disableOverpressureDetection config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["disableOverpressureDetection"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -604,6 +614,7 @@ _MIGRATIONS = [
     _migrate23to24,
     _migrate24to25,
     _migrate25to26,
+    _migrate26to27,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -41,6 +41,10 @@ def stall_detection_enabled() -> bool:
     return not advs.get_setting_with_env_overload("disableStallDetection")
 
 
+def overpressure_detection_enabled() -> bool:
+    return not advs.get_setting_with_env_overload("disableOverpressureDetection")
+
+
 def status_bar_enabled() -> bool:
     """Whether the status bar is enabled."""
     return not advs.get_setting_with_env_overload("disableStatusBar")

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -954,23 +954,19 @@ class OT3Controller:
                 try:
                     yield
                 finally:
-                    pass
 
-            def _pop_queue() -> Optional[ErrorCode]:
-                try:
-                    return errors.get_nowait()
-                except asyncio.QueueEmpty:
-                    return None
+                    def _pop_queue() -> Optional[ErrorCode]:
+                        try:
+                            return errors.get_nowait()
+                        except asyncio.QueueEmpty:
+                            return None
 
-            if _pop_queue():
-                raise OverPressureDetected(
-                    f"The pressure sensor on the {mount} mount has exceeded operational limits."
-                )
+                    if _pop_queue():
+                        raise OverPressureDetected(
+                            f"The pressure sensor on the {mount} mount has exceeded operational limits."
+                        )
         else:
-            try:
-                yield
-            finally:
-                pass
+            yield
 
     async def liquid_probe(
         self,

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -268,7 +268,9 @@ class OT3Simulator:
         return axis_convert(self._encoder_position, 0.0)
 
     @asynccontextmanager
-    async def monitor_overpressure(self, mount: OT3Mount, sensor_id: SensorId = SensorId.S0) -> AsyncIterator[None]:
+    async def monitor_overpressure(
+        self, mount: OT3Mount, sensor_id: SensorId = SensorId.S0
+    ) -> AsyncIterator[None]:
         yield
 
     @ensure_yield

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -267,6 +267,10 @@ class OT3Simulator:
         """Get the encoder current position."""
         return axis_convert(self._encoder_position, 0.0)
 
+    @asynccontextmanager
+    async def monitor_overpressure(self, mount: OT3Mount, sensor_id: SensorId = SensorId.S0) -> AsyncIterator[None]:
+        yield
+
     @ensure_yield
     async def liquid_probe(
         self,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -32,7 +32,7 @@ from opentrons_hardware.hardware_control.motion_planning import (
     Move,
     CoordinateValue,
 )
-from opentrons_hardware.hardware_control.tool_sensors import ProbeTarget
+from opentrons_hardware.hardware_control.tool_sensors import InstrumentProbeTarget
 from opentrons_hardware.hardware_control.motion_planning.move_utils import (
     unit_vector_multiplication,
 )
@@ -401,14 +401,14 @@ def axis_convert(
     return ret
 
 
-_sensor_node_lookup: Dict[OT3Mount, ProbeTarget] = {
+_sensor_node_lookup: Dict[OT3Mount, InstrumentProbeTarget] = {
     OT3Mount.LEFT: NodeId.pipette_left,
     OT3Mount.RIGHT: NodeId.pipette_right,
     OT3Mount.GRIPPER: NodeId.gripper,
 }
 
 
-def sensor_node_for_mount(mount: OT3Mount) -> ProbeTarget:
+def sensor_node_for_mount(mount: OT3Mount) -> InstrumentProbeTarget:
     return _sensor_node_lookup[mount]
 
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -32,7 +32,10 @@ from opentrons_hardware.hardware_control.motion_planning import (
     Move,
     CoordinateValue,
 )
-from opentrons_hardware.hardware_control.tool_sensors import InstrumentProbeTarget
+from opentrons_hardware.hardware_control.tool_sensors import (
+    InstrumentProbeTarget,
+    PipetteProbeTarget,
+)
 from opentrons_hardware.hardware_control.motion_planning.move_utils import (
     unit_vector_multiplication,
 )
@@ -407,9 +410,18 @@ _sensor_node_lookup: Dict[OT3Mount, InstrumentProbeTarget] = {
     OT3Mount.GRIPPER: NodeId.gripper,
 }
 
+_sensor_node_lookup_pipettes_only: Dict[OT3Mount, PipetteProbeTarget] = {
+    OT3Mount.LEFT: NodeId.pipette_left,
+    OT3Mount.RIGHT: NodeId.pipette_right,
+}
+
 
 def sensor_node_for_mount(mount: OT3Mount) -> InstrumentProbeTarget:
     return _sensor_node_lookup[mount]
+
+
+def sensor_node_for_pipette(mount: OT3Mount) -> PipetteProbeTarget:
+    return _sensor_node_lookup_pipettes_only[mount]
 
 
 _instr_sensor_id_lookup: Dict[InstrumentProbeType, SensorId] = {

--- a/api/src/opentrons/hardware_control/errors.py
+++ b/api/src/opentrons/hardware_control/errors.py
@@ -61,6 +61,12 @@ class FirmwareUpdateFailed(RuntimeError):
     pass
 
 
+class OverPressureDetected(RuntimeError):
+    """An error raised when the pressure sensor max value is exceeded."""
+
+    pass
+
+
 class InvalidPipetteName(KeyError):
     """Raised for an invalid pipette."""
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1476,16 +1476,17 @@ class OT3API(
             )
             backlash_pos = target_pos.copy()
             backlash_pos[pip_ax] -= instrument.backlash_distance
-            await self._move(
-                backlash_pos,
-                speed=aspirate_spec.speed,
-                home_flagged_axes=False,
-            )
-            await self._move(
-                target_pos,
-                speed=aspirate_spec.speed,
-                home_flagged_axes=False,
-            )
+            async with self._backend.monitor_overpressure(mount):
+                await self._move(
+                    backlash_pos,
+                    speed=aspirate_spec.speed,
+                    home_flagged_axes=False,
+                )
+                await self._move(
+                    target_pos,
+                    speed=aspirate_spec.speed,
+                    home_flagged_axes=False,
+                )
         except Exception:
             self._log.exception("Aspirate failed")
             aspirate_spec.instr.set_current_volume(0)
@@ -1517,11 +1518,12 @@ class OT3API(
             await self._backend.set_active_current(
                 {OT3Axis.from_axis(dispense_spec.axis): dispense_spec.current}
             )
-            await self._move(
-                target_pos,
-                speed=dispense_spec.speed,
-                home_flagged_axes=False,
-            )
+            async with self._backend.monitor_overpressure(mount):
+                await self._move(
+                    target_pos,
+                    speed=dispense_spec.speed,
+                    home_flagged_axes=False,
+                )
         except Exception:
             self._log.exception("Dispense failed")
             dispense_spec.instr.set_current_volume(0)
@@ -1682,6 +1684,7 @@ class OT3API(
         """Drop tip at the current location."""
         realmount = OT3Mount.from_mount(mount)
         spec, _remove = self._pipette_handler.plan_check_drop_tip(realmount, home_after)
+
         for move in spec.drop_moves:
             await self._backend.set_active_current(
                 {
@@ -1709,11 +1712,12 @@ class OT3API(
                 target_pos = target_position_from_plunger(
                     realmount, move.target_position, self._current_position
                 )
-                await self._move(
-                    target_pos,
-                    speed=move.speed,
-                    home_flagged_axes=False,
-                )
+                async with self._backend.monitor_overpressure(mount):
+                    await self._move(
+                        target_pos,
+                        speed=move.speed,
+                        home_flagged_axes=False,
+                    )
         if move.home_after:
             await self._home([OT3Axis.from_axis(ax) for ax in move.home_axes])
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -695,7 +695,8 @@ class OT3API(
         """
 
         checked_mount = OT3Mount.from_mount(mount)
-        await self.home([OT3Axis.of_main_tool_actuator(checked_mount)])
+        async with self._backend.monitor_overpressure(mount):
+            await self.home([OT3Axis.of_main_tool_actuator(checked_mount)])
         instr = self._pipette_handler.hardware_instruments[checked_mount]
         if instr:
             self._log.info("Attempting to move the plunger to bottom.")
@@ -1567,11 +1568,12 @@ class OT3API(
         )
 
         try:
-            await self._move(
-                target_pos,
-                speed=blowout_spec.speed,
-                home_flagged_axes=False,
-            )
+            async with self._backend.monitor_overpressure(realmount):
+                await self._move(
+                    target_pos,
+                    speed=blowout_spec.speed,
+                    home_flagged_axes=False,
+                )
         except Exception:
             self._log.exception("Blow out failed")
             raise

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 26
+    return 27
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -26,6 +26,7 @@ def default_file_settings() -> Dict[str, Any]:
         "rearPanelIntegration": True,
         "disableStallDetection": None,
         "disableStatusBar": None,
+        "disableOverpressureDetection": None,
     }
 
 
@@ -320,6 +321,18 @@ def v26_config(v25_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v27_config(v26_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v26_config.copy()
+    r.update(
+        {
+            "_version": 27,
+            "disableOverpressureDetection": None,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -351,6 +364,7 @@ def v26_config(v25_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v24_config"),
         lazy_fixture("v25_config"),
         lazy_fixture("v26_config"),
+        lazy_fixture("v27_config"),
     ],
 )
 def old_settings(request: pytest.FixtureRequest) -> Dict[str, Any]:

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -989,7 +989,10 @@ async def test_update_required_flag_disabled(
         await controller.set_active_current({OT3Axis.X: 2})
 
 
-async def test_monitor_pressure(controller: OT3Controller, mock_messenger: CanMessenger, mock_move_group_run, mock_present_devices) -> None:
+async def test_monitor_pressure(
+    controller: OT3Controller,
+    mock_move_group_run: mock.AsyncMock,
+) -> None:
     mount = OT3Mount.LEFT
     mock_move_group_run.side_effect = move_group_run_side_effect(
         controller, [OT3Axis.P_L]

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -991,10 +991,9 @@ async def test_update_required_flag_disabled(
 
 async def test_monitor_pressure(controller: OT3Controller, mock_messenger: CanMessenger, mock_move_group_run, mock_present_devices) -> None:
     mount = OT3Mount.LEFT
-    mock_move_group_run.side_effect = move_group_run_side_effect(controller, [OT3Axis.P_L])
+    mock_move_group_run.side_effect = move_group_run_side_effect(
+        controller, [OT3Axis.P_L]
+    )
     async with controller.monitor_overpressure(mount):
         await controller.home([OT3Axis.P_L], GantryLoad.LOW_THROUGHPUT)
-        mock_messenger.ensure_send.assert_called_once()
-        # mock_messenger.reset_mock()
-    # mock_messenger.ensure_send.assert_called_once()
     mock_move_group_run.assert_called_once()

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -992,6 +992,7 @@ async def test_update_required_flag_disabled(
 async def test_monitor_pressure(
     controller: OT3Controller,
     mock_move_group_run: mock.AsyncMock,
+    mock_present_devices: None,
 ) -> None:
     mount = OT3Mount.LEFT
     mock_move_group_run.side_effect = move_group_run_side_effect(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -987,3 +987,14 @@ async def test_update_required_flag_disabled(
         fake_src,
     ):
         await controller.set_active_current({OT3Axis.X: 2})
+
+
+async def test_monitor_pressure(controller: OT3Controller, mock_messenger: CanMessenger, mock_move_group_run, mock_present_devices) -> None:
+    mount = OT3Mount.LEFT
+    mock_move_group_run.side_effect = move_group_run_side_effect(controller, [OT3Axis.P_L])
+    async with controller.monitor_overpressure(mount):
+        await controller.home([OT3Axis.P_L], GantryLoad.LOW_THROUGHPUT)
+        mock_messenger.ensure_send.assert_called_once()
+        # mock_messenger.reset_mock()
+    # mock_messenger.ensure_send.assert_called_once()
+    mock_move_group_run.assert_called_once()

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -226,6 +226,7 @@ class ErrorCode(int, Enum):
     estop_released = 0x0A
     motor_busy = 0x0B
     stop_requested = 0x0C
+    over_pressure = 0x0D
 
 
 @unique
@@ -292,6 +293,7 @@ class SensorOutputBinding(int, Enum):
     none = 0x0
     sync = 0x01
     report = 0x02
+    max_threshold_sync = 0x04
 
 
 @unique

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -34,6 +34,9 @@ LOG = getLogger(__name__)
 PipetteProbeTarget = Literal[NodeId.pipette_left, NodeId.pipette_right]
 InstrumentProbeTarget = Union[PipetteProbeTarget, Literal[NodeId.gripper]]
 
+# FIXME we should organize all of these functions to use the sensor drivers.
+# FIXME we should restrict some of these functions by instrument type.
+
 
 def _build_pass_step(
     movers: List[NodeId],
@@ -126,10 +129,15 @@ async def liquid_probe(
     return positions
 
 
-async def check_overpressure(messenger: CanMessenger, tool: PipetteProbeTarget, sensor_id: SensorId = SensorId.S0):
+async def check_overpressure(
+    messenger: CanMessenger, tool: PipetteProbeTarget, sensor_id: SensorId = SensorId.S0
+):
     sensor_scheduler = SensorScheduler()
     sensor_info = SensorInformation(SensorType.pressure, sensor_id, tool)
-    return partial(sensor_scheduler.monitor_exceed_max_threshold, sensor_info, messenger)
+    return partial(
+        sensor_scheduler.monitor_exceed_max_threshold, sensor_info, messenger
+    )
+
 
 async def capacitive_probe(
     messenger: CanMessenger,
@@ -202,5 +210,3 @@ async def capacitive_pass(
                 break
 
     return list(_drain())
-
-

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -35,7 +35,8 @@ from opentrons_hardware.hardware_control.tool_sensors import (
     capacitive_probe,
     capacitive_pass,
     liquid_probe,
-    ProbeTarget,
+    InstrumentProbeTarget,
+    PipetteProbeTarget,
 )
 from opentrons_hardware.firmware_bindings.constants import (
     NodeId,
@@ -116,7 +117,7 @@ async def test_liquid_probe(
     mock_bind_output: AsyncMock,
     message_send_loopback: CanLoopback,
     mock_sensor_threshold: AsyncMock,
-    target_node: ProbeTarget,
+    target_node: PipetteProbeTarget,
     motor_node: NodeId,
     threshold_pascals: float,
 ) -> None:
@@ -222,7 +223,7 @@ async def test_capacitive_probe(
     message_send_loopback: CanLoopback,
     mock_sensor_threshold: AsyncMock,
     mock_bind_sync: AsyncMock,
-    target_node: ProbeTarget,
+    target_node: InstrumentProbeTarget,
     motor_node: NodeId,
     caplog: Any,
     distance: float,
@@ -302,7 +303,7 @@ async def test_capacitive_sweep(
     message_send_loopback: CanLoopback,
     mock_sensor_threshold: AsyncMock,
     mock_bind_sync: AsyncMock,
-    target_node: ProbeTarget,
+    target_node: InstrumentProbeTarget,
     motor_node: NodeId,
     distance: float,
     speed: float,

--- a/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
+++ b/hardware/tests/opentrons_hardware/sensors/test_scheduler.py
@@ -9,6 +9,8 @@ from opentrons_hardware.firmware_bindings.constants import (
     SensorId,
     SensorType,
     SensorOutputBinding,
+    ErrorSeverity,
+    ErrorCode,
 )
 from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
@@ -26,10 +28,12 @@ from opentrons_hardware.firmware_bindings.messages.fields import (
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     ReadFromSensorResponse,
     BindSensorOutputRequest,
+    ErrorMessage,
 )
 from opentrons_hardware.firmware_bindings.messages.payloads import (
     BindSensorOutputRequestPayload,
     ReadFromSensorResponsePayload,
+    ErrorMessagePayload,
 )
 
 from tests.conftest import MockCanMessageNotifier
@@ -101,3 +105,71 @@ async def test_capture_output(
 
     for index, value in enumerate(_drain()):
         assert value == index
+
+
+async def test_capture_error_max_threshold(
+    mock_messenger: mock.AsyncMock, can_message_notifier: MockCanMessageNotifier
+) -> None:
+    subject = scheduler.SensorScheduler()
+    stim_message = BindSensorOutputRequest(
+        payload=BindSensorOutputRequestPayload(
+            sensor=SensorTypeField(SensorType.pressure),
+            sensor_id=SensorIdField(SensorId.S0),
+            binding=SensorOutputBindingField(
+                SensorOutputBinding.max_threshold_sync.value
+            ),
+        )
+    )
+    reset_message = BindSensorOutputRequest(
+        payload=BindSensorOutputRequestPayload(
+            sensor=SensorTypeField(SensorType.pressure),
+            sensor_id=SensorIdField(SensorId.S0),
+            binding=SensorOutputBindingField(SensorOutputBinding.none.value),
+        )
+    )
+
+    async with subject.monitor_exceed_max_threshold(
+        sensor_types.SensorInformation(
+            sensor_type=SensorType.pressure,
+            sensor_id=SensorId.S0,
+            node_id=NodeId.pipette_left,
+        ),
+        mock_messenger,
+    ) as output_queue:
+        mock_messenger.ensure_send.assert_called_with(
+            node_id=NodeId.pipette_left,
+            message=stim_message,
+            expected_nodes=[NodeId.pipette_left],
+        )
+        can_message_notifier.notify(
+            ErrorMessage(
+                payload=ErrorMessagePayload(
+                    severity=ErrorSeverity.unrecoverable,
+                    error_code=ErrorCode.over_pressure,
+                )
+            ),
+            ArbitrationId(
+                parts=ArbitrationIdParts(
+                    message_id=ErrorMessage.message_id,
+                    node_id=NodeId.host,
+                    originating_node_id=NodeId.pipette_left,
+                    function_code=0,
+                )
+            ),
+        )
+    mock_messenger.ensure_send.assert_called_with(
+        node_id=NodeId.pipette_left,
+        message=reset_message,
+        expected_nodes=[NodeId.pipette_left],
+    )
+
+    def _drain() -> Iterator[float]:
+        while True:
+            try:
+                yield output_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+    for value in _drain():
+        assert value.severity == ErrorSeverity.unrecoverable
+        assert value.error_code == ErrorCode.over_pressure


### PR DESCRIPTION
# Overview

Although a low chance, we should monitor whether the pressure sensor ever exceeds its max rated value.

# TODO

- [x] Finish tests for `tool_sensors`
- [x] Finish tests for `ot3controller`
- [x] Add a check in the blow out function

# Test Plan

- [x] Execute a protocol with a few pipetting functions (i.e. aspirate/dispense/blowout/drop tip) and verify via the serial log or CAN logs that a bind request for max threshold is sent. To ease testing, you can also tell the request to log so you can see the pressure values being print to screen.
- [x] Using monitor sensors, determine a sufficient occlusion material (maybe a piece of cloth?) to get it to exceed 3.9kpa. This should cause the firmware to throw and error and stop all movement.

# Changelog

- Added tests at all levels from scheduler, tool_sensors and up to ot3controller
- Added a context manager that will throw an error if it receives an error message from firmware
- This currently only monitors 1 pressure sensor for a given pipette, we should figure out a nice way to monitor both sensors and can maybe tackle it as part of the partial tip pick up project.

# Review requests

Not a huge fan of the partial function workaround, but I wanted the ot3controller to have an actual context manager so we could nest specific moves inside the pipetting functions without pushing it down to `tool_sensors.py`. If anyone has better suggestions, I am definitely open.

Also please let me know if I missed any high risk pipetting functions!

# Risk assessment

Ideally low, but this could have unforeseen consequences regarding anything utilizing the i2c bus (for example the eeprom). We should closely monitor in the coming weeks.