### PR TITLE
fix(api): change Flex front USB port number to 9 to disambiguate

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/types.py
+++ b/api/src/opentrons/drivers/rpi_drivers/types.py
@@ -111,7 +111,7 @@ class USBPort:
                 if (board_revision == BoardRevision.FLEX_B2) and (
                     hub == FLEX_B2_USB_PORT_GROUP_FRONT
                 ):
-                    port = 1
+                    port = 9
                     hub_port = int(port_info[2])
                 else:
                     port = int(port_info[2])
@@ -120,7 +120,7 @@ class USBPort:
             if board_revision == BoardRevision.FLEX_B2:
                 port_info = port_nodes[0].split(".")
                 hub = int(port_info[1])
-                port = 1
+                port = 9
                 hub_port = None
                 name = port_nodes[0]
             else:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -24,7 +24,7 @@ from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons import types as top_types
 from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig, OT3Config
-from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.drivers.rpi_drivers.types import USBPort, PortGroup
 
 from .util import use_or_initialize_loop, check_motion_bounds
 from .instruments.ot2.pipette import (
@@ -1109,7 +1109,7 @@ class API(
 
         return await self._backend.module_controls.build_module(
             port="",
-            usb_port=USBPort(name="", port_number=0),
+            usb_port=USBPort(name="", port_number=1, port_group=PortGroup.MAIN),
             type=modules.ModuleType.from_model(model),
             sim_model=model.value,
         )

--- a/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
+++ b/api/src/opentrons/hardware_control/emulation/module_server/helpers.py
@@ -83,9 +83,7 @@ class ModuleListener:
             ModuleAtPort(
                 port=c.url,
                 name=c.module_type,
-                usb_port=USBPort(
-                    name=c.identifier, port_number=0, hub=True, hub_port=_next_index()
-                ),
+                usb_port=USBPort(name=c.identifier, port_number=_next_index()),
             )
             for c in message.connections
         ]

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -39,7 +39,7 @@ from opentrons.config.types import (
     CapacitivePassSettings,
     LiquidProbeSettings,
 )
-from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.drivers.rpi_drivers.types import USBPort, PortGroup
 from opentrons_hardware.hardware_control.motion_planning import (
     Move,
     MoveManager,
@@ -461,7 +461,7 @@ class OT3API(
 
         return await self._backend.module_controls.build_module(
             port="",
-            usb_port=USBPort(name="", port_number=0),
+            usb_port=USBPort(name="", port_number=1, port_group=PortGroup.LEFT),
             type=modules.ModuleType.from_model(model),
             sim_model=model.value,
         )

--- a/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
+++ b/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
@@ -171,7 +171,7 @@ def test_modify_module_list(revision: BoardRevision, usb_bus: USBBus):
         expected_name = "1-1.7"
         assert updated_list[0].usb_port == USBPort(
             name=expected_name,
-            port_number=1,
+            port_number=9,
             port_group=PortGroup.FRONT,
             device_path="1.0/tty/ttyACM4/dev",
             hub=False,
@@ -188,7 +188,7 @@ def test_modify_module_list(revision: BoardRevision, usb_bus: USBBus):
         expected_name = "1-1.7.4"
         assert updated_list[0].usb_port == USBPort(
             name=expected_name,
-            port_number=1,
+            port_number=9,
             port_group=PortGroup.FRONT,
             device_path="1.0/tty/ttyACM5/dev",
             hub=True,

--- a/api/tests/opentrons/hardware_control/emulation/module_server/test_helpers.py
+++ b/api/tests/opentrons/hardware_control/emulation/module_server/test_helpers.py
@@ -47,9 +47,7 @@ def modules_at_port() -> List[ModuleAtPort]:
         ModuleAtPort(
             port=f"url{i}",
             name=f"module_type{i}",
-            usb_port=USBPort(
-                name=f"identifier{i}", port_number=0, hub=True, hub_port=i + 1
-            ),
+            usb_port=USBPort(name=f"identifier{i}", port_number=i + 1),
         )
         for i in range(5)
     ]


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The Flex has 1 front USB port. It was previously given port number 1. This changes it to port number 9 to disambiguate it from the first port on the left USB port bank.

This PR also changes simulation and emulation port numbers from 0 so as not to be interpreted as null by layers higher in the stack.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

 - [x] verify front USB port displays as 9 in App network/module settings
 - [x] verify USBPort(port=1, hub=false, portGroup="main") for OT-2 simulation
 - [x] verify USBPort(port=1, hub=false, portGroup="left") for Flex simulation

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
