### PR TITLE
fix(api): Position plunger to bottom before picking up a tip

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1668,6 +1668,7 @@ class OT3API(
             realmount, tip_length, presses, increment
         )
 
+        await self._move_to_plunger_bottom(realmount, rate=1.0)
         if spec.pick_up_motor_actions:
             await self._motor_pick_up_tip(realmount, spec.pick_up_motor_actions)
         else:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1339,7 +1339,7 @@ async def test_pick_up_tip_full_tiprack(
     ot3_hardware: ThreadManager[OT3API],
     mock_instrument_handlers: Tuple[Mock],
     mock_ungrip: AsyncMock,
-    mock_move_to_plunger_bottom: AsyncMock
+    mock_move_to_plunger_bottom: AsyncMock,
 ) -> None:
     mock_ungrip.return_value = None
     await ot3_hardware.home()

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1339,6 +1339,7 @@ async def test_pick_up_tip_full_tiprack(
     ot3_hardware: ThreadManager[OT3API],
     mock_instrument_handlers: Tuple[Mock],
     mock_ungrip: AsyncMock,
+    mock_move_to_plunger_bottom: AsyncMock
 ) -> None:
     mock_ungrip.return_value = None
     await ot3_hardware.home()

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3.py
@@ -795,7 +795,7 @@ async def _test_diagnostics_pressure(
     if not api.is_simulator:
         _get_operator_answer_to_question('REMOVE tip to nozzle, enter "y" when ready')
     print("moving plunger back down to BOTTOM position")
-    await helpers_ot3.move_plunger_absolute_ot3(api, mount, bottom)
+    await api.dispense(mount)
     await api.remove_tip(mount)
     return pressure_open_air_pass and pressure_sealed_pass and pressure_compress_pass
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR moves the plunger to its bottom position immediately before picking up a new tip. This is to avoid the scenario where a protocol (or a test script!) has just started with all axes homed, and the then positions to bottom after picking up the first tip. This is bad for two reasons:
1. We need to wait for it, for sometimes several seconds, and it always kind of feels like something wrong is happening
2. Volumetric tests show that tips perform differently depending on how long they are held, and so we want all tips to be held for the same amount of time during volumetric tests

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
