### PR TITLE
feat(engine): support loading offsets for labware with OnLabwareLocation

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -457,6 +457,10 @@ class EquipmentHandler:
             if base_labware_offset_location is None:
                 # No offset for labware sitting on labware off-deck
                 return None
+
+            # If labware is being stacked on itself, all labware in the stack will share a labware offset due to
+            # them sharing the same definitionUri in `LabwareOffsetLocation`. This will not be true for the
+            # bottom-most labware, which will have a `DeckSlotLocation` and have its definitionUri field empty.
             return LabwareOffsetLocation(
                 slotName=base_labware_offset_location.slotName,
                 moduleModel=base_labware_offset_location.moduleModel,

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -39,6 +39,7 @@ from ..types import (
     LabwareLocation,
     DeckSlotLocation,
     ModuleLocation,
+    OnLabwareLocation,
     LabwareOffset,
     LabwareOffsetLocation,
     ModuleModel,
@@ -435,6 +436,46 @@ class EquipmentHandler:
                 location=LabwareOffsetLocation(
                     slotName=slot_name,
                     moduleModel=module_model,
+                ),
+            )
+            return self._get_id_from_offset(offset)
+
+        elif isinstance(labware_location, OnLabwareLocation):
+            parent_labware_id = labware_location.labwareId
+            parent_labware_uri = self._state_store.labware.get_definition_uri(
+                parent_labware_id
+            )
+
+            base_location = self._state_store.labware.get_parent_location(
+                parent_labware_id
+            )
+
+            if isinstance(base_location, ModuleLocation):
+                module_id = base_location.moduleId
+                module_model = self._state_store.modules.get_requested_model(
+                    module_id=module_id
+                )
+                assert module_model is not None, (
+                    "Can't find offsets for labware"
+                    " that are loaded on modules"
+                    " that were loaded with ProtocolEngine.use_attached_modules()."
+                )
+                module_location = self._state_store.modules.get_location(
+                    module_id=module_id
+                )
+                slot_name = module_location.slotName
+            elif isinstance(base_location, DeckSlotLocation):
+                slot_name = base_location.slotName
+                module_model = None
+            else:  # No offset for labware sitting on labware off-deck
+                return None
+
+            offset = self._state_store.labware.find_applicable_labware_offset(
+                definition_uri=labware_definition_uri,
+                location=LabwareOffsetLocation(
+                    slotName=slot_name,
+                    moduleModel=module_model,
+                    definitionUri=parent_labware_uri,
                 ),
             )
             return self._get_id_from_offset(offset)

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -510,6 +510,9 @@ class LabwareOffsetLocation(BaseModel):
         description=(
             "The definition URI of a labware that a labware can be loaded onto,"
             " if applicable."
+            "\n\n"
+            "This can be combined with moduleModel if the labware is loaded on top of"
+            " an adapter that is loaded on a module."
         ),
     )
 


### PR DESCRIPTION
# Overview

Closes RLAB-359.

This PR is a follow-up to #12928 and #13016, and adds logic to Protocol Engine's `find_applicable_labware_offset_id` to support labware that has the `OnLabwareLocation` i.e. is loaded on top of a labware/adapter. It uses the `LabwareOffsetLocation` `definitionUri` field and, if the adapter is loaded onto a module, the `LabwareOffsetLocation` `moduleModel` field to determine the correct offset ID when a labware is loaded.

# Test Plan

This was tested using Postman to ensure that an added labware offset with the `definitionUri` field, with and without the `moduleModel` field, had its offset ID correctly found when loading the labware.

# Changelog

- Updated `EquipmentHandler.find_applicable_labware_offset_id` to correctly handle finding the offset for labware with an `OnLabwareLocation`
- Updated doc string for `LabwareOffsetLocation` definitionUri to reflect that it can be used with `moduleModel` 

# Review requests

Does the logic for determining offsets make sense and can any issues be foreseen that would make this untenable when more than one labware can be stacked on top of each other.

# Risk assessment

Low, this only affects labware with the `OnLabwareLocation` and adds behavior that wasn't correctly supported before.