### PR TITLE
feat(protocol-designer): allow tip racks but not trash selection in moveLabware form

### DIFF
--- a/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
+++ b/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
@@ -151,6 +151,36 @@ describe('labware selectors', () => {
       ])
     })
 
+    it('should return labware options for move labware with tips and no trash', () => {
+      const labwareEntities = {
+        ...tipracks,
+        ...trash,
+        ...otherLabware,
+      }
+      const initialDeckSetup = {
+        labware: labwareEntities,
+        modules: {},
+        pipettes: {},
+      }
+
+      const presavedStepForm = {
+        stepType: 'moveLabware',
+      }
+      expect(
+        //  @ts-expect-error(jr, 7/17/23): resultFunc doesn't exist on type Selector<Options>
+        getLabwareOptions.resultFunc(
+          labwareEntities,
+          names,
+          initialDeckSetup,
+          presavedStepForm
+        )
+      ).toEqual([
+        { name: 'Opentrons Tip Rack 10 µL', value: 'tiprack10Id' },
+        { name: 'Opentrons Tip Rack 1000 µL', value: 'tiprack100Id' },
+        { name: 'Source Plate', value: 'wellPlateId' },
+      ])
+    })
+
     it('should return labware options with module prefixes when a labware is on module', () => {
       const labware = {
         wellPlateId: {

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -42,7 +42,10 @@ export const getLabwareOptions: Selector<Options> = createSelector(
   stepFormSelectors.getLabwareEntities,
   getLabwareNicknamesById,
   stepFormSelectors.getInitialDeckSetup,
-  (labwareEntities, nicknamesById, initialDeckSetup) => {
+  stepFormSelectors.getPresavedStepForm,
+  (labwareEntities, nicknamesById, initialDeckSetup, presavedStepForm) => {
+    const moveLabwarePresavedStep = presavedStepForm?.stepType === 'moveLabware'
+
     const options = reduce(
       labwareEntities,
       (
@@ -59,15 +62,30 @@ export const getLabwareOptions: Selector<Options> = createSelector(
         const nickName = prefix
           ? `${prefix} ${nicknamesById[labwareId]}`
           : nicknamesById[labwareId]
-        return getIsTiprack(labwareEntity.def)
-          ? acc
-          : [
-              ...acc,
-              {
-                name: nickName,
-                value: labwareId,
-              },
-            ]
+
+        if (!moveLabwarePresavedStep) {
+          return getIsTiprack(labwareEntity.def)
+            ? acc
+            : [
+                ...acc,
+                {
+                  name: nickName,
+                  value: labwareId,
+                },
+              ]
+        } else {
+          //  TODO(jr, 7/17/23): filter out moving trash for now in MoveLabware step type
+          //  remove this when we support other slots for trash
+          return nickName === 'Trash'
+            ? acc
+            : [
+                ...acc,
+                {
+                  name: nickName,
+                  value: labwareId,
+                },
+              ]
+        }
       },
       []
     )


### PR DESCRIPTION
closes RAUT-561 and RQA-1076 and RQA-1114

# Overview

When you move a labware, tip racks on the deck are now selectable but the trash is no longer selectable (for now since only a fixed trash is supported)

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_labware-dropdown-options/

add a move labware step in the timeline, doesn't matter which robot type it is. The tipracks on the deck should be selectable but the trash should not be selectable in the drop down.

add a transfer or mix to the timeline. The labware selection should not show tip racks but should show the trash.

# Changelog

- modify `getLabwareOptions` selector and test to have branching logic for tipracks and trash when the presaved step is `moveLabware`

# Review requests

see test plan

# Risk assessment

low