### PR TITLE
fix(hardware-testing): 96ch photometric confirm volume at beginning

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -297,11 +297,10 @@ def _run_trial(
             liquid_tracker.set_start_volume(source, required_ul)
         reservoir_ul = liquid_tracker.get_volume(source)
         print(
-            f"software thinks there is {reservoir_ul} mL "
-            f"of liquid in the reservoir (required = {required_ul} ml)"
+            f"software thinks there is {round(reservoir_ul / 1000, 1)} mL "
+            f"of liquid in the reservoir (required = {round(required_ul / 1000, 1)} ml)"
         )
         if required_ul <= reservoir_ul < _MAX_VOLUME_UL:
-            print("good")
             break
         elif required_ul > _MAX_VOLUME_UL:
             raise NotImplementedError(
@@ -323,7 +322,9 @@ def _run_trial(
             )
             pipette.move_to(location=source.top().move(channel_offset))
         else:
-            print("huh?")
+            raise RuntimeError(
+                f"bad volume in reservoir: {round(reservoir_ul / 1000, 1)} ml"
+            )
     # RUN ASPIRATE
     aspirate_with_liquid_class(
         ctx,

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -153,8 +153,6 @@ def _load_labware(
         print(f'Loading tiprack "{ls[1]}" in slot #{ls[0]}')
     reservoir = ctx.load_labware(cfg.reservoir, location=cfg.reservoir_slot)
     tiprack_namespace = "custom_beta"
-    if ctx.is_simulating():
-        tiprack_namespace = "opentrons"
     tipracks = [
         ctx.load_labware(ls[1], location=ls[0], namespace=tiprack_namespace)
         for ls in tiprack_load_settings


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If the 96ch is tilted then the volume in the reservoir may need to be greater than specified, so this PR adds a step where the operator can add more liquid at the beginning of the test-run if needed.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
