### PR TITLE
feat(api,shared-data): error codes in PE

### DIFF
--- a/api/src/opentrons/protocol_engine/clients/transports.py
+++ b/api/src/opentrons/protocol_engine/clients/transports.py
@@ -103,9 +103,10 @@ class ChildThreadTransport(AbstractSyncTransport):
             loop=self._loop,
         ).result()
 
+        # TODO: this needs to have an actual code
         if command.error is not None:
             error = command.error
-            raise ProtocolEngineError(f"{error.errorType}: {error.detail}")
+            raise ProtocolEngineError(message=f"{error.errorType}: {error.detail}")
 
         # FIXME(mm, 2023-04-10): This assert can easily trigger from this sequence:
         #

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -1,8 +1,10 @@
 """Models for concrete occurrences of specific errors."""
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List, Type, Union
 from pydantic import BaseModel, Field
-from .exceptions import ErrorCode
+from opentrons_shared_data.errors.codes import ErrorCodes
+from .exceptions import ProtocolEngineError
+from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 
 # TODO(mc, 2021-11-12): flesh this model out with structured error data
@@ -10,13 +12,40 @@ from .exceptions import ErrorCode
 class ErrorOccurrence(BaseModel):
     """An occurrence of a specific error during protocol execution."""
 
+    @classmethod
+    def from_failed(
+        cls: Type["ErrorOccurrence"],
+        id: str,
+        createdAt: datetime,
+        error: Union[ProtocolEngineError, EnumeratedError],
+    ) -> "ErrorOccurrence":
+        """Build an ErrorOccurrence from the details available from a FailedAction or FinishAction."""
+        return cls.construct(
+            id=id,
+            createdAt=createdAt,
+            errorType=type(error).__name__,
+            detail=error.message or str(error),
+            errorInfo=error.detail,
+            errorCode=error.code.value.code,
+            wrappedErrors=[
+                cls.from_failed(id, createdAt, err) for err in error.wrapping
+            ],
+        )
+
     id: str = Field(..., description="Unique identifier of this error occurrence.")
     errorType: str = Field(..., description="Specific error type that occurred.")
     createdAt: datetime = Field(..., description="When the error occurred.")
     detail: str = Field(..., description="A human-readable message about the error.")
     errorCode: str = Field(
-        default=ErrorCode.UNKNOWN.value,
+        default=ErrorCodes.GENERAL_ERROR.value.code,
         description="An enumerated error code for the error type.",
+    )
+    errorInfo: Dict[str, str] = Field(
+        default={},
+        description="Specific details about the error that may be useful for determining cause.",
+    )
+    wrappedErrors: List["ErrorOccurrence"] = Field(
+        default=[], description="Errors that may have caused this one."
     )
 
     class Config:
@@ -26,13 +55,16 @@ class ErrorOccurrence(BaseModel):
         def schema_extra(schema: Dict[str, Any], model: object) -> None:
             """Append the schema to make the errorCode appear required.
 
-            `errorCode` has a default because it is not included in earlier
+            `errorCode`, `wrappedErrors`, and `errorInfo` have defaults because they are not included in earlier
             versions of this model, _and_ this model is loaded directly from
             the on-robot store. That means that, without a default, it will
             fail to parse. Once a default is defined, the automated schema will
             mark this as a non-required field, which is misleading as this is
             a response from the server to the client and it will always have an
             errorCode defined. This hack is required because it informs the client
-            that it does not, in fact, have to account for a missing errorCode.
+            that it does not, in fact, have to account for a missing errorCode, wrappedError, or errorInfo.
             """
-            schema["required"].append("errorCode")
+            schema["required"].extend(["errorCode", "wrappedErrors", "errorInfo"])
+
+
+ErrorOccurrence.update_forward_refs()

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1,20 +1,31 @@
 """Protocol engine exceptions."""
 
-from enum import Enum, unique
+from logging import getLogger
+from typing import Any, Dict, Optional, Union, Iterator, Sequence
+
+from opentrons_shared_data.errors import ErrorCodes
+from opentrons_shared_data.errors.exceptions import EnumeratedError, GeneralError
+
+log = getLogger(__name__)
 
 
-@unique
-class ErrorCode(Enum):
-    """Enumerated error codes."""
-
-    UNKNOWN = "4000"  # Catch-all code for any unclassified error
-
-
-class ProtocolEngineError(RuntimeError):
+class ProtocolEngineError(EnumeratedError):
     """Base Protocol Engine error class."""
 
-    # This default error code should be overridden in every child class.
-    ERROR_CODE: str = ErrorCode.UNKNOWN.value
+    def __init__(
+        self,
+        code: Optional[ErrorCodes] = None,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ProtocolEngineError."""
+        super().__init__(
+            code=code or ErrorCodes.GENERAL_ERROR,
+            message=message,
+            detail=detail,
+            wrapping=wrapping,
+        )
 
 
 class UnexpectedProtocolError(ProtocolEngineError):
@@ -25,12 +36,27 @@ class UnexpectedProtocolError(ProtocolEngineError):
     and wrapped.
     """
 
-    ERROR_CODE: str = ErrorCode.UNKNOWN.value
-
-    def __init__(self, original_error: Exception) -> None:
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        wrapping: Optional[Sequence[Union[EnumeratedError, BaseException]]] = None,
+    ) -> None:
         """Initialize an UnexpectedProtocolError with an original error."""
-        super().__init__(str(original_error))
-        self.original_error: Exception = original_error
+
+        def _convert_exc() -> Iterator[EnumeratedError]:
+            if not wrapping:
+                return
+            for exc in wrapping:
+                if isinstance(exc, EnumeratedError):
+                    yield exc
+                else:
+                    yield GeneralError(wrapping=[exc])
+
+        super().__init__(
+            code=ErrorCodes.GENERAL_ERROR,
+            message=message,
+            wrapping=[e for e in _convert_exc()],
+        )
 
 
 # TODO(mc, 2020-10-18): differentiate between pipette missing vs incorrect.
