### PR TITLE
fix(hardware): increase move group timeout

### DIFF
--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -795,7 +795,7 @@ async def test_tip_action_move_runner_fail_receives_one_response(
         (
             "opentrons_hardware.hardware_control.move_group_runner",
             30,
-            "Move set 0 timed out, expected duration 1.1",
+            "Move set 0 timed out of max duration 2.0. Expected time: 1.1",
         ),
         (
             "opentrons_hardware.hardware_control.move_group_runner",


### PR DESCRIPTION
 
# Overview

We've had at least a few crashes due to move group timeouts because the hardware controller caches the motor positions based on the _last_ move group stage completion message from each axis. Therefore, if an axis only sends a completion for the 1st or 2nd stage out of 3, the hardware controller calculates the _next_ move with the wrong starting position (and often smacks into something).

This PR takes the easy way out by bumping up the timeout by a bit. It still tracks if the move group takes longer than the _original_ timeout (1.1x move group length) to help in debugging when/why this happens, but hopefully this change will reduce the number of legitimate crashes in the near term.

# Test Plan

Tested on a robot by uploading changes but with the "expected" time using a 0.8x multiplier so every move should time out. Confirmed that all successful movements would log the time it took vs the "expected" time as a warning.


# Changelog

- Increase move group timeout to 2x move group estimated time
- Add logging if move group takes longer than 1.x calculated time

# Review requests



# Risk assessment

