### PR TITLE
fix(hardware-testing): Remove tips using them for finding liquid height

### DIFF
--- a/hardware-testing/.flake8
+++ b/hardware-testing/.flake8
@@ -5,8 +5,8 @@
 max-line-length = 100
 
 # max cyclomatic complexity
-# NOTE: (andy s) increasing this from 9 to 15 b/c test scripts often handle all logic in main
-max-complexity = 15
+# NOTE: (andy s) increasing this from 9 to 20 b/c test scripts often handle all logic in main
+max-complexity = 20
 
 extend-ignore =
     # ignore E203 because black might reformat it

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -232,10 +232,8 @@ def _run_trial(
     liquid_tracker: LiquidTracker,
     blank: bool,
     inspect: bool,
-    do_jog: bool,
     cfg: config.PhotometricConfig,
     mix: bool = False,
-    stable: bool = True,
 ) -> None:
     """Aspirate dye and dispense into a photometric plate."""
 
@@ -281,50 +279,6 @@ def _run_trial(
 
     _record_measurement_and_store(MeasurementType.INIT)
     pipette.move_to(location=source.top().move(channel_offset), minimum_z_height=133)
-    while do_jog:
-        required_ul = max(
-            (volume * channel_count * cfg.trials) + _MIN_END_VOLUME_UL,
-            _MIN_START_VOLUME_UL,
-        )
-        if not ctx.is_simulating():
-            _liquid_height = _jog_to_find_liquid_height(ctx, pipette, source)
-            height_below_top = source.depth - _liquid_height
-            print(f"liquid is {height_below_top} mm below top of reservoir")
-            liquid_tracker.set_start_volume_from_liquid_height(
-                source, _liquid_height, name="Dye"
-            )
-        else:
-            liquid_tracker.set_start_volume(source, required_ul)
-        reservoir_ul = liquid_tracker.get_volume(source)
-        print(
-            f"software thinks there is {round(reservoir_ul / 1000, 1)} mL "
-            f"of liquid in the reservoir (required = {round(required_ul / 1000, 1)} ml)"
-        )
-        if required_ul <= reservoir_ul < _MAX_VOLUME_UL:
-            break
-        elif required_ul > _MAX_VOLUME_UL:
-            raise NotImplementedError(
-                f"too many trials ({cfg.trials}) at {volume} uL, "
-                f"refilling reservoir is currently not supported"
-            )
-        elif reservoir_ul < required_ul:
-            error_msg = (
-                f"not enough volume in reservoir to aspirate {volume} uL "
-                f"across {channel_count}x channels for {cfg.trials}x trials"
-            )
-            if ctx.is_simulating():
-                raise ValueError(error_msg)
-            ui.print_error(error_msg)
-            pipette.move_to(location=source.top(100).move(channel_offset))
-            difference_ul = required_ul - reservoir_ul
-            ui.get_user_ready(
-                f"ADD {round(difference_ul / 1000.0, 1)} mL more liquid to RESERVOIR"
-            )
-            pipette.move_to(location=source.top().move(channel_offset))
-        else:
-            raise RuntimeError(
-                f"bad volume in reservoir: {round(reservoir_ul / 1000, 1)} ml"
-            )
     # RUN ASPIRATE
     aspirate_with_liquid_class(
         ctx,
@@ -533,9 +487,63 @@ def run(ctx: ProtocolContext, cfg: config.PhotometricConfig) -> None:
     #       and so we can use pick-up-tip from there again
     try:
         trial_count = 0
+        source = reservoir["A1"]
+        channel_count = 96
+        channel_offset = Point()
+        setup_tip = tips[0][0]
+        volume_for_setup = max(test_volumes)
+        _pick_up_tip(ctx, pipette, cfg, location=setup_tip.top())
+        pipette.home()
+        if not ctx.is_simulating():
+            ui.get_user_ready("REPLACE first tip with NEW TIP")
+        required_ul = max(
+            (volume_for_setup * channel_count * cfg.trials) + _MIN_END_VOLUME_UL,
+            _MIN_START_VOLUME_UL,
+        )
+        if not ctx.is_simulating():
+            _liquid_height = _jog_to_find_liquid_height(ctx, pipette, source)
+            height_below_top = source.depth - _liquid_height
+            print(f"liquid is {height_below_top} mm below top of reservoir")
+            liquid_tracker.set_start_volume_from_liquid_height(
+                source, _liquid_height, name="Dye"
+            )
+        else:
+            liquid_tracker.set_start_volume(source, required_ul)
+        reservoir_ul = liquid_tracker.get_volume(source)
+        print(
+            f"software thinks there is {round(reservoir_ul / 1000, 1)} mL "
+            f"of liquid in the reservoir (required = {round(required_ul / 1000, 1)} ml)"
+        )
+        if required_ul <= reservoir_ul < _MAX_VOLUME_UL:
+            print("valid liquid height")
+        elif required_ul > _MAX_VOLUME_UL:
+            raise NotImplementedError(
+                f"too many trials ({cfg.trials}) at {volume_for_setup} uL, "
+                f"refilling reservoir is currently not supported"
+            )
+        elif reservoir_ul < required_ul:
+            error_msg = (
+                f"not enough volume in reservoir to aspirate {volume_for_setup} uL "
+                f"across {channel_count}x channels for {cfg.trials}x trials"
+            )
+            if ctx.is_simulating():
+                raise ValueError(error_msg)
+            ui.print_error(error_msg)
+            pipette.move_to(location=source.top(100).move(channel_offset))
+            difference_ul = required_ul - reservoir_ul
+            ui.get_user_ready(
+                f"ADD {round(difference_ul / 1000.0, 1)} mL more liquid to RESERVOIR"
+            )
+            pipette.move_to(location=source.top().move(channel_offset))
+        else:
+            raise RuntimeError(
+                f"bad volume in reservoir: {round(reservoir_ul / 1000, 1)} ml"
+            )
+        pipette.drop_tip(home_after=False)  # always trash setup tips
+        # NOTE: the first tip-rack should have already been replaced
+        #       with new tips by the operator
         for volume in test_volumes:
             ui.print_title(f"{volume} uL")
-            do_jog = True
             for trial in range(cfg.trials):
                 trial_count += 1
                 ui.print_header(f"{volume} uL ({trial + 1}/{cfg.trials})")
@@ -545,27 +553,22 @@ def run(ctx: ProtocolContext, cfg: config.PhotometricConfig) -> None:
                 next_tip: Well = _next_tip()
                 next_tip_location = next_tip.top()
                 _pick_up_tip(ctx, pipette, cfg, location=next_tip_location)
-
                 _run_trial(
                     ctx=ctx,
                     test_report=test_report,
                     pipette=pipette,
-                    source=reservoir["A1"],
+                    source=source,
                     dest=photoplate,
-                    channel_offset=Point(),
+                    channel_offset=channel_offset,
                     tip_volume=cfg.tip_volume,
                     volume=volume,
                     trial=trial,
                     liquid_tracker=liquid_tracker,
                     blank=False,
                     inspect=cfg.inspect,
-                    do_jog=do_jog,
                     cfg=cfg,
                     mix=cfg.mix,
-                    stable=True,
                 )
-                if volume < 250:
-                    do_jog = False
 
     finally:
         ui.print_title("CHANGE PIPETTES")


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Using the same tips to find liquid height as well as do Trial 1's aspiration is causing error on that first trial. This PR makes it so that the tips used for finding the liquid height are entirely different tips than what is used for Trial 1.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
