### PR TITLE
feat(shared-data): alphabetizes orderedSlots in Flex deck def

### DIFF
--- a/shared-data/deck/definitions/3/ot3_standard.json
+++ b/shared-data/deck/definitions/3/ot3_standard.json
@@ -13,15 +13,15 @@
   "locations": {
     "orderedSlots": [
       {
-        "id": "D1",
-        "position": [0.0, 0.0, 0.0],
+        "id": "A1",
+        "position": [0.0, 321.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot D1",
+        "displayName": "Slot A1",
         "compatibleModuleTypes": [
           "magneticModuleType",
           "temperatureModuleType",
@@ -29,15 +29,15 @@
         ]
       },
       {
-        "id": "D2",
-        "position": [164.0, 0.0, 0.0],
+        "id": "A2",
+        "position": [164.0, 321.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot D2",
+        "displayName": "Slot A2",
         "compatibleModuleTypes": [
           "magneticModuleType",
           "temperatureModuleType",
@@ -45,15 +45,59 @@
         ]
       },
       {
-        "id": "D3",
-        "position": [328.0, 0.0, 0.0],
+        "id": "A3",
+        "position": [328.0, 321.0, 0.0],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Slot A3",
+        "compatibleModuleTypes": []
+      },
+      {
+        "id": "B1",
+        "position": [0.0, 214.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot D3",
+        "displayName": "Slot B1",
+        "compatibleModuleTypes": [
+          "magneticModuleType",
+          "temperatureModuleType",
+          "thermocyclerModuleType",
+          "heaterShakerModuleType"
+        ]
+      },
+      {
+        "id": "B2",
+        "position": [164.0, 214.0, 0.0],
+        "matingSurfaceUnitVector": [-1, 1, -1],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Slot B2",
+        "compatibleModuleTypes": [
+          "magneticModuleType",
+          "temperatureModuleType",
+          "heaterShakerModuleType"
+        ]
+      },
+      {
+        "id": "B3",
+        "position": [328.0, 214.0, 0.0],
+        "matingSurfaceUnitVector": [-1, 1, -1],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Slot B3",
         "compatibleModuleTypes": [
           "magneticModuleType",
           "temperatureModuleType",
@@ -109,32 +153,15 @@
         ]
       },
       {
-        "id": "B1",
-        "position": [0.0, 214.0, 0.0],
+        "id": "D1",
+        "position": [0.0, 0.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot B1",
-        "compatibleModuleTypes": [
-          "magneticModuleType",
-          "temperatureModuleType",
-          "thermocyclerModuleType",
-          "heaterShakerModuleType"
-        ]
-      },
-      {
-        "id": "B2",
-        "position": [164.0, 214.0, 0.0],
-        "matingSurfaceUnitVector": [-1, 1, -1],
-        "boundingBox": {
-          "xDimension": 128.0,
-          "yDimension": 86.0,
-          "zDimension": 0
-        },
-        "displayName": "Slot B2",
+        "displayName": "Slot D1",
         "compatibleModuleTypes": [
           "magneticModuleType",
           "temperatureModuleType",
@@ -142,15 +169,15 @@
         ]
       },
       {
-        "id": "B3",
-        "position": [328.0, 214.0, 0.0],
+        "id": "D2",
+        "position": [164.0, 0.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot B3",
+        "displayName": "Slot D2",
         "compatibleModuleTypes": [
           "magneticModuleType",
           "temperatureModuleType",
@@ -158,47 +185,20 @@
         ]
       },
       {
-        "id": "A1",
-        "position": [0.0, 321.0, 0.0],
+        "id": "D3",
+        "position": [328.0, 0.0, 0.0],
         "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot A1",
+        "displayName": "Slot D3",
         "compatibleModuleTypes": [
           "magneticModuleType",
           "temperatureModuleType",
           "heaterShakerModuleType"
         ]
-      },
-      {
-        "id": "A2",
-        "position": [164.0, 321.0, 0.0],
-        "matingSurfaceUnitVector": [-1, 1, -1],
-        "boundingBox": {
-          "xDimension": 128.0,
-          "yDimension": 86.0,
-          "zDimension": 0
-        },
-        "displayName": "Slot A2",
-        "compatibleModuleTypes": [
-          "magneticModuleType",
-          "temperatureModuleType",
-          "heaterShakerModuleType"
-        ]
-      },
-      {
-        "id": "A3",
-        "position": [328.0, 321.0, 0.0],
-        "boundingBox": {
-          "xDimension": 128.0,
-          "yDimension": 86.0,
-          "zDimension": 0
-        },
-        "displayName": "Slot A3",
-        "compatibleModuleTypes": []
       }
     ],
     "calibrationPoints": [],


### PR DESCRIPTION
closes RQA-1077

# Overview

In PD, it is hard to tell which slot you want to add a module to since the Flex deck slots were ordered the way the Ot-2 slots are ordered. But since the flex slots are prefaced with a letter, that way of ordering is confusing. So this PR alphabetizes the ordered Slots.

# Test Plan

Do some smoke testing in app/odd and PD to make sure everything works as expected

# Changelog

- change the flex deck definition `orderedSlots` to be in alphabetical order 

# Review requests

see test plan

# Risk assessment

low