### PR TITLE
fix(hardware): specify nodes when clearing move groups

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -206,16 +206,16 @@ class MoveGroupRunner:
         Args:
             can_messenger: a can messenger
         """
-
         error = await can_messenger.ensure_send(
             node_id=NodeId.broadcast,
             message=ClearAllMoveGroupsRequest(payload=EmptyPayload()),
-            expected_nodes=list(self._all_nodes()),
+            expected_nodes=list(self.all_nodes()),
         )
         if error != ErrorCode.ok:
             log.warning("Clear move group failed")
 
-    def _all_nodes(self) -> Set[NodeId]:
+    def all_nodes(self) -> Set[NodeId]:
+        """Get all of the nodes in the move group runner's move gruops."""
         node_set: Set[NodeId] = set()
         for group in self._move_groups:
             for sequence in group:

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -206,12 +206,22 @@ class MoveGroupRunner:
         Args:
             can_messenger: a can messenger
         """
+
         error = await can_messenger.ensure_send(
             node_id=NodeId.broadcast,
             message=ClearAllMoveGroupsRequest(payload=EmptyPayload()),
+            expected_nodes=list(self._all_nodes()),
         )
         if error != ErrorCode.ok:
             log.warning("Clear move group failed")
+
+    def _all_nodes(self) -> Set[NodeId]:
+        node_set: Set[NodeId] = set()
+        for group in self._move_groups:
+            for sequence in group:
+                for node in sequence.keys():
+                    node_set.add(node)
+        return node_set
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:
         """Send commands to set up the message groups."""

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -277,7 +277,13 @@ async def test_multi_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
     await subject.prep(can_messenger=mock_can_messenger)
-    expected = subject._all_nodes()
+    expected = subject.all_nodes()
+    # Test that the expected nodes are correct
+    for group in move_group_multiple:
+        for step in group:
+            for node in step.keys():
+                assert node in expected
+
     mock_can_messenger.ensure_send.assert_has_calls(
         [
             call(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -261,7 +261,13 @@ async def test_single_group_clear(
     subject = MoveGroupRunner(move_groups=move_group_single)
     await subject._clear_groups(can_messenger=mock_can_messenger)
     mock_can_messenger.ensure_send.assert_has_calls(
-        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
+        [
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ClearAllMoveGroupsRequest(),
+                expected_nodes=[NodeId.head],
+            )
+        ],
     )
 
 
@@ -271,8 +277,15 @@ async def test_multi_group_clear(
     """It should send a clear group command before setup."""
     subject = MoveGroupRunner(move_groups=move_group_multiple)
     await subject.prep(can_messenger=mock_can_messenger)
+    expected = subject._all_nodes()
     mock_can_messenger.ensure_send.assert_has_calls(
-        [call(node_id=NodeId.broadcast, message=md.ClearAllMoveGroupsRequest())],
+        [
+            call(
+                node_id=NodeId.broadcast,
+                message=md.ClearAllMoveGroupsRequest(),
+                expected_nodes=list(expected),
+            )
+        ],
     )
 
 


### PR DESCRIPTION


# Overview

The call to `ensure_send` when clearing move groups didn't specify what nodes to listen for and it ended up printing out a ton of errors. This should eliminate those errors.

# Test Plan

Run ot3repl on an OT-3 with this change, make sure the warning messages don't pop up.

# Changelog

- Specify expected CAN nodes when clearing move groups.

# Review requests



# Risk assessment