@@ -43,85 +69,256 @@ class FailedToLoadPipetteError(ProtocolEngineError):
     - A missing pipette on the requested mount
     """
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a FailedToLoadPipetteError."""
+        super().__init__(ErrorCodes.PIPETTE_NOT_PRESENT, message, details, wrapping)
+
 
 # TODO(mc, 2020-10-18): differentiate between pipette missing vs incorrect
 class PipetteNotAttachedError(ProtocolEngineError):
     """Raised when an operation's required pipette is not attached."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PipetteNotAttachedError."""
+        super().__init__(ErrorCodes.PIPETTE_NOT_PRESENT, message, details, wrapping)
+
 
 class TipNotAttachedError(ProtocolEngineError):
     """Raised when an operation's required pipette tip is not attached."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PIpetteNotAttachedError."""
+        super().__init__(ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, details, wrapping)
 
 
 class TipAttachedError(ProtocolEngineError):
     """Raised when a tip shouldn't be attached, but is."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PIpetteNotAttachedError."""
+        super().__init__(ErrorCodes.UNEXPECTED_TIP_ATTACH, message, details, wrapping)
+
 
 class CommandDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a command that does not exist."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a CommandDoesNotExistError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class LabwareNotLoadedError(ProtocolEngineError):
     """Raised when referencing a labware that has not been loaded."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareNotLoadedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class LabwareNotLoadedOnModuleError(ProtocolEngineError):
     """Raised when referencing a labware on a module that has not been loaded."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareNotLoadedOnModuleError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class LabwareNotOnDeckError(ProtocolEngineError):
     """Raised when a labware can't be used because it's off-deck."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareNotOnDeckError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class LiquidDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a liquid that has not been loaded."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LiquidDoesNotExistError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class LabwareDefinitionDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a labware definition that does not exist."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareDefinitionDoesNotExistError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class LabwareOffsetDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a labware offset that does not exist."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareOffsetDoesNotExistError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class LabwareIsNotTipRackError(ProtocolEngineError):
     """Raised when trying to use a regular labware as a tip rack."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareIsNotTiprackError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class LabwareIsTipRackError(ProtocolEngineError):
     """Raised when trying to use a command not allowed on tip rack."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareIsTiprackError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class TouchTipDisabledError(ProtocolEngineError):
     """Raised when touch tip is used on well with touchTipDisabled quirk."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a TouchTipDisabledError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class WellDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a well that does not exist."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a WellDoesNotExistError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class PipetteNotLoadedError(ProtocolEngineError):
     """Raised when referencing a pipette that has not been loaded."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PipetteNotLoadedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class ModuleNotLoadedError(ProtocolEngineError):
     """Raised when referencing a module that has not been loaded."""
 
     def __init__(self, *, module_id: str) -> None:
-        super().__init__(f"Module {module_id} not found.")
+        super().__init__(ErrorCodes.GENERAL_ERROR, f"Module {module_id} not found.")
 
 
 class ModuleNotOnDeckError(ProtocolEngineError):
     """Raised when trying to use a module that is loaded off the deck."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ModuleNotOnDeckError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class ModuleNotConnectedError(ProtocolEngineError):
     """Raised when trying to use a module that is not connected to the robot electrically."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ModuleNotConnectedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class SlotDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a deck slot that does not exist."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a SlotDoesNotExistError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 # TODO(mc, 2020-11-06): flesh out with structured data to replicate
@@ -129,118 +326,388 @@ class SlotDoesNotExistError(ProtocolEngineError):
 class FailedToPlanMoveError(ProtocolEngineError):
     """Raised when a requested movement could not be planned."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a FailedToPlanmoveError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class MustHomeError(ProtocolEngineError):
     """Raised when motors must be homed due to unknown current position."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a MustHomeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class SetupCommandNotAllowedError(ProtocolEngineError):
     """Raised when adding a setup command to a non-idle/non-paused engine."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a SetupCommandNotAllowedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class PauseNotAllowedError(ProtocolEngineError):
     """Raised when attempting to pause a run that is not running."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PauseNotAllowedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class RunStoppedError(ProtocolEngineError):
     """Raised when attempting to interact with a stopped engine."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a RunStoppedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class ModuleNotAttachedError(ProtocolEngineError):
     """Raised when a requested module is not attached."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ModuleNotAttached."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class ModuleAlreadyPresentError(ProtocolEngineError):
     """Raised when a module is already present in a requested location."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ModuleAlreadyPresentError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class WrongModuleTypeError(ProtocolEngineError):
     """Raised when performing a module action on the wrong kind of module."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a WrongModuleTypeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class ThermocyclerNotOpenError(ProtocolEngineError):
     """Raised when trying to move to a labware that's in a closed Thermocycler."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ThermocyclerNotOpenError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class RobotDoorOpenError(ProtocolEngineError):
     """Raised when executing a protocol command when a robot door is open."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a RobotDoorOpenError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class PipetteMovementRestrictedByHeaterShakerError(ProtocolEngineError):
     """Raised when trying to move to labware that's restricted by a module."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PipetteMovementRestrictedByHeaterShakerError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class HeaterShakerLabwareLatchNotOpenError(ProtocolEngineError):
     """Raised when Heater-Shaker latch is not open when it is expected to be so."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a HeaterShakerLabwareLatchNotOpenError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class HeaterShakerLabwareLatchStatusUnknown(ProtocolEngineError):
     """Raised when Heater-Shaker latch has not been set before moving to it."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a HeaterShakerLabwareLatchStatusUnknown."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class EngageHeightOutOfRangeError(ProtocolEngineError):
     """Raised when a Magnetic Module engage height is out of bounds."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a EngageHeightOutOfRangeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class NoMagnetEngageHeightError(ProtocolEngineError):
     """Raised if a Magnetic Module engage height is missing."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a NoMagnetEngageHeightError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class NoTargetTemperatureSetError(ProtocolEngineError):
     """Raised when awaiting temperature when no target was set."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a NoTargetTemperatureSetError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class InvalidTargetTemperatureError(ProtocolEngineError):
     """Raised when attempting to set an invalid target temperature."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidTargetTemperatureError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class InvalidBlockVolumeError(ProtocolEngineError):
     """Raised when attempting to set an invalid block max volume."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidBlockVolumeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class InvalidHoldTimeError(ProtocolEngineError):
     """An error raised when attempting to set an invalid temperature hold time."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidHoldTimeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class InvalidTargetSpeedError(ProtocolEngineError):
     """Raised when attempting to set an invalid target speed."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidTargetSpeedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class CannotPerformModuleAction(ProtocolEngineError):
     """Raised when trying to perform an illegal hardware module action."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a CannotPerformModuleAction."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class ProtocolCommandFailedError(ProtocolEngineError):
     """Raised if a fatal command execution error has occurred."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ProtocolCommandFailedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class HardwareNotSupportedError(ProtocolEngineError):
     """Raised when executing a command on the wrong hardware."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a HardwareNotSupportedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class GripperNotAttachedError(ProtocolEngineError):
     """Raised when executing a gripper action without an attached gripper."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a GripperNotAttachedError."""
