### PR TITLE
chore(robot-server): fix timing-out test

### DIFF
--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -17,7 +17,7 @@ on:
       - 'notify-server/**/*'
       - 'scripts/**/*.mk'
       - 'scripts/**/*.py'
-      - '.github/workflows/robot-server-test-lint.yaml'
+      - '.github/workflows/robot-server-lint-test.yaml'
       - '.github/actions/python/**'
     branches:
       - 'edge'
@@ -37,7 +37,7 @@ on:
       - 'notify-server/**/*'
       - 'scripts/**/*.mk'
       - 'scripts/**/*.py'
-      - '.github/workflows/robot-server-test-lint.yaml'
+      - '.github/workflows/robot-server-lint-test.yaml'
       - '.github/actions/python/**'
   workflow_dispatch:
 
@@ -78,7 +78,7 @@ jobs:
         run: make -C robot-server lint
       - if: ${{ matrix.with-ot-hardware == 'false' }}
         name: Test without opentrons_hardware
-        run: make -C robot-server test-cov test_opts="-m 'not ot3_only'"
+        run: make -C robot-server test-cov test_opts="--ot2-only"
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         name: Test with opentrons_hardware
         run: make -C robot-server test-cov

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -78,7 +78,7 @@ jobs:
         run: make -C robot-server lint
       - if: ${{ matrix.with-ot-hardware == 'false' }}
         name: Test without opentrons_hardware
-        run: make -C robot-server test-cov test_opts="--ot2-only"
+        run: make -C robot-server test-cov test_opts="-m 'not ot3_only'"
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         name: Test with opentrons_hardware
         run: make -C robot-server test-cov

--- a/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
+++ b/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
@@ -23,8 +23,8 @@ async def robot_client(base_url: str) -> AsyncGenerator[RobotClient, None]:
     [
         (lazy_fixture("ot2_server_base_url"), "1", "2", "1", "2"),
         (lazy_fixture("ot2_server_base_url"), "D1", "D2", "1", "2"),
-        (lazy_fixture("ot3_server_base_url"), "1", "2", "D1", "D2"),
-        (lazy_fixture("ot3_server_base_url"), "D1", "D2", "D1", "D2"),
+        pytest.param(lazy_fixture("ot3_server_base_url"), "1", "2", "D1", "D2", marks=pytest.mark.ot3_only),
+        pytest.param(lazy_fixture("ot3_server_base_url"), "D1", "D2", "D1", "D2", marks=pytest.mark.ot3_only),
     ],
 )
 async def test_deck_slot_standardization(

--- a/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
+++ b/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
@@ -23,8 +23,22 @@ async def robot_client(base_url: str) -> AsyncGenerator[RobotClient, None]:
     [
         (lazy_fixture("ot2_server_base_url"), "1", "2", "1", "2"),
         (lazy_fixture("ot2_server_base_url"), "D1", "D2", "1", "2"),
-        pytest.param(lazy_fixture("ot3_server_base_url"), "1", "2", "D1", "D2", marks=pytest.mark.ot3_only),
-        pytest.param(lazy_fixture("ot3_server_base_url"), "D1", "D2", "D1", "D2", marks=pytest.mark.ot3_only),
+        pytest.param(
+            lazy_fixture("ot3_server_base_url"),
+            "1",
+            "2",
+            "D1",
+            "D2",
+            marks=pytest.mark.ot3_only,
+        ),
+        pytest.param(
+            lazy_fixture("ot3_server_base_url"),
+            "D1",
+            "D2",
+            "D1",
+            "D2",
+            marks=pytest.mark.ot3_only,
+        ),
     ],
 )
 async def test_deck_slot_standardization(


### PR DESCRIPTION
The ot2-only tests were running an ot3 test and that simply won't do. The right fix for this is more in depth but this will fix it quickly.
