### PR TITLE
feat(app): add a new type for red frame

### DIFF
--- a/app/src/molecules/LegacyModal/LegacyModal.stories.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModal.stories.tsx
@@ -48,13 +48,3 @@ Primary.args = {
   title: 'Modal Title',
   children: Children,
 }
-
-export const Error = Template.bind({})
-Error.args = {
-  type: 'error',
-  onClose: () => {},
-  closeOnOutsideClick: false,
-  title: 'Error Modal',
-  children: Children,
-  isError: true,
-}

--- a/app/src/molecules/LegacyModal/LegacyModal.stories.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModal.stories.tsx
@@ -48,3 +48,13 @@ Primary.args = {
   title: 'Modal Title',
   children: Children,
 }
+
+export const Error = Template.bind({})
+Error.args = {
+  type: 'error',
+  onClose: () => {},
+  closeOnOutsideClick: false,
+  title: 'Error Modal',
+  children: Children,
+  isError: true,
+}

--- a/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
@@ -53,6 +53,7 @@ export const LegacyModalHeader = (
         paddingX={SPACING.spacing24}
         paddingY={SPACING.spacing16}
         backgroundColor={backgroundColor}
+        data-testid="Modal_header"
       >
         <Flex>
           {icon != null && <Icon {...icon} data-testid="Modal_header_icon" />}

--- a/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
@@ -19,8 +19,8 @@ import type { IconProps } from '@opentrons/components'
 export interface LegacyModalHeaderProps {
   onClose?: React.MouseEventHandler
   title: React.ReactNode
-  backgroundColor: string
-  color: string
+  backgroundColor?: string
+  color?: string
   icon?: IconProps
   closeButton?: JSX.Element
 }

--- a/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
@@ -19,9 +19,10 @@ import type { IconProps } from '@opentrons/components'
 export interface LegacyModalHeaderProps {
   onClose?: React.MouseEventHandler
   title: React.ReactNode
+  backgroundColor: string
+  color: string
   icon?: IconProps
   closeButton?: JSX.Element
-  isError?: boolean
 }
 
 const closeIconStyles = css`
@@ -43,24 +44,22 @@ const closeIconStyles = css`
 export const LegacyModalHeader = (
   props: LegacyModalHeaderProps
 ): JSX.Element => {
-  const { icon, onClose, title, closeButton, isError = false } = props
+  const { icon, onClose, title, backgroundColor, color, closeButton } = props
   return (
     <>
       <Flex
-        backgroundColor={isError ? COLORS.errorEnabled : undefined}
         alignItems={ALIGN_CENTER}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
         paddingX={SPACING.spacing24}
         paddingY={SPACING.spacing16}
+        backgroundColor={backgroundColor}
       >
         <Flex>
-          {icon != null && (
-            <Icon {...icon} color={isError ? COLORS.white : icon.color} />
-          )}
+          {icon != null && <Icon {...icon} />}
           <StyledText
             as="h3"
             fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            color={isError ? COLORS.white : COLORS.darkBlackEnabled}
+            color={color}
           >
             {title}
           </StyledText>
@@ -79,7 +78,7 @@ export const LegacyModalHeader = (
                   name="close"
                   width={SPACING.spacing24}
                   height={SPACING.spacing24}
-                  color={isError ? COLORS.white : undefined}
+                  color={color}
                 />
               </Btn>
             )}

--- a/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
@@ -55,7 +55,7 @@ export const LegacyModalHeader = (
         backgroundColor={backgroundColor}
       >
         <Flex>
-          {icon != null && <Icon {...icon} />}
+          {icon != null && <Icon {...icon} data-testid="Modal_header_icon" />}
           <StyledText
             as="h3"
             fontWeight={TYPOGRAPHY.fontWeightSemiBold}

--- a/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalHeader.tsx
@@ -21,6 +21,7 @@ export interface LegacyModalHeaderProps {
   title: React.ReactNode
   icon?: IconProps
   closeButton?: JSX.Element
+  isError?: boolean
 }
 
 const closeIconStyles = css`
@@ -42,18 +43,25 @@ const closeIconStyles = css`
 export const LegacyModalHeader = (
   props: LegacyModalHeaderProps
 ): JSX.Element => {
-  const { icon, onClose, title, closeButton } = props
+  const { icon, onClose, title, closeButton, isError = false } = props
   return (
     <>
       <Flex
+        backgroundColor={isError ? COLORS.errorEnabled : undefined}
         alignItems={ALIGN_CENTER}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
         paddingX={SPACING.spacing24}
         paddingY={SPACING.spacing16}
       >
         <Flex>
-          {icon != null && <Icon {...icon} />}
-          <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+          {icon != null && (
+            <Icon {...icon} color={isError ? COLORS.white : icon.color} />
+          )}
+          <StyledText
+            as="h3"
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            color={isError ? COLORS.white : COLORS.darkBlackEnabled}
+          >
             {title}
           </StyledText>
         </Flex>
@@ -71,6 +79,7 @@ export const LegacyModalHeader = (
                   name="close"
                   width={SPACING.spacing24}
                   height={SPACING.spacing24}
+                  color={isError ? COLORS.white : undefined}
                 />
               </Btn>
             )}

--- a/app/src/molecules/LegacyModal/LegacyModalShell.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalShell.tsx
@@ -59,6 +59,7 @@ export function LegacyModalShell(props: LegacyModalShellProps): JSX.Element {
     >
       <ContentArea zIndex={zIndex}>
         <ModalArea
+          aria-label="ModalShell_ModalArea"
           isFullPage={fullPage}
           onClick={e => {
             e.stopPropagation()

--- a/app/src/molecules/LegacyModal/LegacyModalShell.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalShell.tsx
@@ -26,8 +26,6 @@ export interface LegacyModalShellProps extends StyleProps {
   footer?: React.ReactNode
   /** Optional full page takeover */
   fullPage?: boolean
-  /** an option for adding additional styles for an error modal */
-  isError?: boolean
 }
 
 /**
@@ -48,7 +46,6 @@ export function LegacyModalShell(props: LegacyModalShellProps): JSX.Element {
     footer,
     fullPage = false,
     children,
-    isError = false,
     ...styleProps
   } = props
 
@@ -66,7 +63,6 @@ export function LegacyModalShell(props: LegacyModalShellProps): JSX.Element {
           onClick={e => {
             e.stopPropagation()
           }}
-          isError={isError}
           {...styleProps}
         >
           {header != null ? <Header>{header}</Header> : null}
@@ -108,11 +104,7 @@ const ContentArea = styled.div<{ zIndex: string | number }>`
 `
 
 const ModalArea = styled.div<
-  {
-    isFullPage: boolean
-    backgroundColor?: string
-    isError?: boolean
-  } & StyleProps
+  { isFullPage: boolean; backgroundColor?: string } & StyleProps
 >`
   position: ${POSITION_RELATIVE};
   overflow-y: ${OVERFLOW_AUTO};
@@ -125,8 +117,6 @@ const ModalArea = styled.div<
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     border-radius: ${BORDERS.borderRadiusSize4};
   }
-  border: ${({ isError }) =>
-    isError ? `0.375rem solid ${COLORS.errorEnabled}` : 'none'};
   ${styleProps};
 `
 

--- a/app/src/molecules/LegacyModal/LegacyModalShell.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalShell.tsx
@@ -26,6 +26,8 @@ export interface LegacyModalShellProps extends StyleProps {
   footer?: React.ReactNode
   /** Optional full page takeover */
   fullPage?: boolean
+  /** an option for adding additional styles for an error modal */
+  isError?: boolean
 }
 
 /**
@@ -46,6 +48,7 @@ export function LegacyModalShell(props: LegacyModalShellProps): JSX.Element {
     footer,
     fullPage = false,
     children,
+    isError = false,
     ...styleProps
   } = props
 
@@ -63,6 +66,7 @@ export function LegacyModalShell(props: LegacyModalShellProps): JSX.Element {
           onClick={e => {
             e.stopPropagation()
           }}
+          isError={isError}
           {...styleProps}
         >
           {header != null ? <Header>{header}</Header> : null}
@@ -104,7 +108,11 @@ const ContentArea = styled.div<{ zIndex: string | number }>`
 `
 
 const ModalArea = styled.div<
-  { isFullPage: boolean; backgroundColor?: string } & StyleProps
+  {
+    isFullPage: boolean
+    backgroundColor?: string
+    isError?: boolean
+  } & StyleProps
 >`
   position: ${POSITION_RELATIVE};
   overflow-y: ${OVERFLOW_AUTO};
@@ -117,6 +125,8 @@ const ModalArea = styled.div<
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     border-radius: ${BORDERS.borderRadiusSize4};
   }
+  border: ${({ isError }) =>
+    isError ? `0.375rem solid ${COLORS.errorEnabled}` : 'none'};
   ${styleProps};
 `
 

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModal.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModal.test.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+
+import { COLORS, renderWithProviders } from '@opentrons/components'
+
+import { LegacyModal } from '..'
+
+const render = (props: React.ComponentProps<typeof LegacyModal>) => {
+  return renderWithProviders(<LegacyModal {...props} />)
+}
+
+describe('LegacyModal', () => {
+  let props: React.ComponentProps<typeof LegacyModal>
+
+  beforeEach(() => {
+    props = {
+      type: 'info',
+      title: 'mock info modal',
+      children: <div>mock modal content</div>,
+    }
+  })
+
+  it('should render modal without header icon when type is info', () => {
+    const [{ getByText, queryByTestId, getByTestId }] = render(props)
+    expect(queryByTestId('Modal_header_icon')).not.toBeInTheDocument()
+    getByText('mock info modal')
+    expect(getByTestId('Modal_header')).toHaveStyle(
+      `background-color: ${COLORS.white}`
+    )
+  })
+
+  it('should render modal with orange header icon when type is warning', () => {
+    props.type = 'warning'
+    const [{ getByTestId }] = render(props)
+    const headerIcon = getByTestId('Modal_header_icon')
+    expect(headerIcon).toBeInTheDocument()
+    expect(headerIcon).toHaveStyle(`color: ${COLORS.warningEnabled}`)
+    expect(getByTestId('Modal_header')).toHaveStyle(
+      `background-color: ${COLORS.white}`
+    )
+  })
+
+  it('should render modal with red header icon when type is error', () => {
+    props.type = 'error'
+    const [{ getByTestId }] = render(props)
+    const headerIcon = getByTestId('Modal_header_icon')
+    expect(headerIcon).toBeInTheDocument()
+    expect(headerIcon).toHaveStyle(`color: ${COLORS.errorEnabled}`)
+    expect(getByTestId('Modal_header')).toHaveStyle(
+      `background-color: ${COLORS.white}`
+    )
+  })
+
+  it('should render outlined modal when type is outlinedError', () => {
+    props.type = 'outlinedError'
+    const [{ getByTestId }] = render(props)
+    const headerIcon = getByTestId('Modal_header_icon')
+    expect(headerIcon).toBeInTheDocument()
+    expect(headerIcon).toHaveStyle(`color: ${COLORS.white}`)
+    expect(getByTestId('Modal_header')).toHaveStyle(
+      `background-color: ${COLORS.errorEnabled}`
+    )
+  })
+})

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModalHeader.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModalHeader.test.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+
+import {
+  ALIGN_CENTER,
+  COLORS,
+  JUSTIFY_CENTER,
+  renderWithProviders,
+  SPACING,
+} from '@opentrons/components'
+
+import { LegacyModalHeader } from '../LegacyModalHeader'
+
+const mockClose = jest.fn()
+
+const render = (props: React.ComponentProps<typeof LegacyModalHeader>) => {
+  return renderWithProviders(<LegacyModalHeader {...props} />)
+}
+
+describe('LegacyModalHeader', () => {
+  let props: React.ComponentProps<typeof LegacyModalHeader>
+
+  beforeEach(() => {
+    props = {
+      onClose: mockClose,
+      title: 'mock modal header title',
+      backgroundColor: COLORS.white,
+      color: COLORS.darkBlackEnabled,
+    }
+  })
+
+  it('should render text and close icon', () => {
+    const [{ getByText, getByTestId }] = render(props)
+    const title = getByText('mock modal header title')
+    expect(title).toHaveStyle(`color: ${COLORS.darkBlackEnabled}`)
+    getByTestId('ModalHeader_icon_close_mock modal header title')
+  })
+
+  it('should render text, icon, and close icon', () => {
+    props.icon = {
+      name: 'ot-alert',
+      color: COLORS.darkBlackEnabled,
+      size: '1.25rem',
+      marginRight: SPACING.spacing8,
+    }
+    const [{ getByTestId }] = render(props)
+    expect(getByTestId('Modal_header_icon')).toHaveStyle(
+      `color: ${COLORS.darkBlackEnabled}`
+    )
+    expect(getByTestId('Modal_header_icon')).toHaveStyle(`width: 1.25rem`)
+    expect(getByTestId('Modal_header_icon')).toHaveStyle(`height: 1.25rem`)
+    expect(getByTestId('Modal_header_icon')).toHaveStyle(
+      `margin-right: ${SPACING.spacing8}`
+    )
+  })
+
+  it('should call a mock function when clicking close icon', () => {
+    const [{ getByTestId }] = render(props)
+    const closeIcon = getByTestId(
+      'ModalHeader_icon_close_mock modal header title'
+    )
+    expect(closeIcon).toHaveStyle('width: 1.625rem')
+    expect(closeIcon).toHaveStyle('height: 1.625rem')
+    expect(closeIcon).toHaveStyle('display: flex')
+    expect(closeIcon).toHaveStyle(`justify-content: ${JUSTIFY_CENTER}`)
+    expect(closeIcon).toHaveStyle(`align-items: ${ALIGN_CENTER}`)
+    expect(closeIcon).toHaveStyle('border-radius: 0.875rem')
+    expect(closeIcon).toHaveStyleRule(
+      'background-color',
+      COLORS.lightGreyHover,
+      {
+        modifier: ':hover',
+      }
+    )
+    expect(closeIcon).toHaveStyleRule(
+      'background-color',
+      COLORS.lightGreyPressed,
+      {
+        modifier: ':active',
+      }
+    )
+    closeIcon.click()
+    expect(mockClose).toHaveBeenCalled()
+  })
+})

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModalShell.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModalShell.test.tsx
@@ -26,7 +26,7 @@ describe('LegacyModalShell', () => {
 
   it('should render full size modal when fullSize is true', () => {
     props.fullPage = true
-    const [{ getByText, getByLabelText }] = render(props)
+    const [{ getByLabelText }] = render(props)
     expect(getByLabelText('ModalShell_ModalArea')).toHaveStyle('height: 100%')
   })
 

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModalShell.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModalShell.test.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react'
 
-import {
-  COLORS,
-  POSITION_STICKY,
-  renderWithProviders,
-} from '@opentrons/components'
+import { renderWithProviders } from '@opentrons/components'
 
 import { LegacyModalShell } from '../LegacyModalShell'
 

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModalShell.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModalShell.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react'
+
+import {
+  COLORS,
+  POSITION_STICKY,
+  renderWithProviders,
+} from '@opentrons/components'
+
+import { LegacyModalShell } from '../LegacyModalShell'
+
+const render = (props: React.ComponentProps<typeof LegacyModalShell>) => {
+  return renderWithProviders(<LegacyModalShell {...props} />)
+}
+
+describe('LegacyModalShell', () => {
+  let props: React.ComponentProps<typeof LegacyModalShell>
+
+  beforeEach(() => {
+    props = {
+      children: <div>mock modal shell</div>,
+      fullPage: false,
+    }
+  })
+
+  it('should render content', () => {
+    const [{ getByText, getByLabelText }] = render(props)
+    getByText('mock modal shell')
+    expect(getByLabelText('ModalShell_ModalArea')).toHaveStyle('height: auto')
+  })
+
+  it('should render full size modal when fullSize is true', () => {
+    props.fullPage = true
+    const [{ getByText, getByLabelText }] = render(props)
+    expect(getByLabelText('ModalShell_ModalArea')).toHaveStyle('height: 100%')
+  })
+
+  it('should render header and footer', () => {
+    props.header = <div>mock header</div>
+    props.footer = <div>mock footer</div>
+    const [{ getByText }] = render(props)
+    getByText('mock header')
+    getByText('mock footer')
+  })
+})

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -3,7 +3,6 @@ import { SPACING, COLORS, Box } from '@opentrons/components'
 import { LegacyModalHeader } from './LegacyModalHeader'
 import { LegacyModalShell } from './LegacyModalShell'
 import type { StyleProps } from '@opentrons/components'
-import { isError } from 'lodash'
 
 type ModalType = 'info' | 'warning' | 'error'
 export * from './LegacyModalShell'

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -52,31 +52,6 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
     marginRight: SPACING.spacing8,
   }
 
-  // const MODAL_PROPS_BY_TYPE: Record<
-  //   ModalType,
-  //   { icon?: IconProps; backgroundColor?: string; hasOutline?: boolean }
-  // > = {
-  //   info: {
-  //     icon: undefined,
-  //     hasOutline: false,
-  //   },
-  //   warning: {
-  //     icon: modalIcon,
-  //     backgroundColor: '',
-  //     hasOutline: false,
-  //   },
-  //   error: {
-  //     icon: modalIcon,
-  //     backgroundColor: '',
-  //     hasOutline: false,
-  //   },
-  //   outlinedError: {
-  //     icon: modalIcon,
-  //     backgroundColor: '',
-  //     hasOutline: true,
-  //   },
-  // }
-
   const modalHeader = (
     <LegacyModalHeader
       onClose={onClose}

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -3,6 +3,7 @@ import { SPACING, COLORS, Box } from '@opentrons/components'
 import { LegacyModalHeader } from './LegacyModalHeader'
 import { LegacyModalShell } from './LegacyModalShell'
 import type { StyleProps } from '@opentrons/components'
+import { isError } from 'lodash'
 
 type ModalType = 'info' | 'warning' | 'error'
 export * from './LegacyModalShell'
@@ -16,6 +17,7 @@ export interface LegacyModalProps extends StyleProps {
   fullPage?: boolean
   childrenPadding?: string | number
   children?: React.ReactNode
+  isError?: boolean
 }
 
 export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
@@ -26,6 +28,7 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
     title,
     childrenPadding = `${SPACING.spacing16} ${SPACING.spacing24} ${SPACING.spacing24}`,
     children,
+    isError = false,
     ...styleProps
   } = props
 
@@ -44,6 +47,7 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
             }
           : undefined
       }
+      isError={isError}
     />
   )
 

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -2,9 +2,9 @@ import * as React from 'react'
 import { SPACING, COLORS, Box } from '@opentrons/components'
 import { LegacyModalHeader } from './LegacyModalHeader'
 import { LegacyModalShell } from './LegacyModalShell'
-import type { StyleProps } from '@opentrons/components'
+import type { IconProps, StyleProps } from '@opentrons/components'
 
-type ModalType = 'info' | 'warning' | 'error'
+type ModalType = 'info' | 'warning' | 'error' | 'outlinedError'
 export * from './LegacyModalShell'
 export * from './LegacyModalHeader'
 
@@ -16,7 +16,6 @@ export interface LegacyModalProps extends StyleProps {
   fullPage?: boolean
   childrenPadding?: string | number
   children?: React.ReactNode
-  isError?: boolean
 }
 
 export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
@@ -27,26 +26,70 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
     title,
     childrenPadding = `${SPACING.spacing16} ${SPACING.spacing24} ${SPACING.spacing24}`,
     children,
-    isError = false,
     ...styleProps
   } = props
+
+  const iconColor = (type: ModalType): string => {
+    let iconColor: string = ''
+    switch (type) {
+      case 'warning':
+        iconColor = COLORS.warningEnabled
+        break
+      case 'error':
+        iconColor = COLORS.errorEnabled
+        break
+      case 'outlinedError':
+        iconColor = COLORS.white
+        break
+    }
+    return iconColor
+  }
+
+  const modalIcon: IconProps = {
+    name: 'ot-alert',
+    color: iconColor(type),
+    size: '1.25rem',
+    marginRight: SPACING.spacing8,
+  }
+
+  // const MODAL_PROPS_BY_TYPE: Record<
+  //   ModalType,
+  //   { icon?: IconProps; backgroundColor?: string; hasOutline?: boolean }
+  // > = {
+  //   info: {
+  //     icon: undefined,
+  //     hasOutline: false,
+  //   },
+  //   warning: {
+  //     icon: modalIcon,
+  //     backgroundColor: '',
+  //     hasOutline: false,
+  //   },
+  //   error: {
+  //     icon: modalIcon,
+  //     backgroundColor: '',
+  //     hasOutline: false,
+  //   },
+  //   outlinedError: {
+  //     icon: modalIcon,
+  //     backgroundColor: '',
+  //     hasOutline: true,
+  //   },
+  // }
 
   const modalHeader = (
     <LegacyModalHeader
       onClose={onClose}
       title={title}
       icon={
-        ['error', 'warning'].includes(type)
-          ? {
-              name: 'ot-alert',
-              color:
-                type === 'error' ? COLORS.errorEnabled : COLORS.warningEnabled,
-              size: SPACING.spacing20,
-              marginRight: SPACING.spacing8,
-            }
+        ['error', 'warning', 'outlinedError'].includes(type)
+          ? modalIcon
           : undefined
       }
-      isError={isError}
+      color={type === 'outlinedError' ? COLORS.white : COLORS.darkBlackEnabled}
+      backgroundColor={
+        type === 'outlinedError' ? COLORS.errorEnabled : COLORS.white
+      }
     />
   )
 
@@ -57,6 +100,11 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
       onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
       marginLeft="7.125rem"
+      border={
+        type === 'outlinedError'
+          ? `0.375rem solid ${COLORS.errorEnabled}`
+          : 'none'
+      }
       {...props}
     >
       <Box padding={childrenPadding}>{children}</Box>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
A modal with red frame is used by e-stop modal when a run is active which is the same as touchscreen app.
close RCORE-800
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- run StoryBook and check LegacyModal and select `outlinedError`
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update LegacyModal components
- add test for LegacyModalHeader
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
