### PR TITLE
feat(api): add a stateless command to control the status bar

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -239,6 +239,15 @@ from .blow_out_in_place import (
     BlowOutInPlace,
 )
 
+from .set_status_bar import (
+    SetStatusBar,
+    SetStatusBarParams,
+    SetStatusBarCreate,
+    SetStatusBarResult,
+    SetStatusBarImplementation,
+    SetStatusBarCommandType,
+)
+
 __all__ = [
     # command type unions
     "Command",
@@ -400,6 +409,13 @@ __all__ = [
     "BlowOutInPlaceCreate",
     "BlowOutInPlaceImplementation",
     "BlowOutInPlace",
+    # set status bar command models
+    "SetStatusBar",
+    "SetStatusBarParams",
+    "SetStatusBarCreate",
+    "SetStatusBarResult",
+    "SetStatusBarImplementation",
+    "SetStatusBarCommandType",
     # load liquid command models
     "LoadLiquid",
     "LoadLiquidCreate",

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -169,6 +169,7 @@ class AbstractCommandImpl(
         tip_handler: execution.TipHandler,
         run_control: execution.RunControlHandler,
         rail_lights: execution.RailLightsHandler,
+        status_bar: execution.StatusBarHandler,
     ) -> None:
         """Initialize the command implementation with execution handlers."""
         pass

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -209,6 +209,14 @@ from .blow_out_in_place import (
     BlowOutInPlaceResult,
 )
 
+from .set_status_bar import (
+    SetStatusBar,
+    SetStatusBarParams,
+    SetStatusBarCreate,
+    SetStatusBarResult,
+    SetStatusBarCommandType,
+)
+
 Command = Union[
     Aspirate,
     AspirateInPlace,
@@ -235,6 +243,7 @@ Command = Union[
     SavePosition,
     SetRailLights,
     TouchTip,
+    SetStatusBar,
     heater_shaker.WaitForTemperature,
     heater_shaker.SetTargetTemperature,
     heater_shaker.DeactivateHeater,
@@ -288,6 +297,7 @@ CommandParams = Union[
     SavePositionParams,
     SetRailLightsParams,
     TouchTipParams,
+    SetStatusBarParams,
     heater_shaker.WaitForTemperatureParams,
     heater_shaker.SetTargetTemperatureParams,
     heater_shaker.DeactivateHeaterParams,
@@ -342,6 +352,7 @@ CommandType = Union[
     SavePositionCommandType,
     SetRailLightsCommandType,
     TouchTipCommandType,
+    SetStatusBarCommandType,
     heater_shaker.WaitForTemperatureCommandType,
     heater_shaker.SetTargetTemperatureCommandType,
     heater_shaker.DeactivateHeaterCommandType,
@@ -395,6 +406,7 @@ CommandCreate = Union[
     SavePositionCreate,
     SetRailLightsCreate,
     TouchTipCreate,
+    SetStatusBarCreate,
     heater_shaker.WaitForTemperatureCreate,
     heater_shaker.SetTargetTemperatureCreate,
     heater_shaker.DeactivateHeaterCreate,
@@ -448,6 +460,7 @@ CommandResult = Union[
     SavePositionResult,
     SetRailLightsResult,
     TouchTipResult,
+    SetStatusBarResult,
     heater_shaker.WaitForTemperatureResult,
     heater_shaker.SetTargetTemperatureResult,
     heater_shaker.DeactivateHeaterResult,

--- a/api/src/opentrons/protocol_engine/commands/set_status_bar.py
+++ b/api/src/opentrons/protocol_engine/commands/set_status_bar.py
@@ -1,0 +1,82 @@
+"""setStatusBar command request, result, and implementation models."""
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING, Optional, Type
+from typing_extensions import Literal
+import enum
+
+from opentrons.hardware_control.types import StatusBarState
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import StatusBarHandler
+
+SetStatusBarCommandType = Literal["setStatusBar"]
+
+
+class StatusBarAnimation(enum.Enum):
+    """Status Bar animation options."""
+
+    IDLE = "idle"
+    CONFIRM = "confirm"
+    UPDATING = "updating"
+    DISCO = "disco"
+    OFF = "off"
+
+
+def _animation_to_status_bar_state(animation: StatusBarAnimation) -> StatusBarState:
+    return {
+        StatusBarAnimation.IDLE: StatusBarState.IDLE,
+        StatusBarAnimation.CONFIRM: StatusBarState.CONFIRMATION,
+        StatusBarAnimation.UPDATING: StatusBarState.UPDATING,
+        StatusBarAnimation.DISCO: StatusBarState.DISCO,
+        StatusBarAnimation.OFF: StatusBarState.OFF,
+    }[animation]
+
+
+class SetStatusBarParams(BaseModel):
+    """Payload required to set the status bar to run an animation."""
+
+    animation: StatusBarAnimation = Field(
+        ...,
+        description="The animation that should be executed on the status bar.",
+    )
+
+
+class SetStatusBarResult(BaseModel):
+    """Result data from the execution of a SetStatusBar command."""
+
+
+class SetStatusBarImplementation(
+    AbstractCommandImpl[SetStatusBarParams, SetStatusBarResult]
+):
+    """setStatusBar command implementation."""
+
+    def __init__(self, status_bar: StatusBarHandler, **kwargs: object) -> None:
+        self._status_bar = status_bar
+
+    async def execute(self, params: SetStatusBarParams) -> SetStatusBarResult:
+        """Execute the setStatusBar command."""
+        if not self._status_bar.status_bar_should_not_be_changed():
+            state = _animation_to_status_bar_state(params.animation)
+            await self._status_bar.set_status_bar(state)
+        return SetStatusBarResult()
+
+
+class SetStatusBar(BaseCommand[SetStatusBarParams, SetStatusBarResult]):
+    """setStatusBar command model."""
+
+    commandType: SetStatusBarCommandType = "setStatusBar"
+    params: SetStatusBarParams
+    result: Optional[SetStatusBarResult]
+
+    _ImplementationCls: Type[SetStatusBarImplementation] = SetStatusBarImplementation
+
+
+class SetStatusBarCreate(BaseCommandCreate[SetStatusBarParams]):
+    """setStatusBar command request model."""
+
+    commandType: SetStatusBarCommandType = "setStatusBar"
+    params: SetStatusBarParams
+
+    _CommandCls: Type[SetStatusBar] = SetStatusBar

--- a/api/src/opentrons/protocol_engine/execution/__init__.py
+++ b/api/src/opentrons/protocol_engine/execution/__init__.py
@@ -18,6 +18,7 @@ from .rail_lights import RailLightsHandler
 from .run_control import RunControlHandler
 from .hardware_stopper import HardwareStopper
 from .door_watcher import DoorWatcher
+from .status_bar import StatusBarHandler
 
 # .thermocycler_movement_flagger omitted from package's public interface.
 
@@ -39,4 +40,5 @@ __all__ = [
     "HardwareStopper",
     "DoorWatcher",
     "RailLightsHandler",
+    "StatusBarHandler",
 ]

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -18,6 +18,7 @@ from .pipetting import PipettingHandler
 from .tip_handler import TipHandler
 from .run_control import RunControlHandler
 from .rail_lights import RailLightsHandler
+from .status_bar import StatusBarHandler
 
 
 log = getLogger(__name__)
@@ -43,6 +44,7 @@ class CommandExecutor:
         tip_handler: TipHandler,
         run_control: RunControlHandler,
         rail_lights: RailLightsHandler,
+        status_bar: StatusBarHandler,
         model_utils: Optional[ModelUtils] = None,
     ) -> None:
         """Initialize the CommandExecutor with access to its dependencies."""
@@ -58,6 +60,7 @@ class CommandExecutor:
         self._run_control = run_control
         self._rail_lights = rail_lights
         self._model_utils = model_utils or ModelUtils()
+        self._status_bar = status_bar
 
     async def execute(self, command_id: str) -> None:
         """Run a given command's execution procedure.
@@ -78,6 +81,7 @@ class CommandExecutor:
             tip_handler=self._tip_handler,
             run_control=self._run_control,
             rail_lights=self._rail_lights,
+            status_bar=self._status_bar,
         )
 
         started_at = self._model_utils.get_timestamp()

--- a/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
@@ -13,6 +13,7 @@ from .tip_handler import create_tip_handler
 from .run_control import RunControlHandler
 from .command_executor import CommandExecutor
 from .queue_worker import QueueWorker
+from .status_bar import StatusBarHandler
 
 
 def create_queue_worker(
@@ -69,6 +70,8 @@ def create_queue_worker(
         hardware_api=hardware_api,
     )
 
+    status_bar_handler = StatusBarHandler(hardware_api=hardware_api)
+
     command_executor = CommandExecutor(
         hardware_api=hardware_api,
         state_store=state_store,
@@ -81,6 +84,7 @@ def create_queue_worker(
         tip_handler=tip_handler,
         run_control=run_control_handler,
         rail_lights=rail_lights_handler,
+        status_bar=status_bar_handler,
     )
 
     return QueueWorker(

--- a/api/src/opentrons/protocol_engine/execution/status_bar.py
+++ b/api/src/opentrons/protocol_engine/execution/status_bar.py
@@ -1,0 +1,34 @@
+"""Status Bar command handling."""
+
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import StatusBarState
+
+
+class StatusBarHandler:
+    """Handle interaction with the status bar."""
+
+    _hardware_api: HardwareControlAPI
+
+    def __init__(
+        self,
+        hardware_api: HardwareControlAPI,
+    ) -> None:
+        """Initialize a StatusBarHandler instance."""
+        self._hardware_api = hardware_api
+
+    async def set_status_bar(
+        self,
+        status: StatusBarState,
+    ) -> None:
+        """Set the status bar."""
+        await self._hardware_api.set_status_bar_state(state=status)
+
+    def status_bar_should_not_be_changed(self) -> bool:
+        """Checks whether the status bar is seemingly busy."""
+        state = self._hardware_api.get_status_bar_state()
+
+        return state not in [
+            StatusBarState.IDLE,
+            StatusBarState.UPDATING,
+            StatusBarState.OFF,
+        ]

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.execution import (
     RunControlHandler,
     RailLightsHandler,
     LabwareMovementHandler,
+    StatusBarHandler,
 )
 from opentrons.protocol_engine.state import StateView
 
@@ -55,3 +56,9 @@ def run_control(decoy: Decoy) -> RunControlHandler:
 def rail_lights(decoy: Decoy) -> RailLightsHandler:
     """Get a mocked out RailLightsHandler."""
     return decoy.mock(cls=RailLightsHandler)
+
+
+@pytest.fixture
+def status_bar(decoy: Decoy) -> StatusBarHandler:
+    """Get a mocked out StatusBarHandler."""
+    return decoy.mock(cls=StatusBarHandler)

--- a/api/tests/opentrons/protocol_engine/commands/test_set_status_bar.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_set_status_bar.py
@@ -1,0 +1,67 @@
+"""Test setStatusBar commands."""
+
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.commands.set_status_bar import (
+    SetStatusBarParams,
+    SetStatusBarResult,
+    SetStatusBarImplementation,
+    StatusBarAnimation,
+)
+
+from opentrons.hardware_control.types import StatusBarState
+from opentrons.protocol_engine.execution.status_bar import StatusBarHandler
+
+
+@pytest.fixture
+def subject(
+    status_bar: StatusBarHandler,
+) -> SetStatusBarImplementation:
+    """Returns subject under test."""
+    return SetStatusBarImplementation(status_bar=status_bar)
+
+
+async def test_status_bar_busy(
+    decoy: Decoy,
+    status_bar: StatusBarHandler,
+    subject: SetStatusBarImplementation,
+) -> None:
+    """Test when the status bar is busy."""
+    decoy.when(status_bar.status_bar_should_not_be_changed()).then_return(True)
+
+    data = SetStatusBarParams(animation=StatusBarAnimation.OFF)
+
+    result = await subject.execute(params=data)
+
+    assert result == SetStatusBarResult()
+
+    decoy.verify(await status_bar.set_status_bar(status=StatusBarState.OFF), times=0)
+
+
+@pytest.mark.parametrize(
+    argnames=["animation", "expected_state"],
+    argvalues=[
+        [StatusBarAnimation.CONFIRM, StatusBarState.CONFIRMATION],
+        [StatusBarAnimation.DISCO, StatusBarState.DISCO],
+        [StatusBarAnimation.OFF, StatusBarState.OFF],
+        [StatusBarAnimation.IDLE, StatusBarState.IDLE],
+        [StatusBarAnimation.UPDATING, StatusBarState.UPDATING],
+    ],
+)
+async def test_set_status_bar_animation(
+    decoy: Decoy,
+    status_bar: StatusBarHandler,
+    subject: SetStatusBarImplementation,
+    animation: StatusBarAnimation,
+    expected_state: StatusBarState,
+) -> None:
+    """Test when status bar is NOT busy."""
+    decoy.when(status_bar.status_bar_should_not_be_changed()).then_return(False)
+
+    data = SetStatusBarParams(animation=animation)
+
+    result = await subject.execute(params=data)
+    assert result == SetStatusBarResult()
+
+    decoy.verify(await status_bar.set_status_bar(status=expected_state), times=1)

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -35,6 +35,7 @@ from opentrons.protocol_engine.execution import (
     TipHandler,
     RunControlHandler,
     RailLightsHandler,
+    StatusBarHandler,
 )
 
 
@@ -111,6 +112,12 @@ def rail_lights(decoy: Decoy) -> RailLightsHandler:
 
 
 @pytest.fixture
+def status_bar(decoy: Decoy) -> StatusBarHandler:
+    """Get a mocked out StatusBarHandler."""
+    return decoy.mock(cls=StatusBarHandler)
+
+
+@pytest.fixture
 def subject(
     hardware_api: HardwareControlAPI,
     state_store: StateStore,
@@ -123,6 +130,7 @@ def subject(
     mock_tip_handler: TipHandler,
     run_control: RunControlHandler,
     rail_lights: RailLightsHandler,
+    status_bar: StatusBarHandler,
     model_utils: ModelUtils,
 ) -> CommandExecutor:
     """Get a CommandExecutor test subject with its dependencies mocked out."""
@@ -139,6 +147,7 @@ def subject(
         run_control=run_control,
         model_utils=model_utils,
         rail_lights=rail_lights,
+        status_bar=status_bar,
     )
 
 
@@ -168,6 +177,7 @@ async def test_execute(
     mock_tip_handler: TipHandler,
     run_control: RunControlHandler,
     rail_lights: RailLightsHandler,
+    status_bar: StatusBarHandler,
     model_utils: ModelUtils,
     subject: CommandExecutor,
 ) -> None:
@@ -240,6 +250,7 @@ async def test_execute(
             tip_handler=mock_tip_handler,
             run_control=run_control,
             rail_lights=rail_lights,
+            status_bar=status_bar,
         )
     ).then_return(
         command_impl  # type: ignore[arg-type]
@@ -290,6 +301,7 @@ async def test_execute_raises_protocol_engine_error(
     mock_tip_handler: TipHandler,
     run_control: RunControlHandler,
     rail_lights: RailLightsHandler,
+    status_bar: StatusBarHandler,
     model_utils: ModelUtils,
     subject: CommandExecutor,
     command_error: Exception,
@@ -349,6 +361,7 @@ async def test_execute_raises_protocol_engine_error(
             tip_handler=mock_tip_handler,
             run_control=run_control,
             rail_lights=rail_lights,
+            status_bar=status_bar,
         )
     ).then_return(
         command_impl  # type: ignore[arg-type]

--- a/api/tests/opentrons/protocol_engine/execution/test_status_bar_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_status_bar_handler.py
@@ -1,0 +1,54 @@
+"""StatusBar handler."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.execution.status_bar import StatusBarHandler
+from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
+from opentrons.hardware_control.types import StatusBarState
+
+
+@pytest.fixture
+def subject(
+    hardware_api: HardwareControlAPI,
+) -> StatusBarHandler:
+    """Create a StatusBarHandler with its dependencies mocked out."""
+    return StatusBarHandler(hardware_api=hardware_api)
+
+
+@pytest.mark.parametrize("setting", [StatusBarState.IDLE, StatusBarState.RUN_COMPLETED])
+async def test_set_status_bar(
+    decoy: Decoy,
+    subject: StatusBarHandler,
+    hardware_api: OT2HardwareControlAPI,
+    setting: StatusBarState,
+) -> None:
+    """The hardware controller should be called."""
+    await subject.set_status_bar(setting)
+
+    decoy.verify(await hardware_api.set_status_bar_state(state=setting), times=1)
+
+
+@pytest.mark.parametrize(
+    argnames=["setting", "should_be_busy"],
+    argvalues=[
+        [StatusBarState.IDLE, False],
+        [StatusBarState.UPDATING, False],
+        [StatusBarState.OFF, False],
+        [StatusBarState.HARDWARE_ERROR, True],
+        [StatusBarState.SOFTWARE_ERROR, True],
+        [StatusBarState.RUN_COMPLETED, True],
+        [StatusBarState.RUNNING, True],
+        [StatusBarState.PAUSED, True],
+    ],
+)
+async def test_check_status_bar_should_not_be_changed(
+    decoy: Decoy,
+    subject: StatusBarHandler,
+    hardware_api: OT2HardwareControlAPI,
+    setting: StatusBarState,
+    should_be_busy: bool,
+) -> None:
+    """IDLE, UPDATING, and OFF should be the only states allowed to change."""
+    decoy.when(hardware_api.get_status_bar_state()).then_return(setting)
+
+    assert subject.status_bar_should_not_be_changed() == should_be_busy

--- a/robot-server/robot_server/commands/stateless_commands.py
+++ b/robot-server/robot_server/commands/stateless_commands.py
@@ -5,6 +5,7 @@ from opentrons.protocol_engine import commands
 StatelessCommandCreate = Union[
     commands.HomeCreate,
     commands.SetRailLightsCreate,
+    commands.SetStatusBarCreate,
     commands.magnetic_module.EngageCreate,
     commands.magnetic_module.DisengageCreate,
     commands.temperature_module.SetTargetTemperatureCreate,
@@ -26,6 +27,7 @@ StatelessCommandCreate = Union[
 StatelessCommand = Union[
     commands.Home,
     commands.SetRailLights,
+    commands.SetStatusBar,
     commands.magnetic_module.Engage,
     commands.magnetic_module.Disengage,
     commands.temperature_module.SetTargetTemperature,

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -160,11 +160,7 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "type": "string"
     },
     "WellOffset": {
@@ -249,21 +245,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup"
-      ],
+      "enum": ["protocol", "setup"],
       "type": "string"
     },
     "AspirateCreate": {
@@ -274,9 +261,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": [
-            "aspirate"
-          ],
+          "enum": ["aspirate"],
           "type": "string"
         },
         "params": {
@@ -296,9 +281,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -323,11 +306,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -337,9 +316,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": [
-            "aspirateInPlace"
-          ],
+          "enum": ["aspirateInPlace"],
           "type": "string"
         },
         "params": {
@@ -359,9 +336,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -374,9 +349,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ]
+      "required": ["message"]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -386,9 +359,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": [
-            "comment"
-          ],
+          "enum": ["comment"],
           "type": "string"
         },
         "params": {
@@ -408,9 +379,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -426,9 +395,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": [
-            "custom"
-          ],
+          "enum": ["custom"],
           "type": "string"
         },
         "params": {
@@ -448,9 +415,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -494,13 +459,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -510,9 +469,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": [
-            "dispense"
-          ],
+          "enum": ["dispense"],
           "type": "string"
         },
         "params": {
@@ -532,9 +489,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -559,11 +514,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -573,9 +524,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": [
-            "dispenseInPlace"
-          ],
+          "enum": ["dispenseInPlace"],
           "type": "string"
         },
         "params": {
@@ -595,9 +544,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -635,12 +582,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -650,9 +592,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": [
-            "blowout"
-          ],
+          "enum": ["blowout"],
           "type": "string"
         },
         "params": {
@@ -672,9 +612,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -693,10 +631,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -706,9 +641,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": [
-            "blowOutInPlace"
-          ],
+          "enum": ["blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -728,19 +661,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -802,11 +728,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ]
+      "required": ["pipetteId", "labwareId", "wellName"]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -816,9 +738,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": [
-            "dropTip"
-          ],
+          "enum": ["dropTip"],
           "type": "string"
         },
         "params": {
@@ -838,9 +758,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -858,9 +776,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -870,9 +786,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": [
-            "dropTipInPlace"
-          ],
+          "enum": ["dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -892,9 +806,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -933,9 +845,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": [
-            "home"
-          ],
+          "enum": ["home"],
           "type": "string"
         },
         "params": {
@@ -955,9 +865,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1003,9 +911,7 @@
           ]
         }
       },