+        super().__init__(ErrorCodes.GRIPPER_NOT_PRESENT, message, details, wrapping)
 
 
 class LabwareMovementNotAllowedError(ProtocolEngineError):
     """Raised when attempting an illegal labware movement."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LabwareMovementNotAllowedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class LocationIsOccupiedError(ProtocolEngineError):
     """Raised when attempting to place labware in a non-empty location."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LocationIsOccupiedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class FirmwareUpdateRequired(ProtocolEngineError):
     """Raised when the firmware needs to be updated."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a LocationIsOccupiedError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class PipetteNotReadyToAspirateError(ProtocolEngineError):
     """Raised when the pipette is not ready to aspirate."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PipetteNotReadyToAspirateError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
 class InvalidPipettingVolumeError(ProtocolEngineError):
     """Raised when pipetting a volume larger than the pipette volume."""
 
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidPipettingVolumeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
 
 class InvalidAxisForRobotType(ProtocolEngineError):
     """Raised when attempting to use an axis that is not present on the given type of robot."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidAxisForRobotType."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from typing import Any, Dict, Optional, Union, Iterator, Sequence
 
 from opentrons_shared_data.errors import ErrorCodes
-from opentrons_shared_data.errors.exceptions import EnumeratedError, GeneralError
+from opentrons_shared_data.errors.exceptions import EnumeratedError, PythonException
 
 log = getLogger(__name__)
 
@@ -50,7 +50,7 @@ class UnexpectedProtocolError(ProtocolEngineError):
                 if isinstance(exc, EnumeratedError):
                     yield exc
                 else:
-                    yield GeneralError(wrapping=[exc])
+                    yield PythonException(exc)
 
         super().__init__(
             code=ErrorCodes.GENERAL_ERROR,

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -104,7 +104,7 @@ class CommandExecutor:
             if isinstance(error, asyncio.CancelledError):
                 error = RunStoppedError("Run was cancelled")
             elif not isinstance(error, ProtocolEngineError):
-                error = UnexpectedProtocolError(error)
+                error = UnexpectedProtocolError(message=str(error), wrapping=[error])
 
             self._action_dispatcher.dispatch(
                 FailCommandAction(

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -20,7 +20,7 @@ from opentrons.protocol_engine.resources import (
     pipette_data_provider,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.errors import ErrorCodes, EnumeratedError
+from opentrons_shared_data.errors import ErrorCodes, EnumeratedError, PythonException
 from opentrons.protocol_api.core.legacy.deck import FIXED_TRASH_ID
 
 from .legacy_wrappers import (
@@ -58,14 +58,9 @@ class LegacyContextCommandError(ProtocolEngineError):
             )
         else:
             super().__init__(
-                ErrorCodes.GENERAL_ERROR,
-                "\n".join(format_exception_only(type(wrapping_exc), wrapping_exc)),
-                {
-                    "wrapping_exception": "\n".join(
-                        format_exception(type(wrapping_exc), wrapping_exc, None)
-                    )
-                },
-                None,
+                code=ErrorCodes.GENERAL_ERROR,
+                message=str(wrapping_exc),
+                wrapping=[PythonException(wrapping_exc)]
             )
 
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -3,7 +3,6 @@
 from collections import defaultdict
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Union
-from traceback import format_exception, format_exception_only
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName, Location
@@ -60,7 +59,7 @@ class LegacyContextCommandError(ProtocolEngineError):
             super().__init__(
                 code=ErrorCodes.GENERAL_ERROR,
                 message=str(wrapping_exc),
-                wrapping=[PythonException(wrapping_exc)]
+                wrapping=[PythonException(wrapping_exc)],
             )
 
 

--- a/api/src/opentrons/protocols/execution/errors.py
+++ b/api/src/opentrons/protocols/execution/errors.py
@@ -1,4 +1,6 @@
-class ExceptionInProtocolError(Exception):
+from opentrons_shared_data.errors.exceptions import GeneralError, PythonException
+
+class ExceptionInProtocolError(GeneralError):
     """This exception wraps an exception that was raised from a protocol
     for proper error message formatting by the rpc, since it's only here that
     we can properly figure out formatting
@@ -9,11 +11,13 @@ class ExceptionInProtocolError(Exception):
         self.original_tb = original_tb
         self.message = message
         self.line = line
-        super().__init__(original_exc, original_tb, message, line)
+        super().__init__(
+            wrapping=[original_exc],
+            message="{}{}: {}".format(
+                self.original_exc.__class__.__name__,
+                " [line {}]".format(self.line) if self.line else "",
+                self.message,
+            ))
 
     def __str__(self):
