### PR TITLE
feat(api): add limit switch backoff move to 96-channel pipette tip motor home sequence

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -40,6 +40,7 @@ from .ot3utils import (
     create_gripper_jaw_home_group,
     create_gripper_jaw_hold_group,
     create_tip_action_group,
+    create_tip_action_home_group,
     PipetteAction,
     motor_nodes,
     LIMIT_SWITCH_OVERTRAVEL_DISTANCE,
@@ -569,10 +570,17 @@ class OT3Controller:
     ) -> None:
         if tip_action == "home":
             speed = speed * -1
-        move_group = create_tip_action_group(
-            axes, distance, speed, cast(PipetteAction, tip_action)
-        )
-        runner = MoveGroupRunner(move_groups=[move_group])
+            runner = MoveGroupRunner(
+                move_groups=create_tip_action_home_group(axes, distance, speed)
+            )
+        else:
+            runner = MoveGroupRunner(
+                move_groups=[
+                    create_tip_action_group(
+                        axes, distance, speed, cast(PipetteAction, tip_action)
+                    )
+                ]
+            )
         positions = await runner.run(can_messenger=self._messenger)
         for axis, point in positions.items():
             self._position.update({axis: point[0]})

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -170,6 +170,19 @@ def create_home_step(
     return step
 
 
+def create_tip_action_backoff_step(velocity: Dict[NodeId, np.float64]) -> MoveGroupStep:
+    """Create a sequence to back away from the limit switch and re-home."""
+    backoff: MoveGroupStep = {}
+    for axis, v in velocity.items():
+        backoff[axis] = MoveGroupTipActionStep(
+            velocity_mm_sec=abs(v),
+            duration_sec=abs(np.float64(BACKOFF_MAX_MM) / abs(v)),
+            stop_condition=MoveStopCondition.limit_switch_backoff,
+            action=PipetteTipActionType.home,
+        )
+    return backoff
+
+
 def create_tip_action_step(
     velocity: Dict[NodeId, np.float64],
     distance: Dict[NodeId, np.float64],

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -337,27 +337,33 @@ class MoveScheduler:
         self._durations: List[float] = []
         self._stop_condition: List[List[MoveStopCondition]] = []
         self._start_at_index = start_at_index
-        self._expected_tip_action_motors = []
+        self._expected_tip_action_motors: List[List[List[GearMotorId]]] = []
 
         for move_group in move_groups:
             move_set = set()
             duration = 0.0
             stop_cond = []
+            expected_motors = []
             for seq_id, move in enumerate(move_group):
                 movesteps = list(move.values())
                 move_set.update(set((k.value, seq_id) for k in move.keys()))
                 duration += float(movesteps[0].duration_sec)
                 if any(isinstance(g, MoveGroupTipActionStep) for g in movesteps):
-                    self._expected_tip_action_motors = [
-                        GearMotorId.left,
-                        GearMotorId.right,
-                    ]
+                    expected_motors.append(
+                        [
+                            GearMotorId.left,
+                            GearMotorId.right,
+                        ]
+                    )
+                else:
+                    expected_motors.append([])
                 for step in move_group[seq_id]:
                     stop_cond.append(move_group[seq_id][step].stop_condition)
 
             self._moves.append(move_set)
             self._stop_condition.append(stop_cond)
             self._durations.append(duration)
+            self._expected_tip_action_motors.append(expected_motors)
         log.debug(f"Move scheduler running for groups {move_groups}")
         self._completion_queue: asyncio.Queue[_CompletionPacket] = asyncio.Queue()
         self._event = asyncio.Event()
@@ -450,13 +456,20 @@ class MoveScheduler:
             self._remove_move_group(message, arbitration_id)
             self._handle_move_completed(message, arbitration_id)
         elif isinstance(message, TipActionResponse):
-            gear_id = GearMotorId(message.payload.gear_motor_id.value)
-            self._expected_tip_action_motors.remove(gear_id)
-            if len(self._expected_tip_action_motors) == 0:
+            if self._handle_tip_action_motors(message):
                 self._remove_move_group(message, arbitration_id)
             self._handle_move_completed(message, arbitration_id)
         elif isinstance(message, ErrorMessage):
             self._handle_error(message, arbitration_id)
+
+    def _handle_tip_action_motors(self, message: TipActionResponse) -> bool:
+        gear_id = GearMotorId(message.payload.gear_motor_id.value)
+        group_id = message.payload.group_id.value - self._start_at_index
+        seq_id = message.payload.seq_id.value
+        self._expected_tip_action_motors[group_id][seq_id].remove(gear_id)
+        if len(self._expected_tip_action_motors[group_id][seq_id]) == 0:
+            return True
+        return False
 
     def _get_nodes_in_move_group(self, group_id: int) -> List[NodeId]:
         nodes = []


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We want to add limit switch backoff to the tip motors during the home sequence so they behave the same way as the other stepper motors in the system. 