### PR TITLE
fix(app): redirect to run summary screen based on run endpoint

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -8,6 +8,7 @@ import {
   useAllProtocolIdsQuery,
   useAllRunsQuery,
   useHost,
+  useRunQuery,
 } from '@opentrons/react-api-client'
 import {
   getProtocol,
@@ -118,25 +119,35 @@ export function useCurrentRunRoute(): string | null {
         ) // trim link path down to only runId
       : null
 
-  const status = currentRun?.status
-  const actions = currentRun?.actions
-  if (status == null || actions == null || currentRun == null) return null
+  const currentRunId = currentRun?.id ?? null
 
-  const hasBeenStarted = actions?.some(
+  const { data: runRecord } = useRunQuery(currentRunId, {
+    staleTime: Infinity,
+    enabled: currentRunId != null,
+  })
+
+  const runStatus = runRecord?.data.status
+  const runActions = runRecord?.data.actions
+
+  if (runRecord == null || runStatus == null || runActions == null) return null
+  // grabbing run id off of the run query to have all routing info come from one source of truth
+  const runId = runRecord.data.id
+
+  const hasBeenStarted = runActions?.some(
     action => action.actionType === RUN_ACTION_TYPE_PLAY
   )
   if (
-    status === RUN_STATUS_SUCCEEDED ||
-    status === RUN_STATUS_STOPPED ||
-    status === RUN_STATUS_FAILED
+    runStatus === RUN_STATUS_SUCCEEDED ||
+    runStatus === RUN_STATUS_STOPPED ||
+    runStatus === RUN_STATUS_FAILED
   ) {
-    return `/runs/${currentRun.id}/summary`
+    return `/runs/${runId}/summary`
   } else if (
-    status === RUN_STATUS_IDLE ||
-    (!hasBeenStarted && status === RUN_STATUS_BLOCKED_BY_OPEN_DOOR)
+    runStatus === RUN_STATUS_IDLE ||
+    (!hasBeenStarted && runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR)
   ) {
-    return `/runs/${currentRun.id}/setup`
+    return `/runs/${runId}/setup`
   } else {
-    return `/runs/${currentRun.id}/run`
+    return `/runs/${runId}/run`
   }
 }


### PR DESCRIPTION
# Overview
This PR changes the app's current run route logic to reroute based on info coming from the `/runs/runId` endpoint rather than the `/runs` endpoint. This is because the run summary screen reads data from the `/runs/runId` endpoint and we want run state information to be coming from the same place.

This fixes a bug where a run would succeed/fail but we wouldn't render the run succeeded/failed spash screen inside the run summary screen. The reason this bug was happening was because the app would redirect the run summary screen when the `/runs` endpoint reflected that the current run is in a completed/failed/stop requested state. BUT the run summary screen only renders the splash when the `/runs/runId` endpoint reflects that the run is in a completed/failed state. Because these are two different endpoints with two different react queries with two different refetch intervals, the data got out of sync.

closes RQA-1098


# Risk assessment

Low