### PR TITLE
feat(protocol-designer, components): some more misc things for trash slot, modals, and copy updates

### DIFF
--- a/components/src/slotmap/SlotMap.tsx
+++ b/components/src/slotmap/SlotMap.tsx
@@ -25,7 +25,7 @@ const OT2_SLOT_MAP_SLOTS = [
 ]
 
 const FLEX_SLOT_MAP_SLOTS = [
-  ['A1', 'A2', 'A3'],
+  ['A1', 'A2'],
   ['B1', 'B2', 'B3'],
   ['C1', 'C2', 'C3'],
   ['D1', 'D2', 'D3'],

--- a/components/src/slotmap/__tests__/SlotMap.test.tsx
+++ b/components/src/slotmap/__tests__/SlotMap.test.tsx
@@ -35,7 +35,7 @@ describe('SlotMap', () => {
     const wrapper = shallow(
       <SlotMap occupiedSlots={['D1']} robotType={FLEX_ROBOT_TYPE} />
     )
-    expect(wrapper.find('rect')).toHaveLength(12)
+    expect(wrapper.find('rect')).toHaveLength(11)
   })
 
   it('component renders crash info icon when collision slots present for flex', () => {

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -130,7 +130,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
 
           cy.get('div')
             .contains(
-              'This protocol can only run on app and robot server version 6.2 or higher'
+              'This protocol can only run on app and robot server version 7.0 or higher'
             )
             .should('exist')
           cy.get('button').contains('continue', { matchCase: false }).click()

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -91,7 +91,7 @@ export const VIEWBOX_HEIGHT = 414
 
 const OT2_VIEWBOX = `${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`
 const FLEX_VIEWBOX = '-144.31 -76.59 750 580'
-
+const FLEX_TRASH_SLOT = 'A3'
 export interface SwapBlockedArgs {
   hoveredLabware?: LabwareOnDeckType | null
   draggedLabware?: LabwareOnDeckType | null
@@ -146,7 +146,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     deckDef,
     robotType,
   } = props
-
+  const trashSlot = robotType === FLEX_ROBOT_TYPE ? FLEX_TRASH_SLOT : 12
   // NOTE: handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls.
   // But when swapping labware when at least one is on a module, we need to be aware
@@ -357,7 +357,8 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
         .filter(
           slot =>
             !slotIdsBlockedBySpanning.includes(slot.id) &&
-            getSlotIsEmpty(activeDeckSetup, slot.id)
+            getSlotIsEmpty(activeDeckSetup, slot.id) &&
+            slot.id !== trashSlot
         )
         .map(slot => {
           return (

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -91,7 +91,6 @@ export const VIEWBOX_HEIGHT = 414
 
 const OT2_VIEWBOX = `${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`
 const FLEX_VIEWBOX = '-144.31 -76.59 750 580'
-const FLEX_TRASH_SLOT = 'A3'
 export interface SwapBlockedArgs {
   hoveredLabware?: LabwareOnDeckType | null
   draggedLabware?: LabwareOnDeckType | null
@@ -146,7 +145,6 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     deckDef,
     robotType,
   } = props
-  const trashSlot = robotType === FLEX_ROBOT_TYPE ? FLEX_TRASH_SLOT : 12
   // NOTE: handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls.
   // But when swapping labware when at least one is on a module, we need to be aware
@@ -357,8 +355,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
         .filter(
           slot =>
             !slotIdsBlockedBySpanning.includes(slot.id) &&
-            getSlotIsEmpty(activeDeckSetup, slot.id) &&
-            slot.id !== trashSlot
+            getSlotIsEmpty(activeDeckSetup, slot.id)
         )
         .map(slot => {
           return (

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -91,6 +91,7 @@ export const VIEWBOX_HEIGHT = 414
 
 const OT2_VIEWBOX = `${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`
 const FLEX_VIEWBOX = '-144.31 -76.59 750 580'
+
 export interface SwapBlockedArgs {
   hoveredLabware?: LabwareOnDeckType | null
   draggedLabware?: LabwareOnDeckType | null
@@ -145,6 +146,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     deckDef,
     robotType,
   } = props
+
   // NOTE: handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls.
   // But when swapping labware when at least one is on a module, we need to be aware

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -166,12 +166,12 @@ function getWarningContent({
   return null
 }
 
-export const v6WarningContent: JSX.Element = (
+export const v7WarningContent: JSX.Element = (
   <div>
     <p>
-      {i18n.t(`alert.hint.export_v6_protocol_6_20.body1`)}{' '}
-      <strong>{i18n.t(`alert.hint.export_v6_protocol_6_20.body2`)}</strong>
-      {i18n.t(`alert.hint.export_v6_protocol_6_20.body3`)}
+      {i18n.t(`alert.hint.export_v7_protocol_7_0.body1`)}{' '}
+      <strong>{i18n.t(`alert.hint.export_v7_protocol_7_0.body2`)}</strong>
+      {i18n.t(`alert.hint.export_v7_protocol_7_0.body3`)}
     </p>
   </div>
 )
@@ -249,8 +249,8 @@ export function FileSidebar(props: Props): JSX.Element {
     content: React.ReactNode
   } => {
     return {
-      hintKey: 'export_v6_protocol_6_20',
-      content: v6WarningContent,
+      hintKey: 'export_v7_protocol_7_0',
+      content: v7WarningContent,
     }
   }
 

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import { useBlockingHint } from '../../Hints/useBlockingHint'
-import { FileSidebar, v6WarningContent } from '../FileSidebar'
+import { FileSidebar, v7WarningContent } from '../FileSidebar'
 
 jest.mock('../../Hints/useBlockingHint')
 jest.mock('../../../file-data/selectors')
@@ -233,8 +233,8 @@ describe('FileSidebar', () => {
     // Before save button is clicked, enabled should be false
     expect(mockUseBlockingHint).toHaveBeenNthCalledWith(1, {
       enabled: false,
-      hintKey: 'export_v6_protocol_6_20',
-      content: v6WarningContent,
+      hintKey: 'export_v7_protocol_7_0',
+      content: v7WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),
     })
@@ -245,8 +245,8 @@ describe('FileSidebar', () => {
     // After save button is clicked, enabled should be true
     expect(mockUseBlockingHint).toHaveBeenLastCalledWith({
       enabled: true,
-      hintKey: 'export_v6_protocol_6_20',
-      content: v6WarningContent,
+      hintKey: 'export_v7_protocol_7_0',
+      content: v7WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),
     })

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
@@ -38,9 +38,11 @@ export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
 
   return (
     <>
-      <Tooltip lineHeight="1.5" {...tooltipProps}>
-        {tooltipContent}
-      </Tooltip>
+      {tooltipContent && (
+        <Tooltip lineHeight="1.5" {...tooltipProps}>
+          {tooltipContent}
+        </Tooltip>
+      )}
       <div className={styles.checkbox_row}>
         <DeprecatedCheckboxField
           className={cx(styles.checkbox_field, className)}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLabwareForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLabwareForm/index.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import {
+  ALIGN_CENTER,
+  Flex,
   FormGroup,
+  SPACING,
   Tooltip,
   TOOLTIP_BOTTOM,
   TOOLTIP_FIXED,
@@ -10,14 +13,14 @@ import {
 import { i18n } from '../../../../localization'
 import {
   LabwareField,
-  ToggleRowField,
   LabwareLocationField,
+  CheckboxRowField,
 } from '../../fields'
 import styles from '../../StepEditForm.css'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { getRobotType } from '../../../../file-data/selectors'
 import { getAdditionalEquipment } from '../../../../step-forms/selectors'
-import { StepFormProps } from '../../types'
+import type { StepFormProps } from '../../types'
 
 export const MoveLabwareForm = (props: StepFormProps): JSX.Element => {
   const { propsForFields } = props
@@ -46,7 +49,11 @@ export const MoveLabwareForm = (props: StepFormProps): JSX.Element => {
           <LabwareField {...propsForFields.labware} />
         </FormGroup>
         {robotType === FLEX_ROBOT_TYPE ? (
-          <>
+          <Flex
+            alignItems={ALIGN_CENTER}
+            marginTop={SPACING.spacing4}
+            marginLeft={SPACING.spacing16}
+          >
             {!isGripperAttached ? (
               <Tooltip {...tooltipProps}>
                 {i18n.t(
@@ -55,23 +62,15 @@ export const MoveLabwareForm = (props: StepFormProps): JSX.Element => {
               </Tooltip>
             ) : null}
             <div {...targetProps}>
-              <FormGroup
-                className={styles.small_field}
-                label={i18n.t('form.step_edit_form.field.useGripper.label')}
-              >
-                <ToggleRowField
+              <FormGroup>
+                <CheckboxRowField
                   {...propsForFields.useGripper}
                   disabled={!isGripperAttached}
-                  offLabel={i18n.t(
-                    'form.step_edit_form.field.useGripper.toggleOff'
-                  )}
-                  onLabel={i18n.t(
-                    'form.step_edit_form.field.useGripper.toggleOn'
-                  )}
+                  label={i18n.t('form.step_edit_form.field.useGripper.label')}
                 />
               </FormGroup>
             </div>
-          </>
+          </Flex>
         ) : null}
       </div>
       <div className={styles.form_row}>

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -4,7 +4,7 @@ import {
   Flex,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_AROUND,
-  SPACING_3,
+  SPACING,
 } from '@opentrons/components'
 import styles from './AnnouncementModal.css'
 
@@ -17,7 +17,7 @@ export interface Announcement {
 
 const batchEditStyles = css`
   justify-content: ${JUSTIFY_SPACE_AROUND};
-  padding: ${SPACING_3};
+  padding: ${SPACING.spacing16};
 
   & img {
     height: 13rem;

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-import { Flex, JUSTIFY_SPACE_AROUND, SPACING_3 } from '@opentrons/components'
+import {
+  Flex,
+  JUSTIFY_CENTER,
+  JUSTIFY_SPACE_AROUND,
+  SPACING_3,
+} from '@opentrons/components'
 import styles from './AnnouncementModal.css'
 
 export interface Announcement {
@@ -186,6 +191,30 @@ export const announcements: Announcement[] = [
         <p>
           All protocols now require Opentrons App version
           <strong> 6.2+ </strong> to run.
+        </p>
+      </>
+    ),
+  },
+  {
+    announcementKey: 'flexSupport7.0',
+    image: (
+      <Flex justifyContent={JUSTIFY_CENTER}>
+        <img
+          height="240"
+          width="240"
+          src={require('../../../images/OpentronsFlex.png')}
+        />
+      </Flex>
+    ),
+    heading: "We've updated the Protocol Designer",
+    message: (
+      <>
+        <p>
+          Introducing the Protocol Designer 7.0 with Opentrons Flex support!
+        </p>
+        <p>
+          All protocols now require Opentrons App version
+          <strong> 7.0+ </strong> to run.
         </p>
       </>
     ),

--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -3,7 +3,11 @@ import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
 import _fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import _fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import _fixture_trash from '@opentrons/shared-data/labware/fixtures/2/fixture_trash.json'
-import { LabwareDefinition2 } from '@opentrons/shared-data'
+import {
+  LabwareDefinition2,
+  OT2_ROBOT_TYPE,
+  OT2_STANDARD_DECKID,
+} from '@opentrons/shared-data'
 import {
   LabwareLiquidState,
   LabwareEntities,
@@ -65,3 +69,5 @@ export const labwareDefsByURI: LabwareDefByDefURI = {
   'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': fixture96Plate,
   'opentrons/opentrons_1_trash_1100ml_fixed/1': fixtureTrash,
 }
+
+export const ot2Robot = { model: OT2_ROBOT_TYPE, deckId: OT2_STANDARD_DECKID }

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -22,6 +22,7 @@ import {
   labwareNicknamesById,
   labwareDefsByURI,
   pipetteEntities,
+  ot2Robot,
 } from '../__fixtures__/createFile/commonFields'
 import * as v6Fixture from '../__fixtures__/createFile/v6Fixture'
 import {
@@ -76,6 +77,7 @@ describe('createFile selector', () => {
       fileMetadata,
       v6Fixture.initialRobotState,
       v6Fixture.robotStateTimeline,
+      ot2Robot,
       dismissedWarnings,
       ingredients,
       ingredLocations,

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -7,16 +7,13 @@ import reduce from 'lodash/reduce'
 import uniq from 'lodash/uniq'
 import {
   FIXED_TRASH_ID,
-  GEN2,
-  GEN3,
-  getPipetteNameSpecs,
+  FLEX_ROBOT_TYPE,
   OT2_STANDARD_DECKID,
   OT2_STANDARD_MODEL,
   OT3_STANDARD_DECKID,
-  OT3_STANDARD_MODEL,
   SPAN7_8_10_11_SLOT,
 } from '@opentrons/shared-data'
-import { getFileMetadata } from './fileFields'
+import { getFileMetadata, getRobotType } from './fileFields'
 import { getInitialRobotState, getRobotStateTimeline } from './commands'
 import { selectors as dismissSelectors } from '../../dismiss'
 import {
@@ -53,6 +50,7 @@ import type {
   LoadPipetteCreateCommand,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 import type { PipetteName } from '@opentrons/shared-data/js/pipettes'
+
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')
 if (isEmpty(process.env.OT_PD_VERSION))
@@ -94,6 +92,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
   getFileMetadata,
   getInitialRobotState,
   getRobotStateTimeline,
+  getRobotType,
   dismissSelectors.getAllDismissedWarnings,
   ingredSelectors.getLiquidGroupsById,
   ingredSelectors.getLiquidsByLabwareId,
@@ -108,6 +107,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     fileMetadata,
     initialRobotState,
     robotStateTimeline,
+    robotType,
     dismissedWarnings,
     ingredients,
     ingredLocations,
@@ -287,40 +287,6 @@ export const createFile: Selector<ProtocolFile> = createSelector(
 
     const commands = [...loadCommands, ...nonLoadCommands]
 
-    interface RobotModel {
-      [pipetteId: string]: { name: PipetteName }
-    }
-
-    //  TODO(jr 6/22/23):  entire method should be replaced with the contents of robotType key
-    //  on the protocol file instead of inferring it from pipette types.
-    const getRobotModelFromPipettes = (
-      pipettes: RobotModel
-    ): {
-      model: typeof OT2_STANDARD_MODEL | typeof OT3_STANDARD_MODEL
-      deckId: typeof OT2_STANDARD_DECKID | typeof OT3_STANDARD_DECKID
-    } => {
-      const loadedPipettes = Object.values(pipettes)
-      const pipetteGEN = loadedPipettes.some(
-        pipette =>
-          getPipetteNameSpecs(pipette.name)?.displayCategory === GEN3 ||
-          getPipetteNameSpecs(pipette.name)?.channels === 96
-      )
-        ? GEN3
-        : GEN2
-      switch (pipetteGEN) {
-        case GEN3:
-          return {
-            model: OT3_STANDARD_MODEL,
-            deckId: OT3_STANDARD_DECKID,
-          }
-        default:
-          return {
-            model: OT2_STANDARD_MODEL,
-            deckId: OT2_STANDARD_DECKID,
-          }
-      }
-    }
-
     const protocolFile = {
       metadata: {
         protocolName: name,
@@ -334,7 +300,10 @@ export const createFile: Selector<ProtocolFile> = createSelector(
         tags: [],
       },
       designerApplication,
-      robot: getRobotModelFromPipettes(pipettes),
+      robot:
+        robotType === FLEX_ROBOT_TYPE
+          ? { model: FLEX_ROBOT_TYPE, deckId: OT3_STANDARD_DECKID }
+          : { model: OT2_STANDARD_MODEL, deckId: OT2_STANDARD_DECKID },
       pipettes,
       labware,
       liquids,

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -49,7 +49,6 @@ import type {
   LoadModuleCreateCommand,
   LoadPipetteCreateCommand,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
-import type { PipetteName } from '@opentrons/shared-data/js/pipettes'
 
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -49,11 +49,11 @@
       "title": "Missing labware",
       "body": "Your module has no labware on it. We recommend you add labware before proceeding."
     },
-    "export_v6_protocol_6_20": {
+    "export_v7_protocol_7_0": {
       "title": "Robot and app update may be required",
       "body1": "This protocol can only run on app and robot server version",
-      "body2": "6.2 or higher",
-      "body3": ". Please ensure your OT-2 is updated to the correct version."
+      "body2": "7.0 or higher",
+      "body3": ". Please ensure your robot is updated to the correct version."
     },
     "change_magnet_module_model": {
       "title": "All existing engage heights will be cleared"

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -141,12 +141,12 @@
         "body": "8-Channel pipettes cannot access labware in front of or behind a Heater-Shaker. They can access Opentrons Tip Racks in this slot. Move labware to a different slot."
       },
       "LABWARE_OFF_DECK": {
-        "title": "Robot interacting with an off deck labware",
-        "body": "Labware must be on the deck for the robot to interact with it. To resolve this error, please make sure the labware is on deck."
+        "title": "Labware is off deck",
+        "body": "The robot can only perform steps on labware that is on the deck. Add or change a Move Labware step to put it on the deck before this step."
       },
       "HEATER_SHAKER_LATCH_CLOSED": {
         "title": "Heater-Shaker labware latch is closed",
-        "body": "Before the robot can interact with labware on the Heater-Shaker module, the labware latch must be open. To resolve this error, please add a Heater-Shaker step ahead of the current step, and set the labware latch status to \"open\"."
+        "body": "The Heater-Shaker’s labware latch must be open when moving labware to or from the module. Add a Heater-Shaker step that opens the latch before this step."
       }
     },
     "warning": {
@@ -212,7 +212,7 @@
     },
     "unused_gripper": {
       "heading": "Unused gripper",
-      "body1": "The Flex Gripper is specified in your protocol is not currently used in any step. In order to run this protocol you will need to connect it to your robot.",
+      "body1": "The Flex Gripper specified in your protocol is not currently used in any step. In order to run this protocol you will need to connect it to your robot.",
       "body2": "If you don't intend to use the Flex Gripper, please consider removing it from your protocol."
     }
   },

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -167,10 +167,6 @@ const HS_AND_TEMP_SLOTS_FLEX: DropdownOption[] = [
     name: 'Slot A1',
     value: 'A1',
   },
-  {
-    name: 'Slot A3',
-    value: 'A3',
-  },
 ]
 
 const MAG_BLOCK_SLOTS_FLEX: DropdownOption[] = [
@@ -217,10 +213,6 @@ const MAG_BLOCK_SLOTS_FLEX: DropdownOption[] = [
   {
     name: 'Slot A2',
     value: 'A2',
-  },
-  {
-    name: 'Slot A3',
-    value: 'A3',
   },
 ]
 export function getAllModuleSlotsByType(

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -4,6 +4,7 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   getDeckDefFromRobotType,
   getModuleDisplayName,
+  FLEX_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import {
   START_TERMINAL_ITEM_ID,
@@ -93,6 +94,7 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
   getRobotType,
   (robotState, moduleEntities, robotType) => {
     const deckDef = getDeckDefFromRobotType(robotType)
+    const trashSlot = robotType === FLEX_ROBOT_TYPE ? 'A3' : '12'
     const allSlotIds = deckDef.locations.orderedSlots.map(slot => slot.id)
     if (robotState == null) return null
 
@@ -140,7 +142,8 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
           !slotIdsOccupiedByModules.includes(slotId) &&
           !Object.values(labware)
             .map(lw => lw.slot)
-            .includes(slotId)
+            .includes(slotId) &&
+          slotId !== trashSlot
       )
       .map(slotId => ({ name: slotId, value: slotId }))
 

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -9,12 +9,13 @@ type HintKey =  // normal hints
   | 'protocol_can_enter_batch_edit'
   // blocking hints
   | 'custom_labware_with_modules'
-  | 'export_v6_protocol_6_20'
+  | 'export_v7_protocol_7_0'
   | 'change_magnet_module_model'
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
 // 'export_v4_protocol'
 // | 'export_v4_protocol_3_18'
 // | 'export_v5_protocol_3_20'
 // | 'export_v6_protocol_6_10'
+// | 'export_v6_protocol_6_20'
 export { actions, rootReducer, selectors }
 export type { RootState, HintKey }

--- a/protocol-designer/typings/reselect.d.ts
+++ b/protocol-designer/typings/reselect.d.ts
@@ -1,6 +1,6 @@
 import { OutputSelector, Selector } from 'reselect'
 declare module 'reselect' {
-  // declaring type for createSelector with 13 selectors because the reselect types only support up to 12 selectors
+  // declaring type for createSelector with 14 selectors because the reselect types only support up to 12 selectors
   export function createSelector<
     S,
     R1,
@@ -16,6 +16,7 @@ declare module 'reselect' {
     R11,
     R12,
     R13,
+    R14,
     T
   >(
     selector1: Selector<S, R1>,
@@ -31,6 +32,7 @@ declare module 'reselect' {
     selector11: Selector<S, R11>,
     selector12: Selector<S, R12>,
     selector13: Selector<S, R13>,
+    selector14: Selector<S, R14>,
     combiner: (
       res1: R1,
       res2: R2,
@@ -44,7 +46,8 @@ declare module 'reselect' {
       res10: R10,
       res11: R11,
       res12: R12,
-      res13: R13
+      res13: R13,
+      res14: R14
     ) => T
   ): OutputSelector<
     S,
@@ -62,7 +65,8 @@ declare module 'reselect' {
       res10: R10,
       res11: R11,
       res12: R12,
-      res13: R13
+      res13: R13,
+      res14: R14
     ) => T
   >
 }


### PR DESCRIPTION
closes RLIQ-413, RLIQ-414, RAUT-535, RAUT-536, RAUT-537

# Overview

A handful of things:
1. updates announcement modal
2. updates export modal
3. copy updates among the timeline errors and the advance setting
4. you can no longer put the modules or move labware to the trash slot A3 (note you can move labware into there but that is to be addressed in a follow up ticket)
5. refactors `fileCreator` to use `robotType` selector instead of getting robot type from the pipettes
6. change gripper toggle to a check box

# Test Plan

To test this: https://sandbox.designer.opentrons.com/pd_trash-slot/

test all those areas mentioned in overview. When you export the file, make sure that the robot key is correct for OT-2 and Flex

# Changelog

- i18n changes
- some trash slot modifcations
- modal updates
- fix cypress tests

# Review requests

see test plan

# Risk assessment

low