### PR TITLE
fix(update-server): persist the machine-id after writing the rootfs to the unused partition.

### DIFF
--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -266,7 +266,10 @@ class OT3UpdateActions(UpdateActionsInterface):
 
     def write_machine_id(self, current_root: str, new_root: str) -> None:
         """Copy the machine id over to the new partition"""
-        pass
+        mid = open(os.path.join(current_root, "etc", "machine-id")).read()
+        with open(os.path.join(new_root, "etc", "machine-id"), "w") as new_mid:
+            new_mid.write(mid)
+        LOG.info(f"Wrote machine_id {mid.strip()} to {new_root}/etc/machine-id")
 
     def write_update(
         self,


### PR DESCRIPTION
# Overview

The `/etc/machine-id` on the Flex is not persisting through updates since the file gets overwritten during an update, this pr fixes that by writing the machine-id to the unused partition after the rootfs has been written to it.

This needs [or-core-pr-87](https://github.com/Opentrons/oe-core/pull/87) openemdedded change to work 

# Test Plan

- [x] Make sure that the UUID in `/etc/machine-id` persists after an update

# Changelog

- After the new rootfs has been written to the unused partition, read the old `/etc/machine-id` and write it to the new rootfs.

# Review requests


# Risk assessment
Low, this changes a small part of the update mechanism.
