### PR TITLE
fix(api): revert firmware binaries dir change to use constant.

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -18,7 +18,7 @@ from opentrons.config import (
     name,
     robot_configs,
     IS_ROBOT,
-    get_opentrons_path,
+    ROBOT_FIRMWARE_DIR,
 )
 from opentrons.util import logging_config
 from opentrons.protocols.types import ApiDeprecationError
@@ -62,8 +62,7 @@ def _find_smoothie_file() -> Tuple[Path, str]:
     # Search for smoothie files in /usr/lib/firmware first then fall back to
     # value packed in wheel
     if IS_ROBOT:
-        firmware_binaries_dir = get_opentrons_path("firmware_binaries_dir")
-        resources.extend(firmware_binaries_dir.iterdir())
+        resources.extend(ROBOT_FIRMWARE_DIR.iterdir())  # type: ignore
 
     resources_path = Path(HERE) / "resources"
     resources.extend(resources_path.iterdir())

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -59,6 +59,9 @@ class SystemArchitecture(Enum):
     YOCTO = auto()
 
 
+ROBOT_FIRMWARE_DIR: Optional[Path] = None
+#: The path to firmware files for modules
+
 ARCHITECTURE: SystemArchitecture = SystemArchitecture.HOST
 #: The system architecture running
 
@@ -84,6 +87,7 @@ if IS_ROBOT:
             ARCHITECTURE = SystemArchitecture.BUILDROOT
         except Exception:
             log.exception("Could not find version file in /etc/VERSION.json")
+    ROBOT_FIRMWARE_DIR = Path("/usr/lib/firmware/")
     JUPYTER_NOTEBOOK_ROOT_DIR = Path("/var/lib/jupyter/notebooks/")
     JUPYTER_NOTEBOOK_LABWARE_DIR = JUPYTER_NOTEBOOK_ROOT_DIR / "labware"
 
@@ -279,13 +283,6 @@ CONFIG_ELEMENTS = (
         Path("robot") / "modules",
         ConfigElementType.DIR,
         "The dir where module calibration is stored",
-    ),
-    ConfigElement(
-        "firmware_binaries_dir",
-        "Firmware Binaries Directory",
-        Path("/usr/lib/firmware"),
-        ConfigElementType.DIR,
-        "The dir where the firmware binaries for subsystems and modules are stored.",
     ),
 )
 #: The available configuration file elements to modify. All of these can be

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -5,7 +5,7 @@ import re
 from pkg_resources import parse_version
 from typing import ClassVar, Mapping, Optional, cast, TypeVar
 
-from opentrons.config import IS_ROBOT, get_opentrons_path
+from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 from ..execution_manager import ExecutionManager
@@ -76,8 +76,7 @@ class AbstractModule(abc.ABC):
         file_prefix = self.firmware_prefix()
 
         MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin)$")
-        firmware_binaries_dir = get_opentrons_path("firmware_binaries_dir")
-        for fw_resource in firmware_binaries_dir.iterdir():
+        for fw_resource in ROBOT_FIRMWARE_DIR.iterdir():  # type: ignore
             matches = MODULE_FW_RE.search(fw_resource.name)
             if matches:
                 return BundledFirmware(version=matches.group(1), path=fw_resource)


### PR DESCRIPTION
This [pr](https://github.com/Opentrons/opentrons/pull/12866) broke the unit tests, let's revert that change and just have the `ROBOT_FIRMWARE_DIR` constant get set to `/usr/lib/firmware` for both ot2 and Flex devices.

# Overview

# Test Plan

# Changelog

# Review requests

# Risk assessment
