### PR TITLE
fix(api): always home right mount first (for FLEX)

### DIFF
--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -190,7 +190,7 @@ class OT3Axis(enum.Enum):
     @classmethod
     def mount_axes(cls) -> Tuple["OT3Axis", "OT3Axis", "OT3Axis"]:
         """The axes which are used for moving instruments up and down."""
-        return cls.Z_L, cls.Z_R, cls.Z_G
+        return cls.Z_R, cls.Z_L, cls.Z_G
 
     @classmethod
     def gantry_axes(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We want to make sure the right mount never gets in the way during a home move when (1) 96 channel pipette is attached, or (2) if the 96-chan mounting plate is on. We don't actually know whether or not the plate is mounted (no sensor), so we just have to always home the right side first. 