### PR TITLE
chore(hardware-testing): add 96 channel support to gravimetric script

### DIFF
--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -96,11 +96,22 @@ test-gravimetric-multi:
 	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 8 --tip 200 --trials 1
 	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 8 --tip 50 --trials 1
 
+.PHONY: test-gravimetric-96
+test-gravimetric-96:
+	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 96 --tip 1000 --trials 1 --increment
+	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 96 --tip 200 --trials 1 --increment
+	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 96 --tip 50 --trials 1 --increment
+	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 96 --tip 1000 --trials 1
+	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 96 --tip 200 --trials 1
+	$(python) -m hardware_testing.gravimetric --simulate --pipette 1000 --channels 96 --tip 50 --trials 1
+
+
 .PHONY: test-gravimetric
 test-gravimetric:
 	-$(MAKE) apply-patches-gravimetric
 	$(MAKE) test-gravimetric-single
 	$(MAKE) test-gravimetric-multi
+	$(MAKE) test-gravimetric-96
 	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-production-qc

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -504,7 +504,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:  # noqa: C
         ), f"more trials ({trial_total}) than tips ({total_tips})"
     else:
         print(f"trial total {trial_total} tips {total_tips}")
-        if trial_total > total_tips:
+        if trial_total > total_tips and not ctx.is_simulating():
             ui.get_user_ready(f"Do you have {trial_total-total_tips} extra tipracks")
     ui.print_header("LOAD SCALE")
     print(

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -118,7 +118,9 @@ def _get_volumes(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> List[fl
     if cfg.increment:
         test_volumes = get_volume_increments(cfg.pipette_volume, cfg.tip_volume)
         if cfg.pipette_channels == 96:
-            test_volumes = [test_volumes[i] for i in range(len(test_volumes)) if (i % 2 == 0)]
+            test_volumes = [
+                test_volumes[i] for i in range(len(test_volumes)) if (i % 2 == 0)
+            ]
     elif cfg.user_volumes and not ctx.is_simulating():
         _inp = input('Enter desired volumes, comma separated (eg: "10,100,1000") :')
         test_volumes = [
@@ -462,7 +464,7 @@ def _get_channel_divider(cfg: config.GravimetricConfig) -> float:
         return float(cfg.pipette_channels)
 
 
-def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
+def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:  # noqa: C901
     """Run."""
     run_id, start_time = create_run_id_and_start_time()
 
@@ -486,7 +488,9 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
     test_volumes = _get_volumes(ctx, cfg)
     for v in test_volumes:
         print(f"\t{v} uL")
-    tips = get_tips(ctx, pipette, all_channels=(cfg.increment or (cfg.pipette_channels == 96)))
+    tips = get_tips(
+        ctx, pipette, all_channels=(cfg.increment or (cfg.pipette_channels == 96))
+    )
     total_tips = len([tip for chnl_tips in tips.values() for tip in chnl_tips])
     channels_to_test = _get_test_channels(cfg)
     if len(channels_to_test) > 1:
@@ -717,7 +721,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
                     if tip_iter >= len(tips[0]) and not (used_tips == trial_total):
                         if not ctx.is_simulating():
                             ui.get_user_ready(
-                            f"replace TIPRACKS in slots {cfg.slots_tiprack}"
+                                f"replace TIPRACKS in slots {cfg.slots_tiprack}"
                             )
                         tip_iter = 0
 

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -734,7 +734,7 @@ def get_test_volumes(pipette: int, channels: int, tip: int) -> List[float]:
         elif tip == 200:
             return [200.0]
         else:
-            raise ValueError(f"no volumes to test for tip size: {tip} uL")
+            return [1000.0]
     else:
         # FIXME: also reduce total number of volumes we test for 1ch & 8ch pipettes
         aspirate_cls_per_volume = _aspirate_defaults[channels][pipette][tip]


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
adds the necessary changes to support the 96 channel in the gravimetric script. 
[marking as draft until we finalize the volumes we want to use for the increment test]
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
