### PR TITLE
feat: Add script for provisioning Flex pipettes in emulation

### DIFF
--- a/hardware/opentrons_hardware/scripts/emulation_pipette_provision.py
+++ b/hardware/opentrons_hardware/scripts/emulation_pipette_provision.py
@@ -1,0 +1,99 @@
+"""Script to write pipette serial numbers to eeprom files.
+
+This script is configured to run against the emulation container.
+High level overview of the script:
+
+- Read pipette definition from environment variables
+- Generate pipette serial code
+- Write pipette serial code to eeprom file
+- Profit
+"""
+
+import os
+import json
+from dataclasses import dataclass
+from typing import Optional
+from typing_extensions import Literal
+from opentrons_hardware.firmware_bindings.constants import PipetteName
+from opentrons_hardware.instruments.pipettes.serials import serial_val_from_parts
+
+LEFT_PIPETTE_ENV_VAR_NAME = "LEFT_OT3_PIPETTE_DEFINITION"
+RIGHT_PIPETTE_ENV_VAR_NAME = "RIGHT_OT3_PIPETTE_DEFINITION"
+
+LEFT_PIPETTE_EEPROM_DIR_PATH = "/volumes/left-pipette-eeprom"
+RIGHT_PIPETTE_EEPROM_DIR_PATH = "/volumes/right-pipette-eeprom"
+
+
+@dataclass
+class OT3PipetteEnvVar:
+    """OT3 Pipette Environment Variable."""
+
+    pipette_name: PipetteName
+    pipette_model: int
+    pipette_serial_code: bytes
+    eeprom_file_name: str
+    mount: Literal["left", "right"]
+
+    @classmethod
+    def from_json_string(
+        cls, env_var_string: str, mount: Literal["left", "right"]
+    ) -> "OT3PipetteEnvVar":
+        """Create OT3PipetteEnvVar from json string."""
+        env_var = json.loads(env_var_string)
+        return cls(
+            pipette_name=PipetteName[env_var["pipette_name"]],
+            pipette_model=env_var["pipette_model"],
+            pipette_serial_code=env_var["pipette_serial_code"].encode("utf-8"),
+            eeprom_file_name=env_var["eeprom_file_name"],
+            mount=mount,
+        )
+
+    def _eeprom_dir_path(self) -> str:
+        """Get eeprom directory path."""
+        return (
+            LEFT_PIPETTE_EEPROM_DIR_PATH
+            if self.mount == "left"
+            else RIGHT_PIPETTE_EEPROM_DIR_PATH
+        )
+
+    @property
+    def eeprom_file_path(self) -> str:
+        """Get eeprom file path."""
+        return "/".join([self._eeprom_dir_path(), self.eeprom_file_name])
+
+    def _generate_serial_code(self) -> bytes:
+        """Generate serial code."""
+        return serial_val_from_parts(
+            self.pipette_name, self.pipette_model, self.pipette_serial_code
+        )
+
+    def generate_eeprom_file(self) -> None:
+        """Generate eeprom file for pipette."""
+        with open(self.eeprom_file_path, "wb") as f:
+            f.write(self._generate_serial_code())
+
+
+def _get_env_var(env_var_name: str) -> str:
+    """Check that environment variable is set."""
+    env_var_value: Optional[str] = os.environ.get(LEFT_PIPETTE_ENV_VAR_NAME)
+    if env_var_value is None or len(env_var_value) == 0:
+        raise ValueError(
+            f"Environment variable {env_var_name} is not set. "
+            "Please set this environment variable and try again."
+        )
+    return env_var_value
+
+
+def main() -> None:
+    """Main function."""
+    left_pipette_json = _get_env_var(LEFT_PIPETTE_ENV_VAR_NAME)
+    right_pipette_json = _get_env_var(RIGHT_PIPETTE_ENV_VAR_NAME)
+
+    OT3PipetteEnvVar.from_json_string(left_pipette_json, "left").generate_eeprom_file()
+    OT3PipetteEnvVar.from_json_string(
+        right_pipette_json, "right"
+    ).generate_eeprom_file()
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/opentrons_hardware/scripts/emulation_pipette_provision.py
+++ b/hardware/opentrons_hardware/scripts/emulation_pipette_provision.py
@@ -12,7 +12,7 @@ High level overview of the script:
 import os
 import json
 from dataclasses import dataclass