-      "required": [
-        "slotName"
-      ]
+      "required": ["slotName"]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1018,9 +924,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1038,9 +942,7 @@
               "$ref": "#/definitions/ModuleLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             }
           ]
@@ -1071,12 +973,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ]
+      "required": ["location", "loadName", "namespace", "version"]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1086,9 +983,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": [
-            "loadLabware"
-          ],
+          "enum": ["loadLabware"],
           "type": "string"
         },
         "params": {
@@ -1108,9 +1003,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1136,11 +1029,7 @@
           }
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ]
+      "required": ["liquidId", "labwareId", "volumeByWell"]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1150,9 +1039,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": [
-            "loadLiquid"
-          ],
+          "enum": ["loadLiquid"],
           "type": "string"
         },
         "params": {
@@ -1172,9 +1059,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1219,10 +1104,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ]
+      "required": ["model", "location"]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1232,9 +1114,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": [
-            "loadModule"
-          ],
+          "enum": ["loadModule"],
           "type": "string"
         },
         "params": {
@@ -1254,9 +1134,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1285,11 +1163,7 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "type": "string"
     },
     "LoadPipetteParams": {
@@ -1305,9 +1179,7 @@
               "$ref": "#/definitions/PipetteNameType"
             },
             {
-              "enum": [
-                "p1000_96"
-              ],
+              "enum": ["p1000_96"],
               "type": "string"
             }
           ]
