### PR TITLE
fix(app): close maintenance run modal if run gets deleted

### DIFF
--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -87,7 +87,7 @@ export const BeforeBeginning = (
   ]
 
   const handleOnClick = (): void => {
-    chainRunCommands(commandsOnProceed, false)
+    chainRunCommands?.(commandsOnProceed, false)
       .then(() => {
         proceed()
       })

--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -68,6 +68,7 @@ export const BeforeBeginning = (
     isRobotMoving,
     chainRunCommands,
     errorMessage,
+    maintenanceRunId,
     setErrorMessage,
   } = props
   const { t } = useTranslation(['gripper_wizard_flows', 'shared'])
@@ -141,7 +142,7 @@ export const BeforeBeginning = (
         />
       }
       proceedButtonText={t('move_gantry_to_front')}
-      proceedIsDisabled={isCreateLoading}
+      proceedIsDisabled={isCreateLoading || maintenanceRunId == null}
       proceed={handleOnClick}
     />
   )

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -46,9 +46,9 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
   const { t } = useTranslation(['gripper_wizard_flows', 'shared'])
 
   const handleOnClick = (): void => {
-    if (movement === REMOVE_PIN_FROM_REAR_JAW || maintenanceRunId == null) {
+    if (movement === REMOVE_PIN_FROM_REAR_JAW) {
       proceed()
-    } else {
+    } else if (maintenanceRunId != null) {
       const jaw = movement === MOVE_PIN_TO_FRONT_JAW ? 'front' : 'rear'
       createRunCommand({
         maintenanceRunId,

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -19,14 +19,14 @@ import calibratingFrontJaw from '../../assets/videos/gripper-wizards/CALIBRATING
 import calibratingRearJaw from '../../assets/videos/gripper-wizards/CALIBRATING_REAR_JAW.webm'
 
 import type { Coordinates } from '@opentrons/shared-data'
-import type { CreateMaintenaceCommand } from '../../resources/runs/hooks'
+import type { CreateMaintenanceCommand } from '../../resources/runs/hooks'
 import type { GripperWizardStepProps, MovePinStep } from './types'
 
 interface MovePinProps extends GripperWizardStepProps, MovePinStep {
   setFrontJawOffset: (offset: Coordinates) => void
   frontJawOffset: Coordinates | null
-  createRunCommand: CreateMaintenaceCommand
   isExiting: boolean
+  createRunCommand: CreateMaintenanceCommand
 }
 
 export const MovePin = (props: MovePinProps): JSX.Element | null => {

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -36,6 +36,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
     goBack,
     movement,
     setFrontJawOffset,
+    maintenanceRunId,
     frontJawOffset,
     createRunCommand,
     errorMessage,
@@ -45,11 +46,12 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
   const { t } = useTranslation(['gripper_wizard_flows', 'shared'])
 
   const handleOnClick = (): void => {
-    if (movement === REMOVE_PIN_FROM_REAR_JAW) {
+    if (movement === REMOVE_PIN_FROM_REAR_JAW || maintenanceRunId == null) {
       proceed()
     } else {
       const jaw = movement === MOVE_PIN_TO_FRONT_JAW ? 'front' : 'rear'
       createRunCommand({
+        maintenanceRunId,
         command: {
           commandType: 'home' as const,
           params: {
@@ -63,6 +65,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
             setErrorMessage(data.error?.detail ?? null)
           }
           createRunCommand({
+            maintenanceRunId,
             command: {
               commandType: 'calibration/calibrateGripper' as const,
               params:
@@ -80,6 +83,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
                 setFrontJawOffset(data.result.jawOffset)
               }
               createRunCommand({
+                maintenanceRunId,
                 command: {
                   commandType: 'calibration/moveToMaintenancePosition' as const,
                   params: {
@@ -248,6 +252,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       bodyText={<StyledText as="p">{body}</StyledText>}
       proceedButtonText={buttonText}
       proceed={handleOnClick}
+      proceedIsDisabled={maintenanceRunId == null}
       back={goBack}
     />
   )

--- a/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
@@ -71,7 +71,10 @@ export const UnmountGripper = (
       .then(() => {
         setIsPending(false)
         if (!isGripperStillAttached) {
-          chainRunCommands([{ commandType: 'home' as const, params: {} }], true)
+          chainRunCommands?.(
+            [{ commandType: 'home' as const, params: {} }],
+            true
+          )
             .then(() => {
               proceed()
             })

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -63,6 +63,7 @@ describe('MovePin', () => {
     const { getByRole } = render()[0]
     await getByRole('button', { name: 'Begin calibration' }).click()
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(1, {
+      maintenanceRunId: 'fakeRunId',
       command: {
         commandType: 'home',
         params: { axes: ['extensionZ', 'extensionJaw'] },
@@ -70,6 +71,7 @@ describe('MovePin', () => {
       waitUntilComplete: true,
     })
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
+      maintenanceRunId: 'fakeRunId',
       command: {
         commandType: 'calibration/calibrateGripper',
         params: { jaw: 'front' },
@@ -77,6 +79,7 @@ describe('MovePin', () => {
       waitUntilComplete: true,
     })
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
+      maintenanceRunId: 'fakeRunId',
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
         params: { mount: 'extension' },
@@ -117,6 +120,7 @@ describe('MovePin', () => {
     await getByRole('button', { name: 'Continue' }).click()
 
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(1, {
+      maintenanceRunId: 'fakeRunId',
       command: {
         commandType: 'home',
         params: { axes: ['extensionZ', 'extensionJaw'] },
@@ -124,6 +128,7 @@ describe('MovePin', () => {
       waitUntilComplete: true,
     })
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
+      maintenanceRunId: 'fakeRunId',
       command: {
         commandType: 'calibration/calibrateGripper',
         params: {
@@ -134,6 +139,7 @@ describe('MovePin', () => {
       waitUntilComplete: true,
     })
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
+      maintenanceRunId: 'fakeRunId',
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
         params: { mount: 'extension' },

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -65,7 +65,7 @@ export function GripperWizardFlows(
   const {
     createMaintenanceRun,
     isLoading: isCreateLoading,
-  } = useCreateMaintenanceRunMutation({})
+  } = useCreateMaintenanceRunMutation()
 
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
     refetchInterval: RUN_REFETCH_INTERVAL,
@@ -91,8 +91,9 @@ export function GripperWizardFlows(
 
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
-    if (maintenanceRunData?.data.id == null) closeFlow()
-    else {
+    if (maintenanceRunData?.data.id == null) {
+      closeFlow()
+    } else {
       chainRunCommands(
         maintenanceRunData?.data.id,
         [{ commandType: 'home' as const, params: {} }],

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -14,6 +14,7 @@ import {
   useCreateMaintenanceCommandMutation,
   useCreateMaintenanceRunMutation,
   useDeleteMaintenanceRunMutation,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
@@ -67,6 +68,18 @@ export function GripperWizardFlows(
       setMaintenanceRunId(response.data.id)
     },
   })
+  const { data: maintenanceRunData } = useCurrentMaintenanceRun({
+    refetchInterval: 5000,
+  })
+  React.useEffect(() => {
+    if (
+      maintenanceRunId !== '' &&
+      maintenanceRunData?.data.id !== maintenanceRunId
+    ) {
+      closeFlow()
+    }
+  }, [maintenanceRunData, maintenanceRunId, closeFlow])
+
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
 

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -79,7 +79,7 @@ export function GripperWizardFlows(
     if (maintenanceRunData?.data.id == null && prevMaintenanceRunId != null) {
       closeFlow()
     }
-  }, [maintenanceRunData, closeFlow])
+  }, [maintenanceRunData?.data.id, closeFlow])
 
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -40,6 +40,9 @@ import type {
 } from '@opentrons/api-client'
 import type { Coordinates } from '@opentrons/shared-data'
 
+const RUN_DELETION_TIMEOUT = 10000
+const RUN_REFETCH_INTERVAL = 5000
+
 interface MaintenanceRunManagerProps {
   flowType: GripperWizardFlowType
   attachedGripper: InstrumentData | null
@@ -69,15 +72,19 @@ export function GripperWizardFlows(
     },
   })
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
-    refetchInterval: 5000,
+    refetchInterval: RUN_REFETCH_INTERVAL,
   })
+  // this will close the modal in case the run was deleted by the terminate
+  // activity modal on the ODD
   React.useEffect(() => {
-    if (
-      maintenanceRunId !== '' &&
-      maintenanceRunData?.data.id !== maintenanceRunId
-    ) {
-      closeFlow()
-    }
+    setTimeout(() => {
+      if (
+        maintenanceRunId !== '' &&
+        maintenanceRunData?.data.id !== maintenanceRunId
+      ) {
+        closeFlow()
+      }
+    }, RUN_DELETION_TIMEOUT)
   }, [maintenanceRunData, maintenanceRunId, closeFlow])
 
   const [isExiting, setIsExiting] = React.useState<boolean>(false)

--- a/app/src/organisms/GripperWizardFlows/types.ts
+++ b/app/src/organisms/GripperWizardFlows/types.ts
@@ -70,12 +70,12 @@ export interface GripperWizardStepProps {
   flowType: GripperWizardFlowType
   proceed: () => void
   goBack: () => void
-  chainRunCommands: (
+  chainRunCommands?: (
     commands: CreateCommand[],
     continuePastCommandFailure: boolean
   ) => Promise<unknown>
   isRobotMoving: boolean
-  maintenanceRunId: string
+  maintenanceRunId?: string
   attachedGripper: {} | null
   errorMessage: string | null
   setErrorMessage: (message: string | null) => void

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -30,8 +30,9 @@ import { useChainMaintenanceCommands } from '../../resources/runs/hooks'
 import { FatalErrorModal } from './FatalErrorModal'
 import { RobotMotionLoader } from './RobotMotionLoader'
 import { getLabwarePositionCheckSteps } from './getLabwarePositionCheckSteps'
-import type { LabwareOffset } from '@opentrons/api-client'
+import type { LabwareOffset, CommandData } from '@opentrons/api-client'
 import type { DropTipCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/pipetting'
+import type { CreateCommand } from '@opentrons/shared-data'
 import type { Axis, Sign, StepSize } from '../../molecules/JogControls/types'
 import type { RegisterPositionAction, WorkingOffset } from './types'
 import { getGoldenCheckSteps } from './utils/getGoldenCheckSteps'
@@ -134,11 +135,11 @@ export const LabwarePositionCheckComponent = (
   const [isExiting, setIsExiting] = React.useState(false)
   const {
     createMaintenanceCommand: createSilentCommand,
-  } = useCreateMaintenanceCommandMutation(maintenanceRunId)
+  } = useCreateMaintenanceCommandMutation()
   const {
     chainRunCommands,
     isCommandMutationLoading: isCommandChainLoading,
-  } = useChainMaintenanceCommands(maintenanceRunId)
+  } = useChainMaintenanceCommands()
 
   const goldenLPC = useFeatureFlag('lpcWithProbe')
   const { createLabwareOffset } = useCreateLabwareOffsetMutation()
@@ -157,6 +158,7 @@ export const LabwarePositionCheckComponent = (
       },
     }))
     chainRunCommands(
+      maintenanceRunId,
       [
         ...dropTipToBeSafeCommands,
         { commandType: 'home' as const, params: {} },
@@ -196,6 +198,7 @@ export const LabwarePositionCheckComponent = (
     const pipetteId = 'pipetteId' in currentStep ? currentStep.pipetteId : null
     if (pipetteId != null) {
       createSilentCommand({
+        maintenanceRunId,
         command: {
           commandType: 'moveRelative',
           params: { pipetteId: pipetteId, distance: step * dir, axis },
@@ -213,10 +216,15 @@ export const LabwarePositionCheckComponent = (
       setFatalError(`could not find pipette to jog with id: ${pipetteId ?? ''}`)
     }
   }
+  const chainMaintenanceRunCommands = (
+    commands: CreateCommand[],
+    continuePastCommandFailure: boolean
+  ): Promise<CommandData[]> =>
+    chainRunCommands(maintenanceRunId, commands, continuePastCommandFailure)
   const movementStepProps = {
     proceed,
     protocolData,
-    chainRunCommands,
+    chainRunCommands: chainMaintenanceRunCommands,
     setFatalError,
     registerPosition,
     handleJog,

--- a/app/src/organisms/ModuleWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/ModuleWizardFlows/BeforeBeginning.tsx
@@ -30,6 +30,7 @@ export const BeforeBeginning = (
     createMaintenanceRun,
     isCreateLoading,
     attachedModule,
+    maintenanceRunId,
   } = props
   const { t } = useTranslation(['module_wizard_flows', 'shared'])
   React.useEffect(() => {
@@ -57,7 +58,7 @@ export const BeforeBeginning = (
         />
       }
       proceedButtonText={t('move_gantry_to_front')}
-      proceedIsDisabled={isCreateLoading}
+      proceedIsDisabled={isCreateLoading || maintenanceRunId == null}
       proceed={proceed}
     />
   )

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import {
   useCreateMaintenanceRunMutation,
   useDeleteMaintenanceRunMutation,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 
 import { LegacyModalShell } from '../../molecules/LegacyModal'
@@ -21,7 +22,8 @@ import { PlaceAdapter } from './PlaceAdapter'
 import { SelectLocation } from './SelectLocation'
 import { Success } from './Success'
 
-import type { AttachedModule } from '@opentrons/api-client'
+import type { AttachedModule, CommandData } from '@opentrons/api-client'
+import type { CreateCommand } from '@opentrons/shared-data'
 import { FirmwareUpdate } from './FirmwareUpdate'
 
 interface ModuleWizardFlowsProps {
@@ -30,6 +32,8 @@ interface ModuleWizardFlowsProps {
   closeFlow: () => void
   onComplete?: () => void
 }
+
+const RUN_REFETCH_INTERVAL = 5000
 
 export const ModuleWizardFlows = (
   props: ModuleWizardFlowsProps
@@ -41,7 +45,6 @@ export const ModuleWizardFlows = (
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
 
   const moduleCalibrationSteps = getModuleCalibrationSteps()
-  const [maintenanceRunId, setMaintenanceRunId] = React.useState<string>('')
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
   const totalStepCount = moduleCalibrationSteps.length - 1
   const currentStep = moduleCalibrationSteps?.[currentStepIndex]
@@ -51,19 +54,29 @@ export const ModuleWizardFlows = (
       currentStepIndex !== totalStepCount ? 0 : currentStepIndex
     )
   }
+  const { data: maintenanceRunData } = useCurrentMaintenanceRun({
+    refetchInterval: RUN_REFETCH_INTERVAL,
+  })
   const {
     chainRunCommands,
     isCommandMutationLoading,
-  } = useChainMaintenanceCommands(maintenanceRunId)
+  } = useChainMaintenanceCommands()
 
   const {
     createMaintenanceRun,
     isLoading: isCreateLoading,
-  } = useCreateMaintenanceRunMutation({
-    onSuccess: response => {
-      setMaintenanceRunId(response.data.id)
-    },
-  })
+  } = useCreateMaintenanceRunMutation()
+
+  const prevMaintenanceRunId = React.useRef<string | undefined>(
+    maintenanceRunData?.data.id
+  )
+  // this will close the modal in case the run was deleted by the terminate
+  // activity modal on the ODD
+  React.useEffect(() => {
+    if (maintenanceRunData?.data.id == null && prevMaintenanceRunId != null) {
+      closeFlow()
+    }
+  }, [maintenanceRunData, closeFlow])
 
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
@@ -89,11 +102,15 @@ export const ModuleWizardFlows = (
 
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
-    if (maintenanceRunId == null) handleClose()
+    if (maintenanceRunData?.data.id == null) handleClose()
     else {
-      chainRunCommands([{ commandType: 'home' as const, params: {} }], false)
+      chainRunCommands(
+        maintenanceRunData?.data.id,
+        [{ commandType: 'home' as const, params: {} }],
+        false
+      )
         .then(() => {
-          deleteMaintenanceRun(maintenanceRunId)
+          deleteMaintenanceRun(maintenanceRunData?.data.id)
         })
         .catch(error => {
           console.error(error.message)
@@ -112,12 +129,26 @@ export const ModuleWizardFlows = (
     }
   }, [isCommandMutationLoading, isExiting])
 
+  let chainMaintenanceRunCommands
+
+  if (maintenanceRunData?.data.id != null) {
+    chainMaintenanceRunCommands = (
+      commands: CreateCommand[],
+      continuePastCommandFailure: boolean
+    ): Promise<CommandData[]> =>
+      chainRunCommands(
+        maintenanceRunData?.data.id,
+        commands,
+        continuePastCommandFailure
+      )
+  }
+
   const calibrateBaseProps = {
     attachedPipettes,
-    chainRunCommands,
+    chainRunCommands: chainMaintenanceRunCommands,
     isRobotMoving,
     proceed,
-    maintenanceRunId,
+    maintenanceRunId: maintenanceRunData?.data.id,
     goBack,
     setErrorMessage,
     errorMessage,

--- a/app/src/organisms/ModuleWizardFlows/types.ts
+++ b/app/src/organisms/ModuleWizardFlows/types.ts
@@ -13,12 +13,12 @@ export type ModuleCalibrationWizardStep =
 export interface ModuleCalibrationWizardStepProps {
   proceed: () => void
   goBack: () => void
-  chainRunCommands: (
+  chainRunCommands?: (
     commands: CreateCommand[],
     continuePastCommandFailure: boolean
   ) => Promise<unknown>
   isRobotMoving: boolean
-  maintenanceRunId: string
+  maintenanceRunId?: string
   attachedModule: AttachedModule
   errorMessage: string | null
   setErrorMessage: (message: string | null) => void

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -60,7 +60,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
-    chainRunCommands(
+    chainRunCommands?.(
       [
         {
           commandType: 'home' as const,

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -172,7 +172,7 @@ export const BeforeBeginning = (
       },
     ]
     if (pipetteId == null) moveToFrontCommands = moveToFrontCommands.slice(1)
-    chainRunCommands(moveToFrontCommands, false)
+    chainRunCommands?.(moveToFrontCommands, false)
       .then(() => {
         proceed()
       })
@@ -203,7 +203,7 @@ export const BeforeBeginning = (
   ]
 
   const handleOnClickAttach = (): void => {
-    chainRunCommands(
+    chainRunCommands?.(
       selectedPipette === SINGLE_MOUNT_PIPETTES
         ? SingleMountAttachCommand
         : NinetySixChannelAttachCommand,

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -39,7 +39,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
   const is96ChannelPipette =
     memoizedAttachedPipettes[mount]?.instrumentName === 'p1000_96'
   const handle96ChannelProceed = (): void => {
-    chainRunCommands(
+    chainRunCommands?.(
       [
         {
           commandType: 'calibration/moveToMaintenancePosition' as const,

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -25,7 +25,7 @@ export const MountingPlate = (
 
   const handleAttachMountingPlate = (): void => {
     setNumberOfTryAgains(numberOfTryAgains + 1)
-    chainRunCommands(
+    chainRunCommands?.(
       [
         {
           commandType: 'home' as const,

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -141,7 +141,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
     ) {
       const axes: MotorAxes =
         mount === LEFT ? ['leftPlunger'] : ['rightPlunger']
-      chainRunCommands(
+      chainRunCommands?.(
         [
           {
             commandType: 'loadPipette' as const,
@@ -171,7 +171,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       flowType === FLOWS.DETACH &&
       currentStepIndex !== totalStepCount
     ) {
-      chainRunCommands(
+      chainRunCommands?.(
         [
           {
             commandType: 'calibration/moveToMaintenancePosition' as const,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   useCreateMaintenanceRunMutation,
   useDeleteMaintenanceRunMutation,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
 import { useChainMaintenanceCommands } from '../../../resources/runs/hooks'
@@ -58,6 +59,9 @@ const mockUseCreateMaintenanceRunMutation = useCreateMaintenanceRunMutation as j
 >
 const mockUseDeleteMaintenanceRunMutation = useDeleteMaintenanceRunMutation as jest.MockedFunction<
   typeof useDeleteMaintenanceRunMutation
+>
+const mockUseCurrentMaintenanceRun = useCurrentMaintenanceRun as jest.MockedFunction<
+  typeof useCurrentMaintenanceRun
 >
 const mockUseRunStatus = useRunStatus as jest.MockedFunction<
   typeof useRunStatus
@@ -139,6 +143,11 @@ describe('PipetteWizardFlows', () => {
     mockUsePipetteFlowWizardHeaderText.mockReturnValue(
       'mock wizard header text'
     )
+    mockUseCurrentMaintenanceRun.mockReturnValue({
+      data: {
+        runId: 'mockRunId',
+      } as any,
+    } as any)
   })
   it('renders the correct information, calling the correct commands for the calibration flow', async () => {
     const { getByText, getByRole } = render(props)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/PipetteWizardFlows.test.tsx
@@ -145,8 +145,10 @@ describe('PipetteWizardFlows', () => {
     )
     mockUseCurrentMaintenanceRun.mockReturnValue({
       data: {
-        runId: 'mockRunId',
-      } as any,
+        data: {
+          id: 'mockRunId',
+        } as any,
+      },
     } as any)
   })
   it('renders the correct information, calling the correct commands for the calibration flow', async () => {
@@ -164,6 +166,7 @@ describe('PipetteWizardFlows', () => {
     fireEvent.click(getStarted)
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           {
             commandType: 'loadPipette',
@@ -190,6 +193,7 @@ describe('PipetteWizardFlows', () => {
     fireEvent.click(initiate)
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           {
             commandType: 'home',
@@ -345,6 +349,7 @@ describe('PipetteWizardFlows', () => {
     fireEvent.click(getStarted)
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           { commandType: 'home' as const, params: {} },
           {
@@ -402,6 +407,7 @@ describe('PipetteWizardFlows', () => {
     fireEvent.click(getStarted)
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           { commandType: 'home' as const, params: {} },
           {
@@ -462,6 +468,7 @@ describe('PipetteWizardFlows', () => {
     fireEvent.click(getStarted)
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           {
             commandType: 'loadPipette',
@@ -533,6 +540,7 @@ describe('PipetteWizardFlows', () => {
     fireEvent.click(getStarted)
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           { commandType: 'home' as const, params: {} },
           {
@@ -562,6 +570,7 @@ describe('PipetteWizardFlows', () => {
     getByRole('button', { name: 'Move gantry to front' }).click()
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           {
             commandType: 'loadPipette',
@@ -587,6 +596,7 @@ describe('PipetteWizardFlows', () => {
     getByRole('button', { name: 'Begin calibration' }).click()
     await waitFor(() => {
       expect(mockChainRunCommands).toHaveBeenCalledWith(
+        'mockRunId',
         [
           {
             commandType: 'home',

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -41,7 +41,7 @@ import { UnskippableModal } from './UnskippableModal'
 
 import type { PipetteMount } from '@opentrons/shared-data'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
-import { CommandData } from '@opentrons/api-client'
+import type { CommandData } from '@opentrons/api-client'
 
 const RUN_REFETCH_INTERVAL = 5000
 

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -110,7 +110,7 @@ export const PipetteWizardFlows = (
   const prevMaintenanceRunId = React.useRef<string | undefined>(
     maintenanceRunData?.data.id
   )
-  // maybe do this conditionally - only if maintenance run id doesn't equal null
+
   React.useEffect(() => {
     prevMaintenanceRunId.current = maintenanceRunData?.data.id
   }, [maintenanceRunData?.data.id])

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -12,6 +12,7 @@ import {
   useHost,
   useCreateMaintenanceRunMutation,
   useDeleteMaintenanceRunMutation,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 
 import { LegacyModalShell } from '../../molecules/LegacyModal'
@@ -116,6 +117,17 @@ export const PipetteWizardFlows = (
     },
     host
   )
+  const { data: maintenanceRunData } = useCurrentMaintenanceRun({
+    refetchInterval: 5000,
+  })
+  React.useEffect(() => {
+    if (
+      maintenanceRunId !== '' &&
+      maintenanceRunData?.data.id !== maintenanceRunId
+    ) {
+      closeFlow()
+    }
+  }, [maintenanceRunData, maintenanceRunId, closeFlow])
 
   const [errorMessage, setShowErrorMessage] = React.useState<null | string>(
     null

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -41,6 +41,9 @@ import { UnskippableModal } from './UnskippableModal'
 import type { PipetteMount } from '@opentrons/shared-data'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
 
+const RUN_DELETION_TIMEOUT = 10000
+const RUN_REFETCH_INTERVAL = 5000
+
 interface PipetteWizardFlowsProps {
   flowType: PipetteWizardFlow
   mount: PipetteMount
@@ -118,15 +121,19 @@ export const PipetteWizardFlows = (
     host
   )
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
-    refetchInterval: 5000,
+    refetchInterval: RUN_REFETCH_INTERVAL,
   })
+  // this will close the modal in case the run was deleted by the terminate
+  // activity modal on the ODD
   React.useEffect(() => {
-    if (
-      maintenanceRunId !== '' &&
-      maintenanceRunData?.data.id !== maintenanceRunId
-    ) {
-      closeFlow()
-    }
+    setTimeout(() => {
+      if (
+        maintenanceRunId !== '' &&
+        maintenanceRunData?.data.id !== maintenanceRunId
+      ) {
+        closeFlow()
+      }
+    }, RUN_DELETION_TIMEOUT)
   }, [maintenanceRunData, maintenanceRunId, closeFlow])
 
   const [errorMessage, setShowErrorMessage] = React.useState<null | string>(

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -40,8 +40,8 @@ import { MountingPlate } from './MountingPlate'
 import { UnskippableModal } from './UnskippableModal'
 
 import type { PipetteMount } from '@opentrons/shared-data'
-import type { PipetteWizardFlow, SelectablePipettes } from './types'
 import type { CommandData } from '@opentrons/api-client'
+import type { PipetteWizardFlow, SelectablePipettes } from './types'
 
 const RUN_REFETCH_INTERVAL = 5000
 

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -72,12 +72,12 @@ export interface PipetteWizardStepProps {
   mount: PipetteMount
   proceed: () => void
   goBack: () => void
-  chainRunCommands: (
+  chainRunCommands?: (
     commands: CreateCommand[],
     continuePastCommandFailure: boolean
   ) => Promise<unknown>
   isRobotMoving: boolean
-  maintenanceRunId: string
+  maintenanceRunId?: string
   attachedPipettes: AttachedPipettesFromInstrumentsQuery
   setShowErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
   errorMessage: string | null

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -3,7 +3,10 @@ import {
   useCreateCommandMutation,
   useCreateMaintenanceCommandMutation,
 } from '@opentrons/react-api-client'
-import { chainRunCommandsRecursive } from './utils'
+import {
+  chainRunCommandsRecursive,
+  chainMaintenanceCommandsRecursive,
+} from './utils'
 import type { CreateCommand } from '@opentrons/shared-data'
 
 export type CreateCommandMutate = ReturnType<
@@ -60,25 +63,24 @@ export function useChainRunCommands(
   }
 }
 
-export function useChainMaintenanceCommands(
-  maintenanceRunId: string
-): {
+export function useChainMaintenanceCommands(): {
   chainRunCommands: (
+    maintenanceRunId: string,
     commands: CreateCommand[],
     continuePastCommandFailure: boolean
-  ) => ReturnType<typeof chainRunCommandsRecursive>
+  ) => ReturnType<typeof chainMaintenanceCommandsRecursive>
   isCommandMutationLoading: boolean
 } {
   const [isLoading, setIsLoading] = React.useState(false)
-  const { createMaintenanceCommand } = useCreateMaintenanceCommandMutation(
-    maintenanceRunId
-  )
+  const { createMaintenanceCommand } = useCreateMaintenanceCommandMutation()
   return {
     chainRunCommands: (
+      maintenanceRunId,
       commands: CreateCommand[],
       continuePastCommandFailure: boolean
     ) =>
-      chainRunCommandsRecursive(
+      chainMaintenanceCommandsRecursive(
+        maintenanceRunId,
         commands,
         createMaintenanceCommand,
         continuePastCommandFailure,

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -17,7 +17,7 @@ export type CreateRunCommand = (
   options?: Parameters<CreateCommandMutate>[1]
 ) => ReturnType<CreateCommandMutate>
 
-export type CreateMaintenaceCommand = ReturnType<
+export type CreateMaintenanceCommand = ReturnType<
   typeof useCreateMaintenanceCommandMutation
 >['createMaintenanceCommand']
 

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import type { CommandData } from '@opentrons/api-client'
 import type { CreateCommand } from '@opentrons/shared-data'
-import type { CreateMaintenaceCommand, CreateRunCommand } from './hooks'
+import type { CreateMaintenanceCommand, CreateRunCommand } from './hooks'
 
 export const chainRunCommandsRecursive = (
   commands: CreateCommand[],
@@ -46,7 +46,7 @@ export const chainRunCommandsRecursive = (
 export const chainMaintenanceCommandsRecursive = (
   maintenanceRunId: string,
   commands: CreateCommand[],
-  createMaintenanceCommand: CreateMaintenaceCommand,
+  createMaintenanceCommand: CreateMaintenanceCommand,
   continuePastCommandFailure: boolean = true,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 ): Promise<CommandData[]> => {

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -5,7 +5,7 @@ import type { CreateMaintenaceCommand, CreateRunCommand } from './hooks'
 
 export const chainRunCommandsRecursive = (
   commands: CreateCommand[],
-  createRunCommand: CreateRunCommand | CreateMaintenaceCommand,
+  createRunCommand: CreateRunCommand,
   continuePastCommandFailure: boolean = true,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 ): Promise<CommandData[]> => {
@@ -30,6 +30,49 @@ export const chainRunCommandsRecursive = (
         return chainRunCommandsRecursive(
           commands.slice(1),
           createRunCommand,
+          continuePastCommandFailure,
+          setIsLoading
+        ).then(deeperResponses => {
+          return [response, ...deeperResponses]
+        })
+      }
+    })
+    .catch(error => {
+      setIsLoading(false)
+      return Promise.reject(error)
+    })
+}
+
+export const chainMaintenanceCommandsRecursive = (
+  maintenanceRunId: string,
+  commands: CreateCommand[],
+  createMaintenanceCommand: CreateMaintenaceCommand,
+  continuePastCommandFailure: boolean = true,
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
+): Promise<CommandData[]> => {
+  if (commands.length < 1)
+    return Promise.reject(new Error('no commands to execute'))
+  setIsLoading(true)
+  return createMaintenanceCommand({
+    maintenanceRunId: maintenanceRunId,
+    command: commands[0],
+    waitUntilComplete: true,
+  })
+    .then(response => {
+      if (!continuePastCommandFailure && response.data.status === 'failed') {
+        setIsLoading(false)
+        return Promise.reject(
+          new Error(response.data.error?.detail ?? 'command failed')
+        )
+      }
+      if (commands.slice(1).length < 1) {
+        setIsLoading(false)
+        return Promise.resolve([response])
+      } else {
+        return chainMaintenanceCommandsRecursive(
+          maintenanceRunId,
+          commands.slice(1),
+          createMaintenanceCommand,
           continuePastCommandFailure,
           setIsLoading
         ).then(deeperResponses => {

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
@@ -41,7 +41,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
       .mockResolvedValue({ data: 'something' } as any)
 
     const { result, waitFor } = renderHook(
-      () => useCreateMaintenanceCommandMutation(MAINTENANCE_RUN_ID),
+      () => useCreateMaintenanceCommandMutation(),
       {
         wrapper,
       }
@@ -50,6 +50,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     expect(result.current.data).toBeUndefined()
     act(() => {
       result.current.createMaintenanceCommand({
+        maintenanceRunId: MAINTENANCE_RUN_ID,
         command: mockAnonLoadCommand,
       })
     })
@@ -70,7 +71,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
       .mockResolvedValue({ data: 'something' } as any)
 
     const { result, waitFor } = renderHook(
-      () => useCreateMaintenanceCommandMutation(MAINTENANCE_RUN_ID),
+      () => useCreateMaintenanceCommandMutation(),
       {
         wrapper,
       }
@@ -79,6 +80,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     expect(result.current.data).toBeUndefined()
     act(() => {
       result.current.createMaintenanceCommand({
+        maintenanceRunId: MAINTENANCE_RUN_ID,
         command: mockAnonLoadCommand,
         waitUntilComplete,
         timeout,

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
@@ -14,6 +14,7 @@ import type {
 import type { CreateCommand } from '@opentrons/shared-data'
 
 interface CreateMaintenanceCommandMutateParams extends CreateCommandParams {
+  maintenanceRunId: string
   command: CreateCommand
   waitUntilComplete?: boolean
   timeout?: number
@@ -37,9 +38,7 @@ export type UseCreateMaintenanceCommandMutationOptions = UseMutationOptions<
   CreateMaintenanceCommandMutateParams
 >
 
-export function useCreateMaintenanceCommandMutation(
-  maintenanceRunId: string
-): UseCreateMaintenanceCommandMutationResult {
+export function useCreateMaintenanceCommandMutation(): UseCreateMaintenanceCommandMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
@@ -47,7 +46,7 @@ export function useCreateMaintenanceCommandMutation(
     CommandData,
     unknown,
     CreateMaintenanceCommandMutateParams
-  >(({ command, waitUntilComplete, timeout }) =>
+  >(({ maintenanceRunId, command, waitUntilComplete, timeout }) =>
     createMaintenanceCommand(host as HostConfig, maintenanceRunId, command, {
       waitUntilComplete,
       timeout,


### PR DESCRIPTION
Fix RQA-1061

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
When a maintenance procedure is canceled from the "Remote Activity" takeover modal on ODD, the corresponding modal on the desktop app should close.

# Test Plan

1. Start a pipette or gripper flow from a desktop app
2. Cancel remote activity from the ODD takeover modal
3. See the modal on desktop close within 5 seconds

<!--

Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Refactor chainMaintenanceRunCommands to take the runId in the callback instead of on instantiation
2. Update Gripper flows, Pipette flows, and LPC to pass the runId in the callback
3. Add a `useRef` to keep track of the previous maintenance run id - if this was previously a string and becomes null, we close the gripper and pipette flows since this means the run has been deleted

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Run through the test plan, look over approach
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
