### PR TITLE
feat(protocol-designer): add flex slot labels to protocol designer deck map

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -11,6 +11,7 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   RobotWorkSpaceRenderProps,
   Module,
+  SlotLabels,
 } from '@opentrons/components'
 import {
   MODULES_WITH_COLLISION_ISSUES,
@@ -457,17 +458,20 @@ export const DeckSetup = (): JSX.Element => {
           height="100%"
         >
           {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
-            <DeckSetupContents
-              robotType={robotType}
-              activeDeckSetup={activeDeckSetup}
-              selectedTerminalItemId={selectedTerminalItemId}
-              {...{
-                deckDef,
-                deckSlotsById,
-                getRobotCoordsFromDOMCoords,
-                showGen1MultichannelCollisionWarnings,
-              }}
-            />
+            <>
+              <DeckSetupContents
+                robotType={robotType}
+                activeDeckSetup={activeDeckSetup}
+                selectedTerminalItemId={selectedTerminalItemId}
+                {...{
+                  deckDef,
+                  deckSlotsById,
+                  getRobotCoordsFromDOMCoords,
+                  showGen1MultichannelCollisionWarnings,
+                }}
+              />
+              <SlotLabels robotType={robotType} />
+            </>
           )}
         </RobotWorkSpace>
       </div>


### PR DESCRIPTION
# Overview

adds flex slot labels to protocol designer deck setup map

![Screen Shot 2023-07-05 at 1 55 18 PM](https://github.com/Opentrons/opentrons/assets/29845468/297eda1c-388e-4fea-90c3-bd8fdfdc0d15)

closes RAUT-526

# Test Plan

manually verified existence and positioning of flex slot labels on deck setup page

# Changelog

 - Adds flex slot labels to protocol designer deck setup map

# Review requests

 - confirm existence and positioning of flex slot labels on deck setup page
 - should the slot labels be added anywhere else in PD?

# Risk assessment

low