### PR TITLE
feat(app): send fatal ODD browser logs to electron layer

### DIFF
--- a/app-shell-odd/src/restart.ts
+++ b/app-shell-odd/src/restart.ts
@@ -7,9 +7,9 @@ export function registerAppRestart(): (action: Action) => unknown {
   return function handleAction(action: Action) {
     switch (action.type) {
       case APP_RESTART:
-        systemd.sendStatus('restart app')
+        systemd.sendStatus(`restarting app: ${action.payload.message}`)
+        console.log(`restarting app: ${action.payload.message}`)
         systemd.restartApp()
-
         break
     }
   }

--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -15,7 +15,7 @@ import {
 import { StyledText } from '../atoms/text'
 import { MediumButton } from '../atoms/buttons'
 import { Modal } from '../molecules/Modal'
-import { appRestart } from '../redux/shell'
+import { appRestart, sendLog } from '../redux/shell'
 
 import type { Dispatch } from '../redux/types'
 import type { ModalHeaderBaseProps } from '../molecules/Modal/types'
@@ -25,13 +25,18 @@ export function OnDeviceDisplayAppFallback({
 }: FallbackProps): JSX.Element {
   const dispatch = useDispatch<Dispatch>()
   const handleRestartClick = (): void => {
-    dispatch(appRestart())
+    dispatch(appRestart(`${error.message}`))
   }
   const modalHeader: ModalHeaderBaseProps = {
     title: 'Restart the app',
     iconName: 'information',
     iconColor: COLORS.white,
   }
+
+  // immediately report to robot logs that something fatal happened
+  React.useEffect(() => {
+    dispatch(sendLog(`ODD app encountered a fatal error: ${error.message}`))
+  }, [])
 
   return (
     <Modal header={modalHeader} isError>

--- a/app/src/redux/shell/actions.ts
+++ b/app/src/redux/shell/actions.ts
@@ -2,6 +2,7 @@ import type {
   UiInitializedAction,
   UsbRequestsAction,
   AppRestartAction,
+  SendLogAction,
 } from './types'
 
 export const UI_INITIALIZED: 'shell:UI_INITIALIZED' = 'shell:UI_INITIALIZED'
@@ -10,6 +11,7 @@ export const USB_HTTP_REQUESTS_START: 'shell:USB_HTTP_REQUESTS_START' =
 export const USB_HTTP_REQUESTS_STOP: 'shell:USB_HTTP_REQUESTS_STOP' =
   'shell:USB_HTTP_REQUESTS_STOP'
 export const APP_RESTART: 'shell:APP_RESTART' = 'shell:APP_RESTART'
+export const SEND_LOG: 'shell:SEND_LOG' = 'shell:SEND_LOG'
 
 export const uiInitialized = (): UiInitializedAction => ({
   type: UI_INITIALIZED,
@@ -26,7 +28,18 @@ export const usbRequestsStop = (): UsbRequestsAction => ({
   meta: { shell: true },
 })
 
-export const appRestart = (): AppRestartAction => ({
+export const appRestart = (message: string): AppRestartAction => ({
   type: APP_RESTART,
+  payload: {
+    message: message,
+  },
+  meta: { shell: true },
+})
+
+export const sendLog = (message: string): SendLogAction => ({
+  type: SEND_LOG,
+  payload: {
+    message: message,
+  },
   meta: { shell: true },
 })

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -57,6 +57,17 @@ export type UsbRequestsAction =
 
 export interface AppRestartAction {
   type: 'shell:APP_RESTART'
+  payload: {
+    message: string
+  }
+  meta: { shell: true }
+}
+
+export interface SendLogAction {
+  type: 'shell:SEND_LOG'
+  payload: {
+    message: string
+  }
   meta: { shell: true }
 }
 
@@ -67,3 +78,4 @@ export type ShellAction =
   | RobotSystemAction
   | UsbRequestsAction
   | AppRestartAction
+  | SendLogAction


### PR DESCRIPTION
# Overview

This PR sends the electron layer a message when a fatal error occurs in the app so it gets picked up in logs. This will help tremendously when debugging ODD browser side errors.


# Risk assessment

Low