-from typing import Dict, Optional, Set, Union
+from typing import Optional
 from opentrons_hardware.firmware_bindings.constants import PipetteName
 from opentrons_hardware.instruments.pipettes.serials import serial_val_from_parts
 

--- a/hardware/opentrons_hardware/scripts/emulation_pipette_provision.py
+++ b/hardware/opentrons_hardware/scripts/emulation_pipette_provision.py
@@ -19,9 +19,6 @@ from opentrons_hardware.instruments.pipettes.serials import serial_val_from_part
 LEFT_PIPETTE_ENV_VAR_NAME = "LEFT_OT3_PIPETTE_DEFINITION"
 RIGHT_PIPETTE_ENV_VAR_NAME = "RIGHT_OT3_PIPETTE_DEFINITION"
 
-LEFT_PIPETTE_EEPROM_DIR_PATH = "/volumes/left-pipette-eeprom"
-RIGHT_PIPETTE_EEPROM_DIR_PATH = "/volumes/right-pipette-eeprom"
-
 
 @dataclass
 class OT3PipetteEnvVar:

--- a/hardware/tests/test_scripts/test_emulation_pipette_provision.py
+++ b/hardware/tests/test_scripts/test_emulation_pipette_provision.py
@@ -1,22 +1,52 @@
 """Tests for the emulation_pipette_provision script."""
+import json
 import os
-from typing import Any, Generator
+from typing import Any, Generator, Tuple
 import pytest
-from unittest.mock import patch
-
+from opentrons_hardware.firmware_bindings.constants import PipetteName
 from opentrons_hardware.scripts import emulation_pipette_provision
+from opentrons_hardware.instruments.pipettes.serials import serial_val_from_parts
 
 
 @pytest.fixture
-def set_env_vars(monkeypatch: Any) -> Generator[None, None, None]:
+def tmp_eeprom_file_paths(tmpdir: Any) -> Tuple[str, str]:
+    """Create temporary eeprom file paths."""
+    volumes = tmpdir.mkdir("volumes")
+    left_dir = volumes.mkdir("left-pipette-eeprom")
+    right_dir = volumes.mkdir("right-pipette-eeprom")
+    left_file_path = left_dir.join("eeprom.bin")
+    right_file_path = right_dir.join("eeprom.bin")
+    return (str(left_file_path), str(right_file_path))
+
+
+@pytest.fixture
+def set_env_vars(
+    tmp_eeprom_file_paths: Generator[Tuple[str, str], None, None], monkeypatch: Any
+) -> Generator[None, None, None]:
     """Set environment variables."""
+    left, right = tmp_eeprom_file_paths
     monkeypatch.setenv(
         "LEFT_OT3_PIPETTE_DEFINITION",
-        '{"pipette_name": "p1000_multi", "pipette_model": 34, "pipette_serial_code": "20230609", "eeprom_file_name": "eeprom.bin"}',
+        json.dumps(
+            {
+                "pipette_name": "p1000_multi",
+                "pipette_model": 34,
+                "pipette_serial_code": "20230609",
+                "eeprom_file_path": left,
+            }
+        ),
     )
+
     monkeypatch.setenv(
         "RIGHT_OT3_PIPETTE_DEFINITION",
-        '{"pipette_name": "p50_single", "pipette_model": 34, "pipette_serial_code": "20230609", "eeprom_file_name": "eeprom.bin"}',
+        json.dumps(
+            {
+                "pipette_name": "p50_multi",
+                "pipette_model": 34,
+                "pipette_serial_code": "20230609",
+                "eeprom_file_path": right,
+            }
+        ),
     )
     yield
     monkeypatch.delenv("LEFT_OT3_PIPETTE_DEFINITION")
