### PR TITLE
fix(robot-server): pulsing white status bar for stop requested engine state

### DIFF
--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -21,9 +21,9 @@ def _engine_status_to_status_bar(status: Optional[EngineStatus]) -> StatusBarSta
         EngineStatus.RUNNING: StatusBarState.RUNNING,
         EngineStatus.PAUSED: StatusBarState.PAUSED,
         EngineStatus.BLOCKED_BY_OPEN_DOOR: StatusBarState.PAUSED,
-        EngineStatus.STOP_REQUESTED: StatusBarState.RUNNING,
-        EngineStatus.STOPPED: StatusBarState.RUNNING,
-        EngineStatus.FINISHING: StatusBarState.RUNNING,
+        EngineStatus.STOP_REQUESTED: StatusBarState.UPDATING,
+        EngineStatus.STOPPED: StatusBarState.IDLE,
+        EngineStatus.FINISHING: StatusBarState.UPDATING,
         EngineStatus.FAILED: StatusBarState.HARDWARE_ERROR,
         EngineStatus.SUCCEEDED: StatusBarState.RUN_COMPLETED,
     }[status]

--- a/robot-server/tests/runs/test_light_control_task.py
+++ b/robot-server/tests/runs/test_light_control_task.py
@@ -65,6 +65,9 @@ async def test_get_current_status(
         ],
         [EngineStatus.RUNNING, EngineStatus.FAILED, StatusBarState.HARDWARE_ERROR],
         [EngineStatus.RUNNING, EngineStatus.SUCCEEDED, StatusBarState.RUN_COMPLETED],
+        [EngineStatus.RUNNING, EngineStatus.STOP_REQUESTED, StatusBarState.UPDATING],
+        [EngineStatus.STOP_REQUESTED, EngineStatus.STOPPED, StatusBarState.IDLE],
+        [EngineStatus.RUNNING, EngineStatus.FINISHING, StatusBarState.UPDATING],
     ],
 )
 async def test_light_controller_update(


### PR DESCRIPTION
# Overview

While a protocol is being canceled, Design has updated the status bar behavior to transition to a pulsing white light until resolving a stop action. 

Also the protocol engine's Finishing state (performing final homing) will map to the pulsing white, instead of static blue as currently implemented.

A cancelled protocol will now have a static white status bar instead of static blue (which is the running state)