@@ -1326,10 +1198,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ]
+      "required": ["pipetteName", "mount"]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1339,9 +1208,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": [
-            "loadPipette"
-          ],
+          "enum": ["loadPipette"],
           "type": "string"
         },
         "params": {
@@ -1361,18 +1228,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1393,11 +1254,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1420,9 +1277,7 @@
               "$ref": "#/definitions/ModuleLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             }
           ]
@@ -1466,11 +1321,7 @@
           ]
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ]
+      "required": ["labwareId", "newLocation", "strategy"]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1480,9 +1331,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": [
-            "moveLabware"
-          ],
+          "enum": ["moveLabware"],
           "type": "string"
         },
         "params": {
@@ -1502,18 +1351,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1540,11 +1383,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ]
+      "required": ["pipetteId", "axis", "distance"]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1554,9 +1393,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": [
-            "moveRelative"
-          ],
+          "enum": ["moveRelative"],
           "type": "string"
         },
         "params": {
@@ -1576,9 +1413,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1598,11 +1433,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1640,10 +1471,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ]
+      "required": ["pipetteId", "coordinates"]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1653,9 +1481,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": [
-            "moveToCoordinates"
-          ],
+          "enum": ["moveToCoordinates"],
           "type": "string"
         },
         "params": {
@@ -1675,9 +1501,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -1725,11 +1549,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -1739,9 +1559,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": [
-            "moveToWell"
-          ],
+          "enum": ["moveToWell"],
           "type": "string"
         },
         "params": {
@@ -1761,9 +1579,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -1785,10 +1601,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "type": "string"
         },
         "params": {
@@ -1808,9 +1621,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -1828,9 +1639,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "seconds"
-      ]
+      "required": ["seconds"]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -1840,9 +1649,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": [
-            "waitForDuration"
-          ],
+          "enum": ["waitForDuration"],
           "type": "string"
         },
         "params": {
@@ -1862,9 +1669,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -1896,11 +1701,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -1910,9 +1711,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": [
-            "pickUpTip"
-          ],
+          "enum": ["pickUpTip"],
           "type": "string"
         },
         "params": {
@@ -1932,9 +1731,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -1952,9 +1749,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -1964,9 +1759,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": [
-            "savePosition"
-          ],
+          "enum": ["savePosition"],
           "type": "string"
         },
         "params": {
@@ -1986,9 +1779,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2001,9 +1792,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ]
+      "required": ["on"]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2013,9 +1802,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": [
-            "setRailLights"
-          ],
+          "enum": ["setRailLights"],
           "type": "string"
         },
         "params": {
@@ -2035,9 +1822,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2080,11 +1865,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2094,9 +1875,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": [
-            "touchTip"
-          ],
+          "enum": ["touchTip"],
           "type": "string"
         },
         "params": {
@@ -2116,20 +1895,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ]
+      "enum": ["idle", "confirm", "updating", "disco", "off"]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2145,9 +1916,7 @@
           ]
         }
       },
