### PR TITLE
feat(protocol-designer, components, step-generation): update modules section to accommodate gripper

### DIFF
--- a/components/src/slotmap/SlotMap.tsx
+++ b/components/src/slotmap/SlotMap.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import cx from 'classnames'
-import { RobotType } from '@opentrons/shared-data'
+import { FLEX_ROBOT_TYPE, RobotType } from '@opentrons/shared-data'
 import { Icon } from '../icons'
 import styles from './styles.css'
 
@@ -40,7 +40,7 @@ const numCols = 3
 export function SlotMap(props: SlotMapProps): JSX.Element {
   const { collisionSlots, occupiedSlots, isError, robotType } = props
   const slots =
-    robotType === 'OT-3 Standard' ? FLEX_SLOT_MAP_SLOTS : OT2_SLOT_MAP_SLOTS
+    robotType === FLEX_ROBOT_TYPE ? FLEX_SLOT_MAP_SLOTS : OT2_SLOT_MAP_SLOTS
 
   return (
     <svg

--- a/components/src/slotmap/SlotMap.tsx
+++ b/components/src/slotmap/SlotMap.tsx
@@ -13,13 +13,21 @@ export interface SlotMapProps {
   collisionSlots?: string[]
   /** Optional error styling */
   isError?: boolean
+  isOt3?: boolean
 }
 
-const SLOT_MAP_SLOTS = [
+const OT2_SLOT_MAP_SLOTS = [
   ['10', '11'],
   ['7', '8', '9'],
   ['4', '5', '6'],
   ['1', '2', '3'],
+]
+
+const FLEX_SLOT_MAP_SLOTS = [
+  ['A1', 'A2', 'A3'],
+  ['B1', 'B2', 'B3'],
+  ['C1', 'C2', 'C3'],
+  ['D1', 'D2', 'D3'],
 ]
 
 const slotWidth = 33
@@ -29,12 +37,14 @@ const numRows = 4
 const numCols = 3
 
 export function SlotMap(props: SlotMapProps): JSX.Element {
-  const { collisionSlots, occupiedSlots, isError } = props
+  const { collisionSlots, occupiedSlots, isError, isOt3 } = props
+  const slots = isOt3 ? FLEX_SLOT_MAP_SLOTS : OT2_SLOT_MAP_SLOTS
+
   return (
     <svg
       viewBox={`-1,-1,${slotWidth * numCols + 2}, ${slotHeight * numRows + 2}`}
     >
-      {SLOT_MAP_SLOTS.flatMap((row, rowIndex) =>
+      {slots.flatMap((row, rowIndex) =>
         row.map((slot, colIndex) => {
           const isCollisionSlot =
             collisionSlots && collisionSlots.includes(slot)

--- a/components/src/slotmap/SlotMap.tsx
+++ b/components/src/slotmap/SlotMap.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import cx from 'classnames'
+import { RobotType } from '@opentrons/shared-data'
 import { Icon } from '../icons'
 import styles from './styles.css'
 
@@ -13,7 +14,7 @@ export interface SlotMapProps {
   collisionSlots?: string[]
   /** Optional error styling */
   isError?: boolean
-  isOt3?: boolean
+  robotType?: RobotType
 }
 
 const OT2_SLOT_MAP_SLOTS = [
@@ -37,8 +38,9 @@ const numRows = 4
 const numCols = 3
 
 export function SlotMap(props: SlotMapProps): JSX.Element {
-  const { collisionSlots, occupiedSlots, isError, isOt3 } = props
-  const slots = isOt3 ? FLEX_SLOT_MAP_SLOTS : OT2_SLOT_MAP_SLOTS
+  const { collisionSlots, occupiedSlots, isError, robotType } = props
+  const slots =
+    robotType === 'OT-3 Standard' ? FLEX_SLOT_MAP_SLOTS : OT2_SLOT_MAP_SLOTS
 
   return (
     <svg

--- a/components/src/slotmap/__tests__/SlotMap.test.tsx
+++ b/components/src/slotmap/__tests__/SlotMap.test.tsx
@@ -5,13 +5,13 @@ import { SlotMap } from '../SlotMap'
 import { Icon } from '../../icons'
 
 describe('SlotMap', () => {
-  it('component renders 11 slots', () => {
+  it('component renders 11 slots for ot-2', () => {
     const wrapper = shallow(<SlotMap occupiedSlots={['1']} />)
 
     expect(wrapper.find('rect')).toHaveLength(11)
   })
 
-  it('component renders crash info icon when collision slots present', () => {
+  it('component renders crash info icon when collision slots present for ot-2', () => {
     const wrapper = shallow(
       <SlotMap occupiedSlots={['1']} collisionSlots={['4']} />
     )
@@ -28,5 +28,17 @@ describe('SlotMap', () => {
     expect(wrapperDefault.find('.slot_occupied')).toHaveLength(1)
     expect(wrapperWithError.find('.slot_occupied')).toHaveLength(1)
     expect(wrapperWithError.find('.slot_occupied.slot_error')).toHaveLength(1)
+  })
+
+  it('should render 12 slots for flex', () => {
+    const wrapper = shallow(<SlotMap occupiedSlots={['D1']} isOt3={true} />)
+    expect(wrapper.find('rect')).toHaveLength(12)
+  })
+
+  it('component renders crash info icon when collision slots present for flex', () => {
+    const wrapper = shallow(
+      <SlotMap occupiedSlots={['D1']} collisionSlots={['D2']} isOt3={true} />
+    )
+    expect(wrapper.find(Icon)).toHaveLength(1)
   })
 })

--- a/components/src/slotmap/__tests__/SlotMap.test.tsx
+++ b/components/src/slotmap/__tests__/SlotMap.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { shallow } from 'enzyme'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { SlotMap } from '../SlotMap'
 import { Icon } from '../../icons'
 
@@ -32,7 +33,7 @@ describe('SlotMap', () => {
 
   it('should render 12 slots for flex', () => {
     const wrapper = shallow(
-      <SlotMap occupiedSlots={['D1']} robotType="OT-3 Standard" />
+      <SlotMap occupiedSlots={['D1']} robotType={FLEX_ROBOT_TYPE} />
     )
     expect(wrapper.find('rect')).toHaveLength(12)
   })
@@ -42,7 +43,7 @@ describe('SlotMap', () => {
       <SlotMap
         occupiedSlots={['D1']}
         collisionSlots={['D2']}
-        robotType="OT-3 Standard"
+        robotType={FLEX_ROBOT_TYPE}
       />
     )
     expect(wrapper.find(Icon)).toHaveLength(1)

--- a/components/src/slotmap/__tests__/SlotMap.test.tsx
+++ b/components/src/slotmap/__tests__/SlotMap.test.tsx
@@ -31,13 +31,19 @@ describe('SlotMap', () => {
   })
 
   it('should render 12 slots for flex', () => {
-    const wrapper = shallow(<SlotMap occupiedSlots={['D1']} isOt3={true} />)
+    const wrapper = shallow(
+      <SlotMap occupiedSlots={['D1']} robotType="OT-3 Standard" />
+    )
     expect(wrapper.find('rect')).toHaveLength(12)
   })
 
   it('component renders crash info icon when collision slots present for flex', () => {
     const wrapper = shallow(
-      <SlotMap occupiedSlots={['D1']} collisionSlots={['D2']} isOt3={true} />
+      <SlotMap
+        occupiedSlots={['D1']}
+        collisionSlots={['D2']}
+        robotType="OT-3 Standard"
+      />
     )
     expect(wrapper.find(Icon)).toHaveLength(1)
   })

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -432,7 +432,7 @@ export const DeckSetup = (): JSX.Element => {
   })
 
   return (
-    <React.Fragment>
+    <>
       <div className={styles.deck_row}>
         {drilledDown && <BrowseLabwareModal />}
         <div ref={wrapperRef} className={styles.deck_wrapper}>
@@ -458,7 +458,7 @@ export const DeckSetup = (): JSX.Element => {
           </RobotWorkSpace>
         </div>
       </div>
-    </React.Fragment>
+    </>
   )
 }
 

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -432,33 +432,31 @@ export const DeckSetup = (): JSX.Element => {
   })
 
   return (
-    <>
-      <div className={styles.deck_row}>
-        {drilledDown && <BrowseLabwareModal />}
-        <div ref={wrapperRef} className={styles.deck_wrapper}>
-          <RobotWorkSpace
-            deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
-            deckDef={deckDef}
-            viewBox={robotType === OT2_ROBOT_TYPE ? OT2_VIEWBOX : FLEX_VIEWBOX}
-            width="100%"
-            height="100%"
-          >
-            {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
-              <DeckSetupContents
-                activeDeckSetup={activeDeckSetup}
-                selectedTerminalItemId={selectedTerminalItemId}
-                {...{
-                  deckDef,
-                  deckSlotsById,
-                  getRobotCoordsFromDOMCoords,
-                  showGen1MultichannelCollisionWarnings,
-                }}
-              />
-            )}
-          </RobotWorkSpace>
-        </div>
+    <div className={styles.deck_row}>
+      {drilledDown && <BrowseLabwareModal />}
+      <div ref={wrapperRef} className={styles.deck_wrapper}>
+        <RobotWorkSpace
+          deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
+          deckDef={deckDef}
+          viewBox={robotType === OT2_ROBOT_TYPE ? OT2_VIEWBOX : FLEX_VIEWBOX}
+          width="100%"
+          height="100%"
+        >
+          {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
+            <DeckSetupContents
+              activeDeckSetup={activeDeckSetup}
+              selectedTerminalItemId={selectedTerminalItemId}
+              {...{
+                deckDef,
+                deckSlotsById,
+                getRobotCoordsFromDOMCoords,
+                showGen1MultichannelCollisionWarnings,
+              }}
+            />
+          )}
+        </RobotWorkSpace>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import {
   DeprecatedPrimaryButton,
@@ -9,8 +8,6 @@ import {
 } from '@opentrons/components'
 import { i18n } from '../../localization'
 import { resetScrollElements } from '../../ui/steps/utils'
-import { getRobotType } from '../../file-data/selectors'
-import { getAdditionalEquipment } from '../../step-forms/selectors'
 import { Portal } from '../portals/MainPageModalPortal'
 import { useBlockingHint } from '../Hints/useBlockingHint'
 import { KnowledgeBaseLink } from '../KnowledgeBaseLink'
@@ -25,7 +22,11 @@ import type {
   ModuleOnDeck,
   PipetteOnDeck,
 } from '../../step-forms'
-import type { CreateCommand, ProtocolFile } from '@opentrons/shared-data'
+import type {
+  CreateCommand,
+  ProtocolFile,
+  RobotType,
+} from '@opentrons/shared-data'
 
 export interface Props {
   loadFile: (event: React.ChangeEvent<HTMLInputElement>) => unknown
@@ -36,6 +37,15 @@ export interface Props {
   pipettesOnDeck: InitialDeckSetup['pipettes']
   modulesOnDeck: InitialDeckSetup['modules']
   savedStepForms: SavedStepFormState
+  robotType: RobotType
+  additionalEquipment: AdditionalEquipment
+}
+
+export interface AdditionalEquipment {
+  [additionalEquipmentId: string]: {
+    name: 'gripper'
+    id: string
+  }
 }
 
 interface WarningContent {
@@ -176,13 +186,13 @@ export function FileSidebar(props: Props): JSX.Element {
     modulesOnDeck,
     pipettesOnDeck,
     savedStepForms,
+    robotType,
+    additionalEquipment,
   } = props
   const [
     showExportWarningModal,
     setShowExportWarningModal,
   ] = React.useState<boolean>(false)
-  const robotType = useSelector(getRobotType)
-  const additionalEquipment = useSelector(getAdditionalEquipment)
   const isGripperAttached = Object.values(additionalEquipment).some(
     equipment => equipment?.name === 'gripper'
   )
@@ -214,6 +224,7 @@ export function FileSidebar(props: Props): JSX.Element {
     robotType
   )
 
+  //  TODO(jr, 6/22/23): need to refactor when the gripper toggle is wired up
   const gripperWithoutStep = isGripperAttached && !hasMoveLabware
 
   const hasWarning =

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -206,9 +206,12 @@ export function FileSidebar(props: Props): JSX.Element {
       command => !LOAD_COMMANDS.includes(command.commandType)
     ) ?? []
 
-  const hasMoveLabware =
-    fileData?.commands.find(command => command.commandType === 'moveLabware') !=
-    null
+  const gripperInUse =
+    fileData?.commands.find(
+      command =>
+        command.commandType === 'moveLabware' &&
+        command.params.strategy === 'usingGripper'
+    ) != null
 
   const noCommands = fileData ? nonLoadCommands.length === 0 : true
   const pipettesWithoutStep = getUnusedEntities(
@@ -224,8 +227,7 @@ export function FileSidebar(props: Props): JSX.Element {
     robotType
   )
 
-  //  TODO(jr, 6/22/23): need to refactor when the gripper toggle is wired up
-  const gripperWithoutStep = isGripperAttached && !hasMoveLabware
+  const gripperWithoutStep = isGripperAttached && !gripperInUse
 
   const hasWarning =
     noCommands ||

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -15,10 +15,12 @@ import {
   fixtureP300Single,
 } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
-import { FileSidebar, v6WarningContent } from '../FileSidebar'
 import { useBlockingHint } from '../../Hints/useBlockingHint'
+import { FileSidebar, v6WarningContent } from '../FileSidebar'
 
 jest.mock('../../Hints/useBlockingHint')
+jest.mock('../../../file-data/selectors')
+jest.mock('../../../step-forms/selectors')
 
 const mockUseBlockingHint = useBlockingHint as jest.MockedFunction<
   typeof useBlockingHint
@@ -50,6 +52,8 @@ describe('FileSidebar', () => {
       pipettesOnDeck: {},
       modulesOnDeck: {},
       savedStepForms: {},
+      robotType: 'OT-2 Standard',
+      additionalEquipment: {},
     }
 
     commands = [
@@ -94,7 +98,6 @@ describe('FileSidebar', () => {
   afterEach(() => {
     jest.resetAllMocks()
   })
-
   it('create new button creates new protocol', () => {
     const wrapper = shallow(<FileSidebar {...props} />)
     const createButton = wrapper.find(OutlineButton).at(0)
@@ -152,6 +155,25 @@ describe('FileSidebar', () => {
     expect(alertModal.html()).not.toContain(
       pipettesOnDeck.pipetteLeftId.spec.displayName
     )
+  })
+
+  it('warning modal is shown when export is clicked with unused gripper', () => {
+    const gripperId = 'gripperId'
+    props.modulesOnDeck = modulesOnDeck
+    props.savedStepForms = savedStepForms
+    // @ts-expect-error(sa, 2021-6-22): props.fileData might be null
+    props.fileData.commands = commands
+    props.additionalEquipment = {
+      [gripperId]: { name: 'gripper', id: gripperId },
+    }
+
+    const wrapper = shallow(<FileSidebar {...props} />)
+    const downloadButton = wrapper.find(DeprecatedPrimaryButton).at(0)
+    downloadButton.simulate('click')
+    const alertModal = wrapper.find(AlertModal)
+
+    expect(alertModal).toHaveLength(1)
+    expect(alertModal.prop('heading')).toEqual('Unused gripper')
   })
 
   it('warning modal is shown when export is clicked with unused module', () => {

--- a/protocol-designer/src/components/FileSidebar/index.ts
+++ b/protocol-designer/src/components/FileSidebar/index.ts
@@ -3,11 +3,18 @@ import { i18n } from '../../localization'
 import { actions, selectors } from '../../navigation'
 import { selectors as fileDataSelectors } from '../../file-data'
 import { selectors as stepFormSelectors } from '../../step-forms'
+import { getRobotType } from '../../file-data/selectors'
+import { getAdditionalEquipment } from '../../step-forms/selectors'
 import {
   actions as loadFileActions,
   selectors as loadFileSelectors,
 } from '../../load-file'
-import { FileSidebar as FileSidebarComponent, Props } from './FileSidebar'
+import {
+  AdditionalEquipment,
+  FileSidebar as FileSidebarComponent,
+  Props,
+} from './FileSidebar'
+import type { RobotType } from '@opentrons/shared-data'
 import type { BaseState, ThunkDispatch } from '../../types'
 import type { SavedStepFormState, InitialDeckSetup } from '../../step-forms'
 
@@ -19,6 +26,8 @@ interface SP {
   pipettesOnDeck: InitialDeckSetup['pipettes']
   modulesOnDeck: InitialDeckSetup['modules']
   savedStepForms: SavedStepFormState
+  robotType: RobotType
+  additionalEquipment: AdditionalEquipment
 }
 export const FileSidebar = connect(
   mapStateToProps,
@@ -31,12 +40,17 @@ function mapStateToProps(state: BaseState): SP {
   const fileData = fileDataSelectors.createFile(state)
   const canDownload = selectors.getCurrentPage(state) !== 'file-splash'
   const initialDeckSetup = stepFormSelectors.getInitialDeckSetup(state)
+  const robotType = getRobotType(state)
+  const additionalEquipment = getAdditionalEquipment(state)
+
   return {
     canDownload,
     fileData,
     pipettesOnDeck: initialDeckSetup.pipettes,
     modulesOnDeck: initialDeckSetup.modules,
     savedStepForms: stepFormSelectors.getSavedStepForms(state),
+    robotType: robotType,
+    additionalEquipment: additionalEquipment,
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
@@ -57,6 +71,8 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
+    robotType,
+    additionalEquipment,
   } = stateProps
   const { dispatch } = dispatchProps
   return {
@@ -77,5 +93,7 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
+    robotType,
+    additionalEquipment,
   }
 }

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedEntities.test.ts
@@ -8,6 +8,8 @@ import {
   TEMPERATURE_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
   TEMPERATURE_MODULE_V1,
+  MAGNETIC_BLOCK_TYPE,
+  MAGNETIC_BLOCK_V1,
 } from '@opentrons/shared-data'
 import { TEMPERATURE_DEACTIVATED } from '@opentrons/step-generation'
 import { SavedStepFormState } from '../../../../step-forms'
@@ -41,7 +43,12 @@ describe('getUnusedEntities', () => {
       },
     }
 
-    const result = getUnusedEntities(pipettesOnDeck, stepForms, 'pipette')
+    const result = getUnusedEntities(
+      pipettesOnDeck,
+      stepForms,
+      'pipette',
+      'OT-2 Standard'
+    )
 
     expect(result).toEqual([pipettesOnDeck.pipette456])
   })
@@ -82,7 +89,58 @@ describe('getUnusedEntities', () => {
       },
     }
 
-    const result = getUnusedEntities(modulesOnDeck, stepForms, 'moduleId')
+    const result = getUnusedEntities(
+      modulesOnDeck,
+      stepForms,
+      'moduleId',
+      'OT-2 Standard'
+    )
+
+    expect(result).toEqual([modulesOnDeck.temperature456])
+  })
+
+  it('filters out magnetic block and shows module entities not used in steps are returned for Flex', () => {
+    const stepForms: SavedStepFormState = {
+      step123: {
+        moduleId: 'magnet123',
+        id: 'step123',
+        magnetAction: 'engage',
+        engageHeight: '10',
+        stepType: 'magnet',
+        stepName: 'magnet',
+        stepDetails: '',
+      },
+    }
+    const modulesOnDeck = {
+      magnet123: {
+        id: 'magnet123',
+        type: MAGNETIC_BLOCK_TYPE,
+        model: MAGNETIC_BLOCK_V1,
+        slot: '3',
+        moduleState: {
+          type: MAGNETIC_BLOCK_TYPE,
+          engaged: false,
+        },
+      },
+      temperature456: {
+        id: 'temperature456',
+        type: TEMPERATURE_MODULE_TYPE,
+        model: TEMPERATURE_MODULE_V1,
+        moduleState: {
+          type: TEMPERATURE_MODULE_TYPE,
+          status: TEMPERATURE_DEACTIVATED,
+          targetTemperature: null,
+        },
+        slot: '9',
+      },
+    }
+
+    const result = getUnusedEntities(
+      modulesOnDeck,
+      stepForms,
+      'moduleId',
+      'OT-3 Standard'
+    )
 
     expect(result).toEqual([modulesOnDeck.temperature456])
   })

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedEntities.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedEntities.ts
@@ -1,23 +1,35 @@
 import some from 'lodash/some'
 import reduce from 'lodash/reduce'
+import type { RobotType } from '@opentrons/shared-data'
 import type { SavedStepFormState } from '../../../step-forms'
 
 /** Pull out all entities never specified by step forms. Assumes that all forms share the entityKey */
 export function getUnusedEntities<T>(
   entities: Record<string, T>,
   stepForms: SavedStepFormState,
-  entityKey: 'pipette' | 'moduleId'
+  entityKey: 'pipette' | 'moduleId',
+  robotType: RobotType
 ): T[] {
-  const a = reduce(
+  const unusedEntities = reduce(
     entities,
     (acc, entity: T, entityId): T[] => {
       const stepContainsEntity = some(
         stepForms,
         form => form[entityKey] === entityId
       )
+
+      if (
+        robotType === 'OT-3 Standard' &&
+        entityKey === 'moduleId' &&
+        (entity as any).type === 'magneticBlockType'
+      ) {
+        return acc
+      }
+
       return stepContainsEntity ? acc : [...acc, entity]
     },
     [] as T[]
   )
-  return a
+
+  return unusedEntities
 }

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedEntities.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedEntities.ts
@@ -1,6 +1,6 @@
 import some from 'lodash/some'
 import reduce from 'lodash/reduce'
-import type { RobotType } from '@opentrons/shared-data'
+import { FLEX_ROBOT_TYPE, RobotType } from '@opentrons/shared-data'
 import type { SavedStepFormState } from '../../../step-forms'
 
 /** Pull out all entities never specified by step forms. Assumes that all forms share the entityKey */
@@ -19,7 +19,7 @@ export function getUnusedEntities<T>(
       )
 
       if (
-        robotType === 'OT-3 Standard' &&
+        robotType === FLEX_ROBOT_TYPE &&
         entityKey === 'moduleId' &&
         (entity as any).type === 'magneticBlockType'
       ) {

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLabwareForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLabwareForm/index.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react'
-import { FormGroup } from '@opentrons/components'
+import { useSelector } from 'react-redux'
+import {
+  FormGroup,
+  Tooltip,
+  TOOLTIP_BOTTOM,
+  TOOLTIP_FIXED,
+  useHoverTooltip,
+} from '@opentrons/components'
 import { i18n } from '../../../../localization'
 import {
   LabwareField,
@@ -7,10 +14,22 @@ import {
   LabwareLocationField,
 } from '../../fields'
 import styles from '../../StepEditForm.css'
-import type { StepFormProps } from '../../types'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import { getRobotType } from '../../../../file-data/selectors'
+import { getAdditionalEquipment } from '../../../../step-forms/selectors'
+import { StepFormProps } from '../../types'
 
 export const MoveLabwareForm = (props: StepFormProps): JSX.Element => {
   const { propsForFields } = props
+  const robotType = useSelector(getRobotType)
+  const additionalEquipment = useSelector(getAdditionalEquipment)
+  const isGripperAttached = Object.values(additionalEquipment).some(
+    equipment => equipment?.name === 'gripper'
+  )
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_BOTTOM,
+    strategy: TOOLTIP_FIXED,
+  })
 
   return (
     <div className={styles.form_wrapper}>
@@ -26,16 +45,34 @@ export const MoveLabwareForm = (props: StepFormProps): JSX.Element => {
         >
           <LabwareField {...propsForFields.labware} />
         </FormGroup>
-        <FormGroup
-          className={styles.small_field}
-          label={i18n.t('form.step_edit_form.field.useGripper.label')}
-        >
-          <ToggleRowField
-            {...propsForFields.useGripper}
-            offLabel={i18n.t('form.step_edit_form.field.useGripper.toggleOff')}
-            onLabel={i18n.t('form.step_edit_form.field.useGripper.toggleOn')}
-          />
-        </FormGroup>
+        {robotType === FLEX_ROBOT_TYPE ? (
+          <>
+            {!isGripperAttached ? (
+              <Tooltip {...tooltipProps}>
+                {i18n.t(
+                  'tooltip.step_fields.moveLabware.disabled.gripper_not_used'
+                )}
+              </Tooltip>
+            ) : null}
+            <div {...targetProps}>
+              <FormGroup
+                className={styles.small_field}
+                label={i18n.t('form.step_edit_form.field.useGripper.label')}
+              >
+                <ToggleRowField
+                  {...propsForFields.useGripper}
+                  disabled={!isGripperAttached}
+                  offLabel={i18n.t(
+                    'form.step_edit_form.field.useGripper.toggleOff'
+                  )}
+                  onLabel={i18n.t(
+                    'form.step_edit_form.field.useGripper.toggleOn'
+                  )}
+                />
+              </FormGroup>
+            </div>
+          </>
+        ) : null}
       </div>
       <div className={styles.form_row}>
         <FormGroup

--- a/protocol-designer/src/components/__tests__/FilePage.test.tsx
+++ b/protocol-designer/src/components/__tests__/FilePage.test.tsx
@@ -6,6 +6,7 @@ import { FilePage, Props } from '../FilePage'
 import { EditModules } from '../EditModules'
 import { EditModulesCard } from '../modules'
 import { ModulesForEditModulesCard } from '../../step-forms'
+import { getAdditionalEquipment } from '../../step-forms/selectors'
 
 jest.mock('../EditModules')
 jest.mock('../../step-forms/utils')
@@ -14,6 +15,7 @@ jest.mock('../../feature-flags')
 jest.mock('../../file-data/selectors')
 
 const editModulesMock: jest.MockedFunction<any> = EditModules
+const editGetAdditionalEquipment: jest.MockedFunction<any> = getAdditionalEquipment
 
 describe('File Page', () => {
   let props: Props
@@ -33,6 +35,7 @@ describe('File Page', () => {
       getState: () => ({ mock: 'this is a mocked out getState' }),
     }
     editModulesMock.mockImplementation(() => <div>mock edit modules</div>)
+    editGetAdditionalEquipment.mockReturnValue({})
   })
 
   const render = (props: Props) =>

--- a/protocol-designer/src/components/modals/CreateFileWizard/MetadataTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/MetadataTile.tsx
@@ -14,9 +14,9 @@ import {
 } from '@opentrons/components'
 import { InputField } from './InputField'
 import { GoBackLink } from './GoBackLink'
+import { HandleEnter } from './HandleEnter'
 
 import type { WizardTileProps } from './types'
-import { HandleEnter } from './HandleEnter'
 
 export function MetadataTile(props: WizardTileProps): JSX.Element {
   const { i18n, t } = useTranslation()

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -50,6 +50,7 @@ import { WizardHeader } from './WizardHeader'
 
 import type { NormalizedPipette } from '@opentrons/step-generation'
 import type { FormState } from './types'
+import { toggleIsGripperRequired } from '../../../step-forms/actions/additionalItems'
 
 type WizardStep =
   | 'robotType'
@@ -183,6 +184,11 @@ export function CreateFileWizard(): JSX.Element | null {
       modules.forEach(moduleArgs =>
         dispatch(stepFormActions.createModule(moduleArgs))
       )
+      // add gripper
+      if (values.additionalEquipment.includes('gripper')) {
+        dispatch(toggleIsGripperRequired())
+        console.log(values.additionalEquipment)
+      }
       // auto-generate tipracks for pipettes
       const newTiprackModels: string[] = uniq(
         pipettes.map(pipette => pipette.tiprackDefURI)

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -41,6 +41,7 @@ import * as labwareDefSelectors from '../../../labware-defs/selectors'
 import * as labwareDefActions from '../../../labware-defs/actions'
 import * as labwareIngredActions from '../../../labware-ingred/actions'
 import { actions as steplistActions } from '../../../steplist'
+import { toggleIsGripperRequired } from '../../../step-forms/actions/additionalItems'
 import { RobotTypeTile } from './RobotTypeTile'
 import { MetadataTile } from './MetadataTile'
 import { FirstPipetteTypeTile, SecondPipetteTypeTile } from './PipetteTypeTile'
@@ -50,7 +51,6 @@ import { WizardHeader } from './WizardHeader'
 
 import type { NormalizedPipette } from '@opentrons/step-generation'
 import type { FormState } from './types'
-import { toggleIsGripperRequired } from '../../../step-forms/actions/additionalItems'
 
 type WizardStep =
   | 'robotType'
@@ -187,7 +187,6 @@ export function CreateFileWizard(): JSX.Element | null {
       // add gripper
       if (values.additionalEquipment.includes('gripper')) {
         dispatch(toggleIsGripperRequired())
-        console.log(values.additionalEquipment)
       }
       // auto-generate tipracks for pipettes
       const newTiprackModels: string[] = uniq(

--- a/protocol-designer/src/components/modals/CreateFileWizard/types.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/types.ts
@@ -6,7 +6,7 @@ import type {
 
 import type { NewProtocolFields } from '../../../load-file'
 
-type AdditionalEquipment = 'gripper'
+export type AdditionalEquipment = 'gripper'
 
 export interface FormState {
   fields: NewProtocolFields

--- a/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
@@ -1,24 +1,25 @@
 import * as React from 'react'
 import { useField } from 'formik'
 import { SlotMap } from '@opentrons/components'
+import { RobotType } from '@opentrons/shared-data'
 import styles from './EditModules.css'
 
 interface ConnectedSlotMapProps {
   fieldName: string
-  isOt3: boolean
+  robotType: RobotType
 }
 
 export const ConnectedSlotMap = (
   props: ConnectedSlotMapProps
 ): JSX.Element | null => {
-  const { fieldName, isOt3 } = props
+  const { fieldName, robotType } = props
   const [field, meta] = useField(fieldName)
   return field.value ? (
     <div className={styles.slot_map_container}>
       <SlotMap
         occupiedSlots={[`${field.value}`]}
         isError={Boolean(meta.error)}
-        isOt3={isOt3}
+        robotType={robotType}
       />
     </div>
   ) : null

--- a/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
@@ -5,18 +5,20 @@ import styles from './EditModules.css'
 
 interface ConnectedSlotMapProps {
   fieldName: string
+  isOt3: boolean
 }
 
 export const ConnectedSlotMap = (
   props: ConnectedSlotMapProps
 ): JSX.Element | null => {
-  const { fieldName } = props
+  const { fieldName, isOt3 } = props
   const [field, meta] = useField(fieldName)
   return field.value ? (
     <div className={styles.slot_map_container}>
       <SlotMap
         occupiedSlots={[`${field.value}`]}
         isError={Boolean(meta.error)}
+        isOt3={isOt3}
       />
     </div>
   ) : null

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
@@ -30,6 +30,7 @@ import {
 import * as moduleData from '../../../../modules/moduleData'
 import { MODELS_FOR_MODULE_TYPE } from '../../../../constants'
 import { selectors as featureSelectors } from '../../../../feature-flags'
+import { getRobotType } from '../../../../file-data/selectors'
 import { getLabwareIsCompatible } from '../../../../utils/labwareModuleCompatibility'
 import { isModuleWithCollisionIssue } from '../../../modules/utils'
 import { PDAlert } from '../../../alerts/PDAlert'
@@ -51,6 +52,7 @@ jest.mock('../../../../step-forms/selectors')
 jest.mock('../../../modules/utils')
 jest.mock('../../../../step-forms/utils')
 jest.mock('../form-state')
+jest.mock('../../../../file-data/selectors')
 
 const MODEL_FIELD = 'selectedModel'
 const SLOT_FIELD = 'selectedSlot'
@@ -73,10 +75,13 @@ const getLabwareOnSlotMock: jest.MockedFunction<any> = getLabwareOnSlot
 
 const getIsLabwareAboveHeightMock: jest.MockedFunction<any> = getIsLabwareAboveHeight
 
+const getRobotTypeMock: jest.MockedFunction<any> = getRobotType
+
 describe('Edit Modules Modal', () => {
   let mockStore: any
   let props: EditModulesModalProps
   beforeEach(() => {
+    getRobotTypeMock.mockReturnValue('OT-2 Standard')
     getInitialDeckSetupMock.mockReturnValue(getMockDeckSetup())
     getSlotIdsBlockedBySpanningMock.mockReturnValue([])
     getLabwareOnSlotMock.mockReturnValue({})

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -18,6 +18,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   ModuleType,
   ModuleModel,
+  OT2_STANDARD_MODEL,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import {
@@ -79,7 +80,7 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
   } = props
   const robotType = useSelector(getRobotType)
   const supportedModuleSlot =
-    robotType === 'OT-2 Standard'
+    robotType === OT2_STANDARD_MODEL
       ? SUPPORTED_MODULE_SLOTS_OT2[moduleType][0].value
       : SUPPORTED_MODULE_SLOTS_FLEX[moduleType][0].value
   const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
@@ -295,7 +296,7 @@ const EditModulesModalComponent = (
 
                 <ConnectedSlotMap
                   fieldName="selectedSlot"
-                  isOt3={robotType === 'OT-3 Standard'}
+                  robotType={robotType}
                 />
               </>
             )}

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -31,7 +31,8 @@ import {
   actions as stepFormActions,
 } from '../../../step-forms'
 import {
-  SUPPORTED_MODULE_SLOTS,
+  SUPPORTED_MODULE_SLOTS_OT2,
+  SUPPORTED_MODULE_SLOTS_FLEX,
   getAllModuleSlotsByType,
 } from '../../../modules/moduleData'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
@@ -47,6 +48,7 @@ import { useResetSlotOnModelChange } from './form-state'
 
 import { ModuleOnDeck } from '../../../step-forms/types'
 import { ModelModuleInfo } from '../../EditModules'
+import { getRobotType } from '../../../file-data/selectors'
 
 export interface EditModulesModalProps {
   moduleType: ModuleType
@@ -75,7 +77,11 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
     onCloseClick,
     moduleOnDeck,
   } = props
-  const supportedModuleSlot = SUPPORTED_MODULE_SLOTS[moduleType][0].value
+  const robotType = useSelector(getRobotType)
+  const supportedModuleSlot =
+    robotType === 'OT-2 Standard'
+      ? SUPPORTED_MODULE_SLOTS_OT2[moduleType][0].value
+      : SUPPORTED_MODULE_SLOTS_FLEX[moduleType][0].value
   const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const dispatch = useDispatch()
 
@@ -222,6 +228,7 @@ const EditModulesModalComponent = (
   const disabledModuleRestriction = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
+  const robotType = useSelector(getRobotType)
 
   const noCollisionIssue =
     selectedModel && !isModuleWithCollisionIssue(selectedModel)
@@ -278,15 +285,18 @@ const EditModulesModalComponent = (
                 <div {...targetProps} className={styles.option_slot}>
                   <FormGroup label="Position">
                     <SlotDropdown
-                      fieldName={'selectedSlot'}
-                      options={getAllModuleSlotsByType(moduleType)}
+                      fieldName="selectedSlot"
+                      options={getAllModuleSlotsByType(moduleType, robotType)}
                       disabled={!enableSlotSelection}
                       tabIndex={1}
                     />
                   </FormGroup>
                 </div>
 
-                <ConnectedSlotMap fieldName={'selectedSlot'} />
+                <ConnectedSlotMap
+                  fieldName="selectedSlot"
+                  isOt3={robotType === 'OT-3 Standard'}
+                />
               </>
             )}
           </div>

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -19,6 +19,7 @@ import { SUPPORTED_MODULE_TYPES } from '../../modules'
 import { getRobotType } from '../../file-data/selectors'
 import { CrashInfoBox } from './CrashInfoBox'
 import { ModuleRow } from './ModuleRow'
+import { GripperRow } from './GripperRow'
 import { isModuleWithCollisionIssue } from './utils'
 import styles from './styles.css'
 
@@ -29,12 +30,12 @@ export interface Props {
 
 export function EditModulesCard(props: Props): JSX.Element {
   const { modules, openEditModuleModal } = props
-
   const pipettesByMount = useSelector(
     stepFormSelectors.getPipettesForEditPipetteForm
   )
   const robotType = useSelector(getRobotType)
-
+  // const savedStepForms = useSelector(getSavedStepForms)
+  // const additionalEquipment = savedStepForms.additionalEquipment
   const magneticModuleOnDeck = modules[MAGNETIC_MODULE_TYPE]
   const temperatureModuleOnDeck = modules[TEMPERATURE_MODULE_TYPE]
   const heaterShakerOnDeck = modules[HEATERSHAKER_MODULE_TYPE]
@@ -67,18 +68,19 @@ export function EditModulesCard(props: Props): JSX.Element {
     ].some(pipetteSpecs => pipetteSpecs?.channels !== 1)
 
   const warningsEnabled = !moduleRestrictionsDisabled
+  const isOt3 = robotType === 'OT-3 Standard'
 
   const SUPPORTED_MODULE_TYPES_FILTERED = SUPPORTED_MODULE_TYPES.filter(
     moduleType =>
-      robotType === 'OT-3 Standard'
+      isOt3
         ? moduleType !== 'magneticModuleType'
         : moduleType !== 'magneticBlockType'
   )
 
   return (
-    <Card title="Modules">
+    <Card title={isOt3 ? 'Additional Items' : 'Modules'}>
       <div className={styles.modules_card_content}>
-        {warningsEnabled && (
+        {warningsEnabled && !isOt3 && (
           <CrashInfoBox
             showMagPipetteCollisons={showMagPipetteCollisons}
             showTempPipetteCollisons={showTempPipetteCollisons}
@@ -99,6 +101,7 @@ export function EditModulesCard(props: Props): JSX.Element {
                 showCollisionWarnings={warningsEnabled}
                 key={i}
                 openEditModuleModal={openEditModuleModal}
+                isOt3={isOt3}
               />
             )
           } else {
@@ -111,6 +114,12 @@ export function EditModulesCard(props: Props): JSX.Element {
             )
           }
         })}
+        {isOt3 ? (
+          <GripperRow
+            handleAddGripper={() => console.log('wire this up')}
+            isGripperAdded={true}
+          />
+        ) : null}
       </div>
     </Card>
   )

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -8,6 +8,7 @@ import {
   ModuleType,
   PipetteName,
   getPipetteNameSpecs,
+  FLEX_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import {
   selectors as stepFormSelectors,
@@ -75,11 +76,11 @@ export function EditModulesCard(props: Props): JSX.Element {
     ].some(pipetteSpecs => pipetteSpecs?.channels !== 1)
 
   const warningsEnabled = !moduleRestrictionsDisabled
-  const isOt3 = robotType === 'OT-3 Standard'
+  const isFlex = robotType === FLEX_ROBOT_TYPE
 
   const SUPPORTED_MODULE_TYPES_FILTERED = SUPPORTED_MODULE_TYPES.filter(
     moduleType =>
-      isOt3
+      isFlex
         ? moduleType !== 'magneticModuleType'
         : moduleType !== 'magneticBlockType'
   )
@@ -88,9 +89,9 @@ export function EditModulesCard(props: Props): JSX.Element {
     dispatch(toggleIsGripperRequired())
   }
   return (
-    <Card title={isOt3 ? 'Additional Items' : 'Modules'}>
+    <Card title={isFlex ? 'Additional Items' : 'Modules'}>
       <div className={styles.modules_card_content}>
-        {warningsEnabled && !isOt3 && (
+        {warningsEnabled && !isFlex && (
           <CrashInfoBox
             showMagPipetteCollisons={showMagPipetteCollisons}
             showTempPipetteCollisons={showTempPipetteCollisons}
@@ -111,7 +112,7 @@ export function EditModulesCard(props: Props): JSX.Element {
                 showCollisionWarnings={warningsEnabled}
                 key={i}
                 openEditModuleModal={openEditModuleModal}
-                isOt3={isOt3}
+                robotType={robotType}
               />
             )
           } else {
@@ -124,7 +125,7 @@ export function EditModulesCard(props: Props): JSX.Element {
             )
           }
         })}
-        {isOt3 ? (
+        {isFlex ? (
           <GripperRow
             handleGripper={handleGripperClick}
             isGripperAdded={isGripperAttached}

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { Card } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
@@ -16,6 +16,8 @@ import {
 } from '../../step-forms'
 import { selectors as featureFlagSelectors } from '../../feature-flags'
 import { SUPPORTED_MODULE_TYPES } from '../../modules'
+import { getAdditionalEquipment } from '../../step-forms/selectors'
+import { toggleIsGripperRequired } from '../../step-forms/actions/additionalItems'
 import { getRobotType } from '../../file-data/selectors'
 import { CrashInfoBox } from './CrashInfoBox'
 import { ModuleRow } from './ModuleRow'
@@ -33,9 +35,14 @@ export function EditModulesCard(props: Props): JSX.Element {
   const pipettesByMount = useSelector(
     stepFormSelectors.getPipettesForEditPipetteForm
   )
+  const additionalEquipment = useSelector(getAdditionalEquipment)
+  const isGripperAttached = Object.values(additionalEquipment).some(
+    equipment => equipment?.name === 'gripper'
+  )
+
+  const dispatch = useDispatch()
   const robotType = useSelector(getRobotType)
-  // const savedStepForms = useSelector(getSavedStepForms)
-  // const additionalEquipment = savedStepForms.additionalEquipment
+
   const magneticModuleOnDeck = modules[MAGNETIC_MODULE_TYPE]
   const temperatureModuleOnDeck = modules[TEMPERATURE_MODULE_TYPE]
   const heaterShakerOnDeck = modules[HEATERSHAKER_MODULE_TYPE]
@@ -77,6 +84,9 @@ export function EditModulesCard(props: Props): JSX.Element {
         : moduleType !== 'magneticBlockType'
   )
 
+  const handleGripperClick = (): void => {
+    dispatch(toggleIsGripperRequired())
+  }
   return (
     <Card title={isOt3 ? 'Additional Items' : 'Modules'}>
       <div className={styles.modules_card_content}>
@@ -116,8 +126,8 @@ export function EditModulesCard(props: Props): JSX.Element {
         })}
         {isOt3 ? (
           <GripperRow
-            handleAddGripper={() => console.log('wire this up')}
-            isGripperAdded={true}
+            handleGripper={handleGripperClick}
+            isGripperAdded={isGripperAttached}
           />
         ) : null}
       </div>

--- a/protocol-designer/src/components/modules/GripperRow.tsx
+++ b/protocol-designer/src/components/modules/GripperRow.tsx
@@ -10,12 +10,12 @@ import gripperImage from '../../images/flex_gripper.svg'
 import styles from './styles.css'
 
 interface GripperRowProps {
-  handleAddGripper: () => void
+  handleGripper: () => void
   isGripperAdded: boolean
 }
 
 export function GripperRow(props: GripperRowProps): JSX.Element {
-  const { handleAddGripper, isGripperAdded } = props
+  const { handleGripper, isGripperAdded } = props
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
@@ -27,10 +27,7 @@ export function GripperRow(props: GripperRowProps): JSX.Element {
         className={styles.modules_button_group}
         style={{ alignSelf: ALIGN_CENTER }}
       >
-        <OutlineButton
-          className={styles.module_button}
-          onClick={handleAddGripper}
-        >
+        <OutlineButton className={styles.module_button} onClick={handleGripper}>
           {isGripperAdded ? 'Remove' : 'Add'}
         </OutlineButton>
       </div>

--- a/protocol-designer/src/components/modules/GripperRow.tsx
+++ b/protocol-designer/src/components/modules/GripperRow.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import {
+  OutlineButton,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  ALIGN_CENTER,
+} from '@opentrons/components'
+import gripperImage from '../../images/flex_gripper.svg'
+import styles from './styles.css'
+
+interface GripperRowProps {
+  handleAddGripper: () => void
+  isGripperAdded: boolean
+}
+
+export function GripperRow(props: GripperRowProps): JSX.Element {
+  const { handleAddGripper, isGripperAdded } = props
+
+  return (
+    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <Flex flexDirection="column">
+        <h4 className={styles.row_title}>{'Flex Gripper'}</h4>
+        <AdditionalItemImage src={gripperImage} alt="Opentrons Flex Gripper" />
+      </Flex>
+      <div
+        className={styles.modules_button_group}
+        style={{ alignSelf: ALIGN_CENTER }}
+      >
+        <OutlineButton
+          className={styles.module_button}
+          onClick={handleAddGripper}
+        >
+          {isGripperAdded ? 'Remove' : 'Add'}
+        </OutlineButton>
+      </div>
+    </Flex>
+  )
+}
+
+const AdditionalItemImage = styled.img`
+  width: 6rem;
+  max-height: 4rem;
+  display: block;
+`

--- a/protocol-designer/src/components/modules/GripperRow.tsx
+++ b/protocol-designer/src/components/modules/GripperRow.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
 import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
 import {
   OutlineButton,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 import gripperImage from '../../images/flex_gripper.svg'
 import styles from './styles.css'
@@ -16,11 +18,12 @@ interface GripperRowProps {
 
 export function GripperRow(props: GripperRowProps): JSX.Element {
   const { handleGripper, isGripperAdded } = props
+  const { i18n, t } = useTranslation()
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-      <Flex flexDirection="column">
-        <h4 className={styles.row_title}>{'Flex Gripper'}</h4>
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <h4 className={styles.row_title}>Flex Gripper</h4>
         <AdditionalItemImage src={gripperImage} alt="Opentrons Flex Gripper" />
       </Flex>
       <div
@@ -28,7 +31,9 @@ export function GripperRow(props: GripperRowProps): JSX.Element {
         style={{ alignSelf: ALIGN_CENTER }}
       >
         <OutlineButton className={styles.module_button} onClick={handleGripper}>
-          {isGripperAdded ? 'Remove' : 'Add'}
+          {isGripperAdded
+            ? i18n.format(t('shared.remove'), 'capitalize')
+            : i18n.format(t('shared.add'), 'capitalize')}
         </OutlineButton>
       </div>
     </Flex>

--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -22,10 +22,14 @@ import { ModuleDiagram } from './ModuleDiagram'
 import { isModuleWithCollisionIssue } from './utils'
 import styles from './styles.css'
 
-import { ModuleType, THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import {
+  ModuleType,
+  RobotType,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 interface Props {
-  isOt3?: boolean
+  robotType?: RobotType
   moduleOnDeck?: ModuleOnDeck
   showCollisionWarnings?: boolean
   type: ModuleType
@@ -37,9 +41,10 @@ export function ModuleRow(props: Props): JSX.Element {
     moduleOnDeck,
     openEditModuleModal,
     showCollisionWarnings,
-    isOt3,
+    robotType,
   } = props
   const type: ModuleType = moduleOnDeck?.type || props.type
+  const isFlex = robotType === 'OT-3 Standard'
 
   const model = moduleOnDeck?.model
   const slot = moduleOnDeck?.slot
@@ -72,7 +77,7 @@ export function ModuleRow(props: Props): JSX.Element {
     slotDisplayName = 'Slot 7'
     occupiedSlotsForMap = ['7', '8', '10', '11']
     //  TC on Flex
-  } else if (isOt3 && type === THERMOCYCLER_MODULE_TYPE && slot === 'B1') {
+  } else if (isFlex && type === THERMOCYCLER_MODULE_TYPE && slot === 'B1') {
     occupiedSlotsForMap = ['A1', 'B1']
   }
   // If collisionSlots are populated, check which slot is occupied
@@ -149,7 +154,7 @@ export function ModuleRow(props: Props): JSX.Element {
               <SlotMap
                 occupiedSlots={occupiedSlotsForMap}
                 collisionSlots={collisionSlots}
-                isOt3={isOt3}
+                robotType={robotType}
               />
             </div>
           )}

--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -22,9 +22,10 @@ import { ModuleDiagram } from './ModuleDiagram'
 import { isModuleWithCollisionIssue } from './utils'
 import styles from './styles.css'
 
-import { ModuleType } from '@opentrons/shared-data'
+import { ModuleType, THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 
 interface Props {
+  isOt3?: boolean
   moduleOnDeck?: ModuleOnDeck
   showCollisionWarnings?: boolean
   type: ModuleType
@@ -32,12 +33,16 @@ interface Props {
 }
 
 export function ModuleRow(props: Props): JSX.Element {
-  const { moduleOnDeck, openEditModuleModal, showCollisionWarnings } = props
+  const {
+    moduleOnDeck,
+    openEditModuleModal,
+    showCollisionWarnings,
+    isOt3,
+  } = props
   const type: ModuleType = moduleOnDeck?.type || props.type
 
   const model = moduleOnDeck?.model
   const slot = moduleOnDeck?.slot
-
   /*
   TODO (ka 2020-2-3): This logic is very specific to this individual implementation
   of SlotMap. Kept it here (for now?) because it spells out the different cases.
@@ -66,8 +71,10 @@ export function ModuleRow(props: Props): JSX.Element {
   if (slot === SPAN7_8_10_11_SLOT) {
     slotDisplayName = 'Slot 7'
     occupiedSlotsForMap = ['7', '8', '10', '11']
+    //  TC on Flex
+  } else if (isOt3 && type === THERMOCYCLER_MODULE_TYPE && slot === 'B1') {
+    occupiedSlotsForMap = ['A1', 'B1']
   }
-
   // If collisionSlots are populated, check which slot is occupied
   // and render module specific crash warning. This logic assumes
   // default module slot placement magnet = Slot1 temperature = Slot3
@@ -142,6 +149,7 @@ export function ModuleRow(props: Props): JSX.Element {
               <SlotMap
                 occupiedSlots={occupiedSlotsForMap}
                 collisionSlots={collisionSlots}
+                isOt3={isOt3}
               />
             </div>
           )}

--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -12,6 +12,10 @@ import {
   SIZE_1,
   SPACING,
 } from '@opentrons/components'
+import {
+  FLEX_ROBOT_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import { actions as stepFormActions, ModuleOnDeck } from '../../step-forms'
 import {
@@ -22,11 +26,7 @@ import { ModuleDiagram } from './ModuleDiagram'
 import { isModuleWithCollisionIssue } from './utils'
 import styles from './styles.css'
 
-import {
-  ModuleType,
-  RobotType,
-  THERMOCYCLER_MODULE_TYPE,
-} from '@opentrons/shared-data'
+import type { ModuleType, RobotType } from '@opentrons/shared-data'
 
 interface Props {
   robotType?: RobotType
@@ -44,7 +44,7 @@ export function ModuleRow(props: Props): JSX.Element {
     robotType,
   } = props
   const type: ModuleType = moduleOnDeck?.type || props.type
-  const isFlex = robotType === 'OT-3 Standard'
+  const isFlex = robotType === FLEX_ROBOT_TYPE
 
   const model = moduleOnDeck?.model
   const slot = moduleOnDeck?.slot

--- a/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
@@ -8,6 +8,7 @@ import {
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V1,
   OT2_ROBOT_TYPE,
+  FLEX_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import { TEMPERATURE_DEACTIVATED } from '@opentrons/step-generation'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
@@ -78,7 +79,7 @@ describe('EditModulesCard', () => {
       tiprackDefURI: 'tiprack300',
     }
     mockGetAdditionalEquipment.mockReturnValue({})
-    mockGetRobotType.mockReturnValue('OT-2 Standard')
+    mockGetRobotType.mockReturnValue(OT2_ROBOT_TYPE)
     getDisableModuleRestrictionsMock.mockReturnValue(false)
     getPipettesForEditPipetteFormMock.mockReturnValue({
       left: crashablePipette,
@@ -224,7 +225,7 @@ describe('EditModulesCard', () => {
     })
   })
   it('displays module row with module to add when no moduleData for Flex', () => {
-    mockGetRobotType.mockReturnValue('OT-3 Standard')
+    mockGetRobotType.mockReturnValue(FLEX_ROBOT_TYPE)
     const wrapper = render(props)
     const SUPPORTED_MODULE_TYPES_FILTERED = SUPPORTED_MODULE_TYPES.filter(
       moduleType => moduleType !== 'magneticModuleType'
@@ -240,14 +241,14 @@ describe('EditModulesCard', () => {
     })
   })
   it('displays gripper row with no gripper', () => {
-    mockGetRobotType.mockReturnValue('OT-3 Standard')
+    mockGetRobotType.mockReturnValue(FLEX_ROBOT_TYPE)
     const wrapper = render(props)
     expect(wrapper.find(GripperRow)).toHaveLength(1)
     expect(wrapper.find(GripperRow).props().isGripperAdded).toEqual(false)
   })
   it('displays gripper row with gripper attached', () => {
     const mockGripperId = 'gripeprId'
-    mockGetRobotType.mockReturnValue('OT-3 Standard')
+    mockGetRobotType.mockReturnValue(FLEX_ROBOT_TYPE)
     mockGetAdditionalEquipment.mockReturnValue({
       [mockGripperId]: { name: 'gripper', id: mockGripperId },
     })

--- a/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
@@ -7,6 +7,7 @@ import {
   MAGNETIC_MODULE_V2,
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V1,
+  OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import { TEMPERATURE_DEACTIVATED } from '@opentrons/step-generation'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
@@ -199,7 +200,7 @@ describe('EditModulesCard', () => {
     expect(
       wrapper.find(ModuleRow).filter({ type: MAGNETIC_MODULE_TYPE }).props()
     ).toEqual({
-      isOt3: false,
+      robotType: OT2_ROBOT_TYPE,
       type: MAGNETIC_MODULE_TYPE,
       moduleOnDeck: crashableMagneticModule,
       showCollisionWarnings: true,

--- a/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/EditModulesCard.test.tsx
@@ -16,10 +16,12 @@ import {
 } from '../../../step-forms'
 import { getRobotType } from '../../../file-data/selectors'
 import { FormPipette } from '../../../step-forms/types'
+import { getAdditionalEquipment } from '../../../step-forms/selectors'
 import { SUPPORTED_MODULE_TYPES } from '../../../modules'
 import { EditModulesCard } from '../EditModulesCard'
 import { CrashInfoBox } from '../CrashInfoBox'
 import { ModuleRow } from '../ModuleRow'
+import { GripperRow } from '../GripperRow'
 
 jest.mock('../../../feature-flags')
 jest.mock('../../../step-forms/selectors')
@@ -34,7 +36,9 @@ const getPipettesForEditPipetteFormMock = stepFormSelectors.getPipettesForEditPi
 const mockGetRobotType = getRobotType as jest.MockedFunction<
   typeof getRobotType
 >
-
+const mockGetAdditionalEquipment = getAdditionalEquipment as jest.MockedFunction<
+  typeof getAdditionalEquipment
+>
 describe('EditModulesCard', () => {
   let store: any
   let crashableMagneticModule: ModuleOnDeck | undefined
@@ -72,7 +76,7 @@ describe('EditModulesCard', () => {
       pipetteName: 'p300_multi_test',
       tiprackDefURI: 'tiprack300',
     }
-
+    mockGetAdditionalEquipment.mockReturnValue({})
     mockGetRobotType.mockReturnValue('OT-2 Standard')
     getDisableModuleRestrictionsMock.mockReturnValue(false)
     getPipettesForEditPipetteFormMock.mockReturnValue({
@@ -195,6 +199,7 @@ describe('EditModulesCard', () => {
     expect(
       wrapper.find(ModuleRow).filter({ type: MAGNETIC_MODULE_TYPE }).props()
     ).toEqual({
+      isOt3: false,
       type: MAGNETIC_MODULE_TYPE,
       moduleOnDeck: crashableMagneticModule,
       showCollisionWarnings: true,
@@ -232,5 +237,21 @@ describe('EditModulesCard', () => {
         openEditModuleModal: props.openEditModuleModal,
       })
     })
+  })
+  it('displays gripper row with no gripper', () => {
+    mockGetRobotType.mockReturnValue('OT-3 Standard')
+    const wrapper = render(props)
+    expect(wrapper.find(GripperRow)).toHaveLength(1)
+    expect(wrapper.find(GripperRow).props().isGripperAdded).toEqual(false)
+  })
+  it('displays gripper row with gripper attached', () => {
+    const mockGripperId = 'gripeprId'
+    mockGetRobotType.mockReturnValue('OT-3 Standard')
+    mockGetAdditionalEquipment.mockReturnValue({
+      [mockGripperId]: { name: 'gripper', id: mockGripperId },
+    })
+    const wrapper = render(props)
+    expect(wrapper.find(GripperRow)).toHaveLength(1)
+    expect(wrapper.find(GripperRow).props().isGripperAdded).toEqual(true)
   })
 })

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -45,13 +45,13 @@ import type {
 import type {
   CreateCommand,
   ProtocolFile,
-} from '@opentrons/shared-data/protocol/types/schemaV7'
+} from '@opentrons/shared-data/protocol/types/schemaV6'
 import type { Selector } from '../../types'
 import type {
   LoadLabwareCreateCommand,
   LoadModuleCreateCommand,
   LoadPipetteCreateCommand,
-} from '@opentrons/shared-data/protocol/types/schemaV7/command/setup'
+} from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type { PipetteName } from '@opentrons/shared-data/js/pipettes'
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')
@@ -340,8 +340,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     }
     return {
       ...protocolFile,
-      $otSharedSchema: '#/protocol/schemas/7',
-      schemaVersion: 7,
+      $otSharedSchema: '#/protocol/schemas/6',
+      schemaVersion: 6,
       modules,
       commands,
     }

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -291,6 +291,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       [pipetteId: string]: { name: PipetteName }
     }
 
+    //  TODO(jr 6/22/23):  entire method should be replaced with the contents of robotType key
+    //  on the protocol file instead of inferring it from pipette types.
     const getRobotModelFromPipettes = (
       pipettes: RobotModel
     ): {

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -45,13 +45,13 @@ import type {
 import type {
   CreateCommand,
   ProtocolFile,
-} from '@opentrons/shared-data/protocol/types/schemaV6'
+} from '@opentrons/shared-data/protocol/types/schemaV7'
 import type { Selector } from '../../types'
 import type {
   LoadLabwareCreateCommand,
   LoadModuleCreateCommand,
   LoadPipetteCreateCommand,
-} from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+} from '@opentrons/shared-data/protocol/types/schemaV7/command/setup'
 import type { PipetteName } from '@opentrons/shared-data/js/pipettes'
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')
@@ -338,8 +338,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     }
     return {
       ...protocolFile,
-      $otSharedSchema: '#/protocol/schemas/6',
-      schemaVersion: 6,
+      $otSharedSchema: '#/protocol/schemas/7',
+      schemaVersion: 7,
       modules,
       commands,
     }

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -299,7 +299,9 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     } => {
       const loadedPipettes = Object.values(pipettes)
       const pipetteGEN = loadedPipettes.some(
-        pipette => getPipetteNameSpecs(pipette.name)?.displayCategory === GEN3
+        pipette =>
+          getPipetteNameSpecs(pipette.name)?.displayCategory === GEN3 ||
+          getPipetteNameSpecs(pipette.name)?.channels === 96
       )
         ? GEN3
         : GEN2

--- a/protocol-designer/src/load-file/reducers.ts
+++ b/protocol-designer/src/load-file/reducers.ts
@@ -66,6 +66,7 @@ const unsavedChanges = (
     case 'CREATE_MODULE':
     case 'DELETE_MODULE':
     case 'EDIT_MODULE':
+    case 'IS_GRIPPER_REQUIRED':
       return true
 
     default:

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -201,6 +201,11 @@
       "heading": "Unused modules",
       "body1": "The {{modulesDetails}} specified in your protocol are not currently used in any step. In order to run this protocol you will need to power up and connect the modules to your robot.",
       "body2": "If you don't intend to use these modules, please consider removing them from your protocol."
+    },
+    "unused_gripper": {
+      "heading": "Unused gripper",
+      "body1": "The Flex Gripper is specified in your protocol is not currently used in any step. In order to run this protocol you will need to connect it to your robot.",
+      "bodh2": "If you don't intend to use the Flex Gripper, please consider removing it from your protocol."
     }
   },
   "crash": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -205,7 +205,7 @@
     "unused_gripper": {
       "heading": "Unused gripper",
       "body1": "The Flex Gripper is specified in your protocol is not currently used in any step. In order to run this protocol you will need to connect it to your robot.",
-      "bodh2": "If you don't intend to use the Flex Gripper, please consider removing it from your protocol."
+      "body2": "If you don't intend to use the Flex Gripper, please consider removing it from your protocol."
     }
   },
   "crash": {

--- a/protocol-designer/src/localization/en/shared.json
+++ b/protocol-designer/src/localization/en/shared.json
@@ -2,5 +2,7 @@
   "exit": "exit",
   "go_back": "go back",
   "next": "next",
-  "step": "Step {{current}} / {{max}}"
+  "step": "Step {{current}} / {{max}}",
+  "remove": "remove",
+  "add": "add"
 }

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -70,6 +70,11 @@
         "blowout_checkbox": "Redundant with disposal volume"
       }
     },
+    "moveLabware": {
+      "disabled": {
+        "gripper_not_used": "Attach Gripper to move labware"
+      }
+    },
     "batch_edit": {
       "disabled": {
         "pipette-different": "Cannot edit unless selected steps share the same pipette.",

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -6,17 +6,18 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   ModuleType,
   MAGNETIC_BLOCK_TYPE,
+  RobotType,
 } from '@opentrons/shared-data'
 import { DropdownOption } from '@opentrons/components'
 export const SUPPORTED_MODULE_TYPES: ModuleType[] = [
   HEATERSHAKER_MODULE_TYPE,
+  MAGNETIC_BLOCK_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  MAGNETIC_BLOCK_TYPE,
 ]
 type SupportedSlotMap = Record<ModuleType, DropdownOption[]>
-export const SUPPORTED_MODULE_SLOTS: SupportedSlotMap = {
+export const SUPPORTED_MODULE_SLOTS_OT2: SupportedSlotMap = {
   [MAGNETIC_MODULE_TYPE]: [
     {
       name: 'Slot 1 (supported)',
@@ -48,7 +49,39 @@ export const SUPPORTED_MODULE_SLOTS: SupportedSlotMap = {
     },
   ],
 }
-const ALL_MODULE_SLOTS: DropdownOption[] = [
+export const SUPPORTED_MODULE_SLOTS_FLEX: SupportedSlotMap = {
+  [MAGNETIC_MODULE_TYPE]: [
+    {
+      name: 'Slot D1 (supported)',
+      value: 'D1',
+    },
+  ],
+  [TEMPERATURE_MODULE_TYPE]: [
+    {
+      name: 'Slot D3 (supported)',
+      value: 'D3',
+    },
+  ],
+  [THERMOCYCLER_MODULE_TYPE]: [
+    {
+      name: 'Thermocycler slots',
+      value: 'B1',
+    },
+  ],
+  [HEATERSHAKER_MODULE_TYPE]: [
+    {
+      name: 'Slot D1 (supported)',
+      value: 'D1',
+    },
+  ],
+  [MAGNETIC_BLOCK_TYPE]: [
+    {
+      name: 'Slot D2 (supported)',
+      value: 'D2',
+    },
+  ],
+}
+const ALL_MODULE_SLOTS_OT2: DropdownOption[] = [
   {
     name: 'Slot 1',
     value: '1',
@@ -78,7 +111,8 @@ const ALL_MODULE_SLOTS: DropdownOption[] = [
     value: '10',
   },
 ]
-const HEATER_SHAKER_SLOTS: DropdownOption[] = [
+
+const HEATER_SHAKER_SLOTS_OT2: DropdownOption[] = [
   {
     name: 'Slot 1',
     value: '1',
@@ -104,22 +138,132 @@ const HEATER_SHAKER_SLOTS: DropdownOption[] = [
     value: '10',
   },
 ]
+const HS_AND_TEMP_SLOTS_FLEX: DropdownOption[] = [
+  {
+    name: 'Slot D1',
+    value: 'D1',
+  },
+  {
+    name: 'Slot D3',
+    value: 'D3',
+  },
+  {
+    name: 'Slot C1',
+    value: 'C1',
+  },
+  {
+    name: 'Slot C3',
+    value: 'C3',
+  },
+  {
+    name: 'Slot B1',
+    value: 'B1',
+  },
+  {
+    name: 'Slot B3',
+    value: 'B3',
+  },
+  {
+    name: 'Slot A1',
+    value: 'A1',
+  },
+  {
+    name: 'Slot A3',
+    value: 'A3',
+  },
+]
+
+const MAG_BLOCK_SLOTS_FLEX: DropdownOption[] = [
+  {
+    name: 'Slot D1',
+    value: 'D1',
+  },
+  {
+    name: 'Slot D2',
+    value: 'D2',
+  },
+  {
+    name: 'Slot D3',
+    value: 'D3',
+  },
+  {
+    name: 'Slot C1',
+    value: 'C1',
+  },
+  {
+    name: 'Slot C2',
+    value: 'C2',
+  },
+  {
+    name: 'Slot C3',
+    value: 'C3',
+  },
+  {
+    name: 'Slot B1',
+    value: 'B1',
+  },
+  {
+    name: 'Slot B2',
+    value: 'B2',
+  },
+  {
+    name: 'Slot B3',
+    value: 'B3',
+  },
+  {
+    name: 'Slot A1',
+    value: 'A1',
+  },
+  {
+    name: 'Slot A2',
+    value: 'A2',
+  },
+  {
+    name: 'Slot A3',
+    value: 'A3',
+  },
+]
 export function getAllModuleSlotsByType(
-  moduleType: ModuleType
+  moduleType: ModuleType,
+  robotType: RobotType
 ): DropdownOption[] {
-  const supportedSlotOption = SUPPORTED_MODULE_SLOTS[moduleType]
+  const supportedSlotOption =
+    robotType === 'OT-2 Standard'
+      ? SUPPORTED_MODULE_SLOTS_OT2[moduleType]
+      : SUPPORTED_MODULE_SLOTS_FLEX[moduleType]
 
-  if (moduleType === THERMOCYCLER_MODULE_TYPE) {
-    return supportedSlotOption
-  }
-  if (moduleType === HEATERSHAKER_MODULE_TYPE) {
-    return supportedSlotOption.concat(
-      HEATER_SHAKER_SLOTS.filter(s => s.value !== supportedSlotOption[0].value)
+  let slot = supportedSlotOption
+
+  if (robotType === 'OT-2 Standard') {
+    if (moduleType === THERMOCYCLER_MODULE_TYPE) {
+      slot = supportedSlotOption
+    }
+    if (moduleType === HEATERSHAKER_MODULE_TYPE) {
+      slot = supportedSlotOption.concat(
+        HEATER_SHAKER_SLOTS_OT2.filter(
+          s => s.value !== supportedSlotOption[0].value
+        )
+      )
+    }
+    const allOtherSlots = ALL_MODULE_SLOTS_OT2.filter(
+      s => s.value !== supportedSlotOption[0].value
     )
+    slot = supportedSlotOption.concat(allOtherSlots)
+  } else {
+    if (moduleType === THERMOCYCLER_MODULE_TYPE) {
+      slot = supportedSlotOption
+    } else if (
+      moduleType === HEATERSHAKER_MODULE_TYPE ||
+      moduleType === TEMPERATURE_MODULE_TYPE
+    ) {
+      slot = HS_AND_TEMP_SLOTS_FLEX.filter(
+        s => s.value !== supportedSlotOption[0].value
+      )
+    } else {
+      slot = MAG_BLOCK_SLOTS_FLEX.filter(
+        s => s.value !== supportedSlotOption[0].value
+      )
+    }
   }
-
-  const allOtherSlots = ALL_MODULE_SLOTS.filter(
-    s => s.value !== supportedSlotOption[0].value
-  )
-  return supportedSlotOption.concat(allOtherSlots)
+  return slot
 }

--- a/protocol-designer/src/step-forms/actions/additionalItems.ts
+++ b/protocol-designer/src/step-forms/actions/additionalItems.ts
@@ -1,7 +1,7 @@
-export interface SetGripperAction {
-  type: 'IS_GRIPPER_REQUIRED'
+export interface ToggleIsGripperRequiredAction {
+  type: 'TOGGLE_IS_GRIPPER_REQUIRED'
 }
 
-export const toggleIsGripperRequired = (): SetGripperAction => ({
-  type: 'IS_GRIPPER_REQUIRED',
+export const toggleIsGripperRequired = (): ToggleIsGripperRequiredAction => ({
+  type: 'TOGGLE_IS_GRIPPER_REQUIRED',
 })

--- a/protocol-designer/src/step-forms/actions/additionalItems.ts
+++ b/protocol-designer/src/step-forms/actions/additionalItems.ts
@@ -1,0 +1,7 @@
+export interface SetGripperAction {
+  type: 'IS_GRIPPER_REQUIRED'
+}
+
+export const toggleIsGripperRequired = (): SetGripperAction => ({
+  type: 'IS_GRIPPER_REQUIRED',
+})

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1270,18 +1270,6 @@ const initialAdditionalEquipmentState = {}
 
 export const additionalEquipmentInvariantProperties = handleActions(
   {
-    LOAD_FILE: (
-      state: NoramlizedAdditionalEquipmentById
-    ): NoramlizedAdditionalEquipmentById => {
-      const additionalEquipmentId = uuid()
-      const updatedEquipment = {
-        [additionalEquipmentId]: {
-          name: 'gripper' as const,
-          id: additionalEquipmentId,
-        },
-      }
-      return { ...state, ...updatedEquipment }
-    },
     IS_GRIPPER_REQUIRED: (
       state: NoramlizedAdditionalEquipmentById
     ): NoramlizedAdditionalEquipmentById => {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1268,8 +1268,35 @@ export const pipetteInvariantProperties: Reducer<
 
 const initialAdditionalEquipmentState = {}
 
-export const additionalEquipmentInvariantProperties = handleActions(
+export const additionalEquipmentInvariantProperties = handleActions<NoramlizedAdditionalEquipmentById>(
   {
+    //  TODO(jr, 6/22/23): wire this up when schemav7 migration is complete
+    //  Additionally, wire up the the gripper logic using the toggle in moveLabware step
+    //  @ts-expect-error
+    LOAD_FILE: (
+      state,
+      action: LoadFileAction
+    ): NoramlizedAdditionalEquipmentById => {
+      const { file } = action.payload
+      const gripper =
+        // @ts-expect-error (jr, 6/22/23): moveLabware doesn't exist in schemav6
+        file.commands.filter(command => command.commandType === 'moveLabware')
+      const hasGripper = gripper.length > 0
+      // @ts-expect-error  (jr, 6/22/23): OT-3 Standard doesn't exist on schemav6
+      const isOt3 = file.robot.model === 'OT-3 Standard'
+      const additionalEquipmentId = uuid()
+      const updatedEquipment = {
+        [additionalEquipmentId]: {
+          name: 'gripper' as const,
+          id: additionalEquipmentId,
+        },
+      }
+      if (hasGripper && isOt3) {
+        return { ...state, ...updatedEquipment }
+      } else {
+        return { ...state }
+      }
+    },
     IS_GRIPPER_REQUIRED: (
       state: NoramlizedAdditionalEquipmentById
     ): NoramlizedAdditionalEquipmentById => {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -7,6 +7,7 @@ import omit from 'lodash/omit'
 import omitBy from 'lodash/omitBy'
 import reduce from 'lodash/reduce'
 import {
+  FLEX_ROBOT_TYPE,
   getLabwareDefaultEngageHeight,
   getLabwareDefURI,
   getModuleType,
@@ -1285,7 +1286,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       )
       const hasGripper = gripper.length > 0
       // @ts-expect-error  (jr, 6/22/23): OT-3 Standard doesn't exist on schemav6
-      const isOt3 = file.robot.model === 'OT-3 Standard'
+      const isOt3 = file.robot.model === FLEX_ROBOT_TYPE
       const additionalEquipmentId = uuid()
       const updatedEquipment = {
         [additionalEquipmentId]: {

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -15,7 +15,10 @@ import {
   PipetteName,
   MAGNETIC_BLOCK_TYPE,
 } from '@opentrons/shared-data'
-import { TEMPERATURE_DEACTIVATED } from '@opentrons/step-generation'
+import {
+  NoramlizedAdditionalEquipmentById,
+  TEMPERATURE_DEACTIVATED,
+} from '@opentrons/step-generation'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import {
   getFormWarnings,
@@ -147,10 +150,21 @@ export const _getPipetteEntitiesRootState: (
   labwareDefSelectors._getLabwareDefsByIdRootState,
   denormalizePipetteEntities
 )
+
 export const getPipetteEntities: Selector<
   BaseState,
   PipetteEntities
 > = createSelector(rootSelector, _getPipetteEntitiesRootState)
+
+export const _getAdditionalEquipmentRootState: (
+  arg: RootState
+) => NoramlizedAdditionalEquipmentById = rs =>
+  rs.additionalEquipmentInvariantProperties
+
+export const getAdditionalEquipment: Selector<
+  BaseState,
+  NoramlizedAdditionalEquipmentById
+> = createSelector(rootSelector, _getAdditionalEquipmentRootState)
 
 const _getInitialDeckSetupStepFormRootState: (
   arg: RootState

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -16,7 +16,7 @@ import {
   MAGNETIC_BLOCK_TYPE,
 } from '@opentrons/shared-data'
 import {
-  NoramlizedAdditionalEquipmentById,
+  NormalizedAdditionalEquipmentById,
   TEMPERATURE_DEACTIVATED,
 } from '@opentrons/step-generation'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
@@ -158,12 +158,12 @@ export const getPipetteEntities: Selector<
 
 export const _getAdditionalEquipmentRootState: (
   arg: RootState
-) => NoramlizedAdditionalEquipmentById = rs =>
+) => NormalizedAdditionalEquipmentById = rs =>
   rs.additionalEquipmentInvariantProperties
 
 export const getAdditionalEquipment: Selector<
   BaseState,
-  NoramlizedAdditionalEquipmentById
+  NormalizedAdditionalEquipmentById
 > = createSelector(rootSelector, _getAdditionalEquipmentRootState)
 
 const _getInitialDeckSetupStepFormRootState: (

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -1647,7 +1647,7 @@ describe('unsavedForm reducer', () => {
     'SAVE_STEP_FORM',
     'SELECT_TERMINAL_ITEM',
     'SELECT_MULTIPLE_STEPS',
-    'IS_GRIPPER_REQUIRED',
+    'TOGGLE_IS_GRIPPER_REQUIRED',
   ]
   actionTypes.forEach(actionType => {
     it(`should clear the unsaved form when any ${actionType} action is dispatched`, () => {

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -336,6 +336,7 @@ describe('labwareInvariantProperties reducer', () => {
     })
   })
 })
+
 describe('moduleInvariantProperties reducer', () => {
   let prevState: Record<string, ModuleEntity>
   const existingModuleId = 'existingModuleId'
@@ -977,42 +978,39 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       }> = [
         {
           testName: 'create mag mod -> override mag step module id',
-          // @ts-expect-error(sa, 2021-6-14): not a valid module model
           action: {
             type: 'CREATE_MODULE',
             payload: {
               id: 'newMagdeckId',
               slot: '1',
               type: MAGNETIC_MODULE_TYPE,
-              model: 'someMagModel',
+              model: 'magneticModuleV1',
             },
           },
           expectedModuleId: 'newMagdeckId',
         },
         {
           testName: 'create temp mod -> DO NOT override mag step module id',
-          // @ts-expect-error(sa, 2021-6-14): not a valid module model
           action: {
             type: 'CREATE_MODULE',
             payload: {
               id: 'tempdeckId',
               slot: '1',
               type: TEMPERATURE_MODULE_TYPE,
-              model: 'someTempModel',
+              model: 'temperatureModuleV1',
             },
           },
           expectedModuleId: 'magdeckId',
         },
         {
           testName: 'create TC -> DO NOT override mag step module id',
-          // @ts-expect-error(sa, 2021-6-14): not a valid module model
           action: {
             type: 'CREATE_MODULE',
             payload: {
               id: 'ThermocyclerId',
               slot: '1',
               type: THERMOCYCLER_MODULE_TYPE,
-              model: 'someThermoModel',
+              model: 'thermocyclerModuleV1',
             },
           },
           expectedModuleId: 'magdeckId',
@@ -1025,42 +1023,39 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       }> = [
         {
           testName: 'create TC -> override TC step module id',
-          // @ts-expect-error(sa, 2021-6-14): not a valid module model
           action: {
             type: 'CREATE_MODULE',
             payload: {
               id: 'NewTCId',
               slot: SPAN7_8_10_11_SLOT,
               type: THERMOCYCLER_MODULE_TYPE,
-              model: 'someTCModel',
+              model: 'thermocyclerModuleV1',
             },
           },
           expectedModuleId: 'NewTCId',
         },
         {
           testName: 'create temp mod -> DO NOT override TC step module id',
-          // @ts-expect-error(sa, 2021-6-14): not a valid module model
           action: {
             type: 'CREATE_MODULE',
             payload: {
               id: 'tempdeckId',
               slot: '1',
               type: TEMPERATURE_MODULE_TYPE,
-              model: 'someTempModel',
+              model: 'temperatureModuleV1',
             },
           },
           expectedModuleId: 'TCId',
         },
         {
           testName: 'create magnetic mod -> DO NOT override TC step module id',
-          // @ts-expect-error(sa, 2021-6-14): not a valid module model
           action: {
             type: 'CREATE_MODULE',
             payload: {
               id: 'newMagdeckId',
               slot: '1',
               type: MAGNETIC_MODULE_TYPE,
-              model: 'someMagModel',
+              model: 'magneticModuleV2',
             },
           },
           expectedModuleId: 'TCId',
@@ -1652,6 +1647,7 @@ describe('unsavedForm reducer', () => {
     'SAVE_STEP_FORM',
     'SELECT_TERMINAL_ITEM',
     'SELECT_MULTIPLE_STEPS',
+    'IS_GRIPPER_REQUIRED',
   ]
   actionTypes.forEach(actionType => {
     it(`should clear the unsaved form when any ${actionType} action is dispatched`, () => {

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect'
-import { useSelector } from 'react-redux'
 import mapValues from 'lodash/mapValues'
 import {
   THERMOCYCLER_MODULE_TYPE,
@@ -91,8 +90,8 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
 > = createSelector(
   getRobotStateAtActiveItem,
   getModuleEntities,
-  (robotState, moduleEntities) => {
-    const robotType = useSelector(getRobotType)
+  getRobotType,
+  (robotState, moduleEntities, robotType) => {
     const deckDef = getDeckDefFromRobotType(robotType)
     const allSlotIds = deckDef.locations.orderedSlots.map(slot => slot.id)
     if (robotState == null) return null

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -1,20 +1,18 @@
 {
-  "machine": "OT-3 Standard",
-  "strict_attached_instruments": false,
   "attached_instruments": {
     "right": {
-      "model": "p1000_single_v3.4",
+      "model": "p300_single_v1",
       "id": "321",
-      "max_volume": 1000,
-      "name": "p1000_single_gen3",
+      "max_volume": 300,
+      "name": "p300_single",
       "tip_length": 0,
       "channels": 1
     },
     "left": {
-      "model": "p50_single_v3.4",
+      "model": "p10_single_v1",
       "id": "123",
-      "max_volume": 50,
-      "name": "p50_single_gen3",
+      "max_volume": 10,
+      "name": "p10_single",
       "tip_length": 0,
       "channels": 1
     }

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -1,18 +1,20 @@
 {
+  "machine": "OT-3 Standard",
+  "strict_attached_instruments": false,
   "attached_instruments": {
     "right": {
-      "model": "p300_single_v1",
+      "model": "p1000_single_v3.4",
       "id": "321",
-      "max_volume": 300,
-      "name": "p300_single",
+      "max_volume": 1000,
+      "name": "p1000_single_gen3",
       "tip_length": 0,
       "channels": 1
     },
     "left": {
-      "model": "p10_single_v1",
+      "model": "p50_single_v3.4",
       "id": "123",
-      "max_volume": 10,
-      "name": "p10_single",
+      "max_volume": 50,
+      "name": "p50_single_gen3",
       "tip_length": 0,
       "channels": 1
     }

--- a/shared-data/protocol/index.ts
+++ b/shared-data/protocol/index.ts
@@ -16,4 +16,5 @@ export type JsonProtocolFile =
   | Readonly<ProtocolFileV4<{}>>
   | Readonly<ProtocolFileV5<{}>>
 
+//  TODO(jr, 6/21/23): update to schemaV7
 export * from './types/schemaV6'

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -8,13 +8,13 @@ import {
   LabwareLocation,
 } from '@opentrons/shared-data'
 import type {
+  CreateCommand,
   LabwareDefinition2,
   ModuleType,
   ModuleModel,
   PipetteNameSpecs,
   PipetteName,
 } from '@opentrons/shared-data'
-import type { CreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command'
 import type {
   AtomicProfileStep,
   EngageMagnetParams,
@@ -110,6 +110,13 @@ export interface NormalizedPipetteById {
   }
 }
 
+export interface NoramlizedAdditionalEquipmentById {
+  [additionalEquipmentId: string]: {
+    name: 'gripper'
+    id: string
+  }
+}
+
 export type NormalizedPipette = NormalizedPipetteById[keyof NormalizedPipetteById]
 
 // "entities" have only properties that are time-invariant
@@ -123,7 +130,6 @@ export type PipetteEntity = NormalizedPipette & {
 export interface PipetteEntities {
   [pipetteId: string]: PipetteEntity
 }
-
 // ===== MIX-IN TYPES =====
 export type ChangeTipOptions =
   | 'always'

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -8,13 +8,13 @@ import {
   LabwareLocation,
 } from '@opentrons/shared-data'
 import type {
-  CreateCommand,
   LabwareDefinition2,
   ModuleType,
   ModuleModel,
   PipetteNameSpecs,
   PipetteName,
 } from '@opentrons/shared-data'
+import type { CreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command'
 import type {
   AtomicProfileStep,
   EngageMagnetParams,

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -110,7 +110,7 @@ export interface NormalizedPipetteById {
   }
 }
 
-export interface NoramlizedAdditionalEquipmentById {
+export interface NormalizedAdditionalEquipmentById {
   [additionalEquipmentId: string]: {
     name: 'gripper'
     id: string


### PR DESCRIPTION
closes RLIQ-416, RAUT-504, RAUT-506, RAUT-510

# Overview

For the Flex protocols, the modules section is updated to allow for adding/removing gripper and the deckmap and edit modules is updated.

<img width="848" alt="Screen Shot 2023-06-22 at 9 29 40 AM" src="https://github.com/Opentrons/opentrons/assets/66035149/3ebf1958-04be-4d04-ae01-d33149b205f1">


# Test Plan

Test creating a Flex protocol, modify the modules and gripper and ensure that it works properly. When exporting with a magnetic block, you shouldn't get an "unused module" modal. When exporting with an unused gripper, you sohuld get an "unused gripper" modal. 

Test creating an Ot-2 protocol, should work as normal.

# Changelog

- add `additionalEquipmentInvariantProperties` key to root state in redux
- create a `IS_GRIPPER_REQUIRED` type redux action (`toggleIsGripperRequired`), reducer and selector (`getAdditionalEquipment`)
- add the action to `CreateFileWizard` and `EditModulesCard` for adding/removing a gripper
- create a `gripperRow` to the Modules section and rename the section to `AdditionalItems` to encompass modules and gripper
- update the slotmap view for Flex and make sure it highlights the correct slots where the modules sit
- update the `FileSideBar` container to take in robot type and additional equipment for wiring up logic for unused gripper and unused module modal
- update tests

# Review requests

see test plan

# Risk assessment

low
