### PR TITLE
refactor(app): rename robot slideout for Flex

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -175,7 +175,7 @@
   "recalibration_recommended": "Recalibration recommended",
   "reinstall": "reinstall",
   "remind_me_later": "Remind me later",
-  "rename_robot_input_error": "Oops! Robot name must follow the character count and limitations",
+  "rename_robot_input_error": "Oops! Robot name must follow the character count and limitations.",
   "rename_robot_input_limitation_detail": "Please enter 17 characters max using valid inputs: letters and numbers.",
   "rename_robot_prefer_usb_connection": "To ensure reliable renaming of your robot, please connect to it via USB.",
   "rename_robot_title": "Rename Robot",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -176,7 +176,7 @@
   "reinstall": "reinstall",
   "remind_me_later": "Remind me later",
   "rename_robot_input_error": "Oops! Robot name must follow the character count and limitations",
-  "rename_robot_input_limitation_detail": "Please enter 17 characters max using valid inputs: letters and numbers",
+  "rename_robot_input_limitation_detail": "Please enter 17 characters max using valid inputs: letters and numbers.",
   "rename_robot_prefer_usb_connection": "To ensure reliable renaming of your robot, please connect to it via USB.",
   "rename_robot_title": "Rename Robot",
   "rename_robot": "Rename robot",

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -26,6 +26,7 @@ import { Slideout } from '../../../../../atoms/Slideout'
 import { StyledText } from '../../../../../atoms/text'
 import { InputField } from '../../../../../atoms/InputField'
 import { Banner } from '../../../../../atoms/Banner'
+import { useIsOT3 } from '../../../hooks'
 
 import type { UpdatedRobotName } from '@opentrons/api-client'
 import type { State, Dispatch } from '../../../../../redux/types'
@@ -55,6 +56,7 @@ export function RenameRobotSlideout({
   const [previousRobotName, setPreviousRobotName] = React.useState<string>(
     robotName
   )
+  const isOt3 = useIsOT3(robotName)
   const trackEvent = useTrackEvent()
   const history = useHistory()
   const dispatch = useDispatch<Dispatch>()
@@ -144,9 +146,11 @@ export function RenameRobotSlideout({
       }
     >
       <Flex flexDirection={DIRECTION_COLUMN}>
-        <Banner type="informing" marginBottom={SPACING.spacing16}>
-          {t('rename_robot_prefer_usb_connection')}
-        </Banner>
+        {isOt3 ? null : (
+          <Banner type="informing" marginBottom={SPACING.spacing16}>
+            {t('rename_robot_prefer_usb_connection')}
+          </Banner>
+        )}
         <StyledText as="p" marginBottom={SPACING.spacing16}>
           {t('rename_robot_input_limitation_detail')}
         </StyledText>
@@ -170,7 +174,11 @@ export function RenameRobotSlideout({
           {t('characters_max')}
         </StyledText>
         {formik.errors.newRobotName && (
-          <StyledText as="label" color={COLORS.errorEnabled}>
+          <StyledText
+            as="label"
+            color={COLORS.errorEnabled}
+            marginTop={SPACING.spacing4}
+          >
             {formik.errors.newRobotName}
           </StyledText>
         )}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
@@ -17,9 +17,11 @@ import {
 } from '../../../../../../redux/discovery/__fixtures__'
 
 import { RenameRobotSlideout } from '../RenameRobotSlideout'
+import { useIsOT3 } from '../../../../hooks'
 
 jest.mock('../../../../../../redux/discovery/selectors')
 jest.mock('../../../../../../redux/analytics')
+jest.mock('../../../../hooks')
 
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots
@@ -30,6 +32,7 @@ const mockGetReachableRobots = getReachableRobots as jest.MockedFunction<
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const mockOnCloseClick = jest.fn()
 let mockTrackEvent: jest.Mock
@@ -55,6 +58,7 @@ describe('RobotSettings RenameRobotSlideout', () => {
     mockReachableRobot.name = 'reachableOtie'
     mockGetConnectableRobots.mockReturnValue([mockConnectableRobot])
     mockGetReachableRobots.mockReturnValue([mockReachableRobot])
+    mockUseIsOT3.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -66,7 +70,30 @@ describe('RobotSettings RenameRobotSlideout', () => {
 
     getByText('Rename Robot')
     getByText(
-      'Please enter 17 characters max using valid inputs: letters and numbers'
+      'To ensure reliable renaming of your robot, please connect to it via USB.'
+    )
+    getByText(
+      'Please enter 17 characters max using valid inputs: letters and numbers.'
+    )
+    getByText('Robot Name')
+    getByText('17 characters max')
+    getByRole('textbox')
+    const renameButton = getByRole('button', { name: 'Rename robot' })
+    expect(renameButton).toBeInTheDocument()
+    expect(renameButton).toBeDisabled()
+  })
+
+  it('should render title, description, label, input, and button for flex', () => {
+    mockUseIsOT3.mockReturnValue(true)
+    const [{ getByText, getByRole, queryByText }] = render()
+    getByText('Rename Robot')
+    expect(
+      queryByText(
+        'To ensure reliable renaming of your robot, please connect to it via USB.'
+      )
+    ).not.toBeInTheDocument()
+    getByText(
+      'Please enter 17 characters max using valid inputs: letters and numbers.'
     )
     getByText('Robot Name')
     getByText('17 characters max')


### PR DESCRIPTION
closes RAUT-494

# Overview

adjust rename robot slideout for Flex

# Test Plan

See ticket - a Flex should not see the `To ensure reliable renaming of your robot, please connect to it via USB.` banner but the banner should still be there for an OT-2.

# Changelog

- change `RenameRobotSlideout` to accommodate ot-3 and update test
- various tiny UI fixes to match designs including an i18n value change

# Review requests

see test plan

# Risk assessment

low