### PR TITLE
fix(api): fix thread manager definition

### DIFF
--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -99,7 +99,7 @@ if ff.enable_ot3_hardware_controller():
     def wrap_async_util_fn(fn: Any, *bind_args: Any, **bind_kwargs: Any) -> Any:
         @wraps(fn)
         def synchronizer(*args: Any, **kwargs: Any) -> Any:
-            return asyncio.get_event_loop().run_until_complete(
+            return asyncio.new_event_loop().run_until_complete(
                 fn(*bind_args, *args, **bind_kwargs, **kwargs)
             )
 

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -9,6 +9,8 @@ from functools import wraps
 import asyncio
 import logging
 from logging.config import dictConfig
+from opentrons.hardware_control.api import API
+from opentrons.hardware_control.ot3api import OT3API
 
 update_firmware = True
 has_robot_server = True
@@ -54,7 +56,6 @@ from opentrons.hardware_control.ot3_calibration import (  # noqa: E402
     find_axis_center,
     gripper_pin_offsets_mean,
 )
-from opentrons.hardware_control import HardwareControlAPI  # noqa: E402
 from opentrons.hardware_control.thread_manager import ThreadManager  # noqa: E402
 
 
@@ -83,9 +84,6 @@ LOG_CONFIG = {
         },
     },
 }
-
-from opentrons.hardware_control.api import API
-from opentrons.hardware_control.ot3api import OT3API
 
 if ff.enable_ot3_hardware_controller():
 
@@ -147,7 +145,7 @@ def build_api() -> ThreadManager[Union[API, OT3API]]:
     return tm
 
 
-def do_interact(api: ThreadManager[HardwareControlAPI]) -> None:
+def do_interact(api: ThreadManager[Union[API, OT3API]]) -> None:
     interact(
         banner=(
             "Hardware Control API REPL\nCall methods on api like "

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -84,12 +84,14 @@ LOG_CONFIG = {
     },
 }
 
+from opentrons.hardware_control.api import API
+from opentrons.hardware_control.ot3api import OT3API
+
 if ff.enable_ot3_hardware_controller():
-    from opentrons.hardware_control.ot3api import OT3API
 
-    HCApi: Union[Type[OT3API], Type["API"]] = OT3API
+    HCApi: Union[Type[OT3API], Type[API]] = OT3API
 
-    def build_thread_manager() -> ThreadManager[Union["API", OT3API]]:
+    def build_thread_manager() -> ThreadManager[Union[API, OT3API]]:
         return ThreadManager(
             OT3API.build_hardware_controller,
             use_usb_bus=ff.rear_panel_integration(),
@@ -106,7 +108,6 @@ if ff.enable_ot3_hardware_controller():
         return synchronizer
 
 else:
-    from opentrons.hardware_control.api import API
 
     HCApi = API
 
@@ -125,7 +126,7 @@ def stop_server() -> None:
     run(["systemctl", "stop", "opentrons-robot-server"])
 
 
-def build_api() -> ThreadManager[HardwareControlAPI]:
+def build_api() -> ThreadManager[Union[API, OT3API]]:
     # NOTE: We are using StreamHandler so when the hw controller is
     # being built we can log firmware update progress to stdout.
     stream_handler = logging.StreamHandler()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Attempts to address the following issue:

`Hi, we are having the following issue when trying to run calibrate_belts() from ot3repl on DVT-10 robot with ot3@0.12.0-alpha.3:`
`>>> calibrate_belts(OT3Mount.LEFT, "P50SV3420230621A01")
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/opt/opentrons-robot-server/opentrons/hardware_control/scripts/repl.py", line 102, in synchronizer
    return asyncio.get_event_loop().run_until_complete(
  File "/usr/lib/python3.8/asyncio/events.py", line 639, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'.`

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

 - [x] verify multiple calls of `calibrate_belts` method call produce accurate results without above error

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
