### PR TITLE
feat(hardware-testing): Added hardware testing usb package

### DIFF
--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -9,11 +9,13 @@ ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
 project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
 
-sdist_file = dist/hardware_testing-0.0.1.tar.gz
-wheel_file = dist/hardware_testing-0.0.1-py3-none-any.whl
+package_name = hardware_testing
+package_version = $(call python_package_version,hardware-testing,$(project_ot3_default))
+wheel_file = dist/$(call python_get_wheelname,hardware-testing,$(project_rs_default),$(package_name),$(BUILD_NUMBER))
+sdist_file = dist/$(call python_get_sdistname,hardware-testing,$(project_ot3_default),$(package_name))
+usb_file =   dist/$(package_name)-usb-$(package_version).tar.gz
 # Find the branch, sha, version that will be used to update the VERSION.json file
-usb_fileversion_file = $(call python_get_git_version,hardware-testing,$(project_ot3_default),hardware-testing)
-usb_file = dist/hardware_testing_usb-0.0.1.tar.gz
+version_file = $(call python_get_git_version,hardware-testing,$(project_ot3_default),hardware-testing)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -56,21 +58,21 @@ teardown:
 clean:
 	$(clean_cmd)
 
-$(sdist_file): setup.py $(ot_sources) clean
-	$(python) setup.py sdist
-	$(SHX) rm -rf build
-	$(SHX) ls dist
-
-$(wheel_file): setup.py $(ot_sources) clean
-	$(python) setup.py bdist_wheel
+.PHONY: wheel
+wheel: export OPENTRONS_PROJECT=$(project_rs_default)
+wheel:
+	rm -rf dist/*.whl
+	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) rm -rf build
 	$(SHX) ls dist
 
 .PHONY: sdist
-sdist: $(sdist_file)
-
-.PHONY: wheel
-wheel: $(wheel_file)
+sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist:
+	$(clean_cmd)
+	$(python) setup.py sdist
+	$(SHX) rm -rf build
+	$(SHX) ls dist
 
 .PHONY: test
 test:
@@ -172,7 +174,7 @@ restart:
 	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: push-no-restart
-push-no-restart:
+push-no-restart: wheel
 	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push
@@ -284,9 +286,6 @@ get-latest-tag:
 setup-usb-module: sdist Pipfile.lock
 	@echo "Creating hardware-testing USB package."
 
-	# Clean the old dir
-	rm -rf ./dist/hardware_testing_usb/
-
 	# create git-description
 	$(shell $(python) -c "from hardware_testing.data import *; create_git_description_file()")
 
@@ -297,8 +296,10 @@ setup-usb-module: sdist Pipfile.lock
 	cp -r ./hardware_testing/tools/usb-package/* ./dist/hardware_testing_usb/
 	cp -r ./hardware_testing/tools/plot ./dist/hardware_testing_usb/
 
-	# Create the usb-package tarbaltar
+	# Create the usb-package tar file
 	tar -zcvf $(usb_file) -C ./dist/ ./hardware_testing_usb/
+	rm -rf ./dist/hardware_testing_usb
+
 	# Lets extract the usb package to the usb device if given
 	$(if $(usb_dir), tar -xvf $(usb_file) -C $(usb_dir))
 

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -5,9 +5,15 @@ include ../scripts/python.mk
 
 SHX := npx shx
 
+ot_project := $(OPENTRONS_PROJECT)
+project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
+project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+
 sdist_file = dist/hardware_testing-0.0.1.tar.gz
 wheel_file = dist/hardware_testing-0.0.1-py3-none-any.whl
-
+# Find the branch, sha, version that will be used to update the VERSION.json file
+version_file = $(call python_get_git_version,hardware-testing,$(project_ot3_default),hardware-testing)
+usb_file = dist/hardware_testing_usb-0.0.1.tar.gz
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -26,6 +32,9 @@ ssh_opts ?= $(default_ssh_opts)
 # For the python sources
 ot_py_sources := $(filter %.py,$(shell $(SHX) find hardware_testing/))
 ot_sources := $(ot_py_sources)
+
+# usb package options
+usb_dir ?=
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
@@ -175,7 +184,7 @@ restart-ot3:
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist Pipfile.lock
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"hardware_testing")
+	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"hardware_testing",,,$(version_file))
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3 push-plot-webpage-ot3 push-description-ot3
@@ -268,3 +277,18 @@ push-photometric-ot2:
 .PHONY: get-latest-tag
 get-latest-tag:
 	git tag -l --sort=-v:refname "ot3@*" --merged | (head -n 1 || Select -First 1)
+
+
+# Creates a tarball of the hardware-testing module that can be deployed to a thumb-drive
+.PHONY: setup-usb-module-ot3
+setup-usb-module: sdist Pipfile.lock
+	@echo "Creating hardware-testing USB package."
+
+	# Create the usb-package tarball
+	tar -zcvf $(usb_file) \
+		-C ./dist ./hardware_testing-0.0.1.tar.gz \
+		-C ../hardware_testing/scripts/ ./setup.sh \
+
+	# Lets extract the usb package to the usb device if given
+	$(if $(usb_dir), tar -xvf $(usb_file) -C $(usb_dir))
+

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -287,10 +287,14 @@ setup-usb-module: sdist Pipfile.lock
 	# Clean the old dir
 	rm -rf ./dist/hardware_testing_usb/
 
+	# create git-description
+	$(shell $(python) -c "from hardware_testing.data import *; create_git_description_file()")
+
 	# Copy files to dir
 	mkdir -p ./dist/hardware_testing_usb/
+	mv .hardware-testing-description ./dist/hardware_testing_usb/
 	cp -r $(sdist_file) ./dist/hardware_testing_usb/
-	cp -r ./hardware_testing/scripts/setup.sh ./dist/hardware_testing_usb/
+	cp -r ./hardware_testing/tools/usb-package/* ./dist/hardware_testing_usb/
 	cp -r ./hardware_testing/tools/plot ./dist/hardware_testing_usb/
 
 	# Create the usb-package tarbaltar

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -12,7 +12,7 @@ project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
 sdist_file = dist/hardware_testing-0.0.1.tar.gz
 wheel_file = dist/hardware_testing-0.0.1-py3-none-any.whl
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,hardware-testing,$(project_ot3_default),hardware-testing)
+usb_fileversion_file = $(call python_get_git_version,hardware-testing,$(project_ot3_default),hardware-testing)
 usb_file = dist/hardware_testing_usb-0.0.1.tar.gz
 
 # These variables can be overriden when make is invoked to customize the
@@ -284,11 +284,17 @@ get-latest-tag:
 setup-usb-module: sdist Pipfile.lock
 	@echo "Creating hardware-testing USB package."
 
-	# Create the usb-package tarball
-	tar -zcvf $(usb_file) \
-		-C ./dist ./hardware_testing-0.0.1.tar.gz \
-		-C ../hardware_testing/scripts/ ./setup.sh \
+	# Clean the old dir
+	rm -rf ./dist/hardware_testing_usb/
 
+	# Copy files to dir
+	mkdir -p ./dist/hardware_testing_usb/
+	cp -r $(sdist_file) ./dist/hardware_testing_usb/
+	cp -r ./hardware_testing/scripts/setup.sh ./dist/hardware_testing_usb/
+	cp -r ./hardware_testing/tools/plot ./dist/hardware_testing_usb/
+
+	# Create the usb-package tarbaltar
+	tar -zcvf $(usb_file) -C ./dist/ ./hardware_testing_usb/
 	# Lets extract the usb package to the usb device if given
 	$(if $(usb_dir), tar -xvf $(usb_file) -C $(usb_dir))
 

--- a/hardware-testing/hardware_testing/scripts/setup.sh
+++ b/hardware-testing/hardware_testing/scripts/setup.sh
@@ -2,12 +2,15 @@
 
 # This script sets up the hardware-testing module to run from usb or some other dir on the Flex robot
 
-USB_DIR=.
-PACKAGE_NAME="hardware_testing"
-PACKAGE_TAR_FILE="./${PACKAGE_NAME}-*.tar.gz"
-SYSTEM_VERSION_FILE="/etc/VERSION.json"
-PKG_INFO_FILE="PKG-INFO"
+USB_DIR=$(pwd)
 PACKAGE_VERSION=""
+PACKAGE_NAME="hardware_testing"
+PACKAGE_DIR=$(echo ${USB_DIR}/${PACKAGE_NAME}-*/)
+PACKAGE_TAR_FILE=$(echo ${USB_DIR}/${PACKAGE_NAME}-*.tar.gz)
+PKG_INFO_FILE=$PACKAGE_DIR/PKG-INFO
+SYSTEM_VERSION_FILE="/etc/VERSION.json"
+DEFAULT_ENV_PROFILE="/etc/profile.d/ot-environ.sh"
+ENV_PROFILE="/etc/profile.d/ot-usb-environ.sh"
 
 # Script entry-point
 main() {
@@ -46,13 +49,14 @@ validate() {
 		echo "Could not find package tarball - ${PACKAGE_TAR_FILE}"
 		exit 1;
 	fi
-	echo "Extracting tarball ${usb_module_filename}"
-	tar -xvf $usb_module_filename -C ./
+}
 
-	# Enter the extracted dir
-	cd $PACKAGE_NAME*/
+_extract_tarball() {
+	echo "Extracting tarball ${usb_module_filename}"
+	tar -xvf $usb_module_filename -C $USB_DIR
 
 	# Get the version of the package
+	echo "SOEMTHING: $PKG_INFO_FILE"
 	if [ ! -f $PKG_INFO_FILE ]; then
 		echo "error: ${PKG_INFO_FILE} was not found!"
 		exit 1;
@@ -60,26 +64,64 @@ validate() {
 	PACKAGE_VERSION=$(cat ${PKG_INFO_FILE} | grep Version)
 }
 
+
+# Helper function to write/delete environment variable profile script
+_env_profile() {
+	# mount the filesystem rw
+	mount -o remount,rw /
+
+	if [[ $1 =~ "delete" ]]; then
+		echo "Deleting usb-package env file - ${ENV_PROFILE}"
+		rm -rf $ENV_PROFILE
+		return;
+	fi
+
+	echo "Writting usb-package env profile - $ENV_PROFILE"
+
+cat <<EOF > $ENV_PROFILE
+#!/usr/bin/env sh
+
+# check that the hardware-tesing dir in the usb device exists
+if [ ! -d $USB_DIR ]; then
+	echo "################## WARNING ##################"
+	echo "The Hardware-Testing package is enabled, but was not found."
+	echo "Please make sure that the usb is plugged in and mounted to - $USB_DIR."
+	echo "If you are done using the Hardware-Testing package, make sure its disabled."
+	echo "You can disable by runing './setup teardown' from the usb."
+	echo "################## WARNING ##################"
+	return 1;
+fi
+
+echo "Hardware-Testing package enabled at $USB_DIR"
+export PYTHONPATH=\$PYTHONPATH:$USB_DIR
+
+# set OT_SYSTEM_VERSION if not set
+if [ -z \$OT_SYSTEM_VERSION ]; then
+	export OT_SYSTEM_VERSION="0.0.0"
+fi
+EOF
+	# remount filesystem as ro
+	mount -o remount,ro /
+}
+
 # Sets up the hardware-testing module to be used from usb location
 setup() {
 	echo "Setting up hardware-testing module ${PACKAGE_VERSION}"
-	echo "1. Setting up environment variables"
-	here=$(pwd)
-	export PYTHONPATH=$PYTHONPATH:$here:
-	echo $PYTHONPATH
-	# set PYTHONBINDIR to the usb dir
-	# maybe set OT_SYSTEM_VERSION for now
-	# also set OT_OT3_HARDWARE_CONTROLLER or w.e its called
 
-	# 2. Lets set the logging location for hardware-testing scripts
-	# maybe edit the config file we pass the logging usb module??
-	# 
+	# lets extract that tarball
+	_extract_tarball
+
+	# Lets set up the environment profile
+	_env_profile
+
+	# TODO (ba, 2023-07-19): set the logging location for hardware-testing scripts to usb
+	# We need to consilidate hardware-testing logging before being able to do this.
+
+	# Lets deal with plot-webpage since the sdist file only contains .py files
+	cp -r $USB_DIR/plot $PACKAGE_DIR/$PACKAGE_NAME/tools/
 
 	# 3. Lets deal with hardware-testing-description
 	# file needs to be part of the tarball so we can place it in its proper location here
-
-	# 4. Lets deal with plot-webpage 
-	# file needs to be part of tarball so we can place it in its proper location here
 
 	# 5. Lets apply the patch files
 	# patch files are part of this package so we need to apply them here 
@@ -89,11 +131,15 @@ setup() {
 	# This gets applied in get_testing_data_directory, look into it
 
 	# 7. Lets deal with push-grav-ot3 and replicate that setup here
+	echo "Hardare-Testing module has been setup, re-login to apply changes."
 }
 
 # Tearsdown the hardare-testing module
 teardown() {
 	echo "Teardown usb package"
 }
+
+set -e -o pipefail
+trap teardown EXIT
 
 main "$@"

--- a/hardware-testing/hardware_testing/scripts/setup.sh
+++ b/hardware-testing/hardware_testing/scripts/setup.sh
@@ -1,0 +1,90 @@
+#! /bin/bash
+
+# This script sets up the hardware-testing module to run from usb or some other dir on the Flex robot
+
+USB_DIR=.
+SYSTEM_VERSION_FILE="/etc/VERSION.json"
+PKG_INFO_FILE="PKG-INFO"
+PACKAGE_VERSION=""
+
+# Script entry-point
+main() {
+	echo "Validating files"
+	validate "$@"
+
+	# execute action
+	case $1 in
+		teardown)
+			echo "Teardown"
+			teardown
+			;;
+		*)
+			echo "Setup"
+			setup
+			;;
+	esac
+}
+
+# Make sure we have the correct files before doing anything
+validate() {
+	# Check if we are running on the robot or not
+	if [ ! -f $SYSTEM_VERSION_FILE ]; then
+		echo "${SYSTEM_VERSION_FILE} not found, make sure you're running this from a robot!"
+		exit 1;
+	fi
+	is_flex=$(cat $SYSTEM_VERSION_FILE | grep OT-3)
+	echo "is_flex: $(is_flex)"
+
+	# validate the package files
+	if [ ! -z "$2" ]; then
+		USB_DIR=$2
+		if [ ! -d "$USB_DIR" ]; then
+			echo "error: usb dir does not exist - ${USB_DIR}"
+			exit 1;
+		fi
+	fi
+	echo "usb dir is - ${USB_DIR}"
+
+	# Get the version of the package
+	if [ ! -f $PKG_INFO_FILE ]; then
+		echo "error: ${PKG_INFO_FILE} was not found!"
+		exit 1;
+	fi
+	PACKAGE_VERSION="cat ${PKG_INFO_FILE} | grep version"
+	# Check that the hardware-testing dir exists
+}
+
+# Sets up the hardware-testing module to be used from usb location
+setup() {
+	echo "Setting up hardware-testing module ${PACKAGE_VERSION}"
+	# 1. Lets get our environment variables setup
+	# set PYTHONBINDIR to the usb dir
+	# maybe set OT_SYSTEM_VERSION for now
+	# also set OT_OT3_HARDWARE_CONTROLLER or w.e its called
+
+	# 2. Lets set the logging location for hardware-testing scripts
+	# maybe edit the config file we pass the logging usb module??
+	# 
+
+	# 3. Lets deal with hardware-testing-description
+	# file needs to be part of the tarball so we can place it in its proper location here
+
+	# 4. Lets deal with plot-webpage 
+	# file needs to be part of tarball so we can place it in its proper location here
+
+	# 5. Lets apply the patch files
+	# patch files are part of this package so we need to apply them here 
+	# use the same mechanism we use when applying from makefile
+
+	# 6. Lets deal with hardware-testing data
+	# This gets applied in get_testing_data_directory, look into it
+
+	# 7. Lets deal with push-grav-ot3 and replicate that setup here
+}
+
+# Tearsdown the hardare-testing module
+teardown() {
+	echo "Teardown usb package"
+}
+
+main "$@"

--- a/hardware-testing/hardware_testing/tools/usb-package/readme.txt
+++ b/hardware-testing/hardware_testing/tools/usb-package/readme.txt
@@ -1,0 +1,79 @@
+## OVERVIEW
+The usb-package bundles up the hardware_testing module so it can run from a usb thumbdrive on the Flex.
+
+## INSTRUCTIONS
+
+### How to make package:
+make -C hardware-testing setup-usb-module
+This will produce a tar file **hardware_testing_usb-<version>.tar.gz** in **hardware-testing/dist/**
+example:
+	hardware_testing_usb-0.0.1.tar.gz
+
+You can also make and install the tar file to a target with the **usb_dir** option
+This will extract the contents to the specified location
+make -C hardware-testing setup-usb-module usb_dir="/Volumes/ENFAIN/"
+
+### How to deploy:
+If you use the **usb_dir** option the usb-package will be installed on the usb drive
+You can also manually extract the tar file onto a target like so
+tar -xvf hardware_testing_usb-0.0.1.tar.gz -C "<drive-location>"
+
+### How to install on the Flex:
+Once you have an usb thumdrive with the usb-packge deployed you can plug in the thumbdrive to
+a Flex and start the setup script to install the required files like so
+
+0. Make sure the Flex is powered on
+1. ssh to the robot with
+	ssh root@<ip-address>
+	NOTE: You can also use screen or similar if you are using an FTDI connection
+	screen /dev/<ftdi-device> 115200
+2. Plug in the hardware-testing thumbdrive to the Flex
+	The device should be mounted to **/media/sda** or similar
+	Note: You can also manually mount the thumbdrive with
+	a. From the Linux command line list usb devices with
+		blkid
+		Note:
+		Your drive address should be something like
+		**/dev/sda: LABEL="ENFAIN"...**
+		The LABEL should be the name of your usb thumbdrive
+	b. mount the drive
+		mount /dev/sda /mnt
+	c. the device should now be accessed thorugh /mnt
+3. Navigate to the mounted drive
+	a. if drive was automatically mounted, run
+	cd /media/sdx/hardware_testing_usb where x is the enumerated drive
+	b. or if mounted manually
+		cd /mnt/hardware_testing_usb
+4. Run the setup script
+	a. From the usb-packge dir **hardware_testing_usb** run
+	./setup
+5. Re-logging to apply
+	a. from the command shell run
+	logout
+	b. use ssh or screen to log back in
+	see step 1 above.
+6. You should now see
+	**Hardware-Testing package enabled at <mount-location>/hardware_testing_usb**
+
+	Note: **<mount-location>** is where the thumbdrive was mounted typically **/media/sdx**
+	but could also be **/mnt** or different if mounted manually
+7. Done
+	a. The hardware-testing package is now setup and can be used as normal
+	example:
+		python3 -m hardware_testing.scripts.module_calibration
+
+
+### How to uninstall from the Flex:
+With the usb thumbdrive plugged into the Flex
+1. Navigate to usb-packge dir
+	cd <mount-location>/hardware_testing_usb
+2. Run the setup script
+	./setup teardown
+	You should see **Teardown Success**
+3. The usb drive can now be removed
+
+
+### Troubleshoting
+
+If the usb thumbdrive is removed and replugged it could enumerate differently.
+This means you will need to run the ./setup script again

--- a/hardware-testing/hardware_testing/tools/usb-package/setup.sh
+++ b/hardware-testing/hardware_testing/tools/usb-package/setup.sh
@@ -10,7 +10,6 @@ PACKAGE_DIR=$(echo ${USB_DIR}/${PACKAGE_NAME}-*/)
 PACKAGE_TAR_FILE=$(echo ${USB_DIR}/${PACKAGE_NAME}-*.tar.gz)
 PKG_INFO_FILE=$PACKAGE_DIR/PKG-INFO
 SYSTEM_VERSION_FILE="/etc/VERSION.json"
-DEFAULT_ENV_PROFILE="/etc/profile.d/ot-environ.sh"
 ENV_PROFILE="/etc/profile.d/ot-usb-environ.sh"
 
 # Script entry-point
@@ -82,15 +81,11 @@ _env_profile() {
 cat <<EOF > $ENV_PROFILE
 #!/usr/bin/env sh
 
-# check that the hardware-tesing dir in the usb device exists
+# Do an auto-teardown if the usb device is not found
 if [ ! -d $USB_DIR ]; then
-	echo "################## WARNING ##################"
-	echo "The Hardware-Testing package is enabled, but was not found."
-	echo "Please make sure that the usb is plugged in and mounted to - $MOUNT_DIR"
-	echo "If plugged in and mounted but not found, re-run the ./setup.sh script."
-	echo "If you are done using the Hardware-Testing package, make sure its uninstalled."
-	echo "You can uninstall it by runing './setup teardown' from the usb."
-	echo "################## WARNING ##################"
+	mount -o remount,rw /
+	rm -rf $ENV_PROFILE
+	mount -o remount,ro /
 	return 1;
 fi
 

--- a/hardware-testing/setup.py
+++ b/hardware-testing/setup.py
@@ -1,10 +1,29 @@
 """Setup script."""
 
+import os
+import sys
+
 from setuptools import setup, find_packages
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(HERE, "..", "scripts"))
+from python_build_utils import normalize_version  # noqa: E402
+
+
+def get_version():
+    buildno = os.getenv("BUILD_NUMBER")
+    project = os.getenv("OPENTRONS_PROJECT", "ot3")
+    git_dir = os.getenv("OPENTRONS_GIT_DIR", None)
+    if buildno:
+        normalize_opts = {"extra_tag": buildno}
+    else:
+        normalize_opts = {}
+    return normalize_version("hardware-testing", project, git_dir=git_dir, **normalize_opts)
+
 
 setup(
     name="hardware_testing",
-    version="0.0.1",
+    version=get_version(),
     packages=find_packages(where=".", exclude=["tests.*", "tests"]),
     url="",
     license="",

--- a/hardware-testing/setup.py
+++ b/hardware-testing/setup.py
@@ -18,7 +18,9 @@ def get_version():
         normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version("hardware-testing", project, git_dir=git_dir, **normalize_opts)
+    return normalize_version(
+        "hardware-testing", project, git_dir=git_dir, **normalize_opts
+    )
 
 
 setup(

--- a/hardware-testing/setup.py
+++ b/hardware-testing/setup.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.join(HERE, "..", "scripts"))
 from python_build_utils import normalize_version  # noqa: E402
 
 
-def get_version():
+def _get_version():
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "ot3")
     git_dir = os.getenv("OPENTRONS_GIT_DIR", None)
@@ -25,7 +25,7 @@ def get_version():
 
 setup(
     name="hardware_testing",
-    version=get_version(),
+    version=_get_version(),
     packages=find_packages(where=".", exclude=["tests.*", "tests"]),
     url="",
     license="",

--- a/hardware-testing/setup.py
+++ b/hardware-testing/setup.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.join(HERE, "..", "scripts"))
 from python_build_utils import normalize_version  # noqa: E402
 
 
-def _get_version():
+def _get_version() -> None:
     buildno = os.getenv("BUILD_NUMBER")
     project = os.getenv("OPENTRONS_PROJECT", "ot3")
     git_dir = os.getenv("OPENTRONS_GIT_DIR", None)

--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -29,6 +29,7 @@ package_entries = {
     'shared-data': PackageEntry('shared_data'),
     'notify-server': PackageEntry('notify_server'),
     'hardware': PackageEntry('opentrons_hardware'),
+    'hardware-testing': PackageEntry('hardware_testing'),
     'usb-bridge': PackageEntry('usb_bridge'),
     'system-server': PackageEntry('system_server'),
     'server-utils': PackageEntry('server_utils'),


### PR DESCRIPTION
# Overview

The hardware-testing package is used for testing various parts of the Flex, however in order to use it you have to have a computer that has all of our packages, and dependencies and has been set up to run our software. This poses some friction as it requires a lot to get up and running. This pr solves this problem by creating a hardware-testing package, that can be run from a USB drive plugged directly into the Flex.

# Test Plan

- [x] Use `make -C hardware-testing setup-usb-module` and make sure it generates a **/dist/hardware_testing_usb-*.tar.gz** file
- [x] Use `make -C hardware-testing setup-usb-module usb_dir="<usb dir>"` and make sure a **hardware_testing_usb** dir is extracted to the usb dir specified.
- [x] Make sure you can run hardware-testing scripts after running `./setup.sh` from the Flex
- [x] Make sure you can run hardware-testing scripts even after reboots
- [x] Make sure you cant run hardware-testing scripts if the USB thumb drive has been removed.
- [x] Make sure you cant run hardware-testing scripts after running `./setup teardown` and re-login.
- [x] Make sure the script does an auto teardown if the USB is not found.

# Changelog

- Added `setup-usb-module` to hardware-testing Makefile, which creates a USB package
- Added hardware-testing entry to scripts/python_build_utils.py so we can get the package version
- Added correct versioning based on git tags when producing sdist/wheel files

# Review requests

- If we want to have hardware-testing logging go to the thumb drive that should be a separate pr.
- Anything I might be missing?

# Risk assessment

Low, internal tooling