@@ -24,44 +54,34 @@ def set_env_vars(monkeypatch: Any) -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def override_eeprom_dir(tmpdir: Any) -> Generator[str, None, None]:
-    """Override eeprom directory."""
-    volumes = tmpdir.mkdir("volumes")
-    left = volumes.mkdir("left-pipette-eeprom")
-    right = volumes.mkdir("right-pipette-eeprom")
-
-    with patch.multiple(
-        emulation_pipette_provision,
-        LEFT_PIPETTE_EEPROM_DIR_PATH=str(left),
-        RIGHT_PIPETTE_EEPROM_DIR_PATH=str(right),
-    ):
-        yield tmpdir
-
-
-@pytest.fixture
-def left_eeprom_path(override_eeprom_dir: Generator[str, None, None]) -> str:
-    """Left eeprom path."""
-    return os.path.join(
-        emulation_pipette_provision.LEFT_PIPETTE_EEPROM_DIR_PATH, "eeprom.bin"
-    )
-
-
-@pytest.fixture
-def right_eeprom_path(override_eeprom_dir: Generator[str, None, None]) -> str:
-    """Right eeprom path."""
-    return os.path.join(
-        emulation_pipette_provision.RIGHT_PIPETTE_EEPROM_DIR_PATH, "eeprom.bin"
+def expected_values() -> Tuple[bytes, bytes]:
+    """Expected values."""
+    return (
+        serial_val_from_parts(
+            PipetteName["p1000_multi"], 34, "20230609".encode("utf-8")
+        ),
+        serial_val_from_parts(PipetteName["p50_multi"], 34, "20230609".encode("utf-8")),
     )
 
 
 def test_main(
     set_env_vars: Generator[None, None, None],
-    left_eeprom_path: str,
-    right_eeprom_path: str,
+    tmp_eeprom_file_paths: Tuple[str, str],
+    expected_values: Tuple[bytes, bytes],
 ) -> None:
     """Test main."""
+    left_eeprom_path, right_eeprom_path = tmp_eeprom_file_paths
+    expected_left, expected_right = expected_values
     assert not os.path.exists(left_eeprom_path)
     assert not os.path.exists(right_eeprom_path)
     emulation_pipette_provision.main()
     assert os.path.exists(left_eeprom_path)
     assert os.path.exists(right_eeprom_path)
+
+    with open(left_eeprom_path, "rb") as f:
+        left_eeprom = f.read()
+    with open(right_eeprom_path, "rb") as f:
+        right_eeprom = f.read()
+
+    assert left_eeprom == expected_left
+    assert right_eeprom == expected_right

--- a/hardware/tests/test_scripts/test_emulation_pipette_provision.py
+++ b/hardware/tests/test_scripts/test_emulation_pipette_provision.py
@@ -1,0 +1,67 @@
+"""Tests for the emulation_pipette_provision script."""
+import os
+from typing import Any, Generator
+import pytest
+from unittest.mock import patch
+
+from opentrons_hardware.scripts import emulation_pipette_provision
+
+
+@pytest.fixture
+def set_env_vars(monkeypatch: Any) -> Generator[None, None, None]:
+    """Set environment variables."""
+    monkeypatch.setenv(
+        "LEFT_OT3_PIPETTE_DEFINITION",
+        '{"pipette_name": "p1000_multi", "pipette_model": 34, "pipette_serial_code": "20230609", "eeprom_file_name": "eeprom.bin"}',
+    )
+    monkeypatch.setenv(
+        "RIGHT_OT3_PIPETTE_DEFINITION",
+        '{"pipette_name": "p50_single", "pipette_model": 34, "pipette_serial_code": "20230609", "eeprom_file_name": "eeprom.bin"}',
+    )
+    yield
+    monkeypatch.delenv("LEFT_OT3_PIPETTE_DEFINITION")
+    monkeypatch.delenv("RIGHT_OT3_PIPETTE_DEFINITION")
+
+
+@pytest.fixture
+def override_eeprom_dir(tmpdir: Any) -> Generator[str, None, None]:
+    """Override eeprom directory."""
+    volumes = tmpdir.mkdir("volumes")
+    left = volumes.mkdir("left-pipette-eeprom")
+    right = volumes.mkdir("right-pipette-eeprom")
+
+    with patch.multiple(
+        emulation_pipette_provision,
+        LEFT_PIPETTE_EEPROM_DIR_PATH=str(left),
+        RIGHT_PIPETTE_EEPROM_DIR_PATH=str(right),
+    ):
+        yield tmpdir
+
+
+@pytest.fixture
+def left_eeprom_path(override_eeprom_dir: Generator[str, None, None]) -> str:
+    """Left eeprom path."""
+    return os.path.join(
+        emulation_pipette_provision.LEFT_PIPETTE_EEPROM_DIR_PATH, "eeprom.bin"
+    )
+
+
+@pytest.fixture
+def right_eeprom_path(override_eeprom_dir: Generator[str, None, None]) -> str:
+    """Right eeprom path."""
+    return os.path.join(
+        emulation_pipette_provision.RIGHT_PIPETTE_EEPROM_DIR_PATH, "eeprom.bin"
+    )
+
+
+def test_main(
+    set_env_vars: Generator[None, None, None],
+    left_eeprom_path: str,
+    right_eeprom_path: str,
+) -> None:
+    """Test main."""
+    assert not os.path.exists(left_eeprom_path)
+    assert not os.path.exists(right_eeprom_path)
+    emulation_pipette_provision.main()
+    assert os.path.exists(left_eeprom_path)
+    assert os.path.exists(right_eeprom_path)


### PR DESCRIPTION
# Overview

Add script for provisioning Flex pipettes in emulation. This script is run inside the `ot3-firmware-builder` container from opentrons-emulation

Script Flow: 

1. Read from environment variables: `LEFT_OT3_PIPETTE_DEFINITION` and `RIGHT_OT3_PIPETTE_DEFINITION`
2. Convert env var content to `OT3PipetteEnvVar` dataclass object
3. Generate serial code by using `opentrons_hardware.instruments.pipettes.serials.serial_val_from_parts`
4. Create eeprom files for each pipette inside of that pipette's volume folder. Note that the volume folders are created inside the emulation scope. 

----

**Note:**
It is out of scope for this PR to actually ensure that the pipettes run correctly in emulation. They currently do not, and I cannot figure out why. Going to circle up with the wizards in embedded land to see if they can help me figure it out. A followup PR will address them actually working

----

# Test Plan

- [x] Add unit test to validate that exercising the above flow creates the file
- [x] Validate against emulation repo
  - [x] Using opentrons-emulation local dev, bind mount the latest version of this branch into the emulation system. 
  - [x] Validate that framework automatically creates correct env vars for script to parse
  - [x] Validate that script is automatically called with no required user inpur
  - [x] Validate that eeprom files are created on ot3-firmware-builder
  - [x] Validate that eeprom files are pushed to the pipette containers through the volume connection


# Changelog

- Add script
- Add test

# Review requests

Do you think it is okay to not validate that the content of the eeprom file is correct? 
I am not doing this for a few reasons: 

1. Figuring out what the content is actually supposed to be sounds like a pain
2. I am using a monorepo utility function to do the actual serial number provisioning. This functionality should be tested in the monorepo and not in the context of emulation
3. The new functionality is parsing the env vars and pushing to the file. Which testing was added for 

# Risk assessment

Low 

- Script is not used by this repo
- Tests do not affect this repo
- No dependencies or existing source code were modified