### PR TITLE
fix(hardware-testing): Support resupplying tipracks during a 96ch increment tests

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -1,4 +1,5 @@
 """Gravimetric."""
+from dataclasses import dataclass
 from inspect import getsource
 from statistics import stdev
 from typing import Optional, Tuple, List, Dict
@@ -43,6 +44,8 @@ from .tips import get_tips, MULTI_CHANNEL_TEST_ORDER
 _MEASUREMENTS: List[Tuple[str, MeasurementData]] = list()
 
 _PREV_TRIAL_GRAMS: Optional[MeasurementData] = None
+
+_tip_counter: Dict[int, int] = {}
 
 
 def _generate_callbacks_for_trial(
@@ -520,6 +523,70 @@ def _change_pipettes(
     pipette.move_to(ctx.deck.position_for(5).move(Point(x=0, y=9 * 7, z=150)))
 
 
+def _next_tip_for_channel(
+    ctx: ProtocolContext,
+    cfg: config.GravimetricConfig,
+    tips: Dict[int, List[Well]],
+    channel: int,
+    max_tips: int,
+) -> Well:
+    _tips_used = sum([tc for tc in _tip_counter.values()])
+    if _tips_used >= max_tips:
+        if cfg.pipette_channels != 96:
+            raise RuntimeError("ran out of tips")
+        if not ctx.is_simulating():
+            ui.print_title("Reset 96ch Tip Racks")
+            ui.get_user_ready(f"ADD {max_tips}x new tip-racks")
+        _tip_counter[channel] = 0
+    _tip = tips[channel][_tip_counter[channel]]
+    _tip_counter[channel] += 1
+    return _tip
+
+
+@dataclass
+class _RunParameters:
+    test_volumes: List[float]
+    tips: Dict[int, List[Well]]
+    num_channels_per_transfer: int
+    channels_to_test: List[int]
+    trial_total: int
+    total_tips: int
+
+
+def _calculate_parameters(
+    ctx: ProtocolContext, cfg: config.GravimetricConfig, pipette: InstrumentContext
+) -> _RunParameters:
+    test_volumes = _get_volumes(ctx, cfg)
+    for v in test_volumes:
+        print(f"\t{v} uL")
+    all_channels_same_time = cfg.increment or cfg.pipette_channels == 96
+    tips = get_tips(ctx, pipette, all_channels=all_channels_same_time)
+    total_tips = len([tip for chnl_tips in tips.values() for tip in chnl_tips])
+    channels_to_test = _get_test_channels(cfg)
+    for channel in channels_to_test:
+        # initialize the global tip counter, per each channel that will be tested
+        _tip_counter[channel] = 0
+    if len(channels_to_test) > 1:
+        num_channels_per_transfer = 1
+    else:
+        num_channels_per_transfer = cfg.pipette_channels
+    trial_total = len(test_volumes) * cfg.trials * len(channels_to_test)
+    support_tip_resupply = bool(cfg.pipette_channels == 96 and cfg.increment)
+    if trial_total > total_tips:
+        if not support_tip_resupply:
+            raise ValueError(f"more trials ({trial_total}) than tips ({total_tips})")
+        elif not ctx.is_simulating():
+            ui.get_user_ready(f"prepare {trial_total - total_tips} extra tip-racks")
+    return _RunParameters(
+        test_volumes=test_volumes,
+        tips=tips,
+        num_channels_per_transfer=num_channels_per_transfer,
+        channels_to_test=channels_to_test,
+        trial_total=trial_total,
+        total_tips=total_tips,
+    )
+
+
 def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
     """Run."""
     run_id, start_time = create_run_id_and_start_time()
@@ -534,24 +601,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
     pipette_tag = _get_tag_from_pipette(pipette, cfg)
 
     ui.print_header("GET PARAMETERS")
-    test_volumes = _get_volumes(ctx, cfg)
-    for v in test_volumes:
-        print(f"\t{v} uL")
-    all_channels_same_time = cfg.increment or cfg.pipette_channels == 96
-    tips = get_tips(ctx, pipette, all_channels=all_channels_same_time)
-    total_tips = len([tip for chnl_tips in tips.values() for tip in chnl_tips])
-    channels_to_test = _get_test_channels(cfg)
-    if len(channels_to_test) > 1:
-        num_channels_per_transfer = 1
-    else:
-        num_channels_per_transfer = cfg.pipette_channels
-    trial_total = len(test_volumes) * cfg.trials * len(channels_to_test)
-    assert (
-        trial_total <= total_tips
-    ), f"more trials ({trial_total}) than tips ({total_tips})"
-
-    def _next_tip_for_channel(channel: int) -> Well:
-        return tips[channel].pop(0)
+    parameters = _calculate_parameters(ctx, cfg, pipette)
 
     ui.print_header("LOAD SCALE")
     print(
@@ -580,7 +630,9 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
     print(f'scale is recording to "{recorder.file_name}"')
 
     ui.print_header("CREATE TEST-REPORT")
-    test_report = report.create_csv_test_report(test_volumes, cfg, run_id=run_id)
+    test_report = report.create_csv_test_report(
+        parameters.test_volumes, cfg, run_id=run_id
+    )
     test_report.set_tag(pipette_tag)
     test_report.set_operator(_get_operator_name(ctx.is_simulating()))
     serial_number = _get_robot_serial(ctx.is_simulating())
@@ -607,7 +659,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
         print("homing...")
         ctx.home()
         pipette.home_plunger()
-        first_tip = tips[0][0]
+        first_tip = parameters.tips[0][0]
         setup_channel_offset = _get_channel_offset(cfg, channel=0)
         first_tip_location = first_tip.top().move(setup_channel_offset)
         _pick_up_tip(ctx, pipette, cfg, location=first_tip_location)
@@ -651,9 +703,9 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
                     well=labware_on_scale["A1"],
                     channel_offset=Point(),  # first channel
                     tip_volume=cfg.tip_volume,
-                    volume=test_volumes[-1],
+                    volume=parameters.test_volumes[-1],
                     channel=0,  # first channel
-                    channel_count=num_channels_per_transfer,
+                    channel_count=parameters.num_channels_per_transfer,
                     trial=trial,
                     recorder=recorder,
                     test_report=test_report,
@@ -689,7 +741,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
         _drop_tip(pipette, return_tip=False)  # always trash calibration tips
         calibration_tip_in_use = False
         trial_count = 0
-        for volume in test_volumes:
+        for volume in parameters.test_volumes:
             actual_asp_list_all = []
             actual_disp_list_all = []
             ui.print_title(f"{volume} uL")
@@ -700,7 +752,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
             trial_disp_dict: Dict[int, List[float]] = {
                 trial: [] for trial in range(cfg.trials)
             }
-            for channel in channels_to_test:
+            for channel in parameters.channels_to_test:
                 if cfg.isolate_channels and (channel + 1) not in cfg.isolate_channels:
                     print(f"skipping channel {channel + 1}")
                     continue
@@ -714,10 +766,12 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
                     ui.print_header(
                         f"{volume} uL channel {channel + 1} ({trial + 1}/{cfg.trials})"
                     )
-                    print(f"trial total {trial_count}/{trial_total}")
+                    print(f"trial total {trial_count}/{parameters.trial_total}")
                     # NOTE: always pick-up new tip for each trial
                     #       b/c it seems tips heatup
-                    next_tip: Well = _next_tip_for_channel(channel)
+                    next_tip: Well = _next_tip_for_channel(
+                        ctx, cfg, parameters.tips, channel, parameters.total_tips
+                    )
                     next_tip_location = next_tip.top().move(channel_offset)
                     _pick_up_tip(ctx, pipette, cfg, location=next_tip_location)
                     (
@@ -733,7 +787,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
                         tip_volume=cfg.tip_volume,
                         volume=volume,
                         channel=channel,
-                        channel_count=num_channels_per_transfer,
+                        channel_count=parameters.num_channels_per_transfer,
                         trial=trial,
                         recorder=recorder,
                         test_report=test_report,
@@ -898,7 +952,7 @@ def run(ctx: ProtocolContext, cfg: config.GravimetricConfig) -> None:
         _change_pipettes(ctx, pipette, _return_tip)
     ui.print_title("RESULTS")
     _print_final_results(
-        volumes=test_volumes,
-        channel_count=len(channels_to_test),
+        volumes=parameters.test_volumes,
+        channel_count=len(parameters.channels_to_test),
         test_report=test_report,
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR brings back allowing tip-racks to be re-supplied, but only for 96ch tests running in `increment` mode. Other scenarios can be added in future PRs.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