-      "required": [
-        "animation"
-      ]
+      "required": ["animation"]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2157,9 +1926,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": [
-            "setStatusBar"
-          ],
+          "enum": ["setStatusBar"],
           "type": "string"
         },
         "params": {
@@ -2179,9 +1946,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2199,9 +1964,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2211,9 +1974,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": [
-            "heaterShaker/waitForTemperature"
-          ],
+          "enum": ["heaterShaker/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -2233,9 +1994,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2253,10 +2012,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2266,9 +2022,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": [
-            "heaterShaker/setTargetTemperature"
-          ],
+          "enum": ["heaterShaker/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -2288,9 +2042,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -2303,9 +2055,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -2315,9 +2065,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": [
-            "heaterShaker/deactivateHeater"
-          ],
+          "enum": ["heaterShaker/deactivateHeater"],
           "type": "string"
         },
         "params": {
@@ -2337,9 +2085,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -2357,10 +2103,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ]
+      "required": ["moduleId", "rpm"]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -2370,9 +2113,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": [
-            "heaterShaker/setAndWaitForShakeSpeed"
-          ],
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "type": "string"
         },
         "params": {
@@ -2392,9 +2133,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -2407,9 +2146,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -2419,9 +2156,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": [
-            "heaterShaker/deactivateShaker"
-          ],
+          "enum": ["heaterShaker/deactivateShaker"],
           "type": "string"
         },
         "params": {
@@ -2441,9 +2176,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -2456,9 +2189,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -2468,9 +2199,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": [
-            "heaterShaker/openLabwareLatch"
-          ],
+          "enum": ["heaterShaker/openLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -2490,9 +2219,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -2505,9 +2232,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -2517,9 +2242,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": [
-            "heaterShaker/closeLabwareLatch"
-          ],
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -2539,9 +2262,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -2554,9 +2275,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -2566,9 +2285,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": [
-            "magneticModule/disengage"
-          ],
+          "enum": ["magneticModule/disengage"],
           "type": "string"
         },
         "params": {
@@ -2588,9 +2305,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -2608,10 +2323,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ]
+      "required": ["moduleId", "height"]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -2621,9 +2333,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": [
-            "magneticModule/engage"
-          ],
+          "enum": ["magneticModule/engage"],
           "type": "string"
         },
         "params": {
@@ -2643,9 +2353,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2663,10 +2371,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2676,9 +2381,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": [
-            "temperatureModule/setTargetTemperature"
-          ],
+          "enum": ["temperatureModule/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -2698,9 +2401,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2718,9 +2419,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2730,9 +2429,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": [
-            "temperatureModule/waitForTemperature"
-          ],
+          "enum": ["temperatureModule/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -2752,9 +2449,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -2767,9 +2462,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -2779,9 +2472,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": [
-            "temperatureModule/deactivate"
-          ],
+          "enum": ["temperatureModule/deactivate"],
           "type": "string"
         },
         "params": {
@@ -2801,9 +2492,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -2831,10 +2520,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -2844,9 +2530,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": [
-            "thermocycler/setTargetBlockTemperature"
-          ],
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -2866,9 +2550,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -2881,9 +2563,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -2893,9 +2573,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": [
-            "thermocycler/waitForBlockTemperature"
-          ],
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -2915,9 +2593,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -2935,10 +2611,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -2948,9 +2621,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": [
-            "thermocycler/setTargetLidTemperature"
-          ],
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -2970,9 +2641,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -2985,9 +2654,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -2997,9 +2664,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": [
-            "thermocycler/waitForLidTemperature"
-          ],
+          "enum": ["thermocycler/waitForLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -3019,9 +2684,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -3034,9 +2697,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -3046,9 +2707,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": [
-            "thermocycler/deactivateBlock"
-          ],
+          "enum": ["thermocycler/deactivateBlock"],
           "type": "string"
         },
         "params": {
@@ -3068,9 +2727,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -3083,9 +2740,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -3095,9 +2750,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": [
-            "thermocycler/deactivateLid"
-          ],
+          "enum": ["thermocycler/deactivateLid"],
           "type": "string"
         },
         "params": {
@@ -3117,9 +2770,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -3132,9 +2783,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -3144,9 +2793,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": [
-            "thermocycler/openLid"
-          ],
+          "enum": ["thermocycler/openLid"],
           "type": "string"
         },
         "params": {
@@ -3166,9 +2813,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -3181,9 +2826,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -3193,9 +2836,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": [
-            "thermocycler/closeLid"
-          ],
+          "enum": ["thermocycler/closeLid"],
           "type": "string"
         },
         "params": {
@@ -3215,9 +2856,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -3235,10 +2874,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ]
+      "required": ["celsius", "holdSeconds"]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -3264,10 +2900,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ]
+      "required": ["moduleId", "profile"]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -3277,9 +2910,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": [
-            "thermocycler/runProfile"
-          ],
+          "enum": ["thermocycler/runProfile"],
           "type": "string"
         },
         "params": {
@@ -3299,17 +2930,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": [
-        "front",
-        "rear"
-      ]
+      "enum": ["front", "rear"]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -3329,11 +2955,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -3358,9 +2980,7 @@
           ]
         }
       },
