### PR TITLE
chore: parse tags in utf8 explicitly in python

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -80,9 +80,9 @@ def _latest_tag_for_prefix(prefix, git_dir):
             'Could not find tag in {check_dir} matching {prefix} '.format(
                 check_dir=check_dir, prefix=prefix)
             + '- build before release or no tags. Using 0.0.0-dev\n')
-        tags_result = prefix.encode() + b'0.0.0-dev'
+        tags_result = prefix.encode('utf-8') + b'0.0.0-dev'
     tags_matching = tags_result.strip().split(b'\n')
-    return tags_matching[-1].decode()
+    return tags_matching[-1].decode('utf-8')
 
 def _latest_version_for_project(project, git_dir):
     prefix = project_entries[project].tag_prefix
@@ -95,11 +95,11 @@ def _ref_from_sha(sha):
     # it exists. Then all the tag and head refs
     branch_name = subprocess.check_output(
         ['git', 'rev-parse', '--symbolic-full-name', '--verify', '--quiet', 'HEAD'],
-        cwd=CWD).strip().decode().split('\n')
+        cwd=CWD).strip().decode('utf-8').split('\n')
 
     allrefs = subprocess.check_output(
         ['git', 'show-ref', '--tags', '--heads'],
-        cwd=CWD).strip().decode().split('\n')
+        cwd=CWD).strip().decode('utf-8').split('\n')
     # Keep...
     matching = [
         this_ref for this_sha, this_ref in   # the refs
@@ -137,7 +137,7 @@ def dump_br_version(package, project, extra_tag='', git_dir=None):
     """
     normalized = get_version(package, project, extra_tag, git_dir)
     sha = subprocess.check_output(
-        ['git', 'rev-parse', 'HEAD'], cwd=CWD).strip().decode()
+        ['git', 'rev-parse', 'HEAD'], cwd=CWD).strip().decode('utf-8')
     branch = _ref_from_sha(sha)
     pref = package_entries[package].br_version_prefix
     return json.dumps({pref+'_version': normalized,


### PR DESCRIPTION
When we parse tags, we didn't explicitly set a codec for parsing the bytes. This is fine in most cases because the locale is set for utf-8, but in the docker container that builds buildroot the locale is C and that means ascii and that means that any tags that have utf-8 characters cause builds to fail.
