### PR TITLE
 feat(api, app): add engine command for retracting axes and retract axes during LPC

### DIFF
--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -211,3 +211,7 @@ class MotionController(Protocol[AxisType]):
         Works regardless of critical point or home status.
         """
         ...
+
+    async def retract_axis(self, axis: Axis) -> None:
+        """Retract the specified axis to its home position."""
+        ...

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -256,6 +256,14 @@ from .set_status_bar import (
     SetStatusBarCommandType,
 )
 
+from .retract_axis import (
+    RetractAxis,
+    RetractAxisParams,
+    RetractAxisCreate,
+    RetractAxisResult,
+    RetractAxisCommandType,
+)
+
 __all__ = [
     # command type unions
     "Command",
@@ -327,6 +335,12 @@ __all__ = [
     "HomeCreate",
     "HomeResult",
     "HomeCommandType",
+    # retract axis command models
+    "RetractAxis",
+    "RetractAxisCreate",
+    "RetractAxisParams",
+    "RetractAxisResult",
+    "RetractAxisCommandType",
     # load labware command models
     "LoadLabware",
     "LoadLabwareCreate",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -225,6 +225,14 @@ from .set_status_bar import (
     SetStatusBarCommandType,
 )
 
+from .retract_axis import (
+    RetractAxis,
+    RetractAxisParams,
+    RetractAxisCreate,
+    RetractAxisResult,
+    RetractAxisCommandType,
+)
+
 Command = Union[
     Aspirate,
     AspirateInPlace,
@@ -237,6 +245,7 @@ Command = Union[
     DropTip,
     DropTipInPlace,
     Home,
+    RetractAxis,
     LoadLabware,
     LoadAdapter,
     LoadLiquid,
@@ -292,6 +301,7 @@ CommandParams = Union[
     DropTipParams,
     DropTipInPlaceParams,
     HomeParams,
+    RetractAxisParams,
     LoadLabwareParams,
     LoadAdapterParams,
     LoadLiquidParams,
@@ -348,6 +358,7 @@ CommandType = Union[
     DropTipCommandType,
     DropTipInPlaceCommandType,
     HomeCommandType,
+    RetractAxisCommandType,
     LoadLabwareCommandType,
     LoadAdapterCommandType,
     LoadLiquidCommandType,
@@ -403,6 +414,7 @@ CommandCreate = Union[
     DropTipCreate,
     DropTipInPlaceCreate,
     HomeCreate,
+    RetractAxisCreate,
     LoadLabwareCreate,
     LoadAdapterCreate,
     LoadLiquidCreate,
@@ -458,6 +470,7 @@ CommandResult = Union[
     DropTipResult,
     DropTipInPlaceResult,
     HomeResult,
+    RetractAxisResult,
     LoadLabwareResult,
     LoadAdapterResult,
     LoadLiquidResult,

--- a/api/src/opentrons/protocol_engine/commands/retract_axes.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axes.py
@@ -1,0 +1,65 @@
+"""Retract Axis command payload, result, and implementation models."""
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING, Optional, List, Type
+from typing_extensions import Literal
+
+from ..types import MotorAxis
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import MovementHandler
+
+RetractAxisCommandType = Literal["retractAxis"]
+
+
+class RetractAxisParams(BaseModel):
+    """Payload required for a Retract Axis command."""
+
+    axes: Optional[List[MotorAxis]] = Field(
+        None,
+        description=(
+            "Axes to retract to their home positions."
+            " If ommitted, will retract all motors."
+            " The difference between retracting an axis and homing an axis using the"
+            " home command is that a home will move the axis (slowly) until it finds"
+            " the home limit switch, while retraction attempts to move the axis"
+            " either to the previously recorded home position in case of the Flex,"
+            " or a safe distance away from the previously recorded home position"
+            " in the case of the OT-2."
+        )
+    )
+
+
+class RetractAxisResult(BaseModel):
+    """Result data from the execution of a Rectract Axis command."""
+
+
+class RetractAxisImplementation(AbstractCommandImpl[RetractAxisParams, RetractAxisResult]):
+    """Retract Axis command implementation."""
+
+    def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
+        self._movement = movement
+
+    async def execute(self, params: RetractAxisParams) -> RetractAxisResult:
+        """Retract some or all axes."""
+        await self._movement.retract_axis(axes=params.axes)
+        return RetractAxisResult()
+
+class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult]):
+    """Command to retract some or all axes near their home positions."""
+
+    commandType = RetractAxisCommandType = "retractAxis"
+    params = RetractAxisParams
+    result = Optional[RetractAxisResult]
+
+    _ImplementationCls: Type[RetractAxisImplementation] = RetractAxisImplementation
+
+
+class RetractAxisCreate(BaseCommandCreate[RetractAxisParams]):
+    """Data to create a Retract Axis command."""
+
+    commandType = RetractAxisCommandType = "retractAxis"
+    params = RetractAxisParams
+
+    _CommandCls: Type[RetractAxis] = RetractAxis

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -1,7 +1,7 @@
 """Retract Axis command payload, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, List, Type
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from ..types import MotorAxis
@@ -16,18 +16,17 @@ RetractAxisCommandType = Literal["retractAxis"]
 class RetractAxisParams(BaseModel):
     """Payload required for a Retract Axis command."""
 
