### PR TITLE
 fix(hardware): don't stop reading from CAN after most exceptions

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -49,7 +49,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import ErrorMessageP
 
 from opentrons_hardware.firmware_bindings.utils import BinarySerializableException
 
-from .errors import AsyncHardwareError
+from .errors import AsyncHardwareError, CanError
 
 log = logging.getLogger(__name__)
 
@@ -349,17 +349,18 @@ class CanMessenger:
             self._listeners.pop(listener)
 
     async def _read_task_shield(self) -> None:
-        try:
-            await self._read_task()
-        except asyncio.CancelledError:
-            pass
-        except CANCommunicationError:
-            raise
-        except AsyncHardwareError:
-            raise
-        except Exception as exc:
-            log.exception("Exception in read")
-            raise CANCommunicationError(exc=exc)
+        while True:
+            try:
+                await self._read_task()
+            except asyncio.CancelledError:
+                return
+            except (CANCommunicationError, AsyncHardwareError, CanError) as e:
+                log.exception(f"Nonfatal error in CAN read task: {e}")
+                continue
+            except Exception as e:
+                # Log this separately if it's some unknown error
+                log.exception(f"Unexpected error in CAN read task: {e}")
+                continue
 
     async def _read_task(self) -> None:
         """Read task."""


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The CAN messenger reader task will exit if it gets any exceptions. We actually want to keep reading unless the task is cancelled. There are a few exceptions that are normal to receive and we don't want to completely stop reading.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
