### PR TITLE
fix(app): Add back button to still attached modal [RAUT-420]

### DIFF
--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -61,6 +61,7 @@ const BUTTON_STYLE = css`
   padding-bottom: ${SPACING.spacing32};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    justify-content: ${JUSTIFY_SPACE_BETWEEN};
     padding-bottom: ${SPACING.spacing32};
     padding-left: ${SPACING.spacing32};
   }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import {
+  Btn,
   COLORS,
+  RESPONSIVENESS,
   TYPOGRAPHY,
   SPACING,
   PrimaryButton,
@@ -17,6 +20,7 @@ import {
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { SmallButton } from '../../atoms/buttons'
+import { StyledText } from '../../atoms/text'
 import { CheckPipetteButton } from './CheckPipetteButton'
 import { FLOWS } from './constants'
 import type { PipetteWizardStepProps } from './types'
@@ -33,6 +37,7 @@ interface ResultsProps extends PipetteWizardStepProps {
 
 export const Results = (props: ResultsProps): JSX.Element => {
   const {
+    goBack,
     proceed,
     flowType,
     attachedPipettes,
@@ -237,10 +242,33 @@ export const Results = (props: ResultsProps): JSX.Element => {
     requiredPipDisplayName == null &&
     (flowType === FLOWS.ATTACH || flowType === FLOWS.DETACH)
   ) {
+    const GO_BACK_BUTTON_STYLE = css`
+      ${TYPOGRAPHY.pSemiBold};
+      color: ${COLORS.darkGreyEnabled};
+
+      &:hover {
+        opacity: 70%;
+      }
+
+      @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+        font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+        font-size: ${TYPOGRAPHY.fontSize22};
+
+        &:hover {
+          opacity: 100%;
+        }
+      }
+    `
     subHeader = numberOfTryAgains > 2 ? t('something_seems_wrong') : undefined
     button = (
       <>
-        {isOnDevice ? null : (
+        {isOnDevice ? (
+          <Btn onClick={goBack} aria-label="back">
+            <StyledText css={GO_BACK_BUTTON_STYLE}>
+              {t('shared:go_back')}
+            </StyledText>
+          </Btn>
+        ) : (
           <SecondaryButton
             isDangerous
             onClick={handleCleanUpAndClose}


### PR DESCRIPTION

# Overview

This PR adds a "Go back" button to the "Pipette is still attached" modal when unsuccessfully detaching a pipette. The button goes back one step rather than starting over like the "try again" button does.

Closes RAUT-420

# Test Plan

Manually tested on ODD and simulated ODD. See attached screenshot.

# Changelog

- Added Flex ODD spacing to SimpleWizardBody
- Added "Go back" button to ODD "still attached" modal

# Review requests

Verify Go back button is present, as described in RAUT-420

# Risk assessment

Low

![Screenshot 2023-06-30 at 12 25 50 AM](https://github.com/Opentrons/opentrons/assets/2960/2d5de05e-5647-46a2-bab1-2658587e0393)

