### PR TITLE
feat(api): drop tips in predetermined locations

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -325,7 +325,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         location: Optional[Location],
         well_core: WellCore,
         home_after: Optional[bool],
-        randomize_drop_location: Optional[bool] = False,
+        alternate_drop_location: Optional[bool] = False,
     ) -> None:
         """Move to and drop a tip into a given well.
 
@@ -334,7 +334,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
                 Used to calculate the relative well offset for the drop command.
             well_core: The well we're dropping into
             home_after: Whether to home the pipette after the tip is dropped.
-            randomize_drop_location: Whether to randomize the exact location to drop tip
+            alternate_drop_location: Whether to randomize the exact location to drop tip
                 within the specified well.
         """
         well_name = well_core.get_name()
@@ -362,7 +362,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             well_name=well_name,
             well_location=well_location,
             home_after=home_after,
-            randomize_drop_location=randomize_drop_location,
+            alternateDropLocation=alternate_drop_location,
         )
 
         self._protocol_core.set_last_location(location=location, mount=self.get_mount())

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -116,7 +116,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         location: Optional[types.Location],
         well_core: WellCoreType,
         home_after: Optional[bool],
-        randomize_drop_location: Optional[bool] = False,
+        alternate_drop_location: Optional[bool] = False,
     ) -> None:
         """Move to and drop a tip into a given well.
 
@@ -125,7 +125,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
                 If unspecified, the default drop location of the well will be used.
             well_core: The well we're dropping into
             home_after: Whether to home the pipette after the tip is dropped.
-            randomize_drop_location: Whether to randomize the exact location to drop tip
+            alternate_drop_location: Whether to randomize the exact location to drop tip
                 within the specified well.
         """
         ...

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -220,7 +220,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         location: Optional[types.Location],
         well_core: LegacyWellCore,
         home_after: Optional[bool],
-        randomize_drop_location: Optional[bool] = False,
+        alternate_drop_location: Optional[bool] = False,
     ) -> None:
         """Move to and drop a tip into a given well.
 
@@ -230,7 +230,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
             well_core: The well we're dropping into
             home_after: Whether to home the pipette after the tip is dropped.
         """
-        if randomize_drop_location:
+        if alternate_drop_location:
             raise APIVersionError(
                 "Tip drop randomization is not supported in this API version."
             )

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -194,11 +194,11 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
         location: Optional[types.Location],
         well_core: LegacyWellCore,
         home_after: Optional[bool],
-        randomize_drop_location: Optional[bool] = False,
+        alternate_drop_location: Optional[bool] = False,
     ) -> None:
-        if randomize_drop_location:
+        if alternate_drop_location:
             raise APIVersionError(
-                "Tip drop randomization is not supported in this API version."
+                "Tip drop alternation is not supported in this API version."
             )
         labware_core = well_core.geometry.parent
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -45,8 +45,8 @@ _PREP_AFTER_ADDED_IN = APIVersion(2, 13)
 """The version after which the pick-up tip procedure should also prepare the plunger."""
 _PRESSES_INCREMENT_REMOVED_IN = APIVersion(2, 14)
 """The version after which the pick-up tip procedure deprecates presses and increment arguments."""
-_DROP_TIP_LOCATION_RANDOMIZED_IN = APIVersion(2, 15)
-"""The version after which a drop-tip-into-trash procedure drops tips in a random location within the trash well."""
+_DROP_TIP_LOCATION_ALTERNATING_ADDED_IN = APIVersion(2, 15)
+"""The version after which a drop-tip-into-trash procedure drops tips in different alternating locations within the trash well."""
 
 
 class InstrumentContext(publisher.CommandPublisher):
@@ -837,8 +837,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
         If no location is passed, the Pipette will drop the tip into its
         :py:attr:`trash_container`, which if not specified defaults to
-        the fixed trash in slot 12.  From API version 2.15 on, the exact position
-        where the pipette drops the tip(s) within the trash will be randomized
+        the fixed trash in slot 12.  From API version 2.15 on, the API will default to
+        alternating between two different drop tip locations within the trash container
         in order to prevent tips from piling up in a single location in the trash.
 
         The location in which to drop the tip can be manually specified with
