### PR TITLE
refactor(app): retract all axes in LPC instead of move to fixed trash

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -8,7 +8,6 @@ import { PrepareSpace } from './PrepareSpace'
 import { JogToWell } from './JogToWell'
 import {
   CreateCommand,
-  FIXED_TRASH_ID,
   getIsTiprack,
   getLabwareDefURI,
   getLabwareDisplayName,
@@ -217,19 +216,12 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
         },
       },
       {
-        commandType: 'moveToWell' as const,
-        params: {
-          pipetteId: pipetteId,
-          labwareId: FIXED_TRASH_ID,
-          wellName: 'A1',
-          wellLocation: { origin: 'top' as const },
-        },
+        commandType: 'retractAxis' as const,
+        params: { axis: 'x' },
       },
       {
         commandType: 'retractAxis' as const,
-        params: {
-          axis: pipetteZMotorAxis,
-        },
+        params: { axis: 'y' },
       },
       {
         commandType: 'moveLabware' as const,

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -9,7 +9,6 @@ import { JogToWell } from './JogToWell'
 import {
   CompletedProtocolAnalysis,
   CreateCommand,
-  FIXED_TRASH_ID,
   getLabwareDefURI,
   getLabwareDisplayName,
   getModuleType,
@@ -215,19 +214,12 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
           },
         },
         {
-          commandType: 'moveToWell' as const,
-          params: {
-            pipetteId: pipetteId,
-            labwareId: FIXED_TRASH_ID,
-            wellName: 'A1',
-            wellLocation: { origin: 'top' as const },
-          },
+          commandType: 'retractAxis' as const,
+          params: { axis: 'x' },
         },
         {
           commandType: 'retractAxis' as const,
-          params: {
-            axis: pipetteZMotorAxis,
-          },
+          params: { axis: 'y' },
         },
         {
           commandType: 'moveLabware' as const,

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -280,19 +280,12 @@ describe('CheckItem', () => {
           },
         },
         {
-          commandType: 'moveToWell',
-          params: {
-            pipetteId: 'pipetteId1',
-            labwareId: 'fixedTrash',
-            wellName: 'A1',
-            wellLocation: { origin: 'top', offset: undefined },
-          },
+          commandType: 'retractAxis' as const,
+          params: { axis: 'x' },
         },
         {
           commandType: 'retractAxis' as const,
-          params: {
-            axis: 'leftZ',
-          },
+          params: { axis: 'y' },
         },
         {
           commandType: 'moveLabware',

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -218,18 +218,15 @@ describe('CheckItem', () => {
             },
           },
           {
-            commandType: 'moveToWell',
+            commandType: 'retractAxis' as const,
             params: {
-              pipetteId: 'pipetteId1',
-              labwareId: 'fixedTrash',
-              wellName: 'A1',
-              wellLocation: { origin: 'top', offset: undefined },
+              axis: 'x',
             },
           },
           {
             commandType: 'retractAxis' as const,
             params: {
-              axis: 'leftZ',
+              axis: 'y',
             },
           },
           {

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -389,18 +389,15 @@ describe('PickUpTip', () => {
           },
         },
         {
-          commandType: 'moveToWell',
+          commandType: 'retractAxis' as const,
           params: {
-            pipetteId: 'pipetteId1',
-            labwareId: 'fixedTrash',
-            wellName: 'A1',
-            wellLocation: { origin: 'top' },
+            axis: 'x',
           },
         },
         {
           commandType: 'retractAxis' as const,
           params: {
-            axis: 'leftZ',
+            axis: 'y',
           },
         },
         {


### PR DESCRIPTION
# Overview

Instead of using fixed trash's A1 well as a proxy for "a safe location for the gantry to be out of the way", use the new purpose built retract axis command to move the gantry out of the user's way during LPC.

Closes RSS-254

# Review requests

- LPC should function as expected on OT-2 and Flex. When moving gantry out of the way, it will retract axes in order of z, x, y

# Risk assessment
med, this is a small change, but it's replacing old stable functionality with new more stable behavior.