### PR TITLE
docs(api): MagneticBlockContext in API reference

### DIFF
--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -37,7 +37,7 @@ When you load a module in a protocol, you inform the OT-2 that you want the spec
 
 .. versionadded:: 2.0
 
-.. _available_modules
+.. _available_modules:
 
 Available Modules
 -----------------

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -42,9 +42,14 @@ Labware and Wells
 Modules
 -------
 
-.. autoclass:: opentrons.protocol_api.TemperatureModuleContext
+.. autoclass:: opentrons.protocol_api.HeaterShakerContext
    :members:
-   :exclude-members: start_set_temperature, await_temperature, broker, geometry, load_labware_object
+   :exclude-members: broker, geometry, load_labware_object
+   :inherited-members:
+
+.. autoclass:: opentrons.protocol_api.MagneticBlockContext
+   :members:
+   :exclude-members: broker, geometry, load_labware_object
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.MagneticModuleContext
@@ -52,16 +57,16 @@ Modules
    :exclude-members: calibrate, broker, geometry, load_labware_object
    :inherited-members:
 
+.. autoclass:: opentrons.protocol_api.TemperatureModuleContext
+   :members:
+   :exclude-members: start_set_temperature, await_temperature, broker, geometry, load_labware_object
+   :inherited-members:
+
 .. autoclass:: opentrons.protocol_api.ThermocyclerContext
    :members:
    :exclude-members: total_step_count, current_cycle_index, total_cycle_count, hold_time, ramp_rate, current_step_index, broker, geometry, load_labware_object
    :inherited-members:
    
-.. autoclass:: opentrons.protocol_api.HeaterShakerContext
-   :members:
-   :exclude-members: broker, geometry, load_labware_object
-   :inherited-members:
-
 
 .. _protocol-api-types:
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -648,14 +648,18 @@ class ProtocolContext(CommandPublisher):
 
         :type location: str or int or None
         :returns: The loaded and initialized module---a
-                  :py:class:`TemperatureModuleContext`,
-                  :py:class:`MagneticModuleContext`,
-                  :py:class:`ThermocyclerContext`, or
                   :py:class:`HeaterShakerContext`,
+                  :py:class:`MagneticBlockContext`,
+                  :py:class:`MagneticModuleContext`,
+                  :py:class:`TemperatureModuleContext`, or
+                  :py:class:`ThermocyclerContext`,
                   depending on what you requested with ``module_name``.
 
+                  .. versionchanged:: 2.13
+                    Added ``HeaterShakerContext`` return value.
+
                   .. versionchanged:: 2.15
-                    Added :py:class:`MagneticBlockContext` return value.
+                    Added ``MagneticBlockContext`` return value.
         """
         if configuration:
             if self._api_version < APIVersion(2, 4):


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Displays the new `MagneticBlockContext` in the API reference and makes minor changes to docstrings.

Addresses RTC-283

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Check out the [API Reference in the branch sandbox](http://sandbox.docs.opentrons.com/docs-MagneticBlockContext/v2/new_protocol_api.html).

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- added autoclass for `MagneticBlockContext` to reference
- alphabetized module contexts in reference
- alphabetized module contexts in docstring for `load_module`
- fixed broken reference in docstring for `load_module`
- added `versionadded` note for H-S as a new output of `load_module` as of 2.13

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Are these the methods we want surfaced for Magnetic Block? Do we want to say anything else in its reference docstring? There will be a separate explanation on how it is an unpowered module on the Modules page, coming in a separate PR.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

v low, docs and docstrings only