### PR TITLE
feat(step-generation, protocol-designer): add timeline error for off deck labware

### DIFF
--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -15,7 +15,8 @@ import type {
   StylesConfig,
   CSSObjectWithLabel,
 } from 'react-select'
-import { Box, SPACING } from '..'
+import { Box } from '../primitives'
+import { SPACING } from '../ui-style-constants'
 
 export { reactSelectComponents }
 
@@ -66,41 +67,38 @@ export type SelectProps = ReactSelectProps<SelectOption>
 const VOID_STYLE: unknown = undefined
 const NO_STYLE_FN = (): CSSObjectWithLabel => VOID_STYLE as CSSObjectWithLabel
 
-const CLEAR_STYLES: StylesConfig<SelectOption> = {
-  clearIndicator: NO_STYLE_FN,
-  container: NO_STYLE_FN,
-  control: (styles: CSSObjectWithLabel) => ({
-    ...styles,
-    width: '15rem',
-  }),
-  dropdownIndicator: NO_STYLE_FN,
-  group: NO_STYLE_FN,
-  groupHeading: NO_STYLE_FN,
-  indicatorsContainer: NO_STYLE_FN,
-  indicatorSeparator: NO_STYLE_FN,
-  input: (styles: CSSObjectWithLabel) => ({
-    ...styles,
-    zIndex: 2,
-    position: 'absolute',
-  }),
-  loadingIndicator: NO_STYLE_FN,
-  loadingMessage: NO_STYLE_FN,
-  menu: NO_STYLE_FN,
-  menuList: NO_STYLE_FN,
-  multiValue: NO_STYLE_FN,
-  multiValueLabel: NO_STYLE_FN,
-  multiValueRemove: NO_STYLE_FN,
-  option: NO_STYLE_FN,
-  // the following should not be cleared to ensure proper positioning
-  // included as comments so we can see what we're not touching
-  // noOptionsMessage: NO_STYLE_FN,
-  // menuPortal: _ => _,
-  // placeholder: _ => _,
-  // singleValue: _ => _,
-  // valueContainer: _ => _,
-}
-
 export function Select(props: SelectProps): JSX.Element {
+  const CLEAR_STYLES: StylesConfig<SelectOption> = {
+    clearIndicator: NO_STYLE_FN,
+    container: NO_STYLE_FN,
+    control: NO_STYLE_FN,
+    dropdownIndicator: NO_STYLE_FN,
+    group: NO_STYLE_FN,
+    groupHeading: NO_STYLE_FN,
+    indicatorsContainer: NO_STYLE_FN,
+    indicatorSeparator: NO_STYLE_FN,
+    input: (styles: CSSObjectWithLabel) => ({
+      ...styles,
+      zIndex: 2,
+      position: 'absolute',
+    }),
+    loadingIndicator: NO_STYLE_FN,
+    loadingMessage: NO_STYLE_FN,
+    menu: NO_STYLE_FN,
+    menuList: NO_STYLE_FN,
+    multiValue: NO_STYLE_FN,
+    multiValueLabel: NO_STYLE_FN,
+    multiValueRemove: NO_STYLE_FN,
+    option: NO_STYLE_FN,
+    // the following should not be cleared to ensure proper positioning
+    // included as comments so we can see what we're not touching
+    // noOptionsMessage: NO_STYLE_FN,
+    // menuPortal: _ => _,
+    // placeholder: _ => _,
+    // singleValue: _ => _,
+    // valueContainer: _ => _,
+  }
+
   return (
     <ReactSelect
       {...props}
@@ -119,7 +117,7 @@ function DropdownIndicator(
     <reactSelectComponents.DropdownIndicator {...props}>
       <Box
         position={POSITION_ABSOLUTE}
-        top="0.55rem"
+        top="0.25rem"
         right={SPACING.spacing8}
         width={SPACING.spacing20}
       >

--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -67,38 +67,38 @@ export type SelectProps = ReactSelectProps<SelectOption>
 const VOID_STYLE: unknown = undefined
 const NO_STYLE_FN = (): CSSObjectWithLabel => VOID_STYLE as CSSObjectWithLabel
 
-export function Select(props: SelectProps): JSX.Element {
-  const CLEAR_STYLES: StylesConfig<SelectOption> = {
-    clearIndicator: NO_STYLE_FN,
-    container: NO_STYLE_FN,
-    control: NO_STYLE_FN,
-    dropdownIndicator: NO_STYLE_FN,
-    group: NO_STYLE_FN,
-    groupHeading: NO_STYLE_FN,
-    indicatorsContainer: NO_STYLE_FN,
-    indicatorSeparator: NO_STYLE_FN,
-    input: (styles: CSSObjectWithLabel) => ({
-      ...styles,
-      zIndex: 2,
-      position: 'absolute',
-    }),
-    loadingIndicator: NO_STYLE_FN,
-    loadingMessage: NO_STYLE_FN,
-    menu: NO_STYLE_FN,
-    menuList: NO_STYLE_FN,
-    multiValue: NO_STYLE_FN,
-    multiValueLabel: NO_STYLE_FN,
-    multiValueRemove: NO_STYLE_FN,
-    option: NO_STYLE_FN,
-    // the following should not be cleared to ensure proper positioning
-    // included as comments so we can see what we're not touching
-    // noOptionsMessage: NO_STYLE_FN,
-    // menuPortal: _ => _,
-    // placeholder: _ => _,
-    // singleValue: _ => _,
-    // valueContainer: _ => _,
-  }
+const CLEAR_STYLES: StylesConfig<SelectOption> = {
+  clearIndicator: NO_STYLE_FN,
+  container: NO_STYLE_FN,
+  control: NO_STYLE_FN,
+  dropdownIndicator: NO_STYLE_FN,
+  group: NO_STYLE_FN,
+  groupHeading: NO_STYLE_FN,
+  indicatorsContainer: NO_STYLE_FN,
+  indicatorSeparator: NO_STYLE_FN,
+  input: (styles: CSSObjectWithLabel) => ({
+    ...styles,
+    zIndex: 2,
+    position: 'absolute',
+  }),
+  loadingIndicator: NO_STYLE_FN,
+  loadingMessage: NO_STYLE_FN,
+  menu: NO_STYLE_FN,
+  menuList: NO_STYLE_FN,
+  multiValue: NO_STYLE_FN,
+  multiValueLabel: NO_STYLE_FN,
+  multiValueRemove: NO_STYLE_FN,
+  option: NO_STYLE_FN,
+  // the following should not be cleared to ensure proper positioning
+  // included as comments so we can see what we're not touching
+  // noOptionsMessage: NO_STYLE_FN,
+  // menuPortal: _ => _,
+  // placeholder: _ => _,
+  // singleValue: _ => _,
+  // valueContainer: _ => _,
+}
 
+export function Select(props: SelectProps): JSX.Element {
   return (
     <ReactSelect
       {...props}

--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -6,6 +6,8 @@ import ReactSelect, {
 import cx from 'classnames'
 
 import { Icon } from '../icons'
+import { Box } from '../primitives'
+import { SPACING } from '../ui-style-constants'
 import { POSITION_ABSOLUTE, POSITION_FIXED } from '../styles'
 import styles from './Select.css'
 
@@ -15,8 +17,6 @@ import type {
   StylesConfig,
   CSSObjectWithLabel,
 } from 'react-select'
-import { Box } from '../primitives'
-import { SPACING } from '../ui-style-constants'
 
 export { reactSelectComponents }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -133,3 +133,7 @@
 .module_model {
   height: 3rem;
 }
+
+.pipette_select {
+  width: 100%;
+}

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -7,6 +7,7 @@ import {
   PipetteSelect,
   OutlineButton,
   Mount,
+  Flex,
 } from '@opentrons/components'
 import {
   getIncompatiblePipetteNames,
@@ -99,24 +100,27 @@ export function PipetteFields(props: Props): JSX.Element {
     const nameBlockList = [...OT2_PIPETTES, 'p1000_96']
 
     return (
-      <PipetteSelect
-        nameBlocklist={
-          robotType === OT2_ROBOT_TYPE ? OT3_PIPETTES : nameBlockList
-        }
-        enableNoneOption
-        tabIndex={tabIndex}
-        pipetteName={pipetteName != null ? pipetteName : null}
-        onPipetteChange={pipetteName => {
-          const nameAccessor = `pipettesByMount.${mount}.pipetteName`
-          const value = pipetteName
-          const targetToClear = `pipettesByMount.${mount}.tiprackDefURI`
-          // this select does not return an event so we have to manually set the field val
-          onSetFieldValue(nameAccessor, value)
-          onSetFieldValue(targetToClear, null)
-          onSetFieldTouched(targetToClear, false)
-        }}
-        id={`PipetteSelect_${mount}`}
-      />
+      <Flex width="15rem">
+        <PipetteSelect
+          nameBlocklist={
+            robotType === OT2_ROBOT_TYPE ? OT3_PIPETTES : nameBlockList
+          }
+          enableNoneOption
+          tabIndex={tabIndex}
+          pipetteName={pipetteName != null ? pipetteName : null}
+          onPipetteChange={pipetteName => {
+            const nameAccessor = `pipettesByMount.${mount}.pipetteName`
+            const value = pipetteName
+            const targetToClear = `pipettesByMount.${mount}.tiprackDefURI`
+            // this select does not return an event so we have to manually set the field val
+            onSetFieldValue(nameAccessor, value)
+            onSetFieldValue(targetToClear, null)
+            onSetFieldTouched(targetToClear, false)
+          }}
+          id={`PipetteSelect_${mount}`}
+          className={styles.pipette_select}
+        />
+      </Flex>
     )
   }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -95,15 +95,14 @@ export function PipetteFields(props: Props): JSX.Element {
   const renderPipetteSelect = (props: PipetteSelectProps): JSX.Element => {
     const { tabIndex, mount } = props
     const pipetteName = values[mount].pipetteName
-
-    //  adding 96-channel to the nameBlockstlist for the Flex for now
-    const nameBlockList = [...OT2_PIPETTES, 'p1000_96']
-
     return (
       <Flex width="15rem">
         <PipetteSelect
           nameBlocklist={
-            robotType === OT2_ROBOT_TYPE ? OT3_PIPETTES : nameBlockList
+            //  filtering out 96-channel for Flex for now
+            robotType === OT2_ROBOT_TYPE
+              ? OT3_PIPETTES
+              : [...OT2_PIPETTES, 'p1000_96']
           }
           enableNoneOption
           tabIndex={tabIndex}

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -141,8 +141,8 @@
         "body": "8-Channel pipettes cannot access labware in front of or behind a Heater-Shaker. They can access Opentrons Tip Racks in this slot. Move labware to a different slot."
       },
       "LABWARE_OFF_DECK": {
-        "title": "Labware off deck",
-        "body": "The labware must be on the deck in order for the robot to interact with it. To resolve this error, move the labware back onto the deck."
+        "title": "Robot interacting with an off deck labware",
+        "body": "Labware must be on the deck for the robot to interact with it. To resolve this error, please make sure the labware is on deck."
       }
     },
     "warning": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -139,6 +139,10 @@
       "HEATER_SHAKER_NORTH_SOUTH__OF_NON_TIPRACK_WITH_MULTI_CHANNEL": {
         "title": "8-Channel pipette cannot access labware",
         "body": "8-Channel pipettes cannot access labware in front of or behind a Heater-Shaker. They can access Opentrons Tip Racks in this slot. Move labware to a different slot."
+      },
+      "LABWARE_OFF_DECK": {
+        "title": "Labware off deck",
+        "body": "The labware must be on the deck in order for the robot to interact with it. To resolve this error, move the labware back onto the deck."
       }
     },
     "warning": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -143,6 +143,10 @@
       "LABWARE_OFF_DECK": {
         "title": "Robot interacting with an off deck labware",
         "body": "Labware must be on the deck for the robot to interact with it. To resolve this error, please make sure the labware is on deck."
+      },
+      "HEATER_SHAKER_LATCH_CLOSED": {
+        "title": "Heater-Shaker labware latch is closed",
+        "body": "Before the robot can interact with labware on the Heater-Shaker module, the labware latch must be open. To resolve this error, please add a Heater-Shaker step ahead of the current step, and set the labware latch status to \"open\"."
       }
     },
     "warning": {

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -60,9 +60,7 @@ export const aspirate: CommandCreator<AspirateParams> = (
         labware,
       })
     )
-  }
-
-  if (prevRobotState.labware[labware].slot === 'offDeck') {
+  } else if (prevRobotState.labware[labware].slot === 'offDeck') {
     errors.push(errorCreators.labwareOffDeck())
   }
 

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -62,6 +62,10 @@ export const aspirate: CommandCreator<AspirateParams> = (
     )
   }
 
+  if (prevRobotState.labware[labware].slot === 'offDeck') {
+    errors.push(errorCreators.labwareOffDeck())
+  }
+
   if (
     modulePipetteCollision({
       pipette,

--- a/step-generation/src/commandCreators/atomic/blowout.ts
+++ b/step-generation/src/commandCreators/atomic/blowout.ts
@@ -45,9 +45,7 @@ export const blowout: CommandCreator<BlowoutParams> = (
         labware,
       })
     )
-  }
-
-  if (prevRobotState.labware[labware].slot === 'offDeck') {
+  } else if (prevRobotState.labware[labware].slot === 'offDeck') {
     errors.push(errorCreators.labwareOffDeck())
   }
 

--- a/step-generation/src/commandCreators/atomic/blowout.ts
+++ b/step-generation/src/commandCreators/atomic/blowout.ts
@@ -47,6 +47,10 @@ export const blowout: CommandCreator<BlowoutParams> = (
     )
   }
 
+  if (prevRobotState.labware[labware].slot === 'offDeck') {
+    errors.push(errorCreators.labwareOffDeck())
+  }
+
   if (errors.length > 0) {
     return {
       errors,

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -82,6 +82,10 @@ export const dispense: CommandCreator<DispenseParams> = (
     )
   }
 
+  if (prevRobotState.labware[labware].slot === 'offDeck') {
+    errors.push(errorCreators.labwareOffDeck())
+  }
+
   if (
     thermocyclerPipetteCollision(
       prevRobotState.modules,

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -80,9 +80,7 @@ export const dispense: CommandCreator<DispenseParams> = (
         labware,
       })
     )
-  }
-
-  if (prevRobotState.labware[labware].slot === 'offDeck') {
+  } else if (prevRobotState.labware[labware].slot === 'offDeck') {
     errors.push(errorCreators.labwareOffDeck())
   }
 

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -55,6 +55,9 @@ export const moveLabware: CommandCreator<MoveLabwareArgs> = (
       ? newLocation.moduleId
       : null
 
+  if (newLocation === 'offDeck' && useGripper) {
+    errors.push(errorCreators.labwareOffDeck())
+  }
   if (destModuleId != null) {
     const destModuleState = prevRobotState.modules[destModuleId].moduleState
     if (

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -28,6 +28,8 @@ export const moveLabware: CommandCreator<MoveLabwareArgs> = (
         labware,
       })
     )
+  } else if (prevRobotState.labware[labware].slot === 'offDeck' && useGripper) {
+    errors.push(errorCreators.labwareOffDeck())
   }
 
   const initialLabwareSlot = prevRobotState.labware[labware]?.slot

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -54,9 +54,7 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
         labware,
       })
     )
