### PR TITLE
feat(hardware-testing): 96ch tip-rack adapters share LPC offsets

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/workarounds.py
+++ b/hardware-testing/hardware_testing/gravimetric/workarounds.py
@@ -81,10 +81,17 @@ def get_latest_offset_for_labware(
         return _v["x"] != 0 or _v["y"] != 0 or _v["z"] != 0
 
     def _offset_applies_to_labware(_o: dict) -> bool:
-        if _o["definitionUri"] != lw_uri:
-            return False
         if _o["location"]["slotName"] != lw_slot:
             return False
+        offset_uri = _o["definitionUri"]
+        if offset_uri != lw_uri:
+            # NOTE: we're allowing tip-rack adapters to share offsets
+            #       because it doesn't make a difference which volume
+            #       of tip it holds
+            o_is_adp = "custom_beta" in offset_uri and "_adp" in offset_uri
+            l_is_adp = "custom_beta" in lw_uri and "_adp" in lw_uri
+            if not o_is_adp or not l_is_adp:
+                return False
         return _is_offset_present(_o)
 
     lw_offsets = [


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR speeds up setup/calibration for 96ch volumetric testing, by allowing all tip-rack adapters to share the same labware offsets regardless of which tip-volume they currently hold. Offsets are only shared within each slot, so if you run LPC on a 1000uL rack in slot D2, then running the volumetric test with a 200uL rack in slot D2 will use the same LPC offsets as the 1000uL rack.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