-    axes: Optional[List[MotorAxis]] = Field(
-        None,
+    axis: MotorAxis = Field(
+        ...,
         description=(
-            "Axes to retract to their home positions."
-            " If ommitted, will retract all motors."
+            "Axis to retract as close to its home positions as safely possible."
             " The difference between retracting an axis and homing an axis using the"
             " home command is that a home will move the axis (slowly) until it finds"
             " the home limit switch, while retraction attempts to move the axis"
             " either to the previously recorded home position in case of the Flex,"
             " or a safe distance away from the previously recorded home position"
             " in the case of the OT-2."
-        )
+        ),
     )
 
 
@@ -35,19 +34,22 @@ class RetractAxisResult(BaseModel):
     """Result data from the execution of a Rectract Axis command."""
 
 
-class RetractAxisImplementation(AbstractCommandImpl[RetractAxisParams, RetractAxisResult]):
+class RetractAxisImplementation(
+    AbstractCommandImpl[RetractAxisParams, RetractAxisResult]
+):
     """Retract Axis command implementation."""
 
     def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
         self._movement = movement
 
     async def execute(self, params: RetractAxisParams) -> RetractAxisResult:
-        """Retract some or all axes."""
-        await self._movement.retract_axis(axes=params.axes)
+        """Retract the specified axis."""
+        await self._movement.retract_axis(axis=params.axis)
         return RetractAxisResult()
 
+
 class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult]):
-    """Command to retract some or all axes near their home positions."""
+    """Command to retract the specified axis near its home position."""
 
     commandType = RetractAxisCommandType = "retractAxis"
     params = RetractAxisParams

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -51,9 +51,9 @@ class RetractAxisImplementation(
 class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult]):
     """Command to retract the specified axis near its home position."""
 
-    commandType = RetractAxisCommandType = "retractAxis"
-    params = RetractAxisParams
-    result = Optional[RetractAxisResult]
+    commandType: RetractAxisCommandType = "retractAxis"
+    params: RetractAxisParams
+    result: Optional[RetractAxisResult]
 
     _ImplementationCls: Type[RetractAxisImplementation] = RetractAxisImplementation
 
@@ -61,7 +61,7 @@ class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult]):
 class RetractAxisCreate(BaseCommandCreate[RetractAxisParams]):
     """Data to create a Retract Axis command."""
 
