### PR TITLE
fix(hardware-testing): convert deck slot names when applying offsets

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/workarounds.py
+++ b/hardware-testing/hardware_testing/gravimetric/workarounds.py
@@ -48,19 +48,22 @@ def http_get_all_labware_offsets() -> List[dict]:
     protocols_list = runs_json["data"]
     return [offset for p in protocols_list for offset in p["labwareOffsets"]]
 
+
 def _old_slot_to_ot3_slot(old_api_slot: str) -> str:
-    conversion_dict = {  "1":"D1",
-                         "2":"D2",
-                         "3":"D3",
-                         "4":"C1",
-                         "5":"C2",
-                         "6":"C3",
-                         "7":"B1",
-                         "8":"B2",
-                         "9":"B3",
-                         "10":"A1",
-                         "11":"A2",
-                         "12":"A3"}
+    conversion_dict = {
+        "1": "D1",
+        "2": "D2",
+        "3": "D3",
+        "4": "C1",
+        "5": "C2",
+        "6": "C3",
+        "7": "B1",
+        "8": "B2",
+        "9": "B3",
+        "10": "A1",
+        "11": "A2",
+        "12": "A3",
+    }
     return conversion_dict[old_api_slot]
 
 
@@ -79,7 +82,6 @@ def get_latest_offset_for_labware(
         if _o["definitionUri"] != lw_uri:
             return False
         if _o["location"]["slotName"] != lw_slot:
-            print(f"offset for {_o['definitionUri']} in slot {_o['location']['slotName']}doesn't apply to slot {lw_slot}")
             return False
         return _is_offset_present(_o)
 

--- a/hardware-testing/hardware_testing/gravimetric/workarounds.py
+++ b/hardware-testing/hardware_testing/gravimetric/workarounds.py
@@ -48,13 +48,28 @@ def http_get_all_labware_offsets() -> List[dict]:
     protocols_list = runs_json["data"]
     return [offset for p in protocols_list for offset in p["labwareOffsets"]]
 
+def _old_slot_to_ot3_slot(old_api_slot: str) -> str:
+    conversion_dict = {  "1":"D1",
+                         "2":"D2",
+                         "3":"D3",
+                         "4":"C1",
+                         "5":"C2",
+                         "6":"C3",
+                         "7":"B1",
+                         "8":"B2",
+                         "9":"B3",
+                         "10":"A1",
+                         "11":"A2",
+                         "12":"A3"}
+    return conversion_dict[old_api_slot]
+
 
 def get_latest_offset_for_labware(
     labware_offsets: List[dict], labware: Labware
 ) -> Point:
     """Get latest offset for labware."""
     lw_uri = str(labware.uri)
-    lw_slot = str(labware.parent)
+    lw_slot = _old_slot_to_ot3_slot(str(labware.parent))
 
     def _is_offset_present(_o: dict) -> bool:
         _v = _o["vector"]
@@ -64,6 +79,7 @@ def get_latest_offset_for_labware(
         if _o["definitionUri"] != lw_uri:
             return False
         if _o["location"]["slotName"] != lw_slot:
+            print(f"offset for {_o['definitionUri']} in slot {_o['location']['slotName']}doesn't apply to slot {lw_slot}")
             return False
         return _is_offset_present(_o)
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
