### PR TITLE
fix(api): separate home and backoff steps into separate move groups

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -31,7 +31,7 @@ from .ot3utils import (
     create_move_group,
     axis_to_node,
     get_current_settings,
-    create_home_group,
+    create_home_groups,
     node_to_axis,
     sensor_node_for_mount,
     sensor_node_for_pipette,
@@ -475,10 +475,8 @@ class OT3Controller:
 
         move_group_pipette = []
         if distances_pipette and velocities_pipette:
-            pipette_move = self._filter_move_group(
-                create_home_group(distances_pipette, velocities_pipette)
-            )
-            move_group_pipette.append(pipette_move)
+            for group in create_home_groups(distances_pipette, velocities_pipette):
+                move_group_pipette.append(self._filter_move_group(group))
 
         if move_group_pipette:
             return MoveGroupRunner(move_groups=move_group_pipette, start_at_index=2)
@@ -515,21 +513,17 @@ class OT3Controller:
         }
         move_group_gantry_z = []
         if distances_z and velocities_z:
-            z_move = self._filter_move_group(
-                create_home_group(distances_z, velocities_z)
-            )
-            move_group_gantry_z.append(z_move)
+            for group in create_home_groups(distances_z, velocities_z):
+                move_group_gantry_z.append(self._filter_move_group(group))
         if distances_gantry and velocities_gantry:
             # home X axis before Y axis, to avoid collision with thermo-cycler lid
             # that could be in the back-left corner
             for ax in [OT3Axis.X, OT3Axis.Y]:
                 if ax in axes:
-                    gantry_move = self._filter_move_group(
-                        create_home_group(
-                            {ax: distances_gantry[ax]}, {ax: velocities_gantry[ax]}
-                        )
-                    )
-                    move_group_gantry_z.append(gantry_move)
+                    for group in create_home_groups(
+                        {ax: distances_gantry[ax]}, {ax: velocities_gantry[ax]}
+                    ):
+                        move_group_gantry_z.append(self._filter_move_group(group))
         if move_group_gantry_z:
             return MoveGroupRunner(move_groups=move_group_gantry_z)
         return None

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -348,21 +348,18 @@ def create_move_group(
     return move_group, {k: float(v) for k, v in pos.items()}
 
 
-def create_home_group(
+def create_home_groups(
     distance: Dict[OT3Axis, float], velocity: Dict[OT3Axis, float]
-) -> MoveGroup:
+) -> Tuple[MoveGroup, MoveGroup]:
     node_id_distances = _convert_to_node_id_dict(distance)
     node_id_velocities = _convert_to_node_id_dict(velocity)
-    home = create_home_step(
-        distance=node_id_distances,
-        velocity=node_id_velocities,
-    )
+    home_group = [
+        create_home_step(distance=node_id_distances, velocity=node_id_velocities)
+    ]
     # halve the homing speed for backoff
     backoff_velocities = {k: v / 2 for k, v in node_id_velocities.items()}
-    backoff = create_backoff_step(backoff_velocities)
-
-    move_group: MoveGroup = [home, backoff]
-    return move_group
+    backoff_group = [create_backoff_step(backoff_velocities)]
+    return home_group, backoff_group
 
 
 def create_tip_action_group(

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -350,7 +350,7 @@ def create_move_group(
 
 def create_home_groups(
     distance: Dict[OT3Axis, float], velocity: Dict[OT3Axis, float]
-) -> Tuple[MoveGroup, MoveGroup]:
+) -> List[MoveGroup]:
     node_id_distances = _convert_to_node_id_dict(distance)
     node_id_velocities = _convert_to_node_id_dict(velocity)
     home_group = [
@@ -359,7 +359,7 @@ def create_home_groups(
     # halve the homing speed for backoff
     backoff_velocities = {k: v / 2 for k, v in node_id_velocities.items()}
     backoff_group = [create_backoff_step(backoff_velocities)]
-    return home_group, backoff_group
+    return [home_group, backoff_group]
 
 
 def create_tip_action_group(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
 from decoy import Decoy
-from itertools import chain
 
 from contextlib import nullcontext as does_not_raise
 from typing import (
@@ -63,7 +62,6 @@ from opentrons_hardware.firmware_bindings.messages.messages import MessageDefini
 from opentrons_hardware.hardware_control.motion import (
     MoveType,
     MoveStopCondition,
-    MoveGroupStep,
     MoveGroupSingleAxisStep,
 )
 from opentrons_hardware.hardware_control.types import PCBARevision

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -308,7 +308,7 @@ async def test_home_execute(
     mock_present_devices: None,
 ) -> None:
     config = {"run.side_effect": move_group_run_side_effect(controller, axes)}
-    with mock.patch(
+    with mock.patch(  # type: ignore [call-overload]
         "opentrons.hardware_control.backends.ot3controller.MoveGroupRunner",
         spec=mock.Mock(MoveGroupRunner),
         **config
@@ -325,7 +325,9 @@ async def test_home_execute(
             for group in arg.kwargs["move_groups"]
         ]
 
-        actual_nodes_steps = {ax: [] for ax in axes}
+        actual_nodes_steps: Dict[OT3Axis, List[MoveGroupSingleAxisStep]] = {
+            ax: [] for ax in axes
+        }
         for group in all_groups:
             for step in group:
                 for k, v in step.items():


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Since the limit switch and backoff moves are in the same move group, the node will immediately execute the backoff move upon the home completion. This causes a catastrophe if the home request fails: the encoder position will no longer be reporting the correct value and the axis would not be able to home again until powercycled. 

We are fixing this by separating the home and the backoff moves into two consecutive move groups, the MoveGroupRunner would now be able to stop the subsystem to perform a backoff move if the home request was not completed by condition.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
