### PR TITLE
fix(app): toast and snackbar tweaks [RAUT-379]

### DIFF
--- a/app/src/atoms/Snackbar/__tests__/Snackbar.test.tsx
+++ b/app/src/atoms/Snackbar/__tests__/Snackbar.test.tsx
@@ -48,7 +48,7 @@ describe('Snackbar', () => {
     })
     expect(props.onClose).not.toHaveBeenCalled()
     act(() => {
-      jest.advanceTimersByTime(4000)
+      jest.advanceTimersByTime(5000)
     })
     expect(props.onClose).toHaveBeenCalled()
   })
@@ -67,7 +67,7 @@ describe('Snackbar', () => {
     })
     expect(props.onClose).not.toHaveBeenCalled()
     act(() => {
-      jest.advanceTimersByTime(4000)
+      jest.advanceTimersByTime(5000)
     })
     expect(props.onClose).toHaveBeenCalled()
   })

--- a/app/src/atoms/Snackbar/index.tsx
+++ b/app/src/atoms/Snackbar/index.tsx
@@ -37,16 +37,37 @@ const OPEN_STYLE = css`
   }
 `
 
+const CLOSE_STYLE = css`
+  animation-duration: ${SNACKBAR_ANIMATION_DURATION}ms;
+  animation-name: fadeout;
+  overflow: hidden;
+
+  @keyframes fadeout {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+`
+
 export function Snackbar(props: SnackbarProps): JSX.Element {
   const { message, onClose, duration = 4000, ...styleProps } = props
+  const [isClosed, setIsClosed] = React.useState<boolean>(false)
+
+  const animationStyle = isClosed ? CLOSE_STYLE : OPEN_STYLE
 
   setTimeout(() => {
-    onClose?.()
+    setIsClosed(true)
+    setTimeout(() => {
+      onClose?.()
+    }, SNACKBAR_ANIMATION_DURATION - 50)
   }, duration)
 
   return (
     <Flex
-      css={OPEN_STYLE}
+      css={animationStyle}
       alignItems={ALIGN_CENTER}
       borderRadius={BORDERS.borderRadiusSize3}
       boxShadow={BORDERS.shadowSmall}

--- a/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
 import { act, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
 import { Toast } from '..'
 
 const render = (props: React.ComponentProps<typeof Toast>) => {
-  return renderWithProviders(<Toast {...props} displayType="odd" />)[0]
+  return renderWithProviders(<Toast {...props} displayType="odd" />, {
+    i18nInstance: i18n,
+  })[0]
 }
 
 describe('Toast', () => {

--- a/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
@@ -102,7 +102,7 @@ describe('Toast', () => {
     })
     expect(props.onClose).not.toHaveBeenCalled()
     act(() => {
-      jest.advanceTimersByTime(7000)
+      jest.advanceTimersByTime(8000)
     })
     expect(props.onClose).toHaveBeenCalled()
   })
@@ -144,7 +144,7 @@ describe('Toast', () => {
     })
     expect(props.onClose).not.toHaveBeenCalled()
     act(() => {
-      jest.advanceTimersByTime(8000)
+      jest.advanceTimersByTime(9000)
     })
     expect(props.onClose).toHaveBeenCalled()
   })

--- a/app/src/atoms/Toast/__tests__/Toast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/Toast.test.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
 import { act, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
 import { Toast } from '..'
 
 const render = (props: React.ComponentProps<typeof Toast>) => {
-  return renderWithProviders(<Toast {...props} displayType="desktop" />)[0]
+  return renderWithProviders(<Toast {...props} displayType="desktop" />, {
+    i18nInstance: i18n,
+  })[0]
 }
 
 describe('Toast', () => {

--- a/app/src/atoms/Toast/__tests__/Toast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/Toast.test.tsx
@@ -119,7 +119,7 @@ describe('Toast', () => {
     })
     expect(props.onClose).not.toHaveBeenCalled()
     act(() => {
-      jest.advanceTimersByTime(8000)
+      jest.advanceTimersByTime(9000)
     })
     expect(props.onClose).toHaveBeenCalled()
   })
@@ -163,7 +163,7 @@ describe('Toast', () => {
     })
     expect(props.onClose).not.toHaveBeenCalled()
     act(() => {
-      jest.advanceTimersByTime(8000)
+      jest.advanceTimersByTime(9000)
     })
     expect(props.onClose).toHaveBeenCalled()
   })

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -210,7 +210,7 @@ export function Toast(props: ToastProps): JSX.Element {
       <Flex
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_ROW}
-        gridGap={SPACING.spacing4}
+        gridGap={SPACING.spacing8}
         overflow="hidden"
         width="100%"
       >
