### PR TITLE
fix(app): remove temporary instrument loading text on robot card

### DIFF
--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -167,7 +167,7 @@ function AttachedInstruments(props: { robotName: string }): JSX.Element {
   const rightPipetteModel = pipettesData?.right?.model ?? null
   const extensionMountDisplayName =
     extensionInstrument != null &&
-    extensionInstrument.instrumentModel === 'gripperV1'
+      extensionInstrument.instrumentModel === 'gripperV1'
       ? getGripperDisplayName(extensionInstrument.instrumentModel)
       : null
 
@@ -186,36 +186,34 @@ function AttachedInstruments(props: { robotName: string }): JSX.Element {
         {t('shared:instruments')}
       </StyledText>
 
-      {isInstrumentsQueryLoading ? 'INSTRUMENTS' : null}
-      {isPipetteQueryLoading ? 'PIPETTES' : null}
-      {isPipetteQueryLoading || isInstrumentsQueryLoading ? (
-        <StyledText as="h5">{t('loading').toUpperCase()}</StyledText>
-      ) : (
-        <Flex flexWrap={WRAP} gridGap={SPACING.spacing4}>
-          {leftAndRightMountsPipetteDisplayName != null ? (
-            <InstrumentContainer
-              displayName={leftAndRightMountsPipetteDisplayName}
-            />
-          ) : null}
-          {leftPipetteModel != null ? (
-            <InstrumentContainer
-              displayName={
-                getPipetteModelSpecs(leftPipetteModel)?.displayName ?? ''
-              }
-            />
-          ) : null}
-          {rightPipetteModel != null ? (
-            <InstrumentContainer
-              displayName={
-                getPipetteModelSpecs(rightPipetteModel)?.displayName ?? ''
-              }
-            />
-          ) : null}
-          {extensionMountDisplayName != null ? (
-            <InstrumentContainer displayName={extensionMountDisplayName} />
-          ) : null}
-        </Flex>
-      )}
+      {isPipetteQueryLoading || isInstrumentsQueryLoading ?
+        null
+        : (
+          <Flex flexWrap={WRAP} gridGap={SPACING.spacing4}>
+            {leftAndRightMountsPipetteDisplayName != null ? (
+              <InstrumentContainer
+                displayName={leftAndRightMountsPipetteDisplayName}
+              />
+            ) : null}
+            {leftPipetteModel != null ? (
+              <InstrumentContainer
+                displayName={
+                  getPipetteModelSpecs(leftPipetteModel)?.displayName ?? ''
+                }
+              />
+            ) : null}
+            {rightPipetteModel != null ? (
+              <InstrumentContainer
+                displayName={
+                  getPipetteModelSpecs(rightPipetteModel)?.displayName ?? ''
+                }
+              />
+            ) : null}
+            {extensionMountDisplayName != null ? (
+              <InstrumentContainer displayName={extensionMountDisplayName} />
+            ) : null}
+          </Flex>
+        )}
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/RobotCard.tsx
+++ b/app/src/organisms/Devices/RobotCard.tsx
@@ -167,7 +167,7 @@ function AttachedInstruments(props: { robotName: string }): JSX.Element {
   const rightPipetteModel = pipettesData?.right?.model ?? null
   const extensionMountDisplayName =
     extensionInstrument != null &&
-      extensionInstrument.instrumentModel === 'gripperV1'
+    extensionInstrument.instrumentModel === 'gripperV1'
       ? getGripperDisplayName(extensionInstrument.instrumentModel)
       : null
 
@@ -186,34 +186,32 @@ function AttachedInstruments(props: { robotName: string }): JSX.Element {
         {t('shared:instruments')}
       </StyledText>
 
-      {isPipetteQueryLoading || isInstrumentsQueryLoading ?
-        null
-        : (
-          <Flex flexWrap={WRAP} gridGap={SPACING.spacing4}>
-            {leftAndRightMountsPipetteDisplayName != null ? (
-              <InstrumentContainer
-                displayName={leftAndRightMountsPipetteDisplayName}
-              />
-            ) : null}
-            {leftPipetteModel != null ? (
-              <InstrumentContainer
-                displayName={
-                  getPipetteModelSpecs(leftPipetteModel)?.displayName ?? ''
-                }
-              />
-            ) : null}
-            {rightPipetteModel != null ? (
-              <InstrumentContainer
-                displayName={
-                  getPipetteModelSpecs(rightPipetteModel)?.displayName ?? ''
-                }
-              />
-            ) : null}
-            {extensionMountDisplayName != null ? (
-              <InstrumentContainer displayName={extensionMountDisplayName} />
-            ) : null}
-          </Flex>
-        )}
+      {isPipetteQueryLoading || isInstrumentsQueryLoading ? null : (
+        <Flex flexWrap={WRAP} gridGap={SPACING.spacing4}>
+          {leftAndRightMountsPipetteDisplayName != null ? (
+            <InstrumentContainer
+              displayName={leftAndRightMountsPipetteDisplayName}
+            />
+          ) : null}
+          {leftPipetteModel != null ? (
+            <InstrumentContainer
+              displayName={
+                getPipetteModelSpecs(leftPipetteModel)?.displayName ?? ''
+              }
+            />
+          ) : null}
+          {rightPipetteModel != null ? (
+            <InstrumentContainer
+              displayName={
+                getPipetteModelSpecs(rightPipetteModel)?.displayName ?? ''
+              }
+            />
+          ) : null}
+          {extensionMountDisplayName != null ? (
+            <InstrumentContainer displayName={extensionMountDisplayName} />
+          ) : null}
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -179,11 +179,4 @@ describe('RobotCard', () => {
     const [{ getByText }] = render(props)
     getByText('Mock RobotStatusHeader')
   })
-
-  it('renders loading text while loading instruments', () => {
-    const [{ getByText }] = render(props)
-
-    getByText('instruments')
-    getByText('LOADING')
-  })
 })


### PR DESCRIPTION
# Overview

Remove unnecessary loading text for instruments on the robot card.  In a performance fix from a few weeks back, we lazily loaded the instruments and pipettes on each instance of the Robot Card on the device list page.  There were leftover placeholder loading states that got merged in that need to be removed.