### PR TITLE
feat(robot-server): Expose tip status in instruments

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -759,15 +759,17 @@ class OT3Controller:
         return {node_to_axis(node): bool(val) for node, val in res.items()}
 
     async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> None:
+        """Raise an error if the expected tip state does not match the current state."""
+        res = await self.get_tip_present_state(mount)
+        if res != tip_state.value:
+            raise FailedTipStateCheck(tip_state, res)
+
+    async def get_tip_present_state(self, mount: OT3Mount) -> int:
         """Get the state of the tip ejector flag for a given mount."""
-        # TODO (lc 06/09/2023) We should create a separate type for
-        # pipette specific sensors. This work is done in the overpressure
-        # PR.
         res = await get_tip_ejector_state(
             self._messenger, sensor_node_for_mount(OT3Mount(mount.value))  # type: ignore
         )
-        if res != tip_state.value:
-            raise FailedTipStateCheck(tip_state, res)
+        return res
 
     @staticmethod
     def _tip_motor_nodes(axis_current_keys: KeysView[Axis]) -> List[NodeId]:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -369,6 +369,10 @@ class OT3Simulator:
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
 
     async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> None:
+        """Raise an error if the given state doesn't match the physical state."""
+        pass
+
+    async def get_tip_present_state(self, mount: OT3Mount) -> int:
         """Get the state of the tip ejector flag for a given mount."""
         pass
 

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -91,6 +91,10 @@ class PipetteDict(InstrumentDict):
     default_blow_out_volume: float
 
 
+class PipetteStateDict(TypedDict):
+    tip_detected: bool
+
+
 class GripperDict(InstrumentDict):
     model: GripperModel
     gripper_id: str

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -140,6 +140,7 @@ from .dev_types import (
     AttachedGripper,
     AttachedPipette,
     PipetteDict,
+    PipetteStateDict,
     InstrumentDict,
     GripperDict,
 )
@@ -1849,6 +1850,16 @@ class OT3API(
     def get_attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
         # Warning: don't use this in new code, used `get_attached_pipettes` instead
         return self.get_attached_pipettes()
+
+    async def get_instrument_state(
+        self, mount: Union[top_types.Mount, OT3Mount]
+    ) -> PipetteStateDict:
+        # TODO we should have a PipetteState that can be returned from
+        # this function with additional state (such as critical points)
+        realmount = OT3Mount.from_mount(mount)
+        res = await self._backend.get_tip_present_state(realmount)
+        pipette_state_for_mount: PipetteStateDict = {"tip_detected": bool(res)}
+        return pipette_state_for_mount
 
     def reset_instrument(
         self, mount: Union[top_types.Mount, OT3Mount, None] = None

--- a/robot-server/robot_server/instruments/instrument_models.py
+++ b/robot-server/robot_server/instruments/instrument_models.py
@@ -81,6 +81,15 @@ class PipetteData(BaseModel):
     #  add calibration data as decided by https://opentrons.atlassian.net/browse/RSS-167
 
 
+class PipetteState(BaseModel):
+    """State from an attached pipette."""
+
+    tip_detected: bool = Field(
+        None,
+        description="Physical state of the tip photointerrupter on the Flex. Null for OT-2",
+    )
+
+
 class Pipette(_GenericInstrument[PipetteModel, PipetteData]):
     """Attached pipette info & configuration."""
 
@@ -88,6 +97,7 @@ class Pipette(_GenericInstrument[PipetteModel, PipetteData]):
     instrumentName: PipetteName
     instrumentModel: PipetteModel
     data: PipetteData
+    state: Optional[PipetteState]
 
 
 class Gripper(_GenericInstrument[GripperModelStr, GripperData]):

--- a/robot-server/robot_server/instruments/instrument_models.py
+++ b/robot-server/robot_server/instruments/instrument_models.py
@@ -84,9 +84,10 @@ class PipetteData(BaseModel):
 class PipetteState(BaseModel):
     """State from an attached pipette."""
 
-    tip_detected: bool = Field(
+    tipDetected: bool = Field(
         None,
         description="Physical state of the tip photointerrupter on the Flex. Null for OT-2",
+        alias="tip_detected",
     )
 
 


### PR DESCRIPTION
# Overview
We are now exposing the tip presence status (which is only valid on the Flex) through the `/instruments` endpoint. Closes [RSS-291](https://opentrons.atlassian.net/jira/software/c/projects/RSS/boards/155?modal=detail&selectedIssue=RSS-291&assignee=60343207783a4600685f4759)

# Test Plan

- Test on Flex, make sure the instruments endpoint returns updated data for the tip presence. You can test this on a single/multi by pushed the ejector flag up. (This feature is NOT yet implemented on the 96 channel and so the data there cannot be trusted).

# Changelog

- Add a `PipetteStateDict` in the hardware controller. This is currently only used in the ot3api, but we can (and should) definitely expand on this state in the future
- Add a separate `get_instrument_state` function in the `ot3api.py` which gets the current state of the tip ejector. Unfortunately we currently have to ask for the state each time this function is called because we currently don't have a state store for the hardware controller as it relates to specific hardware components (such as sensors).

# Review requests

Does it look OK for now? Anything you want me to add and/or take away?

# Risk assessment

Low. New feature add.

[RSS-291]: https://opentrons.atlassian.net/browse/RSS-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