### PR TITLE
feat(api): add errorCode field to ErrorOccurrence model

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -20,6 +20,8 @@ class ErrorOccurrence(BaseModel):
     )
 
     class Config:
+        """Customize configuration for this model."""
+
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model: object) -> None:
             """Append the schema to make the errorCode appear required.
@@ -31,5 +33,6 @@ class ErrorOccurrence(BaseModel):
             mark this as a non-required field, which is misleading as this is
             a response from the server to the client and it will always have an
             errorCode defined. This hack is required because it informs the client
-            that it does not, in fact, have to account for a missing errorCode."""
+            that it does not, in fact, have to account for a missing errorCode.
+            """
             schema["required"].append("errorCode")

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -15,7 +15,7 @@ class ErrorOccurrence(BaseModel):
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
     errorCode: str = Field(
-        default=ErrorCode.UNKNOWN,
+        default=ErrorCode.UNKNOWN.value,
         description="An enumerated error code for the error type.",
     )
 

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -1,5 +1,6 @@
 """Models for concrete occurrences of specific errors."""
 from datetime import datetime
+from typing import Any, Dict
 from pydantic import BaseModel, Field
 from .exceptions import ErrorCode
 
@@ -13,7 +14,22 @@ class ErrorOccurrence(BaseModel):
     errorType: str = Field(..., description="Specific error type that occurred.")
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
-    errorCode: int = Field(
+    errorCode: str = Field(
         default=ErrorCode.UNKNOWN,
         description="An enumerated error code for the error type.",
     )
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: object) -> None:
+            """Append the schema to make the errorCode appear required.
+
+            `errorCode` has a default because it is not included in earlier
+            versions of this model, _and_ this model is loaded directly from
+            the on-robot store. That means that, without a default, it will
+            fail to parse. Once a default is defined, the automated schema will
+            mark this as a non-required field, which is misleading as this is
+            a response from the server to the client and it will always have an
+            errorCode defined. This hack is required because it informs the client
+            that it does not, in fact, have to account for a missing errorCode."""
+            schema["required"].append("errorCode")

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -12,4 +12,6 @@ class ErrorOccurrence(BaseModel):
     errorType: str = Field(..., description="Specific error type that occurred.")
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
-    errorCode: int = Field(..., description="An enumerated error code for the error type.")
+    errorCode: int = Field(
+        ..., description="An enumerated error code for the error type."
+    )

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -12,3 +12,4 @@ class ErrorOccurrence(BaseModel):
     errorType: str = Field(..., description="Specific error type that occurred.")
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
+    errorCode: int = Field(..., description="An enumerated error code for the error type.")

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -1,7 +1,7 @@
 """Models for concrete occurrences of specific errors."""
 from datetime import datetime
 from pydantic import BaseModel, Field
-from .exceptions import ProtocolEngineError
+from .exceptions import ErrorCode
 
 
 # TODO(mc, 2021-11-12): flesh this model out with structured error data
@@ -14,6 +14,6 @@ class ErrorOccurrence(BaseModel):
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
     errorCode: int = Field(
-        default=ProtocolEngineError.ERROR_CODE,
+        default=ErrorCode.UNKNOWN,
         description="An enumerated error code for the error type.",
     )

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -1,6 +1,7 @@
 """Models for concrete occurrences of specific errors."""
 from datetime import datetime
 from pydantic import BaseModel, Field
+from .exceptions import ProtocolEngineError
 
 
 # TODO(mc, 2021-11-12): flesh this model out with structured error data
@@ -13,5 +14,6 @@ class ErrorOccurrence(BaseModel):
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
     errorCode: int = Field(
-        ..., description="An enumerated error code for the error type."
+        default=ProtocolEngineError.ERROR_CODE,
+        description="An enumerated error code for the error type.",
     )

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1,11 +1,20 @@
 """Protocol engine exceptions."""
 
+from enum import IntEnum, unique
+
+
+@unique
+class ErrorCode(IntEnum):
+    """Enumerated error codes."""
+
+    UNKNOWN = 4000  # Catch-all code for any unclassified error
+
 
 class ProtocolEngineError(RuntimeError):
     """Base Protocol Engine error class."""
 
     # This default error code should be overridden in every child class.
-    ERROR_CODE = 4000
+    ERROR_CODE: int = ErrorCode.UNKNOWN
 
 
 class UnexpectedProtocolError(ProtocolEngineError):
@@ -16,8 +25,7 @@ class UnexpectedProtocolError(ProtocolEngineError):
     and wrapped.
     """
 
-    # Any "unclassified" error gets error code 4000
-    ERROR_CODE = 4000
+    ERROR_CODE: int = ErrorCode.UNKNOWN
 
     def __init__(self, original_error: Exception) -> None:
         """Initialize an UnexpectedProtocolError with an original error."""

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -4,6 +4,9 @@
 class ProtocolEngineError(RuntimeError):
     """Base Protocol Engine error class."""
 
