### PR TITLE
fix(api): Switch plunger backlash to pre-load for aspirations

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1467,10 +1467,13 @@ class OT3API(
             # save time by using max speed
             max_speeds = self.config.motion_settings.default_max_speed
             speed = max_speeds[self.gantry_load][OT3AxisKind.P]
-        if current_pos > target_pos[pip_ax]:
+        # IMPORTANT: Here is our backlash compensation.
+        #            The plunger is pre-loaded in the "aspirate" direction
+        # NOTE: plunger position (mm) decreases up towards homing switch
+        if current_pos < target_pos[pip_ax]:
+            # move down below "bottom", before moving back up to "bottom"
             backlash_pos = target_pos.copy()
-            backlash_pos[pip_ax] -= instrument.backlash_distance
-
+            backlash_pos[pip_ax] += instrument.backlash_distance
             await self._move(
                 backlash_pos,
                 speed=(speed * rate),
@@ -1511,10 +1514,6 @@ class OT3API(
         if not aspirate_spec:
             return
 
-        checked_mount = OT3Mount.from_mount(mount)
-        instrument = self._pipette_handler.get_pipette(checked_mount)
-        pip_ax = OT3Axis.of_main_tool_actuator(mount)
-
         target_pos = target_position_from_plunger(
             realmount,
             aspirate_spec.plunger_distance,
@@ -1524,13 +1523,6 @@ class OT3API(
         try:
             await self._backend.set_active_current(
                 {OT3Axis.from_axis(aspirate_spec.axis): aspirate_spec.current}
-            )
-            backlash_pos = target_pos.copy()
-            backlash_pos[pip_ax] -= instrument.backlash_distance
-            await self._move(
-                backlash_pos,
-                speed=aspirate_spec.speed,
-                home_flagged_axes=False,
             )
             await self._move(
                 target_pos,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1106,6 +1106,7 @@ async def test_move_to_plunger_bottom(
     await ot3_hardware.cache_pipette(mount, instr_data, None)
     pipette = ot3_hardware.hardware_pipettes[mount.to_mount()]
     assert pipette
+    pip_ax = OT3Axis.of_main_tool_actuator(mount)
 
     max_speeds = ot3_hardware.config.motion_settings.default_max_speed
     target_pos = target_position_from_plunger(
@@ -1113,6 +1114,8 @@ async def test_move_to_plunger_bottom(
         pipette.plunger_positions.bottom,
         ot3_hardware._current_position,
     )
+    backlash_pos = target_pos.copy()
+    backlash_pos[pip_ax] += pipette.backlash_distance
 
     # plunger will move at different speeds, depending on if:
     #  - no tip attached (max speed)
@@ -1130,7 +1133,12 @@ async def test_move_to_plunger_bottom(
     await ot3_hardware.home()
     mock_move.reset_mock()
     await ot3_hardware.home_plunger(mount)
-    mock_move.assert_called_once_with(
+    # make sure we've done the backlash compensation
+    mock_move.assert_any_call(
+        backlash_pos, speed=expected_speed_no_tip, acquire_lock=False
+    )
+    # make sure the final move is to our target position
+    mock_move.assert_called_with(
         target_pos, speed=expected_speed_no_tip, acquire_lock=False
     )
 
@@ -1139,25 +1147,21 @@ async def test_move_to_plunger_bottom(
     await ot3_hardware.add_tip(mount, 100)
     mock_move.reset_mock()
     await ot3_hardware.prepare_for_aspirate(mount)
-    # make sure when plunger is going down that only one move is called,
-    # and there's no backlash move queued
-    mock_move.assert_called_once_with(
+    # make sure we've done the backlash compensation
+    mock_move.assert_any_call(
+        backlash_pos, speed=expected_speed_moving_down, acquire_lock=True
+    )
+    # make sure the final move is to our target position
+    mock_move.assert_called_with(
         target_pos, speed=expected_speed_moving_down, acquire_lock=True
     )
 
     # tip attached, moving UP towards "bottom" position
     # NOTE: _move() is mocked, so we need to update the OT3API's
     #       cached coordinates in the test
-    pip_ax = OT3Axis.of_main_tool_actuator(mount)
     ot3_hardware._current_position[pip_ax] = target_pos[pip_ax] + 1
     mock_move.reset_mock()
     await ot3_hardware.prepare_for_aspirate(mount)
-    # make sure we've done the backlash compensation
-    backlash_pos = target_pos.copy()
-    backlash_pos[pip_ax] -= pipette.backlash_distance
-    mock_move.assert_any_call(
-        backlash_pos, speed=expected_speed_moving_up, acquire_lock=True
-    )
     # make sure the final move is to our target position
     mock_move.assert_called_with(
         target_pos, speed=expected_speed_moving_up, acquire_lock=True


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR changes backlash to ensure that all aspirations are pre-loaded.

Test data is showing that aspiration volumes are varying more between pipettes with the currently implemented backlash compensation. This is likely due to the variations between each pipette's true backlash distance causing both differences in aspiration distances. This is especially true at low volumes, where we are seeing large variations in volumes between pipettes.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
