### PR TITLE
fix(api): Fix opentrons_execute ignoring args for custom labware and data

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -413,6 +413,8 @@ def main() -> int:
     execute(
         protocol_file=args.protocol,
         protocol_name=args.protocol.name,
+        custom_labware_paths=args.custom_labware_path,
+        custom_data_paths=(args.custom_data_path + args.custom_data_file),
         log_level=log_level,
         emit_runlog=printer,
     )

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -188,8 +188,9 @@ def get_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "Only directories specified directly by "
         "this argument are searched, not their children. JSON files that "
         "do not define labware will be ignored with a message. "
-        "By default, the current directory (the one in which you are "
-        "invoking this program) will be searched for labware.",
+        "The current directory (the one from which you are "
+        "invoking this program) will always be included implicitly, "
+        "in addition to any directories that you specify.",
     )
     parser.add_argument(
         "-D",

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -411,8 +411,8 @@ def main() -> int:
         log_level = "warning"
     # Try to migrate containers from database to v2 format
     execute(
-        args.protocol,
-        args.protocol.name,
+        protocol_file=args.protocol,
+        protocol_name=args.protocol.name,
         log_level=log_level,
         emit_runlog=printer,
     )

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -668,11 +668,8 @@ def main() -> int:
     runlog, maybe_bundle = simulate(
         protocol_file=args.protocol,
         file_name=args.protocol.name,
-        custom_labware_paths=getattr(args, "custom_labware_path", []),
-        custom_data_paths=(
-            getattr(args, "custom_data_path", [])
-            + getattr(args, "custom_data_file", [])
-        ),
+        custom_labware_paths=args.custom_labware_path,
+        custom_data_paths=(args.custom_data_path + args.custom_data_file),
         duration_estimator=duration_estimator,
         hardware_simulator_file_path=getattr(args, "custom_hardware_simulator_file"),
         log_level=args.log_level,

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -666,10 +666,13 @@ def main() -> int:
     duration_estimator = DurationEstimator() if args.estimate_duration else None  # type: ignore[no-untyped-call]
 
     runlog, maybe_bundle = simulate(
-        args.protocol,
-        args.protocol.name,
-        getattr(args, "custom_labware_path", []),
-        getattr(args, "custom_data_path", []) + getattr(args, "custom_data_file", []),
+        protocol_file=args.protocol,
+        file_name=args.protocol.name,
+        custom_labware_paths=getattr(args, "custom_labware_path", []),
+        custom_data_paths=(
+            getattr(args, "custom_data_path", [])
+            + getattr(args, "custom_data_file", [])
+        ),
         duration_estimator=duration_estimator,
         hardware_simulator_file_path=getattr(args, "custom_hardware_simulator_file"),
         log_level=args.log_level,

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -545,8 +545,9 @@ def get_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "Only directories specified directly by "
         "this argument are searched, not their children. JSON files that "
         "do not define labware will be ignored with a message. "
-        "By default, the current directory (the one from which you are "
-        "invoking this program) will be searched for labware.",
+        "The current directory (the one from which you are "
+        "invoking this program) will always be included implicitly, "
+        "in addition to any directories that you specify.",
     )
     parser.add_argument(
         "-D",


### PR DESCRIPTION
# Changelog

* Fix a bug where the `--custom-labware-path` (`-L`), `--custom-data-path` (`-D`), and `--custom-data-file`) (`-d`) arguments to `opentrons_execute` had no effect.
    * This closes #9256. :)
    * This bug appears to have been present since #4574.
* In the `--help` text, clarify how `--custom-labware-path` (`-L)` affects the default behavior of searching the current working directory.
* Refactor: Remove some unnecessary `getattr()` calls to read attributes that should always be present.

# Test Plan

* [x] Run `opentrons_execute -L <dir>` and make sure it searches the directory you provide, in addition to the Jupyter Notebook directory.
* [x] Run `opentrons_execute` without `-L` and make sure it searches just the Jupyter Notebook directory.
* [x] Test `--custom-data-file` and `--custom-data-path` with `opentrons_execute` and `opentrons_simulate` to ensure it still works.

# Review requests

Does anyone understand what this is doing in the specification for  `--custom-data-path`?

```python
    parser.add_argument(
        "-D",
        "--custom-data-path",
        action="append",
        nargs="?",
        const=".",
        default=[],
        ...
```

What are `const` and `nargs` doing there? Why aren't they also present on `--custom-labware-path` or `--custom-data-file`?

# Risk assessment

Medium? Testing this exhaustively has to be done manually.