### PR TITLE
feature(api): Allow load_labware to accept off-deck as a valid location

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/exceptions.py
+++ b/api/src/opentrons/protocol_api/core/engine/exceptions.py
@@ -17,7 +17,3 @@ class InvalidModuleLocationError(ValueError):
 
 class InvalidMagnetEngageHeightError(ValueError):
     """Error raised if a Magnetic Module engage height is invalid."""
-
-
-class UnknownLocationError(ValueError):
-    """Raised when attempting to place labware in a unknown location."""

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -508,7 +508,7 @@ class ProtocolCore(
 
     def get_labware_location(
         self, labware_core: LabwareCore
-    ) -> Union[str, ModuleCore, NonConnectedModuleCore, None]:
+    ) -> Union[str, ModuleCore, NonConnectedModuleCore, OffDeckType]:
         """Get labware parent location."""
         labware_location = self._engine_client.state.labware.get_location(
             labware_core.labware_id
@@ -519,4 +519,5 @@ class ProtocolCore(
             )
         elif isinstance(labware_location, ModuleLocation):
             return self._module_cores_by_id.get(labware_location.moduleId)
-        return None
+
+        return OffDeckType.OFF_DECK

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -52,7 +52,7 @@ from .module_core import (
     NonConnectedModuleCore,
     MagneticBlockCore,
 )
-from .exceptions import InvalidModuleLocationError, UnknownLocationError
+from .exceptions import InvalidModuleLocationError
 from . import load_labware_params
 from . import deck_conflict
 

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -518,6 +518,8 @@ class ProtocolCore(
                 labware_location.slotName, self._engine_client.state.config.robot_type
             )
         elif isinstance(labware_location, ModuleLocation):
-            return self._module_cores_by_id.get(labware_location.moduleId)
+            # TODO (tz. 06-12-23) this will raise a key exception if module not found instead of returning None.
+            # This does not need to return OFF_DECK.
+            return self._module_cores_by_id[labware_location.moduleId]
 
         return OffDeckType.OFF_DECK

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -450,6 +450,6 @@ class LegacyProtocolCore(
 
     def get_labware_location(
         self, labware_core: LegacyLabwareCore
-    ) -> Union[str, legacy_module_core.LegacyModuleCore, None]:
+    ) -> Union[str, legacy_module_core.LegacyModuleCore, OffDeckType]:
         """Get labware parent location."""
         assert False, "get_labware_location only supported on engine core"

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -155,7 +155,7 @@ class LegacyProtocolCore(
         """Load a labware using its identifying parameters."""
         if isinstance(location, OffDeckType):
             raise APIVersionError(
-                "Loading a labware off deck is not supported in this API version"
+                "Loading a labware off deck is only supported with apiLevel 2.15 and newer."
             )
 
         deck_slot = (

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -147,12 +147,17 @@ class LegacyProtocolCore(
     def load_labware(
         self,
         load_name: str,
-        location: Union[DeckSlotName, legacy_module_core.LegacyModuleCore],
+        location: Union[DeckSlotName, legacy_module_core.LegacyModuleCore, OffDeckType],
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LegacyLabwareCore:
         """Load a labware using its identifying parameters."""
+        if isinstance(location, OffDeckType):
+            raise APIVersionError(
+                "Loading a labware off deck is not supported in this API version"
+            )
+
         deck_slot = (
             location if isinstance(location, DeckSlotName) else location.get_deck_slot()
         )

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -181,5 +181,5 @@ class AbstractProtocol(
     @abstractmethod
     def get_labware_location(
         self, labware_core: LabwareCoreType
-    ) -> Union[str, ModuleCoreType, None]:
+    ) -> Union[str, ModuleCoreType, OffDeckType]:
         """Get labware parent location."""

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -60,7 +60,7 @@ class AbstractProtocol(
     def load_labware(
         self,
         load_name: str,
-        location: Union[DeckSlotName, ModuleCoreType],
+        location: Union[DeckSlotName, ModuleCoreType, OffDeckType],
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -352,6 +352,8 @@ class Labware:
         .. versionchanged:: 2.14
             Return type for module parent changed to :py:class:`ModuleContext`.
             Prior to this version, an internal geometry interface is returned.
+        .. versionchanged:: 2.15
+            Return type for off-deck changed from None to off-deck.
         """
         if isinstance(self._core, LegacyLabwareCore):
             # Type ignoring to preserve backwards compatibility

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -347,7 +347,7 @@ class Labware:
 
         If the labware is on the deck, a `str` deck slot name will be returned.
         If on a module, the parent :py:class:`ModuleContext` will be returned.
-        If off deck, `off-deck` will be returned.
+        If off deck, :py:obj:`OFF_DECK` will be returned.
 
         .. versionchanged:: 2.14
             Return type for module parent changed to :py:class:`ModuleContext`.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple, cast
 from opentrons_shared_data.labware.dev_types import LabwareDefinition, LabwareParameters
 
 from opentrons.types import Location, Point
-from ._types import OffDeckType
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import requires_version, APIVersionError
 
@@ -32,6 +31,7 @@ from opentrons.protocols.labware import (  # noqa: F401
 
 from . import validation
 from ._liquid import Liquid
+from ._types import OffDeckType
 from .core import well_grid
 from .core.engine import ENGINE_CORE_API_VERSION
 from .core.labware import AbstractLabware

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -353,7 +353,9 @@ class Labware:
             Return type for module parent changed to :py:class:`ModuleContext`.
             Prior to this version, an internal geometry interface is returned.
         .. versionchanged:: 2.15
-            Return type for off-deck changed from None to off-deck.
+            Will now return :py:obj:`OFF_DECK` if the labware is off-deck.
+            Formerly, if the labware was removed by using ``del`` on :py:obj:`.deck`,
+            this would return where it was before its removal.
         """
         if isinstance(self._core, LegacyLabwareCore):
             # Type ignoring to preserve backwards compatibility

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple, cast
 from opentrons_shared_data.labware.dev_types import LabwareDefinition, LabwareParameters
 
 from opentrons.types import Location, Point
+from ._types import OffDeckType
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import requires_version, APIVersionError
 
@@ -341,12 +342,12 @@ class Labware:
 
     @property  # type: ignore[misc]
     @requires_version(2, 0)
-    def parent(self) -> Union[str, ModuleTypes, None]:
+    def parent(self) -> Union[str, ModuleTypes, OffDeckType]:
         """The parent of this labware.
 
         If the labware is on the deck, a `str` deck slot name will be returned.
         If on a module, the parent :py:class:`ModuleContext` will be returned.
-        If off deck, `None` will be returned.
+        If off deck, `off-deck` will be returned.
 
         .. versionchanged:: 2.14
             Return type for module parent changed to :py:class:`ModuleContext`.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -316,7 +316,7 @@ class ProtocolContext(CommandPublisher):
             `Labware Library <https://labware.opentrons.com>`_.
 
         :param location: The slot into which to load the labware,
-            such as ``1`` or ``"1"`` or off deck using :py:obj:`OFF_DECK`.
+            such as ``1`` or ``"1"`` or off-deck using :py:obj:`OFF_DECK`.
 
         :type location: int or str or :py:obj:`OFF_DECK
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -340,7 +340,7 @@ class ProtocolContext(CommandPublisher):
         """
         if isinstance(location, OffDeckType) and self._api_version < APIVersion(2, 15):
             raise APIVersionError(
-                "Loading a labware off-deck is supported at apiLevel 2.15 and higher."
+                "Loading a labware off-deck requires apiLevel 2.15 or higher."
             )
         load_name = validation.ensure_lowercase_name(load_name)
         load_location: Union[OffDeckType, DeckSlotName]

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -318,7 +318,7 @@ class ProtocolContext(CommandPublisher):
         :param location: The slot into which to load the labware,
             such as ``1`` or ``"1"`` or off-deck using :py:obj:`OFF_DECK`.
 
-        :type location: int or str or :py:obj:`OFF_DECK
+        :type location: int or str or :py:obj:`OFF_DECK`
 
         :param str label: An optional special name to give the labware. If specified, this
             is the name the labware will appear as in the run log and the calibration

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -338,6 +338,10 @@ class ProtocolContext(CommandPublisher):
         :param version: The version of the labware definition. You should normally
             leave this unspecified to let the implementation choose a good default.
         """
+        if isinstance(location, OffDeckType) and self._api_version < APIVersion(2, 15):
+            raise APIVersionError(
+                "Loading a labware off deck is supported at apiLevel 2.15 and higher."
+            )
         load_name = validation.ensure_lowercase_name(load_name)
         load_location: Union[OffDeckType, DeckSlotName]
         if isinstance(location, OffDeckType):

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -297,12 +297,12 @@ class ProtocolContext(CommandPublisher):
     def load_labware(
         self,
         load_name: str,
-        location: DeckLocation,
+        location: Union[DeckLocation, OffDeckType],
         label: Optional[str] = None,
         namespace: Optional[str] = None,
         version: Optional[int] = None,
     ) -> Labware:
-        """Load a labware onto the deck given its name.
+        """Load a labware onto a location.
 
         For labware already defined by Opentrons, this is a convenient way
         to collapse the two stages of labware initialization (creating
@@ -316,9 +316,9 @@ class ProtocolContext(CommandPublisher):
             `Labware Library <https://labware.opentrons.com>`_.
 
         :param location: The slot into which to load the labware,
-            such as ``1`` or ``"1"``.
+            such as ``1`` or ``"1"`` or off deck using :py:obj:`OFF_DECK`.
 
-        :type location: int or str
+        :type location: int or str or :py:obj:`OFF_DECK
 
         :param str label: An optional special name to give the labware. If specified, this
             is the name the labware will appear as in the run log and the calibration
@@ -339,11 +339,15 @@ class ProtocolContext(CommandPublisher):
             leave this unspecified to let the implementation choose a good default.
         """
         load_name = validation.ensure_lowercase_name(load_name)
-        deck_slot = validation.ensure_deck_slot(location, self._api_version)
+        load_location: Union[OffDeckType, DeckSlotName]
+        if isinstance(location, OffDeckType):
+            load_location = location
+        else:
+            load_location = validation.ensure_deck_slot(location, self._api_version)
 
         labware_core = self._core.load_labware(
             load_name=load_name,
-            location=deck_slot,
+            location=load_location,
             label=label,
             namespace=namespace,
             version=version,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -340,7 +340,7 @@ class ProtocolContext(CommandPublisher):
         """
         if isinstance(location, OffDeckType) and self._api_version < APIVersion(2, 15):
             raise APIVersionError(
-                "Loading a labware off deck is supported at apiLevel 2.15 and higher."
+                "Loading a labware off-deck is supported at apiLevel 2.15 and higher."
             )
         load_name = validation.ensure_lowercase_name(load_name)
         load_location: Union[OffDeckType, DeckSlotName]

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import enum
 from typing import TYPE_CHECKING, Type, Optional
 from typing_extensions import Literal
-import logging
 
 from pydantic import BaseModel, Field
 
@@ -20,8 +19,6 @@ from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardwa
 if TYPE_CHECKING:
     from opentrons.hardware_control import HardwareControlAPI
     from ...state import StateView
-
-logger = logging.getLogger(__name__)
 
 # These offsets supplied from HW
 _ATTACH_POINT = Point(x=0, y=110)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -106,8 +106,8 @@ class GeometryView:
         elif labware_data.location == OFF_DECK_LOCATION:
             # Labware is off-deck
             raise errors.LabwareNotOnDeckError(
-                f"Labware {labware_id} does not have a parent associated with it"
-                f" since it is no longer on the deck."
+                f"Cannot access labware {labware_id} since it is no longer on the deck. "
+                f"Either it has been loaded off-deck or its been moved off-deck."
             )
 
         slot_pos = self._labware.get_slot_position(slot_name)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -106,7 +106,7 @@ class GeometryView:
         elif labware_data.location == OFF_DECK_LOCATION:
             # Labware is off-deck
             raise errors.LabwareNotOnDeckError(
-                f"Cannot access labware {labware_id} since it is no longer on the deck. "
+                f"Cannot access labware {labware_id} since it is not on the deck. "
                 f"Either it has been loaded off-deck or its been moved off-deck."
             )
 

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -5,10 +5,18 @@ if TYPE_CHECKING:
     from opentrons.protocol_api.labware import Labware, Well
     from opentrons.protocol_api.core.legacy.module_geometry import ModuleGeometry
     from opentrons.protocol_api.module_contexts import ModuleContext
+    from opentrons.protocol_api._types import OffDeckType
 
 
 WrappableLabwareLike = Union[
-    "Labware", "Well", str, "ModuleGeometry", "LabwareLike", None, "ModuleContext"
+    "Labware",
+    "Well",
+    str,
+    "ModuleGeometry",
+    "LabwareLike",
+    None,
+    "OffDeckType",
+    "ModuleContext",
 ]
 
 

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -7,7 +7,6 @@ if TYPE_CHECKING:
     from opentrons.protocol_api.module_contexts import ModuleContext
     from opentrons.protocol_api._types import OffDeckType
 
-
 WrappableLabwareLike = Union[
     "Labware",
     "Well",
@@ -26,6 +25,7 @@ class LabwareLikeType(int, Enum):
     WELL = auto()
     MODULE = auto()
     NONE = auto()
+    OFF_DECK = auto()
 
 
 class LabwareLike:
@@ -41,6 +41,7 @@ class LabwareLike:
             ModuleGeometry,
         )
         from opentrons.protocol_api.module_contexts import ModuleContext
+        from opentrons.protocol_api._types import OffDeckType
 
         self._labware_like = labware_like
         self._type = LabwareLikeType.NONE
@@ -63,6 +64,9 @@ class LabwareLike:
             self._type = self._labware_like._type
             self._as_str = self._labware_like._as_str
             self._labware_like = self._labware_like.object
+        elif isinstance(self._labware_like, OffDeckType):
+            self._type = LabwareLikeType.OFF_DECK
+            self._as_str = repr(self._labware_like)
         else:
             self._as_str = ""
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -118,6 +118,7 @@ class Location:
         ],
     ):
         self._point = point
+        self._given_labware = labware
         self._labware = LabwareLike(labware)
 
     # todo(mm, 2021-10-01): Figure out how to get .point and .labware to show up
@@ -166,14 +167,8 @@ class Location:
             >>> assert loc.point == Point(1, 1, 1)  # True
 
         """
-        from opentrons.protocol_api._types import OffDeckType
 
-        return Location(
-            point=self.point + point,
-            labware=self._labware.object
-            if not isinstance(self._labware.object, OffDeckType)
-            else None,
-        )
+        return Location(point=self.point + point, labware=self._given_labware)
 
     def __repr__(self) -> str:
         return f"Location(point={repr(self._point)}, labware={self._labware})"

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -104,7 +104,19 @@ class Location:
        of each item.
     """
 
-    def __init__(self, point: Point, labware: LocationLabware):
+    def __init__(
+        self,
+        point: Point,
+        labware: Union[
+            "Labware",
+            "Well",
+            str,
+            "ModuleGeometry",
+            LabwareLike,
+            None,
+            "ModuleContext",
+        ],
+    ):
         self._point = point
         self._labware = LabwareLike(labware)
 
@@ -154,7 +166,14 @@ class Location:
             >>> assert loc.point == Point(1, 1, 1)  # True
 
         """
-        return Location(point=self.point + point, labware=self._labware.object)
+        from opentrons.protocol_api._types import OffDeckType
+
+        return Location(
+            point=self.point + point,
+            labware=self._labware.object
+            if not isinstance(self._labware.object, OffDeckType)
+            else None,
+        )
 
     def __repr__(self) -> str:
         return f"Location(point={repr(self._point)}, labware={self._labware})"
@@ -326,17 +345,17 @@ class DeckSlotName(enum.Enum):
 
 # fmt: off
 _slot_equivalencies = [
-    (DeckSlotName.SLOT_1,      DeckSlotName.SLOT_D1),
-    (DeckSlotName.SLOT_2,      DeckSlotName.SLOT_D2),
-    (DeckSlotName.SLOT_3,      DeckSlotName.SLOT_D3),
-    (DeckSlotName.SLOT_4,      DeckSlotName.SLOT_C1),
-    (DeckSlotName.SLOT_5,      DeckSlotName.SLOT_C2),
-    (DeckSlotName.SLOT_6,      DeckSlotName.SLOT_C3),
-    (DeckSlotName.SLOT_7,      DeckSlotName.SLOT_B1),
-    (DeckSlotName.SLOT_8,      DeckSlotName.SLOT_B2),
-    (DeckSlotName.SLOT_9,      DeckSlotName.SLOT_B3),
-    (DeckSlotName.SLOT_10,     DeckSlotName.SLOT_A1),
-    (DeckSlotName.SLOT_11,     DeckSlotName.SLOT_A2),
+    (DeckSlotName.SLOT_1, DeckSlotName.SLOT_D1),
+    (DeckSlotName.SLOT_2, DeckSlotName.SLOT_D2),
+    (DeckSlotName.SLOT_3, DeckSlotName.SLOT_D3),
+    (DeckSlotName.SLOT_4, DeckSlotName.SLOT_C1),
+    (DeckSlotName.SLOT_5, DeckSlotName.SLOT_C2),
+    (DeckSlotName.SLOT_6, DeckSlotName.SLOT_C3),
+    (DeckSlotName.SLOT_7, DeckSlotName.SLOT_B1),
+    (DeckSlotName.SLOT_8, DeckSlotName.SLOT_B2),
+    (DeckSlotName.SLOT_9, DeckSlotName.SLOT_B3),
+    (DeckSlotName.SLOT_10, DeckSlotName.SLOT_A1),
+    (DeckSlotName.SLOT_11, DeckSlotName.SLOT_A2),
     (DeckSlotName.FIXED_TRASH, DeckSlotName.SLOT_A3),
 ]
 # fmt: on

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -338,7 +338,6 @@ class DeckSlotName(enum.Enum):
         return self.id
 
 
-# fmt: off
 _slot_equivalencies = [
     (DeckSlotName.SLOT_1, DeckSlotName.SLOT_D1),
     (DeckSlotName.SLOT_2, DeckSlotName.SLOT_D2),
@@ -353,7 +352,6 @@ _slot_equivalencies = [
     (DeckSlotName.SLOT_11, DeckSlotName.SLOT_A2),
     (DeckSlotName.FIXED_TRASH, DeckSlotName.SLOT_A3),
 ]
-# fmt: on
 
 _ot2_to_ot3 = {ot2: ot3 for ot2, ot3 in _slot_equivalencies}
 _ot3_to_ot2 = {ot3: ot2 for ot2, ot3 in _slot_equivalencies}

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from .protocol_api.labware import Labware, Well
     from .protocol_api.core.legacy.module_geometry import ModuleGeometry
     from .protocol_api.module_contexts import ModuleContext
+    from .protocol_api._types import OffDeckType
 
 
 class PipetteNotAttachedError(KeyError):
@@ -66,7 +67,14 @@ class Point(NamedTuple):
 
 
 LocationLabware = Union[
-    "Labware", "Well", str, "ModuleGeometry", LabwareLike, None, "ModuleContext"
+    "Labware",
+    "Well",
+    str,
+    "ModuleGeometry",
+    LabwareLike,
+    None,
+    "OffDeckType",
+    "ModuleContext",
 ]
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -345,18 +345,6 @@ def test_load_labware_off_deck(
         )
     )
 
-    decoy.when(
-        mock_engine_client.state.geometry.get_slot_item(
-            slot_name=DeckSlotName.SLOT_5,
-            allowed_labware_ids={"fixed-trash-123", "abc123"},
-            allowed_module_ids=set(),
-        )
-    ).then_return(
-        LoadedLabware.construct(id="abc123")  # type: ignore[call-arg]
-    )
-
-    assert subject.get_slot_item(DeckSlotName.SLOT_5) is result
-
 
 @pytest.mark.parametrize(
     argnames=["use_gripper", "expected_strategy"],
@@ -1142,4 +1130,4 @@ def test_get_labware_location_off_deck(
         engine_client=mock_engine_client,
     )
 
-    assert subject.get_labware_location(labware) is None
+    assert subject.get_labware_location(labware) is OFF_DECK

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -10,6 +10,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
 
 from opentrons.types import DeckSlotName, Location, Mount, Point
+from opentrons.protocol_api import OFF_DECK
 from opentrons.equipment_broker import EquipmentBroker
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -17,6 +18,7 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import ModuleType, TemperatureModuleModel
 from opentrons.protocols import labware as mock_labware
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api.core.legacy.module_geometry import ModuleGeometry
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocol_api.core.labware import LabwareLoadParams
@@ -161,6 +163,24 @@ def test_load_instrument(
             )
         ),
     )
+
+
+def test_load_labware_off_deck_raises(
+    decoy: Decoy,
+    mock_deck: Deck,
+    mock_labware_offset_provider: AbstractLabwareOffsetProvider,
+    mock_equipment_broker: EquipmentBroker[LoadInfo],
+    subject: LegacyProtocolCore,
+) -> None:
+    """It should raise an api error."""
+    with pytest.raises(APIVersionError):
+        subject.load_labware(
+            load_name="cool load name",
+            location=OFF_DECK,
+            label="cool label",
+            namespace="cool namespace",
+            version=1337,
+        )
 
 
 def test_load_labware(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -292,6 +292,24 @@ def test_load_labware_off_deck(
     decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
+def test_load_labware_off_deck_raises(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    subject: ProtocolContext,
+) -> None:
+    """It should raise and api error."""
+    with pytest.raises(APIVersionError):
+        subject.load_labware(
+            load_name="UPPERCASE_LABWARE",
+            label="some_display_name",
+            namespace="some_namespace",
+            version=1337,
+            location=OFF_DECK,
+        )
+
+
 def test_load_labware_from_definition(
     decoy: Decoy,
     mock_core: ProtocolCore,

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -251,6 +251,47 @@ def test_load_labware(
     decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
 
 
+def test_load_labware_off_deck(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    subject: ProtocolContext,
+) -> None:
+    """It should load labware off-deck."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
+        "lowercase_labware"
+    )
+
+    decoy.when(
+        mock_core.load_labware(
+            load_name="lowercase_labware",
+            location=OFF_DECK,
+            label="some_display_name",
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+    decoy.when(mock_labware_core.get_display_name()).then_return("Display Name")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    result = subject.load_labware(
+        load_name="UPPERCASE_LABWARE",
+        label="some_display_name",
+        namespace="some_namespace",
+        version=1337,
+        location=OFF_DECK,
+    )
+
+    assert isinstance(result, Labware)
+    assert result.name == "Full Name"
+
+    decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
+
+
 def test_load_labware_from_definition(
     decoy: Decoy,
     mock_core: ProtocolCore,

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from opentrons.hardware_control.modules.types import TemperatureModuleModel
-from opentrons.protocol_api import labware
+from opentrons.protocol_api import labware, OFF_DECK
 from opentrons.protocols.api_support.labware_like import LabwareLike, LabwareLikeType
 from opentrons.protocols.api_support.deck_type import STANDARD_OT2_DECK
 from opentrons.protocol_api.core.legacy import module_geometry
@@ -85,6 +85,14 @@ def test_empty():
     assert ll.parent.object is None
     assert ll.object is None
     assert ll.object_type == LabwareLikeType.NONE
+
+
+def test_off_deck():
+    ll = LabwareLike(OFF_DECK)
+    assert ll.has_parent is False
+    assert ll.parent.object is None
+    assert ll.object is OFF_DECK
+    assert ll.object_type == LabwareLikeType.OFF_DECK
 
 
 def test_module_parent(trough, module, mod_trough):


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RLAB-344.
Allow `load_labware` to accept `off-deck` as a valid location. 

# Test Plan
Upload the following protocol with versions 2.15 and version 2.14.
Make sure you are able to upload the protocol with an off-deck location for 2.15.
Make sure this works of OT-2 and OT-3.
```
from typing import cast
from opentrons import protocol_api, types
from opentrons.protocol_api import OFF_DECK

metadata = {
    "protocolName": "Mad Block",
    "author": "Opentrons <engineering@opentrons.com>",
    "description": "A Magnetic Module Test",
    "source": "Opentrons Repository",
    "apiLevel": "2.15",
}

def run(protocol: protocol_api.ProtocolContext) -> None:
    tiprack_200_1       = protocol.load_labware('opentrons_ot3_96_tiprack_200ul', OFF_DECK)
    print(tiprack_200_1.parent)
```

Make sure you are not able to upload the protocol with an off-deck location for 2.14.
```
from typing import cast
from opentrons import protocol_api, types
from opentrons.protocol_api import OFF_DECK

metadata = {
    "protocolName": "Mad Block",
    "author": "Opentrons <engineering@opentrons.com>",
    "description": "A Magnetic Module Test",
    "source": "Opentrons Repository",
    "apiLevel": "2.14",
}

def run(protocol: protocol_api.ProtocolContext) -> None:
    tiprack_200_1       = protocol.load_labware('opentrons_ot3_96_tiprack_200ul', OFF_DECK)
    print(tiprack_200_1.parent)
```

uploading the following protocol should resolve in an error that you cannot access a off-deck item
```
from opentrons.protocol_api import OFF_DECK
metadata = {"apiLevel": "2.15"}


def run(ctx):
    ctx.home()

    tiprack1 = ctx.load_labware_by_name("opentrons_96_tiprack_300ul", "1")
    tiprack2 = ctx.load_labware_by_name("opentrons_96_tiprack_300ul", "2")
    tiprack3 = ctx.load_labware("opentrons_96_filtertiprack_20ul", "3")
    tiprack4 = ctx.load_labware("opentrons_96_tiprack_20ul", "4")

    plate1 = ctx.load_labware("corning_96_wellplate_360ul_flat", "7")
    plate2 = ctx.load_labware("corning_96_wellplate_360ul_flat", OFF_DECK)
    print(f"parent {plate2.parent}")
    pip = ctx.load_instrument(
        "p20_single_gen2", mount="left", tip_racks=[tiprack3, tiprack4]
    )
    pip2 = ctx.load_instrument(
        "p300_single_gen2", mount="right", tip_racks=[tiprack1, tiprack2]
    )
    pip.transfer(
        10,
        plate1.wells("A1"),
        [
            plate2[well].top()
            for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
        ],
    )
    pip2.transfer(
        50,
        plate1.wells("A2"),
        [
            plate2[well].bottom()
            for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
        ],
    )
    # mix behavior
    pip.transfer(
        50,
        plate1.wells("A3"),
        [
            plate2[well].top()
            for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
        ],
    )
```

# Changelog

- Added logic for `load_labware` location arg to accept a OffDeckType gated to 2.15
- `get_labware_location` now defaulting to `off-deck` instead of None.
- ` Labware.parent` will return off-deck as one of the options.
- added OffDeckType to LabwareLike type options.
- added OffDeckType to `LocationLabware` type options.


# Review requests

Do you have any protocols I should test with to validate `LabwareLike` changes and `LocationLabware` changes? looking at the code there is no way this will resolve as `off-deck` from legacy bc we were not able to load a labware with an unknown location and move labware was not implemented before 2.15.
Does the raise exception make more sense?

# Risk assessment

Low. Should only effect versions 2.15 that involve move_labware and load_labware off-deck. 
