### PR TITLE
fix(api): do not open jaw after gripper calibration

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -737,7 +737,6 @@ async def calibrate_gripper_jaw(
         return offset
     finally:
         hcapi.remove_gripper_probe()
-        await hcapi.ungrip()
 
 
 async def calibrate_gripper(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We don't need to ungrip the jaw whenever we finishes calibration, because holding the jaw closed is the ideal gripper state, we can just leave it as that. 
