### PR TITLE
refactor(robot-server): use the server.log file to store logs coming in from the robot server

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -212,6 +212,15 @@ CONFIG_ELEMENTS = (
         "relative path it will be relative to log_dir"
         "The location of the file to save serial logs to",
     ),
+    ConfigElement(
+        "server_log_file",
+        "Server Log File",
+        Path("logs") / "server.log",
+        ConfigElementType.FILE,
+        "The location of the file to save robot server logs to. If this is"
+        " an absolute path, it will be used directly. If it is a "
+        "relative path it will be relative to log_dir",
+    ),
     # Unlike other config elements, the wifi keys dir is still in
     # /data/user_storage/opentrons_data because these paths are fed directly to
     # NetworkManager and stored in connections files there. To change this

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -212,15 +212,6 @@ CONFIG_ELEMENTS = (
         "relative path it will be relative to log_dir"
         "The location of the file to save serial logs to",
     ),
-    ConfigElement(
-        "server_log_file",
-        "Server Log File",
-        Path("logs") / "server.log",
-        ConfigElementType.FILE,
-        "The location of the file to save robot server logs to. If this is"
-        " an absolute path, it will be used directly. If it is a "
-        "relative path it will be relative to log_dir",
-    ),
     # Unlike other config elements, the wifi keys dir is still in
     # /data/user_storage/opentrons_data because these paths are fed directly to
     # NetworkManager and stored in connections files there. To change this

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -23,10 +23,11 @@ async def get_records_dumb(selector: str, records: int, mode: str) -> bytes:
     :param records: The maximum number of records to print
     :param mode: A journalctl dump mode. Should be either "short-precise" or "json".
     """
+    selector_flag = "-u" if selector == "opentrons-robot-server" else "-t"
     proc = await asyncio.create_subprocess_exec(
         "journalctl",
         "--no-pager",
-        "-u",
+        selector_flag,
         selector,
         "-n",
         str(records),

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -7,7 +7,7 @@ This is the implementation of the endpoints in
 import asyncio
 import logging
 import subprocess
-from typing import Tuple
+from typing import Tuple, List
 
 
 LOG = logging.getLogger(__name__)
@@ -16,18 +16,18 @@ MAX_RECORDS = 100000
 DEFAULT_RECORDS = 50000
 
 
-async def get_records_dumb(selector: str, records: int, mode: str) -> bytes:
+async def get_records_dumb(selector_list: List[str], records: int, mode: str) -> bytes:
     """Dump the log files.
 
     :param selector: The syslog selector to limit responses to
     :param records: The maximum number of records to print