-      "required": [
-        "jaw"
-      ]
+      "required": ["jaw"]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -3370,9 +2990,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": [
-            "calibration/calibrateGripper"
-          ],
+          "enum": ["calibration/calibrateGripper"],
           "type": "string"
         },
         "params": {
@@ -3392,9 +3010,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -3410,9 +3026,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -3422,9 +3036,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": [
-            "calibration/calibratePipette"
-          ],
+          "enum": ["calibration/calibratePipette"],
           "type": "string"
         },
         "params": {
@@ -3444,9 +3056,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -3472,11 +3082,7 @@
           ]
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ]
+      "required": ["moduleId", "labwareId", "mount"]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -3486,9 +3092,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": [
-            "calibration/calibrateModule"
-          ],
+          "enum": ["calibration/calibrateModule"],
           "type": "string"
         },
         "params": {
@@ -3508,17 +3112,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ]
+      "enum": ["attachPlate", "attachInstrument"]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -3543,9 +3142,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -3555,9 +3152,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": [
-            "calibration/moveToMaintenancePosition"
-          ],
+          "enum": ["calibration/moveToMaintenancePosition"],
           "type": "string"
         },
         "params": {
@@ -3577,9 +3172,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     }
   },
   "$id": "opentronsCommandSchemaV7",

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -78,6 +78,9 @@
       "$ref": "#/definitions/TouchTipCreate"
     },
     {
+      "$ref": "#/definitions/SetStatusBarCreate"
+    },
+    {
       "$ref": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate"
     },
     {
@@ -157,7 +160,11 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
       "type": "string"
     },
     "WellOffset": {
@@ -242,12 +249,21 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup"],
+      "enum": [
+        "protocol",
+        "setup"
+      ],
       "type": "string"
     },
     "AspirateCreate": {
@@ -258,7 +274,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": ["aspirate"],
+          "enum": [
+            "aspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -278,7 +296,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -303,7 +323,11 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -313,7 +337,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": ["aspirateInPlace"],
+          "enum": [
+            "aspirateInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -333,7 +359,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -346,7 +374,9 @@
           "type": "string"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -356,7 +386,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": ["comment"],
+          "enum": [
+            "comment"
+          ],
           "type": "string"
         },
         "params": {
@@ -376,7 +408,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -392,7 +426,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": ["custom"],
+          "enum": [
+            "custom"
+          ],
           "type": "string"
         },
         "params": {
@@ -412,7 +448,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -456,7 +494,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -466,7 +510,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": ["dispense"],
+          "enum": [
+            "dispense"
+          ],
           "type": "string"
         },
         "params": {
@@ -486,7 +532,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -511,7 +559,11 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -521,7 +573,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": ["dispenseInPlace"],
+          "enum": [
+            "dispenseInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -541,7 +595,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -579,7 +635,12 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -589,7 +650,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": ["blowout"],
+          "enum": [
+            "blowout"
+          ],
           "type": "string"
         },
         "params": {
@@ -609,7 +672,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -628,7 +693,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -638,7 +706,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": ["blowOutInPlace"],
+          "enum": [
+            "blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -658,12 +728,19 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -725,7 +802,11 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"]
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -735,7 +816,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": ["dropTip"],
+          "enum": [
+            "dropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -755,7 +838,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -773,7 +858,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -783,7 +870,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": ["dropTipInPlace"],
+          "enum": [
+            "dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -803,7 +892,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -842,7 +933,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": ["home"],
+          "enum": [
+            "home"
+          ],
           "type": "string"
         },
         "params": {
@@ -862,7 +955,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -908,7 +1003,9 @@
           ]
         }
       },
-      "required": ["slotName"]
+      "required": [
+        "slotName"
+      ]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -921,7 +1018,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -939,7 +1038,9 @@
               "$ref": "#/definitions/ModuleLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             }
           ]
@@ -970,7 +1071,12 @@
           "type": "string"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"]
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -980,7 +1086,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": ["loadLabware"],
+          "enum": [
+            "loadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1000,7 +1108,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1026,7 +1136,11 @@
           }
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"]
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1036,7 +1150,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": ["loadLiquid"],
+          "enum": [
+            "loadLiquid"
+          ],
           "type": "string"
         },
         "params": {
@@ -1056,7 +1172,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1101,7 +1219,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"]
+      "required": [
+        "model",
+        "location"
+      ]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1111,7 +1232,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": ["loadModule"],
+          "enum": [
+            "loadModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -1131,7 +1254,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1160,7 +1285,11 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "type": "string"
     },
     "LoadPipetteParams": {
@@ -1176,7 +1305,9 @@
               "$ref": "#/definitions/PipetteNameType"
             },
             {
-              "enum": ["p1000_96"],
+              "enum": [
+                "p1000_96"
+              ],
               "type": "string"
             }
           ]
@@ -1195,7 +1326,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteName", "mount"]
+      "required": [
+        "pipetteName",
+        "mount"
+      ]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1205,7 +1339,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": ["loadPipette"],
+          "enum": [
+            "loadPipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -1225,12 +1361,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1251,7 +1393,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1274,7 +1420,9 @@
               "$ref": "#/definitions/ModuleLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             }
           ]
@@ -1318,7 +1466,11 @@
           ]
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"]
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1328,7 +1480,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": ["moveLabware"],
+          "enum": [
+            "moveLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1348,12 +1502,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1380,7 +1540,11 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "axis", "distance"]
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1390,7 +1554,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": ["moveRelative"],
+          "enum": [
+            "moveRelative"
+          ],
           "type": "string"
         },
         "params": {
@@ -1410,7 +1576,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1430,7 +1598,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1468,7 +1640,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "coordinates"]
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1478,7 +1653,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": ["moveToCoordinates"],
+          "enum": [
+            "moveToCoordinates"
+          ],
           "type": "string"
         },
         "params": {
@@ -1498,7 +1675,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -1546,7 +1725,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -1556,7 +1739,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": ["moveToWell"],
+          "enum": [
+            "moveToWell"
+          ],
           "type": "string"
         },
         "params": {
@@ -1576,7 +1761,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -1598,7 +1785,10 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "type": "string"
         },
         "params": {
@@ -1618,7 +1808,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -1636,7 +1828,9 @@
           "type": "string"
         }
       },
