### PR TITLE
refactor(shared-data): allow all flex tipracks for PD

### DIFF
--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -57,9 +57,6 @@ export const LABWAREV2_DO_NOT_LIST = [
 export const PD_DO_NOT_LIST = [
   'opentrons_calibrationblock_short_side_left',
   'opentrons_calibrationblock_short_side_right',
-  'opentrons_flex_96_tiprack_200ul',
-  'opentrons_flex_96_tiprack_1000ul',
-  'opentrons_flex_96_tiprack_50ul',
 ]
 
 export function getLabwareV1Def(


### PR DESCRIPTION
# Overview

Just noticed a small bug for flex tiprack selection in PD and found the culprit was from the `PD_DO_NOT_LIST`. I think something changed in the past week regarding flex tiprack definitions (like there were duplicates or something?) so thats why i noticed this bug. But anyways, it is fixed now.

# Test Plan

just verify that that a PD flex pipette can select both unfiltered and filtered version of the tip
sandbox can be found here when the build is done: https://sandbox.designer.opentrons.com/shared_data-pd-flex-tips

# Changelog

- change const

# Review requests

see test plan

# Risk assessment

low