### PR TITLE
feat(robot-server): Present error codes in error responses

### DIFF
--- a/robot-server/robot_server/errors/error_responses.py
+++ b/robot-server/robot_server/errors/error_responses.py
@@ -113,11 +113,7 @@ class ErrorDetails(BaseErrorBody):
 
     @classmethod
     def from_exc(
-        cls: Type["ErrorDetailsT"],
-        exc: BaseException,
-        *,
-        override_defaults: bool = False,
-        **supplemental_kwargs: Any
+        cls: Type["ErrorDetailsT"], exc: BaseException, **supplemental_kwargs: Any
     ) -> "ErrorDetailsT":
         """Build an ErrorDetails model from an exception.
 
@@ -143,10 +139,6 @@ class ErrorDetails(BaseErrorBody):
             }
 
         values["meta"] = _exc_to_meta(checked_exc)
-        if not override_defaults:
-            for fieldname, fieldval in cls.__fields__.items():
-                if not fieldval.required and fieldval.default is not None:
-                    values.pop(fieldname, None)
         return cls(**values)
 
     def as_error(self, status_code: int) -> ApiError:

--- a/robot-server/robot_server/errors/error_responses.py
+++ b/robot-server/robot_server/errors/error_responses.py
@@ -4,9 +4,10 @@ from pydantic.generics import GenericModel
 from typing import Any, Dict, Generic, Optional, Sequence, Tuple, TypeVar
 
 from robot_server.service.json_api import BaseResponseBody, ResourceLinks
+from opentrons_shared_data.errors import ErrorCodes, EnumeratedError
 
 
-class ApiError(Exception):
+class ApiError(EnumeratedError):
     """An exception to throw when an endpoint should respond with an error."""
 
     def __init__(self, status_code: int, content: Dict[str, Any]) -> None:
@@ -105,6 +106,10 @@ class ErrorDetails(BaseErrorBody):
             "occurrence of the error"
         ),
     )
+    errorCode: str = Field(
+        ...,
+        description=("The Opentrons error code associated with the error"),
+    )
 
     def as_error(self, status_code: int) -> ApiError:
         """Serial this ErrorDetails as an ApiError from an ErrorResponse."""
@@ -120,6 +125,9 @@ class LegacyErrorResponse(BaseErrorBody):
     message: str = Field(
         ...,
         description="A human-readable message describing the error.",
+    )
+    errorCode: str = Field(
+        ..., description="The Opentrons error code associated with the error"
     )
 
 

--- a/robot-server/robot_server/errors/error_responses.py
+++ b/robot-server/robot_server/errors/error_responses.py
@@ -4,7 +4,7 @@ from pydantic.generics import GenericModel
 from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Type
 
 from robot_server.service.json_api import BaseResponseBody, ResourceLinks
-from opentrons_shared_data.errors import EnumeratedError, PythonException
+from opentrons_shared_data.errors import EnumeratedError, PythonException, ErrorCodes
 
 
 class ApiError(Exception):
@@ -107,7 +107,7 @@ class ErrorDetails(BaseErrorBody):
         ),
     )
     errorCode: str = Field(
-        None,
+        ErrorCodes.GENERAL_ERROR.value.code,
         description=("The Opentrons error code associated with the error"),
     )
 

--- a/robot-server/robot_server/errors/exception_handlers.py
+++ b/robot-server/robot_server/errors/exception_handlers.py
@@ -5,8 +5,9 @@ from fastapi.routing import APIRoute
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from traceback import format_exception, format_exception_only
 from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, Type, Union
+
+from opentrons_shared_data.errors import ErrorCodes, EnumeratedError, PythonException
 
 from robot_server.versioning import (
     API_VERSION,
@@ -40,7 +41,12 @@ log = getLogger(__name__)
 
 def _code_or_default(exc: BaseException) -> str:
     if isinstance(exc, EnumeratedError):
-        return exc.error_code
+        # For a reason I cannot fathom, mypy thinks this is an Any.
+        # reveal_type(exc) # -> opentrons_shared_data.errors.exceptions.EnumeratedError
+        # reveal_type(exc.code) # -> opentrons_shared_data.errors.codes.ErrorCodes
+        # reveal_type(exc.code.value) # Any (????????????)
+        # This doesn't happen anywhere else or indeed in the else side of this clause.
+        return exc.code.value.code  # type: ignore [no-any-return]
     else:
         return ErrorCodes.GENERAL_ERROR.value.code
 
@@ -102,7 +108,9 @@ async def handle_framework_error(
 ) -> JSONResponse:
     """Map an HTTP exception from the framework to an API response."""
     if _route_is_legacy(request):
-        response: BaseErrorBody = LegacyErrorResponse(message=error.detail)
+        response: BaseErrorBody = LegacyErrorResponse(
+            message=error.detail, errorCode=ErrorCodes.GENERAL_ERROR.value.code
+        )
     else:
         response = BadRequest(detail=error.detail)
 
@@ -121,7 +129,9 @@ async def handle_validation_error(
             f"{'.'.join([str(v) for v in val_error['loc']])}: {val_error['msg']}"
             for val_error in validation_errors
         )
-        response: BaseErrorBody = LegacyErrorResponse(message=message)
+        response: BaseErrorBody = LegacyErrorResponse(
+            message=message, errorCode=ErrorCodes.GENERAL_ERROR.value.code
+        )
     else:
         response = MultiErrorResponse(
             errors=[
@@ -139,19 +149,19 @@ async def handle_validation_error(
     )
 
 
-async def handle_unexpected_error(request: Request, error: Exception) -> JSONResponse:
+async def handle_unexpected_error(
+    request: Request, error: BaseException
+) -> JSONResponse:
     """Map an unhandled Exception to an API response."""
-    detail = "".join(format_exception_only(type(error), error)).strip()
-    stacktrace = "".join(
-        format_exception(type(error), error, error.__traceback__, limit=-5)
-    ).strip()
+    if isinstance(error, EnumeratedError):
+        enumerated: EnumeratedError = error
+    else:
+        enumerated = PythonException(error)
 
     if _route_is_legacy(request):
-        response: BaseErrorBody = LegacyErrorResponse(
-            message=detail, errorCode=_code_or_default(error)
-        )
+        response: BaseErrorBody = LegacyErrorResponse.from_exc(enumerated)
     else:
-        response = UnexpectedError(detail=detail, meta={"stacktrace": stacktrace})
+        response = UnexpectedError.from_exc(enumerated)
 
     return await handle_api_error(
         request,
@@ -163,15 +173,10 @@ async def handle_firmware_upgrade_required_error(
     request: Request, error: HWFirmwareUpdateRequired
 ) -> JSONResponse:
     """Map a FirmwareUpdateRequired error from hardware to an API response."""
-    detail = "".join(
-        format_exception(type(error), error, error.__traceback__, limit=0)
-    ).strip()
     if _route_is_legacy(request):
-        response: BaseErrorBody = LegacyErrorResponse(message=detail)
+        response: BaseErrorBody = LegacyErrorResponse.from_exc(error)
     else:
-        response = FirmwareUpdateRequired(
-            detail=detail, meta={"status_url": "/subsystems/status"}
-        )
+        response = FirmwareUpdateRequired.from_exc(error)
     return await handle_api_error(
         request, response.as_error(status.HTTP_503_SERVICE_UNAVAILABLE)
     )

--- a/robot-server/robot_server/errors/global_errors.py
+++ b/robot-server/robot_server/errors/global_errors.py
@@ -1,5 +1,6 @@
 """Global error types."""
 from typing_extensions import Literal
+from typing import Type, Any
 
 from .error_responses import ErrorDetails
 from opentrons_shared_data.errors import ErrorCodes
@@ -43,3 +44,22 @@ class FirmwareUpdateRequired(ErrorDetails):
     id: Literal["FirmwareUpdateRequired"] = "FirmwareUpdateRequired"
     title: str = "Firmware Update Required"
     errorCode: str = ErrorCodes.FIRMWARE_UPDATE_REQUIRED.value.code
+
+    @classmethod
+    def from_exc(
+        cls: Type["FirmwareUpdateRequired"],
+        exc: BaseException,
+        *,
+        override_defaults: bool = False,
+        **supplemental_kwargs: Any
+    ) -> "FirmwareUpdateRequired":
+        """Build a FirmwareUpdateRequired from a specific exception. Preserves metadata."""
+        parent_inst = ErrorDetails.from_exc(
+            exc, override_defaults=override_defaults, **supplemental_kwargs
+        )
+        inst = FirmwareUpdateRequired(**parent_inst.dict())
+        if not inst.meta:
+            inst.meta = {"update_url": "/subsystems/update"}
+        else:
+            inst.meta["update_url"] = "/subsystems/update"
+        return inst

--- a/robot-server/robot_server/errors/global_errors.py
+++ b/robot-server/robot_server/errors/global_errors.py
@@ -2,6 +2,7 @@
 from typing_extensions import Literal
 
 from .error_responses import ErrorDetails
+from opentrons_shared_data.errors import ErrorCodes
 
 
 class UnexpectedError(ErrorDetails):
@@ -9,6 +10,7 @@ class UnexpectedError(ErrorDetails):
 
     id: Literal["UnexpectedError"] = "UnexpectedError"
     title: str = "Unexpected Internal Error"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
 class BadRequest(ErrorDetails):
@@ -16,6 +18,7 @@ class BadRequest(ErrorDetails):
 
     id: Literal["BadRequest"] = "BadRequest"
     title: str = "Bad Request"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
 class InvalidRequest(ErrorDetails):
@@ -23,6 +26,7 @@ class InvalidRequest(ErrorDetails):
 
     id: Literal["InvalidRequest"] = "InvalidRequest"
     title: str = "Invalid Request"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
 class IDNotFound(ErrorDetails):
@@ -30,6 +34,7 @@ class IDNotFound(ErrorDetails):
 
     id: Literal["IDNotFound"] = "IDNotFound"
     title: str = "ID Not Found"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
 class FirmwareUpdateRequired(ErrorDetails):
@@ -37,3 +42,4 @@ class FirmwareUpdateRequired(ErrorDetails):
 
     id: Literal["FirmwareUpdateRequired"] = "FirmwareUpdateRequired"
     title: str = "Firmware Update Required"
+    errorCode: str = ErrorCodes.FIRMWARE_UPDATE_REQUIRED.value.code

--- a/robot-server/robot_server/errors/global_errors.py
+++ b/robot-server/robot_server/errors/global_errors.py
@@ -49,14 +49,10 @@ class FirmwareUpdateRequired(ErrorDetails):
     def from_exc(
         cls: Type["FirmwareUpdateRequired"],
         exc: BaseException,
-        *,
-        override_defaults: bool = False,
         **supplemental_kwargs: Any
     ) -> "FirmwareUpdateRequired":
         """Build a FirmwareUpdateRequired from a specific exception. Preserves metadata."""
-        parent_inst = ErrorDetails.from_exc(
-            exc, override_defaults=override_defaults, **supplemental_kwargs
-        )
+        parent_inst = ErrorDetails.from_exc(exc, **supplemental_kwargs)
         inst = FirmwareUpdateRequired(**parent_inst.dict())
         if not inst.meta:
             inst.meta = {"update_url": "/subsystems/update"}

--- a/robot-server/robot_server/robot/calibration/errors.py
+++ b/robot-server/robot_server/robot/calibration/errors.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 
+from opentrons_shared_data.errors import ErrorCodes
 from robot_server.service.errors import ErrorDef, ErrorCreateDef
 
 
@@ -8,40 +9,48 @@ class CalibrationError(ErrorDef):
         status_code=HTTPStatus.FORBIDDEN,
         title="No Pipette Attached",
         format_string="No pipette present on {mount} mount",
+        error_code=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
     )
     NO_PIPETTE_ATTACHED = ErrorCreateDef(
         status_code=HTTPStatus.FORBIDDEN,
         title="No Pipette Attached",
         format_string="Cannot start {flow} with fewer than one pipette",
+        error_code=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
     )
     BAD_LABWARE_DEF = ErrorCreateDef(
         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         title="Bad Labware Definition",
         format_string="Bad definition for tip rack under calibration",
+        error_code=ErrorCodes.GENERAL_ERROR.value.code,
     )
     BAD_STATE_TRANSITION = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
         title="Illegal State Transition",
         format_string="The action {action} may not occur in the state {state}",
+        error_code=ErrorCodes.GENERAL_ERROR.value.code,
     )
     NO_STATE_TRANSITION = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
         title="No State Transition",
         format_string="No transition available for state {state}",
+        error_code=ErrorCodes.GENERAL_ERROR.value.code,
     )
     UNMET_STATE_TRANSITION_REQ = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
         title="Unmet State Transition Requirement",
         format_string="The command handler {handler} may not occur in the"
         ' state {state} when "{condition}" is not true',
+        error_code=ErrorCodes.GENERAL_ERROR.value.code,
     )
     UNCALIBRATED_ROBOT = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
         title="No Calibration Data Found",
         format_string="Cannot start {flow} without robot calibration",
+        error_code=ErrorCodes.GENERAL_ERROR.value.code,
     )
     ERROR_DURING_TRANSITION = ErrorCreateDef(
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         title="Error During State Transition",
         format_string="Event {action} failed to transition " "from {state}: {error}",
+        error_code=ErrorCodes.GENERAL_ERROR.value.code,
     )

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -116,12 +116,10 @@ async def create_run_action(
         )
 
     except RunActionNotAllowedError as e:
-        raise RunActionNotAllowed(detail=str(e)).as_error(
-            status.HTTP_409_CONFLICT
-        ) from e
+        raise RunActionNotAllowed.from_exc(e).as_error(status.HTTP_409_CONFLICT) from e
 
     except RunNotFoundError as e:
-        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+        raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
 
     return await PydanticResponse.create(
         content=SimpleBody.construct(data=action),

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -11,6 +11,8 @@ from typing_extensions import Literal
 from fastapi import APIRouter, Depends, status, Query
 from pydantic import BaseModel, Field
 
+from opentrons_shared_data.errors import ErrorCodes
+
 from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.service.dependencies import get_current_time, get_unique_id
 
@@ -48,6 +50,7 @@ class RunNotFound(ErrorDetails):
 
     id: Literal["RunNotFound"] = "RunNotFound"
     title: str = "Run Not Found"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
 class RunAlreadyActive(ErrorDetails):
@@ -55,6 +58,7 @@ class RunAlreadyActive(ErrorDetails):
 
     id: Literal["RunAlreadyActive"] = "RunAlreadyActive"
     title: str = "Run Already Active"
+    errorCode: str = ErrorCodes.ROBOT_IN_USE.value.code
 
 
 class RunNotIdle(ErrorDetails):
@@ -66,6 +70,7 @@ class RunNotIdle(ErrorDetails):
         "Run is currently active. Allow the run to finish or"
         " stop it with a `stop` action before attempting to modify it."
     )
+    errorCode: str = ErrorCodes.ROBOT_IN_USE.value.code
 
 
 class RunStopped(ErrorDetails):
@@ -73,6 +78,7 @@ class RunStopped(ErrorDetails):
 
     id: Literal["RunStopped"] = "RunStopped"
     title: str = "Run Stopped"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
 class AllRunsLinks(BaseModel):

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -197,9 +197,9 @@ async def create_run_command(
         command = protocol_engine.add_command(command_create)
 
     except pe_errors.SetupCommandNotAllowedError as e:
-        raise CommandNotAllowed(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
+        raise CommandNotAllowed.from_exc(e).as_error(status.HTTP_409_CONFLICT)
     except pe_errors.RunStoppedError as e:
-        raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
+        raise RunStopped.from_exc(e).as_error(status.HTTP_409_CONFLICT)
 
     if waitUntilComplete:
         timeout_sec = None if timeout is None else timeout / 1000.0
@@ -261,7 +261,7 @@ async def get_run_commands(
             length=pageLength,
         )
     except RunNotFoundError as e:
-        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+        raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
 
     current_command = run_data_manager.get_current_command(run_id=runId)
 
@@ -335,9 +335,9 @@ async def get_run_command(
     try:
         command = run_data_manager.get_command(run_id=runId, command_id=commandId)
     except RunNotFoundError as e:
-        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+        raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
     except CommandNotFoundError as e:
-        raise CommandNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+        raise CommandNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
 
     return await PydanticResponse.create(
         content=SimpleBody.construct(data=command),

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 
 from opentrons.protocol_engine import ProtocolEngineError
+from opentrons_shared_data.errors.exceptions import RoboticsInteractionError
 
 from robot_server.service.task_runner import TaskRunner
 
@@ -14,7 +15,7 @@ from .action_models import RunAction, RunActionType
 log = logging.getLogger(__name__)
 
 
-class RunActionNotAllowedError(ValueError):
+class RunActionNotAllowedError(RoboticsInteractionError):
     """Error raised when a given run action is not allowed."""
 
 
@@ -79,7 +80,7 @@ class RunController:
                 self._task_runner.run(self._engine_store.runner.stop)
 
         except ProtocolEngineError as e:
-            raise RunActionNotAllowedError(str(e)) from e
+            raise RunActionNotAllowedError(message=e.message, wrapping=[e]) from e
 
         self._run_store.insert_action(run_id=self._run_id, action=action)
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -17,6 +17,7 @@ from opentrons.protocol_engine import (
     LabwareOffsetCreate,
     Liquid,
 )
+from opentrons_shared_data.errors import GeneralError
 from robot_server.service.json_api import ResourceModel
 from .action_models import RunAction
 
@@ -149,9 +150,11 @@ class LabwareDefinitionSummary(BaseModel):
     )
 
 
-class RunNotFoundError(ValueError):
+class RunNotFoundError(GeneralError):
     """Error raised when a given Run ID is not found in the store."""
 
     def __init__(self, run_id: str) -> None:
         """Initialize the error message from the missing ID."""
-        super().__init__(f"Run {run_id} was not found.")
+        super().__init__(
+            message=f"Run {run_id} was not found.", detail={"runId": run_id}
+        )

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal, NoReturn
 
 from fastapi import APIRouter, Depends, status
 
+from opentrons_shared_data.errors import ErrorCodes
 from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.versioning import get_requested_version
 from robot_server.service.labware import models as lw_models
@@ -25,6 +26,7 @@ class LabwareCalibrationEndpointsRemoved(ErrorDetails):
     ] = "LabwareCalibrationEndpointsRemoved"
     title: str = "Labware Calibration Endpoints Removed"
     detail: str = "Use the `/runs` endpoints to manage labware offsets."
+    errorCode: str = ErrorCodes.API_REMOVED.value.code
 
 
 @router.get(

--- a/robot-server/robot_server/service/legacy/routers/motors.py
+++ b/robot-server/robot_server/service/legacy/routers/motors.py
@@ -2,6 +2,8 @@ from starlette import status
 from fastapi import APIRouter, Depends
 from pydantic import ValidationError
 
+from opentrons_shared_data.errors import ErrorCodes
+
 from opentrons.hardware_control.types import Axis
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.errors import HardwareNotSupportedError
@@ -34,8 +36,10 @@ async def get_engaged_motors(
         }
         return model.EngagedMotors(**axes_dict)
     except ValidationError as e:
-        raise LegacyErrorResponse(message=str(e)).as_error(
-            status.HTTP_500_INTERNAL_SERVER_ERROR
+        raise LegacyErrorResponse(
+            message=str(e), errorCode=ErrorCodes.GENERAL_ERROR.value.code
+        ).as_error(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
 

--- a/robot-server/tests/errors/test_error_responses.py
+++ b/robot-server/tests/errors/test_error_responses.py
@@ -26,6 +26,7 @@ def test_error_details() -> None:
                 "id": "SomeErrorId",
                 "title": "Some Error Title",
                 "detail": "Some error detail",
+                "errorCode": "4000",
             },
         )
     }
@@ -50,6 +51,7 @@ def test_error_details_with_meta() -> None:
                 "title": "Some Error Title",
                 "detail": "Some error detail",
                 "source": {"pointer": "/foo/bar/baz"},
+                "errorCode": "4000",
                 "meta": {"some": "meta information"},
             },
         )
@@ -75,6 +77,7 @@ def test_error_response() -> None:
                 id="SomeErrorId",
                 title="Some Error Title",
                 detail="Some error detail",
+                errorCode="4006",
                 meta={"some": "meta information"},
             ),
         )
@@ -88,6 +91,7 @@ def test_error_response() -> None:
                 "id": "SomeErrorId",
                 "title": "Some Error Title",
                 "detail": "Some error detail",
+                "errorCode": "4006",
                 "meta": {"some": "meta information"},
             },
         )
@@ -102,6 +106,7 @@ def test_multi_error_response() -> None:
                 id="SomeErrorId",
                 title="Some Error Title",
                 detail="Some error detail",
+                errorCode="51231",
                 meta={"some": "meta information"},
             ),
             ErrorDetails(
@@ -121,12 +126,14 @@ def test_multi_error_response() -> None:
                 "id": "SomeErrorId",
                 "title": "Some Error Title",
                 "detail": "Some error detail",
+                "errorCode": "51231",
                 "meta": {"some": "meta information"},
             },
             {
                 "id": "SomeOtherErrorId",
                 "title": "Some Other Error Title",
                 "detail": "Some other error detail",
+                "errorCode": "4000",
                 "meta": {"some": "other meta information"},
             },
         ]

--- a/robot-server/tests/errors/test_error_responses.py
+++ b/robot-server/tests/errors/test_error_responses.py
@@ -1,4 +1,5 @@
 """Tests for API error exceptions and response model serialization."""
+from opentrons_shared_data.errors import ErrorCodes
 from robot_server.errors.error_responses import (
     ApiError,
     ErrorSource,
@@ -58,12 +59,12 @@ def test_error_details_with_meta() -> None:
 def test_legacy_error_response() -> None:
     """It should serialize an error response from a LegacyErrorResponse."""
     result = LegacyErrorResponse(
-        message="Some error detail",
+        message="Some error detail", errorCode=ErrorCodes.GENERAL_ERROR.value.code
     ).as_error(status_code=400)
 
     assert isinstance(result, ApiError)
     assert result.status_code == 400
-    assert result.content == {"message": "Some error detail"}
+    assert result.content == {"message": "Some error detail", "errorCode": "4000"}
 
 
 def test_error_response() -> None:

--- a/robot-server/tests/errors/test_exception_handlers.py
+++ b/robot-server/tests/errors/test_exception_handlers.py
@@ -69,10 +69,19 @@ def test_handles_unexpected_errors(app: FastAPI, client: TestClient) -> None:
                 "id": "UnexpectedError",
                 "title": "Unexpected Internal Error",
                 "detail": "Exception: Oh no!",
+                "errorCode": "4000",
                 "meta": {
-                    "stacktrace": matchers.StringMatching(
-                        r'raise Exception\("Oh no!"\)'
-                    )
+                    "code": "4000",
+                    "message": "Exception: Oh no!",
+                    "type": "Exception",
+                    "detail": {
+                        "args": "('Oh no!',)",
+                        "class": "Exception",
+                        "traceback": matchers.StringMatching(
+                            r'raise Exception\("Oh no!"\)'
+                        ),
+                    },
+                    "wrapping": [],
                 },
             }
         ]
@@ -89,7 +98,7 @@ def test_handles_legacy_unexpected_errors(app: FastAPI, client: TestClient) -> N
     response = client.get("/internal-server-error-legacy")
 
     assert response.status_code == 500
-    assert response.json() == {"message": "Exception: Oh no!"}
+    assert response.json() == {"message": "Exception: Oh no!", "errorCode": "4000"}
 
 
 def test_handles_framework_exceptions(app: FastAPI, client: TestClient) -> None:
@@ -105,6 +114,7 @@ def test_handles_framework_exceptions(app: FastAPI, client: TestClient) -> None:
     assert response.json() == {
         "errors": [
             {
+                "errorCode": "4000",
                 "id": "BadRequest",
                 "title": "Bad Request",
                 "detail": "Method Not Allowed",
@@ -124,6 +134,7 @@ def test_handles_legacy_framework_exceptions(app: FastAPI, client: TestClient) -
 
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert response.json() == {
+        "errorCode": "4000",
         "message": "Method Not Allowed",
     }
 
@@ -144,18 +155,21 @@ def test_handles_body_validation_error(app: FastAPI, client: TestClient) -> None
     assert response.json() == {
         "errors": [
             {
+                "errorCode": "4000",
                 "id": "InvalidRequest",
                 "title": "Invalid Request",
                 "detail": "field required",
                 "source": {"pointer": "/string_field"},
             },
             {
+                "errorCode": "4000",
                 "id": "InvalidRequest",
                 "title": "Invalid Request",
                 "detail": "value is not a valid integer",
                 "source": {"pointer": "/int_field"},
             },
             {
+                "errorCode": "4000",
                 "id": "InvalidRequest",
                 "title": "Invalid Request",
                 "detail": "value could not be parsed to a boolean",
@@ -178,6 +192,7 @@ def test_handles_query_validation_error(app: FastAPI, client: TestClient) -> Non
     assert response.json() == {
         "errors": [
             {
+                "errorCode": "4000",
                 "id": "InvalidRequest",
                 "title": "Invalid Request",
                 "detail": "value is not a valid integer",
@@ -200,6 +215,7 @@ def test_handles_header_validation_error(app: FastAPI, client: TestClient) -> No
     assert response.json() == {
         "errors": [
             {
+                "errorCode": "4000",
                 "id": "InvalidRequest",
                 "title": "Invalid Request",
                 "detail": "field required",
@@ -223,9 +239,10 @@ def test_handles_legacy_validation_error(app: FastAPI, client: TestClient) -> No
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert response.json() == {
+        "errorCode": "4000",
         "message": (
             "body.string_field: none is not an allowed value; "
             "body.int_field: value is not a valid integer; "
             "body.array_field.0: value could not be parsed to a boolean"
-        )
+        ),
     }

--- a/robot-server/tests/integration/http_api/protocols/test_404.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_404.tavern.yaml
@@ -15,6 +15,7 @@ stages:
           - id: ProtocolNotFound
             title: Protocol Not Found
             detail: "'Protocol idontexist was not found.'"
+            errorCode: '4000'
 
 ---
 test_name: Verify error upon DELETE of nonexistent protocol id.
@@ -34,3 +35,4 @@ stages:
         - id: ProtocolNotFound
           title: Protocol Not Found
           detail: "'Protocol idontexist was not found.'"
+          errorCode: '4000'

--- a/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
@@ -23,5 +23,6 @@ stages:
           - id: ProtocolRobotTypeMismatch
             title: Protocol For Different Robot Type
             detail: "This protocol is for OT-3 Standard robots. It can't be analyzed or run on this robot, which is an OT-2 Standard."
+            errorCode: '4000'
 
 # TODO(mm, 2022-12-12): Also make sure an OT-3 server rejects OT-2 protocols.

--- a/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_pause_run_not_started.tavern.yaml
@@ -36,4 +36,6 @@ stages:
         errors:
           - id: 'RunActionNotAllowed'
             title: 'Run Action Not Allowed'
-            detail: 'Error 4000 GENERAL_ERROR (PauseNotAllowedError): Cannot pause a run that is not running.'
+            detail: 'Cannot pause a run that is not running.'
+            errorCode: '3000'
+            meta: !anydict

--- a/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
@@ -279,3 +279,4 @@ stages:
           - id: 'ProtocolUsedByRun'
             title: 'Protocol Used by Run'
             detail: 'Protocol {protocol_id} is used by a run and cannot be deleted.'
+            errorCode: '4000'

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -39,6 +39,7 @@ stages:
           - id: "InvalidRequest"
             title: "Invalid Request"
             detail: "field required"
+            errorCode: '4000'
             source:
               pointer: "/data/systemTime"
   - name: System Time PUT request on a dev server raises error
@@ -56,3 +57,4 @@ stages:
           - id: "UncategorizedError"
             title: "Not implemented"
             detail: "Method not implemented. Not supported on dev server."
+            errorCode: '4000'

--- a/robot-server/tests/integration/test_identify.tavern.yaml
+++ b/robot-server/tests/integration/test_identify.tavern.yaml
@@ -28,3 +28,4 @@ stages:
       status_code: 422
       json:
         message: "query.seconds: field required"
+        errorCode: "4000"

--- a/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
+++ b/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
@@ -14,6 +14,7 @@ stages:
           - id: 'LabwareCalibrationEndpointsRemoved'
             title: 'Labware Calibration Endpoints Removed'
             detail: 'Use the `/runs` endpoints to manage labware offsets.'
+            errorCode: '4002'
   - name: GET /labware/calibrations/:id returns 410
     request:
       url: '{ot2_server_base_url}/labware/calibrations/some-id'
@@ -25,6 +26,7 @@ stages:
           - id: 'LabwareCalibrationEndpointsRemoved'
             title: 'Labware Calibration Endpoints Removed'
             detail: 'Use the `/runs` endpoints to manage labware offsets.'
+            errorCode: '4002'
   - name: DELETE /labware/calibrations/:id returns 410
     request:
       url: '{ot2_server_base_url}/labware/calibrations/some-id'
@@ -36,6 +38,7 @@ stages:
           - id: 'LabwareCalibrationEndpointsRemoved'
             title: 'Labware Calibration Endpoints Removed'
             detail: 'Use the `/runs` endpoints to manage labware offsets.'
+            errorCode: '4002'
   - name: GET /labware/calibrations returns empty list on version <= 3
     request:
       url: '{ot2_server_base_url}/labware/calibrations'
@@ -60,6 +63,7 @@ stages:
           - id: 'UncategorizedError'
             title: 'Resource Not Found'
             detail: "Resource type 'calibration' with id 'some-id' was not found"
+            errorCode: '4000'
   - name: DELETE /labware/calibrations/:id returns 404 on version <=3
     request:
       url: '{ot2_server_base_url}/labware/calibrations/some-id'
@@ -73,3 +77,4 @@ stages:
           - id: 'UncategorizedError'
             title: 'Resource Not Found'
             detail: "Resource type 'calibration' with id 'some-id' was not found"
+            errorCode: '4000'

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -157,4 +157,5 @@ stages:
     response:
       status_code: 400
       json:
-        message: '{tavern.request_vars.json.id} is not recognized'
+        message: 'ValueError: {tavern.request_vars.json.id} is not recognized'
+        errorCode: '4000'

--- a/robot-server/tests/integration/test_settings_log_level.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_log_level.tavern.yaml
@@ -38,6 +38,7 @@ stages:
       status_code: 422
       json:
         message: "body.log_level: '{tavern.request_vars.json.log_level}' is not a valid LogLevels"
+        errorCode: '4000'
 ---
 test_name: POST Set log level to nothing
 marks:
@@ -54,3 +55,4 @@ stages:
       status_code: 422
       json:
         message: "log_level must be set"
+        errorCode: '4000'

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -186,6 +186,7 @@ stages:
       status_code: 412
       json: 
         message: "dropTip out of range with {tavern.request_vars.json.fields.dropTip.value}"
+        errorCode: "4000"
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} value too high
@@ -206,6 +207,7 @@ stages:
       status_code: 412
       json: 
         message: "dropTip out of range with {tavern.request_vars.json.fields.dropTip.value}"
+        errorCode: "4000"
       strict: true
 ---
 test_name: PATCH Pipette {pipette_id} no value

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -121,6 +121,7 @@ stages:
       status_code: 403
       json:
         message: "gripperOffsetCalibrations is not a valid reset option."
+        errorCode: "4000"
 ---
 test_name: POST Reset non existant option
 marks:
@@ -137,3 +138,4 @@ stages:
       status_code: 422
       json:
         message: !re_search 'value is not a valid enumeration member'
+        errorCode: "4000"

--- a/robot-server/tests/integration/test_version_headers.tavern.yaml
+++ b/robot-server/tests/integration/test_version_headers.tavern.yaml
@@ -65,6 +65,7 @@ stages:
           - id: 'OutdatedAPIVersion'
             title: 'Requested HTTP API version no longer supported'
             detail: The requested API version '1' is not supported. 'Opentrons-Version' must be at least '2'. Please upgrade your Opentrons App or other HTTP API client.
+            errorCode: '4000'
       headers:
         Opentrons-Version: '4'
         Opentrons-Min-Version: '2'

--- a/robot-server/tests/runs/router/test_actions_router.py
+++ b/robot-server/tests/runs/router/test_actions_router.py
@@ -103,7 +103,7 @@ async def test_play_action_clears_maintenance_run(
 @pytest.mark.parametrize(
     ("exception", "expected_error_id", "expected_status_code"),
     [
-        (RunActionNotAllowedError("oh no"), "RunActionNotAllowed", 409),
+        (RunActionNotAllowedError(message="oh no"), "RunActionNotAllowed", 409),
         (RunNotFoundError("oh no"), "RunNotFound", 404),
     ],
 )

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -214,8 +214,9 @@ async def test_add_conflicting_setup_command(
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["detail"] == matchers.StringMatching(
-        ".*4000.*oh no"
+        "oh no"
     )
+    assert exc_info.value.content["errors"][0]["errorCode"] == "4000"
 
 
 async def test_add_command_to_stopped_engine(
@@ -241,8 +242,9 @@ async def test_add_command_to_stopped_engine(
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["detail"] == matchers.StringMatching(
-        ".*4000.*oh no"
+        "oh no"
     )
+    assert exc_info.value.content["errors"][0]["errorCode"] == "4000"
 
 
 async def test_get_run_commands(

--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -244,7 +244,8 @@ async def test_concurrent_motion_fails(hardware, blocking_call, blocking_call_da
         with pytest.raises(ApiError) as exc_info:
             await func
         assert exc_info.value.status_code == 403
-        assert exc_info.value.content["message"].find("Robot is currently moving") == 0
+        assert "currently moving" in exc_info.value.content["message"]
+        assert exc_info.value.content["errorCode"] == "4000"
 
     forbidden_home = loop.create_task(
         failure(

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -236,7 +236,10 @@ def test_post_serial_update_no_bundled_fw(api_client, hardware, magdeck):
 
     body = resp.json()
     assert resp.status_code == 500
-    assert body == {"message": "Bundled fw file not found for module of type: magdeck"}
+    assert body == {
+        "message": "Bundled fw file not found for module of type: magdeck",
+        "errorCode": "1005",
+    }
 
 
 def test_post_serial_update_no_modules(api_client, hardware):
@@ -244,7 +247,7 @@ def test_post_serial_update_no_modules(api_client, hardware):
 
     body = resp.json()
     assert resp.status_code == 404
-    assert body == {"message": "Module dummySerialMD not found"}
+    assert body == {"message": "Module dummySerialMD not found", "errorCode": "3015"}
 
 
 def test_post_serial_update_no_match(api_client, hardware, tempdeck):
@@ -254,7 +257,10 @@ def test_post_serial_update_no_match(api_client, hardware, tempdeck):
 
     body = resp.json()
     assert resp.status_code == 404
-    assert body == {"message": "Module superDummySerialMD not found"}
+    assert body == {
+        "message": "Module superDummySerialMD not found",
+        "errorCode": "3015",
+    }
 
 
 def test_post_serial_update_error(api_client, hardware, magdeck):
@@ -271,7 +277,7 @@ def test_post_serial_update_error(api_client, hardware, magdeck):
 
         body = resp.json()
         assert resp.status_code == 500
-        assert body == {"message": "Update error: not possible"}
+        assert body == {"message": "Update error: not possible", "errorCode": "1005"}
 
 
 def test_post_serial_timeout_error(api_client, hardware, magdeck):
@@ -288,7 +294,7 @@ def test_post_serial_timeout_error(api_client, hardware, magdeck):
 
         body = resp.json()
         assert resp.status_code == 500
-        assert body == {"message": "Module not responding"}
+        assert body == {"message": "Module not responding", "errorCode": "1005"}
 
 
 def test_post_serial_update(api_client, hardware, tempdeck):

--- a/robot-server/tests/service/legacy/routers/test_networking.py
+++ b/robot-server/tests/service/legacy/routers/test_networking.py
@@ -135,7 +135,7 @@ def test_wifi_configure_value_error(api_client, monkeypatch):
     resp = api_client.post("/wifi/configure", json={"ssid": "asasd", "foo": "bar"})
     assert resp.status_code == 400
     body = resp.json()
-    assert {"message": "nope!"} == body
+    assert {"message": "ValueError: nope!", "errorCode": "4000"} == body
 
 
 def test_wifi_configure_nmcli_error(api_client, monkeypatch):
@@ -149,7 +149,7 @@ def test_wifi_configure_nmcli_error(api_client, monkeypatch):
     resp = api_client.post("/wifi/configure", json={"ssid": "asasd", "foo": "bar"})
     assert resp.status_code == 401
     body = resp.json()
-    assert {"message": "no"} == body
+    assert {"errorCode": "4000", "message": "no"} == body
 
 
 def test_wifi_disconnect(api_client, monkeypatch):
@@ -299,7 +299,12 @@ def test_add_key_response(add_key_return, expected_status, expected_body, api_cl
 @pytest.mark.parametrize(
     "arg,remove_key_return,expected_status,expected_body",
     [
-        ("12345", None, 404, {"message": "No such key file 12345"}),
+        (
+            "12345",
+            None,
+            404,
+            {"message": "No such key file 12345", "errorCode": "4000"},
+        ),
         ("54321", "myfile.pem", 200, {"message": "Key file myfile.pem deleted"}),
     ],
 )

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -100,6 +100,7 @@ def test_sessions_create_error(sessions_api_client, mock_session_manager):
                 "id": "UncategorizedError",
                 "detail": "Please attach pipettes before proceeding",
                 "title": "Action Forbidden",
+                "errorCode": "4000",
             }
         ]
     }
@@ -167,6 +168,7 @@ def test_sessions_delete_not_found(sessions_api_client, mock_session_manager):
                 "id": "UncategorizedError",
                 "title": "Resource Not Found",
                 "detail": "Resource type 'session' with id 'check' was not found",
+                "errorCode": "4000",
             }
         ],
         "links": {
@@ -217,6 +219,7 @@ def test_sessions_get_not_found(mock_session_manager, sessions_api_client):
                 "id": "UncategorizedError",
                 "detail": "Resource type 'session' with id '1234' was not found",
                 "title": "Resource Not Found",
+                "errorCode": "4000",
             }
         ],
         "links": {
@@ -306,6 +309,7 @@ def test_sessions_execute_command_no_session(sessions_api_client, mock_session_m
                 "id": "UncategorizedError",
                 "title": "Resource Not Found",
                 "detail": "Resource type 'session' with id '1234' was not found",
+                "errorCode": "4000",
             }
         ],
         "links": {
@@ -402,6 +406,7 @@ def test_execute_command_error(
                 "detail": "Cannot do it",
                 "title": "Action Forbidden",
                 "id": "UncategorizedError",
+                "errorCode": "4000",
             }
         ]
     }
@@ -431,6 +436,7 @@ def test_execute_command_session_inactive(
                 "detail": f"Session '{mock_session.meta.identifier}'"
                 f" is not active. Only the active session can "
                 f"execute commands",
+                "errorCode": "4000",
             }
         ]
     }

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -48,6 +48,7 @@ def test_delete_tip_length_calibration(
                 "title": "Resource Not Found",
                 "detail": "Resource type 'TipLengthCalibration' with id "
                 "'wronghash&fake_pip' was not found",
+                "errorCode": "4000",
             }
         ]
     }

--- a/robot-server/tests/system/test_system_router.py
+++ b/robot-server/tests/system/test_system_router.py
@@ -49,6 +49,7 @@ def test_raise_system_synchronized_error(
                 "detail": "Cannot set system time; already synchronized with NTP "
                 "or RTC",
                 "title": "Action Forbidden",
+                "errorCode": "4000",
             }
         ]
     }
@@ -75,6 +76,7 @@ def test_raise_system_exception(
                 "id": "UncategorizedError",
                 "detail": "Something went wrong",
                 "title": "Internal Server Error",
+                "errorCode": "4000",
             }
         ]
     }

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -110,6 +110,10 @@
       "detail": "Unexpected Tip Presence",
       "category": "roboticsInteractionError"
     },
+    "3013": {
+      "detail": "Firmware Update Required",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -114,8 +114,24 @@
       "detail": "Firmware Update Required",
       "category": "roboticsInteractionError"
     },
+    "3014": {
+      "detail": "Invalid Actuator",
+      "category": "roboticsInteractionError"
+    },
+    "3015": {
+      "detail": "Module Not Present",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
+      "category": "generalError"
+    },
+    "4001": {
+      "detail": "Robot In Use",
+      "category": "generalError"
+    },
+    "4002": {
+      "detail": "API Removed",
       "category": "generalError"
     }
   }

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -57,6 +57,7 @@ class ErrorCodes(Enum):
     PIPETTE_NOT_PRESENT = _code_from_dict_entry("3010")
     GRIPPER_NOT_PRESENT = _code_from_dict_entry("3011")
     UNEXPECTED_TIP_ATTACH = _code_from_dict_entry("3012")
+    FIRMWARE_UPDATE_REQUIRED = _code_from_dict_entry("3013")
     GENERAL_ERROR = _code_from_dict_entry("4000")
 
     @classmethod

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -58,7 +58,11 @@ class ErrorCodes(Enum):
     GRIPPER_NOT_PRESENT = _code_from_dict_entry("3011")
     UNEXPECTED_TIP_ATTACH = _code_from_dict_entry("3012")
     FIRMWARE_UPDATE_REQUIRED = _code_from_dict_entry("3013")
+    INVALID_ACTUATOR = _code_from_dict_entry("3014")
+    MODULE_NOT_PRESENT = _code_from_dict_entry("3015")
     GENERAL_ERROR = _code_from_dict_entry("4000")
+    ROBOT_IN_USE = _code_from_dict_entry("4001")
+    API_REMOVED = _code_from_dict_entry("4002")
 
     @classmethod
     @lru_cache(25)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -392,6 +392,19 @@ class UnexpectedTipAttachError(RoboticsInteractionError):
         super().__init__(ErrorCodes.UNEXPECTED_TIP_ATTACH, message, detail, wrapping)
 
 
+class FirmwareUpdateRequiredError(RoboticsInteractionError):
+    """An error indicating that a firmware update is required."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a FirmwareUpdateRequiredError."""
+        super().__init__(ErrorCodes.FIRMWARE_UPDATE_REQUIRED, message, detail, wrapping)
+
+
 class PipetteOverpressureError(RoboticsInteractionError):
     """An error indicating that a pipette experienced an overpressure event, likely because of a clog."""
 

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -202,6 +202,19 @@ class PythonException(GeneralError):
         )
 
 
