### PR TITLE
perf(api,robot-server): Optimize command parsing

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/parse.py
+++ b/api/src/opentrons/protocol_engine/commands/parse.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, Type
+from typing_extensions import get_args
+
+from .command_unions import Command, CommandCreate
+
+
+def parse_command(command: Dict[str, Any]) -> Command:
+    # TODO: Type checking.
+    command_class = _command_classes[command["commandType"]]
+    # TODO: Leave room for by_alias, etc.
+    return command_class.parse_obj(command)
+
+
+def parse_command_create(command_create: Dict[str, Any]) -> CommandCreate:
+    command_create_class = _command_create_classes[command_create["commandType"]]
+    return command_create_class.parse_obj(command_create)
+
+
+# TODO: Clean this up.
+_command_classes: Dict[str, Type[Command]] = {
+    command_class.__fields__["commandType"].get_default(): command_class
+    for command_class in get_args(Command)
+}
+
+# TODO: Clean this up.
+_command_create_classes: Dict[str, Type[CommandCreate]] = {
+    command_create_class.__fields__["commandType"].get_default(): command_create_class
+    for command_create_class in get_args(CommandCreate)
+}

--- a/api/tests/opentrons/protocol_engine/commands/test_parse.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_parse.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+
+from opentrons.protocol_engine.commands import HomeCreate, Home, HomeParams, HomeResult
+from opentrons.protocol_engine.commands.parse import parse_command, parse_command_create
+
+from opentrons.protocol_engine.types import MotorAxis
+
+from opentrons.protocol_engine.commands.command import CommandStatus
+
+
+def test_parse_command() -> None:
+    # TODO: Should this test with string datetimes and enums,
+    # or real Python datetimes and enums, or both?
+    input = {
+        "id": "command-id",
+        "createdAt": "2020-01-02T03:04:05.678901Z",
+        "commandType": "home",
+        "key": "command-key",
+        "status": "succeeded",
+        "params": {"axes": ["x", "y"]},
+        "result": {},
+    }
+    result = parse_command(input)
+
+    assert result == Home(
+        id="command-id",
+        createdAt=datetime(
+            year=2020,
+            month=1,
+            day=2,
+            hour=3,
+            minute=4,
+            second=5,
+            microsecond=678901,
+            tzinfo=timezone.utc,
+        ),
+        key="command-key",
+        status=CommandStatus.SUCCEEDED,
+        params=HomeParams(
+            axes=[MotorAxis.X, MotorAxis.Y],
+        ),
+        result=HomeResult(),
+    )
+
+
+def test_parse_command_create() -> None:
+    input = {
+        "commandType": "home",
+        "params": {"axes": ["x", "y"]},
+    }
+    result = parse_command_create(input)
+
+    assert result == HomeCreate(
+        params=HomeParams(
+            axes=[MotorAxis.X, MotorAxis.Y],
+        ),
+    )
+
+
+# TODO: Port to Hypothesis.

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -1,9 +1,11 @@
 """Response models for protocol analysis."""
 # TODO(mc, 2021-08-25): add modules to simulation result
 from enum import Enum
-from pydantic import BaseModel, Field
-from typing import List, Union
+from pydantic import BaseModel, Field, validator
+from typing import Any, Dict, List, Union
 from typing_extensions import Literal
+
+from opentrons.protocol_engine.commands.parse import parse_command
 
 from opentrons.protocol_engine import (
     Command,
@@ -102,10 +104,17 @@ class CompletedAnalysis(BaseModel):
         default_factory=list,
         description="Modules that have been loaded into the run.",
     )
+
     commands: List[Command] = Field(
         ...,
         description="The protocol commands the run is expected to produce",
     )
+
+    @validator("commands", each_item=True, pre=True)
+    @classmethod
+    def parse_command(cls, command: Dict[str, Any]) -> Command:
+        return parse_command(command)
+
     errors: List[ErrorOccurrence] = Field(
         ...,
         description="Any errors the protocol run produced",

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -22,6 +22,7 @@ from robot_server.persistence import legacy_pickle
 
 from .analysis_models import (
     AnalysisSummary,
+    FastParseCommand,
     ProtocolAnalysis,
     PendingAnalysis,
     CompletedAnalysis,
@@ -143,7 +144,7 @@ class AnalysisStore:
         completed_analysis = CompletedAnalysis.construct(
             id=analysis_id,
             result=result,
-            commands=commands,
+            commands=[FastParseCommand.construct(__root__=c) for c in commands],
             labware=labware,
             modules=modules,
             pipettes=pipettes,


### PR DESCRIPTION
# Overview

Experiments towards RSS-128.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Benchmarking

With a local dev server, and the 60k-command Python protocol in RESC-139, `GET /protocols/{id}/analyses/{id}` takes ~9s on `edge` and ~4s with this branch.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Medium. This does weird stuff with Pydantic. There's a risk of subtly breaking something, for example with field aliases.