-        return "{}{}: {}".format(
-            self.original_exc.__class__.__name__,
-            " [line {}]".format(self.line) if self.line else "",
-            self.message,
-        )
+        return self.message

--- a/api/src/opentrons/protocols/execution/errors.py
+++ b/api/src/opentrons/protocols/execution/errors.py
@@ -1,4 +1,5 @@
-from opentrons_shared_data.errors.exceptions import GeneralError, PythonException
+from opentrons_shared_data.errors.exceptions import GeneralError
+
 
 class ExceptionInProtocolError(GeneralError):
     """This exception wraps an exception that was raised from a protocol
@@ -17,7 +18,8 @@ class ExceptionInProtocolError(GeneralError):
                 self.original_exc.__class__.__name__,
                 " [line {}]".format(self.line) if self.line else "",
                 self.message,
-            ))
+            ),
+        )
 
     def __str__(self):
         return self.message

--- a/api/tests/opentrons/protocol_engine/errors/test_error_occurrence.py
+++ b/api/tests/opentrons/protocol_engine/errors/test_error_occurrence.py
@@ -11,8 +11,9 @@ def test_error_occurrence_schema() -> None:
     This is explicitly tested because we are overriding the schema
     due to a default value for errorCode.
     """
-    required_items: List[str] = ErrorOccurrence.schema()["required"]
-
+    required_items: List[str] = ErrorOccurrence.schema()["definitions"][
+        "ErrorOccurrence"
+    ]["required"]
     assert "errorCode" in required_items
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -264,7 +264,7 @@ async def test_execute(
     ["command_error", "expected_error"],
     [
         (
-            errors.ProtocolEngineError("oh no"),
+            errors.ProtocolEngineError(message="oh no"),
             matchers.ErrorMatching(errors.ProtocolEngineError, match="oh no"),
         ),
         (

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -830,29 +830,17 @@ def test_command_store_saves_unknown_finish_error() -> None:
                 # and they wrap
                 wrappedErrors=[
                     errors.ErrorOccurrence(
-                        # the wrapped error(s) have the same id and creation time
                         id="error-id",
                         createdAt=datetime(year=2021, month=1, day=1),
-                        # but the details of the wrapped exception
-                        errorType="GeneralError",
-                        detail="Error 4000 GENERAL_ERROR (GeneralError)",
+                        errorType="PythonException",
+                        detail="RuntimeError: oh no\n",
                         errorCode="4000",
-                        # including further wrapped errors
-                        wrappedErrors=[
-                            errors.ErrorOccurrence(
-                                id="error-id",
-                                createdAt=datetime(year=2021, month=1, day=1),
-                                errorType="PythonException",
-                                detail="RuntimeError: oh no\n",
-                                errorCode="4000",
-                                # and we get some fun extra info if this wraps a normal exception
-                                errorInfo={
-                                    "class": "RuntimeError",
-                                    "args": "('oh no',)",
-                                },
-                                wrappedErrors=[],
-                            )
-                        ],
+                        # and we get some fun extra info if this wraps a normal exception
+                        errorInfo={
+                            "class": "RuntimeError",
+                            "args": "('oh no',)",
+                        },
+                        wrappedErrors=[],
                     )
                 ],
             )

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import NamedTuple, Type
 
+from opentrons_shared_data.errors import ErrorCodes
 from opentrons.ordered_set import OrderedSet
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName
@@ -455,7 +456,7 @@ def test_command_failure_clears_queues() -> None:
         command_id="command-id-1",
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
-        error=errors.ProtocolEngineError("oh no"),
+        error=errors.ProtocolEngineError(message="oh no"),
     )
 
     expected_failed_1 = commands.WaitForResume(
@@ -466,7 +467,7 @@ def test_command_failure_clears_queues() -> None:
             errorType="ProtocolEngineError",
             detail="oh no",
             createdAt=datetime(year=2023, month=3, day=3),
-            errorCode=errors.ProtocolEngineError.ERROR_CODE,
+            errorCode=ErrorCodes.GENERAL_ERROR.value.code,
         ),
         createdAt=datetime(year=2021, month=1, day=1),
         startedAt=datetime(year=2022, month=2, day=2),
@@ -557,7 +558,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
         command_id="command-id-2",
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
-        error=errors.ProtocolEngineError("oh no"),
+        error=errors.ProtocolEngineError(message="oh no"),
     )
     expected_failed_cmd_2 = commands.WaitForResume(
         id="command-id-2",
@@ -567,7 +568,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
             errorType="ProtocolEngineError",
             detail="oh no",
             createdAt=datetime(year=2023, month=3, day=3),
-            errorCode=errors.ProtocolEngineError.ERROR_CODE,
+            errorCode=ErrorCodes.GENERAL_ERROR.value.code,
         ),
         createdAt=datetime(year=2021, month=1, day=1),
         startedAt=datetime(year=2022, month=2, day=2),
@@ -819,10 +820,41 @@ def test_command_store_saves_unknown_finish_error() -> None:
             "error-id": errors.ErrorOccurrence(
                 id="error-id",
                 createdAt=datetime(year=2021, month=1, day=1),
-                errorType="RuntimeError",
+                # this is wrapped into an UnexpectedProtocolError because it's not
+                # enumerated
+                errorType="UnexpectedProtocolError",
+                # but it has the information about what created it
                 detail="oh no",
                 # Unknown errors use the default error code
-                errorCode=errors.ProtocolEngineError.ERROR_CODE,
+                errorCode=ErrorCodes.GENERAL_ERROR.value.code,
+                # and they wrap
+                wrappedErrors=[
+                    errors.ErrorOccurrence(
+                        # the wrapped error(s) have the same id and creation time
+                        id="error-id",
+                        createdAt=datetime(year=2021, month=1, day=1),
+                        # but the details of the wrapped exception
+                        errorType="GeneralError",
+                        detail="Error 4000 GENERAL_ERROR (GeneralError)",
+                        errorCode="4000",
+                        # including further wrapped errors
+                        wrappedErrors=[
+                            errors.ErrorOccurrence(
+                                id="error-id",
+                                createdAt=datetime(year=2021, month=1, day=1),
+                                errorType="PythonException",
+                                detail="RuntimeError: oh no\n",
+                                errorCode="4000",
+                                # and we get some fun extra info if this wraps a normal exception
+                                errorInfo={
+                                    "class": "RuntimeError",
+                                    "args": "('oh no',)",
+                                },
+                                wrappedErrors=[],
+                            )
+                        ],
+                    )
+                ],
             )
         },
         run_started_at=None,
