### PR TITLE
feat(hardware-testing): Dispense liquid-class settings are configurable per test volume

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -18,106 +18,304 @@ _default_retract_mm = 3.0
 _dispense_defaults = {
     1: {
         50: {  # P50
-            50: DispenseSettings(  # T50
-                flow_rate=57,
-                delay=0.5,
-                submerge=_default_submerge_mm_t50,
-                retract=_default_retract_mm,
-                acceleration=40000,  # this is a fake number
-                deceleration=40000,  # this is a fake number
-            ),
+            50: {  # T50
+                1: DispenseSettings(  # 1uL
+                    flow_rate=57,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=40000,  # this is a fake number
+                    deceleration=40000,  # this is a fake number
+                ),
+                10: DispenseSettings(  # 10uL
+                    flow_rate=57,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=40000,  # this is a fake number
+                    deceleration=40000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=57,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=40000,  # this is a fake number
+                    deceleration=40000,  # this is a fake number
+                ),
+            },
         },
         1000: {  # P1000
-            50: DispenseSettings(  # T50
-                flow_rate=160,
-                delay=0.5,
-                submerge=_default_submerge_mm_t50,
-                retract=_default_retract_mm,
-                acceleration=10000,  # this is a fake number
-                deceleration=20000,  # this is a fake number
-            ),
-            200: DispenseSettings(  # T200
-                flow_rate=160,
-                delay=0.5,
-                submerge=_default_submerge_mm,
-                retract=_default_retract_mm,
-                acceleration=10000,  # this is a fake number
-                deceleration=20000,  # this is a fake number
-            ),
-            1000: DispenseSettings(  # T1000
-                flow_rate=160,
-                delay=0.5,
-                submerge=_default_submerge_mm,
-                retract=_default_retract_mm,
-                acceleration=10000,
-                deceleration=20000,
-            ),
+            50: {  # T50
+                5: DispenseSettings(  # 5uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                10: DispenseSettings(  # 10uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 10uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+            },
+            200: {  # T200
+                5: DispenseSettings(  # 5uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                200: DispenseSettings(  # 200uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+            },
+            1000: {  # T1000
+                10: DispenseSettings(  # 10uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+                100: DispenseSettings(  # 100uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+                1000: DispenseSettings(  # 1000uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+            },
         },
     },
     8: {
         50: {  # P50
-            50: DispenseSettings(  # T50
-                flow_rate=57,
-                delay=0.5,
-                submerge=_default_submerge_mm_t50,
-                retract=_default_retract_mm,
-                acceleration=40000,  # this is a fake number
-                deceleration=40000,  # this is a fake number
-            ),
+            50: {  # T50
+                1: DispenseSettings(  # 1uL
+                    flow_rate=57,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=40000,  # this is a fake number
+                    deceleration=40000,  # this is a fake number
+                ),
+                5: DispenseSettings(  # 5uL
+                    flow_rate=57,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=40000,  # this is a fake number
+                    deceleration=40000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=57,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=40000,  # this is a fake number
+                    deceleration=40000,  # this is a fake number
+                ),
+            },
         },
         1000: {  # P1000
-            50: DispenseSettings(  # T50
-                flow_rate=160,
-                delay=0.5,
-                submerge=_default_submerge_mm_t50,
-                retract=_default_retract_mm,
-                acceleration=10000,  # this is a fake number
-                deceleration=20000,  # this is a fake number
-            ),
-            200: DispenseSettings(  # T200
-                flow_rate=160,
-                delay=0.5,
-                submerge=_default_submerge_mm,
-                retract=_default_retract_mm,
-                acceleration=10000,  # this is a fake number
-                deceleration=20000,  # this is a fake number
-            ),
-            1000: DispenseSettings(  # T1000
-                flow_rate=160,
-                delay=0.5,
-                submerge=_default_submerge_mm,
-                retract=_default_retract_mm,
-                acceleration=10000,
-                deceleration=20000,
-            ),
+            50: {  # T50
+                5: DispenseSettings(  # 5uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                10: DispenseSettings(  # 10uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+            },
+            200: {  # T200
+                5: DispenseSettings(  # 5uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                200: DispenseSettings(  # 200uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+            },
+            1000: {  # T1000
+                10: DispenseSettings(  # 10uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+                100: DispenseSettings(  # 100uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+                1000: DispenseSettings(  # 1000uL
+                    flow_rate=160,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+            },
         },
     },
     96: {
         1000: {  # P1000
-            50: DispenseSettings(  # T50
-                flow_rate=80,  # 160 ul/sec ==  10 mm/sec
-                delay=0.5,
-                submerge=_default_submerge_mm_t50,
-                retract=_default_retract_mm,
-                acceleration=10000,  # this is a fake number
-                deceleration=20000,  # this is a fake number
-            ),
-            200: DispenseSettings(  # T200
-                flow_rate=80,
-                delay=0.5,
-                submerge=_default_submerge_mm,
-                retract=_default_retract_mm,
-                acceleration=10000,  # this is a fake number
-                deceleration=20000,  # this is a fake number
-            ),
-            1000: DispenseSettings(  # T1000
-                flow_rate=80,
-                delay=0.5,
-                submerge=_default_submerge_mm,
-                retract=_default_retract_mm,
-                acceleration=10000,
-                deceleration=20000,
-            ),
+            50: {  # T50
+                5: DispenseSettings(  # 5uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                10: DispenseSettings(  # 10uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm_t50,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+            },
+            200: {  # T200
+                5: DispenseSettings(  # 5uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                50: DispenseSettings(  # 50uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+                200: DispenseSettings(  # 200uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,  # this is a fake number
+                    deceleration=20000,  # this is a fake number
+                ),
+            },
+            1000: {  # T1000
+                10: DispenseSettings(  # 10uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+                100: DispenseSettings(  # 100uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+                1000: DispenseSettings(  # 1000uL
+                    flow_rate=80,
+                    delay=0.5,
+                    submerge=_default_submerge_mm,
+                    retract=_default_retract_mm,
+                    acceleration=10000,
+                    deceleration=20000,
+                ),
+            },
         },
     },
 }
@@ -499,7 +697,7 @@ def get_liquid_class(
 ) -> LiquidClassSettings:
     """Get liquid class."""
     aspirate_cls_per_volume = _aspirate_defaults[channels][pipette][tip]
-    dispense_cls = _dispense_defaults[channels][pipette][tip]
+    dispense_cls_per_volume = _dispense_defaults[channels][pipette][tip]
     defined_volumes = list(aspirate_cls_per_volume.keys())
     defined_volumes.sort()
     assert len(defined_volumes) == 3
@@ -507,7 +705,7 @@ def get_liquid_class(
     def _build_liquid_class(vol: int) -> LiquidClassSettings:
         return LiquidClassSettings(
             aspirate=aspirate_cls_per_volume[vol],
-            dispense=dispense_cls,
+            dispense=dispense_cls_per_volume[vol],
         )
 
     def _get_interp_liq_class(lower_ul: int, upper_ul: int) -> LiquidClassSettings:

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -330,7 +330,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.5,
+                        leading_air_gap=2,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -340,7 +340,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=2.5,
+                        leading_air_gap=2,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -350,7 +350,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=2.5,
+                        leading_air_gap=2,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -364,7 +364,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -374,7 +374,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -384,7 +384,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -396,7 +396,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=5,
                         trailing_air_gap=5,
                     ),
                 ),
@@ -406,7 +406,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=5,
                         trailing_air_gap=3.5,
                     ),
                 ),
@@ -416,7 +416,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=5,
                         trailing_air_gap=2,
                     ),
                 ),
@@ -428,7 +428,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -438,7 +438,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -448,7 +448,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -464,7 +464,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=1.5,
+                        leading_air_gap=2,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -474,7 +474,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=2.5,
+                        leading_air_gap=2,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -484,7 +484,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=2.5,
+                        leading_air_gap=2,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -498,7 +498,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -508,7 +508,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -518,7 +518,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -530,7 +530,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=5,
                         trailing_air_gap=5,
                     ),
                 ),
@@ -540,7 +540,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=5,
                         trailing_air_gap=3.5,
                     ),
                 ),
@@ -550,7 +550,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=5,
                         trailing_air_gap=2,
                     ),
                 ),
@@ -562,7 +562,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -572,7 +572,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -582,7 +582,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -608,7 +608,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -618,7 +618,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm_t50,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=0.1,
                     ),
                 ),
