### PR TITLE
feat(api): check if a tip is present on a pipette in the hardware controller

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -74,7 +74,6 @@ from opentrons_hardware.hardware_control.motor_position_status import (
 )
 from opentrons_hardware.hardware_control.limit_switches import get_limit_switches
 from opentrons_hardware.hardware_control.tip_presence import get_tip_ejector_state
-from opentrons_hardware.hardware_control.network import NetworkInfo
 from opentrons_hardware.hardware_control.current_settings import (
     set_run_current,
     set_hold_current,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -734,7 +734,7 @@ class OT3Controller:
         return {node_to_axis(node): bool(val) for node, val in res.items()}
 
     async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> None:
-        """Get the state of the gantry's limit switches on each axis."""
+        """Get the state of the tip ejector flag for a given mount."""
         # TODO (lc 06/09/2023) We should create a separate type for
         # pipette specific sensors. This work is done in the overpressure
         # PR.

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -365,7 +365,7 @@ class OT3Simulator:
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
 
     async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> bool:
-        if tip_state == TipStateType.PICK_UP:
+        if tip_state == TipStateType.PRESENT:
             return True
         else:
             return False

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -364,11 +364,9 @@ class OT3Simulator:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
 
-    async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> bool:
-        if tip_state == TipStateType.PRESENT:
-            return True
-        else:
-            return False
+    async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> None:
+        """Get the state of the tip ejector flag for a given mount."""
+        pass
 
     @ensure_yield
     async def tip_action(

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -60,6 +60,7 @@ from opentrons.hardware_control.types import (
     UpdateState,
     SubSystem,
     SubSystemState,
+    TipStateType,
 )
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control import status_bar
@@ -362,6 +363,12 @@ class OT3Simulator:
     ) -> None:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
+
+    async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> bool:
+        if tip_state == TipStateType.PICK_UP:
+            return True
+        else:
+            return False
 
     @ensure_yield
     async def tip_action(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -95,6 +95,8 @@ from .types import (
     UpdateStatus,
     StatusBarState,
     SubSystemState,
+    TipStateType,
+
 )
 from .errors import (
     MustHomeError,
@@ -1658,6 +1660,9 @@ class OT3API(
         for rel_point, speed in spec.shake_off_list:
             await self.move_rel(realmount, rel_point, speed=speed)
 
+        # TODO change to enum
+        await self._backend.get_tip_present(realmount, TipStateType.PICK_UP)
+
         _add_tip_to_instrs()
 
         if prep_after:
@@ -1735,6 +1740,9 @@ class OT3API(
                 for axis, current in spec.ending_current.items()
             }
         )
+
+        # TODO change to enum
+        await self._backend.get_tip_present(realmount, TipStateType.DROP)
         _remove()
 
     async def clean_up(self) -> None:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1659,7 +1659,6 @@ class OT3API(
         for rel_point, speed in spec.shake_off_list:
             await self.move_rel(realmount, rel_point, speed=speed)
 
-        # TODO change to enum
         await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
 
         _add_tip_to_instrs()
@@ -1740,7 +1739,6 @@ class OT3API(
             }
         )
 
-        # TODO change to enum
         await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
         _remove()
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -96,7 +96,6 @@ from .types import (
     StatusBarState,
     SubSystemState,
     TipStateType,
-
 )
 from .errors import (
     MustHomeError,
@@ -1661,7 +1660,7 @@ class OT3API(
             await self.move_rel(realmount, rel_point, speed=speed)
 
         # TODO change to enum
-        await self._backend.get_tip_present(realmount, TipStateType.PICK_UP)
+        await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
 
         _add_tip_to_instrs()
 
@@ -1742,7 +1741,7 @@ class OT3API(
         )
 
         # TODO change to enum
-        await self._backend.get_tip_present(realmount, TipStateType.DROP)
+        await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
         _remove()
 
     async def clean_up(self) -> None:

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -618,6 +618,14 @@ class GripperProbe(enum.Enum):
             return InstrumentProbeType.PRIMARY
 
 
+class TipStateType(enum.Enum):
+    DROP = False
+    PICK_UP = True
+
+    def __str__(self) -> str:
+        return self.name
+
+
 class EarlyLiquidSenseTrigger(RuntimeError):
     """Error raised if sensor threshold reached before minimum probing distance."""
 
@@ -641,4 +649,15 @@ class LiquidNotFound(RuntimeError):
         super().__init__(
             f"Liquid threshold not found, current_position = {position}"
             f"position at max travel allowed = {max_z_pos}"
+        )
+
+
+class FailedTipStateCheck(RuntimeError):
+    """Error raised if the tip ejector state does not match the expected value."""
+
+    def __init__(self, tip_state_type: TipStateType, actual_state: bool) -> None:
+        """Iniitialize FailedTipStateCheck error."""
+        super().__init__(
+            f"Failed to correctly determine tip state for {str(tip_state_type)}"
+            f"received {actual_state} but expected {tip_state_type.value}"
         )

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -619,8 +619,8 @@ class GripperProbe(enum.Enum):
 
 
 class TipStateType(enum.Enum):
-    DROP = False
-    PICK_UP = True
+    ABSENT = False
+    PRESENT = True
 
     def __str__(self) -> str:
         return self.name

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -619,8 +619,8 @@ class GripperProbe(enum.Enum):
 
 
 class TipStateType(enum.Enum):
-    ABSENT = False
-    PRESENT = True
+    ABSENT = 0
+    PRESENT = 1
 
     def __str__(self) -> str:
         return self.name
@@ -655,9 +655,9 @@ class LiquidNotFound(RuntimeError):
 class FailedTipStateCheck(RuntimeError):
     """Error raised if the tip ejector state does not match the expected value."""
 
-    def __init__(self, tip_state_type: TipStateType, actual_state: bool) -> None:
+    def __init__(self, tip_state_type: TipStateType, actual_state: int) -> None:
         """Iniitialize FailedTipStateCheck error."""
         super().__init__(
-            f"Failed to correctly determine tip state for {str(tip_state_type)}"
-            f"received {actual_state} but expected {tip_state_type.value}"
+            f"Failed to correctly determine tip state for tip {str(tip_state_type)} "
+            f"received {bool(actual_state)} but expected {bool(tip_state_type.value)}"
         )

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -4,7 +4,17 @@ from decoy import Decoy
 from itertools import chain
 
 from contextlib import nullcontext as does_not_raise
-from typing import Dict, List, Optional, Set, Tuple, Any, Iterator, AsyncIterator, ContextManager
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Any,
+    Iterator,
+    AsyncIterator,
+    ContextManager,
+)
 
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
 from opentrons.hardware_control.backends.ot3utils import (
@@ -1009,20 +1019,20 @@ async def test_monitor_pressure(
 @pytest.mark.parametrize(
     "tip_state_type, mocked_ejector_response, expectation",
     [
-        [TipStateType.PICK_UP, True, does_not_raise()],
-        [TipStateType.DROP, False, does_not_raise()],
-        [TipStateType.PICK_UP, False, pytest.raises(FailedTipStateCheck)],
-        [TipStateType.DROP, True, pytest.raises(FailedTipStateCheck)],
+        [TipStateType.PRESENT, True, does_not_raise()],
+        [TipStateType.ABSENT, False, does_not_raise()],
+        [TipStateType.PRESENT, False, pytest.raises(FailedTipStateCheck)],
+        [TipStateType.ABSENT, True, pytest.raises(FailedTipStateCheck)],
     ],
 )
 async def test_get_tip_present(
     controller: OT3Controller,
     tip_state_type: TipStateType,
     mocked_ejector_response: bool,
-    expectation: ContextManager,
-):
+    expectation: ContextManager[None],
+) -> None:
     mount = OT3Mount.LEFT
-    with patch(
+    with mock.patch(
         "opentrons.hardware_control.backends.ot3controller.get_tip_ejector_state",
         return_value=mocked_ejector_response,
     ):

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1019,16 +1019,16 @@ async def test_monitor_pressure(
 @pytest.mark.parametrize(
     "tip_state_type, mocked_ejector_response, expectation",
     [
-        [TipStateType.PRESENT, True, does_not_raise()],
-        [TipStateType.ABSENT, False, does_not_raise()],
-        [TipStateType.PRESENT, False, pytest.raises(FailedTipStateCheck)],
-        [TipStateType.ABSENT, True, pytest.raises(FailedTipStateCheck)],
+        [TipStateType.PRESENT, 1, does_not_raise()],
+        [TipStateType.ABSENT, 0, does_not_raise()],
+        [TipStateType.PRESENT, 0, pytest.raises(FailedTipStateCheck)],
+        [TipStateType.ABSENT, 1, pytest.raises(FailedTipStateCheck)],
     ],
 )
 async def test_get_tip_present(
     controller: OT3Controller,
     tip_state_type: TipStateType,
-    mocked_ejector_response: bool,
+    mocked_ejector_response: int,
     expectation: ContextManager[None],
 ) -> None:
     mount = OT3Mount.LEFT

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -1,5 +1,58 @@
-async def get_tip_present(
-    can_messenger: CanMessenger, nodes: Set[NodeId]
+import asyncio
+import logging
+
+from typing_extensions import Literal
+
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+
+from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    TipStatusQueryRequest,
+    PushTipPresenceNotification,
+)
+
+from opentrons_hardware.firmware_bindings.constants import MessageId, NodeId, ErrorCode
+
+log = logging.getLogger(__name__)
+
+
+async def get_tip_ejector_state(
+    can_messenger: CanMessenger,
+    node: Literal[NodeId.pipette_left, NodeId.pipette_right],
 ) -> bool:
-    """Get state of limit switches for each node."""
-    return False
+    """Get the state of the tip presence interrupter.
+    When the tip ejector flag is occuluded, then we
+    know that there is a tip on the pipette."""
+    tip_ejector_state = False
+
+    event = asyncio.Event()
+
+    def _listener(message: MessageDefinition, arb_id: ArbitrationId):
+        nonlocal tip_ejector_state
+        if isinstance(message, PushTipPresenceNotification):
+            event.set()
+            tip_ejector_state = bool(message.payload.ejector_flag_status)
+
+    def _filter(arbitration_id: ArbitrationId) -> bool:
+        return (NodeId(arbitration_id.parts.originating_node_id) == node) and (
+            MessageId(arbitration_id.parts.message_id)
+            == MessageId.tip_presence_notification
+        )
+
+    can_messenger.add_listener(_listener, _filter)
+    error = await can_messenger.ensure_send(
+        node_id=node, message=TipStatusQueryRequest(), expected_nodes=[node]
+    )
+
+    if error != ErrorCode.ok:
+        log.error(
+            f"recieved error {str(error)} trying to get tip ejector status {str(node)}"
+        )
+    try:
+        await asyncio.wait_for(event.wait(), 1.0)
+    except asyncio.TimeoutError:
+        log.error("tip ejector state request timed out before expected nodes responded")
+    finally:
+        can_messenger.remove_listener(_listener)
+        return tip_ejector_state

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -21,13 +21,13 @@ log = logging.getLogger(__name__)
 async def get_tip_ejector_state(
     can_messenger: CanMessenger,
     node: Literal[NodeId.pipette_left, NodeId.pipette_right],
-) -> bool:
+) -> int:
     """Get the state of the tip presence interrupter.
 
     When the tip ejector flag is occuluded, then we
     know that there is a tip on the pipette.
     """
-    tip_ejector_state = False
+    tip_ejector_state = 0
 
     event = asyncio.Event()
 
@@ -35,7 +35,7 @@ async def get_tip_ejector_state(
         nonlocal tip_ejector_state
         if isinstance(message, PushTipPresenceNotification):
             event.set()
-            tip_ejector_state = message.payload.ejector_flag_status.value != 0
+            tip_ejector_state = message.payload.ejector_flag_status.value
 
     def _filter(arbitration_id: ArbitrationId) -> bool:
         return (NodeId(arbitration_id.parts.originating_node_id) == node) and (

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -1,3 +1,4 @@
+"""Utilities for reading the current status of the tip presence photointerrupter."""
 import asyncio
 import logging
 
@@ -22,13 +23,15 @@ async def get_tip_ejector_state(
     node: Literal[NodeId.pipette_left, NodeId.pipette_right],
 ) -> bool:
     """Get the state of the tip presence interrupter.
+
     When the tip ejector flag is occuluded, then we
-    know that there is a tip on the pipette."""
+    know that there is a tip on the pipette.
+    """
     tip_ejector_state = False
 
     event = asyncio.Event()
 
-    def _listener(message: MessageDefinition, arb_id: ArbitrationId):
+    def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
         nonlocal tip_ejector_state
         if isinstance(message, PushTipPresenceNotification):
             event.set()

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -1,0 +1,5 @@
+async def get_tip_present(
+    can_messenger: CanMessenger, nodes: Set[NodeId]
+) -> bool:
+    """Get state of limit switches for each node."""
+    return False

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -13,7 +13,7 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     PushTipPresenceNotification,
 )
 
-from opentrons_hardware.firmware_bindings.constants import MessageId, NodeId, ErrorCode
+from opentrons_hardware.firmware_bindings.constants import MessageId, NodeId
 
 log = logging.getLogger(__name__)
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
@@ -1,0 +1,61 @@
+from mock import AsyncMock
+
+from typing import List, Tuple
+
+from opentrons_hardware.hardware_control.tip_presence import get_tip_ejector_state
+from opentrons_hardware.firmware_bindings.messages import (
+    MessageDefinition,
+    message_definitions,
+)
+from opentrons_hardware.firmware_bindings.messages.payloads import (
+    PushTipPresenceNotificationPayload,
+)
+from opentrons_hardware.firmware_bindings.utils import UInt8Field
+from opentrons_hardware.firmware_bindings import NodeId
+from tests.conftest import CanLoopback
+
+
+async def test_get_tip_ejector_state(
+    mock_messenger: AsyncMock, message_send_loopback: CanLoopback
+) -> None:
+    """Test that get tip ejector state sends the correct request and receives a response."""
+    node = NodeId.pipette_left
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        """Mock send method."""
+        if isinstance(message, message_definitions.TipStatusQueryRequest):
+            return [
+                (
+                    NodeId.host,
+                    message_definitions.PushTipPresenceNotification(
+                        payload=PushTipPresenceNotificationPayload(
+                            ejector_flag_status=UInt8Field(1)
+                        )
+                    ),
+                    node,
+                )
+            ]
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    res = await get_tip_ejector_state(mock_messenger, node)
+
+    # We should have sent a request
+    mock_messenger.ensure_send.assert_called_once_with(
+        node_id=node,
+        message=message_definitions.TipStatusQueryRequest(),
+        expected_nodes=[node],
+    )
+
+    assert res == True
+
+
+async def test_tip_ejector_state_times_out(mock_messenger: AsyncMock) -> None:
+    """Test that a timeout is handled."""
+    node = NodeId.pipette_left
+
+    res = await get_tip_ejector_state(mock_messenger, node)
+    assert res == False

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
@@ -48,10 +48,8 @@ async def test_get_tip_ejector_state(
     )
 
     # We should have sent a request
-    mock_messenger.ensure_send.assert_called_once_with(
-        node_id=node,
-        message=message_definitions.TipStatusQueryRequest(),
-        expected_nodes=[node],
+    mock_messenger.send.assert_called_once_with(
+        node_id=node, message=message_definitions.TipStatusQueryRequest()
     )
 
     assert res


### PR DESCRIPTION
# Overview
We have tip presence ability on pipettes and so we should use it to inform the user of an error if a tip fails to pick up. This is the very beginning of tip presence handling and so it does **not**:

- continuously check to see if the tip state has changed while running a protocol
- re-try picking up or dropping a tip (although we can do that in a follow-up PR once we figure out a number here)
- Support tip sensing for the 96 channel


# Test Plan

Create a protocol that picks up and drops tip a few times. On the robot, you should have a tiprack that is missing some tips so that when a pick up tip fails to detect the tip and error raises. This will stop the protocol. You can do the same thing for drop tip by simply removing a tip after it has successfully picked up. I would suggest adding pauses between pick up/drop tip to make this easier to test.

- [ ] Check that pick up tip will fail in a protocol if it does not pick up a tip
- [ ] Check that drop tip will fail in a protocol if it does not drop an existing tip (we will have to fake this by removing the tip beforehand)
- [ ] Check that LPC can handle a failed pick up or drop gracefully
- [ ] Once we have done the above, run a regular (short) protocol to check the reliability
- [ ] Test all in-use DVT pipettes to see if they have incorrect photointerrupter (definitely on single channels, maybe on multi-channels)

# Changelog

- Add a command you can use in the hardware controller to query the tip state
- Raises an error if the state does not match the expected value when you're picking up or dropping tip.

# Review requests

Might've flipped the state. Please check me on this.

# Risk assessment

Medium/high. Could potentially be disruptive to ABR work. 
