### PR TITLE
feat(shared-data): validate all models in the v2 pipette folder

### DIFF
--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -8,14 +8,14 @@ from typing_extensions import Literal
 # Needed for Int Comparison. Keeping it next to
 # the Literal type for ease of readability
 PipetteModelMajorVersion = [1, 2, 3]
-PipetteModelMinorVersion = [0, 1, 2, 3, 4, 5]
+PipetteModelMinorVersion = [0, 1, 2, 3, 4, 5, 6]
 
 # TODO Literals are only good for writing down
 # exact values. Is there a better typing mechanism
 # so we don't need to keep track of versions in two
 # different places?
 PipetteModelMajorVersionType = Literal[1, 2, 3]
-PipetteModelMinorVersionType = Literal[0, 1, 2, 3, 4, 5]
+PipetteModelMinorVersionType = Literal[0, 1, 2, 3, 4, 5, 6]
 
 
 class PipetteTipType(enum.Enum):

--- a/shared-data/python/tests/pipette/test_validate_schema.py
+++ b/shared-data/python/tests/pipette/test_validate_schema.py
@@ -1,0 +1,36 @@
+import os
+from opentrons_shared_data import get_shared_data_root
+
+from opentrons_shared_data.pipette.pipette_definition import PipetteConfigurations
+from opentrons_shared_data.pipette.load_data import load_definition
+from opentrons_shared_data.pipette.pipette_load_name_conversions import (
+    convert_pipette_model,
+)
+from opentrons_shared_data.pipette.dev_types import PipetteModel
+
+
+def test_check_all_models_are_valid() -> None:
+    paths_to_validate = (
+        get_shared_data_root() / "pipette" / "definitions" / "2" / "liquid"
+    )
+    _channel_model_str = {
+        "single_channel": "single",
+        "ninety_six_channel": "96",
+        "eight_channel": "multi",
+    }
+    for channel_dir in os.listdir(paths_to_validate):
+        for model_dir in os.listdir(paths_to_validate / channel_dir):
+            for version_file in os.listdir(paths_to_validate / channel_dir / model_dir):
+                version_list = version_file.split(".json")[0].split("_")
+                built_model: PipetteModel = PipetteModel(
+                    f"{model_dir}_{_channel_model_str[channel_dir]}_v{version_list[0]}.{version_list[1]}"
+                )
+
+                model_version = convert_pipette_model(built_model)
+                loaded_model = load_definition(
+                    model_version.pipette_type,
+                    model_version.pipette_channels,
+                    model_version.pipette_version,
+                )
+
+                assert isinstance(loaded_model, PipetteConfigurations)


### PR DESCRIPTION
## Overview

We should actually have a test that passes all of the files into the pydantic validator to ensure that the configurations can be properly loaded. Found a bug from the test! Let me know if you want me to test anything else in particular.