### PR TITLE
refactor(hardware-testing): Use new force-gauge fixture for PVT Grippers

### DIFF
--- a/hardware-testing/hardware_testing/drivers/mark10/mark10_fg.py
+++ b/hardware-testing/hardware_testing/drivers/mark10/mark10_fg.py
@@ -110,6 +110,6 @@ class Mark10(Mark10Base):
                     return float(force_val)
             except ValueError as e:
                 print(e)
-                print(f"bad data: \"{line}\"")
+                print(f'bad data: "{line}"')
                 continue
         raise TimeoutError(f"unable to read from gauge within {timeout} seconds")

--- a/hardware-testing/hardware_testing/drivers/mark10/mark10_fg.py
+++ b/hardware-testing/hardware_testing/drivers/mark10/mark10_fg.py
@@ -100,16 +100,16 @@ class Mark10(Mark10Base):
         while time() < start_time + timeout:
             # return "12.3 N"
             line = self._force_guage.readline().decode("utf-8").strip()
-            force_val, units = line.split(" ")
-            if not force_val:
-                continue
-            if units != "N":
-                self._force_guage.write("N\r\n")  # Set force gauge units to Newtons
-                print(f'Setting gauge units from {units} to "N" (newtons)')
-                continue
             try:
-                return float(force_val)
+                force_val, units = line.split(" ")
+                if units != "N":
+                    self._force_guage.write("N\r\n")  # Set force gauge units to Newtons
+                    print(f'Setting gauge units from {units} to "N" (newtons)')
+                    continue
+                else:
+                    return float(force_val)
             except ValueError as e:
                 print(e)
+                print(f"bad data: \"{line}\"")
                 continue
         raise TimeoutError(f"unable to read from gauge within {timeout} seconds")

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -492,17 +492,11 @@ async def move_gripper_jaw_relative_ot3(api: OT3API, delta: float) -> None:
 
 def get_endstop_position_ot3(api: OT3API, mount: OT3Mount) -> Dict[OT3Axis, float]:
     """Get the endstop's position per mount."""
