### PR TITLE
fix(app): add box shadow to sticky header on ODD settings page

### DIFF
--- a/app/src/organisms/Navigation/__tests__/Navigation.test.tsx
+++ b/app/src/organisms/Navigation/__tests__/Navigation.test.tsx
@@ -57,6 +57,24 @@ const mockRoutes = [
 
 mockConnectedRobot.name = '12345678901234567'
 
+class MockIntersectionObserver {
+  observe = jest.fn()
+  disconnect = jest.fn()
+  unobserve = jest.fn()
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+})
+
+Object.defineProperty(global, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+})
+
 const render = (props: React.ComponentProps<typeof Navigation>) => {
   return renderWithProviders(
     <MemoryRouter>

--- a/app/src/organisms/Navigation/index.tsx
+++ b/app/src/organisms/Navigation/index.tsx
@@ -17,6 +17,7 @@ import {
   DIRECTION_COLUMN,
   POSITION_STICKY,
   POSITION_STATIC,
+  BORDERS,
 } from '@opentrons/components'
 
 import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
@@ -58,8 +59,21 @@ export function Navigation(props: NavigationProps): JSX.Element {
     }
     setShowNavMenu(openMenu)
   }
+
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const [isScrolled, setIsScrolled] = React.useState<boolean>(false)
+
+  const observer = new IntersectionObserver(([entry]) => {
+    setIsScrolled(!entry.isIntersecting)
+  })
+  if (scrollRef.current != null) {
+    observer.observe(scrollRef.current)
+  }
+
   return (
     <>
+      {/* Empty box to detect scrolling */}
+      <Flex ref={scrollRef} />
       <Flex
         flexDirection={DIRECTION_ROW}
         alignItems={ALIGN_CENTER}
@@ -71,9 +85,11 @@ export function Navigation(props: NavigationProps): JSX.Element {
             ? POSITION_STATIC
             : POSITION_STICKY
         }
+        paddingX={SPACING.spacing40}
         top="0"
         width="100%"
         backgroundColor={COLORS.white}
+        boxShadow={isScrolled ? BORDERS.shadowBig : ''}
         gridGap={SPACING.spacing24}
         aria-label="Navigation_container"
       >

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -42,76 +42,78 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
   const { lightsEnabled, toggleLights } = useLEDLights(robotName)
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} paddingX={SPACING.spacing40}>
+    <Flex flexDirection={DIRECTION_COLUMN}>
       <Navigation routes={onDeviceDisplayRoutes} />
-      <RobotSettingButton
-        settingName={t('network_settings')}
-        settingInfo={networkConnection?.connectionStatus}
-        currentOption="NetworkSettings"
-        setCurrentOption={setCurrentOption}
-        iconName="wifi"
-      />
-      <Link to="/robot-settings/rename-robot">
+      <Flex flexDirection={DIRECTION_COLUMN} paddingX={SPACING.spacing40}>
         <RobotSettingButton
-          settingName={t('robot_name')}
-          settingInfo={robotName}
-          currentOption="RobotName"
+          settingName={t('network_settings')}
+          settingInfo={networkConnection?.connectionStatus}
+          currentOption="NetworkSettings"
           setCurrentOption={setCurrentOption}
-          iconName="flex-robot"
+          iconName="wifi"
         />
-      </Link>
-      <RobotSettingButton
-        settingName={t('robot_system_version')}
-        settingInfo={
-          robotServerVersion != null
-            ? `v${robotServerVersion}`
-            : t('robot_settings_advanced_unknown')
-        }
-        currentOption="RobotSystemVersion"
-        setCurrentOption={setCurrentOption}
-        isUpdateAvailable={isUpdateAvailable}
-        iconName="update"
-      />
-      <RobotSettingButton
-        settingName={t('display_led_lights')}
-        settingInfo={t('display_led_lights_description')}
-        setCurrentOption={setCurrentOption}
-        iconName="light"
-        ledLights
-        lightsOn={lightsEnabled}
-        toggleLights={toggleLights}
-      />
-      <RobotSettingButton
-        settingName={t('touchscreen_sleep')}
-        currentOption="TouchscreenSleep"
-        setCurrentOption={setCurrentOption}
-        iconName="sleep"
-      />
-      <RobotSettingButton
-        settingName={t('touchscreen_brightness')}
-        currentOption="TouchscreenBrightness"
-        setCurrentOption={setCurrentOption}
-        iconName="brightness"
-      />
-      <RobotSettingButton
-        settingName={t('device_reset')}
-        currentOption="DeviceReset"
-        setCurrentOption={setCurrentOption}
-        iconName="reset"
-      />
-      <RobotSettingButton
-        settingName={t('app_settings:update_channel')}
-        currentOption="UpdateChannel"
-        setCurrentOption={setCurrentOption}
-        iconName="update-channel"
-      />
-      <RobotSettingButton
-        settingName={t('app_settings:enable_dev_tools')}
-        settingInfo={t('dev_tools_description')}
-        iconName="build"
-        enabledDevTools
-        devToolsOn={devToolsOn}
-      />
+        <Link to="/robot-settings/rename-robot">
+          <RobotSettingButton
+            settingName={t('robot_name')}
+            settingInfo={robotName}
+            currentOption="RobotName"
+            setCurrentOption={setCurrentOption}
+            iconName="flex-robot"
+          />
+        </Link>
+        <RobotSettingButton
+          settingName={t('robot_system_version')}
+          settingInfo={
+            robotServerVersion != null
+              ? `v${robotServerVersion}`
+              : t('robot_settings_advanced_unknown')
+          }
+          currentOption="RobotSystemVersion"
+          setCurrentOption={setCurrentOption}
+          isUpdateAvailable={isUpdateAvailable}
+          iconName="update"
+        />
+        <RobotSettingButton
+          settingName={t('display_led_lights')}
+          settingInfo={t('display_led_lights_description')}
+          setCurrentOption={setCurrentOption}
+          iconName="light"
+          ledLights
+          lightsOn={lightsEnabled}
+          toggleLights={toggleLights}
+        />
+        <RobotSettingButton
+          settingName={t('touchscreen_sleep')}
+          currentOption="TouchscreenSleep"
+          setCurrentOption={setCurrentOption}
+          iconName="sleep"
+        />
+        <RobotSettingButton
+          settingName={t('touchscreen_brightness')}
+          currentOption="TouchscreenBrightness"
+          setCurrentOption={setCurrentOption}
+          iconName="brightness"
+        />
+        <RobotSettingButton
+          settingName={t('device_reset')}
+          currentOption="DeviceReset"
+          setCurrentOption={setCurrentOption}
+          iconName="reset"
+        />
+        <RobotSettingButton
+          settingName={t('app_settings:update_channel')}
+          currentOption="UpdateChannel"
+          setCurrentOption={setCurrentOption}
+          iconName="update-channel"
+        />
+        <RobotSettingButton
+          settingName={t('app_settings:enable_dev_tools')}
+          settingInfo={t('dev_tools_description')}
+          iconName="build"
+          enabledDevTools
+          devToolsOn={devToolsOn}
+        />
+      </Flex>
     </Flex>
   )
 }


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Addresses DQA for settings page round 2. updates some styling to give the header on the ODD settings page a lower box shadow when the page is scrolled

closes RAUT-454


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Visited settings page and verified a box shadow is visible when list is scrolled

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- moves around some padding to give the settings nav menu the full width of the page
- adds some logic to detect scroll and display box shadow when scrolled

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

Ensure the box shadow shows up appropriately on the ODD settings page

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