@@ -902,11 +902,11 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :returns: This instance
         """
-        randomize_drop_location: bool = False
+        alternate_drop_location: bool = False
         if location is None:
             well = self.trash_container.wells()[0]
-            if self.api_version >= _DROP_TIP_LOCATION_RANDOMIZED_IN:
-                randomize_drop_location = True
+            if self.api_version >= _DROP_TIP_LOCATION_ALTERNATING_ADDED_IN:
+                alternate_drop_location = True
 
         elif isinstance(location, labware.Well):
             well = location
@@ -942,7 +942,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 location=location,
                 well_core=well._core,
                 home_after=home_after,
-                randomize_drop_location=randomize_drop_location,
+                alternate_drop_location=alternate_drop_location,
             )
 
         self._last_tip_picked_up_from = None

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -224,7 +224,7 @@ class SyncClient:
         well_name: str,
         well_location: DropTipWellLocation,
         home_after: Optional[bool],
-        randomize_drop_location: Optional[bool],
+        alternateDropLocation: Optional[bool],
     ) -> commands.DropTipResult:
         """Execute a DropTip command and return the result."""
         request = commands.DropTipCreate(
@@ -234,7 +234,7 @@ class SyncClient:
                 wellName=well_name,
                 wellLocation=well_location,
                 homeAfter=home_after,
-                randomizeDropLocation=randomize_drop_location,
+                alternateDropLocation=alternateDropLocation,
             )
         )
         result = self._transport.execute_command(request=request)

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -44,9 +44,6 @@ from ..types import (
     LoadedLabware,
     ModuleLocation,
     ModuleModel,
-    DropTipWellLocation,
-    DropTipWellOrigin,
-    WellOffset,
     OverlapOffset,
 )
 from ..actions import (

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1,7 +1,6 @@
 """Basic labware data state and store."""
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -701,22 +700,6 @@ class LabwareView(HasState[LabwareState]):
                     f"Labware {top_labware_definition.parameters.loadName} cannot be loaded"
                     f" onto labware on top of adapter"
                 )
-
-    def get_random_drop_tip_location(
-        self, labware_id: str, well_name: str
-    ) -> DropTipWellLocation:
-        """Get a random location along the x-axis within 3/4th length of the well top plane."""
-        well_dims = self.get_well_size(labware_id=labware_id, well_name=well_name)
-        random_offset_in_well = WellOffset(
-            x=random.randrange(
-                start=int(well_dims[0] * -3 / 8), stop=int(well_dims[0] * 3 / 8), step=1
-            ),
-            y=0,
-            z=0,
-        )
-        return DropTipWellLocation(
-            origin=DropTipWellOrigin.DEFAULT, offset=random_offset_in_well
-        )
 
     def _is_magnetic_module_uri_in_half_millimeter(self, labware_id: str) -> bool:
         """Check whether the labware uri needs to be calculated in half a millimeter."""

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -69,6 +69,7 @@ class StaticPipetteConfig:
     display_name: str
     min_volume: float
     max_volume: float
+    channels: int
     return_tip_scale: float
     nominal_tip_overlap: Dict[str, float]
     home_position: float
@@ -121,6 +122,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 display_name=config.display_name,
                 min_volume=config.min_volume,
                 max_volume=config.max_volume,
+                channels=config.channels,
                 return_tip_scale=config.return_tip_scale,
                 nominal_tip_overlap=config.nominal_tip_overlap,
                 home_position=config.home_position,

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -265,12 +265,7 @@ def test_drop_tip_no_location(
         engine_client=mock_engine_client,
     )
 
-    subject.drop_tip(
-        location=None,
-        well_core=well_core,
-        home_after=True,
-        randomize_drop_location=False,
-    )
+    subject.drop_tip(location=None, well_core=well_core, home_after=True)
 
     decoy.verify(
         mock_engine_client.drop_tip(
@@ -282,7 +277,7 @@ def test_drop_tip_no_location(
                 offset=WellOffset(x=0, y=0, z=0),
             ),
             home_after=True,
-            randomize_drop_location=False,
+            alternateDropLocation=False,
         ),
         times=1,
     )
@@ -307,12 +302,7 @@ def test_drop_tip_with_location(
         )
     ).then_return(WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)))
 
-    subject.drop_tip(
-        location=location,
-        well_core=well_core,
-        home_after=True,
-        randomize_drop_location=True,
-    )
+    subject.drop_tip(location=location, well_core=well_core, home_after=True)
 
     decoy.verify(
         mock_engine_client.drop_tip(
@@ -323,7 +313,7 @@ def test_drop_tip_with_location(
                 origin=DropTipWellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
             ),
             home_after=True,
-            randomize_drop_location=True,
+            alternateDropLocation=False,
         ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -599,7 +599,7 @@ def test_drop_tip_to_well(
             location=None,
             well_core=mock_well._core,
             home_after=False,
-            randomize_drop_location=False,
+            alternate_drop_location=False,
         ),
         times=1,
     )
@@ -624,7 +624,7 @@ def test_drop_tip_to_trash(
             location=None,
             well_core=mock_well._core,
             home_after=None,
-            randomize_drop_location=False,
+            alternate_drop_location=False,
         ),
         times=1,
     )
@@ -649,7 +649,7 @@ def test_drop_tip_to_randomized_trash_location(
             location=None,
             well_core=mock_well._core,
             home_after=None,
-            randomize_drop_location=True,
+            alternate_drop_location=True,
         ),
         times=1,
     )
@@ -678,7 +678,7 @@ def test_return_tip(
             location=None,
             well_core=mock_well._core,
             home_after=None,
-            randomize_drop_location=False,
+            alternate_drop_location=False,
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -303,7 +303,7 @@ def test_drop_tip(
             wellName="A2",
             wellLocation=DropTipWellLocation(),
             homeAfter=True,
-            randomizeDropLocation=True,
+            alternateDropLocation=True,
         )
     )
     response = commands.DropTipResult(position=DeckPoint(x=4, y=5, z=6))
@@ -316,7 +316,7 @@ def test_drop_tip(
         well_name="A2",
         well_location=DropTipWellLocation(),
         home_after=True,
-        randomize_drop_location=True,
+        alternateDropLocation=True,
     )
 
     assert result == response

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -87,7 +87,7 @@ async def test_drop_tip_implementation(
     )
 
     decoy.when(
-        mock_state_view.geometry.get_tip_drop_location(
+        mock_state_view.geometry.get_checked_tip_drop_location(
             pipette_id="abc",
             labware_id="123",
             well_location=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
@@ -113,7 +113,7 @@ async def test_drop_tip_implementation(
     )
 
 
-async def test_drop_tip_with_randomization(
+async def test_drop_tip_with_alternating_locations(
     decoy: Decoy,
     mock_state_view: StateView,
     mock_movement_handler: MovementHandler,
@@ -131,22 +131,20 @@ async def test_drop_tip_with_randomization(
         wellName="A3",
         wellLocation=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
         homeAfter=True,
-        randomizeDropLocation=True,
+        alternateDropLocation=True,
     )
     drop_location = DropTipWellLocation(
         origin=DropTipWellOrigin.DEFAULT, offset=WellOffset(x=10, y=20, z=30)
     )
     decoy.when(
-        mock_state_view.labware.get_random_drop_tip_location(
-            labware_id="123", well_name="A3"
+        mock_state_view.geometry.get_next_tip_drop_location(
+            labware_id="123", well_name="A3", pipette_id="abc"
         )
     ).then_return(drop_location)
 
     decoy.when(
-        mock_state_view.geometry.get_tip_drop_location(
-            pipette_id="abc",
-            labware_id="123",
-            well_location=drop_location,
+        mock_state_view.geometry.get_checked_tip_drop_location(
+            pipette_id="abc", labware_id="123", well_location=drop_location
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -27,7 +27,6 @@ from opentrons.protocol_engine.types import (
     OnLabwareLocation,
     LabwareLocation,
     OFF_DECK_LOCATION,
-    DropTipWellLocation,
     OverlapOffset,
 )
 from opentrons.protocol_engine.state.move_types import EdgePathType

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -1,7 +1,7 @@
 """Labware state store tests."""
 import pytest
 from datetime import datetime
-from typing import Dict, Optional, cast, ContextManager, Any, Union, List
+from typing import Dict, Optional, cast, ContextManager, Any, Union
 from contextlib import nullcontext as does_not_raise
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
@@ -1204,31 +1204,3 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
             ),
             bottom_labware_id="labware-id",
         )
-
-
-def test_get_random_drop_tip_location(
-    ot3_fixed_trash_def: LabwareDefinition,
-) -> None:
-    """It should provide a random location within 3/4th of well top center every time."""
-    subject = get_labware_view(
-        labware_by_id={
-            "trash-id": trash,
-        },
-        definitions_by_uri={
-            "some-trash-uri": ot3_fixed_trash_def,
-        },
-    )
-    drop_location: List[DropTipWellLocation] = []
-    for i in range(50):
-        drop_location.append(
-            subject.get_random_drop_tip_location(labware_id="trash-id", well_name="A1")
-        )
-
-    for i in range(50):
-        print(drop_location[i])
-        assert not all(drop_location[i] == another_loc for another_loc in drop_location)
-        # trash's well A1 dimensions:
-        # "xDimension": 225
-        assert -84 <= drop_location[i].offset.x < 84
-        assert drop_location[i].offset.y == 0
-        assert drop_location[i].offset.z == 0

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -620,6 +620,7 @@ def test_add_pipette_config(subject: PipetteStore) -> None:
         display_name="pipette name",
         min_volume=1.23,
         max_volume=4.56,
+        channels=7,
         return_tip_scale=4,
         nominal_tip_overlap={"default": 5},
         home_position=8.9,

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -237,6 +237,7 @@ def test_get_pipette_working_volume() -> None:
             "pipette-id": StaticPipetteConfig(
                 min_volume=1,
                 max_volume=9001,
+                channels=5,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
@@ -261,6 +262,7 @@ def test_get_pipette_working_volume_raises_if_tip_volume_is_none() -> None:
             "pipette-id": StaticPipetteConfig(
                 min_volume=1,
                 max_volume=9001,
+                channels=5,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
@@ -294,6 +296,7 @@ def test_get_pipette_available_volume() -> None:
             "pipette-id": StaticPipetteConfig(
                 min_volume=1,
                 max_volume=123,
+                channels=3,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
@@ -305,6 +308,7 @@ def test_get_pipette_available_volume() -> None:
             "pipette-id-none": StaticPipetteConfig(
                 min_volume=1,
                 max_volume=123,
+                channels=5,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
@@ -413,6 +417,7 @@ def test_get_static_config() -> None:
         serial_number="serial-number",
         min_volume=1.23,
         max_volume=4.56,
+        channels=9,
         return_tip_scale=7.89,
         nominal_tip_overlap={},
         home_position=10.12,
@@ -442,6 +447,7 @@ def test_get_nominal_tip_overlap() -> None:
         serial_number="",
         min_volume=0,
         max_volume=0,
+        channels=10,
         return_tip_scale=0,
         nominal_tip_overlap={
             "some-uri": 100,

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -443,7 +443,7 @@ stages:
                       x: 0
                       y: 0
                       z: 0
-                  randomizeDropLocation: false
+                  alternateDropLocation: false
                 result:
                   position: { 'x': 347.84000000000003, 'y': 325.06, 'z': 82.0 }
                 startedAt: !anystr

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -287,7 +287,7 @@ stages:
                   x: 0
                   y: 0
                   z: 0
-              randomizeDropLocation: false
+              alternateDropLocation: false
           - id: '{setup_command_id}'
             key: '{setup_command_key}'
             intent: setup
@@ -558,7 +558,7 @@ stages:
                   x: 0
                   y: 0
                   z: 0
-              randomizeDropLocation: false
+              alternateDropLocation: false
           - id: '{setup_command_id}'
             key: '{setup_command_key}'
             intent: setup

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -123,7 +123,7 @@ stages:
                   x: 0
                   y: 0
                   z: 0
-              randomizeDropLocation: false
+              alternateDropLocation: false
           - id: !anystr
             key: !anystr
             commandType: pickUpTip

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -122,4 +122,4 @@ stages:
                   x: 0
                   y: 0
                   z: 0
-              randomizeDropLocation: false
+              alternateDropLocation: false

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -724,9 +724,9 @@
           "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
           "type": "boolean"
         },
-        "randomizeDropLocation": {
-          "title": "Randomizedroplocation",
-          "description": "Whether to randomize the location where tip is dropped within the labware. If True, this command will ignore the wellLocation provided and drop tip at a random location within a set area of the specified labware well. If False, the tip will be dropped at the top center of the well.",
+        "alternateDropLocation": {
+          "title": "Alternatedroplocation",
+          "description": "Whether to alternate location where tip is dropped within the labware. If True, this command will ignore the wellLocation provided and alternate between dropping tips at two predetermined locations inside the specified labware well. If False, the tip will be dropped at the top center of the well.",
           "default": false,
           "type": "boolean"
         }

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 opentrons_shared_data.pipette: functions and types for pipette config
 """
 import copy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 import json
 from functools import lru_cache
 
