### PR TITLE
fix(update-server): clean up the downloaded update files after an update.

### DIFF
--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -179,6 +179,13 @@ class OT2UpdateActions(UpdateActionsInterface):
             new_mid.write(mid)
         LOG.info(f"Wrote machine_id {mid.strip()} to {new_root}/etc/machine-id")
 
+    def clean_up(self, download_dir: str) -> None:
+        """Deletes the update contents in the download dir."""
+        LOG.info(f"Cleaning up download dir {download_dir}.")
+        for file in os.listdir(download_dir):
+            LOG.debug(f"Deleting {file}")
+            os.remove(file)
+
 
 def _find_unused_partition() -> RootPartitions:
     """Find the currently-unused root partition to write to"""

--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -183,8 +183,12 @@ class OT2UpdateActions(UpdateActionsInterface):
         """Deletes the update contents in the download dir."""
         LOG.info(f"Cleaning up download dir {download_dir}.")
         for file in os.listdir(download_dir):
-            LOG.debug(f"Deleting {file}")
-            os.remove(file)
+            filepath = os.path.join(download_dir, file)
+            LOG.debug(f"Deleting {filepath}")
+            try:
+                os.remove(filepath)
+            except Exception:
+                LOG.exception(f"Could not delete update file {filepath}.")
 
 
 def _find_unused_partition() -> RootPartitions:

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -246,6 +246,10 @@ async def commit(request: web.Request, session: UpdateSession) -> web.Response:
         except (OSError, CalledProcessError):
             LOG.exception("Failed to update machine-id")
         actions.commit_update()
+
+        # Clean up stale update files from the download dir
+        actions.clean_up(session.download_path)
+
         session.set_stage(Stages.READY_FOR_RESTART)
 
     return web.json_response(data=session.state, status=200)

--- a/update-server/otupdate/common/update_actions.py
+++ b/update-server/otupdate/common/update_actions.py
@@ -96,3 +96,8 @@ class UpdateActionsInterface:
     def write_machine_id(self, current_root: str, new_root: str) -> None:
         """Copy the machine id over to the new partition"""
         ...
+
+    @abc.abstractmethod
+    def clean_up(self, download_dir: str) -> None:
+        """Deletes the update files from the download dir."""
+        ...

--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -307,5 +307,9 @@ class OT3UpdateActions(UpdateActionsInterface):
         """Deletes the update contents in the download dir."""
         LOG.info(f"Cleaning up download dir {download_dir}.")
         for file in os.listdir(download_dir):
-            LOG.debug(f"Deleting {file}")
-            os.remove(file)
+            filepath = os.path.join(download_dir, file)
+            LOG.debug(f"Deleting {filepath}")
+            try:
+                os.remove(filepath)
+            except Exception:
+                LOG.exception(f"Could not delete update file {filepath}.")

--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -302,3 +302,10 @@ class OT3UpdateActions(UpdateActionsInterface):
         )
         if not success:
             raise RuntimeError(msg)
+
+    def clean_up(self, download_dir: str) -> None:
+        """Deletes the update contents in the download dir."""
+        LOG.info(f"Cleaning up download dir {download_dir}.")
+        for file in os.listdir(download_dir):
+            LOG.debug(f"Deleting {file}")
+            os.remove(file)


### PR DESCRIPTION
# Overview

The downloaded updated files are kept on the robot indefinitely, even after an update has been completed and the files are no longer needed. This leads to us always holding on to ~500MB+ of stale data on the user partition. This pr addresses this issue by cleaning up the download dir after the rootfs has been successfully written to the unused partition, the update has been committed, and the system is ready to restart.

# Test Plan

- [x] Make sure we can still update the Flex with this change
- [x] Make sure we can still update the OT2 with this change
- [x] Make sure that the download dir `/var/lib/otupdate/downloads` on the FLex is empty after an update is complete
- [x] Make sure that the download dir `/var/lib/otupdate/downloads` on the OT2 is empty after an update is complete

# Changelog

- Added a clean_up update action that removes all files from the otupdate download dir after an update.

# Review requests

- Make sure there arent any obvious issues.


# Risk assessment

Medium, this touches on update code for both the Flex and OT2 and needs to be tested on both.