+    # This default error code should be overridden in every child class.
+    ERROR_CODE = 4000
+
 
 class UnexpectedProtocolError(ProtocolEngineError):
     """Raised when an unexpected error occurs.
@@ -12,6 +15,9 @@ class UnexpectedProtocolError(ProtocolEngineError):
     exception was raised somewhere in the stack and it was not properly caught
     and wrapped.
     """
+
+    # Any "unclassified" error gets error code 4000
+    ERROR_CODE = 4000
 
     def __init__(self, original_error: Exception) -> None:
         """Initialize an UnexpectedProtocolError with an original error."""

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1,20 +1,20 @@
 """Protocol engine exceptions."""
 
-from enum import IntEnum, unique
+from enum import Enum, unique
 
 
 @unique
-class ErrorCode(IntEnum):
+class ErrorCode(Enum):
     """Enumerated error codes."""
 
-    UNKNOWN = 4000  # Catch-all code for any unclassified error
+    UNKNOWN = "4000"  # Catch-all code for any unclassified error
 
 
 class ProtocolEngineError(RuntimeError):
     """Base Protocol Engine error class."""
 
     # This default error code should be overridden in every child class.
-    ERROR_CODE: int = ErrorCode.UNKNOWN
+    ERROR_CODE: str = ErrorCode.UNKNOWN.value
 
 
 class UnexpectedProtocolError(ProtocolEngineError):
