### PR TITLE
feat(shared-data): add definition for nest 1 well reservoir with 290ml capacity

### DIFF
--- a/shared-data/labware/definitions/2/nest_1_reservoir_290ml/1.json
+++ b/shared-data/labware/definitions/2/nest_1_reservoir_290ml/1.json
@@ -1,0 +1,54 @@
+{
+  "ordering": [["A1"]],
+  "brand": {
+    "brand": "NEST",
+    "brandId": ["360206", "360266"],
+    "links": ["https://www.nest-biotech.com/reagent-reserviors"]
+  },
+  "metadata": {
+    "displayName": "NEST 1 Well Reservoir 290 mL",
+    "displayCategory": "reservoir",
+    "displayVolumeUnits": "mL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.47,
+    "zDimension": 44.4
+  },
+  "wells": {
+    "A1": {
+      "depth": 39.55,
+      "shape": "rectangular",
+      "xDimension": 106.8,
+      "yDimension": 71.2,
+      "totalLiquidVolume": 290000,
+      "x": 63.88,
+      "y": 42.74,
+      "z": 4.85
+    }
+  },
+  "groups": [
+    {
+      "metadata": {
+        "wellBottomShape": "v"
+      },
+      "wells": ["A1"]
+    }
+  ],
+  "parameters": {
+    "format": "trough",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
+    "loadName": "nest_1_reservoir_290ml"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}


### PR DESCRIPTION
# Overview

Add new definition to labware data for Nest 1 well reservoir 290ml.

Closes RAUT-558

![Screen Shot 2023-07-18 at 2 13 13 PM](https://github.com/Opentrons/opentrons/assets/4731953/b59f8c05-8a50-4a5d-b2bc-31b56fd9ce1f)

# Risk assessment
low