+class RobotInUseError(CommunicationError):
+    """An error indicating that an action cannot proceed because another is in progress."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a CanbusCommunicationError."""
+        super().__init__(ErrorCodes.ROBOT_IN_USE, message, detail, wrapping)
+
+
 class CanbusCommunicationError(CommunicationError):
     """An error indicating a problem with canbus communication."""
 
@@ -468,3 +481,59 @@ class GripperNotPresentError(RoboticsInteractionError):
     ) -> None:
         """Build an GripperNotPresentError."""
         super().__init__(ErrorCodes.GRIPPER_NOT_PRESENT, message, detail, wrapping)
+
+
+class InvalidActuator(RoboticsInteractionError):
+    """An error indicating that a specified actuator is not valid."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an GripperNotPresentError."""
+        super().__init__(ErrorCodes.INVALID_ACTUATOR, message, detail, wrapping)
+
+
+class ModuleNotPresent(RoboticsInteractionError):
+    """An error indicating that a specific module was not present."""
+
+    def __init__(
+        self,
+        identifier: str,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ModuleNotPresentError."""
+        checked_detail: Dict[str, Any] = detail or {}
+        checked_detail["identifier"] = identifier
+        checked_message = message or f"Module {identifier} is not present"
+        super().__init__(
+            ErrorCodes.MODULE_NOT_PRESENT, checked_message, checked_detail, wrapping
+        )
+
+
+class APIRemoved(GeneralError):
+    """An error indicating that a specific API is no longer available."""
+
+    def __init__(
+        self,
+        api_element: str,
+        since_version: str,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an APIRemoved error."""
+        checked_detail: Dict[str, Any] = detail or {}
+        checked_detail["identifier"] = api_element
+        checked_detail["since_version"] = since_version
+        checked_message = (
+            message
+            or f"{api_element} is no longer available since version {since_version}."
+        )
+        super().__init__(
+            ErrorCodes.API_REMOVED, checked_message, checked_detail, wrapping
+        )

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -479,7 +479,7 @@ class GripperNotPresentError(RoboticsInteractionError):
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build an GripperNotPresentError."""
+        """Build a GripperNotPresentError."""
         super().__init__(ErrorCodes.GRIPPER_NOT_PRESENT, message, detail, wrapping)
 
 


### PR DESCRIPTION
This PR does the equivalent of #12936 for the non-protocol-engine robot server error responses - both the `LegacyErrorResponse` (which now has an `errorCode` entry as well as a `message`, but otherwise not a whole lot else) and the `ErrorResponse` and `MultiErrorResponse`, which now have a top level `errorCode` and also properly intern the exception chain in their multiple-error-body responses.

We also go through and add a couple new useful errors, which is a process that will continue.

## Review Requests
- Does the way we treat `MultipleErrorResponse` and `ErrorResponse` make sense? What's the point of the multi error response anyway, given that error response can hold multiple errors?

## Testing
- [x] Make sure that in practice, errors from both legacy and non-legacy routes that don't have anything to do with protocol engine send back errors properly

## Next steps
Similarly to #12936 , now that the catchalls and structure is in place we need to go through and make sure that the exceptions that we raise to start any given error response off have error codes and tuned messages.