### PR TITLE
fix(api): dont emit 0-duration moves

### DIFF
--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -2,6 +2,7 @@ from opentrons_hardware.hardware_control.motion_planning import Move
 from opentrons.hardware_control.backends import ot3utils
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons.hardware_control.types import OT3Axis
+from numpy import float64 as f64
 
 
 def test_create_step() -> None:
@@ -16,6 +17,12 @@ def test_create_step() -> None:
     moves = [
         Move.build_dummy([OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.P_L])
     ]
+    for block in moves[0].blocks:
+        block.distance = f64(25.0)
+        block.time = f64(1.0)
+        block.initial_speed = f64(25.0)
+        block.acceleration = f64(0.0)
+        block.final_speed = f64(25.0)
     present_nodes = [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l]
     move_group, final_pos = ot3utils.create_move_group(
         origin=origin,
@@ -23,6 +30,35 @@ def test_create_step() -> None:
         present_nodes=present_nodes,
     )
     assert len(move_group) == 3
+    for step in move_group:
+        assert set(present_nodes) == set(step.keys())
+
+
+def test_filter_zero_duration_step() -> None:
+    origin = {
+        OT3Axis.X: 0,
+        OT3Axis.Y: 0,
+        OT3Axis.Z_L: 0,
+        OT3Axis.Z_R: 0,
+        OT3Axis.P_L: 0,
+        OT3Axis.P_R: 0,
+    }
+    moves = [
+        Move.build_dummy([OT3Axis.X, OT3Axis.Y, OT3Axis.Z_L, OT3Axis.Z_R, OT3Axis.P_L])
+    ]
+    for block in (moves[0].blocks[0], moves[0].blocks[1]):
+        block.distance = f64(25.0)
+        block.time = f64(1.0)
+        block.initial_speed = f64(25.0)
+        block.acceleration = f64(0.0)
+        block.final_speed = f64(25.0)
+    present_nodes = [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l]
+    move_group, final_pos = ot3utils.create_move_group(
+        origin=origin,
+        moves=moves,
+        present_nodes=present_nodes,
+    )
+    assert len(move_group) == 2
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
 


### PR DESCRIPTION
They really stress the microcontrollers and they do absolutely nothing, so let's not put them on the bus.

This should fix the last known-issue gantry stall. 

Tested by running normalize (a lot) on a machine and running some calibrations.