### PR TITLE
refactor(app): remove red-stroke from modal components

### DIFF
--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -48,7 +48,7 @@ export function OnDeviceDisplayAppFallback({
   }, [])
 
   return (
-    <Modal header={modalHeader} isError>
+    <Modal header={modalHeader}>
       <Flex
         marginTop={SPACING.spacing32}
         flexDirection={DIRECTION_COLUMN}

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModal.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModal.test.tsx
@@ -49,15 +49,4 @@ describe('LegacyModal', () => {
       `background-color: ${COLORS.white}`
     )
   })
-
-  it('should render outlined modal when type is outlinedError', () => {
-    props.type = 'outlinedError'
-    const [{ getByTestId }] = render(props)
-    const headerIcon = getByTestId('Modal_header_icon')
-    expect(headerIcon).toBeInTheDocument()
-    expect(headerIcon).toHaveStyle(`color: ${COLORS.white}`)
-    expect(getByTestId('Modal_header')).toHaveStyle(
-      `background-color: ${COLORS.errorEnabled}`
-    )
-  })
 })

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -4,7 +4,7 @@ import { LegacyModalHeader } from './LegacyModalHeader'
 import { LegacyModalShell } from './LegacyModalShell'
 import type { IconProps, StyleProps } from '@opentrons/components'
 
-type ModalType = 'info' | 'warning' | 'error' | 'outlinedError'
+type ModalType = 'info' | 'warning' | 'error'
 export * from './LegacyModalShell'
 export * from './LegacyModalHeader'
 
@@ -38,9 +38,6 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
       case 'error':
         iconColor = COLORS.errorEnabled
         break
-      case 'outlinedError':
-        iconColor = COLORS.white
-        break
     }
     return iconColor
   }
@@ -56,15 +53,9 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
     <LegacyModalHeader
       onClose={onClose}
       title={title}
-      icon={
-        ['error', 'warning', 'outlinedError'].includes(type)
-          ? modalIcon
-          : undefined
-      }
-      color={type === 'outlinedError' ? COLORS.white : COLORS.darkBlackEnabled}
-      backgroundColor={
-        type === 'outlinedError' ? COLORS.errorEnabled : COLORS.white
-      }
+      icon={['error', 'warning'].includes(type) ? modalIcon : undefined}
+      color={COLORS.darkBlackEnabled}
+      backgroundColor={COLORS.white}
     />
   )
 
@@ -75,11 +66,6 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
       onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
       marginLeft="7.125rem"
-      border={
-        type === 'outlinedError'
-          ? `0.375rem solid ${COLORS.errorEnabled}`
-          : 'none'
-      }
       {...props}
     >
       <Box padding={childrenPadding}>{children}</Box>

--- a/app/src/molecules/Modal/Modal.stories.tsx
+++ b/app/src/molecules/Modal/Modal.stories.tsx
@@ -35,5 +35,4 @@ Default.args = {
       children goes here
     </Flex>
   ),
-  isError: false,
 }

