### PR TITLE
chore: `make push` in dependency order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,33 +131,33 @@ push-update-server:
 push: export host=$(usb_host)
 push:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
-	# TODO (amit, 2021-09-28): re-enable when opentrons-hardware is worth deploying.
-	# $(MAKE) -C $(HARDWARE_DIR) push-no-restart
-	# sleep 1
-	$(MAKE) -C $(API_DIR) push-no-restart
-	sleep 1
 	$(MAKE) -C $(SHARED_DATA_DIR) push-no-restart
 	sleep 1
-	$(MAKE) -C $(UPDATE_SERVER_DIR) push
-	sleep 1
-	$(MAKE) -C $(NOTIFY_SERVER_DIR) push
-	sleep 1
-	$(MAKE) -C $(ROBOT_SERVER_DIR) push
+# TODO (amit, 2021-09-28): re-enable when opentrons-hardware is worth deploying.
+# $(MAKE) -C $(HARDWARE_DIR) push-no-restart
+# sleep 1
+	$(MAKE) -C $(API_DIR) push-no-restart
 	sleep 1
 	$(MAKE) -C $(SERVER_UTILS_DIR) push
 	sleep 1
+	$(MAKE) -C $(NOTIFY_SERVER_DIR) push
+	sleep 1
 	$(MAKE) -C $(SYSTEM_SERVER_DIR) push
+	sleep 1
+	$(MAKE) -C $(ROBOT_SERVER_DIR) push
+	sleep 1
+	$(MAKE) -C $(UPDATE_SERVER_DIR) push
 
 
 .PHONY: push-ot3
 push-ot3:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
-	$(MAKE) -C $(API_DIR) push-no-restart-ot3
-	$(MAKE) -C $(HARDWARE_DIR) push-no-restart-ot3
 	$(MAKE) -C $(SHARED_DATA_DIR) push-no-restart-ot3
-	$(MAKE) -C $(NOTIFY_SERVER_DIR) push-no-restart-ot3
-	$(MAKE) -C $(ROBOT_SERVER_DIR) push-ot3
+	$(MAKE) -C $(HARDWARE_DIR) push-no-restart-ot3
+	$(MAKE) -C $(API_DIR) push-no-restart-ot3
 	$(MAKE) -C $(SERVER_UTILS_DIR) push-ot3
+	$(MAKE) -C $(NOTIFY_SERVER_DIR) push-ot3
+	$(MAKE) -C $(ROBOT_SERVER_DIR) push-ot3
 	$(MAKE) -C $(SYSTEM_SERVER_DIR) push-ot3
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push-ot3
 	$(MAKE) -C $(USB_BRIDGE_DIR) push-ot3

--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,6 @@ push:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
 	$(MAKE) -C $(SHARED_DATA_DIR) push-no-restart
 	sleep 1
-# TODO (amit, 2021-09-28): re-enable when opentrons-hardware is worth deploying.
-# $(MAKE) -C $(HARDWARE_DIR) push-no-restart
-# sleep 1
 	$(MAKE) -C $(API_DIR) push-no-restart
 	sleep 1
 	$(MAKE) -C $(SERVER_UTILS_DIR) push

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -140,7 +140,7 @@ push-no-restart-ot3: sdist
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),,$(ssh_opts),"opentrons-robot-server")
+	$(call restart-server,$(host),,$(ssh_opts),"opentrons-notify-server")
 
 
 .PHONY: install-key


### PR DESCRIPTION
# Overview

Some `make push` fixes and cleanups.

# Test Plan

- [x] Test this with an OT-2
- [x] Test this with an OT-3

# Changelog

* When doing a top-level `make push` or `make push-ot3`, push things in order from dependencies to dependents. Notably, we need to push `server-utils` before pushing `robot-server` and `system-server`.
* Fix an apparent bug where `make -C notify-server push` would restart `opentrons-robot-server` instead of `opentrons-notify-server`.
* Be consistent about restart vs. no-restart choices between the OT-2 and OT-3.

# Review requests



# Risk assessment

Low. Changes are just to dev tooling.