### PR TITLE
feat(shared-data): Support quirks, mount and mutable configs in v2 pipettes

### DIFF
--- a/robot-server/robot_server/service/legacy/models/settings.py
+++ b/robot-server/robot_server/service/legacy/models/settings.py
@@ -5,7 +5,7 @@ from typing import Optional, List, Dict, Any, Union
 
 from pydantic import BaseModel, Field, create_model, validator
 
-from opentrons.config.pipette_config import MUTABLE_CONFIGS, VALID_QUIRKS
+from opentrons_shared_data.pipette import model_constants
 from opentrons.config.reset import ResetOptionId
 
 
@@ -175,7 +175,7 @@ PipetteSettingsFields = create_model(
     __base__=BasePipetteSettingFields,
     **{  # type: ignore[arg-type]
         conf: (PipetteSettingsField, None)
-        for conf in MUTABLE_CONFIGS
+        for conf in model_constants.MUTABLE_CONFIGS_V1
         if conf != "quirks"
     },
 )
@@ -214,11 +214,11 @@ class PipetteSettingsUpdate(BaseModel):
         for key, value in v.items():
             if value is None:
                 pass
-            elif key in MUTABLE_CONFIGS:
+            elif key in model_constants.MUTABLE_CONFIGS_V1:
                 if value.value is not None:
                     # Must be a float for overriding a config field
                     value.value = float(value.value)