--- a/app/src/molecules/Modal/Modal.tsx
+++ b/app/src/molecules/Modal/Modal.tsx
@@ -22,17 +22,9 @@ interface ModalProps {
   modalSize?: ModalSize
   /** see ModalHeader component for more details */
   header?: ModalHeaderBaseProps
-  /** an option for adding additional styles for an error modal */
-  isError?: boolean
 }
 export function Modal(props: ModalProps): JSX.Element {
-  const {
-    modalSize = 'medium',
-    onOutsideClick,
-    children,
-    header,
-    isError,
-  } = props
+  const { modalSize = 'medium', onOutsideClick, children, header } = props
 
   let modalWidth: string = '45.625rem'
   switch (modalSize) {
@@ -55,8 +47,7 @@ export function Modal(props: ModalProps): JSX.Element {
       justifyContent={JUSTIFY_CENTER}
     >
       <Flex
-        backgroundColor={isError ? COLORS.red2 : COLORS.white}
-        border={isError ? `0.375rem solid ${COLORS.red2}` : 'none'}
+        backgroundColor={COLORS.white}
         width={modalWidth}
         height="max-content"
         maxHeight="33.5rem"
@@ -76,7 +67,6 @@ export function Modal(props: ModalProps): JSX.Element {
             iconColor={header.iconColor}
             hasExitIcon={header.hasExitIcon}
             onClick={onOutsideClick}
-            isError={isError}
           />
         ) : null}
         <Flex

--- a/app/src/molecules/Modal/ModalHeader.stories.tsx
+++ b/app/src/molecules/Modal/ModalHeader.stories.tsx
@@ -34,5 +34,4 @@ Default.args = {
   hasExitIcon: true,
   iconName: 'information',
   iconColor: COLORS.black,
-  isError: false,
 }

--- a/app/src/molecules/Modal/ModalHeader.tsx
+++ b/app/src/molecules/Modal/ModalHeader.tsx
@@ -1,32 +1,27 @@
 import * as React from 'react'
 import {
-  Flex,
-  TYPOGRAPHY,
-  SPACING,
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
   DIRECTION_ROW,
+  Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
-  ALIGN_CENTER,
-  COLORS,
-  SIZE_2,
-  BORDERS,
+  SPACING,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import type { ModalHeaderBaseProps } from '../Modal/types'
 
-interface ModalHeaderProps extends ModalHeaderBaseProps {
-  isError?: boolean
-}
-export function ModalHeader(props: ModalHeaderProps): JSX.Element {
-  const { title, hasExitIcon, iconName, iconColor, onClick, isError } = props
+export function ModalHeader(props: ModalHeaderBaseProps): JSX.Element {
+  const { title, hasExitIcon, iconName, iconColor, onClick } = props
   return (
     <Flex
-      backgroundColor={isError ? COLORS.red2 : COLORS.white}
-      color={isError ? COLORS.white : COLORS.black}
+      backgroundColor={COLORS.white}
+      color={COLORS.black}
       height="6.25rem"
       width="100%"
-      paddingX={SPACING.spacing32}
-      paddingY={isError ? SPACING.spacing24 : SPACING.spacing32}
+      padding={SPACING.spacing32}
       flexDirection={DIRECTION_ROW}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       alignItems={ALIGN_CENTER}
@@ -37,8 +32,8 @@ export function ModalHeader(props: ModalHeaderProps): JSX.Element {
           <Icon
             aria-label={`icon_${iconName}`}
             name={iconName}
-            color={isError ? COLORS.white : iconColor}
-            size={SIZE_2}
+            color={iconColor}
+            size="2rem"
             alignSelf={ALIGN_CENTER}
             marginRight={SPACING.spacing16}
           />

--- a/app/src/molecules/Modal/__tests__/Modal.test.tsx
+++ b/app/src/molecules/Modal/__tests__/Modal.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { renderWithProviders, COLORS } from '@opentrons/components'
+import { renderWithProviders } from '@opentrons/components'
 import { ModalHeader } from '../ModalHeader'
 import { Modal } from '../Modal'
 
@@ -49,15 +49,5 @@ describe('Modal', () => {
     const { getByLabelText } = render(props)
     getByLabelText('BackgroundOverlay').click()
     expect(props.onOutsideClick).toHaveBeenCalled()
-  })
-  it('renders red background when isError is true', () => {
-    props = {
-      ...props,
-      isError: true,
-    }
-    const { getByLabelText } = render(props)
-    expect(getByLabelText('modal_medium')).toHaveStyle(
-      `backgroundColor: ${COLORS.red2}`
-    )
   })
 })

--- a/app/src/molecules/Modal/__tests__/ModalHeader.test.tsx
+++ b/app/src/molecules/Modal/__tests__/ModalHeader.test.tsx
@@ -32,16 +32,4 @@ describe('ModalHeader', () => {
     getByLabelText('closeIcon').click()
     expect(props.onClick).toHaveBeenCalled()
   })
-  it('should render the header with red when isError is true', () => {
-    props = {
-      ...props,
-      isError: true,
-      iconName: 'information',
-      iconColor: COLORS.black,
-    }
-    const { getByLabelText } = render(props)
-    expect(getByLabelText('icon_information')).toHaveStyle(
-      `color: ${COLORS.white}`
-    )
-  })
 })

--- a/app/src/organisms/EstopModal/DesktopEstopMissingModal.tsx
+++ b/app/src/organisms/EstopModal/DesktopEstopMissingModal.tsx
@@ -21,7 +21,7 @@ export function DesktopEstopMissingModal({
 }: DesktopEstopMissingModalProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const modalProps: LegacyModalProps = {
-    type: isActiveRun ? 'outlinedError' : 'error',
+    type: 'error',
     title: t('estop_missing'),
     onClose: () => closeModal(),
     closeOnOutsideClick: false,

--- a/app/src/organisms/EstopModal/DesktopEstopPressedModal.tsx
+++ b/app/src/organisms/EstopModal/DesktopEstopPressedModal.tsx
@@ -29,7 +29,7 @@ export function DesktopEstopPressedModal({
 }: DesktopEstopPressedModalProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const modalProps: LegacyModalProps = {
-    type: isActiveRun ? 'outlinedError' : 'error',
+    type: 'error',
     title: t('estop_pressed'),
     onClose: () => closeModal(),
     closeOnOutsideClick: false,

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -79,7 +79,6 @@ export function ConfirmCancelRunModal({
     <Modal
       modalSize="medium"
       header={modalHeader}
-      isError={isActiveRun}
       onOutsideClick={() => setShowConfirmCancelRunModal(false)}
     >
       <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -119,14 +119,6 @@ describe('ConfirmCancelRunModal', () => {
     getByText('mock CancelingRunModal')
   })
 
-  it('should render the modal with red frame', () => {
-    props.isActiveRun = true
-    const [{ getByLabelText }] = render(props)
-    expect(getByLabelText('modal_medium')).toHaveStyle(
-      `backgroundColor: ${COLORS.red2}`
-    )
-  })
-
   it('when tapping go back, the mock function is called', () => {
     const [{ getByText }] = render(props)
     const button = getByText('Go back')

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -3,7 +3,7 @@ import { when, resetAllWhenMocks } from 'jest-when'
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent } from '@testing-library/react'
 
-import { renderWithProviders, COLORS } from '@opentrons/components'
+import { renderWithProviders } from '@opentrons/components'
 import {
   useStopRunMutation,
   useDismissCurrentRunMutation,


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
remove red-stroke from desktop app modal and touchscreen app modal
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- remove `isError` from touchscreen app modal component
- remove `outlinedError` type from desktop app modal component
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