@@ -17,7 +17,20 @@ if TYPE_CHECKING:
         PipetteName,
         PipetteModel,
         PipetteFusedSpec,
+        ChannelCount,
     )
+
+
+# TODO (spp, 2023-06-22: should probably move this to definition)
+"""
+The span of pipettes in X-direction based on number of channels.
+This is needed in order to determine safe tip drop location within a labware.
+"""
+PIPETTE_X_SPAN: Dict[ChannelCount, float] = {
+    1: 75,  # includes a margin
+    8: 75,  # includes a margin
+    96: 161,
+}
 
 
 def model_config() -> PipetteModelSpecs:


### PR DESCRIPTION
Closes RQA-1007

# Overview

Changes the drop tip randomization to drop tips in predetermined locations that it will alternate between. I've selected these two locations based on coverage area and the ability of pipettes to reach that location:
1. location along x-axis from well top-center, at a distance closer to left edge of labware well
2. location along x-axis from well top-center, at a distance closer to right edge of labware well

See comments and docstrings in the PR for detailed descriptions of these locations

# Test Plan

Make sure the following tests succeed:
- [ ] A single/8- channel pipette on **LEFT** mount is able to go through the predetermined locations without hitting the trash or walls when:
    - [ ] trash is in column 1
    - [ ] trash is in column 3
