### PR TITLE
fix(shared-data, app): update the slot name for Flex

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -127,7 +127,7 @@ describe('LabwareListItem', () => {
       isOt3: true,
     })
     getByText('Mock Labware Definition')
-    getByText('Slot 7+10, Thermocycler Module GEN1')
+    getByText('Slot A1+B1, Thermocycler Module GEN1')
   })
 
   it('renders the correct info for a labware on top of a magnetic module', () => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/__tests__/SetupModulesList.test.tsx
@@ -218,7 +218,7 @@ describe('SetupModulesList', () => {
 
     const { getByText } = render(props)
     getByText('Thermocycler Module')
-    getByText('Slot 7+10')
+    getByText('Slot A1+B1')
     getByText('Connected')
   })
 

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -157,6 +157,6 @@ export const SINGLE_MOUNT_PIPETTES: 'Single-Channel_and_8-Channel' =
 
 // Thermocycler module info
 export const TC_MODULE_LOCATION_OT2: '7,8,10,11' = '7,8,10,11'
-export const TC_MODULE_LOCATION_OT3: '7+10' = '7+10'
+export const TC_MODULE_LOCATION_OT3: 'A1+B1' = 'A1+B1'
 
 export const WEIGHT_OF_96_CHANNEL: '~10kg' = '~10kg'


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update the slot name 7+10 to A1+B1

close RAUT-473 and RQA-697


![Screenshot 2023-06-09 at 5 15 37 PM](https://github.com/Opentrons/opentrons/assets/474225/37b294f8-fba4-4e96-85c3-278b5ff566dd)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update the const in shared-data  7+10 -> A1+B1
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