@@ -219,7 +219,7 @@ export function Toast(props: ToastProps): JSX.Element {
           color={toastStyleByType[type].color}
           maxWidth={showODDStyle ? SPACING.spacing32 : SPACING.spacing16}
           minWidth={showODDStyle ? SPACING.spacing32 : SPACING.spacing16}
-          marginRight={SPACING.spacing8}
+          marginRight={showODDStyle ? SPACING.spacing8 : '0'}
           spin={icon?.spin != null ? icon.spin : false}
           aria-label={`icon_${type}`}
         />

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -63,6 +63,7 @@ export function Toast(props: ToastProps): JSX.Element {
     ...styleProps
   } = props
   const { t } = useTranslation('shared')
+  const [isClosed, setIsClosed] = React.useState<boolean>(false)
 
   // We want to be able to storybook both the ODD and the Desktop versions,
   // so let it (and unit tests, for that matter) be able to pass in a parameter
@@ -80,7 +81,7 @@ export function Toast(props: ToastProps): JSX.Element {
       : closeButton === true
       ? t('close')
       : ''
-  const DESKTOP_ANIMATION = css`
+  const DESKTOP_ANIMATION_IN = css`
     animation-duration: ${TOAST_ANIMATION_DURATION}ms;
     animation-name: slidein;
     overflow: hidden;
@@ -94,7 +95,25 @@ export function Toast(props: ToastProps): JSX.Element {
       }
     }
   `
-  const ODD_ANIMATION = css`
+  const DESKTOP_ANIMATION_OUT = css`
+    animation-duration: ${TOAST_ANIMATION_DURATION}ms;
+    animation-name: slideout;
+    overflow: hidden;
+
+    @keyframes slideout {
+      from {
+        transform: translateX(0%);
+      }
+      to {
+        transform: translateX(100%);
+      }
+    }
+  `
+  const desktopAnimation = isClosed
+    ? DESKTOP_ANIMATION_OUT
+    : DESKTOP_ANIMATION_IN
+
+  const ODD_ANIMATION_IN = css`
     animation-duration: ${TOAST_ANIMATION_DURATION}ms;
     animation-name: slideup;
     overflow: hidden;
@@ -108,6 +127,22 @@ export function Toast(props: ToastProps): JSX.Element {
       }
     }
   `
+  const ODD_ANIMATION_OUT = css`
+    animation-duration: ${TOAST_ANIMATION_DURATION}ms;
+    animation-name: slidedown;
+    overflow: hidden;
+
+    @keyframes slidedown {
+      from {
+        transform: translateY(0%);
+      }
+      to {
+        transform: translateY(100%);
+      }
+    }
+  `
+
+  const oddAnimation = isClosed ? ODD_ANIMATION_OUT : ODD_ANIMATION_IN
 
   const toastStyleByType: {
     [k in ToastType]: {
@@ -173,13 +208,16 @@ export function Toast(props: ToastProps): JSX.Element {
 
   if (!disableTimeout) {
     setTimeout(() => {
-      onClose?.()
+      setIsClosed(true)
+      setTimeout(() => {
+        onClose?.()
+      }, TOAST_ANIMATION_DURATION - 50)
     }, calculatedDuration(message, headingText, duration))
   }
 
   return (
     <Flex
-      css={showODDStyle ? ODD_ANIMATION : DESKTOP_ANIMATION}
+      css={showODDStyle ? oddAnimation : desktopAnimation}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       alignItems={ALIGN_CENTER}
       borderRadius={

--- a/app/src/organisms/ToasterOven/ToasterOven.tsx
+++ b/app/src/organisms/ToasterOven/ToasterOven.tsx
@@ -114,6 +114,7 @@ export function ToasterOven({ children }: ToasterOvenProps): JSX.Element {
           position="absolute"
           bottom={SPACING.spacing40}
           zIndex={1000}
+          onClick={() => {eatSnackbar()}}
         >
           <Snackbar
             {...snackbar}

--- a/app/src/organisms/ToasterOven/ToasterOven.tsx
+++ b/app/src/organisms/ToasterOven/ToasterOven.tsx
@@ -114,7 +114,9 @@ export function ToasterOven({ children }: ToasterOvenProps): JSX.Element {
           position="absolute"
           bottom={SPACING.spacing40}
           zIndex={1000}
-          onClick={() => {eatSnackbar()}}
+          onClick={() => {
+            eatSnackbar()
+          }}
         >
           <Snackbar
             {...snackbar}


### PR DESCRIPTION
# Overview

This PR adds a new tap-to-close behavior for snackbars, tweaks icon spacing for toasts, and adds closing animation for both.

Closes RAUT-379

# Test Plan

Manually tested on desktop, ODD, and storybook

# Changelog

- Closes active snackbar when tapped
- Tweaks padding between icon and text on toasts
- Adds closing animations to toasts and snackbars

# Review requests

Trigger a snackbar and tap on it to watch it disappear. Let toasts and snackbars close on their own and watch as the slide out or fade from view gracefully.

# Risk assessment

None
