### PR TITLE
refactor(api): Update flex acc speeds based on EE recs

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -77,19 +77,20 @@ DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (40.5, -60.5, 255.675)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (84.55, -12.75, 93.85)
 DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 DEFAULT_SAFE_HOME_DISTANCE: Final = 5
+DEFAULT_CALIBRATION_AXIS_MAX_SPEED: Final = 30
 
 DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={
-        OT3AxisKind.X: 375,
-        OT3AxisKind.Y: 375,
+        OT3AxisKind.X: 400,
+        OT3AxisKind.Y: 325,
         OT3AxisKind.Z: 35,
         OT3AxisKind.P: 5,
         OT3AxisKind.Z_G: 50,
         OT3AxisKind.Q: 5.5,
     },
     low_throughput={
-        OT3AxisKind.X: 375,
-        OT3AxisKind.Y: 375,
+        OT3AxisKind.X: 400,
+        OT3AxisKind.Y: 325,
         OT3AxisKind.Z: 100,
         OT3AxisKind.P: 45,
         OT3AxisKind.Z_G: 50,
@@ -98,17 +99,17 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
 
 DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={
-        OT3AxisKind.X: 600,
-        OT3AxisKind.Y: 600,
-        OT3AxisKind.Z: 120,
+        OT3AxisKind.X: 800,
+        OT3AxisKind.Y: 500,
+        OT3AxisKind.Z: 150,
         OT3AxisKind.P: 30,
         OT3AxisKind.Z_G: 150,
         OT3AxisKind.Q: 10,
     },
     low_throughput={
-        OT3AxisKind.X: 600,
+        OT3AxisKind.X: 800,
         OT3AxisKind.Y: 600,
-        OT3AxisKind.Z: 300,
+        OT3AxisKind.Z: 150,
         OT3AxisKind.P: 100,
         OT3AxisKind.Z_G: 150,
     },
@@ -174,17 +175,17 @@ DEFAULT_HOLD_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLo
 
 DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
     high_throughput={
-        OT3AxisKind.X: 1.4,
+        OT3AxisKind.X: 1.25,
         OT3AxisKind.Y: 1.4,
-        OT3AxisKind.Z: 1.4,
+        OT3AxisKind.Z: 1.5,
         OT3AxisKind.P: 2.2,
         OT3AxisKind.Z_G: 0.67,
         OT3AxisKind.Q: 1.5,
     },
     low_throughput={
-        OT3AxisKind.X: 1.4,
-        OT3AxisKind.Y: 1.4,
-        OT3AxisKind.Z: 1.4,
+        OT3AxisKind.X: 1.25,
+        OT3AxisKind.Y: 1.25,
+        OT3AxisKind.Z: 1.0,
         # TODO: verify this value
         OT3AxisKind.P: 1.0,
         OT3AxisKind.Z_G: 0.67,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for ot3 hardware control."""
 from typing import Dict, Iterable, List, Set, Tuple, TypeVar, Sequence
 from typing_extensions import Literal
+from opentrons.config.defaults_ot3 import DEFAULT_CALIBRATION_AXIS_MAX_SPEED
 from opentrons.config.types import OT3MotionSettings, OT3CurrentSettings, GantryLoad
 from opentrons.hardware_control.types import (
     OT3Axis,
@@ -231,6 +232,29 @@ def get_system_constraints(
                 conf_by_pip["max_speed_discontinuity"][axis_kind],
                 conf_by_pip["direction_change_speed_discontinuity"][axis_kind],
                 conf_by_pip["default_max_speed"][axis_kind],
+            )
+    return constraints
+
+
+def get_system_constraints_for_calibration(
+    config: OT3MotionSettings,
+    gantry_load: GantryLoad,
+) -> "SystemConstraints[OT3Axis]":
+    conf_by_pip = config.by_gantry_load(gantry_load)
+    constraints = {}
+    for axis_kind in [
+        OT3AxisKind.P,
+        OT3AxisKind.X,
+        OT3AxisKind.Y,
+        OT3AxisKind.Z,
+        OT3AxisKind.Z_G,
+    ]:
+        for axis in OT3Axis.of_kind(axis_kind):
+            constraints[axis] = AxisConstraints.build(
+                conf_by_pip["acceleration"][axis_kind],
+                conf_by_pip["max_speed_discontinuity"][axis_kind],
+                conf_by_pip["direction_change_speed_discontinuity"][axis_kind],
+                DEFAULT_CALIBRATION_AXIS_MAX_SPEED,
             )
     return constraints
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 from typing import (
     AsyncIterator,
     AsyncGenerator,
-    Iterator,
     cast,
     Callable,
     Dict,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -248,7 +248,9 @@ class OT3API(
                 self._config.motion_settings, self._gantry_load
             )
         )
-        mod_log.debug(f"Set system constraints for calibration: {self._move_manager.get_constraints()}")
+        mod_log.debug(
+            f"Set system constraints for calibration: {self._move_manager.get_constraints()}"
+        )
 
     @contextlib.asynccontextmanager
     async def restore_system_constrants(self) -> AsyncIterator[None]:
@@ -257,7 +259,9 @@ class OT3API(
             yield
         finally:
             self._move_manager.update_constraints(old_system_constraints)
-            mod_log.debug(f"Restore previous system constraints: {old_system_constraints}")
+            mod_log.debug(
+                f"Restore previous system constraints: {old_system_constraints}"
+            )
 
     def _update_door_state(self, door_state: DoorState) -> None:
         mod_log.info(f"Updating the window switch status: {door_state}")

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -3,10 +3,12 @@ import contextlib
 from functools import partial, lru_cache
 from dataclasses import replace
 import logging
+from copy import deepcopy
 from collections import OrderedDict
 from typing import (
     AsyncIterator,
     AsyncGenerator,
+    Iterator,
     cast,
     Callable,
     Dict,
@@ -63,6 +65,7 @@ from .backends.ot3controller import OT3Controller
 from .backends.ot3simulator import OT3Simulator
 from .backends.ot3utils import (
     get_system_constraints,
+    get_system_constraints_for_calibration,
     axis_convert,
 )
 from .backends.errors import SubsystemUpdating
@@ -238,6 +241,23 @@ class OT3API(
             get_system_constraints(self._config.motion_settings, gantry_load)
         )
         await self._backend.update_to_default_current_settings(gantry_load)
+
+    async def set_system_constraints_for_calibration(self) -> None:
+        self._move_manager.update_constraints(
+            get_system_constraints_for_calibration(
+                self._config.motion_settings, self._gantry_load
+            )
+        )
+        mod_log.debug(f"Set system constraints for calibration: {self._move_manager.get_constraints()}")
+
+    @contextlib.asynccontextmanager
+    async def restore_system_constrants(self) -> AsyncIterator[None]:
+        old_system_constraints = deepcopy(self._move_manager.get_constraints())
+        try:
+            yield
+        finally:
+            self._move_manager.update_constraints(old_system_constraints)
+            mod_log.debug(f"Restore previous system constraints: {old_system_constraints}")
 
     def _update_door_state(self, door_state: DoorState) -> None:
         mod_log.info(f"Updating the window switch status: {door_state}")

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -91,7 +91,7 @@ if ff.enable_ot3_hardware_controller():
 
     def build_thread_manager() -> ThreadManager[Union["API", OT3API]]:
         return ThreadManager(
-            OT3API.build_hardware_controller,
+            HCApi.build_hardware_controller,
             use_usb_bus=ff.rear_panel_integration(),
             update_firmware=update_firmware,
         )
@@ -112,7 +112,7 @@ else:
 
     def build_thread_manager() -> ThreadManager[Union[API, OT3API]]:
         return ThreadManager(
-            API.build_hardware_controller,
+            HCApi.build_hardware_controller,
             use_usb_bus=ff.rear_panel_integration(),
             update_firmware=update_firmware,
         )

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -91,7 +91,7 @@ if ff.enable_ot3_hardware_controller():
 
     def build_thread_manager() -> ThreadManager[Union["API", OT3API]]:
         return ThreadManager(
-            HCApi.build_hardware_controller,
+            OT3API.build_hardware_controller,
             use_usb_bus=ff.rear_panel_integration(),
             update_firmware=update_firmware,
         )
@@ -112,7 +112,7 @@ else:
 
     def build_thread_manager() -> ThreadManager[Union[API, OT3API]]:
         return ThreadManager(
-            HCApi.build_hardware_controller,
+            API.build_hardware_controller,
             use_usb_bus=ff.rear_panel_integration(),
             update_firmware=update_firmware,
         )

--- a/hardware-testing/hardware_testing/gravimetric/overrides/api.patch
+++ b/hardware-testing/hardware_testing/gravimetric/overrides/api.patch
@@ -3,34 +3,34 @@ index 89696c5b2a..4c2d6184b8 100644
 --- a/api/src/opentrons/config/defaults_ot3.py
 +++ b/api/src/opentrons/config/defaults_ot3.py
 @@ -83,7 +83,7 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
-         OT3AxisKind.X: 375,
-         OT3AxisKind.Y: 375,
+         OT3AxisKind.X: 400,
+         OT3AxisKind.Y: 325,
          OT3AxisKind.Z: 35,
 -        OT3AxisKind.P: 5,
 +        OT3AxisKind.P: 20,
          OT3AxisKind.Z_G: 50,
          OT3AxisKind.Q: 5.5,
      },
-@@ -98,18 +98,18 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
+@@ -100,18 +100,18 @@ DEFAULT_MAX_SPEEDS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad
  
  DEFAULT_ACCELERATIONS: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoad(
      high_throughput={
--        OT3AxisKind.X: 600,
--        OT3AxisKind.Y: 600,
+-        OT3AxisKind.X: 800,
+-        OT3AxisKind.Y: 500,
 +        OT3AxisKind.X: 500,
 +        OT3AxisKind.Y: 500,
-         OT3AxisKind.Z: 120,
+         OT3AxisKind.Z: 150,
 -        OT3AxisKind.P: 30,
 +        OT3AxisKind.P: 1000,
          OT3AxisKind.Z_G: 150,
          OT3AxisKind.Q: 10,
      },
      low_throughput={
--        OT3AxisKind.X: 600,
+-        OT3AxisKind.X: 800,
 -        OT3AxisKind.Y: 600,
 +        OT3AxisKind.X: 500,
 +        OT3AxisKind.Y: 200,
-         OT3AxisKind.Z: 300,
+         OT3AxisKind.Z: 150,
 -        OT3AxisKind.P: 100,
 +        OT3AxisKind.P: 1500,
          OT3AxisKind.Z_G: 150,
@@ -47,9 +47,9 @@ index 89696c5b2a..4c2d6184b8 100644
          OT3AxisKind.Q: 5,
 @@ -176,8 +176,8 @@ DEFAULT_RUN_CURRENT: Final[ByGantryLoad[Dict[OT3AxisKind, float]]] = ByGantryLoa
      high_throughput={
-         OT3AxisKind.X: 1.4,
+         OT3AxisKind.X: 1.25,
          OT3AxisKind.Y: 1.4,
--        OT3AxisKind.Z: 1.4,
+-        OT3AxisKind.Z: 1.5,
 -        OT3AxisKind.P: 2.2,
 +        OT3AxisKind.Z: 1.5,
 +        OT3AxisKind.P: 0.8,

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -29,7 +29,7 @@ class MoveManager(Generic[AxisKey]):
     def update_constraints(self, constraints: SystemConstraints[AxisKey]) -> None:
         """Update system constraints when instruments are changed."""
         self._constraints = constraints
-    
+
     def get_constraints(self) -> SystemConstraints[AxisKey]:
         return self._constraints
 

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -31,6 +31,7 @@ class MoveManager(Generic[AxisKey]):
         self._constraints = constraints
 
     def get_constraints(self) -> SystemConstraints[AxisKey]:
+        """Retrieve current system constraints."""
         return self._constraints
 
     def _clear_blend_log(self) -> None:

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -29,6 +29,9 @@ class MoveManager(Generic[AxisKey]):
     def update_constraints(self, constraints: SystemConstraints[AxisKey]) -> None:
         """Update system constraints when instruments are changed."""
         self._constraints = constraints
+    
+    def get_constraints(self) -> SystemConstraints[AxisKey]:
+        return self._constraints
 
     def _clear_blend_log(self) -> None:
         """Empty the blend log."""


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fresh accelerations and speeds for FLEX gantry axes after some rigorous EE testing.
Note: gripper z axis will be updated in a later PR, as testing is still underway

On top of changing the values for the default accelerations and max speeds, EE also recommended that we use 30 mm/s as the max speed for each axis during calibration. So i added `set_system_constraints_for_calibration()` in `OT3Api` to update the system constraints in the move manager to lower the max speed, and a restore method `restore_system_constrants()` to revert it back once we're done calibrating. 

Motion setting changes requested by the EE team can be viewed [here](https://docs.google.com/presentation/d/1OlfuGUn_MCNfsENFJpg-UaeiAGT1ODlYUIoUoTEKhA8/edit#slide=id.g249d8e7cffe_0_0)