### PR TITLE
fix(api): Disable head motors when attaching an instrument

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -727,7 +727,6 @@ class OT3API(
             await self._move_to_plunger_bottom(
                 checked_mount, rate=1.0, acquire_lock=False
             )
-            await self.current_position_ot3(mount=checked_mount, refresh=True)
 
     @lru_cache(1)
     def _carriage_offset(self) -> top_types.Point:

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -113,6 +113,7 @@ class MoveToMaintenancePositionImplementation(
                     mount_to_axis: _INSTRUMENT_ATTACH_Z_POINT,
                 }
             )
+            await ot3_api.disengage_axes([mount_to_axis])
         else:
             max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
             await ot3_api.move_axes(

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -106,22 +106,23 @@ class MoveToMaintenancePositionImplementation(
                 critical_point=CriticalPoint.MOUNT,
             )
 
-        if params.maintenancePosition == MaintenancePosition.ATTACH_INSTRUMENT:
-            mount_to_axis = OT3Axis.by_mount(params.mount.to_hw_mount())
-            await ot3_api.move_axes(
-                {
-                    mount_to_axis: _INSTRUMENT_ATTACH_Z_POINT,
-                }
-            )
-            await ot3_api.disengage_axes([mount_to_axis])
-        else:
-            max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
-            await ot3_api.move_axes(
-                {
-                    OT3Axis.Z_L: max_motion_range + _LEFT_MOUNT_Z_MARGIN,
-                    OT3Axis.Z_R: max_motion_range + _RIGHT_MOUNT_Z_MARGIN,
-                }
-            )
+        if params.mount != MountType.EXTENSION:
+            if params.maintenancePosition == MaintenancePosition.ATTACH_INSTRUMENT:
+                mount_to_axis = OT3Axis.by_mount(params.mount.to_hw_mount())
+                await ot3_api.move_axes(
+                    {
+                        mount_to_axis: _INSTRUMENT_ATTACH_Z_POINT,
+                    }
+                )
+                await ot3_api.disengage_axes([mount_to_axis])
+            else:
+                max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
+                await ot3_api.move_axes(
+                    {
+                        OT3Axis.Z_L: max_motion_range + _LEFT_MOUNT_Z_MARGIN,
+                        OT3Axis.Z_R: max_motion_range + _RIGHT_MOUNT_Z_MARGIN,
+                    }
+                )
 
         return MoveToMaintenancePositionResult()
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -109,6 +109,7 @@ async def test_calibration_move_to_location_implementation(
         )
 
 
+@pytest.mark.ot3_only
 async def test_calibration_move_to_location_implementation_for_gripper(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -107,3 +107,64 @@ async def test_calibration_move_to_location_implementation(
             ),
             times=1,
         )
+
+
+async def test_calibration_move_to_location_implementation_for_gripper(
+    decoy: Decoy,
+    subject: MoveToMaintenancePositionImplementation,
+    state_view: StateView,
+    ot3_hardware_api: OT3API,
+) -> None:
+    """Command should get a move to target location and critical point and should verify move_to call."""
+    params = MoveToMaintenancePositionParams(
+        mount=MountType.LEFT, maintenancePosition=MaintenancePosition.ATTACH_INSTRUMENT
+    )
+
+    decoy.when(
+        await ot3_hardware_api.gantry_position(
+            Mount.LEFT, critical_point=CriticalPoint.MOUNT
+        )
+    ).then_return(Point(x=1, y=2, z=3))
+
+    decoy.when(
+        ot3_hardware_api.get_instrument_max_height(
+            Mount.LEFT, critical_point=CriticalPoint.MOUNT
+        )
+    ).then_return(250)
+
+    decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
+
+    result = await subject.execute(params=params)
+    assert result == MoveToMaintenancePositionResult()
+
+    decoy.verify(
+        await ot3_hardware_api.move_to(
+            mount=Mount.LEFT,
+            abs_position=Point(x=1, y=2, z=250),
+            critical_point=CriticalPoint.MOUNT,
+        ),
+        times=1,
+    )
+
+    decoy.verify(
+        await ot3_hardware_api.move_to(
+            mount=Mount.LEFT,
+            abs_position=Point(x=0, y=110, z=250),
+            critical_point=CriticalPoint.MOUNT,
+        ),
+        times=1,
+    )
+
+    decoy.verify(
+        await ot3_hardware_api.move_axes(
+            position={OT3Axis.Z_G: 400},
+        ),
+        times=0,
+    )
+
+    decoy.verify(
+        await ot3_hardware_api.disengage_axes(
+            [OT3Axis.Z_G],
+        ),
+        times=0,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -99,3 +99,11 @@ async def test_calibration_move_to_location_implementation(
         ),
         times=1,
     )
+
+    if params.maintenancePosition == MaintenancePosition.ATTACH_INSTRUMENT:
+        decoy.verify(
+            await ot3_hardware_api.disengage_axes(
+                list(verify_axes.keys()),
+            ),
+            times=1,
+        )

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -75,7 +75,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
                   // @ts-expect-error(BC, 2022-03-10): this will pass type checks when we update command types from V6 to V7 in shared-data
                   commandType: 'calibration/moveToMaintenancePosition' as const,
                   params: {
-                    mount: EXTENSION, // TODO: update to gripper mount when RLAB-231 is addressed
+                    mount: EXTENSION,
                   },
                 },
                 waitUntilComplete: true,

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { LEFT } from '@opentrons/shared-data'
+import { EXTENSION } from '@opentrons/shared-data'
 import { css } from 'styled-components'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -75,7 +75,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
                   // @ts-expect-error(BC, 2022-03-10): this will pass type checks when we update command types from V6 to V7 in shared-data
                   commandType: 'calibration/moveToMaintenancePosition' as const,
                   params: {
-                    mount: LEFT, // TODO: update to gripper mount when RLAB-231 is addressed
+                    mount: EXTENSION, // TODO: update to gripper mount when RLAB-231 is addressed
                   },
                 },
                 waitUntilComplete: true,

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -72,7 +72,7 @@ describe('MovePin', () => {
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
-        params: { mount: 'left' },
+        params: { mount: 'extension' },
       },
       waitUntilComplete: true,
     })
