### PR TITLE
refactor(app): zAxis error occurs during Mounting plate step

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -1,73 +1,20 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import capitalize from 'lodash/capitalize'
-import {
-  COLORS,
-  SPACING,
-  TYPOGRAPHY,
-  PrimaryButton,
-  SecondaryButton,
-} from '@opentrons/components'
+import { SPACING, PrimaryButton } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { getPipetteAnimations96 } from './utils'
 import { BODY_STYLE, FLOWS, SECTIONS } from './constants'
 
 import type { PipetteWizardStepProps } from './types'
 
 export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
-  const { goBack, proceed, flowType, chainRunCommands, isOnDevice } = props
+  const { goBack, flowType, isOnDevice, proceed } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
-  const [errorMessage, setErrorMessage] = React.useState<boolean>(false)
-  const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
-  const handleCheckZAxis = (): void => {
-    setNumberOfTryAgains(numberOfTryAgains + 1)
-    chainRunCommands(
-      [
-        {
-          commandType: 'home' as const,
-          params: { axes: ['rightZ'] },
-        },
-      ],
-      false
-    )
-      .then(() => {
-        proceed()
-      })
-      .catch(error => {
-        console.error(error.message)
-        setErrorMessage(true)
-      })
-  }
 
-  return errorMessage ? (
-    <SimpleWizardBody
-      iconColor={COLORS.errorEnabled}
-      header={i18n.format(t('z_axis_still_attached'), 'capitalize')}
-      subHeader={t(
-        numberOfTryAgains > 2
-          ? 'something_seems_wrong'
-          : 'detach_z_axis_screw_again'
-      )}
-      isSuccess={false}
-    >
-      <SecondaryButton
-        isDangerous
-        onClick={goBack}
-        marginRight={SPACING.spacing4}
-      >
-        {i18n.format(t('cancel_attachment'), 'capitalize')}
-      </SecondaryButton>
-      <PrimaryButton
-        textTransform={TYPOGRAPHY.textTransformCapitalize}
-        onClick={handleCheckZAxis}
-      >
-        {t('shared:try_again')}
-      </PrimaryButton>
-    </SimpleWizardBody>
-  ) : (
+  return (
     <GenericWizardTile
       header={i18n.format(
         t(flowType === FLOWS.ATTACH ? 'unscrew_carriage' : 'reattach_carriage'),
@@ -94,12 +41,12 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
       proceedButton={
         isOnDevice ? (
           <SmallButton
-            onClick={handleCheckZAxis}
+            onClick={proceed}
             buttonText={capitalize(t('shared:continue'))}
             buttonType="primary"
           />
         ) : (
-          <PrimaryButton onClick={handleCheckZAxis}>
+          <PrimaryButton onClick={proceed}>
             {capitalize(t('shared:continue'))}
           </PrimaryButton>
         )

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { LEFT } from '@opentrons/shared-data'
-import { SPACING } from '@opentrons/components'
+import {
+  COLORS,
+  PrimaryButton,
+  SecondaryButton,
+  SPACING,
+} from '@opentrons/components'
+import { SmallButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { getPipetteAnimations96 } from './utils'
 import { BODY_STYLE, FLOWS, SECTIONS } from './constants'
@@ -11,18 +18,19 @@ import type { PipetteWizardStepProps } from './types'
 export const MountingPlate = (
   props: PipetteWizardStepProps
 ): JSX.Element | null => {
-  const {
-    goBack,
-    proceed,
-    flowType,
-    chainRunCommands,
-    setShowErrorMessage,
-  } = props
+  const { goBack, proceed, flowType, chainRunCommands, isOnDevice } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
+  const [errorMessage, setErrorMessage] = React.useState<boolean>(false)
+  const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
 
   const handleAttachMountingPlate = (): void => {
+    setNumberOfTryAgains(numberOfTryAgains + 1)
     chainRunCommands(
       [
+        {
+          commandType: 'home' as const,
+          params: { axes: ['rightZ'] },
+        },
         {
           // @ts-expect-error calibration type not yet supported
           commandType: 'calibration/moveToMaintenancePosition' as const,
@@ -37,11 +45,51 @@ export const MountingPlate = (
         proceed()
       })
       .catch(error => {
-        setShowErrorMessage(error.message)
+        console.error(error.message)
+        setErrorMessage(true)
       })
   }
 
-  return (
+  return errorMessage ? (
+    <SimpleWizardBody
+      iconColor={COLORS.errorEnabled}
+      header={i18n.format(t('z_axis_still_attached'), 'capitalize')}
+      subHeader={t(
+        numberOfTryAgains > 2
+          ? 'something_seems_wrong'
+          : 'detach_z_axis_screw_again'
+      )}
+      isSuccess={false}
+    >
+      {isOnDevice ? (
+        <>
+          <SmallButton
+            buttonType="alert"
+            onClick={goBack}
+            buttonText={i18n.format(t('cancel_attachment'), 'capitalize')}
+          />
+          <SmallButton
+            buttonType="primary"
+            onClick={handleAttachMountingPlate}
+            buttonText={i18n.format(t('shared:try_again'), 'capitalize')}
+          />
+        </>
+      ) : (
+        <>
+          <SecondaryButton
+            isDangerous
+            onClick={goBack}
+            marginRight={SPACING.spacing4}
+          >
+            {i18n.format(t('cancel_attachment'), 'capitalize')}
+          </SecondaryButton>
+          <PrimaryButton onClick={handleAttachMountingPlate}>
+            {i18n.format(t('shared:try_again'), 'capitalize')}
+          </PrimaryButton>
+        </>
+      )}
+    </SimpleWizardBody>
+  ) : (
     <GenericWizardTile
       header={t(
         flowType === FLOWS.ATTACH

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Carriage.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { LEFT, NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
@@ -67,23 +67,10 @@ describe('Carriage', () => {
     getByLabelText('back').click()
     expect(props.goBack).toHaveBeenCalled()
   })
-  it('clicking on continue button executes the commands correctly', async () => {
+  it('clicking on continue button executes the commands correctly', () => {
     const { getByRole } = render(props)
     const contBtn = getByRole('button', { name: 'Continue' })
     fireEvent.click(contBtn)
-    expect(props.chainRunCommands).toHaveBeenCalledWith(
-      [
-        {
-          commandType: 'home',
-          params: {
-            axes: ['rightZ'],
-          },
-        },
-      ],
-      false
-    )
-    await waitFor(() => {
-      expect(props.proceed).toHaveBeenCalled()
-    })
+    expect(props.proceed).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -47,6 +47,10 @@ describe('MountingPlate', () => {
       expect(props.chainRunCommands).toHaveBeenCalledWith(
         [
           {
+            commandType: 'home',
+            params: { axes: ['rightZ'] },
+          },
+          {
             commandType: 'calibration/moveToMaintenancePosition',
             params: { mount: LEFT },
           },


### PR DESCRIPTION
closes RLIQ-407

# Overview

Previously, the zAxis error modal occurred during the `Carriage` step but we wanted to move it to the `MountingPlate` step since it doesn't fail until then.

# Test Plan

on a Flex, test the attach 96-channel flow and see that the zaxis modal error is being triggered properly. Observe the modal on both the ODD and the desktop app (make sure that the buttons are correct).

# Changelog

- remove error modal from Carriage component and fix test, also remove the `home` command.
- add the error modal + home command to the Mounting plate component
- fix the tests

# Review requests

see test plan

# Risk assessment

low