### PR TITLE
fix(robot-server): Better logging for postinit

### DIFF
--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -399,7 +399,9 @@ def _format_exc_only(log_prefix: str) -> Iterator[None]:
     try:
         yield
     except _ExcPassthrough as passthrough:
-        log.error(f"{log_prefix}: {''.join(list(passthrough.payload.format_exception_only()))}")
+        log.error(
+            f"{log_prefix}: {''.join(list(passthrough.payload.format_exception_only()))}"
+        )
     except BaseException as be:
         log.error(f"{log_prefix}: {format_exception_only(type(be), be)}")
 
@@ -409,7 +411,9 @@ def _format_exc(log_prefix: str) -> Iterator[None]:
     try:
         yield
     except _ExcPassthrough as passthrough:
-        log.error(f"{log_prefix}: {''.join(list(passthrough.payload.format(chain=True)))}")
+        log.error(
+            f"{log_prefix}: {''.join(list(passthrough.payload.format(chain=True)))}"
+        )
     except BaseException as be:
         log.error(f"{log_prefix}: {format_exception_only(type(be), be)}")
 

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -399,7 +399,7 @@ def _format_exc_only(log_prefix: str) -> Iterator[None]:
     try:
         yield
     except _ExcPassthrough as passthrough:
-        log.error(f"{log_prefix}: {passthrough.payload.format_exception_only()}")
+        log.error(f"{log_prefix}: {''.join(list(passthrough.payload.format_exception_only()))}")
     except BaseException as be:
         log.error(f"{log_prefix}: {format_exception_only(type(be), be)}")
 
@@ -409,7 +409,7 @@ def _format_exc(log_prefix: str) -> Iterator[None]:
     try:
         yield
     except _ExcPassthrough as passthrough:
-        log.error(f"{log_prefix}: {passthrough.payload.format(chain=True)}")
+        log.error(f"{log_prefix}: {''.join(list(passthrough.payload.format(chain=True)))}")
     except BaseException as be:
         log.error(f"{log_prefix}: {format_exception_only(type(be), be)}")
 


### PR DESCRIPTION
We have this awkward situation around logging, particularly for exceptions, in hardware postinit. We really want to be able to print stuff like where an exception occurred, but this is tragically really annoying to do without being in the correct exception stack. There's a way around this but it's weird: in the original exception stack, create a special TracebackException instance, which will capture the right things theoretically. However, that class _is not an exception_, and so either everything has to return an exception or we have to wrap it in an exception so we can raise it and use the old methods... so that's what we do.

## Review Requests
- Does this, like, help?