### PR TITLE
fix(api): pick_up_tip in 2.14+ protocols does not pick up tips before starting tip

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -160,9 +160,9 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - By default, repeated calls to :py:meth:`.drop_tip` cycle through multiple locations above the trash bin to prevent tips from stacking up.
   
-- Known limitations
+- Bug fixes
 
-  - :py:attr:`.InstrumentContext.starting_tip` is not respected on the second and subsequent calls to :py:meth:`.InstrumentContext.pick_up_tip` with no argument.
+  - :py:attr:`.InstrumentContext.starting_tip` is now respected on the second and subsequent calls to :py:meth:`.InstrumentContext.pick_up_tip` with no argument.
 
   
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -101,7 +101,13 @@ class InstrumentContext(publisher.CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def starting_tip(self) -> Union[labware.Well, None]:
-        """The starting tip from which the pipette pick up"""
+        """
+        Which well of a tip rack the pipette should start at when tracking tips.
+
+        The first call to :py:meth:`.pick_up_tip` with no argument will pick up from
+        that well. Subsequent calls will follow the ordering specified by the labware
+        definition and :py:meth:`.Labware.wells`.
+        """
         return self._starting_tip
 
     @starting_tip.setter

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -102,11 +102,16 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 0)
     def starting_tip(self) -> Union[labware.Well, None]:
         """
-        Which well of a tip rack the pipette should start at when tracking tips.
+        Which well of a tip rack the pipette should start at when automatically choosing tips to pick up.
 
-        The first call to :py:meth:`.pick_up_tip` with no argument will pick up from
-        that well. Subsequent calls will follow the ordering specified by the labware
-        definition and :py:meth:`.Labware.wells`.
+        See :py:meth:`.pick_up_tip()`.
+
+        .. note::
+
+            In robot software versions 6.3.0 and 6.3.1, protocols specifying API level 2.14 would
+            not respect ``starting_tip`` on the second and subsequent calls to
+            :py:meth:`.InstrumentContext.pick_up_tip` with no argument. This is fixed for all API
+            levels as of robot software version 7.0.0.
         """
         return self._starting_tip
 
@@ -666,6 +671,9 @@ class InstrumentContext(publisher.CommandPublisher):
 
         If no location is passed, the Pipette will pick up the next available
         tip in its :py:attr:`InstrumentContext.tip_racks` list.
+        Within each tip rack, tips will be picked up in the order specified by
+        the labware definition and :py:meth:`.Labware.wells`.
+        To adjust where the sequence starts, see :py:obj:`.starting_tip`.
 
         The tip to pick up can be manually specified with the `location`
         argument. The `location` argument can be specified in several ways:

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -210,6 +210,80 @@ def test_get_next_tip_skips_picked_up_tip(
     assert result == result_well_name
 
 
+def test_get_next_tip_with_starting_tip(
+    subject: TipStore,
+    load_labware_command: commands.LoadLabware,
+) -> None:
+    """It should return the starting tip, and then the following tip after that."""
+    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        num_tips=1,
+        starting_tip_name="B2",
+    )
+
+    assert result == "B2"
+
+    pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
+        params=commands.PickUpTipParams.construct(
+            pipetteId="pipette-id",
+            labwareId="cool-labware",
+            wellName="B2",
+        ),
+        result=commands.PickUpTipResult.construct(
+            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
+        ),
+    )
+
+    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        num_tips=1,
+        starting_tip_name="B2",
+    )
+
+    assert result == "C2"
+
+
+def test_get_next_tip_with_starting_tip_out_of_tips(
+    subject: TipStore,
+    load_labware_command: commands.LoadLabware,
+) -> None:
+    """It should return the starting tip of H12 and then None after that."""
+    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        num_tips=1,
+        starting_tip_name="H12",
+    )
+
+    assert result == "H12"
+
+    pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
+        params=commands.PickUpTipParams.construct(
+            pipetteId="pipette-id",
+            labwareId="cool-labware",
+            wellName="H12",
+        ),
+        result=commands.PickUpTipResult.construct(
+            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
+        ),
+    )
+
+    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        num_tips=1,
+        starting_tip_name="H12",
+    )
+
+    assert result is None
+
+
 def test_get_next_tip_with_column_and_starting_tip(
     subject: TipStore,
     load_labware_command: commands.LoadLabware,

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -249,6 +249,43 @@ def test_get_next_tip_with_starting_tip(
     assert result == "C2"
 
 
+def test_get_next_tip_with_starting_tip_8_channel(
+    subject: TipStore,
+    load_labware_command: commands.LoadLabware,
+) -> None:
+    """It should return the starting tip, and then the following tip after that."""
+    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        num_tips=8,
+        starting_tip_name="A2",
+    )
+
+    assert result == "A2"
+
+    pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
+        params=commands.PickUpTipParams.construct(
+            pipetteId="pipette-id",
+            labwareId="cool-labware",
+            wellName="A2",
+        ),
+        result=commands.PickUpTipResult.construct(
+            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
+        ),
+    )
+
+    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip))
+
+    result = TipView(subject.state).get_next_tip(
+        labware_id="cool-labware",
+        num_tips=8,
+        starting_tip_name="A2",
+    )
+
+    assert result == "A3"
+
+
 def test_get_next_tip_with_starting_tip_out_of_tips(
     subject: TipStore,
     load_labware_command: commands.LoadLabware,

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -52,7 +52,10 @@ _log = getLogger(__name__)
 #
 # This does not necessarily have any correspondence with the user-facing
 # robot software version.
-_CURRENT_ANALYZER_VERSION: Final = "initial"
+#
+# Version History
+#     * Changed to "2" for version 7.0 from "initial"
+_CURRENT_ANALYZER_VERSION: Final = "2"
 # We have a reasonable limit for a memory cache of analyses.
 _CACHE_MAX_SIZE: Final = 32
 


### PR DESCRIPTION
# Overview

Closes RESC-145.

In api version 2.14 and above (which uses the Protocol Engine), a regression was introduced that made it that if you chose a starting tip and used `pick_up_tip` without any arguments, the wells after the starting tip would be `A1`, `B1`, `C1`, etc instead of returning the wells that followed the starting one. This has been addressed so that the pick up tip behavior is identical to versions 2.13 and below.

# Test Plan

Tested the following protocol with both API levels 2.13 and 2.14 on an OT-2 to verify that they picked up tips in `B2`, `C2`, `D2`...`A3`

```
metadata = {
    'protocolName': 'Tip Regression Behavior',
}

requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.13"
}

def run(context):
    tip_rack = context.load_labware("opentrons_96_tiprack_20ul", location=5)
    pipette = context.load_instrument("p20_single_gen2", mount="left", tip_racks=[tip_rack])

    pipette.starting_tip = tip_rack["B2"]

    for _ in range(8):
        pipette.pick_up_tip()
        pipette.drop_tip()
```

# Changelog

- fixed `TipView.get_next_tip` to drop potential wells before the starting tip well

# Review requests

# Risk assessment

Low, behavior only changes if starting tip is used, and that has been tested to ensure it matches with previous behavior.