-    commandType = RetractAxisCommandType = "retractAxis"
-    params = RetractAxisParams
+    commandType: RetractAxisCommandType = "retractAxis"
+    params: RetractAxisParams
 
     _CommandCls: Type[RetractAxis] = RetractAxis

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -19,7 +19,7 @@ class RetractAxisParams(BaseModel):
     axis: MotorAxis = Field(
         ...,
         description=(
-            "Axis to retract to its home position as safely as possible."
+            "Axis to retract to its home position as quickly as safely possible."
             " The difference between retracting an axis and homing an axis using the"
             " home command is that a home will always probe the limit switch and"
             " will work as the first motion command a robot will need to execute;"

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -19,13 +19,15 @@ class RetractAxisParams(BaseModel):
     axis: MotorAxis = Field(
         ...,
         description=(
-            "Axis to retract as close to its home positions as safely possible."
+            "Axis to retract to its home position as safely as possible."
             " The difference between retracting an axis and homing an axis using the"
-            " home command is that a home will move the axis (slowly) until it finds"
-            " the home limit switch, while retraction attempts to move the axis"
-            " either to the previously recorded home position in case of the Flex,"
-            " or a safe distance away from the previously recorded home position"
-            " in the case of the OT-2."
+            " home command is that a home will always probe the limit switch and"
+            " will work as the first motion command a robot will need to execute;"
+            " On the other hand, retraction will rely on this previously determined "
+            " home position to move to it as fast as safely possible."
+            " So on the Flex, it will move (fast) the axis to the previously recorded home position"
+            " and on the OT2, it will move (fast) the axis a safe distance from the previously"
+            " recorded home position, and then slowly approach the limit switch."
         ),
     )
 
@@ -49,7 +51,7 @@ class RetractAxisImplementation(
 
 
 class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult]):
-    """Command to retract the specified axis near its home position."""
+    """Command to retract the specified axis to its home position."""
 
     commandType: RetractAxisCommandType = "retractAxis"
     params: RetractAxisParams

--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -73,6 +73,9 @@ class GantryMover(TypingProtocol):
         """Home the gantry."""
         ...
 
+    async def retract_axis(self, axis: MotorAxis) -> None:
+        """Retract the specified axis to its home position."""
+
 
 class HardwareGantryMover(GantryMover):
     """Hardware API based gantry movement handler."""
@@ -196,6 +199,18 @@ class HardwareGantryMover(GantryMover):
             # Hardware API will raise error if invalid axes are passed for the type of robot
             await self._hardware_api.home(axes=hardware_axes)
 
+    async def retract_axis(self, axis: MotorAxis) -> None:
+        """Retract specified axis."""
+        hardware_axis = _MOTOR_AXIS_TO_HARDWARE_AXIS[axis]
+        if (
+            self._state_view.config.robot_type == "OT-2 Standard"
+            and hardware_axis not in HardwareAxis.ot2_axes()
+        ):
+            raise InvalidAxisForRobotType(
+                f"{axis} is not valid for OT-2 Standard robot type"
+            )
+        await self._hardware_api.retract_axis(axis=hardware_axis)
+
 
 class VirtualGantryMover(GantryMover):
     """State store based gantry movement handler for simulation/analysis."""
@@ -265,6 +280,10 @@ class VirtualGantryMover(GantryMover):
 
     async def home(self, axes: Optional[List[MotorAxis]]) -> None:
         """Home the gantry. No-op in virtual implementation."""
+        pass
+
+    async def retract_axis(self, axis: MotorAxis) -> None:
+        """Retract the specified axis. No-op in virtual implementation."""
         pass
 
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -152,13 +152,6 @@ class MovementHandler:
 
         return point
 
-    async def home(self, axes: Optional[List[MotorAxis]]) -> None:
-        """Send the requested axes to their "home" positions.
-
-        If axes is `None`, will home all motors.
-        """
-        await self._gantry_mover.home(axes)
-
     async def move_to_coordinates(
         self,
         pipette_id: str,
@@ -194,3 +187,17 @@ class MovementHandler:
         )
 
         return final_point
+
+    async def home(self, axes: Optional[List[MotorAxis]]) -> None:
+        """Send the requested axes to their "home" positions.
+
+        If axes is `None`, will home all motors.
+        """
+        await self._gantry_mover.home(axes)
+
+    async def retract_axis(self, axis: MotorAxis) -> None:
+        """Retract the requested axis as close to its home positions as safely possible.
+
+        For the OT2, the axis will retract to a safe distance from its limit switch.
+        For the OT3, the axis will retract to its known home position.
+        """

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -198,6 +198,7 @@ class MovementHandler:
     async def retract_axis(self, axis: MotorAxis) -> None:
         """Retract the requested axis as close to its home positions as safely possible.
 
-        For the OT2, the axis will retract to a safe distance from its limit switch.
+        For the OT2, the axis will retract to a safe distance from its limit switch,
+        and then probe the limit switch to reach the home position.
         For the OT3, the axis will retract to its known home position.
         """

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -202,3 +202,4 @@ class MovementHandler:
         and then probe the limit switch to reach the home position.
         For the OT3, the axis will retract to its known home position.
         """
+        await self._gantry_mover.retract_axis(axis)

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -212,7 +212,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 MoveToCoordinatesResult,
                 thermocycler.OpenLidResult,
                 thermocycler.CloseLidResult,
-
             ),
         ):
             self._state.current_well = None

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -30,6 +30,7 @@ from ..commands import (
     DropTipResult,
     DropTipInPlaceResult,
     HomeResult,
+    RetractAxisResult,
     BlowOutResult,
     TouchTipResult,
     thermocycler,
@@ -207,9 +208,11 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             command.result,
             (
                 HomeResult,
+                RetractAxisResult,
                 MoveToCoordinatesResult,
                 thermocycler.OpenLidResult,
                 thermocycler.CloseLidResult,
+
             ),
         ):
             self._state.current_well = None
@@ -274,6 +277,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             command.result,
             (
                 HomeResult,
+                RetractAxisResult,
                 thermocycler.OpenLidResult,
                 thermocycler.CloseLidResult,
             ),

--- a/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
@@ -1,0 +1,25 @@
+"""Test retractAxis command."""
+from decoy import Decoy
+
+from opentrons.protocol_engine.types import MotorAxis
+from opentrons.protocol_engine.execution import MovementHandler
+
+from opentrons.protocol_engine.commands.retract_axis import (
+    RetractAxisParams,
+    RetractAxisResult,
+    RetractAxisImplementation,
+)
+
+
+async def test_retract_axis_implementation(
+    decoy: Decoy,
+    movement: MovementHandler,
+) -> None:
+    """A retractAxis command should have an execution implementation."""
+    subject = RetractAxisImplementation(movement=movement)
+
+    data = RetractAxisParams(axis=MotorAxis.Y)
+    result = await subject.execute(data)
+
+    assert result == RetractAxisResult()
+    decoy.verify(await movement.retract_axis(axis=MotorAxis.Y))

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine.types import (
     WellOffset,
     DeckSlotLocation,
     CurrentWell,
+    MotorAxis,
 )
 from opentrons.protocol_engine.state import (
     StateStore,
@@ -418,3 +419,15 @@ async def test_move_to_coordinates(
     )
 
     assert result == Point(x=1, y=5, z=9)
+
+
+async def test_retract_axis(
+    decoy: Decoy,
+    state_store: StateStore,
+    mock_gantry_mover: GantryMover,
+    subject: MovementHandler,
+) -> None:
+    """It should delegate to gantry mover to retract the specified axis."""
+    await subject.retract_axis(axis=MotorAxis.RIGHT_Z)
+
+    decoy.verify(await mock_gantry_mover.retract_axis(MotorAxis.RIGHT_Z), times=1)

--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -213,7 +213,7 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
       {
         commandType: 'retractAxis' as const,
         params: {
-          axis: [pipetteZMotorAxis],
+          axis: pipetteZMotorAxis,
         },
       },
       {
@@ -228,7 +228,7 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
       {
         commandType: 'retractAxis' as const,
         params: {
-          axis: [pipetteZMotorAxis],
+          axis: pipetteZMotorAxis,
         },
       },
       {

--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -62,8 +62,12 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
   } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const labwareDef = getLabwareDef(labwareId, protocolData)
-  const pipetteName =
-    protocolData.pipettes.find(p => p.id === pipetteId)?.pipetteName ?? null
+  const pipette = protocolData.pipettes.find(
+    pipette => pipette.id === pipetteId
+  )
+
+  const pipetteMount = pipette?.mount
+  const pipetteName = pipette?.pipetteName
   let modulePrepCommands: CreateCommand[] = []
   const moduleType =
     (moduleId != null &&
@@ -113,7 +117,10 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
     }
   }, [moduleId])
 
-  if (pipetteName == null || labwareDef == null) return null
+  if (pipetteName == null || labwareDef == null || pipetteMount == null)
+    return null
+  const pipetteZMotorAxis: 'leftZ' | 'rightZ' =
+    pipetteMount === 'left' ? 'leftZ' : 'rightZ'
   const isTiprack = getIsTiprack(labwareDef)
   const displayLocation = getDisplayLocation(location, t)
   const labwareDisplayName = getLabwareDisplayName(labwareDef)
@@ -204,12 +211,24 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
   const handleConfirmPosition = (): void => {
     let confirmPositionCommands: CreateCommand[] = [
       {
+        commandType: 'retractAxis' as const,
+        params: {
+          axis: [pipetteZMotorAxis],
+        },
+      },
+      {
         commandType: 'moveToWell' as const,
         params: {
           pipetteId: pipetteId,
           labwareId: FIXED_TRASH_ID,
           wellName: 'A1',
           wellLocation: { origin: 'top' as const },
+        },
+      },
+      {
+        commandType: 'retractAxis' as const,
+        params: {
+          axis: [pipetteZMotorAxis],
         },
       },
       {

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -62,9 +62,14 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
   const [showTipConfirmation, setShowTipConfirmation] = React.useState(false)
 
   const labwareDef = getLabwareDef(labwareId, protocolData)
-  const pipetteName =
-    protocolData.pipettes.find(p => p.id === pipetteId)?.pipetteName ?? null
-  if (pipetteName == null || labwareDef == null) return null
+  const pipette = protocolData.pipettes.find(p => p.id === pipetteId)
+  const pipetteName = pipette?.pipetteName
+  const pipetteMount = pipette?.mount
+  if (pipetteName == null || labwareDef == null || pipetteMount == null)
+    return null
+
+  const pipetteZMotorAxis: 'leftZ' | 'rightZ' =
+    pipetteMount === 'left' ? 'leftZ' : 'rightZ'
 
   const displayLocation = getDisplayLocation(location, t)
   const labwareDisplayName = getLabwareDisplayName(labwareDef)
@@ -204,12 +209,24 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
     chainRunCommands(
       [
         {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: [pipetteZMotorAxis],
+          },
+        },
+        {
           commandType: 'moveToWell' as const,
           params: {
             pipetteId: pipetteId,
             labwareId: FIXED_TRASH_ID,
             wellName: 'A1',
             wellLocation: { origin: 'top' as const },
+          },
+        },
+        {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: [pipetteZMotorAxis],
           },
         },
         {

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -211,7 +211,7 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: [pipetteZMotorAxis],
+            axis: pipetteZMotorAxis,
           },
         },
         {
@@ -226,7 +226,7 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: [pipetteZMotorAxis],
+            axis: pipetteZMotorAxis,
           },
         },
         {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -214,7 +214,7 @@ describe('CheckItem', () => {
           {
             commandType: 'retractAxis' as const,
             params: {
-              axis: ['leftZ'],
+              axis: 'leftZ',
             },
           },
           {
@@ -229,7 +229,7 @@ describe('CheckItem', () => {
           {
             commandType: 'retractAxis' as const,
             params: {
-              axis: ['leftZ'],
+              axis: 'leftZ',
             },
           },
           {
@@ -279,7 +279,7 @@ describe('CheckItem', () => {
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: ['leftZ'],
+            axis: 'leftZ',
           },
         },
         {
@@ -294,7 +294,7 @@ describe('CheckItem', () => {
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: ['leftZ'],
+            axis: 'leftZ',
           },
         },
         {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -212,12 +212,24 @@ describe('CheckItem', () => {
             params: { pipetteId: 'pipetteId1' },
           },
           {
+            commandType: 'retractAxis' as const,
+            params: {
+              axis: ['leftZ'],
+            },
+          },
+          {
             commandType: 'moveToWell',
             params: {
               pipetteId: 'pipetteId1',
               labwareId: 'fixedTrash',
               wellName: 'A1',
               wellLocation: { origin: 'top', offset: undefined },
+            },
+          },
+          {
+            commandType: 'retractAxis' as const,
+            params: {
+              axis: ['leftZ'],
             },
           },
           {
@@ -265,12 +277,24 @@ describe('CheckItem', () => {
           params: { pipetteId: 'pipetteId1' },
         },
         {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: ['leftZ'],
+          },
+        },
+        {
           commandType: 'moveToWell',
           params: {
             pipetteId: 'pipetteId1',
             labwareId: 'fixedTrash',
             wellName: 'A1',
             wellLocation: { origin: 'top', offset: undefined },
+          },
+        },
+        {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: ['leftZ'],
           },
         },
         {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -385,7 +385,7 @@ describe('PickUpTip', () => {
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: ['leftZ'],
+            axis: 'leftZ',
           },
         },
         {
@@ -400,7 +400,7 @@ describe('PickUpTip', () => {
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: ['leftZ'],
+            axis: 'leftZ',
           },
         },
         {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -383,12 +383,24 @@ describe('PickUpTip', () => {
       3,
       [
         {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: ['leftZ'],
+          },
+        },
+        {
           commandType: 'moveToWell',
           params: {
             pipetteId: 'pipetteId1',
             labwareId: 'fixedTrash',
             wellName: 'A1',
             wellLocation: { origin: 'top' },
+          },
+        },
+        {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: ['leftZ'],
           },
         },
         {

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -14,7 +14,7 @@ import {
   getPipetteNameSpecs,
   LEFT,
   LoadedPipette,
-  MotorAxis,
+  MotorAxes,
   NINETY_SIX_CHANNEL,
 } from '@opentrons/shared-data'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
@@ -138,7 +138,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       flowType === FLOWS.ATTACH &&
       currentStepIndex !== totalStepCount
     ) {
-      let axes: MotorAxis = mount === LEFT ? ['leftPlunger'] : ['rightPlunger']
+      let axes: MotorAxes = mount === LEFT ? ['leftPlunger'] : ['rightPlunger']
       // TODO: (sb)5/25/23 Stop homing leftZ for 96 once motor is disabled
       if (attachedPipettes[mount]?.instrumentName === 'p1000_96') {
         axes = ['leftPlunger', 'leftZ']

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -36,6 +36,9 @@
       "$ref": "#/definitions/HomeCreate"
     },
     {
+      "$ref": "#/definitions/RetractAxisCreate"
+    },
+    {
       "$ref": "#/definitions/LoadLabwareCreate"
     },
     {
@@ -853,6 +856,52 @@
         },
         "params": {
           "$ref": "#/definitions/HomeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "RetractAxisParams": {
+      "title": "RetractAxisParams",
+      "description": "Payload required for a Retract Axis command.",
+      "type": "object",
+      "properties": {
+        "axis": {
+          "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MotorAxis"
+            }
+          ]
+        }
+      },
+      "required": ["axis"]
+    },
+    "RetractAxisCreate": {
+      "title": "RetractAxisCreate",
+      "description": "Data to create a Retract Axis command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "retractAxis",
+          "enum": ["retractAxis"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/RetractAxisParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -461,10 +461,15 @@ export interface ProtocolResource {
 export interface ProtocolAnalysesResource {
   analyses: Array<PendingProtocolAnalysis | CompletedProtocolAnalysis>
 }
+export type MotorAxis =
+  | 'x'
+  | 'y'
+  | 'leftZ'
+  | 'rightZ'
+  | 'leftPlunger'
+  | 'rightPlunger'
 
-export type MotorAxis = Array<
-  'x' | 'y' | 'leftZ' | 'rightZ' | 'leftPlunger' | 'rightPlunger'
->
+export type MotorAxes = MotorAxis[]
 
 export type ThermalAdapterName =
   | 'PCR Adapter'

--- a/shared-data/protocol/types/schemaV6/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV6/command/gantry.ts
@@ -61,6 +61,15 @@ export interface HomeRunTimeCommand
     HomeCreateCommand {
   result?: {}
 }
+export interface RetractAxisCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'retractAxis'
+  params: RetractAxisParams
+}
+export interface RetractAxisRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    RetractAxisCreateCommand {
+  result?: {}
+}
 export type GantryRunTimeCommand =
   | MoveToSlotRunTimeCommand
   | MoveToWellRunTimeCommand
@@ -68,6 +77,7 @@ export type GantryRunTimeCommand =
   | MoveRelativeRunTimeCommand
   | SavePositionRunTimeCommand
   | HomeRunTimeCommand
+  | RetractAxisRunTimeCommand
 export type GantryCreateCommand =
   | MoveToSlotCreateCommand
   | MoveToWellCreateCommand
@@ -75,6 +85,7 @@ export type GantryCreateCommand =
   | MoveRelativeCreateCommand
   | SavePositionCreateCommand
   | HomeCreateCommand
+  | RetractAxisCreateCommand
 
 interface MoveToSlotParams {
   pipetteId: string
@@ -128,4 +139,8 @@ interface SavePositionParams {
 
 interface HomeParams {
   axes?: MotorAxis
+}
+
+interface RetractAxisParams {
+  axis: MotorAxis
 }

--- a/shared-data/protocol/types/schemaV6/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV6/command/gantry.ts
@@ -1,5 +1,5 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
-import type { Coordinates, MotorAxis } from '../../../../js/types'
+import type { MotorAxis, Coordinates, MotorAxes } from '../../../../js/types'
 
 export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToSlot'
@@ -138,7 +138,7 @@ interface SavePositionParams {
 }
 
 interface HomeParams {
-  axes?: MotorAxis
+  axes?: MotorAxes
 }
 
 interface RetractAxisParams {

--- a/shared-data/protocol/types/schemaV7/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV7/command/gantry.ts
@@ -1,5 +1,5 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
-import type { Coordinates, MotorAxis } from '../../../../js/types'
+import type { Coordinates, MotorAxes } from '../../../../js/types'
 
 export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToSlot'
@@ -127,5 +127,5 @@ interface SavePositionParams {
 }
 
 interface HomeParams {
-  axes?: MotorAxis
+  axes?: MotorAxes
 }


### PR DESCRIPTION
Closes RSS-278

# Overview

Adds a new protocol engine command- `retractAxis` to retract a specified robot axis.
Currently the execution of this command just no-ops. Will update the implementation once axis retraction is available in hardware control. This PR serves to unblock client side use of this command.

# Test Plan

Unit tests should suffice for now. Will test command calling with client-side changes.

# Changelog

- adds the new command and test
- updates schema v7

# Review requests

- Usual code review
- Main question @ahiuchingau and I had when deciding on the retraction feature is if it's okay to have the retraction be slightly different for OT2 vs Flex: on the OT-2, it will do a fast move to a safe distance from the axis' home position, and then probe the limit switch to reach the home position, while on the flex, it will move directly to the last known home position of the axis. The cautious approach for the OT2 is based on the original `retract_mount` method on the hardware control API which was created to home a mount after a tip pick-up in order to improve positional accuracy since a pick up action could make the mount motor skip steps.

So essentially `retractAxis` for OT-2 behaves the same as `home` on Flex. 
That said, the final outcome on both the robots is that the axis lands at its home position, faster than homing the axis on that robot.

On one hand, the behavior observed for retraction on the two robots is different and could confuse some users, while on the other hand, if we make the Flex's axis retraction behave the same way, we will be defining a more accurate robot's behavior based on a less accurate robot's constraints and have a slightly slower retraction on the Flex.

# Risk assessment

None. New command that's not wired up anywhere yet.
