### PR TITLE
fix(app): ODD white screen when instrument detaches

### DIFF
--- a/app/src/organisms/InstrumentInfo/index.tsx
+++ b/app/src/organisms/InstrumentInfo/index.tsx
@@ -54,8 +54,10 @@ export const InstrumentInfo = (props: InstrumentInfoProps): JSX.Element => {
     },
   }
   const is96Channel =
+    instrument != null &&
+    instrument.mount !== 'extension' &&
     // @ts-expect-error the mount acts as a type narrower here
-    instrument.mount !== 'extension' && instrument.data?.channels === 96
+    instrument.data?.channels === 96
 
   const handleDetach: React.MouseEventHandler = () => {
     setODDMaintenanceFlowInProgress()

--- a/app/src/organisms/InstrumentInfo/index.tsx
+++ b/app/src/organisms/InstrumentInfo/index.tsx
@@ -55,6 +55,7 @@ export const InstrumentInfo = (props: InstrumentInfoProps): JSX.Element => {
   }
   const is96Channel =
     instrument != null &&
+    instrument.ok &&
     instrument.mount !== 'extension' &&
     // @ts-expect-error the mount acts as a type narrower here
     instrument.data?.channels === 96


### PR DESCRIPTION
fix RQA-992, RQA-1001
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Adding null protection to the InstrumentInfo card where it was missing -- this was triggering the ODD error boundary when an instrument is detached during the detach flow
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->