### PR TITLE
fix(robot-server): do not save calibration offsets if an error occurs

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -583,6 +583,7 @@ async def _calibrate_mount(
             InaccurateNonContactSweepError,
             EarlyCapacitiveSenseTrigger,
             CalibrationStructureNotFoundError,
+            EdgeNotFoundError,
         ):
             LOG.info(
                 "Error occurred during calibration. Resetting to current saved calibration value."
@@ -750,6 +751,32 @@ async def calibrate_gripper(
     return offset
 
 
+async def find_pipette_offset(
+    hcapi: OT3API,
+    mount: Literal[OT3Mount.LEFT, OT3Mount.RIGHT],
+    slot: int = 5,
+    method: CalibrationMethod = CalibrationMethod.BINARY_SEARCH,
+    raise_verify_error: bool = True,
+) -> Point:
+    """
+    Run automatic calibration for pipette and only return the calibration point.
+
+    Before running this function, make sure that the appropriate probe
+    has been attached or prepped on the tool (for instance, a capacitive
+    tip has been attached, or the conductive probe has been attached,
+    or the probe has been lowered).
+
+    This function should be used in the robot server only.
+    """
+    try:
+        await hcapi.reset_instrument_offset(mount)
+        await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+        offset = await _calibrate_mount(hcapi, mount, slot, method, raise_verify_error)
+        return offset
+    finally:
+        await hcapi.remove_tip(mount)
+
+
 async def calibrate_pipette(
     hcapi: OT3API,
     mount: Literal[OT3Mount.LEFT, OT3Mount.RIGHT],
@@ -758,7 +785,7 @@ async def calibrate_pipette(
     raise_verify_error: bool = True,
 ) -> Point:
     """
-    Run automatic calibration for pipette.
+    Run automatic calibration for pipette and save the offset.
 
     Before running this function, make sure that the appropriate probe
     has been attached or prepped on the tool (for instance, a capacitive

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -792,14 +792,9 @@ async def calibrate_pipette(
     tip has been attached, or the conductive probe has been attached,
     or the probe has been lowered).
     """
-    try:
-        await hcapi.reset_instrument_offset(mount)
-        await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
-        offset = await _calibrate_mount(hcapi, mount, slot, method, raise_verify_error)
-        await hcapi.save_instrument_offset(mount, offset)
-        return offset
-    finally:
-        await hcapi.remove_tip(mount)
+    offset = await find_pipette_offset(hcapi, mount, slot, method, raise_verify_error)
+    await hcapi.save_instrument_offset(mount, offset)
+    return offset
 
 
 async def calibrate_module(

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
@@ -55,14 +55,18 @@ class CalibratePipetteImplementation(
             self._hardware_api,
         )
         ot3_mount = OT3Mount.from_mount(params.mount)
-        assert ot3_mount is not OT3Mount.GRIPPER
+        assert (
+            ot3_mount is not OT3Mount.GRIPPER
+        ), "Expected a Pipette mount but Gripper mount was provided."
 
-        pipette_offset = await calibration.calibrate_pipette(
+        pipette_offset = await calibration.find_pipette_offset(
             hcapi=ot3_api, mount=ot3_mount, slot=5
         )
 
-        return CalibratePipetteResult(
-            pipetteOffset=InstrumentOffsetVector(
+        await ot3_api.save_instrument_offset(mount=ot3_mount, delta=pipette_offset)
+
+        return CalibratePipetteResult.construct(
+            pipetteOffset=InstrumentOffsetVector.construct(
                 x=pipette_offset.x, y=pipette_offset.y, z=pipette_offset.z
             )
         )


### PR DESCRIPTION
# Overview

A fix for the behavior where pipette offsets get saved even if an error occurs during the calibration flow.

# Test Plan

Follow steps in [this ticket](https://opentrons.atlassian.net/browse/RQA-1066) to reproduce.

# Changelog

- Save the offset inside the robot server function rather than the pipette function
- Ensure that we're raising on edge detection failed errors as well

# Review requests

Please test on a robot, let me know if anything seems off.

# Risk assessment

Low. Should be fixing a small bug.
