### PR TITLE
fix(api): add yocto to architectures that observe the disabledLogAggregation setting

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -193,7 +193,7 @@ settings = [
     ),
 ]
 
-if ARCHITECTURE == SystemArchitecture.BUILDROOT:
+if ARCHITECTURE == SystemArchitecture.BUILDROOT or ARCHITECTURE == SystemArchitecture.YOCTO:
     settings.append(DisableLogIntegrationSettingDefinition())
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -193,7 +193,10 @@ settings = [
     ),
 ]
 
-if ARCHITECTURE == SystemArchitecture.BUILDROOT or ARCHITECTURE == SystemArchitecture.YOCTO:
+if (
+    ARCHITECTURE == SystemArchitecture.BUILDROOT
+    or ARCHITECTURE == SystemArchitecture.YOCTO
+):
     settings.append(DisableLogIntegrationSettingDefinition())
 
 


### PR DESCRIPTION
# Overview

Add the advanced setting for disabled log aggregation for yocto system architecture.

Closes RSS-289

# Risk assessment
low
