### PR TITLE
fix(app): fix ui component stories

### DIFF
--- a/app/src/DesignTokens/BorderRadius/BorderRadius.stories.tsx
+++ b/app/src/DesignTokens/BorderRadius/BorderRadius.stories.tsx
@@ -24,8 +24,9 @@ interface BorderRadiusStorybookProps {
 
 const Template: Story<BorderRadiusStorybookProps> = args => {
   const targetBorderRadiuses = args.borderRadius.filter(s =>
-    s[0].includes('size_')
+    s[0].includes('borderRadiusSize')
   )
+  console.log(targetBorderRadiuses)
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}

--- a/app/src/atoms/structure/Divider.stories.tsx
+++ b/app/src/atoms/structure/Divider.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import {
+  ALIGN_CENTER,
   Box,
   Flex,
-  SPACING,
-  ALIGN_CENTER,
   JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { StyledText } from '../text'
 import { Divider } from './index'
@@ -21,7 +22,9 @@ const Template: Story<React.ComponentProps<typeof Divider>> = args => (
       <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box marginRight={SPACING.spacing32}>
           <Box marginBottom={SPACING.spacing8}>
-            <StyledText as="h3SemiBold">{'About Calibration'}</StyledText>
+            <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+              {'About Calibration'}
+            </StyledText>
           </Box>
           <StyledText as="p" marginBottom={SPACING.spacing8}>
             {'This section is about calibration.'}
@@ -34,7 +37,9 @@ const Template: Story<React.ComponentProps<typeof Divider>> = args => (
       <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box marginRight={SPACING.spacing32}>
           <Box marginBottom={SPACING.spacing8}>
-            <StyledText as="h3SemiBold">{'Deck Calibration'}</StyledText>
+            <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+              {'Deck Calibration'}
+            </StyledText>
           </Box>
           <StyledText as="p" marginBottom={SPACING.spacing8}>
             {'This section is for deck calibration.'}

--- a/app/src/atoms/structure/Line.stories.tsx
+++ b/app/src/atoms/structure/Line.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import {
+  ALIGN_CENTER,
   Box,
   Flex,
-  SPACING,
-  ALIGN_CENTER,
   JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { StyledText } from '../text'
 import { Line } from './index'
@@ -21,7 +22,9 @@ const Template: Story<React.ComponentProps<typeof Line>> = args => (
       <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box marginRight={SPACING.spacing32}>
           <Box marginBottom={SPACING.spacing8}>
-            <StyledText as="h3SemiBold">{'About Calibration'}</StyledText>
+            <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+              {'About Calibration'}
+            </StyledText>
           </Box>
           <StyledText as="p" marginBottom={SPACING.spacing8}>
             {'This section is about calibration.'}
@@ -34,7 +37,9 @@ const Template: Story<React.ComponentProps<typeof Line>> = args => (
       <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Box marginRight={SPACING.spacing32}>
           <Box marginBottom={SPACING.spacing8}>
-            <StyledText as="h3SemiBold">{'Deck Calibration'}</StyledText>
+            <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+              {'Deck Calibration'}
+            </StyledText>
           </Box>
           <StyledText as="p" marginBottom={SPACING.spacing8}>
             {'This section is for deck calibration.'}

--- a/app/src/atoms/text/StyledText.stories.tsx
+++ b/app/src/atoms/text/StyledText.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { StyledText } from './index'
 import type { Story, Meta } from '@storybook/react'
+import { TYPOGRAPHY } from '@opentrons/components'
 
 export default {
   title: 'App/Atoms/StyledText',
@@ -52,30 +53,35 @@ label.args = {
 
 export const h2SemiBold = Template.bind({})
 h2SemiBold.args = {
-  as: 'h2SemiBold',
+  as: 'h2',
+  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
   children: dummyText,
 }
 
 export const h3SemiBold = Template.bind({})
 h3SemiBold.args = {
-  as: 'h3SemiBold',
+  as: 'h3',
+  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
   children: dummyText,
 }
 
 export const h6SemiBold = Template.bind({})
 h6SemiBold.args = {
-  as: 'h6SemiBold',
+  as: 'h6',
+  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
   children: dummyText,
 }
 
 export const pSemiBold = Template.bind({})
 pSemiBold.args = {
-  as: 'pSemiBold',
+  as: 'p',
+  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
   children: dummyText,
 }
 
 export const labelSemiBold = Template.bind({})
 labelSemiBold.args = {
-  as: 'labelSemiBold',
+  as: 'label',
+  fontWeight: TYPOGRAPHY.fontWeightSemiBold,
   children: dummyText,
 }

--- a/app/src/molecules/GenericWizardTile/GenericWizardTile.stories.tsx
+++ b/app/src/molecules/GenericWizardTile/GenericWizardTile.stories.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
 import {
   DIRECTION_COLUMN,
   Flex,
@@ -9,9 +11,19 @@ import { StyledText } from '../../atoms/text'
 import { Skeleton } from '../../atoms/Skeleton'
 import { LegacyModalShell } from '../LegacyModal'
 import { WizardHeader } from '../WizardHeader'
+import { configReducer } from '../../redux/config/reducer'
 import { GenericWizardTile } from './index'
 
+import type { Store } from 'redux'
 import type { Story, Meta } from '@storybook/react'
+
+const dummyConfig = {
+  config: {
+    isOnDevice: false,
+  },
+} as any
+
+const store: Store<any> = createStore(configReducer, dummyConfig)
 
 export default {
   title: 'App/Molecules/GenericWizardTile',
@@ -21,10 +33,12 @@ export default {
 const Template: Story<
   React.ComponentProps<typeof GenericWizardTile>
 > = args => (
-  <LegacyModalShell>
-    <WizardHeader currentStep={3} totalSteps={4} title="Example Title" />
-    <GenericWizardTile {...args} />
-  </LegacyModalShell>
+  <Provider store={store}>
+    <LegacyModalShell>
+      <WizardHeader currentStep={3} totalSteps={4} title="Example Title" />
+      <GenericWizardTile {...args} />
+    </LegacyModalShell>
+  </Provider>
 )
 const body = (
   <StyledText as="p">

--- a/app/src/molecules/MiniCard/MiniCard.stories.tsx
+++ b/app/src/molecules/MiniCard/MiniCard.stories.tsx
@@ -6,6 +6,7 @@ import {
   TYPOGRAPHY,
   Flex,
   ALIGN_CENTER,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 import OT2_PNG from '../../assets/images/OT2-R_HERO.png'
 import { MiniCard } from './'
@@ -19,13 +20,17 @@ export default {
   component: MiniCard,
 } as Meta
 
-const Template: Story<React.ComponentProps<typeof MiniCard>> = args => (
-  <Slideout title="MiniCard" onCloseClick={() => {}} isExpanded={true}>
-    <MiniCard {...args} />
-    <MiniCard {...args} isSelected={false} />
-    <MiniCard {...args} isSelected={false} />
-  </Slideout>
-)
+const Template: Story<React.ComponentProps<typeof MiniCard>> = args => {
+  return (
+    <Slideout title="MiniCard" onCloseClick={() => {}} isExpanded={true}>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+        <MiniCard {...args} />
+        <MiniCard {...args} isSelected={false} />
+        <MiniCard {...args} isSelected={false} />
+      </Flex>
+    </Slideout>
+  )
+}
 
 const Children = (
   <Flex alignItems={ALIGN_CENTER}>

--- a/app/src/molecules/SimpleWizardBody/SimpleWizardBody.stories.tsx
+++ b/app/src/molecules/SimpleWizardBody/SimpleWizardBody.stories.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
 import { COLORS, PrimaryButton } from '@opentrons/components'
 import { LegacyModalShell } from '../LegacyModal'
 import { WizardHeader } from '../WizardHeader'
+import { configReducer } from '../../redux/config/reducer'
 import { SimpleWizardBody } from './index'
 
+import type { Store } from 'redux'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
@@ -11,11 +15,21 @@ export default {
   component: SimpleWizardBody,
 } as Meta
 
+const dummyConfig = {
+  config: {
+    isOnDevice: false,
+  },
+} as any
+
+const store: Store<any> = createStore(configReducer, dummyConfig)
+
 const Template: Story<React.ComponentProps<typeof SimpleWizardBody>> = args => (
-  <LegacyModalShell>
-    <WizardHeader currentStep={3} totalSteps={4} title="Attach a pipette" />
-    <SimpleWizardBody {...args} />
-  </LegacyModalShell>
+  <Provider store={store}>
+    <LegacyModalShell>
+      <WizardHeader currentStep={3} totalSteps={4} title="Attach a pipette" />
+      <SimpleWizardBody {...args} />
+    </LegacyModalShell>
+  </Provider>
 )
 
 export const AlertIcon = Template.bind({})

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -68,9 +68,9 @@ const BUTTON_STYLE = css`
 `
 const WIZARD_CONTAINER_STYLE = css`
   min-height: 394px;
-  flex-direction: ${DIRECTION_COLUMN}
-  justify-content: ${JUSTIFY_SPACE_BETWEEN}
-  height: 'auto'
+  flex-direction: ${DIRECTION_COLUMN};
+  justify-content: ${JUSTIFY_SPACE_BETWEEN};
+  height: 'auto';
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     height: 472px;
   }


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
remove console errors and fix broken stories.
GenericWizardTile and SimpleWizardBody were broken since they use redux but both of stories didn't use `Provider`

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
In my understanding, we should avoid using redux inside a component that under `molecules`.
What do you think about this?

For GripperWizardFlow, it uses react-query. Do we really need to have the story for that component?
 
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