@@ -832,15 +864,15 @@ def test_command_store_saves_unknown_finish_error() -> None:
 
 def test_command_store_saves_correct_error_code() -> None:
     """If an error is derived from ProtocolEngineError, its ErrorCode should be used."""
-    TEST_CODE = "1234"
 
     class MyCustomError(errors.ProtocolEngineError):
-        ERROR_CODE = TEST_CODE
+        def __init__(self, message: str) -> None:
+            super().__init__(ErrorCodes.PIPETTE_NOT_PRESENT, message)
 
     subject = CommandStore(is_door_open=False, config=_make_config())
 
     error_details = FinishErrorDetails(
-        error=MyCustomError("oh no"),
+        error=MyCustomError(message="oh no"),
         error_id="error-id",
         created_at=datetime(year=2021, month=1, day=1),
     )
@@ -862,7 +894,7 @@ def test_command_store_saves_correct_error_code() -> None:
                 createdAt=datetime(year=2021, month=1, day=1),
                 errorType="MyCustomError",
                 detail="oh no",
-                errorCode=TEST_CODE,
+                errorCode=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
             )
         },
         run_started_at=None,
@@ -927,7 +959,7 @@ def test_command_store_handles_command_failed() -> None:
         errorType="ProtocolEngineError",
         createdAt=datetime(year=2022, month=2, day=2),
         detail="oh no",
-        errorCode=errors.ProtocolEngineError.ERROR_CODE,
+        errorCode=ErrorCodes.GENERAL_ERROR.value.code,
     )
 
     expected_failed_command = create_failed_command(
@@ -943,7 +975,7 @@ def test_command_store_handles_command_failed() -> None:
             command_id="command-id",
             error_id="error-id",
             failed_at=datetime(year=2022, month=2, day=2),
-            error=errors.ProtocolEngineError("oh no"),
+            error=errors.ProtocolEngineError(message="oh no"),
         )
     )
 

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -111,6 +111,8 @@ stages:
               createdAt: !anystr
               detail: 'Cannot perform DROPTIP without a tip attached'
               errorCode: '4000'
+              errorInfo: !anydict
+              wrappedErrors: !anylist
             params:
               pipetteId: pipetteId
               labwareId: tipRackId

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -110,6 +110,8 @@ stages:
               createdAt: !anystr
               detail: 'Cannot perform DROPTIP without a tip attached'
               errorCode: '4000'
+              errorInfo: !anydict
+              wrappedErrors: !anylist
             params:
               pipetteId: !anystr
               labwareId: !anystr

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -36,4 +36,4 @@ stages:
         errors:
           - id: 'RunActionNotAllowed'
             title: 'Run Action Not Allowed'
-            detail: 'Cannot pause a run that is not running.'
+            detail: 'Error 4000 GENERAL_ERROR (PauseNotAllowedError): Cannot pause a run that is not running.'

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -213,7 +213,9 @@ async def test_add_conflicting_setup_command(
         )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.content["errors"][0]["detail"] == "oh no"
