### PR TITLE
fix(app): protocol setup dqa fixes round 2

### DIFF
--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
@@ -226,14 +226,17 @@ const PLAY_BUTTON_STYLE = css`
 `
 interface PlayButtonProps {
   disabled: boolean
+  ready: boolean
   onPlay: () => void
 }
 
-function PlayButton({ disabled, onPlay }: PlayButtonProps): JSX.Element {
+function PlayButton({ disabled, onPlay, ready }: PlayButtonProps): JSX.Element {
   return (
     <Btn
       alignItems={ALIGN_CENTER}
-      backgroundColor={disabled ? COLORS.darkBlack20 : COLORS.blueEnabled}
+      backgroundColor={
+        disabled || !ready ? COLORS.darkBlack20 : COLORS.blueEnabled
+      }
       borderRadius="6.25rem"
       display={DISPLAY_FLEX}
       height="6.25rem"
@@ -245,7 +248,7 @@ function PlayButton({ disabled, onPlay }: PlayButtonProps): JSX.Element {
       css={PLAY_BUTTON_STYLE}
     >
       <Icon
-        color={disabled ? COLORS.darkBlack60 : COLORS.white}
+        color={disabled || !ready ? COLORS.darkBlack60 : COLORS.white}
         name="play-icon"
         size="2.5rem"
       />
@@ -265,6 +268,16 @@ function PrepareToRun({
   const { t, i18n } = useTranslation('protocol_setup')
   const history = useHistory()
   const { makeSnackbar } = useToaster()
+
+  // Watch for scrolling to toggle dropshadow
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const [isScrolled, setIsScrolled] = React.useState<boolean>(false)
+  const observer = new IntersectionObserver(([entry]) => {
+    setIsScrolled(!entry.isIntersecting)
+  })
+  if (scrollRef.current) {
+    observer.observe(scrollRef.current)
+  }
 
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const protocolId = runRecord?.data?.protocolId ?? null
@@ -402,16 +415,20 @@ function PrepareToRun({
 
   return (
     <>
+      {/* Empty box to detect scrolling */}
+      <Flex ref={scrollRef} />
       {/* Protocol Setup Header */}
       <Flex
+        boxShadow={isScrolled ? BORDERS.shadowBig : undefined}
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing24}
-        paddingBottom={SPACING.spacing40}
-        paddingTop={SPACING.spacing32}
+        padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40} ${SPACING.spacing40}`}
         position={POSITION_STICKY}
         top={0}
         backgroundColor={COLORS.white}
         overflowY="hidden"
+        marginLeft={`-${SPACING.spacing32}`}
+        marginRight={`-${SPACING.spacing32}`}
       >
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Flex
@@ -441,6 +458,7 @@ function PrepareToRun({
                 allPipettesCalibrationData == null
               }
               onPlay={onPlay}
+              ready={isReadyToRun}
             />
           </Flex>
         </Flex>
@@ -449,12 +467,15 @@ function PrepareToRun({
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing8}
+        paddingLeft={SPACING.spacing8}
+        paddingRight={SPACING.spacing8}
       >
         <ProtocolSetupStep
           onClickSetupStep={() => setSetupScreen('instruments')}
           title={t('instruments')}
           detail={instrumentsDetail}
           status={instrumentsStatus}
+          disabled={speccedInstrumentCount === 0}
         />
         <ProtocolSetupStep
           onClickSetupStep={() => setSetupScreen('modules')}
@@ -482,6 +503,7 @@ function PrepareToRun({
           detail={labwareDetail}
           subDetail={labwareSubDetail}
           status="general"
+          disabled={labwareDetail === null}
         />
         <ProtocolSetupStep
           onClickSetupStep={() => setSetupScreen('liquids')}
@@ -494,6 +516,7 @@ function PrepareToRun({
                 })
               : t('liquids_not_in_setup')
           }
+          disabled={liquidsInProtocol.length === 0}
         />
       </Flex>
       {LPCWizard}
@@ -572,7 +595,7 @@ function ProtocolSetupSkeleton(props: ProtocolSetupSkeletonProps): JSX.Element {
         </Flex>
         <Flex gridGap={SPACING.spacing24}>
           <CloseButton onClose={() => props.cancelAndClose()} />
-          <PlayButton disabled onPlay={() => {}} />
+          <PlayButton disabled onPlay={() => {}} ready={false} />
         </Flex>
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup.tsx
@@ -225,12 +225,16 @@ const PLAY_BUTTON_STYLE = css`
   }
 `
 interface PlayButtonProps {
-  disabled: boolean
   ready: boolean
   onPlay: () => void
+  disabled?: boolean
 }
 
-function PlayButton({ disabled, onPlay, ready }: PlayButtonProps): JSX.Element {
+function PlayButton({
+  disabled = false,
+  onPlay,
+  ready,
+}: PlayButtonProps): JSX.Element {
   return (
     <Btn
       alignItems={ALIGN_CENTER}
@@ -422,13 +426,12 @@ function PrepareToRun({
         boxShadow={isScrolled ? BORDERS.shadowBig : undefined}
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing24}
-        padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40} ${SPACING.spacing40}`}
+        padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`}
         position={POSITION_STICKY}
         top={0}
         backgroundColor={COLORS.white}
         overflowY="hidden"
-        marginLeft={`-${SPACING.spacing32}`}
-        marginRight={`-${SPACING.spacing32}`}
+        marginX={`-${SPACING.spacing32}`}
       >
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Flex
@@ -467,8 +470,7 @@ function PrepareToRun({
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing8}
-        paddingLeft={SPACING.spacing8}
-        paddingRight={SPACING.spacing8}
+        paddingX={SPACING.spacing8}
       >
         <ProtocolSetupStep
           onClickSetupStep={() => setSetupScreen('instruments')}
@@ -595,7 +597,7 @@ function ProtocolSetupSkeleton(props: ProtocolSetupSkeletonProps): JSX.Element {
         </Flex>
         <Flex gridGap={SPACING.spacing24}>
           <CloseButton onClose={() => props.cancelAndClose()} />
-          <PlayButton disabled onPlay={() => {}} ready={false} />
+          <PlayButton onPlay={() => {}} ready={false} />
         </Flex>
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>


### PR DESCRIPTION

# Overview

Fixes for the DQA feedback given in [RAUT-440]

Closes RAUT-440

# Test Plan

Visually tested against Figma specs. Adjusted unit tests to match behavior changes.

# Changelog

- Fixed left and right page padding
- Added drop shadow after scrolling
- Made play button appear disabled if not ready to run (but still show snackbar when pressed)
- Disabled list buttons if not applicable to the protocol

# Review requests

Please verify feedback on RAUT-440 has been addressed. I've left comments showing how I think I've addressed each one.

# Risk assessment

Low.

https://github.com/Opentrons/opentrons/assets/2960/840173cc-332d-40d7-a698-6940f0389bbc




[RAUT-440]: https://opentrons.atlassian.net/browse/RAUT-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