### PR TITLE
feat(protocol-designer): add flex trash

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -89,7 +89,7 @@ export const VIEWBOX_MIN_X = -64
 export const VIEWBOX_MIN_Y = -10
 export const VIEWBOX_WIDTH = 520
 export const VIEWBOX_HEIGHT = 414
-
+const FLEX_TRASH_SLOT = 'A3'
 const OT2_VIEWBOX = `${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`
 const FLEX_VIEWBOX = '-144.31 -76.59 750 580'
 
@@ -147,6 +147,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     deckDef,
     robotType,
   } = props
+  const trashSlot = robotType === FLEX_ROBOT_TYPE ? FLEX_TRASH_SLOT : '12'
 
   // NOTE: handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls.
@@ -358,7 +359,10 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
         .filter(
           slot =>
             !slotIdsBlockedBySpanning.includes(slot.id) &&
-            getSlotIsEmpty(activeDeckSetup, slot.id)
+            getSlotIsEmpty(activeDeckSetup, slot.id) &&
+            //  todo(jr, 7/13/23): filtering out trash slot for now, remove this
+            //  when we start to support moving the trash location
+            slot.id !== trashSlot
         )
         .map(slot => {
           return (
@@ -456,6 +460,7 @@ export const DeckSetup = (): JSX.Element => {
           viewBox={robotType === OT2_ROBOT_TYPE ? OT2_VIEWBOX : FLEX_VIEWBOX}
           width="100%"
           height="100%"
+          trashSlotName={FLEX_TRASH_SLOT}
         >
           {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
             <>


### PR DESCRIPTION
closes RAUT-543

# Overview

Add flex trash to the deck map and disallow adding labware onto the A3 slot

<img width="765" alt="Screen Shot 2023-07-13 at 5 15 24 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/3fc1d170-f460-43b4-9f6a-9a9cef0e68fa">


# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_add-flex-trash/

just test in PD that the flex deck map shows the trash slot in A3 and that you can't add a labware on top of that slot.

# Changelog

- modify `deckSetup` component in PD

# Review requests

see test plan

# Risk assessment

low