+    assert exc_info.value.content["errors"][0]["detail"] == matchers.StringMatching(
+        ".*4000.*oh no"
+    )
 
 
 async def test_add_command_to_stopped_engine(
@@ -238,7 +240,9 @@ async def test_add_command_to_stopped_engine(
         )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.content["errors"][0]["detail"] == "oh no"
+    assert exc_info.value.content["errors"][0]["detail"] == matchers.StringMatching(
+        ".*4000.*oh no"
+    )
 
 
 async def test_get_run_commands(

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -106,6 +106,10 @@
       "detail": "Gripper Not Present",
       "category": "roboticsInteractionError"
     },
+    "3012": {
+      "detail": "Unexpected Tip Presence",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"

--- a/shared-data/python/opentrons_shared_data/errors/__init__.py
+++ b/shared-data/python/opentrons_shared_data/errors/__init__.py
@@ -9,7 +9,7 @@ our static analysis and dev setup.
 
 from .categories import ErrorCategories, ErrorCategory
 from .codes import ErrorCodes, ErrorCode
-from .exceptions import EnumeratedError
+from .exceptions import EnumeratedError, PythonException, GeneralError, RoboticsControlError, RoboticsInteractionError
 
 __all__ = [
     "ErrorCategory",
@@ -17,4 +17,8 @@ __all__ = [
     "ErrorCode",
     "ErrorCodes",
     "EnumeratedError",
+    "PythonException",
+    "GeneralError",
+    "RoboticsControlError",
+    "RoboticsInteractionError"
 ]

--- a/shared-data/python/opentrons_shared_data/errors/__init__.py
+++ b/shared-data/python/opentrons_shared_data/errors/__init__.py
@@ -9,7 +9,13 @@ our static analysis and dev setup.
 
 from .categories import ErrorCategories, ErrorCategory
 from .codes import ErrorCodes, ErrorCode
-from .exceptions import EnumeratedError, PythonException, GeneralError, RoboticsControlError, RoboticsInteractionError
+from .exceptions import (
+    EnumeratedError,
+    PythonException,
+    GeneralError,
+    RoboticsControlError,
+    RoboticsInteractionError,
+)
 
 __all__ = [
     "ErrorCategory",
@@ -20,5 +26,5 @@ __all__ = [
     "PythonException",
     "GeneralError",
     "RoboticsControlError",
-    "RoboticsInteractionError"
+    "RoboticsInteractionError",
 ]

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -56,6 +56,7 @@ class ErrorCodes(Enum):
     E_STOP_NOT_PRESENT = _code_from_dict_entry("3009")
     PIPETTE_NOT_PRESENT = _code_from_dict_entry("3010")
     GRIPPER_NOT_PRESENT = _code_from_dict_entry("3011")
+    UNEXPECTED_TIP_ATTACH = _code_from_dict_entry("3012")
     GENERAL_ERROR = _code_from_dict_entry("4000")
 
     @classmethod

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -1,6 +1,9 @@
 """Exception hierarchy for error codes."""
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Iterator, Union, Sequence
 from logging import getLogger
+from traceback import format_exception_only, format_tb
+import inspect
+import sys
 
 from .codes import ErrorCodes
 from .categories import ErrorCategories
@@ -17,15 +20,21 @@ class EnumeratedError(Exception):
         code: ErrorCodes,
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence["EnumeratedError"]] = None,
     ) -> None:
         """Build an EnumeratedError."""
         self.code = code
         self.message = message or ""
         self.detail = detail or {}
+        self.wrapping = wrapping or []
 
     def __repr__(self) -> str:
         """Get a representative string for the exception."""
         return f"<{self.__class__.__name__}: code=<{self.code.value.code} {self.code.name}> message={self.message} detail={str(self.detail)}"
+
+    def __str__(self) -> str:
+        """Get a human-readable string."""
+        return f'Error {self.code.value.code} {self.code.name} ({self.__class__.__name__}){f": {self.message}" if self.message else ""}'
 
 
 class CommunicationError(EnumeratedError):
@@ -41,6 +50,7 @@ class CommunicationError(EnumeratedError):
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CommunicationError."""
         if code and code not in code.of_category(
@@ -49,7 +59,9 @@ class CommunicationError(EnumeratedError):
             log.error(
                 f"Error {code.name} is inappropriate for a CommunicationError exception"
             )
-        super().__init__(code or ErrorCodes.COMMUNICATION_ERROR, message, detail)
+        super().__init__(
+            code or ErrorCodes.COMMUNICATION_ERROR, message, detail, wrapping
+        )
 
 
 class RoboticsControlError(EnumeratedError):
@@ -65,6 +77,7 @@ class RoboticsControlError(EnumeratedError):
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a RoboticsControlError."""
         if code and code not in code.of_category(
@@ -74,7 +87,9 @@ class RoboticsControlError(EnumeratedError):
                 f"Error {code.name} is inappropriate for a RoboticsControlError exception"
             )
 
-        super().__init__(code or ErrorCodes.ROBOTICS_CONTROL_ERROR, message, detail)
+        super().__init__(
+            code or ErrorCodes.ROBOTICS_CONTROL_ERROR, message, detail, wrapping
+        )
 
 
 class RoboticsInteractionError(EnumeratedError):
@@ -90,6 +105,7 @@ class RoboticsInteractionError(EnumeratedError):
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a RoboticsInteractionError."""
         if code and code not in code.of_category(
@@ -99,7 +115,9 @@ class RoboticsInteractionError(EnumeratedError):
                 f"Error {code.name} is inappropriate for a RoboticsInteractionError exception"
             )
 
-        super().__init__(code or ErrorCodes.ROBOTICS_INTERACTION_ERROR, message, detail)
+        super().__init__(
+            code or ErrorCodes.ROBOTICS_INTERACTION_ERROR, message, detail, wrapping
+        )
 
 
 class GeneralError(EnumeratedError):
@@ -115,190 +133,311 @@ class GeneralError(EnumeratedError):
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[Union[EnumeratedError, BaseException]]] = None,
     ) -> None:
         """Build a GeneralError."""
         if code and code not in code.of_category(ErrorCategories.GENERAL_ERROR):
             log.error(
                 f"Error {code.name} is inappropriate for a GeneralError exception"
             )
-        super().__init__(code or ErrorCodes.GENERAL_ERROR, message, detail)
+
+        def _wrapped_excs() -> Iterator[EnumeratedError]:
+            if not wrapping:
+                return
+            for exc in wrapping:
+                if isinstance(exc, EnumeratedError):
+                    yield exc
+                else:
+                    yield PythonException(exc)
+
+        super().__init__(
+            code or ErrorCodes.GENERAL_ERROR, message, detail, list(_wrapped_excs())
+        )
+
+
+def _exc_harvest_predicate(v: Any) -> bool:
+    if inspect.isroutine(v):
+        return False
+    if inspect.ismethoddescriptor(v):
+        return False
+    # on python 3.11 and up we can check if things are method wrappers, which basic builtin
+    # dunders like __add__ are, but until then we can't and also don't know this is real
+    if sys.version_info.minor >= 11 and inspect.ismethodwrapper(v):  # type: ignore[attr-defined]
+        return False
+    return True
+
+
+class PythonException(GeneralError):
+    """An exception wrapping a base exception but with a GeneralError code and storing details."""
+
+    def __init__(self, exc: BaseException) -> None:
+        """Build a PythonException."""
+
+        def _descend_exc_ctx(exc: BaseException) -> List[PythonException]:
+            if exc.__cause__:
+                return [PythonException(exc.__cause__)]
+            else:
+                return []
+
+        base_details = {
+            k: str(v)
+            for k, v in inspect.getmembers(exc, _exc_harvest_predicate)
+            if not k.startswith("_")
+        }
+        try:
+            tb = exc.__traceback__
+        except AttributeError:
+            tb = None
+
+        if tb:
+            base_details["traceback"] = "\n".join(format_tb(tb))
+        base_details["class"] = type(exc).__name__
+
+        super().__init__(
+            message="\n".join(format_exception_only(type(exc), exc)),
+            detail=base_details,
+            wrapping=_descend_exc_ctx(exc),
+        )
 
 
 class CanbusCommunicationError(CommunicationError):
     """An error indicating a problem with canbus communication."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CanbusCommunicationError."""
-        super().__init__(ErrorCodes.CANBUS_COMMUNICATION_ERROR, message, detail)
+        super().__init__(
+            ErrorCodes.CANBUS_COMMUNICATION_ERROR, message, detail, wrapping
+        )
 
 
 class InternalUSBCommunicationError(CommunicationError):
     """An error indicating a problem with internal USB communication - e.g. with the rear panel."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InternalUSBCommunicationError."""
-        super().__init__(ErrorCodes.INTERNAL_USB_COMMUNICATION_ERROR, message, detail)
+        super().__init__(
+            ErrorCodes.INTERNAL_USB_COMMUNICATION_ERROR, message, detail, wrapping
+        )
 
 
 class ModuleCommunicationError(CommunicationError):
     """An error indicating a problem with module communication."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build an ModuleCommunicationError."""
-        super().__init__(ErrorCodes.MODULE_COMMUNICATION_ERROR, message, detail)
+        """Build a CanbusCommunicationError."""
+        super().__init__(
+            ErrorCodes.CANBUS_COMMUNICATION_ERROR, message, detail, wrapping
+        )
 
 
 class CommandTimedOutError(CommunicationError):
     """An error indicating that a command timed out."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CommandTimedOutError."""
-        super().__init__(ErrorCodes.COMMAND_TIMED_OUT, message, detail)
+        super().__init__(ErrorCodes.COMMAND_TIMED_OUT, message, detail, wrapping)
 
 
 class FirmwareUpdateFailedError(CommunicationError):
     """An error indicating that a firmware update failed."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FirmwareUpdateFailedError."""
-        super().__init__(ErrorCodes.FIRMWARE_UPDATE_FAILED, message, detail)
+        super().__init__(ErrorCodes.FIRMWARE_UPDATE_FAILED, message, detail, wrapping)
 
 
 class MotionFailedError(RoboticsControlError):
     """An error indicating that a motion failed."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FirmwareUpdateFailedError."""
-        super().__init__(ErrorCodes.MOTION_FAILED, message, detail)
+        super().__init__(ErrorCodes.MOTION_FAILED, message, detail, wrapping)
 
 
 class HomingFailedError(RoboticsControlError):
     """An error indicating that a homing failed."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FirmwareUpdateFailedError."""
-        super().__init__(ErrorCodes.HOMING_FAILED, message, detail)
+        super().__init__(ErrorCodes.HOMING_FAILED, message, detail, wrapping)
 
 
 class StallOrCollisionDetectedError(RoboticsControlError):
     """An error indicating that a stall or collision occurred."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a StallOrCollisionDetectedError."""
-        super().__init__(ErrorCodes.STALL_OR_COLLISION_DETECTED, message, detail)
+        super().__init__(
+            ErrorCodes.STALL_OR_COLLISION_DETECTED, message, detail, wrapping
+        )
 
 
 class MotionPlanningFailureError(RoboticsControlError):
     """An error indicating that motion planning failed."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a MotionPlanningFailureError."""
-        super().__init__(ErrorCodes.MOTION_PLANNING_FAILURE, message, detail)
+        super().__init__(ErrorCodes.MOTION_PLANNING_FAILURE, message, detail, wrapping)
 
 
 class LabwareDroppedError(RoboticsInteractionError):
     """An error indicating that the gripper dropped labware it was holding."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a LabwareDroppedError."""
-        super().__init__(ErrorCodes.LABWARE_DROPPED, message, detail)
+        super().__init__(ErrorCodes.LABWARE_DROPPED, message, detail, wrapping)
 
 
 class TipPickupFailedError(RoboticsInteractionError):
     """An error indicating that a pipette failed to pick up a tip."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a TipPickupFailedError."""
-        super().__init__(ErrorCodes.TIP_PICKUP_FAILED, message, detail)
+        super().__init__(ErrorCodes.TIP_PICKUP_FAILED, message, detail, wrapping)
 
 
 class TipDropFailedError(RoboticsInteractionError):
     """An error indicating that a pipette failed to drop a tip."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a TipPickupFailedError."""
-        super().__init__(ErrorCodes.TIP_DROP_FAILED, message, detail)
+        super().__init__(ErrorCodes.TIP_DROP_FAILED, message, detail, wrapping)
 
 
 class UnexpectedTipRemovalError(RoboticsInteractionError):
     """An error indicating that a pipette did not have a tip when it should (aka it fell off)."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnexpectedTipRemovalError."""
-        super().__init__(ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, detail)
+        super().__init__(ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, detail, wrapping)
+
 
 
 class PipetteOverpressureError(RoboticsInteractionError):
     """An error indicating that a pipette experienced an overpressure event, likely because of a clog."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an PipetteOverpressureError."""
-        super().__init__(ErrorCodes.PIPETTE_OVERPRESSURE, message, detail)
+        super().__init__(ErrorCodes.PIPETTE_OVERPRESSURE, message, detail, wrapping)
 
 
 class EStopActivatedError(RoboticsInteractionError):
     """An error indicating that the E-stop was activated."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an EStopActivatedError."""
-        super().__init__(ErrorCodes.E_STOP_ACTIVATED, message, detail)
+        super().__init__(ErrorCodes.E_STOP_ACTIVATED, message, detail, wrapping)
 
 
 class EStopNotPresentError(RoboticsInteractionError):
     """An error indicating that the E-stop is not present."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an EStopNotPresentError."""
-        super().__init__(ErrorCodes.E_STOP_NOT_PRESENT, message, detail)
+        super().__init__(ErrorCodes.E_STOP_NOT_PRESENT, message, detail, wrapping)
 
 
 class PipetteNotPresentError(RoboticsInteractionError):
     """An error indicating that the specified pipette is not present."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an PipetteNotPresentError."""
-        super().__init__(ErrorCodes.PIPETTE_NOT_PRESENT, message, detail)
+        super().__init__(ErrorCodes.PIPETTE_NOT_PRESENT, message, detail, wrapping)
 
 
 class GripperNotPresentError(RoboticsInteractionError):
     """An error indicating that the specified gripper is not present."""
 
     def __init__(
-        self, message: Optional[str] = None, detail: Optional[Dict[str, Any]] = None
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an GripperNotPresentError."""
-        super().__init__(ErrorCodes.GRIPPER_NOT_PRESENT, message, detail)
+        super().__init__(ErrorCodes.GRIPPER_NOT_PRESENT, message, detail, wrapping)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -174,10 +174,12 @@ class PythonException(GeneralError):
         """Build a PythonException."""
 
         def _descend_exc_ctx(exc: BaseException) -> List[PythonException]:
+            descendants: List[PythonException] = []
+            if exc.__context__:
+                descendants.append(PythonException(exc.__context__))
             if exc.__cause__:
-                return [PythonException(exc.__cause__)]
-            else:
-                return []
+                descendants.append(PythonException(exc.__cause__))
+            return descendants
 
         base_details = {
             k: str(v)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -377,6 +377,18 @@ class UnexpectedTipRemovalError(RoboticsInteractionError):
         super().__init__(ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, detail, wrapping)
 
 
+class UnexpectedTipAttachError(RoboticsInteractionError):
+    """An error indicating that a pipette had a tip when it shouldn't."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an UnexpectedTipAttachError."""
+        super().__init__(ErrorCodes.UNEXPECTED_TIP_ATTACH, message, detail, wrapping)
+
 
 class PipetteOverpressureError(RoboticsInteractionError):
     """An error indicating that a pipette experienced an overpressure event, likely because of a clog."""

--- a/shared-data/python/tests/errors/test_exceptions.py
+++ b/shared-data/python/tests/errors/test_exceptions.py
@@ -1,0 +1,55 @@
+"""Test exception handling."""
+from opentrons_shared_data.errors.exceptions import PythonException
+
+
+def test_exception_wrapping_single_level() -> None:
+    """When we make a PythonException it should capture details of an exception."""
+    try:
+        raise RuntimeError("oh no!")
+    except RuntimeError as e:
+        captured_exc = e
+
+    wrapped = PythonException(captured_exc)
+    assert wrapped.detail["class"] == "RuntimeError"
+    assert wrapped.detail["traceback"]
+    assert wrapped.detail["args"] == "('oh no!',)"
+
+
+def test_exception_wrapping_multi_level() -> None:
+    """We can wrap all exceptions in a raise-from chain."""
+
+    def _raise_inner() -> None:
+        raise KeyError("oh no!")
+
+    try:
+        try:
+            _raise_inner()
+        except KeyError as e:
+            raise RuntimeError("uh oh!") from e
+    except RuntimeError as e:
+        captured_exc = e
+
+    wrapped = PythonException(captured_exc)
+    assert wrapped.detail["class"] == "RuntimeError"
+    assert wrapped.detail["traceback"]
+    assert wrapped.detail["args"] == "('uh oh!',)"
+    second = wrapped.wrapping[0]
+    assert isinstance(second, PythonException)
+    assert second.detail["class"] == "KeyError"
+    assert second.detail["args"] == "('oh no!',)"
+    assert not second.wrapping
+
+
+def test_exception_wrapping_rethrow() -> None:
+    """We can even wrap exceptions inside an except."""
+    try:
+        try:
+            raise RuntimeError("oh no!")
+        except RuntimeError as e:
+            raise PythonException(e) from e
+    except PythonException as pe:
+        wrapped = pe
+
+    assert wrapped.detail["class"] == "RuntimeError"
+    assert wrapped.detail["traceback"]
+    assert wrapped.detail["args"] == "('oh no!',)"


### PR DESCRIPTION
## Draft alert!
This is a draft because I definitely need to get some fixes and further tests in the HTTP API layer and test on a robot and so on and so forth, but I wanted people to be able to see it since this does some medium-dubious jsonschema stuff and pokes into some core PE behavior.

## Overview
This PR adds our new enumerated error codes to ProtocolEngine. This is the first place we're using them. We add the error codes to the protocol engine internal custom error hierarchies and add logic to capture python exceptions that are not `EnumeratedError`s at the three places that we catch exceptions - the core engine action handler, the legacy executor, and the main executor.

The biggest new functionality is error wrapping. The `EnumeratedError`s can now catch, wrap, and store sequences of `raise from` exception contexts that could previously only really be represented as tracebacks. Now the structure of exception raise sequences is preserved all the way up to the `ErrorOccurrence` model and thus to the client to format as they see fit. While some detail isn't really schema controlled (you'll have a `Dict[str, str]` and you'll like it!) the structure actually is, as it's just a tree and pydantic and jsonschema do a pretty good job of supporting type recursion in models.

I'm interested to see early reactions from @sanni-t @jbleon95 @TamarZanzouri and @SyntaxColoring ; I think I'm happy with how this turned out, but further testing will tell.

## Scope and Followups

This PR is intended to add the enumerated error code handling and transformations to PD and correctly send them over HTTP. There's a followup PR needed to scrape through PE and make sure that everything has a correct error code, and that specific hardware calls that might fail in specific ways and already have specific `try`/`except` clauses correctly wrap things in the right error codes and so on. There's also one needed to do that same thing in the other parts of the `api` subdirectory, particularly `hardware_control`, and hardware; and finally, something similar's going to need to happen in the `robot-server`, along with some kind of top-level exception catching there.

## Risks
Well, this modifies serialized data, so a lot, but hopefully in as safe a way as we can do it. It shouldn't introduce new errors, just transform how they're handled.

## Testing
- [x] Put it on a robot and cause a bunch of protocol errors! 