@@ -630,7 +630,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=2,
                     ),
                 ),
@@ -640,7 +640,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=3.2,
+                        leading_air_gap=5,
                         trailing_air_gap=3.5,
                     ),
                 ),
@@ -650,7 +650,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=2,
+                        leading_air_gap=5,
                         trailing_air_gap=2,
                     ),
                 ),
@@ -662,7 +662,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=12,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -672,7 +672,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),
@@ -682,7 +682,7 @@ _aspirate_defaults = {
                     submerge=_default_submerge_mm,
                     retract=_default_retract_mm,
                     air_gap=AirGapSettings(
-                        leading_air_gap=16,
+                        leading_air_gap=20,
                         trailing_air_gap=10,
                     ),
                 ),

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -137,7 +137,7 @@ _dispense_defaults = {
                     acceleration=40000,  # this is a fake number
                     deceleration=40000,  # this is a fake number
                 ),
-                5: DispenseSettings(  # 5uL
+                10: DispenseSettings(  # 5uL
                     flow_rate=57,
                     delay=0.5,
                     submerge=_default_submerge_mm_t50,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR expands the dispense liquid-class configurations dictionary so that dispense settings can be set per test volume. This allows, for example, the dispense flow-rate to be different at 5uL vs 50uL.

Also updates all pipette models' leading-air-gap to the latest/greatest from SZ testing.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
