### PR TITLE
fix(build): Don't sync version for now as this is causing unintended issues.

### DIFF
--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -66,8 +66,6 @@ ssh $(call id-file-arg,$(2)) $(3) root@$(1) \
  mv /var/$(notdir $(4))-unzip/$(basename $(basename $(notdir $(4))))/$(if $(7),$(7)/)$(6)*.$(if $(8),$(8),egg)-info $(5)/$(basename $(basename $(notdir $(4)))).$(if $(8),$(8),egg)-info ; \
  cleanup \
  "
-
-$(if $(9),$(call sync-version-file,$(1),$(2),$(3),$(9)),)
 endef
 
 # restart-service: ssh to a robot and restart one of its systemd units


### PR DESCRIPTION
# Overview

The version syncing is valuable as it lets us know if any code has been manually pushed to the robot, but it causes an issue with the robot app and blocks operations. So for now let's disable this until we can get a full solution without issues.

# Test Plan
# Changelog
# Review requests
# Risk assessment