### PR TITLE
docs(api): new Moving Labware page

### DIFF
--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -10,6 +10,7 @@ Welcome
     tutorial
     versioning
     new_labware
+    moving_labware
     new_modules
     deck_slots
     new_pipette

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -6,4 +6,21 @@
 Moving Labware
 **************
 
-How to move labware, TK.
+You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can can only move labware manually (since it doesn't have a gripper instrument). Use the :py:meth:`move_labware` method to initiate a move, regardless of whether it uses the gripper or not.
+
+Automated vs Manual Moves
+=========================
+
+
+
+.. note::
+
+    Labware definitions don't explicitly declare compatibility or incompatibility with the gripper. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
+
+
+Movement with Modules
+=====================
+
+
+The Off-Deck Location
+=====================

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -24,16 +24,30 @@ Use the :py:meth:`.ProtocolContext.move_labware` method to initiate a move, rega
 
 The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`Labware` object with the name ``plate``. That information gets updated when the move step is complete, so you can move a plate multiple times::
 
-        protocol.move_labware(labware=plate, new_location='D2')
-        protocol.move_labware(labware=plate, new_location='D3')
-        
+    protocol.move_labware(labware=plate, new_location='D2')
+    protocol.move_labware(labware=plate, new_location='D3')
+    
 For the first move, the API knows to find the plate in its initial load location, slot D1. For the second move, the API knows to find the plate in D2.
 
 
 Automated vs Manual Moves
 =========================
 
+Opentrons Flex supports an additional ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` for moving labware with the gripper. Set its value to ``True`` to have the gripper pick up and move the labware without user intervention or pausing the protocol. The default value is ``False``, so if you don't specify a value, the protocol will pause for you to manually move the labware.
 
+.. code-block:: python
+
+    plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D1')
+    # have the gripper move the plate from D1 to D2
+    protocol.move_labware(labware=plate, new_location='D2', use_gripper=True)
+    # pause to move the plate manually from D2 to D3
+    protocol.move_labware(labware=plate, new_location='D3', use_gripper=False)
+    # pause to move the plate manually from D3 to C1
+    protocol.move_labware(labware=plate, new_location='C1')
+
+.. versionadded:: 2.15
+
+All you have to do to specify that a protocol requires the gripper is to include a single ``move_labware()`` command with ``use_labware=True``. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. 
 
 .. note::
 
@@ -46,3 +60,4 @@ Movement with Modules
 
 The Off-Deck Location
 =====================
+

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -127,6 +127,7 @@ Also note the ``hs_mod.open_labware_latch()`` command in the above example. To m
     
 If the labware is inaccessible, the API will raise an error. 
 
+.. _off-deck-location:
 
 The Off-Deck Location
 =====================

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -165,13 +165,10 @@ You can also load labware off-deck, in preparation for a ``move_labware()`` comm
         for i in range(96):
             pipette.pick_up_tip()
             pipette.drop_tip()
-        # move the spent tip rack off-deck
+        # pause to move the spent tip rack off-deck
         protocol.move_labware(labware=tips1, new_location=protocol_api.OFF_DECK)
-        # move the fresh tip rack on-deck
+        # pause to move the fresh tip rack on-deck
         protocol.move_labware(labware=tips2, new_location=1)
         pipette.pick_up_tip()
 
 Using the off-deck location to remove or replace labware lets you continue your workflow in a single protocol, rather than needing to end a protocol, reset the deck, and start a new protocol run.
-
-
-

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -29,29 +29,64 @@ The required arguments of ``move_labware()`` are the ``labware`` you want to mov
     
 For the first move, the API knows to find the plate in its initial load location, slot D1. For the second move, the API knows to find the plate in D2.
 
+Moving the following types of labware is fully supported by Opentrons:
 
-Automated vs Manual Moves
-=========================
+.. list-table::
+    :header-rows: 1
 
-Opentrons Flex supports an additional ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` for moving labware with the gripper. Set its value to ``True`` to have the gripper pick up and move the labware without user intervention or pausing the protocol. The default value is ``False``, so if you don't specify a value, the protocol will pause for you to manually move the labware.
-
-.. code-block:: python
-
-    plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D1')
-    # have the gripper move the plate from D1 to D2
-    protocol.move_labware(labware=plate, new_location='D2', use_gripper=True)
-    # pause to move the plate manually from D2 to D3
-    protocol.move_labware(labware=plate, new_location='D3', use_gripper=False)
-    # pause to move the plate manually from D3 to C1
-    protocol.move_labware(labware=plate, new_location='C1')
-
-.. versionadded:: 2.15
-
-All you have to do to specify that a protocol requires the gripper is to include a single ``move_labware()`` command with ``use_labware=True``. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. 
+    * - Labware Type
+      - API Load Name
+    * - NEST 96 Deep Well Plate 2mL
+      - ``nest_96_wellplate_2ml_deep``
+    * - Armadillo 96 well plate 200 µL Full Skirt
+      - ``armadillo_96_wellplate_200ul_pcr_full_skirt``
+    * - NEST 96 Well Plate 200 µL Flat
+      - ``nest_96_wellplate_200ul_flat``
+    * - All Opentrons Flex 96 Tip Racks 
+      - 
+          * ``opentrons_flex_96_tiprack_50ul``
+          * ``opentrons_flex_96_tiprack_200ul``
+          * ``opentrons_flex_96_tiprack_1000ul``
+          * ``opentrons_flex_96_filtertiprack_50ul``
+          * ``opentrons_flex_96_filtertiprack_200ul``
+          * ``opentrons_flex_96_filtertiprack_1000ul``
+    
+The gripper may work with other ANSI/SLAS standard labware, but this is not recommended.
 
 .. note::
 
     Labware definitions don't explicitly declare compatibility or incompatibility with the gripper. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
+
+Automatic vs Manual Moves
+=========================
+
+There are two ways to move labware:
+
+- Automatically, with the Opentrons Flex Gripper.
+- Manually, by pausing the protocol until a user confirms that they've moved the labware.
+
+The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` determines which way a particular movement should happen. Set its value to ``True`` for an automatic move. The default value is ``False``, so if you don't specify a value, the protocol will pause for a manual move.
+
+.. code-block:: python
+
+    def run(protocol: protocol_api.ProtocolContext):
+        plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D1')
+        
+        # have the gripper move the plate from D1 to D2
+        protocol.move_labware(labware=plate, new_location='D2', use_gripper=True)
+        
+        # pause to move the plate manually from D2 to D3
+        protocol.move_labware(labware=plate, new_location='D3', use_gripper=False)
+        
+        # pause to move the plate manually from D3 to C1
+        protocol.move_labware(labware=plate, new_location='C1')
+
+.. versionadded:: 2.15
+
+The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_labware=True``.
+
+
+
 
 
 Movement with Modules

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -22,10 +22,7 @@ Use the :py:meth:`.ProtocolContext.move_labware` method to initiate a move, rega
         
 .. versionadded:: 2.15
 
-The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`~opentrons.protocol_api.labware.Labware` object — ``plate`` in this example. The destination of the move can be any empty deck slot, or a module that's ready to have labware added to it (see :ref:`movement-modules` below). Attempting to move to an occupied location will raise a ``LocationIsOccupiedError``.
-
-.. note::
-    The slot that a labware currently occupies is considered an occupied destination. This prevents you from creating trivial moves, e.g., from slot D2 to slot D2.
+The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`~opentrons.protocol_api.labware.Labware` object — ``plate`` in this example. The destination of the move can be any empty deck slot, or a module that's ready to have labware added to it (see :ref:`movement-modules` below). Movement to an occupied location — including the labware's current location — will raise a ``LocationIsOccupiedError``.
 
 When the move step is complete, the API updates the labware's location, so you can move the plate multiple times::
 
@@ -43,7 +40,7 @@ There are two ways to move labware:
 - Automatically, with the Opentrons Flex Gripper.
 - Manually, by pausing the protocol until a user confirms that they've moved the labware.
 
-The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` determines which way a particular movement should happen. Set its value to ``True`` for an automatic move. The default value is ``False``, so if you don't specify a value, the protocol will pause for a manual move.
+The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` determines whether a movement is automatic or manual. Set its value to ``True`` for an automatic move. The default value is ``False``, so if you don't specify a value, the protocol will pause for a manual move.
 
 .. code-block:: python
 
@@ -142,7 +139,7 @@ Remove labware from the deck to perform tasks like retrieving samples or discard
     
 .. versionadded:: 2.15
 
-Moving labware off-deck always requires user intervention, since the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise a ``LabwareMovementNotAllowedError``.
+Moving labware off-deck always requires user intervention, because the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise a ``LabwareMovementNotAllowedError``.
 
 You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it `onto` the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one::
 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -6,7 +6,29 @@
 Moving Labware
 **************
 
-You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can can only move labware manually (since it doesn't have a gripper instrument). Use the :py:meth:`move_labware` method to initiate a move, regardless of whether it uses the gripper or not.
+You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can can only move labware manually (since it doesn't have a gripper instrument). 
+
+Basic Movement
+==============
+
+Use the :py:meth:`.ProtocolContext.move_labware` method to initiate a move, regardless of whether it uses the gripper.
+
+.. code-block:: python
+    :substitutions:
+        
+    def run(protocol: protocol_api.ProtocolContext):
+        plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D1')
+        protocol.move_labware(labware=plate, new_location='D2')
+        
+.. versionadded:: 2.15
+
+The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`Labware` object with the name ``plate``. That information gets updated when the move step is complete, so you can move a plate multiple times::
+
+        protocol.move_labware(labware=plate, new_location='D2')
+        protocol.move_labware(labware=plate, new_location='D3')
+        
+For the first move, the API knows to find the plate in its initial load location, slot D1. For the second move, the API knows to find the plate in D2.
+
 
 Automated vs Manual Moves
 =========================

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -1,0 +1,9 @@
+:og:description: How to move labware, with the Flex Gripper or manually, in a Python protocol.
+
+.. _moving-labware:
+
+**************
+Moving Labware
+**************
+
+How to move labware, TK.

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -61,6 +61,9 @@ The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` deter
 
 .. versionadded:: 2.15
 
+.. note::
+    Don't add a ``pause()`` command before ``move_labware()``. When ``use_gripper`` is unset or ``False``, the protocol pauses when it reaches the movement step. The Opentrons App or the touchscreen on Flex shows an animation of the labware movement that you need to perform manually. The protocol only resumes when you press **Confirm and resume**.
+
 The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_labware=True``.
 
 If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise a ``ErrorType TK`` error.

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -63,7 +63,7 @@ The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` deter
 
 The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_labware=True``.
 
-If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise a ``ErrorType TK`` error.
+If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise a ``NotSupportedOnRobotType`` error.
 
 
 Supported Labware

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -69,7 +69,7 @@ If you attempt to use the gripper to move labware in an OT-2 protocol, the API w
 Supported Labware
 =================
 
-Moving the following types of labware is fully supported by Opentrons:
+You can manually move any standard or custom labware. Using the gripper to move the following types of labware is fully supported by Opentrons:
 
 .. list-table::
     :header-rows: 1

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -22,7 +22,7 @@ Use the :py:meth:`.ProtocolContext.move_labware` method to initiate a move, rega
         
 .. versionadded:: 2.15
 
-The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`~opentrons.protocol_api.labware.Labware` object — ``plate`` in this example. The destination of the move can be any empty deck slot, or a module that's ready to have labware added to it (see :ref:`movement-modules` below). Movement to an occupied location — including the labware's current location — will raise a ``LocationIsOccupiedError``.
+The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`~opentrons.protocol_api.labware.Labware` object — ``plate`` in this example. The destination of the move can be any empty deck slot, or a module that's ready to have labware added to it (see :ref:`movement-modules` below). Movement to an occupied location, including the labware's current location, will raise an error.
 
 When the move step is complete, the API updates the labware's location, so you can move the plate multiple times::
 
@@ -63,7 +63,7 @@ The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` deter
 
 The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_labware=True``.
 
-If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise a ``NotSupportedOnRobotType`` error.
+If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise an error.
 
 
 Supported Labware
@@ -118,14 +118,14 @@ When moving labware anywhere that isn't an empty deck slot, consider what physic
 
 .. versionadded:: 2.15
 
-If you try to move the plate to slot C1 or the Heater-Shaker module, you will get a ``LocationIsOccupiedError`` — C1 is occupied by the Heater-Shaker, and the Heater-Shaker is occupied by the adapter. Only the adapter, as the topmost item in that stack, is unoccupied.
+If you try to move the plate to slot C1 or the Heater-Shaker module, the API will raise an error, because C1 is occupied by the Heater-Shaker, and the Heater-Shaker is occupied by the adapter. Only the adapter, as the topmost item in that stack, is unoccupied.
 
 Also note the ``hs_mod.open_labware_latch()`` command in the above example. To move labware onto or off of a module, you have to make sure that it's physically accessible:
 
     - For the Heater-Shaker, use :py:meth:`~.HeaterShakerContext.open_labware_latch`.
     - For the Thermocycler, use :py:meth:`~.ThermocyclerContext.open_lid`.
     
-If the labware is inaccessible, the API will raise a ``LabwareMovementNotAllowedError``. 
+If the labware is inaccessible, the API will raise an error. 
 
 
 The Off-Deck Location
@@ -139,7 +139,7 @@ Remove labware from the deck to perform tasks like retrieving samples or discard
     
 .. versionadded:: 2.15
 
-Moving labware off-deck always requires user intervention, because the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise a ``LabwareMovementNotAllowedError``.
+Moving labware off-deck always requires user intervention, because the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise an error.
 
 You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it `onto` the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one::
 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -6,7 +6,7 @@
 Moving Labware
 **************
 
-You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can can only move labware manually (since it doesn't have a gripper instrument). 
+You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can can only move labware manually, since it doesn't have a gripper instrument. 
 
 Basic Movement
 ==============
@@ -22,40 +22,18 @@ Use the :py:meth:`.ProtocolContext.move_labware` method to initiate a move, rega
         
 .. versionadded:: 2.15
 
-The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`Labware` object with the name ``plate``. That information gets updated when the move step is complete, so you can move a plate multiple times::
+The required arguments of ``move_labware()`` are the ``labware`` you want to move and its ``new_location``. You don't need to specify where the move begins, since that information is already stored in the :py:class:`~opentrons.protocol_api.labware.Labware` object — ``plate`` in this example. The destination of the move can be any empty deck slot, or a module that's ready to have labware added to it (see :ref:`movement-modules` below). Attempting to move to an occupied location will raise a ``LocationIsOccupiedError``.
+
+.. note::
+    The slot that a labware currently occupies is considered an occupied destination. This prevents you from creating trivial moves, e.g., from slot D2 to slot D2.
+
+When the move step is complete, the API updates the labware's location, so you can move the plate multiple times::
 
     protocol.move_labware(labware=plate, new_location='D2')
     protocol.move_labware(labware=plate, new_location='D3')
     
 For the first move, the API knows to find the plate in its initial load location, slot D1. For the second move, the API knows to find the plate in D2.
 
-Moving the following types of labware is fully supported by Opentrons:
-
-.. list-table::
-    :header-rows: 1
-
-    * - Labware Type
-      - API Load Name
-    * - NEST 96 Deep Well Plate 2mL
-      - ``nest_96_wellplate_2ml_deep``
-    * - Armadillo 96 well plate 200 µL Full Skirt
-      - ``armadillo_96_wellplate_200ul_pcr_full_skirt``
-    * - NEST 96 Well Plate 200 µL Flat
-      - ``nest_96_wellplate_200ul_flat``
-    * - All Opentrons Flex 96 Tip Racks 
-      - 
-          * ``opentrons_flex_96_tiprack_50ul``
-          * ``opentrons_flex_96_tiprack_200ul``
-          * ``opentrons_flex_96_tiprack_1000ul``
-          * ``opentrons_flex_96_filtertiprack_50ul``
-          * ``opentrons_flex_96_filtertiprack_200ul``
-          * ``opentrons_flex_96_filtertiprack_1000ul``
-    
-The gripper may work with other ANSI/SLAS standard labware, but this is not recommended.
-
-.. note::
-
-    Labware definitions don't explicitly declare compatibility or incompatibility with the gripper. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
 
 Automatic vs Manual Moves
 =========================
@@ -85,14 +63,112 @@ The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` deter
 
 The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_labware=True``.
 
+If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise a ``ErrorType TK`` error.
 
 
+Supported Labware
+=================
 
+Moving the following types of labware is fully supported by Opentrons:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Labware Type
+      - API Load Name
+    * - NEST 96 Deep Well Plate 2mL
+      - ``nest_96_wellplate_2ml_deep``
+    * - Armadillo 96 well plate 200 µL Full Skirt
+      - ``armadillo_96_wellplate_200ul_pcr_full_skirt``
+    * - NEST 96 Well Plate 200 µL Flat
+      - ``nest_96_wellplate_200ul_flat``
+    * - All Opentrons Flex 96 Tip Racks 
+      - 
+          * ``opentrons_flex_96_tiprack_50ul``
+          * ``opentrons_flex_96_tiprack_200ul``
+          * ``opentrons_flex_96_tiprack_1000ul``
+          * ``opentrons_flex_96_filtertiprack_50ul``
+          * ``opentrons_flex_96_filtertiprack_200ul``
+          * ``opentrons_flex_96_filtertiprack_1000ul``
+    
+The gripper may work with other ANSI/SLAS standard labware, but this is not recommended.
+
+.. note::
+
+    Labware definitions don't explicitly declare compatibility or incompatibility with the gripper. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
+
+
+.. _movement-modules: 
 
 Movement with Modules
 =====================
 
+Moving labware on and off of modules lets you precisely control when the labware is in contact with the hot, cold, or magnetic surfaces of the modules — all within a single protocol.
+
+When moving labware anywhere that isn't an empty deck slot, consider what physical object the labware will rest on following the move. That object should be the value of ``new_location``, and you need to make sure it's already loaded before the move. For example, if you want to move a 96-well flat plate onto a Heater-Shaker module, you actually want to have it rest on top of the Heater-Shaker's 96 Flat Bottom Adapter. Pass the adapter, not the module or the slot, as the value of ``new_location``::
+
+    def run(protocol: protocol_api.ProtocolContext):
+        plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D1")
+        hs_mod = protocol.load_module("heaterShakerModuleV1", "C1")
+        hs_adapter = hs_mod.load_adapter("opentrons_96_flat_bottom_adapter")
+        hs_mod.open_labware_latch()
+        protocol.move_labware(
+            labware=plate, new_location=hs_adapter, use_gripper=True
+        )
+
+.. versionadded:: 2.15
+
+If you try to move the plate to slot C1 or the Heater-Shaker module, you will get a ``LocationIsOccupiedError`` — C1 is occupied by the Heater-Shaker, and the Heater-Shaker is occupied by the adapter. Only the adapter, as the topmost item in that stack, is unoccupied.
+
+Also note the ``hs_mod.open_labware_latch()`` command in the above example. To move labware onto or off of a module, you have to make sure that it's physically accessible:
+
+    - For the Heater-Shaker, use :py:meth:`~.HeaterShakerContext.open_labware_latch`.
+    - For the Thermocycler, use :py:meth:`~.ThermocyclerContext.open_lid`.
+    
+If the labware is inaccessible, the API will raise a ``LabwareMovementNotAllowedError``. 
+
 
 The Off-Deck Location
 =====================
+
+In addition to moving labware around the deck, :py:meth:`~.ProtocolContext.move_labware` can also prompt you to move labware off of or onto the deck. 
+
+Remove labware from the deck to perform tasks like retrieving samples or discarding a spent tip rack. The destination location for such moves is the special constant :py:obj:`~opentrons.protocol_api.OFF_DECK`::
+
+    protocol.move_labware(labware=plate, new_location=protocol_api.OFF_DECK)
+    
+.. versionadded:: 2.15
+
+Moving labware off-deck always requires user intervention, since the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise a ``LabwareMovementNotAllowedError``.
+
+You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it `onto` the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one::
+
+    from opentrons import protocol_api
+
+    metadata = {"apiLevel": "2.15", "protocolName": "Tip rack replacement"}
+    requirements = {"robotType": "OT-2"}
+
+
+    def run(protocol: protocol_api.ProtocolContext):
+        tips1 = protocol.load_labware("opentrons_96_tiprack_1000ul", 1)
+        # load another tip rack but don't put it in a slot yet
+        tips2 = protocol.load_labware(
+            "opentrons_96_tiprack_1000ul", protocol_api.OFF_DECK
+        )
+        pipette = protocol.load_instrument(
+            "p1000_single_gen2", "left", tip_racks=[tips1, tips2]
+        )
+        # use all the on-deck tips
+        for i in range(96):
+            pipette.pick_up_tip()
+            pipette.drop_tip()
+        # move the spent tip rack off-deck
+        protocol.move_labware(labware=tips1, new_location=protocol_api.OFF_DECK)
+        # move the fresh tip rack on-deck
+        protocol.move_labware(labware=tips2, new_location=1)
+        pipette.pick_up_tip()
+
+Using the off-deck location to remove or replace labware lets you continue your workflow in a single protocol, rather than needing to end a protocol, reset the deck, and start a new protocol run.
+
+
 

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -16,7 +16,7 @@ for liquid handling commands from the :py:class:`.InstrumentContext` class.
 Loading A Pipette
 ------------------
 
-Pipettes are specified in a protocol using the method :py:meth:`.ProtocolContext.load_instrument`. This method requires the model of the instrument to load, the mount to load it in, and (optionally) a list of associated tipracks:
+Specify pipettes in your protocol using the :py:meth:`.ProtocolContext.load_instrument` method. This method requires the model of the instrument to load, the mount to load it in, and (optionally) a list of associated tip racks:
 
 .. code-block:: python
     :substitutions:
@@ -26,9 +26,10 @@ Pipettes are specified in a protocol using the method :py:meth:`.ProtocolContext
     metadata = {'apiLevel': '|apiLevel|'}
 
     def run(protocol: protocol_api.ProtocolContext):
-        # Load a P50 multi on the left slot
+        # Load a P50 8-Channel Pipette on the left mount
         left = protocol.load_instrument('p50_multi', 'left')
-        # Load a P1000 Single on the right slot, with two racks of tips
+        # Load a P1000 Single-Channel Pipette on the right mount
+        # with two racks of tips
         tiprack1 = protocol.load_labware('opentrons_96_tiprack_1000ul', 1)
         tiprack2 = protocol.load_labware('opentrons_96_tiprack_1000ul', 2)
         right = protocol.load_instrument('p1000_single', 'right',
@@ -36,9 +37,9 @@ Pipettes are specified in a protocol using the method :py:meth:`.ProtocolContext
 
 .. versionadded:: 2.0
 
-.. note::
+When you load a pipette in this way, you are declaring that you want the specified pipette to be attached to the robot. Even if you don't use the pipette anywhere else in your protocol, the Opentrons App or the touchscreen on Flex will not let your protocol proceed until all pipettes loaded with ``load_instrument`` are attached.
 
-    When you load a pipette in a protocol, you inform the OT-2 that you want the specified pipette to be present. Even if you do not use the pipette anywhere else in your protocol, the Opentrons App and the OT-2 will not let your protocol proceed until all pipettes loaded with ``load_instrument`` are attached to the OT-2.
+If you're writing a protocol that uses the Flex Gripper, you might think that this would be the place in your protocol to declare that. However, the gripper doesn't require ``load_instrument``! Whether your gripper requires a protocol is determined by the presence of :py:meth:`.ProtocolContext.move_labware` commands. See :ref:`moving-labware` for more details.
 
 .. _new-multichannel-pipettes:
 

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -11,13 +11,9 @@ Protocols and Instruments
 -------------------------
 .. module:: opentrons.protocol_api
 
-..
-   TODO(mm, 2023-06-06): When we want to publish move_labware(), un-exclude it here and
-   and also uncomment the inclusion of OFF_DECK, below in this file.
-   https://opentrons.atlassian.net/browse/RTC-288
 .. autoclass:: opentrons.protocol_api.ProtocolContext
    :members:
-   :exclude-members: location_cache, cleanup, clear_commands, commands, move_labware
+   :exclude-members: location_cache, cleanup, clear_commands, commands
 
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:
@@ -80,11 +76,8 @@ Useful Types and Definitions
 .. automodule:: opentrons.types
    :members: PipetteNotAttachedError, Point, Location, Mount
 
-..
-   TODO(mm, 2023-06-06): This should be uncommented when move_labware() is published. See above.
-   https://opentrons.atlassian.net/browse/RTC-288
-   .. autodata:: opentrons.protocol_api.OFF_DECK
-      :no-value:
+.. autodata:: opentrons.protocol_api.OFF_DECK
+   :no-value:
 
 Executing and Simulating Protocols
 ----------------------------------

--- a/api/src/opentrons/protocol_api/_types.py
+++ b/api/src/opentrons/protocol_api/_types.py
@@ -14,5 +14,5 @@ OFF_DECK: Final = OffDeckType.OFF_DECK
 OFF_DECK.__doc__ = """\
 A special location value, indicating that a labware is not currently on the robot's deck.
 
-See :py:obj:`ProtocolContext.move_labware()`.
+See :ref:`off-deck-location` for details on using ``OFF_DECK`` with :py:obj:`ProtocolContext.move_labware()`.
 """

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -532,7 +532,7 @@ class ProtocolContext(CommandPublisher):
         pick_up_offset: Optional[Mapping[str, float]] = None,
         drop_offset: Optional[Mapping[str, float]] = None,
     ) -> None:
-        """Move a loaded labware to a new location.
+        """Move a loaded labware to a new location. See :ref:`moving-labware` for more details.
 
         :param labware: The labware to move. It should be a labware already loaded
                         using :py:meth:`load_labware`.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -534,8 +534,8 @@ class ProtocolContext(CommandPublisher):
     ) -> None:
         """Move a loaded labware to a new location.
 
-        :param labware: The labware to move. Should be a labware already loaded
-                        using :py:meth:`load_labware`
+        :param labware: The labware to move. It should be a labware already loaded
+                        using :py:meth:`load_labware`.
 
         :param new_location: Where to move the labware to. This is either:
 
@@ -547,18 +547,19 @@ class ProtocolContext(CommandPublisher):
                 * The special constant :py:obj:`OFF_DECK`.
 
         :param use_gripper: Whether to use the Flex Gripper for this movement.
-                            If ``True``, will use the gripper to perform an automatic
-                            movement. This will raise an error on an OT-2 protocol.
-                            If False, will pause protocol execution until the user
-                            performs the movement. Protocol execution remains paused until
-                            the user presses **Confirm and resume**.
+
+                * If ``True``, will use the gripper to perform an automatic
+                  movement. This will raise an error on an OT-2 protocol.
+                * If ``False``, will pause protocol execution until the user
+                  performs the movement. Protocol execution remains paused until
+                  the user presses **Confirm and resume**.
 
         Gripper-only parameters:
 
         :param pick_up_offset: Optional x, y, z vector offset to use when picking up labware.
         :param drop_offset: Optional x, y, z vector offset to use when dropping off labware.
 
-        Before moving a labware from or to a hardware module, make sure that the labware's
+        Before moving a labware to or from a hardware module, make sure that the labware's
         current and new locations are accessible, i.e., open the Thermocycler lid or
         open the Heater-Shaker's labware latch.
         """

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -534,9 +534,6 @@ class ProtocolContext(CommandPublisher):
     ) -> None:
         """Move a loaded labware to a new location.
 
-        *** This API method is currently being developed. ***
-        *** Expect changes without API level bump.        ***
-
         :param labware: Labware to move. Should be a labware already loaded
                         using :py:meth:`load_labware`
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -534,7 +534,7 @@ class ProtocolContext(CommandPublisher):
     ) -> None:
         """Move a loaded labware to a new location.
 
-        :param labware: Labware to move. Should be a labware already loaded
+        :param labware: The labware to move. Should be a labware already loaded
                         using :py:meth:`load_labware`
 
         :param new_location: Where to move the labware to. This is either:
@@ -546,27 +546,22 @@ class ProtocolContext(CommandPublisher):
                   with :py:meth:`load_labware` or :py:meth:`load_adapter`.
                 * The special constant :py:obj:`OFF_DECK`.
 
-        :param use_gripper: Whether to use gripper to perform this move.
-                            If True, will use the gripper to perform the move (OT3 only).
-                            If False, will pause protocol execution to allow the user
-                            to perform a manual move and click resume to continue
-                            protocol execution.
+        :param use_gripper: Whether to use the Flex Gripper for this movement.
+                            If ``True``, will use the gripper to perform an automatic
+                            movement. This will raise an error on an OT-2 protocol.
+                            If False, will pause protocol execution until the user
+                            performs the movement. Protocol execution remains paused until
+                            the user presses **Confirm and resume**.
 
-        Other experimental params:
+        Gripper-only parameters:
 
-        :param use_pick_up_location_lpc_offset: Whether to use LPC offset of the labware
-                                                associated with its pick up location.
-        :param use_drop_location_lpc_offset: Whether to use LPC offset of the labware
-                                             associated with its drop off location.
-        :param pick_up_offset: Offset to use when picking up labware.
-        :param drop_offset: Offset to use when dropping off labware.
+        :param pick_up_offset: Optional x, y, z vector offset to use when picking up labware.
+        :param drop_offset: Optional x, y, z vector offset to use when dropping off labware.
 
-        Before moving a labware from or to a hardware module, make sure that the labware
-        and its new location is reachable by the gripper. So, thermocycler lid should be
-        open and heater-shaker's labware latch should be open.
+        Before moving a labware from or to a hardware module, make sure that the labware's
+        current and new locations are accessible, i.e., open the Thermocycler lid or
+        open the Heater-Shaker's labware latch.
         """
-        # TODO (spp, 2022-10-31): re-evaluate whether to allow specifying `use_gripper`
-        #  in the args or whether to have it specified in protocol requirements.
 
         if not isinstance(labware, Labware):
             raise ValueError(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

A new page about Moving Labware, with the gripper and manually. It covers:

- Basic movement with `move_labware()`
- The differences between automatic and manual moves
- Which labware we officially support
- Moving onto and off of modules/adapters
- Moving onto and off of the deck with `OFF_DECK`

Also updates the API Reference entry for `move_labware()`.

Addresses RTC-145.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Code snippets tested against dev robot server on this branch, which rebased on `edge` on July 31.
- Code formatted with `black` using 80-character line
- Formatting and links tested in the [sandbox](http://sandbox.docs.opentrons.com/docs-moving-labware/v2/moving_labware.html)

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- mention on Pipettes page that you don't have to `load_instrument` the gripper + crossref
- entirely new Moving Labware page
- uncomment `move_labware` and `OFF_DECK` from reference
- remove "this method may change" warning in `move_labware` docstring (it's time to commit to its functionality)
- [x] error type for trying to use gripper on OT-2
- removes old LPC parameters from reference
- general prose edits to reference

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Please check all my Python code and make sure that it runs today (and ought to run on release PAPI 2.15). Confirm that we can remove docstring warnings and finalize `move_labware()` behavior.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

low, docs only