### PR TITLE
fix(app): labware setup modal updates to match designs

### DIFF
--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@opentrons/components'
 import {
   getDeckDefFromRobotType,
+  getLabwareDefURI,
   getLabwareDisplayName,
   HEATERSHAKER_MODULE_TYPE,
   inferModuleOrientationFromXCoordinate,
@@ -92,7 +93,11 @@ export function ProtocolSetupLabware({
     setShowLabwareDetailsModal,
   ] = React.useState<boolean>(false)
   const [selectedLabware, setSelectedLabware] = React.useState<
-    (LabwareDefinition2 & { location: LabwareLocation }) | null
+    | (LabwareDefinition2 & {
+        location: LabwareLocation
+        nickName: string | null
+      })
+    | null
   >(null)
 
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
@@ -121,13 +126,17 @@ export function ProtocolSetupLabware({
     labwareDef: LabwareDefinition2,
     labwareId: string
   ): void => {
-    const foundLabwareLocation = mostRecentAnalysis?.labware.find(
+    const foundLabware = mostRecentAnalysis?.labware.find(
       labware => labware.id === labwareId
-    )?.location
-    if (foundLabwareLocation != null) {
+    )
+    if (foundLabware != null) {
+      const nickName = onDeckItems.find(
+        item => getLabwareDefURI(item.definition) === foundLabware.definitionUri
+      )?.nickName
       setSelectedLabware({
         ...labwareDef,
-        location: foundLabwareLocation,
+        location: foundLabware.location,
+        nickName: nickName ?? null,
       })
       setShowLabwareDetailsModal(true)
     }
@@ -261,7 +270,7 @@ export function ProtocolSetupLabware({
               <Flex
                 flexDirection={DIRECTION_COLUMN}
                 alignItems={ALIGN_FLEX_START}
-                gridGap={SPACING.spacing16}
+                gridGap={SPACING.spacing12}
               >
                 <Flex gridGap={SPACING.spacing4}>{location}</Flex>
                 <StyledText
@@ -269,6 +278,9 @@ export function ProtocolSetupLabware({
                   fontSize={TYPOGRAPHY.fontSize22}
                 >
                   {getLabwareDisplayName(selectedLabware)}
+                </StyledText>
+                <StyledText as="p" color={COLORS.darkBlack70}>
+                  {selectedLabware.nickName}
                 </StyledText>
               </Flex>
             </Flex>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

updates the labware modal that is shown when a piece of labware is tapped on the deck map during protocol setup to match the designs

closes RAUT-530

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

opened the deck map from the labware setup page, tapped a labware, verified the modal style matches the designs and outside click behavior works as expected
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- switched out `LegacyModal` for `Modal` in `ProtoclSetupLabware` for the labware details modal
- made use of the `LocationIcon` component instead of the text based location display

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

ensure the PR addresses the noted issues in RAUT-530

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
