### PR TITLE
fix(hardware-testing): Actually use increment protocols so correct labware is loaded

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -104,7 +104,9 @@ def run_gravimetric(
 ) -> None:
     """Run."""
     if increment:
-        protocol_cfg = GRAVIMETRIC_CFG_INCREMENT[pipette_volume][pipette_channels][tip_volume]
+        protocol_cfg = GRAVIMETRIC_CFG_INCREMENT[pipette_volume][pipette_channels][
+            tip_volume
+        ]
     else:
         protocol_cfg = GRAVIMETRIC_CFG[pipette_volume][pipette_channels][tip_volume]
     execute.run(

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -17,6 +17,10 @@ from hardware_testing.protocols import (
     gravimetric_ot3_p1000_96_1000ul_tip,
     photometric_ot3_p1000_96_50ul_tip,
     photometric_ot3_p1000_96_200ul_tip,
+    gravimetric_ot3_p50_multi_50ul_tip_increment,
+    gravimetric_ot3_p1000_multi_50ul_tip_increment,
+    gravimetric_ot3_p1000_multi_200ul_tip_increment,
+    gravimetric_ot3_p1000_multi_1000ul_tip_increment,
 )
 
 from . import execute, helpers, workarounds, execute_photometric
@@ -53,6 +57,30 @@ GRAVIMETRIC_CFG = {
     },
 }
 
+GRAVIMETRIC_CFG_INCREMENT = {
+    50: {
+        1: {50: gravimetric_ot3_p50_single},
+        8: {50: gravimetric_ot3_p50_multi_50ul_tip_increment},
+    },
+    1000: {
+        1: {
+            50: gravimetric_ot3_p1000_single,
+            200: gravimetric_ot3_p1000_single,
+            1000: gravimetric_ot3_p1000_single,
+        },
+        8: {
+            50: gravimetric_ot3_p1000_multi_50ul_tip_increment,
+            200: gravimetric_ot3_p1000_multi_200ul_tip_increment,
+            1000: gravimetric_ot3_p1000_multi_1000ul_tip_increment,
+        },
+        96: {
+            50: gravimetric_ot3_p1000_96_50ul_tip,
+            200: gravimetric_ot3_p1000_96_200ul_tip,
+            1000: gravimetric_ot3_p1000_96_1000ul_tip,
+        },
+    },
+}
+
 PHOTOMETRIC_CFG = {
     50: photometric_ot3_p1000_96_50ul_tip,
     200: photometric_ot3_p1000_96_200ul_tip,
@@ -75,7 +103,10 @@ def run_gravimetric(
     scale_delay: int,
 ) -> None:
     """Run."""
-    protocol_cfg = GRAVIMETRIC_CFG[pipette_volume][pipette_channels][tip_volume]
+    if increment:
+        protocol_cfg = GRAVIMETRIC_CFG_INCREMENT[pipette_volume][pipette_channels][tip_volume]
+    else:
+        protocol_cfg = GRAVIMETRIC_CFG[pipette_volume][pipette_channels][tip_volume]
     execute.run(
         protocol,
         GravimetricConfig(
@@ -173,7 +204,10 @@ if __name__ == "__main__":
             print(f"\t\t{offset['definitionUri']}")
             print(f"\t\t{offset['vector']}")
             LABWARE_OFFSETS.append(offset)
-    _protocol = GRAVIMETRIC_CFG[args.pipette][args.channels][args.tip]
+    if args.increment:
+        _protocol = GRAVIMETRIC_CFG_INCREMENT[args.pipette][args.channels][args.tip]
+    else:
+        _protocol = GRAVIMETRIC_CFG[args.pipette][args.channels][args.tip]
     _ctx = helpers.get_api_context(
         API_LEVEL,  # type: ignore[attr-defined]
         is_simulating=args.simulate,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We were accidentally not loading in the "increment" labware types/locations when executing, so the vial was being assumed instead of the trough and liquid-levels were wrong.

Protocols file are currently used to define labware types and locations per each test scenario. These are then used to run LPC before a test is executed.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