- [ ] A single/8- channel pipette on **RIGHT** mount is able to go through the predetermined locations without hitting the trash or walls when:
    - [ ] trash is in column 1
    - [ ] trash is in column 3
- [ ] A 96-channel pipette is able to go through the predetermined locations without hitting the trash or walls when:
    - [ ] trash is in column 1
    - [ ] trash is in column 3

- [ ] Make sure that return_tip() behavior is not affected by this

Sample test protocol:
```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.15"
}

def run(protocol_context):
	# For Flex:
	tiprack1 = protocol_context.load_labware("opentrons_ot3_96_tiprack_1000ul", "D2")
	pipette = protocol_context.load_instrument("p1000_96", 'left', tip_racks=[tiprack1])
	# pipette = protocol_context.load_instrument("p50_single_gen3", "left", tip_racks=[tiprack1])

	# For OT-2
	# tiprack1 = protocol_context.load_labware("opentrons_96_tiprack_300ul", 2)
	# pipette = protocol_context.load_instrument("p300_single", "right", tip_racks=[tiprack1])

	for _ in range(10):
		pipette.pick_up_tip()
		pipette.drop_tip()
		
		# resets the tiprack so that we can use the same labware for testing w/ 96 channel
		# not needed if testing with other pipettes
		tiprack1.reset()	
		protocol_context.pause(msg="Reload the tips in the tiprack")

	pipette.pick_up_tip()
	pipette.drop_tip(pipette.trash_container['A1'].top())	# Should only go to trash center. `alternateDropLocation` should be false

```

For QA & ABR testing, we only need to test 1, 8 & multi-channel pipettes with the OT3 trash bin in slot A3. Placing the trash in the left column will currently not calculate labware position on deck correctly so we cannot use that for testing.

Should also be tested for OT2 but is not a blocker for internal QA/ science testing for flex.

# Changelog

- removed total randomized drop tip
- added next tip drop location getter to geometry view
- other changes to facilitate fetching the correct locations

# Review requests

- Code review
- Make sure the above points in test plan are tested and they cover all scenarios 
- I have tested all pipette combinations on OT3 for the fixed trash using engine commands and verified that the gantry or pipettes don't crash into anything anymore. We should also test running a python protocol that has a few tip drops.

# Risk assessment

- Less risky than dropping tip at total randomized location, which this replaces. There is still a decent risk that this would cause the pipette to go to an inaccessible location that could result in pipette/ tips bumping against the labware, but hopefully the check for fixed trash suffices for now.
