### PR TITLE
feat(hardware-testing): Option to isolate specific channels on 8ch pipette during grav tests

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -103,6 +103,7 @@ def run_gravimetric(
     user_volumes: bool,
     gantry_speed: int,
     scale_delay: int,
+    isolate_channels: List[int],
 ) -> None:
     """Run."""
     if increment:
@@ -132,6 +133,7 @@ def run_gravimetric(
             user_volumes=user_volumes,
             gantry_speed=gantry_speed,
             scale_delay=scale_delay,
+            isolate_channels=isolate_channels,
         ),
     )
 
@@ -195,6 +197,7 @@ if __name__ == "__main__":
     parser.add_argument("--photometric", action="store_true")
     parser.add_argument("--touch-tip", action="store_true")
     parser.add_argument("--refill", action="store_true")
+    parser.add_argument("--isolate-channels", nargs="+", type=int, default=None)
     args = parser.parse_args()
     if not args.simulate and not args.skip_labware_offsets:
         # getting labware offsets must be done before creating the protocol context
@@ -261,4 +264,5 @@ if __name__ == "__main__":
             args.user_volumes,
             args.gantry_speed,
             args.scale_delay,
+            args.isolate_channels if args.isolate_channels else [],
         )

--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -26,6 +26,7 @@ class GravimetricConfig:
     user_volumes: bool
     gantry_speed: int
     scale_delay: int
+    isolate_channels: List[int]
 
 
 @dataclass

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -269,13 +269,7 @@ def create_csv_test_report(
     for field in fields(config.GravimetricConfig):
         if field.name in config.GRAV_CONFIG_EXCLUDE_FROM_REPORT:
             continue
-        cfg_val = getattr(cfg, field.name)
-        # print(field.type, type(cfg_val), cfg_val)
-        # if field.type == List[int]:
-        #     print("changing")
-        #     cfg_val = list([v for v in cfg_val])
-        #     print(type(cfg_val), cfg_val)
-        report("CONFIG", field.name, [cfg_val])
+        report("CONFIG", field.name, [getattr(cfg, field.name)])
     return report
 
 

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -1,7 +1,7 @@
 """Report."""
 from dataclasses import fields
 from enum import Enum
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 from hardware_testing.data.csv_report import (
     CSVReport,
@@ -178,6 +178,11 @@ def create_csv_test_report(
         + [f"trial_{t+1}" for t in range(cfg.trials)]
     )
 
+    def _field_type_not_using_typing(t: Any) -> Any:
+        if t == List[int]:
+            return list
+        return t
+
     report = CSVReport(
         test_name=cfg.name,
         run_id=run_id,
@@ -196,7 +201,7 @@ def create_csv_test_report(
             CSVSection(
                 title="CONFIG",
                 lines=[
-                    CSVLine(field.name, [field.type])
+                    CSVLine(field.name, [_field_type_not_using_typing(field.type)])
                     for field in fields(config.GravimetricConfig)
                     if field.name not in config.GRAV_CONFIG_EXCLUDE_FROM_REPORT
                 ],
@@ -264,7 +269,13 @@ def create_csv_test_report(
     for field in fields(config.GravimetricConfig):
         if field.name in config.GRAV_CONFIG_EXCLUDE_FROM_REPORT:
             continue
-        report("CONFIG", field.name, [getattr(cfg, field.name)])
+        cfg_val = getattr(cfg, field.name)
+        # print(field.type, type(cfg_val), cfg_val)
+        # if field.type == List[int]:
+        #     print("changing")
+        #     cfg_val = list([v for v in cfg_val])
+        #     print(type(cfg_val), cfg_val)
+        report("CONFIG", field.name, [cfg_val])
     return report
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR helps to speed up debugging issues in gravimetric tests for 8ch pipettes, by allowing the operator to specify which channels to isolate and test only, skipping all other channels. The use case for this is right now P50 multis need their 1uL volumes re-tested but only on 2x or 3x of their channels. Without being able to isolate just those channels, the test would take ~6 hours instead of ~2 hours.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
