### PR TITLE
fix(hardware): minimum movement displacement of 0.05mm

### DIFF
--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -184,8 +184,8 @@ async def test_find_edge(
     # all other moves should only move in the search axis
     for call in checked_calls:
         assert call[0][0] == OT3Mount.RIGHT
-        assert _other_axis_val(call[0][1], search_axis) == _other_axis_val(
-            Point(0, 0, 0), search_axis
+        assert _other_axis_val(call[0][1], search_axis) == pytest.approx(
+            _other_axis_val(Point(0, 0, 0), search_axis)
         )
 
 

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
@@ -24,6 +24,8 @@ log = logging.getLogger(__name__)
 
 FLOAT_THRESHOLD = 0.001  # TODO: re-evaluate this value based on system limitations
 
+MINIMUM_DISPLACEMENT = 0.05
+
 
 class MoveConditionNotMet(ValueError):
     """Error raised if a move does not meet its stop condition before finishing."""
@@ -47,6 +49,10 @@ def get_unit_vector(
     initial_vectorized = vectorize({k: np.float64(v) for k, v in initial.items()})
     target_vectorized = vectorize({k: np.float64(v) for k, v in target.items()})
     displacement: "NDArray[np.float64]" = target_vectorized - initial_vectorized
+    # minimum distance of 0.05mm
+    for i in range(len(displacement)):
+        if abs(displacement[i]) < MINIMUM_DISPLACEMENT:
+            displacement[i] = 0
     distance = np.linalg.norm(displacement)  # type: ignore[no-untyped-call]
     if not distance or np.array_equal(initial_vectorized, target_vectorized):
         raise ZeroLengthMoveError(initial, target)


### PR DESCRIPTION


# Overview

Protocols kept failing with collision errors on release 0.13.0, and logs would show a noticeable drift in the encoder position over time. Release 0.9.0 seemed completely fine with the same exact protocols.

One difference between those releases has been changing the units for acceleration to use µm instead of mm. When we move the pipette down to aspirate/dispense/pick up a tip/etc, there are usually small displacements in the X and Y axes that are due to precision loss on the stepper motor accumulator. With the new, more precise acceleration, we seem to actually commanding some gantry movements that are affecting the error buildup over time.

By clamping the minimum displacement to 0.05mm, this error seems gone. A protocol that transfers liquid from a reservoir into an entire 96-well plate used to fail after the first column, and can now finish successfully. 


# Test Plan

Ran a failing protocol and now it works. There used to be noticeable encoder drift if you disabled stall detection, now the pipettes look fine.

# Changelog

- Added a minimum displacement of 0.05mm in each axis of movement


# Review requests

Any reason to make the minimum displacement smaller? Do we ever actually need to move 0.05mm? 


# Risk assessment