-            elif key in VALID_QUIRKS:
+            elif key in model_constants.VALID_QUIRKS:
                 if not isinstance(value.value, bool):
                     raise ValueError(
                         f"{key} quirk value must " f"be a boolean. Got {value.value}"

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -315,7 +315,7 @@ async def patch_pipette_setting(
             raise LegacyErrorResponse(
                 message=str(e), errorCode=ErrorCodes.GENERAL_ERROR.value.code
             ).as_error(status.HTTP_412_PRECONDITION_FAILED)
-    r = _pipette_settings_from_config(pipette_config, pipette_id)
+    r = _pipette_settings_from_config(pipette_id)
     return r
 
 

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -8,8 +8,8 @@ from fastapi import APIRouter, Depends
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.system import log_control
+from opentrons_shared_data.pipette import mutable_configurations
 from opentrons.config import (
-    pipette_config,
     reset as reset_util,
     robot_configs,
     advanced_settings,
@@ -261,10 +261,10 @@ async def get_robot_settings(
 )
 async def get_pipette_settings() -> MultiPipetteSettings:
     res = {}
-    for pipette_id in pipette_config.known_pipettes():
+    for pipette_id in mutable_configurations.known_pipettes():
         # Have to convert to dict using by_alias due to bug in fastapi
         res[pipette_id] = _pipette_settings_from_config(
-            pipette_config,
+            mutable_configurations,
             pipette_id,
         )
     return res
@@ -281,7 +281,7 @@ async def get_pipette_settings() -> MultiPipetteSettings:
     },
 )
 async def get_pipette_setting(pipette_id: str) -> PipetteSettings:
-    if pipette_id not in pipette_config.known_pipettes():
+    if pipette_id not in mutable_configurations.known_pipettes():
         raise LegacyErrorResponse(
             message=f"{pipette_id} is not a valid pipette id",
             errorCode=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
@@ -309,7 +309,7 @@ async def patch_pipette_setting(
     field_values = {k: None if v is None else v.value for k, v in fields.items()}
     if field_values:
         try:
-            pipette_config.override(fields=field_values, pipette_id=pipette_id)
+            mutable_configurations.save_overrides(fields=field_values, pipette_id=pipette_id)
         except ValueError as e:
             raise LegacyErrorResponse(
                 message=str(e), errorCode=ErrorCodes.GENERAL_ERROR.value.code
@@ -328,9 +328,9 @@ def _pipette_settings_from_config(pc, pipette_id: str) -> PipetteSettings:
     """
     mutuble_configs = pc.list_mutable_configs(pipette_id=pipette_id)
     fields = PipetteSettingsFields(**{k: v for k, v in mutuble_configs.items()})
-    c, m = pc.load_config_dict(pipette_id)
 
     # TODO(mc, 2020-09-17): s/fields/setting_fields (?)
+    # need model and name?
     return PipetteSettings(  # type: ignore[call-arg]
         info=PipetteSettingsInfo(name=c.get("name"), model=m), fields=fields
     )

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 import logging
-from typing import Dict
+from typing import Dict, cast, Union, Any
 
 from starlette import status
 from fastapi import APIRouter, Depends
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.system import log_control
-from opentrons_shared_data.pipette import mutable_configurations
+from opentrons_shared_data.pipette import mutable_configurations, types as pip_types
 from opentrons.config import (
     reset as reset_util,
     robot_configs,
@@ -264,7 +264,6 @@ async def get_pipette_settings() -> MultiPipetteSettings:
     for pipette_id in mutable_configurations.known_pipettes():
         # Have to convert to dict using by_alias due to bug in fastapi
         res[pipette_id] = _pipette_settings_from_config(
-            mutable_configurations,
             pipette_id,
         )
     return res
@@ -286,7 +285,7 @@ async def get_pipette_setting(pipette_id: str) -> PipetteSettings:
             message=f"{pipette_id} is not a valid pipette id",
             errorCode=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
         ).as_error(status.HTTP_404_NOT_FOUND)
-    r = _pipette_settings_from_config(pipette_config, pipette_id)
+    r = _pipette_settings_from_config(pipette_id)
     return r
 
 
@@ -309,7 +308,9 @@ async def patch_pipette_setting(
     field_values = {k: None if v is None else v.value for k, v in fields.items()}
     if field_values:
         try:
-            mutable_configurations.save_overrides(fields=field_values, pipette_id=pipette_id)
+            mutable_configurations.save_overrides(
+                overrides=field_values, pipette_serial_number=pipette_id
+            )
         except ValueError as e:
             raise LegacyErrorResponse(
                 message=str(e), errorCode=ErrorCodes.GENERAL_ERROR.value.code
@@ -318,7 +319,7 @@ async def patch_pipette_setting(
     return r
 
 
-def _pipette_settings_from_config(pc, pipette_id: str) -> PipetteSettings:
+def _pipette_settings_from_config(pipette_id: str) -> PipetteSettings:
     """
     Create a PipetteSettings object from pipette config for single pipette
 
@@ -326,11 +327,26 @@ def _pipette_settings_from_config(pc, pipette_id: str) -> PipetteSettings:
     :param pipette_id: pipette id
     :return: PipetteSettings object
     """
-    mutuble_configs = pc.list_mutable_configs(pipette_id=pipette_id)
-    fields = PipetteSettingsFields(**{k: v for k, v in mutuble_configs.items()})
+    mutable_configs = mutable_configurations.list_mutable_configs(
+        pipette_serial_number=pipette_id
+    )
+    converted_dict: Dict[str, Union[str, Dict[str, Any]]] = {}
+    # TODO rather than doing this gross thing, we should
+    # mess around with pydantic dataclasses.
+    for k, v in mutable_configs.items():
+        if isinstance(v, str):
+            converted_dict[k] = v
+        elif isinstance(v, pip_types.MutableConfig):
+            converted_dict[k] = v.dict_for_encode()
+        elif k == "quirks":
+            converted_dict[k] = {q: b.dict_for_encode() for q, b in v.items()}
+    fields = PipetteSettingsFields(**converted_dict)  # type: ignore
 
     # TODO(mc, 2020-09-17): s/fields/setting_fields (?)
     # need model and name?
     return PipetteSettings(  # type: ignore[call-arg]
-        info=PipetteSettingsInfo(name=c.get("name"), model=m), fields=fields
+        info=PipetteSettingsInfo(
+            name="", model=cast(str, mutable_configs.get("model"))
+        ),
+        fields=fields,
     )

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -356,7 +356,8 @@ def _pipette_settings_from_config(pipette_id: str) -> PipetteSettings:
     # need model and name?
     return PipetteSettings(  # type: ignore[call-arg]
         info=PipetteSettingsInfo(
-            name="", model=cast(str, mutable_configs.get("model"))
+            name=cast(str, mutable_configs.get("name", "")),
+            model=cast(str, mutable_configs.get("model", "")),
         ),
         fields=fields,
     )

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -178,6 +178,11 @@ def attach_pipettes(server_temp_directory: str) -> Iterator[None]:
     pipette_dir_path = os.path.join(server_temp_directory, "pipettes")
     pipette_file_path = os.path.join(pipette_dir_path, "P300MV1020230630.json")
 
+    # FIXME There are random files somehow getting added to this directory
+    # with the IDs 123 & 321. This is a temporary solution to remove
+    # any unexpected files.
+    [fi.unlink() for fi in Path(pipette_dir_path).iterdir() if fi.is_file()]
+
     os.environ["OT_API_CONFIG_DIR"] = server_temp_directory
     with open(pipette_file_path, "w") as pipette_file:
         json.dump(pipette, pipette_file)

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -181,7 +181,9 @@ def attach_pipettes(server_temp_directory: str) -> Iterator[None]:
     # FIXME There are random files somehow getting added to this directory
     # with the IDs 123 & 321. This is a temporary solution to remove
     # any unexpected files.
-    [fi.unlink() for fi in Path(pipette_dir_path).iterdir() if fi.is_file()]
+    for fi in Path(pipette_dir_path).iterdir():
+        if fi.is_file():
+            fi.unlink()
 
     os.environ["OT_API_CONFIG_DIR"] = server_temp_directory
     with open(pipette_file_path, "w") as pipette_file:

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -176,7 +176,7 @@ def attach_pipettes(server_temp_directory: str) -> Iterator[None]:
     pipette = {"dropTipShake": True, "model": "p300_multi_v1"}
 
     pipette_dir_path = os.path.join(server_temp_directory, "pipettes")
-    pipette_file_path = os.path.join(pipette_dir_path, "testpipette01.json")
+    pipette_file_path = os.path.join(pipette_dir_path, "P300MV1020230630.json")
 
     with open(pipette_file_path, "w") as pipette_file:
         json.dump(pipette, pipette_file)

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -178,10 +178,12 @@ def attach_pipettes(server_temp_directory: str) -> Iterator[None]:
     pipette_dir_path = os.path.join(server_temp_directory, "pipettes")
     pipette_file_path = os.path.join(pipette_dir_path, "P300MV1020230630.json")
 
+    os.environ["OT_API_CONFIG_DIR"] = server_temp_directory
     with open(pipette_file_path, "w") as pipette_file:
         json.dump(pipette, pipette_file)
     yield
     os.remove(pipette_file_path)
+    del os.environ["OT_API_CONFIG_DIR"]
 
 
 @pytest.fixture

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -30,7 +30,7 @@ stages:
             top: !anydict
           info:
             model: p300_multi_v1
-            name: !anystr
+            name: p300_multi
       strict: false 
 ---
 test_name: GET Pipette {pipette_id}
@@ -63,7 +63,7 @@ stages:
           top: !anydict
         info:
           model: p300_multi_v1
-          name: !anystr
+          name: p300_multi
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} single value
@@ -106,7 +106,7 @@ stages:
           top: !anydict
         info:
           model: p300_multi_v1
-          name: !anystr
+          name: p300_multi
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} multiple values
@@ -165,7 +165,7 @@ stages:
             value: 18.0
         info:
           model: p300_multi_v1
-          name: !anystr
+          name: p300_multi
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} value too low
@@ -250,5 +250,5 @@ stages:
           top: !anydict
         info:
           model: p300_multi_v1
-          name: !anystr
+          name: p300_multi
       strict: true

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -1,38 +1,43 @@
 ---
-test_name: GET Pipettes
-marks:
-  - usefixtures:
-      - ot2_server_base_url
-      - attach_pipettes
-stages:
-  - name: GET Pipette Settings request returns correct info
-    request:
-      url: "{ot2_server_base_url}/settings/pipettes"
-      method: GET
-    response:
-      status_code: 200
-      json: 
-        testpipette01: 
-          fields: 
-            blowout: !anydict
-            bottom: !anydict
-            dropTip: !anydict
-            dropTipCurrent: !anydict
-            dropTipSpeed: !anydict
-            pickUpCurrent: !anydict
-            pickUpDistance: !anydict
-            pickUpIncrement: !anydict
-            pickUpPresses: !anydict
-            pickUpSpeed: !anydict
-            plungerCurrent: !anydict
-            quirks: !anydict
-            tipLength: !anydict
-            top: !anydict
-          info:
-            model: p300_multi_v1
-            name: !anystr
-      strict: false 
----
+# Temporarily remove this test. I realized that tavern is not
+# actually using the temporary directory path provided by the pytest
+# fixtures because it's technically not running in the same environment
+# I tried to timebox this and couldn't come up with a good solution.
+# Making a ticket to deal with it later.
+# test_name: GET Pipettes
+# marks:
+#   - usefixtures:
+#       - ot2_server_base_url
+#       - attach_pipettes
+# stages:
+#   - name: GET Pipette Settings request returns correct info
+#     request:
+#       url: "{ot2_server_base_url}/settings/pipettes"
+#       method: GET
+#     response:
+#       status_code: 200
+#       json: 
+#         testpipette01: 
+#           fields: 
+#             blowout: !anydict
+#             bottom: !anydict
+#             dropTip: !anydict
+#             dropTipCurrent: !anydict
+#             dropTipSpeed: !anydict
+#             pickUpCurrent: !anydict
+#             pickUpDistance: !anydict
+#             pickUpIncrement: !anydict
+#             pickUpPresses: !anydict
+#             pickUpSpeed: !anydict
+#             plungerCurrent: !anydict
+#             quirks: !anydict
+#             tipLength: !anydict
+#             top: !anydict
+#           info:
+#             model: p300_multi_v1
+#             name: !anystr
+#       strict: false 
+# ---
 test_name: GET Pipette {pipette_id}
 marks:
   - usefixtures:

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -89,8 +89,8 @@ stages:
           dropTip:
             units: mm
             type: float
-            min: -6.0
-            max: 2.0
+            min: -20.0
+            max: 30.0
             default: -2.0
             value: 1.0
           dropTipCurrent: !anydict
@@ -134,15 +134,15 @@ stages:
           blowout:
             units: mm
             type: float
-            min: -4.0
-            max: 10.0
+            min: -20.0
+            max: 30.0
             default: 3.0
             value: 5.0
           bottom:
             units: mm
             type: float
-            min: -2.0
-            max: 19.0
+            min: -20.0
+            max: 30.0
             default: 3.5
             value: 3.0
           dropTip: !anydict
@@ -159,8 +159,8 @@ stages:
           top:
             units: mm
             type: float
-            min: 5.0
-            max: 19.5
+            min: -20.0
+            max: 30.0
             default: 19.5
             value: 18.0
         info:
@@ -181,7 +181,7 @@ stages:
       json:
         fields:
           dropTip:
-            value: -10.0
+            value: -40.0
     response:
       status_code: 412
       json: 
@@ -202,7 +202,7 @@ stages:
       json:
         fields:
           dropTip:
-            value: 5.0
+            value: 50.0
     response:
       status_code: 412
       json: 
@@ -233,8 +233,8 @@ stages:
           dropTip:
             units: mm
             type: float
-            min: -6.0
-            max: 2.0
+            min: -20.0
+            max: 30.0
             default: -2.0
             value: -2.0
           dropTipCurrent: !anydict

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -30,7 +30,7 @@ stages:
             top: !anydict
           info:
             model: p300_multi_v1
-            name: p300_multi
+            name: !anystr
       strict: false 
 ---
 test_name: GET Pipette {pipette_id}
@@ -41,7 +41,7 @@ marks:
 stages:
   - name: GET Pipette Settings of specific pipette request returns correct info
     request:
-      url: "{ot2_server_base_url}/settings/pipettes/testpipette01"
+      url: "{ot2_server_base_url}/settings/pipettes/P300MV1020230630"
       method: GET
     response:
       status_code: 200
@@ -63,7 +63,7 @@ stages:
           top: !anydict
         info:
           model: p300_multi_v1
-          name: p300_multi
+          name: !anystr
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} single value
@@ -74,7 +74,7 @@ marks:
 stages:
   - name: PATCH Pipette Settings of a single value
     request:
-      url: "{ot2_server_base_url}/settings/pipettes/testpipette01"
+      url: "{ot2_server_base_url}/settings/pipettes/P300MV1020230630"
       method: PATCH
       json:
         fields:
@@ -106,7 +106,7 @@ stages:
           top: !anydict
         info:
           model: p300_multi_v1
-          name: p300_multi
+          name: !anystr
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} multiple values
@@ -117,7 +117,7 @@ marks:
 stages:
   - name: PATCH Pipette Settings of multiple values
     request:
-      url: "{ot2_server_base_url}/settings/pipettes/testpipette01"
+      url: "{ot2_server_base_url}/settings/pipettes/P300MV1020230630"
       method: PATCH
       json:
         fields:
@@ -165,7 +165,7 @@ stages:
             value: 18.0
         info:
           model: p300_multi_v1
-          name: p300_multi
+          name: !anystr
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} value too low
@@ -176,7 +176,7 @@ marks:
 stages:
   - name: PATCH Pipette Settings with too low of a value
     request:
-      url: "{ot2_server_base_url}/settings/pipettes/testpipette01"
+      url: "{ot2_server_base_url}/settings/pipettes/P300MV1020230630"
       method: PATCH
       json:
         fields:
@@ -197,7 +197,7 @@ marks:
 stages:
   - name: PATCH Pipette Settings with too high of a value
     request:
-      url: "{ot2_server_base_url}/settings/pipettes/testpipette01"
+      url: "{ot2_server_base_url}/settings/pipettes/P300MV1020230630"
       method: PATCH
       json:
         fields:
@@ -218,7 +218,7 @@ marks:
 stages:
   - name: PATCH Pipette Settings with no value at all (should reset to default)
     request:
-      url: "{ot2_server_base_url}/settings/pipettes/testpipette01"
+      url: "{ot2_server_base_url}/settings/pipettes/P300MV1020230630"
       method: PATCH
       json:
         fields:
@@ -250,5 +250,5 @@ stages:
           top: !anydict
         info:
           model: p300_multi_v1
-          name: p300_multi
+          name: !anystr
       strict: true

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -1,43 +1,38 @@
 ---
-# Temporarily remove this test. I realized that tavern is not
-# actually using the temporary directory path provided by the pytest
-# fixtures because it's technically not running in the same environment
-# I tried to timebox this and couldn't come up with a good solution.
-# Making a ticket to deal with it later.
-# test_name: GET Pipettes
-# marks:
-#   - usefixtures:
-#       - ot2_server_base_url
-#       - attach_pipettes
-# stages:
-#   - name: GET Pipette Settings request returns correct info
-#     request:
-#       url: "{ot2_server_base_url}/settings/pipettes"
-#       method: GET
-#     response:
-#       status_code: 200
-#       json: 
-#         testpipette01: 
-#           fields: 
-#             blowout: !anydict
-#             bottom: !anydict
-#             dropTip: !anydict
-#             dropTipCurrent: !anydict
-#             dropTipSpeed: !anydict
-#             pickUpCurrent: !anydict
-#             pickUpDistance: !anydict
-#             pickUpIncrement: !anydict
-#             pickUpPresses: !anydict
-#             pickUpSpeed: !anydict
-#             plungerCurrent: !anydict
-#             quirks: !anydict
-#             tipLength: !anydict
-#             top: !anydict
-#           info:
-#             model: p300_multi_v1
-#             name: !anystr
-#       strict: false 
-# ---
+test_name: GET Pipettes
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+      - attach_pipettes
+stages:
+  - name: GET Pipette Settings request returns correct info
+    request:
+      url: "{ot2_server_base_url}/settings/pipettes"
+      method: GET
+    response:
+      status_code: 200
+      json: 
+        P300MV1020230630: 
+          fields: 
+            blowout: !anydict
+            bottom: !anydict
+            dropTip: !anydict
+            dropTipCurrent: !anydict
+            dropTipSpeed: !anydict
+            pickUpCurrent: !anydict
+            pickUpDistance: !anydict
+            pickUpIncrement: !anydict
+            pickUpPresses: !anydict
+            pickUpSpeed: !anydict
+            plungerCurrent: !anydict
+            quirks: !anydict
+            tipLength: !anydict
+            top: !anydict
+          info:
+            model: p300_multi_v1
+            name: !anystr
+      strict: false 
+---
 test_name: GET Pipette {pipette_id}
 marks:
   - usefixtures:

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -4,10 +4,13 @@ from dataclasses import make_dataclass
 from typing import Generator
 
 import pytest
+
 from decoy import Decoy
 
 from opentrons.config.reset import ResetOptionId
 from opentrons.config import advanced_settings
+from opentrons_shared_data.pipette import types as pip_types
+
 
 from robot_server import app
 from robot_server.persistence import PersistenceResetter, get_persistence_resetter
@@ -73,10 +76,7 @@ def test_get_robot_settings(api_client, hardware):
 def mock_pipette_data():
     return {
         "p1": {
-            "info": {
-                "name": "p1_name",
-                "model": "p1_model",
-            },
+            "info": {"model": "p1_model", "name": ""},
             "fields": {
                 "pickUpCurrent": {
                     "units": "mm",
@@ -90,18 +90,15 @@ def mock_pipette_data():
             },
         },
         "p2": {
-            "info": {
-                "name": "p2_name",
-                "model": "p2_model",
-            },
+            "info": {"model": "p2_model", "name": ""},
             "fields": {
                 "pickUpIncrement": {
-                    "units": "inch",
+                    "units": "mm/s",
                     "type": "int",
-                    "min": 0,
-                    "max": 2,
+                    "min": 0.0,
+                    "max": 2.0,
                     "default": 1.0,
-                    "value": 2,
+                    "value": 2.0,
                 }
             },
         },
@@ -109,20 +106,77 @@ def mock_pipette_data():
 
 
 @pytest.fixture
-def mock_pipette_config(mock_pipette_data):
-    with patch("robot_server.service.legacy.routers." "settings.pipette_config") as p:
-        p.known_pipettes.return_value = list(mock_pipette_data.keys())
-        p.load_config_dict.side_effect = lambda id: (
-            mock_pipette_data[id]["info"],
-            mock_pipette_data[id]["info"]["model"],
-        )
-        p.list_mutable_configs.side_effect = lambda pipette_id: mock_pipette_data[
-            pipette_id
-        ]["fields"]
-        yield p
+def mock_known_pipettes(decoy: Decoy) -> Decoy:
+    with patch(
+        "opentrons_shared_data.pipette.mutable_configurations.known_pipettes",
+        new=decoy.mock(),
+    ) as m:
+        yield m
 
 
-def test_receive_pipette_settings(api_client, mock_pipette_config, mock_pipette_data):
+@pytest.fixture
+def mock_list_mutable_configs(decoy: Decoy) -> Decoy:
+    with patch(
+        "opentrons_shared_data.pipette.mutable_configurations.list_mutable_configs",
+        new=decoy.mock(),
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_save_overrides(decoy: Decoy) -> Decoy:
+    with patch(
+        "opentrons_shared_data.pipette.mutable_configurations.save_overrides",
+        new=decoy.mock(),
+    ) as m:
+        yield m
+
+
+def test_receive_pipette_settings(
+    decoy: Decoy,
+    api_client,
+    mock_known_pipettes: Decoy,
+    mock_list_mutable_configs: Decoy,
+    mock_pipette_data,
+):
+    decoy.when(mock_known_pipettes()).then_return(["p1", "p2"])
+
+    decoy.when(mock_list_mutable_configs(pipette_serial_number="p1")).then_return(
+        {
+            "pickUpCurrent": pip_types.MutableConfig.build(
+                **{
+                    "units": "mm",
+                    "type": "float",
+                    "min": 0.0,
+                    "max": 2.0,
+                    "default": 1.0,
+                    "value": 0.5,
+                },
+                name="pickUpCurrent",
+            ),
+            "quirks": {
+                "dropTipShake": pip_types.QuirkConfig(name="dropTipShake", value=True)
+            },
+            "model": "p1_model",
+        }
+    )
+
+    decoy.when(mock_list_mutable_configs(pipette_serial_number="p2")).then_return(
+        {
+            "pickUpIncrement": pip_types.MutableConfig.build(
+                **{
+                    "units": "mm/s",
+                    "type": "int",
+                    "min": 0,
+                    "max": 2,
+                    "default": 1.0,
+                    "value": 2,
+                },
+                name="pickUpIncrement",
+            ),
+            "model": "p2_model",
+        }
+    )
 
     resp = api_client.get("/settings/pipettes")
     assert resp.status_code == 200
@@ -130,24 +184,74 @@ def test_receive_pipette_settings(api_client, mock_pipette_config, mock_pipette_
 
 
 def test_receive_pipette_settings_unknown(
-    api_client, mock_pipette_config, mock_pipette_data
+    api_client, mock_known_pipettes: Decoy, decoy: Decoy
 ):
+    decoy.when(mock_known_pipettes()).then_return([])
     # Non-existent pipette id and get 404
     resp = api_client.get("/settings/pipettes/wannabepipette")
     assert resp.status_code == 404
 
 
 def test_receive_pipette_settings_found(
-    api_client, mock_pipette_config, mock_pipette_data
+    decoy: Decoy,
+    mock_known_pipettes: Decoy,
+    mock_list_mutable_configs: Decoy,
+    api_client,
+    mock_pipette_data,
 ):
+    decoy.when(mock_known_pipettes()).then_return(["p1"])
+    decoy.when(mock_list_mutable_configs(pipette_serial_number="p1")).then_return(
+        {
+            "pickUpCurrent": pip_types.MutableConfig.build(
+                **{
+                    "units": "mm",
+                    "type": "float",
+                    "min": 0.0,
+                    "max": 2.0,
+                    "default": 1.0,
+                    "value": 0.5,
+                },
+                name="pickUpCurrent",
+            ),
+            "quirks": {
+                "dropTipShake": pip_types.QuirkConfig(name="dropTipShake", value=True)
+            },
+            "model": "p1_model",
+        }
+    )
     resp = api_client.get("/settings/pipettes/p1")
     assert resp.status_code == 200
     assert resp.json() == mock_pipette_data["p1"]
 
 
 def test_modify_pipette_settings_call_override(
-    api_client, mock_pipette_config, mock_pipette_data
+    decoy: Decoy,
+    api_client,
+    mock_pipette_data,
+    mock_known_pipettes: Decoy,
+    mock_save_overrides: Decoy,
+    mock_list_mutable_configs: Decoy,
 ):
+    decoy.when(mock_known_pipettes()).then_return(["p1"])
+    decoy.when(mock_list_mutable_configs(pipette_serial_number="p1")).then_return(
+        {
+            "pickUpCurrent": pip_types.MutableConfig.build(
+                **{
+                    "units": "mm",
+                    "type": "float",
+                    "min": 0.0,
+                    "max": 2.0,
+                    "default": 1.0,
+                    "value": 1.0,
+                },
+                name="pickUpCurrent",
+            ),
+            "quirks": {
+                "dropTipShake": pip_types.QuirkConfig(name="dropTipShake", value=True)
+            },
+            "model": "p1_model",
+        }
+    )
     pipette_id = "p1"
     changes = {
         "fields": {
@@ -160,7 +264,7 @@ def test_modify_pipette_settings_call_override(
 
     # Check that data is changed and matches the changes specified
     resp = api_client.patch(f"/settings/pipettes/{pipette_id}", json=changes)
-    mock_pipette_config.override.assert_called_once_with(
+    mock_save_overrides.assert_called_once_with(
         fields={
             "pickUpCurrent": 1,
             "dropTipShake": True,
@@ -169,6 +273,18 @@ def test_modify_pipette_settings_call_override(
         },
         pipette_id=pipette_id,
     )
+
+    mock_pipette_data[pipette_id]["fields"] = {
+        "pickUpCurrent": {
+            "units": "mm",
+            "type": "float",
+            "min": 0.0,
+            "max": 2.0,
+            "default": 1.0,
+            "value": 1.0,
+        },
+        "quirks": {"dropTipShake": True},
+    }
     patch_body = resp.json()
     assert resp.status_code == 200
     assert patch_body == {
@@ -179,12 +295,38 @@ def test_modify_pipette_settings_call_override(
 
 @pytest.mark.parametrize(argnames=["body"], argvalues=[[{}], [{"fields": {}}]])
 def test_modify_pipette_settings_do_not_call_override(
-    api_client, mock_pipette_config, mock_pipette_data, body
+    decoy: Decoy,
+    api_client,
+    mock_pipette_data,
+    body,
+    mock_known_pipettes: Decoy,
+    mock_save_overrides: Decoy,
+    mock_list_mutable_configs: Decoy,
 ):
     pipette_id = "p1"
+    decoy.when(mock_known_pipettes()).then_return(["p1"])
+    decoy.when(mock_list_mutable_configs(pipette_serial_number="p1")).then_return(
+        {
+            "pickUpCurrent": pip_types.MutableConfig.build(
+                **{
+                    "units": "mm",
+                    "type": "float",
+                    "min": 0.0,
+                    "max": 2.0,
+                    "default": 1.0,
+                    "value": 0.5,
+                },
+                name="pickUpCurrent",
+            ),
+            "quirks": {
+                "dropTipShake": pip_types.QuirkConfig(name="dropTipShake", value=True)
+            },
+            "model": "p1_model",
+        }
+    )
 
     resp = api_client.patch(f"/settings/pipettes/{pipette_id}", json=body)
-    mock_pipette_config.override.assert_not_called()
+    mock_save_overrides.assert_not_called()
     patch_body = resp.json()
     assert resp.status_code == 200
     assert patch_body == {
@@ -193,21 +335,24 @@ def test_modify_pipette_settings_do_not_call_override(
     }
 
 
-def test_modify_pipette_settings_failure(api_client, mock_pipette_config):
+def test_modify_pipette_settings_failure(
+    decoy: Decoy, api_client, mock_save_overrides: Decoy
+):
     test_id = "p1"
 
-    def mock_override(pipette_id, fields):
-        raise ValueError("Failed!")
+    test_fields = {"pickUpCurrent": {"value": 1}}
 
-    mock_pipette_config.override.side_effect = mock_override
+    decoy.when(
+        mock_save_overrides(
+            overrides={"pickUpCurrent": 1.0}, pipette_serial_number=test_id
+        )
+    ).then_raise(ValueError("Failed!"))
 
     resp = api_client.patch(
         f"/settings/pipettes/{test_id}",
-        json={"fields": {"pickUpCurrent": {"value": 1}}},
+        json={"fields": test_fields},
     )
-    mock_pipette_config.override.assert_called_once_with(
-        pipette_id=test_id, fields={"pickUpCurrent": 1}
-    )
+
     patch_body = resp.json()
     assert resp.status_code == 412
     assert patch_body == {"message": "Failed!", "errorCode": "4000"}

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake", "doubleDropTip"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake", "doubleDropTip"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
@@ -1,8 +1,8 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 Eight Channel GEN3",
+  "displayName": "Flex 8-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.5,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 8-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.5,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 8-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.5,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 8-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.55,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_multi"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_multi"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake", "doubleDropTip"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 3.5,
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_multi"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["needsUnstick"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 3.5,
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_multi"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["needsUnstick"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["doubleDropTip", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 8-Channel 50 μL",
   "model": "p50",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.5,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 8-Channel 50 μL",
   "model": "p50",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.5,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -32,5 +32,6 @@
   "channels": 8,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 8-Channel 50 μL",
   "model": "p50",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.55,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -32,5 +32,6 @@
   "channels": 96,
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
-  "backlashDistance": 0.3
+  "backlashDistance": 0.3,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -1,8 +1,8 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
-  "displayName": "P1000 96 Channel GEN3",
+  "displayName": "Flex 96-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 1.5,
     "presses": 0.0,

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 96-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 1.5,
     "presses": 0.0,

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
@@ -32,5 +32,6 @@
   "channels": 96,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.3
+  "backlashDistance": 0.3,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 96-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 1.5,
     "presses": 0.0,

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
@@ -32,5 +32,6 @@
   "channels": 96,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.3
+  "backlashDistance": 0.3,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 96-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 1.5,
     "presses": 0.0,

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
@@ -39,5 +39,6 @@
   "channels": 96,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.3
+  "backlashDistance": 0.3,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 6.0,
   "shaftULperMM": 28.274,
   "backCompatNames": ["p1000_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 6.0,
   "shaftULperMM": 28.274,
   "backCompatNames": ["p1000_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 6.0,
   "shaftULperMM": 28.274,
   "backCompatNames": ["p1000_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["pickupTipShake", "dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 1-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.15,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
@@ -29,5 +29,6 @@
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 1-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.15,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
@@ -29,5 +29,6 @@
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
@@ -29,5 +29,6 @@
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 1-Channel 1000 μL",
   "model": "p1000",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.2,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 5.0,
   "shaftULperMM": 19.635,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 3.5,
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 3.5,
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_single"],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
@@ -33,5 +33,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
@@ -35,5 +35,6 @@
   "shaftDiameter": 2.0,
   "shaftULperMM": 3.142,
   "backCompatNames": [],
-  "backlashDistance": 0.0
+  "backlashDistance": 0.0,
+  "quirks": ["dropTipShake"]
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 1-Channel 50 μL",
   "model": "p50",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.15,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -29,5 +29,6 @@
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 1-Channel 50 μL",
   "model": "p50",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.15,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -29,5 +29,6 @@
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipettePropertiesSchema.json",
   "displayName": "Flex 1-Channel 50 μL",
   "model": "p50",
-  "displayCategory": "GEN3",
+  "displayCategory": "FLEX",
   "pickUpTipConfigurations": {
     "current": 0.2,
     "presses": 1,

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -29,5 +29,6 @@
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
-  "backlashDistance": 0.1
+  "backlashDistance": 0.1,
+  "quirks": []
 }

--- a/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
+++ b/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
@@ -97,6 +97,11 @@
       "description": "Array of pipette names that are compatible with the given pipette",
       "items": { "type": "string" }
     },
+    "quirks": {
+      "type": "array",
+      "description": "Array of pipette quirks supported on the current pipette",
+      "items": { "type": "string" }
+    },
     "channels": { "$ref": "#/definitions/channels" },
     "partialTipConfigurations": {
       "type": "object",

--- a/shared-data/python/opentrons_shared_data/pipette/file_operation_helpers.py
+++ b/shared-data/python/opentrons_shared_data/pipette/file_operation_helpers.py
@@ -1,7 +1,4 @@
 import json
-import os
-import sys
-from pathlib import Path
 from typing import Any, Dict, Union
 from .types import MutableConfig, QuirkConfig
 from .model_constants import VALID_QUIRKS
@@ -38,32 +35,3 @@ class MutableConfigurationDecoder(json.JSONDecoder):
 
     def _decode_mutable_config(self, k: str, obj: Dict[str, Any]) -> MutableConfig:
         return MutableConfig.build(**obj, name=k)
-
-
-def infer_config_pipette_base_dir() -> Path:
-    """Return the directory to store data in.
-
-    Defaults are ~/.opentrons if not on a pi; OT_API_CONFIG_DIR is
-    respected here.
-
-    When this module is imported, this function is called automatically
-    and the result stored in :py:attr:`APP_DATA_DIR`.
-
-    This directory may not exist when the module is imported. Even if it
-    does exist, it may not contain data, or may require data to be moved
-    to it.
-
-    :return pathlib.Path: The path to the desired root settings dir.
-    """
-    IS_ROBOT = bool(
-        sys.platform.startswith("linux")
-        and (os.environ.get("RUNNING_ON_PI") or os.environ.get("RUNNING_ON_VERDIN"))
-    )
-    if "OT_API_CONFIG_DIR" in os.environ:
-        dir_path = Path(os.environ["OT_API_CONFIG_DIR"]) / Path("pipettes")
-    elif IS_ROBOT:
-        dir_path = Path("/data") / Path("pipettes")
-    else:
-        dir_path = Path.home() / ".opentrons" / Path("pipettes")
-    dir_path.mkdir(parents=True, exist_ok=True)
-    return dir_path

--- a/shared-data/python/opentrons_shared_data/pipette/file_operation_helpers.py
+++ b/shared-data/python/opentrons_shared_data/pipette/file_operation_helpers.py
@@ -1,0 +1,69 @@
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Union
+from .types import MutableConfig, QuirkConfig
+from .model_constants import VALID_QUIRKS
+
+
+DecoderType = Union[Dict[str, Any], Dict[str, QuirkConfig], MutableConfig]
+
+
+class MutableConfigurationEncoder(json.JSONEncoder):
+    def default(self, obj: object) -> Any:
+        if isinstance(obj, MutableConfig) or isinstance(obj, QuirkConfig):
+            return obj.dict_for_encode()
+        return json.JSONEncoder.default(self, obj)
+
+
+class MutableConfigurationDecoder(json.JSONDecoder):
+    def __init__(self) -> None:
+        super().__init__(
+            object_hook=self.dict_to_obj,
+        )
+
+    def dict_to_obj(self, d: object) -> DecoderType:
+        if isinstance(d, dict):
+            converted = dict(d)
+            if converted.get("value"):
+                return self._decode_mutable_config("", converted)
+            elif all(isinstance(v, bool) for v in converted.values()):
+                return {
+                    q: QuirkConfig.validate_and_build(q, b)
+                    for q, b in converted.items()
+                    if q in VALID_QUIRKS
+                }
+        return d  # type: ignore
+
+    def _decode_mutable_config(self, k: str, obj: Dict[str, Any]) -> MutableConfig:
+        return MutableConfig.build(**obj, name=k)
+
+
+def infer_config_pipette_base_dir() -> Path:
+    """Return the directory to store data in.
+
+    Defaults are ~/.opentrons if not on a pi; OT_API_CONFIG_DIR is
+    respected here.
+
+    When this module is imported, this function is called automatically
+    and the result stored in :py:attr:`APP_DATA_DIR`.
+
+    This directory may not exist when the module is imported. Even if it
+    does exist, it may not contain data, or may require data to be moved
+    to it.
+
+    :return pathlib.Path: The path to the desired root settings dir.
+    """
+    IS_ROBOT = bool(
+        sys.platform.startswith("linux")
+        and (os.environ.get("RUNNING_ON_PI") or os.environ.get("RUNNING_ON_VERDIN"))
+    )
+    if "OT_API_CONFIG_DIR" in os.environ:
+        dir_path = Path(os.environ["OT_API_CONFIG_DIR"]) / Path("pipettes")
+    elif IS_ROBOT:
+        dir_path = Path("/data") / Path("pipettes")
+    else:
+        dir_path = Path.home() / ".opentrons" / Path("pipettes")
+    dir_path.mkdir(parents=True, exist_ok=True)
+    return dir_path

--- a/shared-data/python/opentrons_shared_data/pipette/load_data.py
+++ b/shared-data/python/opentrons_shared_data/pipette/load_data.py
@@ -92,7 +92,11 @@ def load_serial_lookup_table() -> Dict[str, str]:
 
                 model_shorthand = _model_shorthand.get(model_dir, model_dir)
 
-                if model_dir == "p300" and int(version_list[0]) == 1 and int(version_list[1]) == 0:
+                if (
+                    model_dir == "p300"
+                    and int(version_list[0]) == 1
+                    and int(version_list[1]) == 0
+                ):
                     # Well apparently, we decided to switch the shorthand of the p300 depending
                     # on whether it's a "V1" model or not...so...here is the lovely workaround.
                     model_shorthand = model_dir

--- a/shared-data/python/opentrons_shared_data/pipette/load_data.py
+++ b/shared-data/python/opentrons_shared_data/pipette/load_data.py
@@ -83,7 +83,7 @@ def load_serial_lookup_table() -> Dict[str, str]:
         "ninety_six_channel": "96",
         "eight_channel": "multi",
     }
-    _model_shorthand = {"p1000": "p1k"}
+    _model_shorthand = {"p1000": "p1k", "p300": "p3h"}
     for channel_dir in os.listdir(config_path):
         for model_dir in os.listdir(config_path / channel_dir):
             for version_file in os.listdir(config_path / channel_dir / model_dir):
@@ -91,6 +91,11 @@ def load_serial_lookup_table() -> Dict[str, str]:
                 built_model = f"{model_dir}_{_channel_model_str[channel_dir]}_v{version_list[0]}.{version_list[1]}"
 
                 model_shorthand = _model_shorthand.get(model_dir, model_dir)
+
+                if model_dir == "p300" and int(version_list[0]) == 1 and int(version_list[1]) == 0:
+                    # Well apparently, we decided to switch the shorthand of the p300 depending
+                    # on whether it's a "V1" model or not...so...here is the lovely workaround.
+                    model_shorthand = model_dir
                 serial_shorthand = f"{model_shorthand.upper()}{_channel_shorthand[channel_dir]}V{version_list[0]}{version_list[1]}"
                 _lookup_table[serial_shorthand] = built_model
     return _lookup_table

--- a/shared-data/python/opentrons_shared_data/pipette/load_data.py
+++ b/shared-data/python/opentrons_shared_data/pipette/load_data.py
@@ -16,7 +16,7 @@ from .pipette_definition import (
     PipetteModelMajorVersion,
     PipetteModelMinorVersion,
 )
-from .model_constants import QUIRKS_LOOKUP_TABLE, MOUNT_CONFIG_LOOKUP_TABLE
+from .model_constants import MOUNT_CONFIG_LOOKUP_TABLE
 
 
 LoadedConfiguration = Dict[str, Union[str, Dict[str, Any]]]
@@ -113,16 +113,7 @@ def load_definition(
 
     generation = PipetteGenerationType(physical_dict["displayCategory"])
     mount_configs = MOUNT_CONFIG_LOOKUP_TABLE[generation.value]
-    model_channel = f"{max_volume.value}_{channels}"
 
-    if generation != PipetteGenerationType.FLEX:
-        model_quirks_dict = QUIRKS_LOOKUP_TABLE[model_channel]
-        generation_quirks_dict = model_quirks_dict.get(generation.value, {})
-        quirks = generation_quirks_dict.get(
-            f"{str(version)}", generation_quirks_dict["default"]
-        )
-    else:
-        quirks = []
     return PipetteConfigurations.parse_obj(
         {
             **geometry_dict,
@@ -130,6 +121,5 @@ def load_definition(
             **liquid_dict,
             "version": version,
             "mount_configurations": mount_configs,
-            "quirks": quirks,
         }
     )

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 from .types import Quirks, RobotMountConfigs, AvailableUnits
 

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -24,6 +24,7 @@ MUTABLE_CONFIGS_V1 = [
     "dropTipCurrent",
     "dropTipSpeed",
     "tipLength",
+    "quirks",
 ]
 
 # Version 2 Configuration Keys.

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -1,0 +1,84 @@
+import enum
+from dataclasses import dataclass
+
+
+@dataclass
+class RobotMountConfigs:
+    stepsPerMM: float
+    homePosition: float
+    travelDistance: float
+
+
+class Quirks(enum.Enum):
+    pickupTipShake = "pickupTipShake"
+    dropTipShake = "dropTipShake"
+    doubleDropTip = "doubleDropTip"
+    needsUnstick = "needsUnstick"
+
+
+QUIRKS_LOOKUP_TABLE = {
+    "p10_single": {
+        "GEN1": {
+            "default": [Quirks.dropTipShake]
+		}
+	},
+    "p10_multi": {
+        "GEN1": {
+            "default": [Quirks.dropTipShake],
+            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
+            "1.6": [Quirks.doubleDropTip, Quirks.dropTipShake]
+		}
+	},
+    "p20_single": {
+        "GEN2": {
+            "default": []
+		}
+	},
+    "p20_multi": {
+        "GEN2": {
+            "default": []
+		} 
+	},
+    "p50_single": { 
+        "GEN1": {
+            "default": [Quirks.dropTipShake],
+		}},
+    "p50_multi": {
+        "GEN1": {
+            "default": [Quirks.dropTipShake],
+            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake]
+		}
+	},
+    "p300_single": {
+        "GEN1": {
+            "default": [Quirks.dropTipShake],
+		},
+        "GEN2": {
+            "default": []
+		}
+	},
+    "p300_multi": {
+        "GEN1": {
+            "default": [Quirks.dropTipShake],
+            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake]
+		},
+        "GEN2": {
+            "default": [Quirks.needsUnstick]
+		},
+    "p1000_single": {
+        "GEN1": {
+            "default": [Quirks.pickupTipShake, Quirks.dropTipShake]
+		},
+    	"GEN2": {
+            "default": [Quirks.pickupTipShake, Quirks.dropTipShake]
+		}
+	}
+	},
+    
+}
+    
+MOUNT_CONFIG_LOOKUP_TABLE = {
+    "GEN1": RobotMountConfigs(768, 220, 30),
+    "GEN2": RobotMountConfigs(3200, 155.75, 60),
+    "FLEX": RobotMountConfigs(2133.33, 230.15, 80)
+}

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -1,84 +1,169 @@
-import enum
-from dataclasses import dataclass
+from typing import Dict, List, Union
+
+from .types import Quirks, RobotMountConfigs, AvailableUnits
 
 
-@dataclass
-class RobotMountConfigs:
-    stepsPerMM: float
-    homePosition: float
-    travelDistance: float
-
-
-class Quirks(enum.Enum):
-    pickupTipShake = "pickupTipShake"
-    dropTipShake = "dropTipShake"
-    doubleDropTip = "doubleDropTip"
-    needsUnstick = "needsUnstick"
-
-
-QUIRKS_LOOKUP_TABLE = {
-    "p10_single": {
-        "GEN1": {
-            "default": [Quirks.dropTipShake]
-		}
-	},
+QUIRKS_LOOKUP_TABLE: Dict[str, Dict[str, Dict[str, List[Quirks]]]] = {
+    "p10_single": {"GEN1": {"default": [Quirks.dropTipShake]}},
     "p10_multi": {
         "GEN1": {
             "default": [Quirks.dropTipShake],
             "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
-            "1.6": [Quirks.doubleDropTip, Quirks.dropTipShake]
-		}
-	},
-    "p20_single": {
-        "GEN2": {
-            "default": []
-		}
-	},
-    "p20_multi": {
-        "GEN2": {
-            "default": []
-		} 
-	},
-    "p50_single": { 
+            "1.6": [Quirks.doubleDropTip, Quirks.dropTipShake],
+        }
+    },
+    "p20_single": {"GEN2": {"default": []}},
+    "p20_multi": {"GEN2": {"default": []}},
+    "p50_single": {
         "GEN1": {
             "default": [Quirks.dropTipShake],
-		}},
+        }
+    },
     "p50_multi": {
         "GEN1": {
             "default": [Quirks.dropTipShake],
-            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake]
-		}
-	},
+            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
+        }
+    },
     "p300_single": {
         "GEN1": {
             "default": [Quirks.dropTipShake],
-		},
-        "GEN2": {
-            "default": []
-		}
-	},
+        },
+        "GEN2": {"default": []},
+    },
     "p300_multi": {
         "GEN1": {
             "default": [Quirks.dropTipShake],
-            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake]
-		},
-        "GEN2": {
-            "default": [Quirks.needsUnstick]
-		},
+            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
+        },
+        "GEN2": {"default": [Quirks.needsUnstick]},
+    },
     "p1000_single": {
-        "GEN1": {
-            "default": [Quirks.pickupTipShake, Quirks.dropTipShake]
-		},
-    	"GEN2": {
-            "default": [Quirks.pickupTipShake, Quirks.dropTipShake]
-		}
-	}
-	},
-    
+        "GEN1": {"default": [Quirks.pickupTipShake, Quirks.dropTipShake]},
+        "GEN2": {"default": [Quirks.pickupTipShake, Quirks.dropTipShake]},
+    },
 }
-    
+
 MOUNT_CONFIG_LOOKUP_TABLE = {
     "GEN1": RobotMountConfigs(768, 220, 30),
     "GEN2": RobotMountConfigs(3200, 155.75, 60),
-    "FLEX": RobotMountConfigs(2133.33, 230.15, 80)
+    "FLEX": RobotMountConfigs(2133.33, 230.15, 80),
+}
+
+
+VALID_QUIRKS = [q.value for q in Quirks]
+MUTABLE_CONFIGS_V1 = [
+    "top",
+    "bottom",
+    "blowout",
+    "dropTip",
+    "pickUpCurrent",
+    "pickUpDistance",
+    "pickUpIncrement",
+    "pickUpPresses",
+    "pickUpSpeed",
+    "plungerCurrent",
+    "dropTipCurrent",
+    "dropTipSpeed",
+    "tipLength",
+]
+
+# Version 2 Configuration Keys.
+MUTABLE_CONFIGS_V2 = [
+    "plungerPositionsConfigurations",
+    "pickUpTipConfigurations",
+    "dropTipConfigurations",
+    "plungerMotorConfigurations",
+    "tipLength",
+]
+
+RESTRICTED_MUTABLE_CONFIG_KEYS = [*VALID_QUIRKS, "model"]
+
+_MAP_KEY_TO_V2: Dict[str, Dict[str, str]] = {
+    "top": {"top_level_name": "plungerPositionsConfigurations", "nested_name": "top"},
+    "bottom": {
+        "top_level_name": "plungerPositionsConfigurations",
+        "nested_name": "bottom",
+    },
+    "blowout": {
+        "top_level_name": "plungerPositionsConfigurations",
+        "nested_name": "blowout",
+    },
+    "dropTip": {
+        "top_level_name": "plungerPositionsConfigurations",
+        "nested_name": "drop",
+    },
+    "pickUpCurrent": {
+        "top_level_name": "pickUpTipConfigurations",
+        "nested_name": "current",
+    },
+    "pickUpDistance": {
+        "top_level_name": "pickUpTipConfigurations",
+        "nested_name": "distance",
+    },
+    "pickUpIncrement": {
+        "top_level_name": "pickUpTipConfigurations",
+        "nested_name": "increment",
+    },
+    "pickUpPresses": {
+        "top_level_name": "pickUpTipConfigurations",
+        "nested_name": "presses",
+    },
+    "pickUpSpeed": {
+        "top_level_name": "pickUpTipConfigurations",
+        "nested_name": "speed",
+    },
+    "plungerCurrent": {
+        "top_level_name": "plungerMotorConfigurations",
+        "nested_name": "run",
+    },
+    "dropTipCurrent": {
+        "top_level_name": "dropTipConfigurations",
+        "nested_name": "current",
+    },
+    "dropTipSpeed": {"top_level_name": "dropTipConfigurations", "nested_name": "speed"},
+    "tipLength": {"top_level_name": "supportedTips", "nested_name": "defaultTipLength"},
+}
+
+
+_MIN_MAX_LOOKUP: Dict[str, Dict[str, Union[int, float]]] = {
+    "current": {"min": 0.1, "max": 2.0},
+    "run": {"min": 0.1, "max": 2.0},
+    "speed": {"min": 0.01, "max": 30},
+    "top": {"min": -20, "max": 30},
+    "bottom": {"min": -20, "max": 30},
+    "blowout": {"min": -20, "max": 30},
+    "drop": {"min": -20, "max": 30},
+    "presses": {"min": 0, "max": 15},
+    "increment": {"min": 0, "max": 10},
+    "distance": {"min": 0, "max": 10},
+    "defaultTipLength": {"min": 0, "max": 100},
+}
+
+_TYPE_LOOKUP: Dict[str, str] = {
+    "current": "float",
+    "run": "float",
+    "speed": "float",
+    "top": "float",
+    "bottom": "float",
+    "blowout": "float",
+    "drop": "float",
+    "presses": "int",
+    "increment": "int",
+    "defaultTipLength": "float",
+    "distance": "float",
+}
+
+_UNITS_LOOKUP = {
+    "current": AvailableUnits.amps,
+    "run": AvailableUnits.amps,
+    "speed": AvailableUnits.speed,
+    "top": AvailableUnits.mm,
+    "bottom": AvailableUnits.mm,
+    "blowout": AvailableUnits.mm,
+    "drop": AvailableUnits.mm,
+    "presses": AvailableUnits.presses,
+    "increment": AvailableUnits.mm,
+    "defaultTipLength": AvailableUnits.mm,
+    "distance": AvailableUnits.mm,
 }

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -2,48 +2,6 @@ from typing import Dict, List, Union
 
 from .types import Quirks, RobotMountConfigs, AvailableUnits
 
-
-QUIRKS_LOOKUP_TABLE: Dict[str, Dict[str, Dict[str, List[Quirks]]]] = {
-    "p10_single": {"GEN1": {"default": [Quirks.dropTipShake]}},
-    "p10_multi": {
-        "GEN1": {
-            "default": [Quirks.dropTipShake],
-            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
-            "1.6": [Quirks.doubleDropTip, Quirks.dropTipShake],
-        }
-    },
-    "p20_single": {"GEN2": {"default": []}},
-    "p20_multi": {"GEN2": {"default": []}},
-    "p50_single": {
-        "GEN1": {
-            "default": [Quirks.dropTipShake],
-        }
-    },
-    "p50_multi": {
-        "GEN1": {
-            "default": [Quirks.dropTipShake],
-            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
-        }
-    },
-    "p300_single": {
-        "GEN1": {
-            "default": [Quirks.dropTipShake],
-        },
-        "GEN2": {"default": []},
-    },
-    "p300_multi": {
-        "GEN1": {
-            "default": [Quirks.dropTipShake],
-            "1.5": [Quirks.doubleDropTip, Quirks.dropTipShake],
-        },
-        "GEN2": {"default": [Quirks.needsUnstick]},
-    },
-    "p1000_single": {
-        "GEN1": {"default": [Quirks.pickupTipShake, Quirks.dropTipShake]},
-        "GEN2": {"default": [Quirks.pickupTipShake, Quirks.dropTipShake]},
-    },
-}
-
 MOUNT_CONFIG_LOOKUP_TABLE = {
     "GEN1": RobotMountConfigs(768, 220, 30),
     "GEN2": RobotMountConfigs(3200, 155.75, 60),

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -263,7 +263,7 @@ def load_with_mutable_configurations(
     return base_configurations
 
 
-def _add_new_overrides_to_existing(
+def _add_new_overrides_to_existing(  # noqa: C901
     base_configs_dict: Dict[str, Any],
     existing_overrides: OverrideType,
     overrides: TypeOverrides,

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -274,6 +274,8 @@ def _add_new_overrides_to_existing(
     # to keep the validation here until we decide to fully wipe/migrate
     # files saved on disk because some of them have unexpected
     # data entries.
+    if not existing_overrides.get("quirks"):
+        existing_overrides["quirks"] = {}
     for key, value in overrides.items():
         # If an existing override is saved as null from endpoint, remove from
         # overrides file

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -74,7 +74,7 @@ def _migrate_to_v2_configurations(
 def _load_available_overrides(
     pipette_serial_number: str,
 ) -> OverrideType:
-    # returns quirks: model: + extra keys
+    """Load the available overrides from disk."""
     pipette_override = infer_config_pipette_base_dir() / f"{pipette_serial_number}.json"
     try:
         with open(pipette_override, "r") as f:
@@ -114,6 +114,7 @@ def _list_all_mutable_configs(
 
 
 def _find_default(name: str, configs: Dict[str, Any]) -> MutableConfig:
+    """Find the default value from the configs and return it as a mutable config."""
     lookup_dict = _MAP_KEY_TO_V2[name]
     nested_name = lookup_dict["nested_name"]
 

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -1,0 +1,305 @@
+import logging
+import json
+from typing import Optional, List, Dict, Any, cast
+
+from .pipette_definition import PipetteConfigurations
+from .model_constants import (
+    MUTABLE_CONFIGS_V1,
+    VALID_QUIRKS,
+    _MAP_KEY_TO_V2,
+    _MIN_MAX_LOOKUP,
+    _TYPE_LOOKUP,
+    _UNITS_LOOKUP,
+)
+from .pipette_load_name_conversions import PipetteModelVersionType
+from .load_data import load_definition, load_serial_lookup_table
+from .types import MutableConfig, Quirks, QuirkConfig, TypeOverrides, OverrideType
+from .pipette_load_name_conversions import convert_pipette_model
+from .file_operation_helpers import (
+    MutableConfigurationEncoder,
+    MutableConfigurationDecoder,
+    infer_config_pipette_base_dir,
+)
+from .dev_types import PipetteModel
+
+
+log = logging.getLogger(__name__)
+
+PIPETTE_SERIAL_MODEL_LOOKUP = load_serial_lookup_table()
+
+
+def _migrate_to_v2_configurations(
+    base_configurations: PipetteConfigurations,
+    v1_mutable_configs: OverrideType,
+) -> PipetteConfigurations:
+    """Helper function to migration V1 Configs to the V2 format.
+
+    Given an input of v1 mutable configs, look up the equivalent keyed
+    value of that configuration."""
+    quirks_list = []
+    dict_of_base_model = base_configurations.dict(by_alias=True)
+
+    for c, v in v1_mutable_configs.items():
+        if isinstance(v, str):
+            # ignore the saved model
+            continue
+        if isinstance(v, bool):
+            # ignore any accidental top level quirks.
+            continue
+        if c == "quirks" and isinstance(v, dict):
+            quirks_list.extend([b.name for b in v.values() if b.value])
+        else:
+            new_names = _MAP_KEY_TO_V2[c]
+            top_name = new_names["top_level_name"]
+            nested_name = new_names["nested_name"]
+            if c == "tipLength" and isinstance(v, MutableConfig):
+                # This is only a concern for OT-2 configs and I think we can
+                # be less smart about handling multiple tip types by updating
+                # all tips.
+                for k in dict_of_base_model[new_names["top_level_name"]].keys():
+                    dict_of_base_model[top_name][k][nested_name] = v.value
+            elif isinstance(v, MutableConfig):
+                # isinstances are needed for type checking.
+                dict_of_base_model[top_name][nested_name] = v.value
+    dict_of_base_model["quirks"] = quirks_list
+
+    # re-serialization is not great for this nested enum so we need
+    # to perform this workaround.
+    dict_of_base_model["supportedTips"] = {
+        k.name: v for k, v in dict_of_base_model["supportedTips"].items()
+    }
+    return PipetteConfigurations.parse_obj(dict_of_base_model)
+
+
+def _load_available_overrides(
+    pipette_serial_number: str,
+) -> OverrideType:
+    # returns quirks: model: + extra keys
+    pipette_override = infer_config_pipette_base_dir() / f"{pipette_serial_number}.json"
+    try:
+        with open(pipette_override, "r") as f:
+            return json.load(f, cls=MutableConfigurationDecoder)
+    except json.JSONDecodeError as e:
+        log.warning(f"pipette override for {pipette_serial_number} is corrupt: {e}")
+        pipette_override.unlink()
+        raise FileNotFoundError()
+
+
+def _list_all_mutable_configs(
+    on_disk_overrides: OverrideType, base_configurations: Dict[str, Any]
+) -> OverrideType:
+    """Get all available mutable configurations"""
+    all_mutable_configs = set([*MUTABLE_CONFIGS_V1, *VALID_QUIRKS])
+    on_disk_configs = set(
+        [
+            v.name
+            for v in on_disk_overrides.values()
+            if isinstance(v, MutableConfig) or isinstance(v, QuirkConfig)
+        ]
+    )
+
+    missing_configurations = all_mutable_configs.difference(on_disk_configs)
+
+    default_configurations: OverrideType = {"quirks": {}}
+    for c in missing_configurations:
+        if c in VALID_QUIRKS:
+            if Quirks(c) in base_configurations["quirks"]:
+                default_configurations["quirks"][c] = QuirkConfig.validate_and_build(  # type: ignore
+                    c, True
+                )
+        else:
+            default_configurations[c] = _find_default(c, base_configurations)
+    default_configurations.update(on_disk_overrides)
+    return default_configurations
+
+
+def _find_default(name: str, configs: Dict[str, Any]) -> MutableConfig:
+    lookup_dict = _MAP_KEY_TO_V2[name]
+    nested_name = lookup_dict["nested_name"]
+
+    min_max_dict = _MIN_MAX_LOOKUP[nested_name]
+    type_lookup = _TYPE_LOOKUP[nested_name]
+    units_lookup = _UNITS_LOOKUP[nested_name]
+    if name == "tipLength":
+        # This is only a concern for OT-2 configs and I think we can
+        # be less smart about handling multiple tip types. Instead, just
+        # get the max tip type.
+        tip_list = list(configs[lookup_dict["top_level_name"]].keys())
+        tip_list.sort(key=lambda o: o.value)
+        default_value = configs[lookup_dict["top_level_name"]][tip_list[-1]][
+            nested_name
+        ]
+    else:
+        default_value = configs[lookup_dict["top_level_name"]][nested_name]
+    return MutableConfig(
+        value=default_value,
+        default=default_value,
+        min=min_max_dict["min"],
+        max=min_max_dict["max"],
+        type=type_lookup,
+        units=units_lookup,
+        name=name,
+    )
+
+
+def known_pipettes() -> List[str]:
+    """List pipette IDs for which we have known overrides"""
+    return [
+        fi.stem
+        for fi in infer_config_pipette_base_dir().iterdir()
+        if fi.is_file() and ".json" in fi.suffixes
+    ]
+
+
+def list_mutable_configs(pipette_serial_number: str) -> OverrideType:
+    """
+    Returns dict of mutable configs only.
+    """
+
+    mutable_configs: OverrideType = {}
+
+    pipette_model = convert_pipette_model(
+        cast(PipetteModel, PIPETTE_SERIAL_MODEL_LOOKUP[pipette_serial_number[0:7]])
+    )
+
+    base_configs = load_definition(
+        pipette_model.pipette_type,
+        pipette_model.pipette_channels,
+        pipette_model.pipette_version,
+    )
+    base_configs_dict = base_configs.dict(by_alias=True)
+
+    try:
+        mutable_configs = _load_available_overrides(pipette_serial_number)
+    except FileNotFoundError:
+        log.info(f"Pipette id {pipette_serial_number} not found")
+    finally:
+        full_mutable_configs = _list_all_mutable_configs(
+            mutable_configs, base_configs_dict
+        )
+        return full_mutable_configs
+
+
+def load_with_mutable_configurations(
+    pipette_model: PipetteModelVersionType, pipette_serial_number: Optional[str] = None
+) -> PipetteConfigurations:
+    """
+    Load pipette config data with any overrides available.
+
+    This function reads from disk each time, so changes to the overrides
+    will be picked up in subsequent calls.
+
+    :param str pipette_model: The pipette model name (i.e. "p10_single_v1.3")
+                              for which to load configuration
+    :param pipette_serial_number: An (optional) unique ID for the pipette to locate
+                       config overrides. If the ID is not specified, the system
+                       assumes this is a simulated pipette and does not
+                       save settings. If the ID is specified but no overrides
+                       corresponding to the ID are found, the system creates a
+                       new overrides file for it.
+    :type pipette_serial_number: str or None
+    :raises KeyError: if ``pipette_model`` is not in the top-level keys of
+                      the pipetteModelSpecs.json file (and therefore not in
+                      :py:attr:`configs`)
+
+    :returns PipetteConfig: The configuration, loaded and checked
+    """
+    base_configurations = load_definition(
+        pipette_model.pipette_type,
+        pipette_model.pipette_channels,
+        pipette_model.pipette_version,
+    )
+    # Load overrides if we have a pipette id
+    if pipette_serial_number:
+        try:
+            override = _load_available_overrides(pipette_serial_number)
+        except FileNotFoundError:
+            pass
+        else:
+            base_configurations = _migrate_to_v2_configurations(
+                base_configurations, override
+            )
+
+    # the ulPerMm functions are structured in pipetteModelSpecs.json as
+    # a list sorted from oldest to newest. That means the latest functions
+    # are always the last element and, as of right now, the older ones are
+    # the first element (for models that only have one function, the first
+    # and last elements are the same, which is fine). If we add more in the
+    # future, we’ll have to change this code to select items more
+    # intelligently
+    # TODO (lc 06/27) Handle versioned ul per mm
+
+    return base_configurations
+
+
+def _add_new_overrides_to_existing(
+    base_configs_dict: Dict[str, Any],
+    existing_overrides: OverrideType,
+    overrides: TypeOverrides,
+) -> OverrideType:
+    """Helper function to add new overrides to the existing ones"""
+    # FIXME remove the validation here for the file save and rely
+    # on the validation in the robot server.
+    for key, value in overrides.items():
+        # If an existing override is saved as null from endpoint, remove from
+        # overrides file
+        if value is None and existing_overrides.get(key):
+            del existing_overrides[key]
+        elif isinstance(value, bool):
+            if key in VALID_QUIRKS:
+                existing_overrides["quirks"][key] = QuirkConfig.validate_and_build(  # type: ignore
+                    key, value
+                )
+            elif key not in MUTABLE_CONFIGS_V1:
+                # Unfortunately, some of the files got corrupted,
+                # so we have to check that the key doesn't exist
+                # in mutable configs before throwing an error.
+                raise ValueError(
+                    f"{value} is invalid for {key} or {key} is not a supported quirk."
+                )
+            elif existing_overrides.get(key):
+                del existing_overrides[key]
+        elif value:
+            if existing_overrides.get(key):
+                existing_overrides[key].validate_and_add(value)  # type: ignore
+            else:
+                new_mutable_config = _find_default(key, base_configs_dict)
+                new_mutable_config.validate_and_add(value)
+                existing_overrides[key] = new_mutable_config
+    return existing_overrides
+
+
+def save_overrides(pipette_serial_number: str, overrides: TypeOverrides) -> None:
+    """
+    Save overrides for the pipette.
+
+    :param pipette_id: The pipette id
+    :param overrides: The incoming values
+    :return: None
+    """
+    # need to load defaults
+    override_dir = infer_config_pipette_base_dir()
+    pipette_model = convert_pipette_model(
+        cast(PipetteModel, PIPETTE_SERIAL_MODEL_LOOKUP[pipette_serial_number[0:7]])
+    )
+
+    base_configs = load_definition(
+        pipette_model.pipette_type,
+        pipette_model.pipette_channels,
+        pipette_model.pipette_version,
+    )
+    base_configs_dict = base_configs.dict(by_alias=True)
+    try:
+        existing_overrides = _load_available_overrides(pipette_serial_number)
+    except FileNotFoundError:
+        existing_overrides = {"quirks": {}}
+
+    updated_overrides = _add_new_overrides_to_existing(
+        base_configs_dict, existing_overrides, overrides
+    )
+
+    if not updated_overrides.get("model"):
+        updated_overrides["model"] = str(pipette_model)
+
+    with open(override_dir / f"{pipette_serial_number}.json", "w") as file:
+        json.dump(updated_overrides, file, cls=MutableConfigurationEncoder)

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -91,7 +91,7 @@ def _list_all_mutable_configs(
     on_disk_overrides: OverrideType, base_configurations: Dict[str, Any]
 ) -> OverrideType:
     """Get all available mutable configurations"""
-    all_mutable_configs = set([*MUTABLE_CONFIGS_V1, *VALID_QUIRKS])
+    all_mutable_configs = set([*MUTABLE_CONFIGS_V1, *VALID_QUIRKS]) - set(["quirks"])
     on_disk_configs = set(
         [
             v.name

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import re
 from typing import Optional, List, Dict, Any, cast
 
 from .pipette_definition import PipetteConfigurations
@@ -26,6 +27,7 @@ from .dev_types import PipetteModel
 log = logging.getLogger(__name__)
 
 PIPETTE_SERIAL_MODEL_LOOKUP = load_serial_lookup_table()
+SERIAL_STUB_REGEX = re.compile(r"P[0-9]{1,3}[KSMHV]{1,2}V[0-9]{2}")
 
 
 def _migrate_to_v2_configurations(
@@ -159,8 +161,9 @@ def list_mutable_configs(pipette_serial_number: str) -> OverrideType:
 
     mutable_configs: OverrideType = {}
 
+    serial_key = SERIAL_STUB_REGEX.match(pipette_serial_number).group(0)
     pipette_model = convert_pipette_model(
-        cast(PipetteModel, PIPETTE_SERIAL_MODEL_LOOKUP[pipette_serial_number[0:7]])
+        cast(PipetteModel, PIPETTE_SERIAL_MODEL_LOOKUP[serial_key])
     )
 
     base_configs = load_definition(

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -16,12 +16,15 @@ from .model_constants import (
 from .pipette_load_name_conversions import PipetteModelVersionType
 from .load_data import load_definition, load_serial_lookup_table
 from .types import MutableConfig, Quirks, QuirkConfig, TypeOverrides, OverrideType
-from .pipette_load_name_conversions import convert_pipette_model
+from .pipette_load_name_conversions import (
+    convert_pipette_model,
+    convert_to_pipette_name_type,
+)
 from .file_operation_helpers import (
     MutableConfigurationEncoder,
     MutableConfigurationDecoder,
 )
-from .dev_types import PipetteModel
+from .dev_types import PipetteModel, PipetteName
 
 
 log = logging.getLogger(__name__)
@@ -192,6 +195,15 @@ def list_mutable_configs(
         full_mutable_configs = _list_all_mutable_configs(
             mutable_configs, base_configs_dict
         )
+
+        if not full_mutable_configs.get("name"):
+            full_mutable_configs["name"] = str(
+                convert_to_pipette_name_type(cast(PipetteName, str(pipette_model)))
+            )
+
+        if not full_mutable_configs.get("model"):
+            full_mutable_configs["model"] = str(pipette_model)
+
         return full_mutable_configs
 
 

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field, validator
 from enum import Enum
 from dataclasses import dataclass
 
+from . import model_constants
+
 PLUNGER_CURRENT_MINIMUM = 0.1
 PLUNGER_CURRENT_MAXIMUM = 1.5
 
@@ -57,7 +59,7 @@ class PipetteModelType(Enum):
 class PipetteGenerationType(Enum):
     GEN1 = "GEN1"
     GEN2 = "GEN2"
-    GEN3 = "GEN3"
+    FLEX = "FLEX"
 
 
 PIPETTE_AVAILABLE_TYPES = [m.name for m in PipetteModelType]
@@ -84,6 +86,15 @@ class PipetteVersionType:
         self,
     ) -> Tuple[PipetteModelMajorVersionType, PipetteModelMinorVersionType]:
         return (self.major, self.minor)
+    
+    @property
+    def to_generation(self) -> PipetteGenerationType:
+        if self.major == 3:
+            return PipetteGenerationType.FLEX
+        elif self.major == 2:
+            return PipetteGenerationType.GEN2
+        else:
+            return PipetteGenerationType.GEN1
 
 
 class SupportedTipsDefinition(BaseModel):
@@ -332,3 +343,5 @@ class PipetteConfigurations(
     version: PipetteVersionType = Field(
         ..., description="The version of the configuration loaded."
     )
+    mount_configurations: model_constants.SmoothieConfigs = Field(..., )
+    quirks: List[model_constants.Quirks] = Field(..., description="The list of quirks available for the loaded configuration")

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -277,7 +277,7 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
         if not v:
             return PipetteGenerationType.GEN1
         return PipetteGenerationType(v)
-    
+
     @validator("quirks", pre=True)
     def convert_quirks(cls, v: str) -> List[pip_types.Quirks]:
         if not v:
@@ -346,4 +346,3 @@ class PipetteConfigurations(
     mount_configurations: pip_types.RobotMountConfigs = Field(
         ...,
     )
-

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field, validator
 from enum import Enum
 from dataclasses import dataclass
 
-from . import model_constants
+from . import types as pip_types
 
 PLUNGER_CURRENT_MINIMUM = 0.1
 PLUNGER_CURRENT_MAXIMUM = 1.5
@@ -86,15 +86,6 @@ class PipetteVersionType:
         self,
     ) -> Tuple[PipetteModelMajorVersionType, PipetteModelMinorVersionType]:
         return (self.major, self.minor)
-    
-    @property
-    def to_generation(self) -> PipetteGenerationType:
-        if self.major == 3:
-            return PipetteGenerationType.FLEX
-        elif self.major == 2:
-            return PipetteGenerationType.GEN2
-        else:
-            return PipetteGenerationType.GEN1
 
 
 class SupportedTipsDefinition(BaseModel):
@@ -343,5 +334,9 @@ class PipetteConfigurations(
     version: PipetteVersionType = Field(
         ..., description="The version of the configuration loaded."
     )
-    mount_configurations: model_constants.SmoothieConfigs = Field(..., )
-    quirks: List[model_constants.Quirks] = Field(..., description="The list of quirks available for the loaded configuration")
+    mount_configurations: pip_types.RobotMountConfigs = Field(
+        ...,
+    )
+    quirks: List[pip_types.Quirks] = Field(
+        ..., description="The list of quirks available for the loaded configuration"
+    )

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -260,6 +260,9 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
         description="The distance of backlash on the plunger motor.",
         alias="backlashDistance",
     )
+    quirks: List[pip_types.Quirks] = Field(
+        ..., description="The list of quirks available for the loaded configuration"
+    )
 
     @validator("pipette_type", pre=True)
     def convert_pipette_model_string(cls, v: str) -> PipetteModelType:
@@ -274,6 +277,12 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
         if not v:
             return PipetteGenerationType.GEN1
         return PipetteGenerationType(v)
+    
+    @validator("quirks", pre=True)
+    def convert_quirks(cls, v: str) -> List[pip_types.Quirks]:
+        if not v:
+            return []
+        return [pip_types.Quirks(q) for q in v]
 
     class Config:
         json_encoders = {
@@ -337,6 +346,4 @@ class PipetteConfigurations(
     mount_configurations: pip_types.RobotMountConfigs = Field(
         ...,
     )
-    quirks: List[pip_types.Quirks] = Field(
-        ..., description="The list of quirks available for the loaded configuration"
-    )
+

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
@@ -124,12 +124,52 @@ def version_from_generation(pipette_name_list: List[str]) -> PipetteVersionType:
         PipetteVersionType: A pipette version object.
 
     """
-    if "gen3" in pipette_name_list:
+    if "flex" in pipette_name_list:
         return PipetteVersionType(3, 0)
     elif "gen2" in pipette_name_list:
         return PipetteVersionType(2, 0)
     else:
         return PipetteVersionType(1, 0)
+
+
+def generation_from_string(pipette_name_list: List[str]) -> PipetteGenerationType:
+    """Convert a string generation name to a py:obj:PipetteGenerationType.
+
+    Args:
+        pipette_name_list (List[str]): A list of strings from the separated by `_`
+        py:data:PipetteName or py:data:PipetteModel.
+
+    Returns:
+        PipetteGenerationType: A pipette version object.
+
+    """
+    if "flex" in pipette_name_list or "3." in pipette_name_list[-1]:
+        return PipetteGenerationType.FLEX
+    elif "gen2" in pipette_name_list or "2." in pipette_name_list[-1]:
+        return PipetteGenerationType.GEN2
+    else:
+        return PipetteGenerationType.GEN1
+
+
+def convert_to_pipette_name_type(name: PipetteName) -> PipetteNameType:
+    """Convert the py:data:PipetteName to a py:obj:PipetteModelVersionType.
+
+    `PipetteNames` are in the format of "p300_single" or "p300_single_gen1".
+
+    Args:
+        name (PipetteName): The pipette name we want to convert.
+
+    Returns:
+        PipetteNameType: An object representing a broken out PipetteName
+        string.
+
+    """
+    split_pipette_name = name.split("_")
+    channels = channels_from_string(split_pipette_name[1])
+    generation = generation_from_string(split_pipette_name)
+    pipette_type = PipetteModelType[split_pipette_name[0]]
+
+    return PipetteNameType(pipette_type, channels, generation)
 
 
 def convert_pipette_name(

--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -1,0 +1,96 @@
+import enum
+from dataclasses import dataclass
+from typing import Union, Dict, Mapping
+
+
+@dataclass
+class RobotMountConfigs:
+    stepsPerMM: float
+    homePosition: float
+    travelDistance: float
+
+
+class Quirks(enum.Enum):
+    pickupTipShake = "pickupTipShake"
+    dropTipShake = "dropTipShake"
+    doubleDropTip = "doubleDropTip"
+    needsUnstick = "needsUnstick"
+
+
+class AvailableUnits(enum.Enum):
+    mm = "mm"
+    amps = "amps"
+    speed = "mm/s"
+    presses = "presses"
+
+
+@dataclass
+class MutableConfig:
+    value: Union[int, float]
+    default: Union[int, float]
+    units: AvailableUnits
+    type: str
+    min: float
+    max: float
+    name: str
+
+    @classmethod
+    def build(
+        cls,
+        value: Union[int, float],
+        default: Union[int, float],
+        units: str,
+        type: str,
+        min: float,
+        max: float,
+        name: str,
+    ) -> "MutableConfig":
+        return cls(
+            value=value,
+            default=default,
+            units=AvailableUnits(units),
+            type=type,
+            min=min,
+            max=max,
+            name=name,
+        )
+
+    def validate_and_add(self, new_value: Union[int, float]) -> None:
+        if new_value < self.min or new_value > self.max:
+            raise ValueError(f"{self.name} out of range with {new_value}")
+        self.value = new_value
+
+    def dict_for_encode(self) -> Dict[str, Union[int, float, str]]:
+        return {
+            "value": self.value,
+            "default": self.default,
+            "units": self.units.value,
+            "type": self.type,
+            "min": self.min,
+            "max": self.max,
+        }
+
+
+@dataclass
+class QuirkConfig:
+    value: bool
+    name: Quirks
+
+    @classmethod
+    def validate_and_build(cls, name: str, value: bool) -> "QuirkConfig":
+        quirk_name = Quirks(name)
+        cls.validate(name, value)
+        return cls(value=value, name=quirk_name)
+
+    @classmethod
+    def validate(cls, name: str, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise ValueError(f"{value} is invalid for {name}")
+
+    def dict_for_encode(self) -> bool:
+        return self.value
+
+
+TypeOverrides = Mapping[str, Union[float, bool, None]]
+
+OverrideType = Dict[str, Union[Dict[str, QuirkConfig], MutableConfig, str]]

--- a/shared-data/python/tests/pipette/test_load_data.py
+++ b/shared-data/python/tests/pipette/test_load_data.py
@@ -1,3 +1,4 @@
+import pytest
 from opentrons_shared_data.pipette import load_data
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteChannelType,
@@ -36,3 +37,16 @@ def test_load_pipette_definition() -> None:
         pipette_config_two.supported_tips[PipetteTipType.t200].default_aspirate_flowrate
         == 25.0
     )
+
+
+@pytest.mark.parametrize(
+    argnames=["key_spot_check", "value_spot_check"],
+    argvalues=[
+        ["P1KSV10", "p1000_single_v1.0"],
+        ["P1KHV33", "p1000_96_v3.3"],
+        ["P20MV21", "p20_multi_v2.1"],
+    ],
+)
+def test_build_serial_number_lookup(key_spot_check: str, value_spot_check: str) -> None:
+    lookup_table = load_data.load_serial_lookup_table()
+    assert lookup_table[key_spot_check] == value_spot_check

--- a/shared-data/python/tests/pipette/test_load_data.py
+++ b/shared-data/python/tests/pipette/test_load_data.py
@@ -46,6 +46,7 @@ def test_load_pipette_definition() -> None:
         ["P1KHV33", "p1000_96_v3.3"],
         ["P20MV21", "p20_multi_v2.1"],
         ["P300MV10", "p300_multi_v1.0"],
+        ["P3HMV14", "p300_multi_v1.4"],
     ],
 )
 def test_build_serial_number_lookup(key_spot_check: str, value_spot_check: str) -> None:

--- a/shared-data/python/tests/pipette/test_load_data.py
+++ b/shared-data/python/tests/pipette/test_load_data.py
@@ -45,6 +45,7 @@ def test_load_pipette_definition() -> None:
         ["P1KSV10", "p1000_single_v1.0"],
         ["P1KHV33", "p1000_96_v3.3"],
         ["P20MV21", "p20_multi_v2.1"],
+        ["P300MV10", "p300_multi_v1.0"],
     ],
 )
 def test_build_serial_number_lookup(key_spot_check: str, value_spot_check: str) -> None:

--- a/shared-data/python/tests/pipette/test_mutable_configurations.py
+++ b/shared-data/python/tests/pipette/test_mutable_configurations.py
@@ -1,0 +1,249 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, Any, cast, Union, Generator
+
+import pytest
+
+from opentrons_shared_data.pipette import (
+    mutable_configurations,
+    types,
+    pipette_load_name_conversions as pip_conversions,
+    load_data,
+    dev_types,
+)
+
+
+TEST_SERIAL_NUMBER = "P50MV1520200304"
+TestOverrideType = Dict[str, Union[float, int, bool]]
+
+
+@pytest.fixture
+def TMPFILE_DATA() -> Dict[str, Any]:
+    return {
+        "dropTipShake": True,
+        "doubleDropTip": True,
+        "model": "p50_multi_v1.5",
+        "quirks": {"pickUpPresses": True, "dropTipShake": True, "doubleDropTip": True},
+        "pickUpSpeed": {
+            "value": 5.0,
+            "min": 1,
+            "max": 100,
+            "units": "mm/s",
+            "type": "float",
+            "default": 30,
+        },
+    }
+
+
+@pytest.fixture
+def override_configuration_path(tmp_path: Path) -> Generator[Path, None, None]:
+    os.environ["OT_API_CONFIG_DIR"] = str(tmp_path)
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    yield tmp_path
+
+    del os.environ["OT_API_CONFIG_DIR"]
+
+
+@pytest.fixture
+def overrides_fixture(
+    override_configuration_path: Path, TMPFILE_DATA: Dict[str, Any]
+) -> types.MutableConfig:
+    parent = override_configuration_path / Path("pipettes")
+    parent.mkdir(parents=True, exist_ok=True)
+    with open(parent / f"{TEST_SERIAL_NUMBER}.json", "w") as f:
+        json.dump(TMPFILE_DATA, f)
+    return types.MutableConfig.build(**TMPFILE_DATA["pickUpSpeed"], name="pickUpSpeed")
+
+
+def test_list_mutable_configs_unknown_pipette_id(
+    override_configuration_path: Path,
+) -> None:
+    """Test unknown pipette id mutable configs.
+
+    Test that a user receives a list of all possible mutable configurations
+    with the default value equal to the regular value.
+    """
+
+    found_configurations = mutable_configurations.list_mutable_configs(
+        TEST_SERIAL_NUMBER
+    )
+    for c in found_configurations:
+        if isinstance(c, str):
+            # model string, ignore
+            continue
+        if isinstance(c, types.QuirkConfig):
+            assert isinstance(c.value, bool)
+        else:
+            assert c.default == c.value
+
+
+def test_list_mutable_configs_known_pipette_id(
+    overrides_fixture: types.MutableConfig,
+) -> None:
+    """Test known pipette id mutable configs.
+
+    Test that a user receives a list of all possible mutable configurations
+    with the expected overrides also listed.
+    """
+    found_configurations = mutable_configurations.list_mutable_configs(
+        TEST_SERIAL_NUMBER
+    )
+
+    for c in found_configurations:
+        if isinstance(c, str):
+            # model string, ignore
+            continue
+        if overrides_fixture.name == c.name:
+            assert c.value == overrides_fixture.value
+        elif isinstance(c, types.QuirkConfig):
+            assert isinstance(c.value, bool)
+        else:
+            assert c.default == c.value
+
+
+@pytest.mark.parametrize(
+    argnames=["overrides_dict", "saved_dict"],
+    argvalues=[
+        [
+            {"pickUpCurrent": 0.5, "dropTipSpeed": 5, "dropTipShake": False},
+            {
+                "quirks": {"dropTipShake": False},
+                "pickUpCurrent": {
+                    "value": 0.5,
+                    "default": 0.8,
+                    "units": "amps",
+                    "type": "float",
+                    "min": 0.1,
+                    "max": 2.0,
+                },
+                "model": "p50_multi_v1.5",
+                "dropTipSpeed": {
+                    "value": 5,
+                    "default": 5.0,
+                    "units": "mm/s",
+                    "type": "float",
+                    "min": 0.01,
+                    "max": 30,
+                },
+            },
+        ]
+    ],
+)
+def test_save_new_overrides_new_file(
+    override_configuration_path: Path,
+    overrides_dict: TestOverrideType,
+    saved_dict: Dict[str, Any],
+) -> None:
+    mutable_configurations.save_overrides(TEST_SERIAL_NUMBER, overrides_dict)
+    with open(
+        override_configuration_path / Path("pipettes") / f"{TEST_SERIAL_NUMBER}.json"
+    ) as f:
+        new_file = json.load(f)
+    assert saved_dict == new_file
+
+
+@pytest.mark.parametrize(
+    argnames=["overrides_dict"],
+    argvalues=[
+        [{"pickUpCurrent": 1, "pickUpSpeed": 10, "dropTipShake": False}],
+        [{"pickUpCurrent": 2}],
+    ],
+)
+def test_save_new_overrides_update_file(
+    override_configuration_path: Path,
+    overrides_fixture: types.MutableConfig,
+    overrides_dict: TestOverrideType,
+    TMPFILE_DATA: Dict[str, Any],
+) -> None:
+    mutable_configurations.save_overrides(TEST_SERIAL_NUMBER, overrides_dict)
+    with open(
+        override_configuration_path / Path("pipettes") / f"{TEST_SERIAL_NUMBER}.json"
+    ) as f:
+        new_file = json.load(f)
+
+    for k, v in overrides_dict.items():
+        if isinstance(v, bool):
+            TMPFILE_DATA["quirks"][k] = v
+        elif TMPFILE_DATA.get(k):
+            TMPFILE_DATA[k]["value"] = v
+
+    TMPFILE_DATA["pickUpCurrent"] = {
+        "default": 0.8,
+        "max": 2.0,
+        "min": 0.1,
+        "type": "float",
+        "units": "amps",
+        "value": overrides_dict["pickUpCurrent"],
+    }
+
+    del TMPFILE_DATA["quirks"]["pickUpPresses"]
+    assert TMPFILE_DATA == new_file
+
+
+@pytest.mark.parametrize(
+    argnames=["overrides_dict"],
+    argvalues=[
+        [{"pickUpCurrent": 1231.213, "dropTipSpeed": 121, "dropTipShake": False}],
+        [{"quirk123": True}],
+    ],
+)
+def test_save_invalid_overrides(
+    overrides_fixture: types.MutableConfig,
+    override_configuration_path: Path,
+    overrides_dict: TestOverrideType,
+    TMPFILE_DATA: Dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError):
+        mutable_configurations.save_overrides(TEST_SERIAL_NUMBER, overrides_dict)
+    with open(
+        override_configuration_path / Path("pipettes") / f"{TEST_SERIAL_NUMBER}.json"
+    ) as f:
+        new_file = json.load(f)
+    assert TMPFILE_DATA == new_file
+
+
+@pytest.mark.parametrize(
+    argnames=["pipette_model", "serial_number"],
+    argvalues=[
+        [
+            pip_conversions.convert_pipette_model(
+                cast(dev_types.PipetteModel, "p1000_96_v3.3")
+            ),
+            "P1KHV3320230629",
+        ],
+        [
+            pip_conversions.convert_pipette_model(
+                cast(dev_types.PipetteModel, "p50_multi_v1.5")
+            ),
+            TEST_SERIAL_NUMBER,
+        ],
+    ],
+)
+def test_load_with_overrides(
+    overrides_fixture: types.MutableConfig,
+    pipette_model: pip_conversions.PipetteModelVersionType,
+    serial_number: str,
+) -> None:
+    """Test that you can load configurations both with pre-existing overrides and non-pre-existing overrides."""
+    updated_configurations = mutable_configurations.load_with_mutable_configurations(
+        pipette_model, serial_number
+    )
+
+    loaded_base_configurations = load_data.load_definition(
+        pipette_model.pipette_type,
+        pipette_model.pipette_channels,
+        pipette_model.pipette_version,
+    )
+
+    if serial_number == TEST_SERIAL_NUMBER:
+        dict_loaded_configs = loaded_base_configurations.dict(by_alias=True)
+        dict_loaded_configs["pickUpTipConfigurations"]["speed"] = 5.0
+        updated_configurations_dict = updated_configurations.dict(by_alias=True)
+        assert set(dict_loaded_configs.pop("quirks")) == set(
+            updated_configurations_dict.pop("quirks")
+        )
+        assert updated_configurations_dict == dict_loaded_configs
+    else:
+        assert updated_configurations == loaded_base_configurations

--- a/shared-data/python/tests/pipette/test_mutable_configurations.py
+++ b/shared-data/python/tests/pipette/test_mutable_configurations.py
@@ -139,9 +139,7 @@ def test_save_new_overrides_new_file(
     mutable_configurations.save_overrides(
         TEST_SERIAL_NUMBER, overrides_dict, override_configuration_path
     )
-    with open(
-        override_configuration_path / f"{TEST_SERIAL_NUMBER}.json"
-    ) as f:
+    with open(override_configuration_path / f"{TEST_SERIAL_NUMBER}.json") as f:
         new_file = json.load(f)
     assert saved_dict == new_file
 
@@ -162,9 +160,7 @@ def test_save_new_overrides_update_file(
     mutable_configurations.save_overrides(
         TEST_SERIAL_NUMBER, overrides_dict, override_configuration_path
     )
-    with open(
-        override_configuration_path / f"{TEST_SERIAL_NUMBER}.json"
-    ) as f:
+    with open(override_configuration_path / f"{TEST_SERIAL_NUMBER}.json") as f:
         new_file = json.load(f)
 
     for k, v in overrides_dict.items():
@@ -203,9 +199,7 @@ def test_save_invalid_overrides(
         mutable_configurations.save_overrides(
             TEST_SERIAL_NUMBER, overrides_dict, override_configuration_path
         )
-    with open(
-        override_configuration_path / f"{TEST_SERIAL_NUMBER}.json"
-    ) as f:
+    with open(override_configuration_path / f"{TEST_SERIAL_NUMBER}.json") as f:
         new_file = json.load(f)
     assert TMPFILE_DATA == new_file
 

--- a/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
+++ b/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
@@ -95,7 +95,7 @@ def test_convert_pipette_model_provided_version(
             ),
         ],
         [
-            "p1000_multi_gen3",
+            "p1000_multi_flex",
             pc.PipetteModelVersionType(
                 PipetteModelType.p1000,
                 PipetteChannelType.EIGHT_CHANNEL,

--- a/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
+++ b/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
@@ -137,7 +137,7 @@ def test_convert_pipette_name(
             # 96 channel has a unique "name" right now
             PipetteModelType.p1000,
             PipetteChannelType.NINETY_SIX_CHANNEL,
-            PipetteGenerationType.GEN3,
+            PipetteGenerationType.FLEX,
             "p1000_96",
         ],
     ],


### PR DESCRIPTION
# Overview

Support mutable configs and smoothie configs with the new v2 pipette schema.

# Test Plan

Throw this on an OT-2 robot and mess around with the pipette config settings to make sure everything still renders correctly.

- [ ] Remove config changes
- [ ] Add a new config change
- [ ] click and un-click quirks.

# Changelog

- Add quirks to schema
- Add mutable config helpers to shared data
- Utilize the new mutable configs in the robot server endpoint


The next step after this PR is to port the OT-2 to the new configs _and_ support loading the new configs in the protocol engine.

# Review requests

Please check it over and let me know what thoughts you have.

# Risk assessment

Medium. Touches core functionality on the OT-2
