### PR TITLE
feat(app): skeleton to recent run protocol card

### DIFF
--- a/app/src/atoms/Skeleton/index.tsx
+++ b/app/src/atoms/Skeleton/index.tsx
@@ -7,11 +7,12 @@ interface SkeletonProps {
   height: string
   //  backgroundSize is the total width to add to every Skeleton in the component which controls the animation speed
   backgroundSize: string
+  borderRadius?: string
 }
 export const Skeleton = (props: SkeletonProps): JSX.Element => {
-  const { width, height, backgroundSize } = props
+  const { width, height, backgroundSize, borderRadius } = props
   const SKELETON_STYLE = css`
-    border-radius: ${BORDERS.radiusSoftCorners};
+    border-radius: ${borderRadius ?? BORDERS.radiusSoftCorners};
     animation: shimmer 2s infinite linear;
     background: linear-gradient(
       to right,

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -18,6 +18,7 @@ import { StyledText } from '../../../atoms/text'
 import { Chip } from '../../../atoms/Chip'
 import { ODD_FOCUS_VISIBLE } from '../../../atoms/buttons//constants'
 import { useTrackEvent } from '../../../redux/analytics'
+import { Skeleton } from '../../../atoms/Skeleton'
 import { useMissingProtocolHardware } from '../../../pages/Protocols/hooks'
 import { useCloneRun } from '../../ProtocolUpload/hooks'
 import { useTrackProtocolRunEvent } from '../../Devices/hooks'
@@ -39,22 +40,30 @@ interface RecentRunProtocolCardProps {
 export function RecentRunProtocolCard({
   runData,
 }: RecentRunProtocolCardProps): JSX.Element | null {
-  const protocolData =
-    useProtocolQuery(runData.protocolId ?? null).data?.data ?? null
-
+  const { data, isFetching, isLoading } = useProtocolQuery(
+    runData.protocolId ?? null
+  )
+  const protocolData = data?.data ?? null
+  const isProtocolFetching = isFetching || isLoading
   return protocolData == null ? null : (
-    <ProtocolWithLastRun protocolData={protocolData} runData={runData} />
+    <ProtocolWithLastRun
+      protocolData={protocolData}
+      runData={runData}
+      isProtocolFetching={isProtocolFetching}
+    />
   )
 }
 
 interface ProtocolWithLastRunProps {
   runData: RunData
   protocolData: ProtocolResource
+  isProtocolFetching: boolean
 }
 
 export function ProtocolWithLastRun({
   runData,
   protocolData,
+  isProtocolFetching,
 }: ProtocolWithLastRunProps): JSX.Element {
   const { t, i18n } = useTranslation('device_details')
   const missingProtocolHardware = useMissingProtocolHardware(protocolData.id)
@@ -114,7 +123,14 @@ export function ProtocolWithLastRun({
     }
   ).replace('about ', '')
 
-  return (
+  return isProtocolFetching ? (
+    <Skeleton
+      height="27.25rem"
+      width="25.8125rem"
+      backgroundSize="64rem"
+      borderRadius={BORDERS.borderRadiusSize3}
+    />
+  ) : (
     <Flex
       aria-label="RecentRunProtocolCard"
       css={PROTOCOL_CARD_STYLE}


### PR DESCRIPTION
closes RAUT-487

# Overview

Add skeletons to each recent run protocol card when the protocol info is fetching or loading

# Test Plan

After you have a few protocols in the recent run protocol carrousel on the robot dashboard, observe that they go into a loading state properly and display the skeleton. 

# Changelog

add optional border radius prop to `Skeleton`
add skeleton and loading logic to `RecentRunProtocolCard` and add a few test cases

# Review requests

see test plan

# Risk assessment

low