### PR TITLE
fix(app): DQA fixes for protocol details pages

### DIFF
--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Hardware.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Hardware.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import {
   BORDERS,
   COLORS,
+  Flex,
   SPACING,
   TYPOGRAPHY,
   WRAP,
@@ -12,12 +13,15 @@ import {
   GRIPPER_V1,
   getGripperDisplayName,
   getModuleDisplayName,
+  getModuleDisplayIcon,
   getPipetteNameSpecs,
 } from '@opentrons/shared-data'
 import { StyledText } from '../../../atoms/text'
+import { LocationIcon } from '../../../molecules/LocationIcon'
 import { useRequiredProtocolHardware } from '../../Protocols/hooks'
 import { EmptySection } from './EmptySection'
 
+import type { IconName } from '@opentrons/components'
 import type { ProtocolHardware } from '../../Protocols/hooks'
 import type { TFunction } from 'react-i18next'
 
@@ -25,7 +29,7 @@ const Table = styled('table')`
   ${TYPOGRAPHY.labelRegular}
   table-layout: auto;
   width: 100%;
-  border-spacing: 0 ${SPACING.spacing4};
+  border-spacing: 0 ${SPACING.spacing8};
   margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
@@ -72,7 +76,18 @@ const getHardwareName = (protocolHardware: ProtocolHardware): string => {
   } else if (protocolHardware.hardwareType === 'pipette') {
     return getPipetteNameSpecs(protocolHardware.pipetteName)?.displayName ?? ''
   } else {
+    console.log(protocolHardware)
     return getModuleDisplayName(protocolHardware.moduleModel)
+  }
+}
+
+const getModuleIcon = (
+  protocolHardware: ProtocolHardware
+): IconName | undefined => {
+  if (protocolHardware.hardwareType === 'module') {
+    return getModuleDisplayIcon(protocolHardware.moduleModel) as IconName
+  } else {
+    return undefined
   }
 }
 
@@ -113,22 +128,36 @@ export const Hardware = (props: { protocolId: string }): JSX.Element => {
           return (
             <TableRow key={id}>
               <TableDatum>
-                <StyledText
-                  as="p"
-                  color={COLORS.darkBlack100}
-                  paddingLeft={SPACING.spacing24}
-                >
-                  {i18n.format(getHardwareLocation(hardware, t), 'capitalize')}
-                </StyledText>
+                <Flex paddingLeft={SPACING.spacing24}>
+                  {hardware.hardwareType === 'module' ? (
+                    <LocationIcon slotName={hardware.slot} />
+                  ) : (
+                    <StyledText
+                      as="p"
+                      color={COLORS.darkBlack100}
+                      fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                    >
+                      {i18n.format(
+                        getHardwareLocation(hardware, t),
+                        'titleCase'
+                      )}
+                    </StyledText>
+                  )}
+                </Flex>
               </TableDatum>
               <TableDatum>
-                <StyledText
-                  as="p"
-                  color={COLORS.darkBlack100}
-                  paddingLeft={SPACING.spacing24}
-                >
-                  {getHardwareName(hardware)}
-                </StyledText>
+                <Flex paddingLeft={SPACING.spacing24}>
+                  {hardware.hardwareType === 'module' &&
+                    getModuleIcon(hardware) !== null && (
+                      <LocationIcon
+                        iconName={getModuleIcon(hardware)}
+                        border={false}
+                      />
+                    )}
+                  <StyledText as="p" color={COLORS.darkBlack100}>
+                    {getHardwareName(hardware)}
+                  </StyledText>
+                </Flex>
               </TableDatum>
             </TableRow>
           )

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Hardware.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Hardware.tsx
@@ -2,9 +2,11 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
+  ALIGN_CENTER,
   BORDERS,
   COLORS,
   Flex,
+  ModuleIcon,
   SPACING,
   TYPOGRAPHY,
   WRAP,
@@ -13,7 +15,7 @@ import {
   GRIPPER_V1,
   getGripperDisplayName,
   getModuleDisplayName,
-  getModuleDisplayIcon,
+  getModuleType,
   getPipetteNameSpecs,
 } from '@opentrons/shared-data'
 import { StyledText } from '../../../atoms/text'
@@ -21,7 +23,6 @@ import { LocationIcon } from '../../../molecules/LocationIcon'
 import { useRequiredProtocolHardware } from '../../Protocols/hooks'
 import { EmptySection } from './EmptySection'
 
-import type { IconName } from '@opentrons/components'
 import type { ProtocolHardware } from '../../Protocols/hooks'
 import type { TFunction } from 'react-i18next'
 
@@ -76,18 +77,7 @@ const getHardwareName = (protocolHardware: ProtocolHardware): string => {
   } else if (protocolHardware.hardwareType === 'pipette') {
     return getPipetteNameSpecs(protocolHardware.pipetteName)?.displayName ?? ''
   } else {
-    console.log(protocolHardware)
     return getModuleDisplayName(protocolHardware.moduleModel)
-  }
-}
-
-const getModuleIcon = (
-  protocolHardware: ProtocolHardware
-): IconName | undefined => {
-  if (protocolHardware.hardwareType === 'module') {
-    return getModuleDisplayIcon(protocolHardware.moduleModel) as IconName
-  } else {
-    return undefined
   }
 }
 
@@ -134,7 +124,6 @@ export const Hardware = (props: { protocolId: string }): JSX.Element => {
                   ) : (
                     <StyledText
                       as="p"
-                      color={COLORS.darkBlack100}
                       fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                     >
                       {i18n.format(
@@ -147,16 +136,20 @@ export const Hardware = (props: { protocolId: string }): JSX.Element => {
               </TableDatum>
               <TableDatum>
                 <Flex paddingLeft={SPACING.spacing24}>
-                  {hardware.hardwareType === 'module' &&
-                    getModuleIcon(hardware) !== null && (
-                      <LocationIcon
-                        iconName={getModuleIcon(hardware)}
-                        border={false}
+                  {hardware.hardwareType === 'module' && (
+                    <Flex
+                      alignItems={ALIGN_CENTER}
+                      height="2rem"
+                      paddingBottom={SPACING.spacing4}
+                      paddingRight={SPACING.spacing8}
+                    >
+                      <ModuleIcon
+                        moduleType={getModuleType(hardware.moduleModel)}
+                        size="1.75rem"
                       />
-                    )}
-                  <StyledText as="p" color={COLORS.darkBlack100}>
-                    {getHardwareName(hardware)}
-                  </StyledText>
+                    </Flex>
+                  )}
+                  <StyledText as="p">{getHardwareName(hardware)}</StyledText>
                 </Flex>
               </TableDatum>
             </TableRow>

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Labware.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Labware.tsx
@@ -77,8 +77,8 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
         <tr>
           <TableHeader>
             <StyledText
-              as="label"
               color={COLORS.darkBlack70}
+              fontSize={TYPOGRAPHY.fontSize20}
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingLeft={SPACING.spacing24}
             >
@@ -88,8 +88,8 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
           <TableHeader>
             <StyledText
               alignItems={ALIGN_CENTER}
-              as="label"
               color={COLORS.darkBlack70}
+              fontSize={TYPOGRAPHY.fontSize20}
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingRight={SPACING.spacing12}
               textAlign={TYPOGRAPHY.textAlignCenter}

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Labware.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Labware.tsx
@@ -77,7 +77,7 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
         <tr>
           <TableHeader>
             <StyledText
-              fontSize={TYPOGRAPHY.fontSize20}
+              as="label"
               color={COLORS.darkBlack70}
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingLeft={SPACING.spacing24}
@@ -87,8 +87,9 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
           </TableHeader>
           <TableHeader>
             <StyledText
+              alignItems={ALIGN_CENTER}
+              as="label"
               color={COLORS.darkBlack70}
-              fontSize={TYPOGRAPHY.fontSize20}
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingRight={SPACING.spacing12}
               textAlign={TYPOGRAPHY.textAlignCenter}
@@ -122,11 +123,7 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
                   ) : (
                     <Flex marginLeft={SPACING.spacing20} />
                   )}
-                  <StyledText
-                    as="p"
-                    alignItems={ALIGN_CENTER}
-                    color={COLORS.darkBlack100}
-                  >
+                  <StyledText as="p" alignItems={ALIGN_CENTER}>
                     {name}
                   </StyledText>
                 </Flex>
@@ -135,7 +132,6 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
                 <StyledText
                   as="p"
                   alignItems={ALIGN_CENTER}
-                  color={COLORS.darkBlack100}
                   textAlign={TYPOGRAPHY.textAlignCenter}
                 >
                   {count}

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Labware.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Labware.tsx
@@ -23,7 +23,7 @@ const Table = styled('table')`
   border-collapse: separate
   table-layout: auto;
   width: 100%;
-  border-spacing: 0 ${SPACING.spacing4};
+  border-spacing: 0 ${SPACING.spacing8};
   margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
@@ -87,10 +87,11 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
           </TableHeader>
           <TableHeader>
             <StyledText
-              fontSize={TYPOGRAPHY.fontSize20}
               color={COLORS.darkBlack70}
+              fontSize={TYPOGRAPHY.fontSize20}
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingRight={SPACING.spacing12}
+              textAlign={TYPOGRAPHY.textAlignCenter}
             >
               {i18n.format(t('quantity'), 'sentenceCase')}
             </StyledText>

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/Hardware.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/Hardware.test.tsx
@@ -65,11 +65,11 @@ describe('Hardware', () => {
   })
   it('should render the correct location, name, and connected status in each table row', () => {
     const { getByRole } = render(props)[0]
-    getByRole('row', { name: 'Left mount P10 Single-Channel GEN1' })
+    getByRole('row', { name: 'Left Mount P10 Single-Channel GEN1' })
     getByRole('row', {
-      name: 'Right mount P1000 Single-Channel GEN1',
+      name: 'Right Mount P1000 Single-Channel GEN1',
     })
-    getByRole('row', { name: 'Slot 1 Heater-Shaker Module GEN1' })
-    getByRole('row', { name: 'Slot 3 Temperature Module GEN2' })
+    getByRole('row', { name: '1 Heater-Shaker Module GEN1' })
+    getByRole('row', { name: '3 Temperature Module GEN2' })
   })
 })

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -143,7 +143,7 @@ describe('ODDProtocolDetails', () => {
   it('renders protocol truncated name that expands when clicked', () => {
     const [{ getByText }] = render()
     const name = getByText(
-      'Nextera XT DNA Library Prep Kit Protocol: Part 1/4 - Tagment Genom...'
+      'Nextera XT DNA Library Prep Kit Protocol: Part 1/4 - Tagment...Amplify Libraries'
     )
     name.click()
     getByText(
@@ -167,7 +167,7 @@ describe('ODDProtocolDetails', () => {
     getByText(
       `Date Added: ${format(
         new Date('2022-05-03T21:36:12.494778+00:00'),
-        'MM/dd/yyyy k:mm'
+        'MM/dd/yy k:mm'
       )}`
     )
   })

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -26,6 +26,19 @@ import { Deck } from '../Deck'
 import { Hardware } from '../Hardware'
 import { Labware } from '../Labware'
 
+// Mock IntersectionObserver
+class IntersectionObserver {
+  observe = jest.fn()
+  disconnect = jest.fn()
+  unobserve = jest.fn()
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: IntersectionObserver,
+})
+
 jest.mock('@opentrons/api-client')
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../../organisms/OnDeviceDisplay/RobotDashboard/hooks')
@@ -130,7 +143,7 @@ describe('ODDProtocolDetails', () => {
   it('renders protocol truncated name that expands when clicked', () => {
     const [{ getByText }] = render()
     const name = getByText(
-      'Nextera XT DNA Library Prep Kit Protocol: Part 1/4 - Tagment Genomic ...nd Amplify Libraries'
+      'Nextera XT DNA Library Prep Kit Protocol: Part 1/4 - Tagment Genom...'
     )
     name.click()
     getByText(

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -75,12 +75,11 @@ const ProtocolHeader = (props: {
       boxShadow={isScrolled ? BORDERS.shadowBig : undefined}
       gridGap={SPACING.spacing40}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
-      padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing32} ${SPACING.spacing40}`}
+      padding={`${SPACING.spacing32} ${SPACING.spacing40}`}
       position={POSITION_STICKY}
       top="0"
       backgroundColor={COLORS.white}
-      marginLeft={`-${SPACING.spacing32}`}
-      marginRight={`-${SPACING.spacing32}`}
+      marginX={`-${SPACING.spacing32}`}
       zIndex={1} // the header is always visble when things scroll beneath
     >
       <Flex
@@ -94,7 +93,7 @@ const ProtocolHeader = (props: {
           onClick={() => history.goBack()}
           width="3rem"
         >
-          <Icon name="back" width="3rem" color={COLORS.darkBlack100} />
+          <Icon name="back" size="3rem" color={COLORS.darkBlack100} />
         </Btn>
         <Flex
           flexDirection={DIRECTION_COLUMN}

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -66,7 +66,7 @@ const ProtocolHeader = (props: {
 
   let displayedTitle = title
   if (title.length > 92 && truncate) {
-    displayedTitle = truncateString(title, 69)
+    displayedTitle = truncateString(title, 80, 60)
   }
 
   return (
@@ -195,7 +195,7 @@ const Summary = (props: {
       >
         <StyledText as="p">{`${t('protocol_info:date_added')}: ${
           date != null
-            ? format(new Date(date), 'MM/dd/yyyy k:mm')
+            ? format(new Date(date), 'MM/dd/yy k:mm')
             : t('shared:no_data')
         }`}</StyledText>
       </Flex>

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -56,42 +56,45 @@ const ProtocolHeader = (props: {
   title: string
   handleRunProtocol: () => void
   chipText: string
+  isScrolled: boolean
 }): JSX.Element => {
   const history = useHistory()
   const { t } = useTranslation(['protocol_info, protocol_details', 'shared'])
-  const { title, handleRunProtocol, chipText } = props
+  const { title, handleRunProtocol, chipText, isScrolled } = props
   const [truncate, setTruncate] = React.useState<boolean>(true)
   const toggleTruncate = (): void => setTruncate(value => !value)
 
   let displayedTitle = title
   if (title.length > 92 && truncate) {
-    displayedTitle = truncateString(title, 92, 69)
+    displayedTitle = truncateString(title, 69)
   }
 
   return (
     <Flex
       alignItems={ALIGN_CENTER}
+      boxShadow={isScrolled ? BORDERS.shadowBig : undefined}
+      gridGap={SPACING.spacing40}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
-      marginX={SPACING.spacing16}
-      paddingY={SPACING.spacing32}
+      padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing32} ${SPACING.spacing40}`}
       position={POSITION_STICKY}
       top="0"
       backgroundColor={COLORS.white}
+      marginLeft={`-${SPACING.spacing32}`}
+      marginRight={`-${SPACING.spacing32}`}
       zIndex={10} // the header is always visble when things scroll beneath
     >
       <Flex
         alignItems={ALIGN_CENTER}
         gridGap={SPACING.spacing16}
-        marginBottom={SPACING.spacing8}
         width="42.125rem"
       >
         <Btn
           paddingLeft="0rem"
-          paddingRight={SPACING.spacing20}
+          paddingRight={SPACING.spacing24}
           onClick={() => history.goBack()}
-          width="2.5rem"
+          width="3rem"
         >
-          <Icon name="back" width="2.5rem" color={COLORS.darkBlack100} />
+          <Icon name="back" width="3rem" color={COLORS.darkBlack100} />
         </Btn>
         <Flex
           flexDirection={DIRECTION_COLUMN}
@@ -170,20 +173,25 @@ const Summary = (props: {
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
         gridGap={SPACING.spacing4}
       >
-        <StyledText as="p">{`${i18n.format(
-          t('author'),
-          'capitalize'
-        )}: `}</StyledText>
-        <StyledText as="p">{author}</StyledText>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+        >{`${i18n.format(t('author'), 'capitalize')}: `}</StyledText>
+        <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+          {author}
+        </StyledText>
       </Flex>
-      <StyledText as="p">
+      <StyledText
+        as="p"
+        color={description === null ? COLORS.darkBlack70 : undefined}
+      >
         {description ?? i18n.format(t('no_summary'), 'capitalize')}
       </StyledText>
       <Flex
         backgroundColor={COLORS.darkBlack20}
         borderRadius={BORDERS.borderRadiusSize1}
         marginTop={SPACING.spacing24}
-        maxWidth="22rem"
+        width="max-content"
         padding={`${SPACING.spacing8} ${SPACING.spacing12}`}
       >
         <StyledText as="p">{`${t('protocol_info:date_added')}: ${
@@ -253,6 +261,16 @@ export function ProtocolDetails(): JSX.Element | null {
   const { data: protocolRecord } = useProtocolQuery(protocolId, {
     staleTime: Infinity,
   })
+
+  // Watch for scrolling to toggle dropshadow
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const [isScrolled, setIsScrolled] = React.useState<boolean>(false)
+  const observer = new IntersectionObserver(([entry]) => {
+    setIsScrolled(!entry.isIntersecting)
+  })
+  if (scrollRef.current) {
+    observer.observe(scrollRef.current)
+  }
 
   let pinnedProtocolIds = useSelector(getPinnedProtocolIds) ?? []
   const pinned = pinnedProtocolIds.includes(protocolId)
@@ -390,10 +408,13 @@ export function ProtocolDetails(): JSX.Element | null {
             handleCloseMaxPinsAlert={() => setShowMaxPinsAlert(false)}
           />
         )}
+        {/* Empty box to detect scrolling */}
+        <Flex ref={scrollRef} />
         <ProtocolHeader
           title={displayName}
           handleRunProtocol={handleRunProtocol}
           chipText={chipText}
+          isScrolled={isScrolled}
         />
         <Flex flexDirection={DIRECTION_COLUMN}>
           <ProtocolSectionTabs
@@ -409,7 +430,8 @@ export function ProtocolDetails(): JSX.Element | null {
             flexDirection={DIRECTION_ROW}
             gridGap={SPACING.spacing8}
             justifyContent={JUSTIFY_SPACE_BETWEEN}
-            margin={SPACING.spacing16}
+            paddingTop={SPACING.spacing60}
+            marginX={SPACING.spacing16}
           >
             <MediumButton
               buttonText={

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -81,7 +81,7 @@ const ProtocolHeader = (props: {
       backgroundColor={COLORS.white}
       marginLeft={`-${SPACING.spacing32}`}
       marginRight={`-${SPACING.spacing32}`}
-      zIndex={10} // the header is always visble when things scroll beneath
+      zIndex={1} // the header is always visble when things scroll beneath
     >
       <Flex
         alignItems={ALIGN_CENTER}

--- a/app/src/pages/OnDeviceDisplay/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/ProtocolSetup.test.tsx
@@ -50,12 +50,6 @@ Object.defineProperty(window, 'IntersectionObserver', {
   value: IntersectionObserver,
 })
 
-Object.defineProperty(global, 'IntersectionObserver', {
-  writable: true,
-  configurable: true,
-  value: IntersectionObserver,
-})
-
 jest.mock('@opentrons/shared-data/js/helpers')
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../organisms/LabwarePositionCheck/useLaunchLPC')


### PR DESCRIPTION
# Overview

This PR addresses the DQA feedback provided on RAUT-451 for the Protocol Details pages.

Closes RAUT-451

# Test Plan

Visually verified changes, made storybook changes when needed, and changed unit tests to match new work

# Changelog

- Added iconName to module definitions
- Tweaked LocationIcon to make border optional
- Tweaked table spacing and colors for labware section
- Fixed spacing and borders for protocol details header
- Fixed spacing and colors for summary section
- Tweaked spacing and iconography tweaks for hardware section

# Review requests

Please compare the protocol details pages to the requested revisions on RAUT-451 (including my comments on that ticket)

# Risk assessment

Low


https://github.com/Opentrons/opentrons/assets/2960/a9fd9633-8b3d-495a-9d36-06e393cfbe5b


