### PR TITLE
fix(api): increase pipette detection timeout

### DIFF
--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -405,7 +405,7 @@ class SubsystemManager:
                 right=self._tool_if_ok(update.right, NodeId.pipette_right),
                 gripper=self._tool_if_ok(update.gripper, NodeId.gripper),
             )
-            self._present_tools = await self._tool_detector.resolve(to_resolve)
+            self._present_tools = await self._tool_detector.resolve(to_resolve, 5.0)
             log.info(f"Present tools are now {self._present_tools}")
             async with self._tool_task_condition:
                 self._tool_task_state = True

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
@@ -268,7 +268,9 @@ class ToolDetectionController:
             else ToolType.nothing_attached,
         )
 
-        self._decoy.when(await self._tool_detector.resolve(arg)).then_return(summary)
+        self._decoy.when(await self._tool_detector.resolve(arg, 5.0)).then_return(
+            summary
+        )
         return summary
 
 


### PR DESCRIPTION
We have a timeout for getting the pipette info response during tool attach, and it was too short, breaking the pipette attach process. By increasing the timeout we fix the issue.

Closes RQA-961