-  }
-
-  if (prevRobotState.labware[labware].slot === 'offDeck') {
+  } else if (prevRobotState.labware[labware].slot === 'offDeck') {
     errors.push(errorCreators.labwareOffDeck())
   }
 

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -56,6 +56,10 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     )
   }
 
+  if (prevRobotState.labware[labware].slot === 'offDeck') {
+    errors.push(errorCreators.labwareOffDeck())
+  }
+
   if (
     modulePipetteCollision({
       pipette,

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -181,3 +181,10 @@ export const heaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette = (): Com
     message: '8-Channel pipette cannot access labware',
   }
 }
+
+export const labwareOffDeck = (): CommandCreatorError => {
+  return {
+    type: 'LABWARE_OFF_DECK',
+    message: 'Attempted to interact with labware off deck',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -501,6 +501,7 @@ export type ErrorType =
   | 'HEATER_SHAKER_EAST_WEST_MULTI_CHANNEL'
   | 'HEATER_SHAKER_NORTH_SOUTH__OF_NON_TIPRACK_WITH_MULTI_CHANNEL'
   | 'HEATER_SHAKER_LATCH_CLOSED'
+  | 'LABWARE_OFF_DECK'
 
 export interface CommandCreatorError {
   message: string


### PR DESCRIPTION
closes RAUT-525

# Overview

If you try to interact with a labware that you moved off deck previously in the protocol, you will get a timeline error

Also fix up some weirdness in the `Select` component causing some dropdowns to have too wide a height and width.

# Test Plan

- move the labware off deck and then add an aspirate, dispense, blow out, moveToWell with the labware that is off deck as a source. When you create the command, you should see an error
- try to move the labware back onto the deck after it is currently off deck with the gripper, you should see the same error

# Changelog

- add i18n strings back for `HEATER_SHAKER_LATCH_CLOSED` - i think i had a merge conflict and accidentally deleted the previous i18n strings 😢 
- create errorCreator `labwareOffDeck` and add to the appropriate atomic commands
- add the error to i18n
- change the width = 100% to be in a parent component rather than tweaking the Select component that more components use.

# Review requests

see test plan

# Risk assessment

low