-      "required": ["seconds"]
+      "required": [
+        "seconds"
+      ]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -1646,7 +1840,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": ["waitForDuration"],
+          "enum": [
+            "waitForDuration"
+          ],
           "type": "string"
         },
         "params": {
@@ -1666,7 +1862,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -1698,7 +1896,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -1708,7 +1910,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": ["pickUpTip"],
+          "enum": [
+            "pickUpTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1728,7 +1932,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -1746,7 +1952,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -1756,7 +1964,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": ["savePosition"],
+          "enum": [
+            "savePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -1776,7 +1986,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -1789,7 +2001,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"]
+      "required": [
+        "on"
+      ]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -1799,7 +2013,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": ["setRailLights"],
+          "enum": [
+            "setRailLights"
+          ],
           "type": "string"
         },
         "params": {
@@ -1819,7 +2035,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -1862,7 +2080,11 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -1872,7 +2094,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": ["touchTip"],
+          "enum": [
+            "touchTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1892,7 +2116,72 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
+    },
+    "StatusBarAnimation": {
+      "title": "StatusBarAnimation",
+      "description": "Status Bar animation options.",
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ]
+    },
+    "SetStatusBarParams": {
+      "title": "SetStatusBarParams",
+      "description": "Payload required to set the status bar to run an animation.",
+      "type": "object",
+      "properties": {
+        "animation": {
+          "description": "The animation that should be executed on the status bar.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StatusBarAnimation"
+            }
+          ]
+        }
+      },
+      "required": [
+        "animation"
+      ]
+    },
+    "SetStatusBarCreate": {
+      "title": "SetStatusBarCreate",
+      "description": "setStatusBar command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "setStatusBar",
+          "enum": [
+            "setStatusBar"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SetStatusBarParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -1910,7 +2199,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -1920,7 +2211,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": ["heaterShaker/waitForTemperature"],
+          "enum": [
+            "heaterShaker/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -1940,7 +2233,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -1958,7 +2253,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -1968,7 +2266,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": ["heaterShaker/setTargetTemperature"],
+          "enum": [
+            "heaterShaker/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -1988,7 +2288,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -2001,7 +2303,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -2011,7 +2315,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": ["heaterShaker/deactivateHeater"],
+          "enum": [
+            "heaterShaker/deactivateHeater"
+          ],
           "type": "string"
         },
         "params": {
@@ -2031,7 +2337,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -2049,7 +2357,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"]
+      "required": [
+        "moduleId",
+        "rpm"
+      ]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -2059,7 +2370,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
+          "enum": [
+            "heaterShaker/setAndWaitForShakeSpeed"
+          ],
           "type": "string"
         },
         "params": {
@@ -2079,7 +2392,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -2092,7 +2407,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -2102,7 +2419,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": ["heaterShaker/deactivateShaker"],
+          "enum": [
+            "heaterShaker/deactivateShaker"
+          ],
           "type": "string"
         },
         "params": {
@@ -2122,7 +2441,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -2135,7 +2456,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -2145,7 +2468,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": ["heaterShaker/openLabwareLatch"],
+          "enum": [
+            "heaterShaker/openLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -2165,7 +2490,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -2178,7 +2505,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -2188,7 +2517,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": ["heaterShaker/closeLabwareLatch"],
+          "enum": [
+            "heaterShaker/closeLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -2208,7 +2539,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -2221,7 +2554,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -2231,7 +2566,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": ["magneticModule/disengage"],
+          "enum": [
+            "magneticModule/disengage"
+          ],
           "type": "string"
         },
         "params": {
@@ -2251,7 +2588,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -2269,7 +2608,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "height"]
+      "required": [
+        "moduleId",
+        "height"
+      ]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -2279,7 +2621,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": ["magneticModule/engage"],
+          "enum": [
+            "magneticModule/engage"
+          ],
           "type": "string"
         },
         "params": {
@@ -2299,7 +2643,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2317,7 +2663,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2327,7 +2676,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": ["temperatureModule/setTargetTemperature"],
+          "enum": [
+            "temperatureModule/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2347,7 +2698,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2365,7 +2718,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2375,7 +2730,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": ["temperatureModule/waitForTemperature"],
+          "enum": [
+            "temperatureModule/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2395,7 +2752,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -2408,7 +2767,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -2418,7 +2779,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": ["temperatureModule/deactivate"],
+          "enum": [
+            "temperatureModule/deactivate"
+          ],
           "type": "string"
         },
         "params": {
@@ -2438,7 +2801,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -2466,7 +2831,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -2476,7 +2844,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": ["thermocycler/setTargetBlockTemperature"],
+          "enum": [
+            "thermocycler/setTargetBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2496,7 +2866,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -2509,7 +2881,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -2519,7 +2893,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": ["thermocycler/waitForBlockTemperature"],
+          "enum": [
+            "thermocycler/waitForBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2539,7 +2915,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -2557,7 +2935,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -2567,7 +2948,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": ["thermocycler/setTargetLidTemperature"],
+          "enum": [
+            "thermocycler/setTargetLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2587,7 +2970,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -2600,7 +2985,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -2610,7 +2997,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": ["thermocycler/waitForLidTemperature"],
+          "enum": [
+            "thermocycler/waitForLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2630,7 +3019,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -2643,7 +3034,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -2653,7 +3046,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": ["thermocycler/deactivateBlock"],
+          "enum": [
+            "thermocycler/deactivateBlock"
+          ],
           "type": "string"
         },
         "params": {
@@ -2673,7 +3068,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -2686,7 +3083,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -2696,7 +3095,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": ["thermocycler/deactivateLid"],
+          "enum": [
+            "thermocycler/deactivateLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -2716,7 +3117,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -2729,7 +3132,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -2739,7 +3144,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": ["thermocycler/openLid"],
+          "enum": [
+            "thermocycler/openLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -2759,7 +3166,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -2772,7 +3181,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -2782,7 +3193,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": ["thermocycler/closeLid"],
+          "enum": [
+            "thermocycler/closeLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -2802,7 +3215,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -2820,7 +3235,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"]
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -2846,7 +3264,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "profile"]
+      "required": [
+        "moduleId",
+        "profile"
+      ]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -2856,7 +3277,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": ["thermocycler/runProfile"],
+          "enum": [
+            "thermocycler/runProfile"
+          ],
           "type": "string"
         },
         "params": {
@@ -2876,12 +3299,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": ["front", "rear"]
+      "enum": [
+        "front",
+        "rear"
+      ]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -2901,7 +3329,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -2926,7 +3358,9 @@
           ]
         }
       },
-      "required": ["jaw"]
+      "required": [
+        "jaw"
+      ]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -2936,7 +3370,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": ["calibration/calibrateGripper"],
+          "enum": [
+            "calibration/calibrateGripper"
+          ],
           "type": "string"
         },
         "params": {
@@ -2956,7 +3392,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -2972,7 +3410,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -2982,7 +3422,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": ["calibration/calibratePipette"],
+          "enum": [
+            "calibration/calibratePipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -3002,7 +3444,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -3028,7 +3472,11 @@
           ]
         }
       },
-      "required": ["moduleId", "labwareId", "mount"]
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -3038,7 +3486,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": ["calibration/calibrateModule"],
+          "enum": [
+            "calibration/calibrateModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -3058,12 +3508,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"]
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -3088,7 +3543,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -3098,7 +3555,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": ["calibration/moveToMaintenancePosition"],
+          "enum": [
+            "calibration/moveToMaintenancePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -3118,7 +3577,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     }
   },
   "$id": "opentronsCommandSchemaV7",


### PR DESCRIPTION

# Overview

This PR adds a command to control the status bar to run a few select animations on it. The animations available are expected to be the ones that the app may want to remotely trigger the robot server to run based on some design workflows.

The animation will NOT run if a protocol is currently running. This is mostly handled implicitly because the stateless commands can't run while a protocol is running, but we also want to block out the animations from running when a protocol is completed but not acknowledged (status bar is either green or red for success or failure). To accomplish this, the command checks if the current status bar state indicates that it is being controlled by the background Light Control Task.

# Test Plan

Used the `POST /commands` endpoint to send `setStatusBar` commands.
- When the robot is idle, you can send any of the enumerated options and they'll animate the bar appropriately
- When the robot is in the middle of a run, the endpoint either gives an error code (if the run is actually running) or silently fails to run the command (if the run is waiting to be acknowledged). This is as expected.

# Changelog

- added a StatusBarHandler class to be able to mock out status bar setting
- added StatusBarHandler to the protocol engine
- added a setStatusBar command to the protocol engine
- updated protocol engine json schema to add new command


# Review requests

- Is this the correct way to have an enumerated string parameter for a command? I copied what the `moveToMaintenancePosition` command does.
- I regenerated the schema after these changes but did I miss anything for integrating the command?

# Risk assessment

Pretty low as long as all the CI for the protocol engine keeps working.