-    :param mode: A journalctl dump mode. Should be either "short" or "json".
+    :param mode: A journalctl dump mode. Should be either "short-precise" or "json".
     """
+    selectors = "".join(f"-t {s}" for s in selector_list)
     proc = await asyncio.create_subprocess_exec(
         "journalctl",
         "--no-pager",
-        "-t",
-        selector,
+        selectors,
         "-n",
         str(records),
         "-o",

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -7,7 +7,7 @@ This is the implementation of the endpoints in
 import asyncio
 import logging
 import subprocess
-from typing import Tuple, List
+from typing import Tuple
 
 
 LOG = logging.getLogger(__name__)
@@ -16,18 +16,18 @@ MAX_RECORDS = 100000
 DEFAULT_RECORDS = 50000
 
 
-async def get_records_dumb(selector_list: List[str], records: int, mode: str) -> bytes:
+async def get_records_dumb(selector: str, records: int, mode: str) -> bytes:
     """Dump the log files.
 
     :param selector: The syslog selector to limit responses to
     :param records: The maximum number of records to print
     :param mode: A journalctl dump mode. Should be either "short-precise" or "json".
     """
-    selectors = "".join(f"-t {s}" for s in selector_list)
     proc = await asyncio.create_subprocess_exec(
         "journalctl",
         "--no-pager",
-        selectors,
+        "-u",
+        selector,
         "-n",
         str(records),
         "-o",

--- a/robot-server/robot_server/service/legacy/models/logs.py
+++ b/robot-server/robot_server/service/legacy/models/logs.py
@@ -7,6 +7,7 @@ class LogIdentifier(str, Enum):
     api = "api.log"
     serial = "serial.log"
     server = "server.log"
+    api_server = "combined_api_server.log"
 
 
 class LogFormat(str, Enum):

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -1,16 +1,16 @@
 from fastapi import APIRouter, Query, Response
-from typing import Dict, List
+from typing import Dict
 
 from opentrons.system import log_control
 from robot_server.service.legacy.models.logs import LogIdentifier, LogFormat
 
 router = APIRouter()
 
-IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, List[str]] = {
-    LogIdentifier.api: ["opentrons-api"],
-    LogIdentifier.serial: ["opentrons-api-serial"],
-    LogIdentifier.server: ["uvicorn"],
-    LogIdentifier.api_server: ["uvicorn", "opentrons-api"],
+IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
+    LogIdentifier.api: "opentrons-api",
+    LogIdentifier.serial: "opentrons-api-serial",
+    LogIdentifier.server: "uvicorn",
+    LogIdentifier.api_server: "opentrons-robot-server",
 }
 
 

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -1,15 +1,16 @@
 from fastapi import APIRouter, Query, Response
-from typing import Dict
+from typing import Dict, List
 
 from opentrons.system import log_control
 from robot_server.service.legacy.models.logs import LogIdentifier, LogFormat
 
 router = APIRouter()
 
-IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
-    LogIdentifier.api: "opentrons-api",
-    LogIdentifier.serial: "opentrons-api-serial",
-    LogIdentifier.server: "uvicorn",
+IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, List[str]] = {
+    LogIdentifier.api: ["opentrons-api"],
+    LogIdentifier.serial: ["opentrons-api-serial"],
+    LogIdentifier.server: ["uvicorn"],
+    LogIdentifier.api_server: ["uvicorn", "opentrons-api"],
 }
 
 
@@ -28,7 +29,7 @@ async def get_logs(
     syslog_id = IDENTIFIER_TO_SYSLOG_ID[log_identifier]
     modes = {
         LogFormat.json: ("json", "application/json"),
-        LogFormat.text: ("short", "text/plain"),
+        LogFormat.text: ("short-precise", "text/plain"),
     }
     format_type, media_type = modes[format]
     output = await log_control.get_records_dumb(syslog_id, records, format_type)

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -44,8 +44,6 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
-                "backupCount": 3,
-                "maxBytes": 5000000,
                 "SYSLOG_IDENTIFIER": "uvicorn",
             },
             "syslog_plus_unit_above_warn": {
@@ -112,7 +110,6 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
                 "class": "logging.StreamHandler",
                 "level": logging.DEBUG,
                 "formatter": "basic",
-                "maxBytes": 5000000,
             }
         },
         "loggers": {

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -71,13 +71,18 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "level": log_level,
                 "propagate": False,
             },
+            "uvicorn": {
+                "handlers": ["syslog_plus_unit"],
+                "level": log_level,
+                "propagate": False,
+            },
             "fastapi": {
-                "handlers": ["unit_only"],
+                "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,
             },
             "starlette": {
-                "handlers": ["unit_only"],
+                "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,
             },

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -1,7 +1,7 @@
 import logging
 from logging.config import dictConfig
 from typing import Any, Dict
-from opentrons.config import IS_ROBOT, robot_configs
+from opentrons.config import IS_ROBOT, CONFIG, robot_configs
 
 
 def initialize_logging() -> None:
@@ -45,12 +45,14 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "level": logging.DEBUG,
                 "formatter": "message_only",
                 "SYSLOG_IDENTIFIER": "opentrons-api",
+                "filename": CONFIG["server_log_file"],
             },
             "syslog_plus_unit_above_warn": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.WARN,
                 "formatter": "message_only",
                 "SYSLOG_IDENTIFER": "opentrons-api",
+                "filename": CONFIG["server_log_file"],
             },
             "unit_only_below_warn": {
                 "class": "systemd.journal.JournalHandler",
@@ -109,6 +111,8 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
                 "class": "logging.StreamHandler",
                 "level": logging.DEBUG,
                 "formatter": "basic",
+                "filename": CONFIG["server_log_file"],
+                "maxBytes": 5000000,
             }
         },
         "loggers": {

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -1,7 +1,7 @@
 import logging
 from logging.config import dictConfig
 from typing import Any, Dict
-from opentrons.config import IS_ROBOT, CONFIG, robot_configs
+from opentrons.config import IS_ROBOT, robot_configs
 
 
 def initialize_logging() -> None:
@@ -39,20 +39,21 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
+                "SYSLOG_IDENTIFER": "opentrons-robot-server",
             },
             "syslog_plus_unit": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
-                "SYSLOG_IDENTIFIER": "opentrons-api",
-                "filename": CONFIG["server_log_file"],
+                "SYSLOG_IDENTIFIER": "opentrons-robot-server",
+                "backupCount": 3,
+                "maxBytes": 5000000,
             },
             "syslog_plus_unit_above_warn": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.WARN,
                 "formatter": "message_only",
-                "SYSLOG_IDENTIFER": "opentrons-api",
-                "filename": CONFIG["server_log_file"],
+                "SYSLOG_IDENTIFER": "opentrons-robot-server",
             },
             "unit_only_below_warn": {
                 "class": "systemd.journal.JournalHandler",
@@ -68,6 +69,11 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "propagate": False,
             },
             "uvicorn.error": {
+                "handlers": ["syslog_plus_unit"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn": {
                 "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,
@@ -111,8 +117,8 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
                 "class": "logging.StreamHandler",
                 "level": logging.DEBUG,
                 "formatter": "basic",
-                "filename": CONFIG["server_log_file"],
                 "maxBytes": 5000000,
+                "SYSLOG_IDENTIFIER": "opentrons-robot-server",
             }
         },
         "loggers": {

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -39,27 +39,27 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
-                "SYSLOG_IDENTIFER": "opentrons-robot-server",
             },
             "syslog_plus_unit": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
-                "SYSLOG_IDENTIFIER": "opentrons-robot-server",
                 "backupCount": 3,
                 "maxBytes": 5000000,
+                "SYSLOG_IDENTIFIER": "uvicorn",
             },
             "syslog_plus_unit_above_warn": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.WARN,
                 "formatter": "message_only",
-                "SYSLOG_IDENTIFER": "opentrons-robot-server",
+                "SYSLOG_IDENTIFIER": "uvicorn",
             },
             "unit_only_below_warn": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
                 "formatter": "message_only",
                 "filters": ["records_below_warning"],
+                "SYSLOG_IDENTIFIER": "uvicorn",
             },
         },
         "loggers": {
@@ -69,11 +69,6 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "propagate": False,
             },
             "uvicorn.error": {
-                "handlers": ["syslog_plus_unit"],
-                "level": log_level,
-                "propagate": False,
-            },
-            "uvicorn": {
                 "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,
@@ -118,7 +113,6 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
                 "level": logging.DEBUG,
                 "formatter": "basic",
                 "maxBytes": 5000000,
-                "SYSLOG_IDENTIFIER": "opentrons-robot-server",
             }
         },
         "loggers": {

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -21,7 +21,7 @@ def test_get_serial_log_with_defaults(api_client):
         assert response.status_code == 200
         assert body == expected
         m.assert_called_once_with(
-            ["opentrons-api-serial"], DEFAULT_RECORDS, "short-precise"
+            "opentrons-api-serial", DEFAULT_RECORDS, "short-precise"
         )
 
 
@@ -59,7 +59,7 @@ def test_get_serial_log_with_params(
         assert body == expected
         assert response.status_code == 200
 
-        m.assert_called_once_with(["opentrons-api-serial"], records_param, mode_param)
+        m.assert_called_once_with("opentrons-api-serial", records_param, mode_param)
 
 
 @pytest.mark.parametrize(
@@ -96,7 +96,7 @@ def test_get_api_log_with_defaults(api_client):
         body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with(["opentrons-api"], DEFAULT_RECORDS, "short-precise")
+        m.assert_called_once_with("opentrons-api", DEFAULT_RECORDS, "short-precise")
 
 
 @pytest.mark.parametrize(
@@ -130,7 +130,7 @@ def test_get_api_log_with_params(api_client, format_param, records_param, mode_p
             body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with(["opentrons-api"], records_param, mode_param)
+        m.assert_called_once_with("opentrons-api", records_param, mode_param)
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -20,16 +20,18 @@ def test_get_serial_log_with_defaults(api_client):
         body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with("opentrons-api-serial", DEFAULT_RECORDS, "short")
+        m.assert_called_once_with(
+            ["opentrons-api-serial"], DEFAULT_RECORDS, "short-precise"
+        )
 
 
 @pytest.mark.parametrize(
     "format_param, records_param, mode_param",
     [
         ("json", MAX_RECORDS - 1, "json"),
-        ("text", MAX_RECORDS - 1, "short"),
+        ("text", MAX_RECORDS - 1, "short-precise"),
         ("json", 1, "json"),
-        ("text", 1, "short"),
+        ("text", 1, "short-precise"),
     ],
 )
 def test_get_serial_log_with_params(
@@ -57,7 +59,7 @@ def test_get_serial_log_with_params(
         assert body == expected
         assert response.status_code == 200
 
-        m.assert_called_once_with("opentrons-api-serial", records_param, mode_param)
+        m.assert_called_once_with(["opentrons-api-serial"], records_param, mode_param)
 
 
 @pytest.mark.parametrize(
@@ -94,16 +96,16 @@ def test_get_api_log_with_defaults(api_client):
         body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with("opentrons-api", DEFAULT_RECORDS, "short")
+        m.assert_called_once_with(["opentrons-api"], DEFAULT_RECORDS, "short-precise")
 
 
 @pytest.mark.parametrize(
     "format_param, records_param, mode_param",
     [
         ("json", MAX_RECORDS - 1, "json"),
-        ("text", MAX_RECORDS - 1, "short"),
+        ("text", MAX_RECORDS - 1, "short-precise"),
         ("json", 1, "json"),
-        ("text", 1, "short"),
+        ("text", 1, "short-precise"),
     ],
 )
 def test_get_api_log_with_params(api_client, format_param, records_param, mode_param):
@@ -128,7 +130,7 @@ def test_get_api_log_with_params(api_client, format_param, records_param, mode_p
             body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with("opentrons-api", records_param, mode_param)
+        m.assert_called_once_with(["opentrons-api"], records_param, mode_param)
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/test_app.py
+++ b/robot-server/tests/test_app.py
@@ -21,6 +21,8 @@ def mock_log_control() -> Iterator[MagicMock]:
     argvalues=[
         "/logs/serial.log",
         "/logs/api.log",
+        "/logs/server.log",
+        "/logs/combined_api_server.log",
         "/",
     ],
 )


### PR DESCRIPTION
## Overview

Looking at the api logs can get confusing when you have a bunch of requests from the robot server. Let's utilize the file that we already download from the app called 'server.log'

# Test Plan

- [ ] Throw this on a robot and run a protocol or two. Verify that the server.log file is populated with robot server requests.

# Review requests

Let me know if you think anything is missing.

# Risk assessment

Should be fairly low.
