### PR TITLE
refactor(shared-data): move pipette name conversion functions to shared-data

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -25,7 +25,7 @@ from typing import (
     Union,
 )
 from opentrons.config.types import OT3Config, GantryLoad
-from opentrons.config import ot3_pipette_config, gripper_config, feature_flags as ff
+from opentrons.config import gripper_config, feature_flags as ff
 from .ot3utils import (
     axis_convert,
     create_move_group,
@@ -137,6 +137,10 @@ from opentrons_hardware.hardware_control.rear_panel_settings import (
 
 from opentrons_hardware.drivers.gpio import OT3GPIO, RemoteOT3GPIO
 from opentrons_shared_data.pipette.dev_types import PipetteName
+from opentrons_shared_data.pipette import (
+    pipette_load_name_conversions as pipette_load_name,
+    load_data as load_pipette_data,
+)
 from opentrons_shared_data.gripper.gripper_definition import GripForceProfile
 
 from .subsystem_manager import SubsystemManager
@@ -638,7 +642,7 @@ class OT3Controller:
     @staticmethod
     def _combine_serial_number(pipette_info: ohc_tool_types.PipetteInformation) -> str:
         serialized_name = OT3Controller._lookup_serial_key(pipette_info.name)
-        version = ot3_pipette_config.version_from_string(pipette_info.model)
+        version = pipette_load_name.version_from_string(pipette_info.model)
         return f"{serialized_name}V{version.major}{version.minor}{pipette_info.serial}"
 
     @staticmethod
@@ -654,11 +658,14 @@ class OT3Controller:
             # for PipetteInformation.serial so we don't have to use
             # helper methods to convert the serial back to what was flashed
             # on the eeprom.
+            converted_name = pipette_load_name.convert_pipette_name(
+                cast(PipetteName, attached.name.name), attached.model
+            )
             return {
-                "config": ot3_pipette_config.load_ot3_pipette(
-                    ot3_pipette_config.convert_pipette_name(
-                        cast(PipetteName, attached.name.name), attached.model
-                    )
+                "config": load_pipette_data.load_definition(
+                    converted_name.pipette_type,
+                    converted_name.pipette_channels,
+                    converted_name.pipette_version,
                 ),
                 "id": OT3Controller._combine_serial_number(attached),
             }

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from opentrons.config.types import OT3Config, GantryLoad
-from opentrons.config import ot3_pipette_config, gripper_config
+from opentrons.config import gripper_config
 from .ot3utils import (
     axis_convert,
     create_move_group,
@@ -65,6 +65,10 @@ from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control import status_bar
 
 from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from opentrons_shared_data.pipette import (
+    pipette_load_name_conversions as pipette_load_name,
+    load_data as load_pipette_data,
+)
 from opentrons_shared_data.gripper.gripper_definition import GripperModel
 from opentrons.hardware_control.dev_types import (
     InstrumentHardwareConfigs,
@@ -149,7 +153,7 @@ class OT3Simulator:
             if not passed_ai or not passed_ai.get("model"):
                 return pipette_spec
 
-            if ot3_pipette_config.supported_pipette(
+            if pipette_load_name.supported_pipette(
                 cast(PipetteModel, passed_ai["model"])
             ):
                 pipette_spec["model"] = cast(PipetteModel, passed_ai.get("model"))
@@ -396,7 +400,7 @@ class OT3Simulator:
         # TODO (lc 12-05-2022) When the time comes, we should think about supporting
         # backwards compatability -- hopefully not relying on config keys only,
         # but TBD.
-        if expected_instr and not ot3_pipette_config.supported_pipette(
+        if expected_instr and not pipette_load_name.supported_pipette(
             cast(PipetteModel, expected_instr)
         ):
             raise RuntimeError(
@@ -410,9 +414,12 @@ class OT3Simulator:
                     )
                 )
             else:
+                converted_name = pipette_load_name.convert_pipette_name(expected_instr)
                 return {
-                    "config": ot3_pipette_config.load_ot3_pipette(
-                        ot3_pipette_config.convert_pipette_name(expected_instr)
+                    "config": load_pipette_data.load_definition(
+                        converted_name.pipette_type,
+                        converted_name.pipette_channels,
+                        converted_name.pipette_version,
                     ),
                     "id": None,
                 }
@@ -422,17 +429,23 @@ class OT3Simulator:
             # constructor of this class)
 
             # OR Instrument detected and no expected instrument specified
+            converted_name = pipette_load_name.convert_pipette_model(found_model)
             return {
-                "config": ot3_pipette_config.load_ot3_pipette(
-                    ot3_pipette_config.convert_pipette_model(found_model)
+                "config": load_pipette_data.load_definition(
+                    converted_name.pipette_type,
+                    converted_name.pipette_channels,
+                    converted_name.pipette_version,
                 ),
                 "id": init_instr["id"],
             }
         elif expected_instr:
             # Expected instrument specified and no instrument detected
+            converted_name = pipette_load_name.convert_pipette_name(expected_instr)
             return {
-                "config": ot3_pipette_config.load_ot3_pipette(
-                    ot3_pipette_config.convert_pipette_name(expected_instr)
+                "config": load_pipette_data.load_definition(
+                    converted_name.pipette_type,
+                    converted_name.pipette_channels,
+                    converted_name.pipette_version,
                 ),
                 "id": None,
             }

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -28,10 +28,13 @@ from opentrons.hardware_control.modules.module_calibration import (
 from opentrons_shared_data.pipette.dev_types import (
     PipetteName,
 )
+from opentrons_shared_data.pipette import (
+    pipette_load_name_conversions as pipette_load_name,
+)
 from opentrons_shared_data.gripper.constants import IDLE_STATE_GRIP_FORCE
 
 from opentrons import types as top_types
-from opentrons.config import robot_configs, ot3_pipette_config
+from opentrons.config import robot_configs
 from opentrons.config.types import (
     RobotConfig,
     OT3Config,
@@ -546,7 +549,7 @@ class OT3API(
             # TODO (lc 12-5-2022) cache instruments should be receiving
             # a pipette type / channels rather than the named config.
             # We should also check version here once we're comfortable.
-            if not ot3_pipette_config.supported_pipette(name):
+            if not pipette_load_name.supported_pipette(name):
                 raise RuntimeError(f"{name} is not a valid pipette name")
         async with self._motion_lock:
             # we're not actually checking the required instrument except in the context

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -69,7 +69,6 @@ from opentrons_shared_data.pipette.pipette_definition import (
     PipetteVersionType,
 )
 from opentrons_shared_data.pipette import (
-    pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,
 )
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -61,12 +61,16 @@ from opentrons.types import Point, Mount
 
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 
-from opentrons.config import gripper_config as gc, ot3_pipette_config
+from opentrons.config import gripper_config as gc
 from opentrons_shared_data.gripper.gripper_definition import GripperModel
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteModelType,
     PipetteChannelType,
     PipetteVersionType,
+)
+from opentrons_shared_data.pipette import (
+    pipette_load_name_conversions as pipette_load_name,
+    load_data as load_pipette_data,
 )
 
 
@@ -346,12 +350,10 @@ async def test_gantry_load_transform(
             instr_data = AttachedGripper(config=gripper_config, id="2345")
             await ot3_hardware.cache_gripper(instr_data)
         else:
-            pipette_config = ot3_pipette_config.load_ot3_pipette(
-                ot3_pipette_config.PipetteModelVersionType(
+            pipette_config = load_pipette_data.load_definition(
                     PipetteModelType(configs["model"]),
                     PipetteChannelType(configs["channels"]),
-                    PipetteVersionType(*configs["version"]),
-                )
+                    PipetteVersionType(*configs["version"])
             )
             instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
             await ot3_hardware.cache_pipette(mount, instr_data, None)
@@ -439,12 +441,10 @@ async def prepare_for_mock_blowout(
     mount: OT3Mount,
     configs: Any,
 ) -> Tuple[Any, ThreadManager[OT3API]]:
-    pipette_config = ot3_pipette_config.load_ot3_pipette(
-        ot3_pipette_config.PipetteModelVersionType(
+    pipette_config = load_pipette_data.load_definition(
             PipetteModelType(configs["model"]),
             PipetteChannelType(configs["channels"]),
-            PipetteVersionType(*configs["version"]),
-        )
+            PipetteVersionType(*configs["version"])
     )
     instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
     await ot3_hardware.cache_pipette(mount, instr_data, None)
@@ -1059,12 +1059,10 @@ async def test_home_plunger(
 ):
     mount = OT3Mount.LEFT
     instr_data = OT3AttachedPipette(
-        config=ot3_pipette_config.load_ot3_pipette(
-            ot3_pipette_config.PipetteModelVersionType(
+        config=load_pipette_data.load_definition(
                 PipetteModelType("p1000"),
                 PipetteChannelType(1),
-                PipetteVersionType(3, 4),
-            )
+                PipetteVersionType(3, 4)
         ),
         id="fakepip",
     )
@@ -1082,12 +1080,10 @@ async def test_prepare_for_aspirate(
 ):
     mount = OT3Mount.LEFT
     instr_data = OT3AttachedPipette(
-        config=ot3_pipette_config.load_ot3_pipette(
-            ot3_pipette_config.PipetteModelVersionType(
+        config=load_pipette_data.load_definition(
                 PipetteModelType("p1000"),
                 PipetteChannelType(1),
                 PipetteVersionType(3, 4),
-            )
         ),
         id="fakepip",
     )
@@ -1105,12 +1101,10 @@ async def test_move_to_plunger_bottom(
 ):
     mount = OT3Mount.LEFT
     instr_data = OT3AttachedPipette(
-        config=ot3_pipette_config.load_ot3_pipette(
-            ot3_pipette_config.PipetteModelVersionType(
+        config=load_pipette_data.load_definition(
                 PipetteModelType("p1000"),
                 PipetteChannelType(1),
-                PipetteVersionType(3, 4),
-            )
+                PipetteVersionType(3, 4)
         ),
         id="fakepip",
     )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -351,9 +351,9 @@ async def test_gantry_load_transform(
             await ot3_hardware.cache_gripper(instr_data)
         else:
             pipette_config = load_pipette_data.load_definition(
-                    PipetteModelType(configs["model"]),
-                    PipetteChannelType(configs["channels"]),
-                    PipetteVersionType(*configs["version"])
+                PipetteModelType(configs["model"]),
+                PipetteChannelType(configs["channels"]),
+                PipetteVersionType(*configs["version"]),
             )
             instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
             await ot3_hardware.cache_pipette(mount, instr_data, None)
@@ -442,9 +442,9 @@ async def prepare_for_mock_blowout(
     configs: Any,
 ) -> Tuple[Any, ThreadManager[OT3API]]:
     pipette_config = load_pipette_data.load_definition(
-            PipetteModelType(configs["model"]),
-            PipetteChannelType(configs["channels"]),
-            PipetteVersionType(*configs["version"])
+        PipetteModelType(configs["model"]),
+        PipetteChannelType(configs["channels"]),
+        PipetteVersionType(*configs["version"]),
     )
     instr_data = OT3AttachedPipette(config=pipette_config, id="fakepip")
     await ot3_hardware.cache_pipette(mount, instr_data, None)
@@ -1060,9 +1060,7 @@ async def test_home_plunger(
     mount = OT3Mount.LEFT
     instr_data = OT3AttachedPipette(
         config=load_pipette_data.load_definition(
-                PipetteModelType("p1000"),
-                PipetteChannelType(1),
-                PipetteVersionType(3, 4)
+            PipetteModelType("p1000"), PipetteChannelType(1), PipetteVersionType(3, 4)
         ),
         id="fakepip",
     )
@@ -1081,9 +1079,9 @@ async def test_prepare_for_aspirate(
     mount = OT3Mount.LEFT
     instr_data = OT3AttachedPipette(
         config=load_pipette_data.load_definition(
-                PipetteModelType("p1000"),
-                PipetteChannelType(1),
-                PipetteVersionType(3, 4),
+            PipetteModelType("p1000"),
+            PipetteChannelType(1),
+            PipetteVersionType(3, 4),
         ),
         id="fakepip",
     )
@@ -1102,9 +1100,7 @@ async def test_move_to_plunger_bottom(
     mount = OT3Mount.LEFT
     instr_data = OT3AttachedPipette(
         config=load_pipette_data.load_definition(
-                PipetteModelType("p1000"),
-                PipetteChannelType(1),
-                PipetteVersionType(3, 4)
+            PipetteModelType("p1000"), PipetteChannelType(1), PipetteVersionType(3, 4)
         ),
         id="fakepip",
     )

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -52,7 +52,11 @@ def hardware_pipette_ot3() -> Callable:
         id: str = "testID",
     ):
         return ot3_pipette.Pipette(
-            load_pipette_data.load_definition(model.pipette_type, model.pipette_channels, model.pipette_version), calibration, id
+            load_pipette_data.load_definition(
+                model.pipette_type, model.pipette_channels, model.pipette_version
+            ),
+            calibration,
+            id,
         )
 
     return _create_pipette

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -13,7 +13,11 @@ from opentrons.hardware_control.instruments.ot3 import (
     instrument_calibration as ot3_calibration,
 )
 from opentrons.hardware_control import types
-from opentrons.config import pipette_config, ot3_pipette_config
+from opentrons.config import pipette_config
+from opentrons_shared_data.pipette import (
+    pipette_load_name_conversions as pipette_load_name,
+    load_data as load_pipette_data,
+)
 
 OT2_PIP_CAL = instrument_calibration.PipetteOffsetByPipetteMount(
     offset=Point(0, 0, 0),
@@ -43,12 +47,12 @@ def hardware_pipette_ot2() -> Callable:
 @pytest.fixture
 def hardware_pipette_ot3() -> Callable:
     def _create_pipette(
-        model: ot3_pipette_config.PipetteModelVersionType,
+        model: pipette_load_name.PipetteModelVersionType,
         calibration: ot3_calibration.PipetteOffsetByPipetteMount = OT3_PIP_CAL,
         id: str = "testID",
     ):
         return ot3_pipette.Pipette(
-            ot3_pipette_config.load_ot3_pipette(model), calibration, id
+            load_pipette_data.load_definition(model.pipette_type, model.pipette_channels, model.pipette_version), calibration, id
         )
 
     return _create_pipette
@@ -60,13 +64,13 @@ def hardware_pipette_ot3() -> Callable:
         [lazy_fixture("hardware_pipette_ot2"), "p10_single_v1"],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_single_v1.0"),
+            pipette_load_name.convert_pipette_model("p1000_single_v1.0"),
         ],
     ],
 )
 def test_tip_tracking(
     pipette_builder: Callable,
-    model: Union[str, ot3_pipette_config.PipetteModelVersionType],
+    model: Union[str, pipette_load_name.PipetteModelVersionType],
 ) -> None:
     hw_pipette = pipette_builder(model)
     with pytest.raises(AssertionError):
@@ -89,14 +93,14 @@ def test_tip_tracking(
         [lazy_fixture("hardware_pipette_ot2"), "p10_single_v1", Point(0, 0, 12.0)],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_single_v3.3"),
+            pipette_load_name.convert_pipette_model("p1000_single_v3.3"),
             Point(-8.0, -22.0, -259.15),
         ],
     ],
 )
 def test_tip_nozzle_position_tracking(
     pipette_builder: Callable,
-    model: Union[str, ot3_pipette_config.PipetteModelVersionType],
+    model: Union[str, pipette_load_name.PipetteModelVersionType],
     nozzle_offset: Point,
 ) -> None:
     hw_pipette = pipette_builder(model)
@@ -131,7 +135,7 @@ def test_tip_nozzle_position_tracking(
         ],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_single_v1.0"),
+            pipette_load_name.convert_pipette_model("p1000_single_v1.0"),
             ot3_calibration.PipetteOffsetByPipetteMount(
                 offset=Point(10, 10, 10),
                 source=cal_types.SourceType.user,
@@ -142,7 +146,7 @@ def test_tip_nozzle_position_tracking(
 )
 def test_critical_points_pipette_offset(
     pipette_builder: Callable,
-    model: Union[str, ot3_pipette_config.PipetteModelVersionType],
+    model: Union[str, pipette_load_name.PipetteModelVersionType],
     calibration: Union[
         instrument_calibration.PipetteOffsetByPipetteMount,
         ot3_calibration.PipetteOffsetByPipetteMount,
@@ -173,14 +177,14 @@ def test_critical_points_pipette_offset(
         [lazy_fixture("hardware_pipette_ot2"), "p10_single_v1", 10.0],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_single_v1.0"),
+            pipette_load_name.convert_pipette_model("p1000_single_v1.0"),
             1000.0,
         ],
     ],
 )
 def test_volume_tracking(
     pipette_builder: Callable,
-    model: Union[str, ot3_pipette_config.PipetteModelVersionType],
+    model: Union[str, pipette_load_name.PipetteModelVersionType],
     max_volume: float,
 ) -> None:
     hw_pipette = pipette_builder(model)
@@ -277,19 +281,19 @@ def test_flow_rate_setting(
         ],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_single_v3.3"),
+            pipette_load_name.convert_pipette_model("p1000_single_v3.3"),
             Point(-8.0, -22.0, -259.15),
             Point(-8.0, -22.0, -259.15),
         ],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_multi_v3.3"),
+            pipette_load_name.convert_pipette_model("p1000_multi_v3.3"),
             Point(-8.0, -47.5, -259.15),
             Point(-8.0, -79.0, -259.15),
         ],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_96", "3.3"),
+            pipette_load_name.convert_pipette_model("p1000_96", "3.3"),
             Point(13.5, -57.0, -259.15),
             Point(-36.0, -88.5, -259.15),
         ],
@@ -297,7 +301,7 @@ def test_flow_rate_setting(
 )
 def test_alternative_critical_points(
     pipette_builder: Callable,
-    model: Union[str, ot3_pipette_config.PipetteModelVersionType],
+    model: Union[str, pipette_load_name.PipetteModelVersionType],
     expected_xy_critical_point: Point,
     expected_front_critical_point: Point,
 ) -> None:
@@ -326,7 +330,7 @@ def test_alternative_critical_points(
         ],
         [
             lazy_fixture("hardware_pipette_ot3"),
-            ot3_pipette_config.convert_pipette_model("p1000_single_v1.0"),
+            pipette_load_name.convert_pipette_model("p1000_single_v1.0"),
             ot3_calibration.PipetteOffsetByPipetteMount(
                 offset=Point(1, 1, 1),
                 source=cal_types.SourceType.user,
@@ -337,7 +341,7 @@ def test_alternative_critical_points(
 )
 def test_reset_instrument_offset(
     pipette_builder: Callable,
-    model: Union[str, ot3_pipette_config.PipetteModelVersionType],
+    model: Union[str, pipette_load_name.PipetteModelVersionType],
     calibration: Union[
         instrument_calibration.PipetteOffsetByPipetteMount,
         ot3_calibration.PipetteOffsetByPipetteMount,
@@ -369,7 +373,7 @@ def test_save_instrument_offset_ot3(hardware_pipette_ot3: Callable) -> None:
     # which should be done in a follow-up refactor.
     path_to_calibrations = "opentrons.hardware_control.instruments.ot3.pipette"
     hw_pipette = hardware_pipette_ot3(
-        ot3_pipette_config.convert_pipette_model("p1000_single_v1.0")
+        pipette_load_name.convert_pipette_model("p1000_single_v1.0")
     )
 
     assert hw_pipette.pipette_offset.offset == Point(0, 0, 0)
@@ -388,7 +392,7 @@ def test_reload_instrument_cal_ot3(
     hardware_pipette_ot3: Callable,
 ) -> None:
     old_pip = hardware_pipette_ot3(
-        ot3_pipette_config.convert_pipette_model("p1000_single_v1.0")
+        pipette_load_name.convert_pipette_model("p1000_single_v1.0")
     )
     # if only calibration is changed
     new_cal = ot3_calibration.PipetteOffsetByPipetteMount(

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
@@ -69,6 +69,7 @@ def supported_pipette(model_or_name: Union[PipetteName, PipetteModel, None]) -> 
         return True
     return False
 
+
 def channels_from_string(channels: str) -> PipetteChannelType:
     """Convert channels from a string.
 
@@ -195,4 +196,3 @@ def convert_pipette_model(
         channels = DEFAULT_CHANNELS
         version = DEFAULT_MODEL_VERSION
     return PipetteModelVersionType(PipetteModelType[pipette_type], channels, version)
-

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
@@ -1,14 +1,12 @@
 import re
 from typing import List, Optional, Union, cast
 from dataclasses import dataclass
-from opentrons_shared_data.pipette import load_data
-from opentrons_shared_data.pipette.dev_types import PipetteModel, PipetteName
-from opentrons_shared_data.pipette.pipette_definition import (
+from .dev_types import PipetteModel, PipetteName
+from .pipette_definition import (
     PipetteChannelType,
     PipetteModelType,
     PipetteVersionType,
     PipetteGenerationType,
-    PipetteConfigurations,
     PIPETTE_AVAILABLE_TYPES,
     PIPETTE_CHANNELS_INTS,
     PipetteModelMajorVersionType,
@@ -50,6 +48,26 @@ class PipetteModelVersionType:
 
         return f"{base_name}_v{self.pipette_version}"
 
+
+def supported_pipette(model_or_name: Union[PipetteName, PipetteModel, None]) -> bool:
+    """Determine if a pipette type is supported.
+
+    Args:
+        model_or_name (Union[PipetteName, PipetteModel, None]): The pipette we want to check.
+
+    Returns:
+        bool: Whether or not the given pipette name or model is supported.
+    """
+    if not model_or_name:
+        return False
+    split_model_or_name = model_or_name.split("_")
+    channels_as_int = channels_from_string(split_model_or_name[1]).as_int
+    if (
+        split_model_or_name[0] in PIPETTE_AVAILABLE_TYPES
+        or channels_as_int in PIPETTE_CHANNELS_INTS
+    ):
+        return True
+    return False
 
 def channels_from_string(channels: str) -> PipetteChannelType:
     """Convert channels from a string.
@@ -178,29 +196,3 @@ def convert_pipette_model(
         version = DEFAULT_MODEL_VERSION
     return PipetteModelVersionType(PipetteModelType[pipette_type], channels, version)
 
-
-def supported_pipette(model_or_name: Union[PipetteName, PipetteModel, None]) -> bool:
-    """Determine if a pipette type is supported.
-
-    Args:
-        model_or_name (Union[PipetteName, PipetteModel, None]): The pipette we want to check.
-
-    Returns:
-        bool: Whether or not the given pipette name or model is supported.
-    """
-    if not model_or_name:
-        return False
-    split_model_or_name = model_or_name.split("_")
-    channels_as_int = channels_from_string(split_model_or_name[1]).as_int
-    if (
-        split_model_or_name[0] in PIPETTE_AVAILABLE_TYPES
-        or channels_as_int in PIPETTE_CHANNELS_INTS
-    ):
-        return True
-    return False
-
-
-def load_ot3_pipette(model_type: PipetteModelVersionType) -> PipetteConfigurations:
-    return load_data.load_definition(
-        model_type.pipette_type, model_type.pipette_channels, model_type.pipette_version
-    )

--- a/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
+++ b/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
@@ -1,59 +1,13 @@
 import pytest
 
-from typing import Tuple, cast
-from opentrons_shared_data.pipette.pipette_definition import (
-    SupportedTipsDefinition,
-    PipetteTipType,
-)
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteChannelType,
     PipetteModelType,
     PipetteVersionType,
     PipetteGenerationType,
-    PipetteModelMajorVersionType,
-    PipetteModelMinorVersionType,
 )
 from opentrons_shared_data.pipette.dev_types import PipetteModel, PipetteName
-from opentrons.config import ot3_pipette_config as pc
-
-
-def test_multiple_tip_configurations() -> None:
-    model_version = pc.PipetteModelVersionType(
-        PipetteModelType.p1000,
-        PipetteChannelType.EIGHT_CHANNEL,
-        PipetteVersionType(3, 3),
-    )
-    loaded_configuration = pc.load_ot3_pipette(model_version)
-    assert list(loaded_configuration.supported_tips.keys()) == [
-        PipetteTipType.t50,
-        PipetteTipType.t200,
-        PipetteTipType.t1000,
-    ]
-    assert isinstance(
-        loaded_configuration.supported_tips[PipetteTipType.t50],
-        SupportedTipsDefinition,
-    )
-
-
-@pytest.mark.parametrize(
-    argnames=["model", "channels", "version"],
-    argvalues=[["p50", 8, (3, 3)], ["p1000", 96, (3, 3)], ["p50", 1, (1, 0)]],
-)
-def test_load_full_pipette_configurations(
-    model: str, channels: int, version: Tuple[int, int]
-) -> None:
-    model_version = pc.PipetteModelVersionType(
-        PipetteModelType(model),
-        PipetteChannelType(channels),
-        PipetteVersionType(
-            cast(PipetteModelMajorVersionType, version[0]),
-            cast(PipetteModelMinorVersionType, version[1]),
-        ),
-    )
-    loaded_configuration = pc.load_ot3_pipette(model_version)
-    assert loaded_configuration.pipette_type.value == model
-    assert loaded_configuration.channels.as_int == channels
-    assert loaded_configuration.version.as_tuple == version
+from opentrons_shared_data.pipette import pipette_load_name_conversions as pc
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview

The protocol engine needs to utilize some of the pipette name conversions that were originally only used in the hardware controller. In order for the protocol engine to access this, I've moved these functions to shared-data.

# Test Plan

- Throw on a robot and make sure nothing breaks

# Changelog

- Moves all the helper functions from `ot3_pipette_config.py` to a new file in `shared_data/python` and associated tests.

# Review requests

Anything you'd like to change?

# Risk assessment

Ideally low...just moving around functions 
