### PR TITLE
feat(hardware-testing): Bring back tip-presence detection

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/overrides/api.patch
+++ b/hardware-testing/hardware_testing/gravimetric/overrides/api.patch
@@ -72,32 +72,6 @@ index 815dada3b9..30121fc4c8 100644
  
      def add_tip(self, tip_length: float) -> None:
          """
-diff --git a/api/src/opentrons/hardware_control/ot3api.py b/api/src/opentrons/hardware_control/ot3api.py
-index 3b3d96fdbf..ca9b0e045b 100644
---- a/api/src/opentrons/hardware_control/ot3api.py
-+++ b/api/src/opentrons/hardware_control/ot3api.py
-@@ -1682,8 +1682,8 @@ class OT3API(
-         # TODO: implement tip-detection sequence during pick-up-tip for 96ch,
-         #       but not with DVT pipettes because those can only detect drops
-
--        if self.gantry_load != GantryLoad.HIGH_THROUGHPUT:
--            await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
-+        # if self.gantry_load != GantryLoad.HIGH_THROUGHPUT:
-+        #     await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
-
-         _add_tip_to_instrs()
-
-@@ -1764,8 +1764,8 @@ class OT3API(
-         )
-
-         # TODO: implement tip-detection sequence during drop-tip for 96ch
--        if self.gantry_load != GantryLoad.HIGH_THROUGHPUT:
--            await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
-+        # if self.gantry_load != GantryLoad.HIGH_THROUGHPUT:
-+        #    await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
-
-         # home mount axis
-         if home_after:
 diff --git a/api/src/opentrons/protocol_api/core/legacy/deck.py b/api/src/opentrons/protocol_api/core/legacy/deck.py
 index 54bca33742..e6b49e47fe 100644
 --- a/api/src/opentrons/protocol_api/core/legacy/deck.py


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Now that all 8ch DVT pipettes in SZ have been reworked, we can enable tip-presence detection during all volumetric tests.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
