### PR TITLE
fix(app): send custom labware files to flex with protocol

### DIFF
--- a/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
@@ -36,12 +36,14 @@ import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/
 import { SendProtocolToOT3Slideout } from '..'
 
 import type { State } from '../../../redux/types'
+import { getValidCustomLabwareFiles } from '../../../redux/custom-labware'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../organisms/ToasterOven')
 jest.mock('../../../redux/buildroot')
 jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/networking')
+jest.mock('../../../redux/custom-labware')
 jest.mock('../../../redux/protocol-storage/selectors')
 
 const mockGetBuildrootUpdateDisplayInfo = getBuildrootUpdateDisplayInfo as jest.MockedFunction<
@@ -72,6 +74,9 @@ const mockGetIsProtocolAnalysisInProgress = getIsProtocolAnalysisInProgress as j
 >
 const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
   typeof getNetworkInterfaces
+>
+const mockGetValidCustomLabwareFiles = getValidCustomLabwareFiles as jest.MockedFunction<
+  typeof getValidCustomLabwareFiles
 >
 
 const render = (
@@ -110,6 +115,7 @@ const mockMakeSnackbar = jest.fn()
 const mockMakeToast = jest.fn()
 const mockEatToast = jest.fn()
 const mockMutateAsync = jest.fn()
+const mockCustomLabwareFile: File = { path: 'fake_custom_labware_path' } as any
 
 describe('SendProtocolToOT3Slideout', () => {
   beforeEach(() => {
@@ -144,6 +150,9 @@ describe('SendProtocolToOT3Slideout', () => {
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, expect.any(String))
       .mockReturnValue({ wifi: null, ethernet: null })
+    when(mockGetValidCustomLabwareFiles)
+      .calledWith({} as State)
+      .mockReturnValue([mockCustomLabwareFile])
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -246,6 +255,9 @@ describe('SendProtocolToOT3Slideout', () => {
     mockRobot.click()
     expect(sendButton).not.toBeDisabled()
     sendButton.click()
-    expect(mockMutateAsync).toBeCalled()
+    expect(mockMutateAsync).toBeCalledWith({
+      files: [expect.any(Object), mockCustomLabwareFile],
+      protocolKey: 'protocolKeyStub',
+    })
   })
 })

--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -20,6 +20,7 @@ import type { IconProps, StyleProps } from '@opentrons/components'
 import type { Robot } from '../../redux/discovery/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
+import { getValidCustomLabwareFiles } from '../../redux/custom-labware'
 
 interface SendProtocolToOT3SlideoutProps extends StyleProps {
   storedProtocolData: StoredProtocolData
@@ -51,6 +52,7 @@ export function SendProtocolToOT3Slideout(
   const isAnalyzing = useSelector((state: State) =>
     getIsProtocolAnalysisInProgress(state, protocolKey)
   )
+  const customLabwareFiles = useSelector(getValidCustomLabwareFiles)
 
   const analysisStatus = getAnalysisStatus(isAnalyzing, mostRecentAnalysis)
 
@@ -82,7 +84,10 @@ export function SendProtocolToOT3Slideout(
       disableTimeout: true,
     })
 
-    createProtocolAsync({ files: srcFileObjects, protocolKey })
+    createProtocolAsync({
+      files: [...srcFileObjects, ...customLabwareFiles],
+      protocolKey,
+    })
       .then(() => {
         eatToast(toastId)
         makeToast(selectedRobot?.name ?? '', SUCCESS_TOAST, {


### PR DESCRIPTION
# Overview

Just as the create run from protocol function spreads in all known custom labware files when creating a protocol record on a robot, the send to robot feature should also include custom labware.

props to @skowalski08 for uncovering this bug 

# Review requests

- upload a new protocol that includes custom labware to a flex via the "send to robot" menu item on the protocol page
- the robot side analysis should succeed on the flex

# Risk assessment
low
