### PR TITLE
feat(hardware-testing): adds tip batch SN as optional data in volumetric tests

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -414,6 +414,13 @@ def _get_robot_serial(is_simulating: bool) -> str:
         return "simulation-serial-number"
 
 
+def _get_tip_batch(is_simulating: bool) -> str:
+    if not is_simulating:
+        return input("TIP BATCH:").strip()
+    else:
+        return "simulation-tip-batch"
+
+
 def _pick_up_tip(
     ctx: ProtocolContext,
     pipette: InstrumentContext,
@@ -526,11 +533,13 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
     test_report.set_tag(pipette_tag)
     test_report.set_operator(_get_operator_name(ctx.is_simulating()))
     serial_number = _get_robot_serial(ctx.is_simulating())
+    tip_batch = _get_tip_batch(ctx.is_simulating())
     test_report.set_version(get_git_description())
     report.store_serial_numbers(
         test_report,
         robot=serial_number,
         pipette=pipette_tag,
+        tips=tip_batch,
         scale=recorder.serial_number,
         environment="None",
         liquid="None",

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -292,6 +292,9 @@ def _run_trial(
         )
     reservoir_ml = round(liquid_tracker.get_volume(source) / 1000, 1)
     print(f"software thinks there is {reservoir_ml} mL of liquid in the reservoir")
+    assert (
+        reservoir_ml - _MIN_END_VOLUME_UL > volume * channel_count
+    ), f"not enough volume in reservoir to aspirate {volume} uL across {channel_count} channels"
     # RUN ASPIRATE
     aspirate_with_liquid_class(
         ctx,
@@ -356,6 +359,13 @@ def _get_robot_serial(is_simulating: bool) -> str:
         return input("ROBOT SERIAL NUMBER:").strip()
     else:
         return "simulation-serial-number"
+
+
+def _get_tip_batch(is_simulating: bool) -> str:
+    if not is_simulating:
+        return input("TIP BATCH:").strip()
+    else:
+        return "simulation-tip-batch"
 
 
 def _pick_up_tip(
@@ -460,11 +470,13 @@ def run(ctx: ProtocolContext, cfg: config.PhotometricConfig) -> None:
     test_report.set_tag(pipette_tag)
     test_report.set_operator(_get_operator_name(ctx.is_simulating()))
     serial_number = _get_robot_serial(ctx.is_simulating())
+    tip_batch = _get_tip_batch(ctx.is_simulating())
     test_report.set_version(get_git_description())
     report.store_serial_numbers_pm(
         test_report,
         robot=serial_number,
         pipette=pipette_tag,
+        tips=tip_batch,
         environment="None",
         liquid="None",
     )

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -104,6 +104,7 @@ def create_csv_test_report_photometric(
                 lines=[
                     CSVLine("robot", [str]),
                     CSVLine("pipette", [str]),
+                    CSVLine("tips", [str]),
                     CSVLine("environment", [str]),
                     CSVLine("liquid", [str]),
                 ],
@@ -186,6 +187,7 @@ def create_csv_test_report(
                 lines=[
                     CSVLine("robot", [str]),
                     CSVLine("pipette", [str]),
+                    CSVLine("tips", [str]),
                     CSVLine("scale", [str]),
                     CSVLine("environment", [str]),
                     CSVLine("liquid", [str]),
@@ -270,12 +272,14 @@ def store_serial_numbers_pm(
     report: CSVReport,
     robot: str,
     pipette: str,
+    tips: str,
     environment: str,
     liquid: str,
 ) -> None:
     """Report serial numbers."""
     report("SERIAL-NUMBERS", "robot", [robot])
     report("SERIAL-NUMBERS", "pipette", [pipette])
+    report("SERIAL-NUMBERS", "tips", [tips])
     report("SERIAL-NUMBERS", "environment", [environment])
     report("SERIAL-NUMBERS", "liquid", [liquid])
 
@@ -295,6 +299,7 @@ def store_serial_numbers(
     report: CSVReport,
     robot: str,
     pipette: str,
+    tips: str,
     scale: str,
     environment: str,
     liquid: str,
@@ -302,6 +307,7 @@ def store_serial_numbers(
     """Report serial numbers."""
     report("SERIAL-NUMBERS", "robot", [robot])
     report("SERIAL-NUMBERS", "pipette", [pipette])
+    report("SERIAL-NUMBERS", "tips", [tips])
     report("SERIAL-NUMBERS", "scale", [scale])
     report("SERIAL-NUMBERS", "environment", [environment])
     report("SERIAL-NUMBERS", "liquid", [liquid])


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds the option to store the tip-rack batch number in the CSV test report. This is to help with quality control.

Also adds a quick check during photometric tests to make sure the liquid in the reservoir is enough for that trial.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