@@ -126,7 +126,7 @@ describe('MovePin', () => {
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
-        params: { mount: 'left' },
+        params: { mount: 'extension' },
       },
       waitUntilComplete: true,
     })

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -7,7 +7,7 @@ import {
   SPACING,
   RESPONSIVENESS,
 } from '@opentrons/components'
-import { NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
+import { NINETY_SIX_CHANNEL, LEFT, MotorAxis } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { CalibrationErrorModal } from './CalibrationErrorModal'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -55,11 +55,18 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const is8Channel = attachedPipettes[mount]?.data.channels === 8
   const is96Channel = attachedPipettes[mount]?.data.channels === 96
   const calSlotNum = 'C2'
+  const axes: MotorAxis = mount === LEFT ? ['leftZ'] : ['rightZ']
 
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
     chainRunCommands(
       [
+        {
+          commandType: 'home' as const,
+          params: {
+            axes: axes,
+          },
+        },
         {
           // @ts-expect-error calibration type not yet supported
           commandType: 'calibration/calibratePipette' as const,

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -133,11 +133,8 @@ export const Results = (props: ResultsProps): JSX.Element => {
       flowType === FLOWS.ATTACH &&
       currentStepIndex !== totalStepCount
     ) {
-      let axes: MotorAxis = mount === LEFT ? ['leftPlunger'] : ['rightPlunger']
-      // TODO: (sb)5/25/23 Stop homing leftZ for 96 once motor is disabled
-      if (attachedPipettes[mount]?.instrumentName === 'p1000_96') {
-        axes = ['leftPlunger', 'leftZ']
-      }
+      const axes: MotorAxis =
+        mount === LEFT ? ['leftPlunger', 'leftZ'] : ['rightPlunger', 'rightZ']
       chainRunCommands(
         [
           {

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -134,7 +134,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       currentStepIndex !== totalStepCount
     ) {
       const axes: MotorAxis =
-        mount === LEFT ? ['leftPlunger', 'leftZ'] : ['rightPlunger', 'rightZ']
+        mount === LEFT ? ['leftPlunger'] : ['rightPlunger']
       chainRunCommands(
         [
           {
@@ -150,13 +150,6 @@ export const Results = (props: ResultsProps): JSX.Element => {
             commandType: 'home' as const,
             params: {
               axes: axes,
-            },
-          },
-          {
-            // @ts-expect-error calibration type not yet supported
-            commandType: 'calibration/moveToMaintenancePosition' as const,
-            params: {
-              mount: mount,
             },
           },
         ],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -61,6 +61,10 @@ describe('AttachProbe', () => {
     expect(props.chainRunCommands).toHaveBeenCalledWith(
       [
         {
+          commandType: 'home',
+          params: { axes: ['leftZ'] },
+        },
+        {
           commandType: 'calibration/calibratePipette',
           params: { mount: 'left' },
         },
@@ -164,6 +168,10 @@ describe('AttachProbe', () => {
     getByRole('button', { name: 'Begin calibration' }).click()
     expect(props.chainRunCommands).toHaveBeenCalledWith(
       [
+        {
+          commandType: 'home',
+          params: { axes: ['leftZ'] },
+        },
         {
           commandType: 'calibration/calibratePipette',
           params: { mount: 'left' },

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -183,6 +183,10 @@ describe('PipetteWizardFlows', () => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
           {
+            commandType: 'home',
+            params: { axes: ['leftZ'] },
+          },
+          {
             commandType: 'calibration/calibratePipette',
             params: { mount: LEFT },
           },
@@ -575,6 +579,10 @@ describe('PipetteWizardFlows', () => {
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
         [
+          {
+            commandType: 'home',
+            params: { axes: ['leftZ'] },
+          },
           {
             commandType: 'calibration/calibratePipette',
             params: { mount: LEFT },

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -100,13 +100,7 @@ describe('Results', () => {
         {
           commandType: 'home' as const,
           params: {
-            axes: ['leftPlunger', 'leftZ'],
-          },
-        },
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: 'left',
+            axes: ['leftPlunger'],
           },
         },
       ],
@@ -138,13 +132,7 @@ describe('Results', () => {
         {
           commandType: 'home' as const,
           params: {
-            axes: ['leftPlunger', 'leftZ'],
-          },
-        },
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: 'left',
+            axes: ['leftPlunger'],
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -100,7 +100,7 @@ describe('Results', () => {
         {
           commandType: 'home' as const,
           params: {
-            axes: ['leftPlunger'],
+            axes: ['leftPlunger', 'leftZ'],
           },
         },
         {
@@ -138,7 +138,7 @@ describe('Results', () => {
         {
           commandType: 'home' as const,
           params: {
-            axes: ['leftPlunger'],
+            axes: ['leftPlunger', 'leftZ'],
           },
         },
         {


### PR DESCRIPTION
# Overview

 closes https://opentrons.atlassian.net/browse/RQA-916.
disable head motors when attaching an instrument. 
only move z and disable the motors for non gripper instruments. 

# Test Plan

- run attach/detach instrument flow and make sure the head does not drop when attaching an instrument. especially the 96c. 
- run attach/detach for the gripper. make sure the z does not move down. 

# Changelog

- when moving to maintenance position and issuing a ATTACH_INSTRUMENT command we are now disabling the head motor. 
- only move z and disable the motors for non gripper instruments. 

# Review requests

Changes make sense?

# Risk assessment

low. head should stop falling when attaching a 96 c.
