### PR TITLE
fix(hardware): move group timeout exception should be raised

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -133,7 +133,7 @@ class MoveGroupRunner:
             raise RuntimeError("A group must be prepped before it can be executed.")
         try:
             move_completion_data = await self._move(can_messenger, self._start_at_index)
-        except Exception:
+        except (RuntimeError, asyncio.TimeoutError):
             log.error("raising error from Move group runner")
             raise
         return self._accumulate_move_completions(move_completion_data)

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -133,7 +133,7 @@ class MoveGroupRunner:
             raise RuntimeError("A group must be prepped before it can be executed.")
         try:
             move_completion_data = await self._move(can_messenger, self._start_at_index)
-        except RuntimeError:
+        except Exception:
             log.error("raising error from Move group runner")
             raise
         return self._accumulate_move_completions(move_completion_data)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,6 +1,5 @@
 """Tests for the move scheduler."""
 import pytest
-import logging
 from typing import List, Any, Tuple
 from numpy import float64, float32, int32
 from mock import AsyncMock, call, MagicMock, patch

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -140,7 +140,16 @@ async def test_liquid_probe(
             return [
                 (
                     NodeId.host,
-                    Acknowledgement(payload=ack_payload),
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            group_id=UInt8Field(0),
+                            seq_id=UInt8Field(0),
+                            current_position_um=UInt32Field(14000),
+                            encoder_position_um=Int32Field(14000),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(2),
+                        )
+                    ),
                     motor_node,
                 ),
                 (
@@ -155,7 +164,7 @@ async def test_liquid_probe(
                             ack_id=UInt8Field(2),
                         )
                     ),
-                    motor_node,
+                    target_node,
                 ),
             ]
         else:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR raises an exception and stops the move group runner when a move group has timed out. This means the active protocol will be stopped when a timeout occurs. 
