### PR TITLE
fix(hardware-testing): Volumetric calibration protocols use 2.15 API

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -21,6 +21,9 @@ from . import execute, helpers, workarounds, execute_photometric
 from .config import GravimetricConfig, GANTRY_MAX_SPEED, PhotometricConfig
 from .measurement import DELAY_FOR_MEASUREMENT
 
+# FIXME: bump to v2.15 to utilize protocol engine
+API_LEVEL = "2.13"
+
 LABWARE_OFFSETS: List[dict] = []
 
 # Keyed by pipette volume, channel count, and tip volume in that order
@@ -163,15 +166,11 @@ if __name__ == "__main__":
             LABWARE_OFFSETS.append(offset)
     _protocol = PROTOCOL_CFG[args.pipette][args.channels][args.tip]
     _ctx = helpers.get_api_context(
-        _protocol.requirements["apiLevel"],  # type: ignore[attr-defined]
+        API_LEVEL,  # type: ignore[attr-defined]
         is_simulating=args.simulate,
+        deck_version="2",
     )
     if args.photometric:
-        _ctx = helpers.get_api_context(
-            _protocol.requirements["apiLevel"],  # type: ignore[attr-defined]
-            is_simulating=args.simulate,
-            deck_version="2",
-        )
         run_pm(
             _ctx,
             args.pipette,
@@ -186,10 +185,6 @@ if __name__ == "__main__":
             args.touch_tip,
         )
     else:
-        _ctx = helpers.get_api_context(
-            _protocol.requirements["apiLevel"],  # type: ignore[attr-defined]
-            is_simulating=args.simulate,
-        )
         run(
             _ctx,
             args.pipette,

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000.py
@@ -24,6 +24,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_single_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_multi_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000-multi-1000ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip_increment.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_multi_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_1000ul_tip_increment.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000-multi-1000ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000-multi-200ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_multi_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip_increment.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000-multi-200ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_200ul_tip_increment.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_multi_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_multi_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000-multi-50ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip_increment.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_multi_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p1000_multi_50ul_tip_increment.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p1000-multi-50ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p50"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50.py
@@ -22,6 +22,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p50_single_gen3", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, vial["A1"].top())
-        pipette.dispense(pipette.min_volume, vial["A1"].top())
+        pipette.aspirate(10, vial["A1"].top())
+        pipette.dispense(10, vial["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50_multi_50ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50_multi_50ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p50-multi"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50_multi_50ul_tip_increment.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_ot3_p50_multi_50ul_tip_increment.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "gravimetric-ot3-p50-multi"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "Flex", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOT_SCALE = 4
 SLOTS_TIPRACK = {

--- a/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_1000ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_1000ul_tip.py
@@ -26,6 +26,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_96", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, reservoir["A1"].top())
-        pipette.dispense(pipette.min_volume, plate["A1"].top())
+        pipette.aspirate(10, reservoir["A1"].top())
+        pipette.dispense(10, plate["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_1000ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_1000ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "photometric-ot3-p1000-96-1000ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "OT-3", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOTS_TIPRACK = {
     1000: [5, 6, 8, 9, 11],

--- a/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_200ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_200ul_tip.py
@@ -26,6 +26,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_96", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, reservoir["A1"].top())
-        pipette.dispense(pipette.min_volume, plate["A1"].top())
+        pipette.aspirate(10, reservoir["A1"].top())
+        pipette.dispense(10, plate["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_200ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_200ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "photometric-ot3-p1000-96-200ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "OT-3", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOTS_TIPRACK = {
     200: [5, 6, 8, 9, 11],

--- a/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_50ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_50ul_tip.py
@@ -26,6 +26,6 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("p1000_96", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
-        pipette.aspirate(pipette.min_volume, reservoir["A1"].top())
-        pipette.dispense(pipette.min_volume, plate["A1"].top())
+        pipette.aspirate(10, reservoir["A1"].top())
+        pipette.dispense(10, plate["A1"].top())
         pipette.drop_tip(home_after=False)

--- a/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_50ul_tip.py
+++ b/hardware-testing/hardware_testing/protocols/photometric_ot3_p1000_96_50ul_tip.py
@@ -2,8 +2,7 @@
 from opentrons.protocol_api import ProtocolContext
 
 metadata = {"protocolName": "photometric-ot3-p1000-96-50ul-tip"}
-# FIXME: bump to v2.14 to utilize protocol engine
-requirements = {"robotType": "OT-3", "apiLevel": "2.13"}
+requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 SLOTS_TIPRACK = {
     50: [5, 6, 8, 9, 11],


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

With the new deck-slot renaming, we need to bump our protocols (used for LPC only) to be at 2.15

The `ProtocolContext` in the actual script remains at 2.13, because Protocol-Engine is not yet able to be ran from CLI.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
