### PR TITLE
feat(api, robot-server): add setting to disable the status bar

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -117,6 +117,7 @@ async def _create_thread_manager() -> ThreadManagedHardware:
             OT3API.build_hardware_controller,
             use_usb_bus=ff.rear_panel_integration(),
             threadmanager_nonblocking=True,
+            status_bar_enabled=ff.status_bar_enabled(),
         )
     else:
         thread_manager = ThreadManager(

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -186,6 +186,11 @@ settings = [
         title="Disable stall detection on the Flex.",
         description="This is an Opentrons-internal setting for hardware-testing.",
     ),
+    SettingDefinition(
+        _id="disableStatusBar",
+        title="Disable the LED status bar on the Flex.",
+        description="This setting disables the LED status bar on the Flex.",
+    ),
 ]
 
 if ARCHITECTURE == SystemArchitecture.BUILDROOT:
@@ -562,6 +567,16 @@ def _migrate24to25(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate25to26(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 26 of the feature flags file.
+
+    - Adds the disableStatusBar config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["disableStatusBar"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -588,6 +603,7 @@ _MIGRATIONS = [
     _migrate22to23,
     _migrate23to24,
     _migrate24to25,
+    _migrate25to26,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -39,3 +39,8 @@ def rear_panel_integration() -> bool:
 
 def stall_detection_enabled() -> bool:
     return not advs.get_setting_with_env_overload("disableStallDetection")
+
+
+def status_bar_enabled() -> bool:
+    """Whether the status bar is enabled."""
+    return not advs.get_setting_with_env_overload("disableStatusBar")

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -352,6 +352,10 @@ class API(
         """The status bar does not exist on OT-2!"""
         return None
 
+    async def set_status_bar_enabled(self, enabled: bool) -> None:
+        """The status bar does not exist on OT-2!"""
+        return None
+
     def get_status_bar_state(self) -> StatusBarState:
         """There is no status bar on OT-2, return IDLE at all times."""
         return StatusBarState.IDLE

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -273,6 +273,7 @@ class OT3API(
         strict_attached_instruments: bool = True,
         use_usb_bus: bool = False,
         update_firmware: bool = True,
+        status_bar_enabled: bool = True,
     ) -> "OT3API":
         """Build an ot3 hardware controller."""
         checked_loop = use_or_initialize_loop(loop)
@@ -286,6 +287,9 @@ class OT3API(
 
         api_instance = cls(backend, loop=checked_loop, config=checked_config)
 
+        await api_instance.set_status_bar_enabled(status_bar_enabled)
+        # TODO: Remove this line once the robot server runs the startup
+        # animation after initialization!
         await api_instance.set_status_bar_state(StatusBarState.IDLE)
         module_controls = await AttachedModulesControl.build(
             api_instance, board_revision=backend.board_revision
@@ -426,6 +430,9 @@ class OT3API(
 
     async def set_status_bar_state(self, state: StatusBarState) -> None:
         await self._status_bar_controller.set_status_bar_state(state)
+
+    async def set_status_bar_enabled(self, enabled: bool) -> None:
+        await self._status_bar_controller.set_enabled(enabled)
 
     def get_status_bar_state(self) -> StatusBarState:
         return self._status_bar_controller.get_current_state()

--- a/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
+++ b/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
@@ -50,6 +50,11 @@ class ChassisAccessoryManager(EventSourcer, Protocol):
         action, while others"""
         ...
 
+    async def set_status_bar_enabled(self, enabled: bool) -> None:
+        """Enable or disable the status bar entirely.
+
+        enabled: True to turn the status bar on, false to turn it off."""
+
     def get_status_bar_state(self) -> StatusBarState:
         """Get the current status bar state.
 

--- a/api/src/opentrons/hardware_control/status_bar_state.py
+++ b/api/src/opentrons/hardware_control/status_bar_state.py
@@ -9,45 +9,60 @@ from typing import List
 
 
 class StatusBarStateController:
-    """Stateful control of the status bar."""
+    """Stateful control of the status bar.
+
+    Note that the controller can be enabled/disabled at any time. If the controller
+    is ever disabled, the lights are set to OFF and future state changes will not
+    write to the rear panel board. However, the proper `StatusBarState` will still
+    be cached, so if the controller becomes enabled/disabled in the future it will
+    be able to resume the correct animation based on the current system state."""
 
     def __init__(self, controller: status_bar.StatusBar) -> None:
         """Create a StatusBarStateController."""
         self._status_bar_state = StatusBarState.IDLE
         self._controller = controller
+        self._enabled = True
 
     async def _status_bar_idle(self) -> None:
         self._status_bar_state = StatusBarState.IDLE
-        await self._controller.static_color(status_bar.WHITE)
+        if self._enabled:
+            await self._controller.static_color(status_bar.WHITE)
 
     async def _status_bar_running(self) -> None:
         self._status_bar_state = StatusBarState.RUNNING
-        await self._controller.static_color(status_bar.BLUE)
+        if self._enabled:
+            await self._controller.static_color(status_bar.BLUE)
 
     async def _status_bar_paused(self) -> None:
         self._status_bar_state = StatusBarState.PAUSED
-        await self._controller.pulse_color(status_bar.BLUE)
+        if self._enabled:
+            await self._controller.pulse_color(status_bar.BLUE)
 
     async def _status_bar_hardware_error(self) -> None:
         self._status_bar_state = StatusBarState.HARDWARE_ERROR
-        await self._controller.flash_color(status_bar.RED)
+        if self._enabled:
+            await self._controller.flash_color(status_bar.RED)
 
     async def _status_bar_software_error(self) -> None:
         self._status_bar_state = StatusBarState.SOFTWARE_ERROR
-        await self._controller.static_color(status_bar.RED)
+        if self._enabled:
+            await self._controller.static_color(status_bar.RED)
 
     async def _status_bar_confirm(self) -> None:
         # Confirm should revert to IDLE
         self._status_bar_state = StatusBarState.IDLE
-        await self._controller.blink_once(status_bar.GREEN, status_bar.WHITE)
+        if self._enabled:
+            await self._controller.blink_once(status_bar.GREEN, status_bar.WHITE)
 
     async def _status_bar_run_complete(self) -> None:
         self._status_bar_state = StatusBarState.RUN_COMPLETED
-        await self._controller.static_color(status_bar.GREEN)
+        if self._enabled:
+            await self._controller.static_color(status_bar.GREEN)
 
     async def _status_bar_updating(self) -> None:
         self._status_bar_state = StatusBarState.UPDATING
-        await self._controller.pulse_color(status_bar.WHITE)
+        if self._enabled:
+            await self._controller.pulse_color(status_bar.WHITE)
 
     async def _status_bar_activation(self) -> None:
         # Activation should revert to IDLE
@@ -70,9 +85,11 @@ class StatusBarStateController:
             ),
             status_bar.ColorStep(LightTransitionType.linear, 250, status_bar.WHITE),
         ]
-        await self._controller.start_animation(
-            steps=steps, type=LightAnimationType.single_shot
-        )
+
+        if self._enabled:
+            await self._controller.start_animation(
+                steps=steps, type=LightAnimationType.single_shot
+            )
 
     async def _status_bar_disco(self) -> None:
         # TODO - update implementation
@@ -127,13 +144,15 @@ class StatusBarStateController:
         )
 
         self._status_bar_state = StatusBarState.IDLE
-        await self._controller.start_animation(
-            steps=steps, type=LightAnimationType.single_shot
-        )
+        if self._enabled:
+            await self._controller.start_animation(
+                steps=steps, type=LightAnimationType.single_shot
+            )
 
     async def _status_bar_off(self) -> None:
         self._status_bar_state = StatusBarState.OFF
-        await self._controller.static_color(status_bar.OFF)
+        if self._enabled:
+            await self._controller.static_color(status_bar.OFF)
 
     async def set_status_bar_state(self, state: StatusBarState) -> None:
         """Main interface to set a new state."""
@@ -155,3 +174,36 @@ class StatusBarStateController:
     def get_current_state(self) -> StatusBarState:
         """Get the current state."""
         return self._status_bar_state
+
+    async def set_enabled(self, enabled: bool) -> None:
+        """Enable or disable the status bar.
+
+        If the status bar is newly disabled, the lights are set OFF
+        and the old status is cached so it can later be restored.
+
+        If the status bar is newly enabled, the last-set animation
+        will be sent to the rear panel.
+
+        NOTE When the status bar is disabled, `set_status_bar_state` will
+        still update the internal status bar setting as if the bar is on!
+        This means that, when the status bar is reenabled, it will look
+        correct for the current robot status."""
+        if enabled == self._enabled:
+            return
+
+        if enabled:
+            # Need to turn Enabled true *first* so that we can actually write
+            # the setting to the rear panel
+            self._enabled = True
+            await self.set_status_bar_state(self._status_bar_state)
+        else:
+            cached_state = self.get_current_state()
+            await self.set_status_bar_state(StatusBarState.OFF)
+            self._enabled = False
+            # This ensures that the status bar will be set to the correct state
+            # if it's reactivated before the state gets set again.
+            self._status_bar_state = cached_state
+
+    def get_enabled(self) -> bool:
+        """Check whether the status bar is enabled."""
+        return self._enabled

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 25
+    return 26
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -25,6 +25,7 @@ def default_file_settings() -> Dict[str, Any]:
         "enableOT3HardwareController": None,
         "rearPanelIntegration": True,
         "disableStallDetection": None,
+        "disableStatusBar": None,
     }
 
 
@@ -307,6 +308,18 @@ def v25_config(v24_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v26_config(v25_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v25_config.copy()
+    r.update(
+        {
+            "_version": 26,
+            "disableStatusBar": None,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -337,6 +350,7 @@ def v25_config(v24_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v23_config"),
         lazy_fixture("v24_config"),
         lazy_fixture("v25_config"),
+        lazy_fixture("v26_config"),
     ],
 )
 def old_settings(request: pytest.FixtureRequest) -> Dict[str, Any]:
@@ -425,4 +439,5 @@ def test_ensures_config() -> None:
         "enableOT3HardwareController": None,
         "rearPanelIntegration": None,
         "disableStallDetection": None,
+        "disableStatusBar": None,
     }

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -66,6 +66,12 @@ stages:
             description: !re_search 'This is an Opentrons-internal setting for hardware-testing.'
             restart_required: false
             value: !anything
+          - id: disableStatusBar
+            old_id: Null
+            title: 'Disable the LED status bar on the Flex.'
+            description: !re_search 'This setting disables the LED status bar on the Flex.'
+            restart_required: false
+            value: !anything
         links: !anydict
 
 ---

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -329,17 +329,16 @@ def test_set_log_level_invalid(
     hardware.update_config.assert_not_called()
     mock_robot_configs.save_robot_settings.assert_not_called()
 
-@pytest.mark.parametrize(
-    argnames=["disabled"],
-    argvalues=[[True], [False]]
-)
-def test_set_status_bar_disabled(
-    api_client, hardware, disabled
-):
+
+@pytest.mark.parametrize(argnames=["disabled"], argvalues=[[True], [False]])
+def test_set_status_bar_disabled(api_client, hardware, disabled):
     """Tests that the endpoint correctly updates the setting of the status bar in the API."""
-    resp = api_client.post("/settings", json={"id": "disableStatusBar", "value": disabled})
+    resp = api_client.post(
+        "/settings", json={"id": "disableStatusBar", "value": disabled}
+    )
     assert resp.status_code == 200
     hardware.set_status_bar_enabled.assert_called_once_with(not disabled)
+
 
 @pytest.mark.parametrize(
     argnames=["body", "expected_log_level", "expected_log_level_name"],

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -329,6 +329,17 @@ def test_set_log_level_invalid(
     hardware.update_config.assert_not_called()
     mock_robot_configs.save_robot_settings.assert_not_called()
 
+@pytest.mark.parametrize(
+    argnames=["disabled"],
+    argvalues=[[True], [False]]
+)
+def test_set_status_bar_disabled(
+    api_client, hardware, disabled
+):
+    """Tests that the endpoint correctly updates the setting of the status bar in the API."""
+    resp = api_client.post("/settings", json={"id": "disableStatusBar", "value": disabled})
+    assert resp.status_code == 200
+    hardware.set_status_bar_enabled.assert_called_once_with(not disabled)
 
 @pytest.mark.parametrize(
     argnames=["body", "expected_log_level", "expected_log_level_name"],


### PR DESCRIPTION

# Overview

Adds a feature flag to the robot to disable the status bar. If the setting is enabled, the status bar is always going to be off. The status bar status cache is still updated so that, if the setting is disabled (to reenable the status bar), it will be set to the correct animation for the current robot context.

# Test Plan

Uploaded to an OT-3 and hit the `POST /settings` endpoint to turn the status bar off and on. It turned off and on, and the value persists when you restart the robot server.

# Changelog

- Add feature flag to disable the status bar
- Added API function to enable/disable the status bar
- Added handling in the Status Bar controller to logically handle being enabled/disabled
- In the `POST /settings` endpoint, always try to update the status bar enabled/disabled setting in case it changed

# Review requests



# Risk assessment

Pretty low.
