### PR TITLE
fix(api): set the module firmware dir to /usr/lib/firmware

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -18,7 +18,7 @@ from opentrons.config import (
     name,
     robot_configs,
     IS_ROBOT,
-    ROBOT_FIRMWARE_DIR,
+    get_opentrons_path,
 )
 from opentrons.util import logging_config
 from opentrons.protocols.types import ApiDeprecationError
@@ -62,7 +62,8 @@ def _find_smoothie_file() -> Tuple[Path, str]:
     # Search for smoothie files in /usr/lib/firmware first then fall back to
     # value packed in wheel
     if IS_ROBOT:
-        resources.extend(ROBOT_FIRMWARE_DIR.iterdir())  # type: ignore
+        firmware_binaries_dir = get_opentrons_path("firmware_binaries_dir")
+        resources.extend(firmware_binaries_dir.iterdir())
 
     resources_path = Path(HERE) / "resources"
     resources.extend(resources_path.iterdir())

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -59,9 +59,6 @@ class SystemArchitecture(Enum):
     YOCTO = auto()
 
 
-ROBOT_FIRMWARE_DIR: Optional[Path] = None
-#: The path to firmware files for modules
-
 ARCHITECTURE: SystemArchitecture = SystemArchitecture.HOST
 #: The system architecture running
 
@@ -79,7 +76,6 @@ if IS_ROBOT:
     if "OT_SYSTEM_VERSION" in os.environ:
         OT_SYSTEM_VERSION = os.environ["OT_SYSTEM_VERSION"]
         ARCHITECTURE = SystemArchitecture.YOCTO
-        ROBOT_FIRMWARE_DIR = Path("/lib/firmware/")
     else:
         try:
             with open("/etc/VERSION.json") as vj:
@@ -88,7 +84,6 @@ if IS_ROBOT:
             ARCHITECTURE = SystemArchitecture.BUILDROOT
         except Exception:
             log.exception("Could not find version file in /etc/VERSION.json")
-        ROBOT_FIRMWARE_DIR = Path("/usr/lib/firmware/")
     JUPYTER_NOTEBOOK_ROOT_DIR = Path("/var/lib/jupyter/notebooks/")
     JUPYTER_NOTEBOOK_LABWARE_DIR = JUPYTER_NOTEBOOK_ROOT_DIR / "labware"
 
@@ -284,6 +279,13 @@ CONFIG_ELEMENTS = (
         Path("robot") / "modules",
         ConfigElementType.DIR,
         "The dir where module calibration is stored",
+    ),
+    ConfigElement(
+        "firmware_binaries_dir",
+        "Firmware Binaries Directory",
+        Path("/usr/lib/firmware"),
+        ConfigElementType.DIR,
+        "The dir where the firmware binaries for subsystems and modules are stored.",
     ),
 )
 #: The available configuration file elements to modify. All of these can be

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -5,7 +5,7 @@ import re
 from pkg_resources import parse_version
 from typing import ClassVar, Mapping, Optional, cast, TypeVar
 
-from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
+from opentrons.config import IS_ROBOT, get_opentrons_path
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 from ..execution_manager import ExecutionManager
@@ -76,7 +76,8 @@ class AbstractModule(abc.ABC):
         file_prefix = self.firmware_prefix()
 
         MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin)$")
-        for fw_resource in ROBOT_FIRMWARE_DIR.iterdir():  # type: ignore
+        firmware_binaries_dir = get_opentrons_path("firmware_binaries_dir")
+        for fw_resource in firmware_binaries_dir.iterdir():
             matches = MODULE_FW_RE.search(fw_resource.name)
             if matches:
                 return BundledFirmware(version=matches.group(1), path=fw_resource)


### PR DESCRIPTION
# Overview

We are adding module binaries to the flex filesystem in [this](https://github.com/Opentrons/oe-core/pull/80) oe-core pull request. The binaries are installed in `/usr/lib/firmware` along with the rest of the firmware, so let's move the module binary dir to `/usr/lib/firmware` for consistency.

# Test Plan

- [x] Make sure that the robot server is able to find the module firmware binaries in `/usr/lib/firmware`
- [x] Make sure that the `hasAvailableUpdate`  flag in the `/modules` endpoint response changes if the binary firmware version is greater than whats running on the module.
- [x] Make sure that there is no functionality change on the OT2 

# Changelog

- Added `firmware_binaries_dir` ConfigElement that points to `/usr/lib/firmware`
- Removed `ROBOT_FIRMWARE_DIR` constant as we are now using the config index

# Review requests

# Risk assessment

Low, flex only work