### PR TITLE
fix(api) Do not check tips on 96 ch yet

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1661,7 +1661,8 @@ class OT3API(
 
         # TODO: implement tip-detection sequence during pick-up-tip for 96ch,
         #       but not with DVT pipettes because those can only detect drops
-        if self._pipette_handler.get_pipette(realmount).channels.value != 96:
+
+        if self.gantry_load != GantryLoad.HIGH_THROUGHPUT:
             await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
 
         _add_tip_to_instrs()
@@ -1743,7 +1744,7 @@ class OT3API(
         )
 
         # TODO: implement tip-detection sequence during drop-tip for 96ch
-        if self._pipette_handler.get_pipette(realmount).channels.value != 96:
+        if self.gantry_load != GantryLoad.HIGH_THROUGHPUT:
             await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
         _remove()
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1659,7 +1659,7 @@ class OT3API(
         for rel_point, speed in spec.shake_off_list:
             await self.move_rel(realmount, rel_point, speed=speed)
 
-        # TODO: implement tip-detection sequence during drop-tip for 96ch,
+        # TODO: implement tip-detection sequence during pick-up-tip for 96ch,
         #       but not with DVT pipettes because those can only detect drops
         if self._pipette_handler.get_pipette(realmount).channels.value != 96:
             await self._backend.get_tip_present(realmount, TipStateType.PRESENT)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1659,7 +1659,10 @@ class OT3API(
         for rel_point, speed in spec.shake_off_list:
             await self.move_rel(realmount, rel_point, speed=speed)
 
-        await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
+        # TODO: implement tip-detection sequence during drop-tip for 96ch,
+        #       but not with DVT pipettes because those can only detect drops
+        if self._pipette_handler.get_pipette(realmount).channels.value != 96:
+            await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
 
         _add_tip_to_instrs()
 
@@ -1739,7 +1742,9 @@ class OT3API(
             }
         )
 
-        await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
+        # TODO: implement tip-detection sequence during drop-tip for 96ch
+        if self._pipette_handler.get_pipette(realmount).channels.value != 96:
+            await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
         _remove()
 
     async def clean_up(self) -> None:


### PR DESCRIPTION
# Overview
We haven't implemented the tip presence routine for the 96 channel yet, and so we need to bypass the tip presence check for now.


# Test Plan
Make sure this fixes pick up and drop tip with the 96 channel.