### PR TITLE
fix(hardware): allow longer for pipettes to boot

### DIFF
--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -405,7 +405,7 @@ class SubsystemManager:
                 right=self._tool_if_ok(update.right, NodeId.pipette_right),
                 gripper=self._tool_if_ok(update.gripper, NodeId.gripper),
             )
-            self._present_tools = await self._tool_detector.resolve(to_resolve, 5.0)
+            self._present_tools = await self._tool_detector.resolve(to_resolve, 10.0)
             log.info(f"Present tools are now {self._present_tools}")
             async with self._tool_task_condition:
                 self._tool_task_state = True

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
@@ -268,7 +268,7 @@ class ToolDetectionController:
             else ToolType.nothing_attached,
         )
 
-        self._decoy.when(await self._tool_detector.resolve(arg, 5.0)).then_return(
+        self._decoy.when(await self._tool_detector.resolve(arg, 10.0)).then_return(
             summary
         )
         return summary


### PR DESCRIPTION
Pipettes sometimes don't boot fast enough on attach and miss the InstrumentInfoRequest that happens when the head tells us a new instrument is present. This didn't used to be an issue because we wouldn't send the request until the user was finished screwing things in, so we just didn't notice.

In addition to our previous timeout - or, at a certain level, instead of it - where we'd wait a long time for the pipette to respond, we'll also now retry sending the request a couple times too.

## Testing
On a flex,
- [x] test that when you attach a 96 channel you retry the instrument info request a couple times until the pipette responds; then it stops retrying
- [x] test that when you then remove it, it doesn't retry

Fixes RQA-998