@@ -25,7 +25,7 @@ class UnexpectedProtocolError(ProtocolEngineError):
     and wrapped.
     """
 
-    ERROR_CODE: int = ErrorCode.UNKNOWN
+    ERROR_CODE: str = ErrorCode.UNKNOWN.value
 
     def __init__(self, original_error: Exception) -> None:
         """Initialize an UnexpectedProtocolError with an original error."""

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -32,6 +32,7 @@ from ..errors import (
     SetupCommandNotAllowedError,
     PauseNotAllowedError,
     ProtocolCommandFailedError,
+    ProtocolEngineError,
 )
 from ..types import EngineStatus
 from .abstract_store import HasState, HandlesActions
@@ -255,6 +256,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
                 createdAt=action.failed_at,
                 errorType=type(action.error).__name__,
                 detail=str(action.error),
+                errorCode=action.error.ERROR_CODE,
             )
 
             prev_entry = self._state.commands_by_id[action.command_id]
@@ -335,11 +337,18 @@ class CommandStore(HasState[CommandState], HandlesActions):
                     created_at = action.error_details.created_at
                     error = action.error_details.error
 
+                    error_code = (
+                        error.ERROR_CODE
+                        if isinstance(error, ProtocolEngineError)
+                        else ProtocolEngineError.ERROR_CODE
+                    )
+
                     self._state.errors_by_id[error_id] = ErrorOccurrence.construct(
                         id=error_id,
                         createdAt=created_at,
                         errorType=type(error).__name__,
                         detail=str(error),
+                        errorCode=error_code,
                     )
 
         elif isinstance(action, HardwareStoppedAction):

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -78,7 +78,7 @@ async def test_execute_command_failure(
         errorType="PrettyBadError",
         createdAt=datetime(year=2021, month=1, day=1),
         detail="Things are not looking good.",
-        errorCode=1234,
+        errorCode="1234",
     )
 
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -78,6 +78,7 @@ async def test_execute_command_failure(
         errorType="PrettyBadError",
         createdAt=datetime(year=2021, month=1, day=1),
         detail="Things are not looking good.",
+        errorCode=1234,
     )
 
     decoy.when(await engine.add_and_execute_command(request=cmd_request)).then_return(

--- a/api/tests/opentrons/protocol_engine/errors/test_error_occurrence.py
+++ b/api/tests/opentrons/protocol_engine/errors/test_error_occurrence.py
@@ -1,0 +1,36 @@
+"""Test ErrorOccurrence module."""
+import datetime
+from typing import List
+
+from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
+
+
+def test_error_occurrence_schema() -> None:
+    """Test that the schema is overwritten succesfully.
+
+    This is explicitly tested because we are overriding the schema
+    due to a default value for errorCode.
+    """
+    required_items: List[str] = ErrorOccurrence.schema()["required"]
+
+    assert "errorCode" in required_items
+
+
+def test_parse_error_occurrence() -> None:
+    """Test that parsing succeeds without an errorCode.
+
+    This is explicitly tested to ensure backwards compatability is maintained.
+    """
+    input = '{"id": "abcdefg","errorType": "a bad one","createdAt": "2023-06-12 15:08:54.730451","detail": "This is a bad error"}'
+
+    result = ErrorOccurrence.parse_raw(input)
+
+    expected = ErrorOccurrence(
+        id="abcdefg",
+        errorType="a bad one",
+        createdAt=datetime.datetime.fromisoformat("2023-06-12 15:08:54.730451"),
+        detail="This is a bad error",
+        errorCode="4000",
+    )
+
+    assert result == expected

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -862,7 +862,6 @@ def test_command_store_saves_correct_error_code() -> None:
                 createdAt=datetime(year=2021, month=1, day=1),
                 errorType="MyCustomError",
                 detail="oh no",
-                # Unknown errors use the default error code
                 errorCode=TEST_CODE,
             )
         },

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -832,7 +832,6 @@ def test_command_store_saves_unknown_finish_error() -> None:
 
 def test_command_store_saves_correct_error_code() -> None:
     """If an error is derived from ProtocolEngineError, its ErrorCode should be used."""
-
     TEST_CODE = 1234
 
     class MyCustomError(errors.ProtocolEngineError):

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -830,6 +830,48 @@ def test_command_store_saves_unknown_finish_error() -> None:
     )
 
 
+def test_command_store_saves_correct_error_code() -> None:
+    """If an error is derived from ProtocolEngineError, its ErrorCode should be used."""
+
+    TEST_CODE = 1234
+
+    class MyCustomError(errors.ProtocolEngineError):
+        ERROR_CODE = TEST_CODE
+
+    subject = CommandStore(is_door_open=False, config=_make_config())
+
+    error_details = FinishErrorDetails(
+        error=MyCustomError("oh no"),
+        error_id="error-id",
+        created_at=datetime(year=2021, month=1, day=1),
+    )
+    subject.handle_action(FinishAction(error_details=error_details))
+
+    assert subject.state == CommandState(
+        queue_status=QueueStatus.PAUSED,
+        run_result=RunResult.FAILED,
+        run_completed_at=None,
+        is_door_blocking=False,
+        running_command_id=None,
+        all_command_ids=[],
+        queued_command_ids=OrderedSet(),
+        queued_setup_command_ids=OrderedSet(),
+        commands_by_id=OrderedDict(),
+        errors_by_id={
+            "error-id": errors.ErrorOccurrence(
+                id="error-id",
+                createdAt=datetime(year=2021, month=1, day=1),
+                errorType="MyCustomError",
+                detail="oh no",
+                # Unknown errors use the default error code
+                errorCode=TEST_CODE,
+            )
+        },
+        run_started_at=None,
+        latest_command_hash=None,
+    )
+
+
 def test_command_store_ignores_stop_after_graceful_finish() -> None:
     """It should no-op on stop if already gracefully finished."""
     subject = CommandStore(is_door_open=False, config=_make_config())

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -466,6 +466,7 @@ def test_command_failure_clears_queues() -> None:
             errorType="ProtocolEngineError",
             detail="oh no",
             createdAt=datetime(year=2023, month=3, day=3),
+            errorCode=errors.ProtocolEngineError.ERROR_CODE,
         ),
         createdAt=datetime(year=2021, month=1, day=1),
         startedAt=datetime(year=2022, month=2, day=2),
@@ -566,6 +567,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
             errorType="ProtocolEngineError",
             detail="oh no",
             createdAt=datetime(year=2023, month=3, day=3),
+            errorCode=errors.ProtocolEngineError.ERROR_CODE,
         ),
         createdAt=datetime(year=2021, month=1, day=1),
         startedAt=datetime(year=2022, month=2, day=2),
@@ -819,6 +821,8 @@ def test_command_store_saves_unknown_finish_error() -> None:
                 createdAt=datetime(year=2021, month=1, day=1),
                 errorType="RuntimeError",
                 detail="oh no",
+                # Unknown errors use the default error code
+                errorCode=errors.ProtocolEngineError.ERROR_CODE,
             )
         },
         run_started_at=None,
@@ -883,6 +887,7 @@ def test_command_store_handles_command_failed() -> None:
         errorType="ProtocolEngineError",
         createdAt=datetime(year=2022, month=2, day=2),
         detail="oh no",
+        errorCode=errors.ProtocolEngineError.ERROR_CODE,
     )
 
     expected_failed_command = create_failed_command(

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -832,7 +832,7 @@ def test_command_store_saves_unknown_finish_error() -> None:
 
 def test_command_store_saves_correct_error_code() -> None:
     """If an error is derived from ProtocolEngineError, its ErrorCode should be used."""
-    TEST_CODE = 1234
+    TEST_CODE = "1234"
 
     class MyCustomError(errors.ProtocolEngineError):
         ERROR_CODE = TEST_CODE

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -244,6 +244,7 @@ def test_get_all_complete_fatal_command_failure() -> None:
             errorType="PrettyBadError",
             createdAt=datetime(year=2021, month=1, day=1),
             detail="Oh no",
+            errorCode=4321,
         ),
     )
 
@@ -268,6 +269,7 @@ def test_get_all_complete_setup_not_fatal() -> None:
             errorType="PrettyBadError",
             createdAt=datetime(year=2021, month=1, day=1),
             detail="Oh no",
+            errorCode=4321,
         ),
     )
 
@@ -452,12 +454,14 @@ def test_get_errors() -> None:
         createdAt=datetime(year=2021, month=1, day=1),
         errorType="ReallyBadError",
         detail="things could not get worse",
+        errorCode=4321,
     )
     error_2 = errors.ErrorOccurrence(
         id="error-2",
         createdAt=datetime(year=2022, month=2, day=2),
         errorType="EvenWorseError",
         detail="things got worse",
+        errorCode=1234,
     )
 
     subject = get_command_view(errors_by_id={"error-1": error_1, "error-2": error_2})

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -244,7 +244,7 @@ def test_get_all_complete_fatal_command_failure() -> None:
             errorType="PrettyBadError",
             createdAt=datetime(year=2021, month=1, day=1),
             detail="Oh no",
-            errorCode=4321,
+            errorCode="4321",
         ),
     )
 
@@ -269,7 +269,7 @@ def test_get_all_complete_setup_not_fatal() -> None:
             errorType="PrettyBadError",
             createdAt=datetime(year=2021, month=1, day=1),
             detail="Oh no",
-            errorCode=4321,
+            errorCode="4321",
         ),
     )
 
@@ -454,14 +454,14 @@ def test_get_errors() -> None:
         createdAt=datetime(year=2021, month=1, day=1),
         errorType="ReallyBadError",
         detail="things could not get worse",
-        errorCode=4321,
+        errorCode="4321",
     )
     error_2 = errors.ErrorOccurrence(
         id="error-2",
         createdAt=datetime(year=2022, month=2, day=2),
         errorType="EvenWorseError",
         detail="things got worse",
-        errorCode=1234,
+        errorCode="1234",
     )
 
     subject = get_command_view(errors_by_id={"error-1": error_1, "error-2": error_2})

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -110,6 +110,7 @@ stages:
               errorType: UnexpectedProtocolError
               createdAt: !anystr
               detail: 'Cannot perform DROPTIP without a tip attached'
+              errorCode: '4000'
             params:
               pipetteId: pipetteId
               labwareId: tipRackId

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -59,6 +59,7 @@ stages:
               errorType: ExceptionInProtocolError
               createdAt: !anystr
               detail: 'NoTipAttachedError [line 9]: Cannot perform DROPTIP without a tip attached'
+              errorCode: '4000'
 
   - name: Verify commands contain the expected results
     request:
@@ -108,6 +109,7 @@ stages:
               errorType: LegacyContextCommandError
               createdAt: !anystr
               detail: 'Cannot perform DROPTIP without a tip attached'
+              errorCode: '4000'
             params:
               pipetteId: !anystr
               labwareId: !anystr


### PR DESCRIPTION
 

# Overview

Adds a field `errorCode` to the `ErrorOccurrence` model as a part of the OT-3 specific error messaging. The error code originates from the exception class that was raised to indicate an error, and in future work the exceptions for protocol engine errors will be configured with their own hard coded error codes. For now, everything gets the catch-all code 4000.

We want this new field to be required in all responses, but we _also_ need to be able to deserialize saved run reports on the robot. If the field is defined without a default, the robot server cannot load old runs; if the field is defined _with_ a default, the schema will imply that it is optional, and the client would have to account for cases where it is missing! To solve this, we define a default value and manually append the `errorCode` field to the list of required fields.

# Test Plan

Run a protocol that results in an error (or cancel the run). Download the run log after the run is cancelled/fails, and verify that there is an error code 4000 in the `ErrorOccurrence`.

To test backwards compatibility, perform the above on a robot _without_ this patch. Upload this patch and view the protocol run record; there should be an error code 4000 even though it wasn't included in the saved run report.

I tested this with a dev server using a persistent server, switching from `edge` to this branch. I was able to download the run fine _as long as there was a default defined for errorCode_.

Tested pushing this patch on top of an OT-3 at 0.11.0 and it was able to load run records fine as well.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

I defined the type of the field as a `str` rather than the actual Enum for flexibility, but is it better to be more specific and type the field off of the enum?

Also please confirm that I'm right about the risk assessment :) 

# Risk assessment

The biggest risk should be backwards compatibility. This _shouldn't_ be an issue because:
- When loading old run records, the default value for the `errorCode` will let it parse successfully
- If you downgrade from this to an older robot server version, the extra field should be ignored because that's how pydantic parsing works
- The app should be fine ignoring this new field for now
