### PR TITLE
fix(app): Display missing font glyphs [RAUT-491]

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,8 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons",
   "dependencies": {
-    "@fontsource/public-sans": "4.5.11",
+    "@fontsource/dejavu-sans": "5.0.3",
+    "@fontsource/public-sans": "5.0.3",
     "@hot-loader/react-dom": "17.0.1",
     "@opentrons/api-client": "link:../api-client",
     "@opentrons/components": "link:../components",

--- a/app/src/atoms/GlobalStyle/index.ts
+++ b/app/src/atoms/GlobalStyle/index.ts
@@ -1,6 +1,7 @@
 import { createGlobalStyle } from 'styled-components'
 import { COLORS } from '@opentrons/components'
 import 'typeface-open-sans'
+import '@fontsource/dejavu-sans'
 import '@fontsource/public-sans'
 import '@fontsource/public-sans/600.css'
 import '@fontsource/public-sans/700.css'
@@ -11,7 +12,9 @@ export const GlobalStyle = createGlobalStyle<{ isOnDevice?: boolean }>`
     margin: 0;
     padding: 0;
     font-family: ${props =>
-      props.isOnDevice ?? false ? 'Public Sans' : 'Open Sans'}, sans-serif;
+      props.isOnDevice ?? false
+        ? 'Public Sans, DejaVu Sans'
+        : 'Open Sans'}, sans-serif;
   }
 
   html,

--- a/app/src/atoms/GlobalStyle/index.ts
+++ b/app/src/atoms/GlobalStyle/index.ts
@@ -6,6 +6,10 @@ import '@fontsource/public-sans'
 import '@fontsource/public-sans/600.css'
 import '@fontsource/public-sans/700.css'
 
+// TODO(ew, 06/19/23): The main font is Public Sans but it does not have subscript glyphs,
+// needed to display chemical formulae on the liquids page. I've added DejaVu Sans, which
+// does have the glyphs, as a fallback so subscripts will get displayed. Mel and the design
+// team will want to revisit the fonts we use at some point in the future.
 export const GlobalStyle = createGlobalStyle<{ isOnDevice?: boolean }>`
   * {
     box-sizing: border-box;

--- a/scripts/setup-global-mocks.js
+++ b/scripts/setup-global-mocks.js
@@ -24,4 +24,5 @@ jest.mock('../protocol-designer/src/labware-defs/utils')
 jest.mock('../protocol-designer/src/components/portals/MainPageModalPortal')
 
 jest.mock('typeface-open-sans', () => {})
+jest.mock('@fontsource/dejavu-sans', () => {})
 jest.mock('@fontsource/public-sans', () => {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,10 +1626,15 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fontsource/public-sans@4.5.11":
-  version "4.5.11"
-  resolved "https://registry.yarnpkg.com/@fontsource/public-sans/-/public-sans-4.5.11.tgz#a95f6129c8bf092da7ae956eebf688b35b389e2c"
-  integrity sha512-waejL3VQnifnLVwQGcW2bULD2vUaevjE9OKmOSAmBACAebZnnYznHL+NL4NgW6B+b1wyltmIr6jBF5XMZVWgYA==
+"@fontsource/dejavu-sans@5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@fontsource/dejavu-sans/-/dejavu-sans-5.0.3.tgz#32fad6738b228a2e6f490f1fa6983393997f9d4b"
+  integrity sha512-VW88zyjoaxAqypEL6TqX2fcPIsCyxj+TPO6Usrine+i5tmJxnSBkh5NJ1dhczy+2ieC2tCHpKygZggw3k6qgUA==
+
+"@fontsource/public-sans@5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@fontsource/public-sans/-/public-sans-5.0.3.tgz#483c13f0ba320ec570d4161495a28c7f1bfaba6a"
+  integrity sha512-qoP6K/rmKIe6TP31kV9ImR73u/R1opPA3sx+4NLH4wQWbxTOQNLbH9nDzKF2PN7IQ9xLpu5e6XnQLgwlPpjeTQ==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -2173,7 +2178,8 @@
 "@opentrons/app@link:app":
   version "0.0.0-dev"
   dependencies:
-    "@fontsource/public-sans" "4.5.11"
+    "@fontsource/dejavu-sans" "5.0.3"
+    "@fontsource/public-sans" "5.0.3"
     "@hot-loader/react-dom" "17.0.1"
     "@opentrons/api-client" "link:api-client"
     "@opentrons/components" "link:components"


### PR DESCRIPTION

# Overview

This PR adds a font on the ODD that displays glyphs that the primary font, Public Sans, does not support. This includes numeric subscripts, as needed for chemical formulas on the liquids page and elsewhere.

# Test Plan

Visually verified the font is loaded and is used when needed.

# Changelog

- Updated Public Sans
- Installed DejaVu Sans
- Use DejaVu Sans as a fallback

# Review requests

Please view the liquids page for a protocol that contains liquids and display chemical formulas and ensure subscripts are displayed. If you know of other places that have shown garbled characters, please look there too.

# Risk assessment

Low. The new font is just a fallback.

![Screenshot 2023-06-16 at 4 53 27 PM](https://github.com/Opentrons/opentrons/assets/2960/8b62f229-9b01-4dcb-89c4-6b0db0dcbbfd)

