### PR TITLE
fix(hardware): use ensure send when clearing move group

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -530,6 +530,7 @@ class MoveScheduler:
                 log.warning(
                     f"Expected nodes in group {str(group_id)}: {str(self._get_nodes_in_move_group(group_id))}"
                 )
+                raise
             except (RuntimeError, MoveConditionNotMet) as e:
                 log.error("canceling move group scheduler")
                 raise e

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -206,10 +206,12 @@ class MoveGroupRunner:
         Args:
             can_messenger: a can messenger
         """
-        await can_messenger.send(
+        error = await can_messenger.ensure_send(
             node_id=NodeId.broadcast,
             message=ClearAllMoveGroupsRequest(payload=EmptyPayload()),
         )
+        if error != ErrorCode.ok:
+            log.warning("Clear move group failed")
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:
         """Send commands to set up the message groups."""

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -620,7 +620,7 @@ class MockSendMoveCompleter:
     ) -> ErrorCode:
         """Mock ensure_send function."""
         await self.mock_send_failure(node_id, message)
-        return ErrorCode.ok
+        return ErrorCode.timeout
 
     async def mock_ensure_send(
         self,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -259,7 +259,7 @@ async def test_single_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_single)
     await subject._clear_groups(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_has_calls(
+    mock_can_messenger.ensure_send.assert_has_calls(
         [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 
@@ -270,7 +270,7 @@ async def test_multi_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
     await subject.prep(can_messenger=mock_can_messenger)
-    mock_can_messenger.send.assert_has_calls(
+    mock_can_messenger.ensure_send.assert_has_calls(
         [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
     )
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We should use ensure_send whenever we can to make sure we're receiving ack messages before sending new moves to the nodes.