-    transforms = api._robot_calibration
-    machine_pos_per_axis = api._backend.home_position()
-    deck_pos_per_axis = deck_from_machine(
-        machine_pos_per_axis,
-        transforms.deck_calibration.attitude,
-        transforms.carriage_offset,
+    carriage_pos = api._deck_from_machine(api._backend.home_position())
+    pos_at_home = api._effector_pos_from_carriage_pos(
+        OT3Mount.from_mount(mount), carriage_pos, None
     )
-    mount_pos_per_axis = api._effector_pos_from_carriage_pos(
-        mount, deck_pos_per_axis, None
-    )
-    return {ax: val for ax, val in mount_pos_per_axis.items()}
+    return {ax: val for ax, val in pos_at_home.items()}
 
 
 def get_gantry_homed_position_ot3(api: OT3API, mount: OT3Mount) -> Point:

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -23,7 +23,6 @@ from opentrons.hardware_control.backends.ot3utils import sensor_node_for_mount
 # have that well defined.
 from opentrons.hardware_control.instruments.ot2.pipette import Pipette as PipetteOT2
 from opentrons.hardware_control.instruments.ot3.pipette import Pipette as PipetteOT3
-from opentrons.hardware_control.motion_utilities import deck_from_machine
 from opentrons.hardware_control.ot3api import OT3API
 
 from .types import (

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
@@ -78,11 +78,15 @@ if __name__ == "__main__":
         ), 'use "--only" for just one test, not multiple tests'
     elif args.increment:
         _t_sections = {
-            s: f for s, f in TESTS_INCREMENT if not getattr(args, f"skip_{s.value.lower()}")
+            s: f
+            for s, f in TESTS_INCREMENT
+            if not getattr(args, f"skip_{s.value.lower()}")
         }
     else:
         _t_sections = {
             s: f for s, f in TESTS if not getattr(args, f"skip_{s.value.lower()}")
         }
-    _config = TestConfig(simulate=args.simulate, tests=_t_sections, increment=args.increment)
+    _config = TestConfig(
+        simulate=args.simulate, tests=_t_sections, increment=args.increment
+    )
     asyncio.run(_main(_config))

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
@@ -8,7 +8,7 @@ from hardware_testing.data.csv_report import RESULTS_OVERVIEW_TITLE
 from hardware_testing.opentrons_api import helpers_ot3
 from hardware_testing.opentrons_api.types import OT3Mount, OT3Axis
 
-from .config import TestSection, TestConfig, build_report, TESTS
+from .config import TestSection, TestConfig, build_report, TESTS, TESTS_INCREMENT
 
 
 async def _main(cfg: TestConfig) -> None:
@@ -65,6 +65,7 @@ async def _main(cfg: TestConfig) -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
+    parser.add_argument("--increment", action="store_true")
     # add each test-section as a skippable argument (eg: --skip-gantry)
     for s in TestSection:
         parser.add_argument(f"--skip-{s.value.lower()}", action="store_true")
@@ -75,9 +76,13 @@ if __name__ == "__main__":
         assert (
             len(list(_t_sections.keys())) < 2
         ), 'use "--only" for just one test, not multiple tests'
+    elif args.increment:
+        _t_sections = {
+            s: f for s, f in TESTS_INCREMENT if not getattr(args, f"skip_{s.value.lower()}")
+        }
     else:
         _t_sections = {
             s: f for s, f in TESTS if not getattr(args, f"skip_{s.value.lower()}")
         }
-    _config = TestConfig(simulate=args.simulate, tests=_t_sections)
+    _config = TestConfig(simulate=args.simulate, tests=_t_sections, increment=args.increment)
     asyncio.run(_main(_config))

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/config.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/config.py
@@ -28,6 +28,7 @@ class TestConfig:
 
     simulate: bool
     tests: Dict[TestSection, Callable]
+    increment: bool
 
 
 TESTS = [
@@ -36,16 +37,23 @@ TESTS = [
         test_mount.run,
     ),
     (
-        TestSection.FORCE,
-        test_force.run,
+        TestSection.PROBE,
+        test_probe.run,
     ),
     (
         TestSection.WIDTH,
         test_width.run,
     ),
     (
-        TestSection.PROBE,
-        test_probe.run,
+        TestSection.FORCE,
+        test_force.run,
+    ),
+]
+
+TESTS_INCREMENT = [
+    (
+        TestSection.FORCE,
+        test_force.run_increment,  # NOTE: different run method
     ),
 ]
 
@@ -59,13 +67,13 @@ def build_report(test_name: str) -> CSVReport:
                 title=TestSection.MOUNT.value, lines=test_mount.build_csv_lines()
             ),
             CSVSection(
-                title=TestSection.FORCE.value, lines=test_force.build_csv_lines()
+                title=TestSection.PROBE.value, lines=test_probe.build_csv_lines()
             ),
             CSVSection(
                 title=TestSection.WIDTH.value, lines=test_width.build_csv_lines()
             ),
             CSVSection(
-                title=TestSection.PROBE.value, lines=test_probe.build_csv_lines()
+                title=TestSection.FORCE.value, lines=test_force.build_csv_lines()
             ),
         ],
     )

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_force.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_force.py
@@ -22,12 +22,14 @@ from hardware_testing.opentrons_api.types import OT3Axis, OT3Mount, Point
 SLOT_FORCE_GAUGE = 6
 GAUGE_OFFSET = Point(x=90, y=37.5, z=75)
 
+WARMUP_SECONDS = 10
+
 FAILURE_THRESHOLD_PERCENTAGE = 10
-GRIP_FORCES_NEWTON: List[int] = [5, 10, 15, 20]
+GRIP_FORCES_NEWTON: List[int] = [20, 15, 10, 5]
 NUM_NEWTONS_TRIALS = 1
 
 NUM_DUTY_CYCLE_TRIALS = 20
-GRIP_DUTY_CYCLES: List[int] = [6, 10, 15, 20, 25, 30, 40, 50]
+GRIP_DUTY_CYCLES: List[int] = [50, 40, 30, 25, 20, 15, 10, 6]
 
 FORCE_GAUGE_TRIAL_SAMPLE_INTERVAL = 0.25  # seconds
 FORCE_GAUGE_TRIAL_SAMPLE_COUNT = 20  # 20 samples = 5 seconds @ 4Hz
@@ -143,7 +145,12 @@ async def _setup(api: OT3API) -> Union[Mark10, SimMark10]:
     await api.move_to(mount, target_pos)
     if not api.is_simulator:
         ui.get_user_ready("about to grip")
-
+    await api.grip(20)
+    for sec in range(WARMUP_SECONDS):
+        print(f"warmup ({sec + 1}/{WARMUP_SECONDS})")
+        if not api.is_simulator:
+            await sleep(1)
+    await api.ungrip()
     return gauge
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR modifies the Gripper QC script to use the new force-gauge fixture hardware. This PR also updates the measurement method so that all forces are recorded from the start of a grip, so that our averages can include both initial and later forces that occur regardless of variance.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
