### PR TITLE
fix(protocol-designer, components): 7.0 candidate a bug fixes

### DIFF
--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -6,8 +6,6 @@ import ReactSelect, {
 import cx from 'classnames'
 
 import { Icon } from '../icons'
-import { Box } from '../primitives'
-import { SPACING } from '../ui-style-constants'
 import { POSITION_ABSOLUTE, POSITION_FIXED } from '../styles'
 import styles from './Select.css'
 
@@ -115,20 +113,13 @@ function DropdownIndicator(
 ): JSX.Element {
   return (
     <reactSelectComponents.DropdownIndicator {...props}>
-      <Box
-        position={POSITION_ABSOLUTE}
-        top="0.25rem"
-        right={SPACING.spacing8}
-        width={SPACING.spacing20}
+      <div
+        className={cx(styles.dropdown_indicator, {
+          [styles.flipped]: props.selectProps.menuIsOpen,
+        })}
       >
-        <Icon
-          name="menu-down"
-          transform={`rotate(${
-            props.selectProps.menuIsOpen === true ? '180' : '0'
-          })`}
-          height="1.25rem"
-        />
-      </Box>
+        <Icon name="menu-down" className={cx(styles.dropdown_indicator_icon)} />
+      </div>
     </reactSelectComponents.DropdownIndicator>
   )
 }

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -34,13 +34,15 @@
   font-weight: var(--fw-semibold);
 }
 
-.title,
-.subtitle {
+.title {
   @apply --truncate;
 
   padding: 0 1.5rem;
 }
 
+.subtitle {
+  padding: 0 1.5rem;
+}
 .title.right {
   margin-left: auto;
 }

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -42,13 +42,11 @@
 
 .subtitle {
   padding: 0 1.5rem;
-}
-.title.right {
-  margin-left: auto;
+  font-weight: normal;
 }
 
-.subtitle {
-  font-weight: normal;
+.title.right {
+  margin-left: auto;
 }
 
 .title_button {

--- a/protocol-designer/cypress/integration/home.spec.js
+++ b/protocol-designer/cypress/integration/home.spec.js
@@ -5,7 +5,7 @@ describe('The Home Page', () => {
   })
 
   it('successfully loads', () => {
-    cy.title().should('equal', 'Opentrons Protocol Designer BETA')
+    cy.title().should('equal', 'Opentrons Protocol Designer')
   })
 
   it('has the right charset', () => {
@@ -23,7 +23,6 @@ describe('The Home Page', () => {
     cy.contains('HELP')
     cy.contains('Settings')
     cy.contains('Protocol Designer')
-    cy.contains('beta')
   })
 
   it('displays all the expected images', () => {})

--- a/protocol-designer/cypress/integration/home.spec.js
+++ b/protocol-designer/cypress/integration/home.spec.js
@@ -5,7 +5,7 @@ describe('The Home Page', () => {
   })
 
   it('successfully loads', () => {
-    cy.title().should('equal', 'Opentrons Protocol Designer')
+    cy.title().should('equal', 'Opentrons Protocol Designer BETA')
   })
 
   it('has the right charset', () => {

--- a/protocol-designer/cypress/integration/transferSettings.spec.js
+++ b/protocol-designer/cypress/integration/transferSettings.spec.js
@@ -335,7 +335,7 @@ describe('Advanced Settings for Transfer Form', () => {
     // Verify that volume is set
     cy.get('[id=TipPositionField_aspirate_touchTip_mmFromBottom]').should(
       'have.value',
-      24
+      13.78
     )
     // Click on step 3 to verify that touchTip has volume set
     cy.get('[data-test="StepItem_3"]').click()
@@ -344,7 +344,7 @@ describe('Advanced Settings for Transfer Form', () => {
     // Verify that volume is set
     cy.get('[id=TipPositionField_aspirate_touchTip_mmFromBottom]').should(
       'have.value',
-      24
+      13.78
     )
   })
 

--- a/protocol-designer/cypress/integration/transferSettings.spec.js
+++ b/protocol-designer/cypress/integration/transferSettings.spec.js
@@ -237,7 +237,7 @@ describe('Advanced Settings for Transfer Form', () => {
     cy.get('[data-test="StepItem_2"]').click()
     cy.get('button[id="AspDispSection_settings_button_aspirate"]').click()
 
-    // Verify that volume is set to 10 and repitions to 2
+    // Verify that volume is set to 10 and repetitions to 2
     cy.get('input[name="aspirate_mix_volume"]').should('have.value', 10)
     cy.get('input[name="aspirate_mix_times"]').should('have.value', 2)
   })

--- a/protocol-designer/fixtures/protocol/5/transferSettings.json
+++ b/protocol-designer/fixtures/protocol/5/transferSettings.json
@@ -41,10 +41,10 @@
         }
       },
       "ingredLocations": {
-        "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1": {
+        "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
           "A1": {
             "0": {
-              "volume": 1000
+              "volume": 100
             }
           }
         },
@@ -177,7 +177,7 @@
           "labwareLocationUpdate": {
             "trashId": "12",
             "3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1": "2",
-            "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1": "4",
+            "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "4",
             "60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1": "5",
             "aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType",
             "ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1": "3e0283e0-3412-11eb-ad93-ed232a2337cf:temperatureModuleType",
@@ -252,7 +252,7 @@
           "path": "single",
           "aspirate_wells_grouped": false,
           "aspirate_flowRate": null,
-          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "aspirate_wells": ["A1"],
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -300,7 +300,7 @@
           "path": "single",
           "aspirate_wells_grouped": false,
           "aspirate_flowRate": null,
-          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "aspirate_wells": ["A1"],
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -348,7 +348,7 @@
           "path": "single",
           "aspirate_wells_grouped": false,
           "aspirate_flowRate": null,
-          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "aspirate_wells": ["A1"],
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -396,7 +396,7 @@
           "path": "single",
           "aspirate_wells_grouped": false,
           "aspirate_flowRate": null,
-          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "aspirate_wells": ["A1"],
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -448,7 +448,7 @@
           "path": "single",
           "aspirate_wells_grouped": false,
           "aspirate_flowRate": null,
-          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+          "aspirate_labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "aspirate_wells": ["A1"],
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -520,10 +520,10 @@
       "displayName": "Opentrons 96 Tip Rack 1000 µL",
       "definitionId": "opentrons/opentrons_96_tiprack_1000ul/1"
     },
-    "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1": {
+    "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
       "slot": "4",
-      "displayName": "NEST 1 Well Reservoir 195 mL",
-      "definitionId": "opentrons/nest_1_reservoir_195ml/1"
+      "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+      "definitionId": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1"
     },
     "60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1": {
       "slot": "5",
@@ -2643,62 +2643,6 @@
           "metadata": {}
         }
       ],
-      "cornerOffsetFromSlot": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      }
-    },
-    "opentrons/nest_1_reservoir_195ml/1": {
-      "ordering": [["A1"]],
-      "brand": {
-        "brand": "NEST",
-        "brandId": ["360103"],
-        "links": [
-          "https://www.nest-biotech.com/reagent-reserviors/59178414.html"
-        ]
-      },
-      "metadata": {
-        "displayName": "NEST 1 Well Reservoir 195 mL",
-        "displayCategory": "reservoir",
-        "displayVolumeUnits": "mL",
-        "tags": []
-      },
-      "dimensions": {
-        "xDimension": 127.76,
-        "yDimension": 85.48,
-        "zDimension": 31.4
-      },
-      "wells": {
-        "A1": {
-          "depth": 25,
-          "shape": "rectangular",
-          "xDimension": 106.8,
-          "yDimension": 71.2,
-          "totalLiquidVolume": 195000,
-          "x": 63.88,
-          "y": 42.74,
-          "z": 4.55
-        }
-      },
-      "groups": [
-        {
-          "metadata": {
-            "wellBottomShape": "v"
-          },
-          "wells": ["A1"]
-        }
-      ],
-      "parameters": {
-        "format": "trough",
-        "isTiprack": false,
-        "isMagneticModuleCompatible": false,
-        "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
-        "loadName": "nest_1_reservoir_195ml"
-      },
-      "namespace": "opentrons",
-      "version": 1,
-      "schemaVersion": 2,
       "cornerOffsetFromSlot": {
         "x": 0,
         "y": 0,
@@ -5301,7 +5245,7 @@
       "params": {
         "pipette": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
         "volume": 100,
-        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "well": "A1",
         "offsetFromBottomMm": 1,
         "flowRate": 137.35
@@ -5339,7 +5283,7 @@
       "params": {
         "pipette": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
         "volume": 100,
-        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:oopentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "well": "A1",
         "offsetFromBottomMm": 1,
         "flowRate": 137.35
@@ -5377,7 +5321,7 @@
       "params": {
         "pipette": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
         "volume": 100,
-        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "well": "A1",
         "offsetFromBottomMm": 1,
         "flowRate": 137.35
@@ -5415,7 +5359,7 @@
       "params": {
         "pipette": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
         "volume": 100,
-        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "well": "A1",
         "offsetFromBottomMm": 1,
         "flowRate": 137.35
@@ -5453,7 +5397,7 @@
       "params": {
         "pipette": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
         "volume": 20,
-        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
+        "labware": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "well": "A1",
         "offsetFromBottomMm": 1,
         "flowRate": 7.6

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
@@ -65,8 +65,9 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
 
   const isTouchTipNotSupportedLabware = getTouchTipNotSupportedLabware(
     allLabware,
-    getLabwareIdForPositioningField(addFieldNamePrefix('touchTip_checkbox')) ??
-      undefined
+    getLabwareIdForPositioningField(
+      addFieldNamePrefix('touchTip_mmFromBottom')
+    ) ?? undefined
   )
 
   let disabledTouchTip: boolean = false
@@ -139,12 +140,7 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
         label={i18n.t('form.step_edit_form.field.touchTip.label')}
         className={styles.small_field}
         tooltipContent={
-          getTouchTipNotSupportedLabware(
-            allLabware,
-            getLabwareIdForPositioningField(
-              addFieldNamePrefix('touchTip_checkbox')
-            ) ?? undefined
-          )
+          isTouchTipNotSupportedLabware
             ? i18n.t('tooltip.step_fields.touchTip.disabled')
             : propsForFields[addFieldNamePrefix('touchTip_checkbox')]
                 .tooltipContent

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 import {
   Box,
   DeprecatedPrimaryButton,
@@ -9,6 +10,7 @@ import {
   TOOLTIP_FIXED,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
+import { getLabwareDefsByURI } from '../../labware-defs/selectors'
 import {
   BlowoutLocationField,
   CheckboxRowField,
@@ -21,6 +23,7 @@ import { MixFields } from '../StepEditForm/fields/MixFields'
 import {
   getBlowoutLocationOptionsForForm,
   getLabwareFieldForPositioningField,
+  getTouchTipNotSupportedLabware,
 } from '../StepEditForm/utils'
 import { FormColumn } from './FormColumn'
 import { FieldPropsByName } from '../StepEditForm/types'
@@ -36,6 +39,7 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
 }): JSX.Element => {
   const { prefix, propsForFields } = props
   const addFieldNamePrefix = (name: string): string => `${prefix}_${name}`
+  const allLabware = useSelector(getLabwareDefsByURI)
 
   const getLabwareIdForPositioningField = (name: string): string | null => {
     const labwareField = getLabwareFieldForPositioningField(name)
@@ -57,6 +61,19 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
     } else {
       return null
     }
+  }
+
+  const isTouchTipNotSupportedLabware = getTouchTipNotSupportedLabware(
+    allLabware,
+    getLabwareIdForPositioningField(addFieldNamePrefix('touchTip_checkbox')) ??
+      undefined
+  )
+
+  let disabledTouchTip: boolean = false
+  if (isTouchTipNotSupportedLabware) {
+    disabledTouchTip = true
+  } else if (propsForFields[addFieldNamePrefix('touchTip_checkbox')].disabled) {
+    disabledTouchTip = true
   }
 
   return (
@@ -121,6 +138,18 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
         {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
         label={i18n.t('form.step_edit_form.field.touchTip.label')}
         className={styles.small_field}
+        tooltipContent={
+          getTouchTipNotSupportedLabware(
+            allLabware,
+            getLabwareIdForPositioningField(
+              addFieldNamePrefix('touchTip_checkbox')
+            ) ?? undefined
+          )
+            ? i18n.t('tooltip.step_fields.touchTip.disabled')
+            : propsForFields[addFieldNamePrefix('touchTip_checkbox')]
+                .tooltipContent
+        }
+        disabled={disabledTouchTip}
       >
         <TipPositionField
           {...propsForFields[addFieldNamePrefix('touchTip_mmFromBottom')]}

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { LabwareNameOverlay } from '@opentrons/components'
+import { LabwareNameOverlay, truncateString } from '@opentrons/components'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { BaseState } from '../../../types'
 import { selectors as uiLabwareSelectors } from '../../../ui/labware'
@@ -17,7 +17,9 @@ type Props = OP & SP
 
 const NameOverlay = (props: Props): JSX.Element => {
   const { labwareOnDeck, nickname } = props
-  const title = nickname || getLabwareDisplayName(labwareOnDeck.def)
+  const truncatedNickName =
+    nickname != null ? truncateString(nickname, 75, 25) : null
+  const title = truncatedNickName ?? getLabwareDisplayName(labwareOnDeck.def)
   return <LabwareNameOverlay title={title} />
 }
 

--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -1,17 +1,17 @@
 // TODO: Ian 2018-10-09 figure out what belongs in LiquidsSidebar vs IngredientsList after #2427
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { selectors } from '../../labware-ingred/selectors'
-import { IconButton, SidePanel } from '@opentrons/components'
+import { SingleLabwareLiquidState } from '@opentrons/step-generation'
+import { IconButton, SidePanel, truncateString } from '@opentrons/components'
 import { sortWells } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
+import { selectors } from '../../labware-ingred/selectors'
 import { PDTitledList, PDListItem } from '../lists'
 import { TitledListNotes } from '../TitledListNotes'
 import { swatchColors } from '../swatchColors'
 import { LabwareDetailsCard } from './LabwareDetailsCard'
-import styles from './IngredientsList.css'
 import { LiquidGroupsById, LiquidGroup } from '../../labware-ingred/types'
-import { SingleLabwareLiquidState } from '@opentrons/step-generation'
+import styles from './IngredientsList.css'
 
 type RemoveWellsContents = (args: {
   liquidGroupId: string
@@ -54,10 +54,11 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): JSX.Element | null => {
     // do not show liquid card if it has no instances for this labware
     return null
   }
-
+  const truncatedName =
+    ingredGroup.name != null ? truncateString(ingredGroup.name, 25) : null
   return (
     <PDTitledList
-      title={ingredGroup.name || i18n.t('card.unnamedLiquid')}
+      title={truncatedName ?? i18n.t('card.unnamedLiquid')}
       iconProps={{
         style: {
           fill: liquidDisplayColors[Number(groupId)] ?? swatchColors(groupId),

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
@@ -9,9 +9,7 @@ export const links = {
   protocolSteps: `https://support.opentrons.com/en/collections/493886-protocol-designer#building-a-protocol-steps`,
   customLabware: `https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions`,
   recommendedLabware:
-    'https://support.opentrons.com/en/articles/4168748-labware-and-module-compatibility',
-  // TODO: fill in real url when it exists
-  heaterShakerLabware: '#',
+    'https://support.opentrons.com/s/article/What-labware-can-I-use-with-my-modules',
   pipetteGen1MultiModuleCollision:
     'https://support.opentrons.com/en/articles/4168741-module-placement',
   betaReleases: `https://support.opentrons.com/en/articles/3854833-opentrons-beta-software-releases`,

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -366,7 +366,6 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
                   inert={!isPopulated}
                 >
                   {labwareByCategory[category]?.map((labwareDef, index) => {
-                    console.log(labwareDef.parameters.loadName)
                     const isFiltered = getIsLabwareFiltered(labwareDef)
                     if (!isFiltered) {
                       return (

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -97,13 +97,13 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
 export const getLabwareIsRecommended = (
   def: LabwareDefinition2,
   moduleType?: ModuleType | null
-): boolean => {
-  return moduleType
+): boolean =>
+  moduleType
     ? RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
         def.parameters.loadName
       )
     : false
-}
+
 export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
   const {
     customLabwareDefs,

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -74,7 +74,11 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
     'opentrons_96_aluminumblock_nest_wellplate_100ul',
   ],
-  [MAGNETIC_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
+  [MAGNETIC_MODULE_TYPE]: [
+    'nest_96_wellplate_100ul_pcr_full_skirt',
+    'nest_96_wellplate_2ml_deep',
+    'armadillo_96_wellplate_200ul_pcr_full_skirt',
+  ],
   [THERMOCYCLER_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
   [HEATERSHAKER_MODULE_TYPE]: [
     'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
@@ -85,19 +89,21 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
   [MAGNETIC_BLOCK_TYPE]: [
     'armadillo_96_wellplate_200ul_pcr_full_skirt',
     'nest_96_wellplate_100ul_pcr_full_skirt',
+    'nest_96_wellplate_2ml_deep',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
 }
 
 export const getLabwareIsRecommended = (
   def: LabwareDefinition2,
   moduleType?: ModuleType | null
-): boolean =>
-  moduleType
+): boolean => {
+  return moduleType
     ? RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
         def.parameters.loadName
       )
     : false
-
+}
 export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
   const {
     customLabwareDefs,
@@ -183,7 +189,6 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
       !getLabwareCompatible(labwareDef),
     [filterRecommended, filterHeight, getLabwareCompatible, moduleType]
   )
-
   const getTitleText = (): string => {
     if (isNextToHeaterShaker) {
       return `Slot ${slot}, Labware to the side of ${i18n.t(
@@ -288,11 +293,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
               )}{' '}
               <KnowledgeBaseLink
                 className={styles.link}
-                to={
-                  isNextToHeaterShaker
-                    ? 'heaterShakerLabware'
-                    : 'recommendedLabware'
-                }
+                to={'recommendedLabware'}
               >
                 here
               </KnowledgeBaseLink>
@@ -365,6 +366,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
                   inert={!isPopulated}
                 >
                   {labwareByCategory[category]?.map((labwareDef, index) => {
+                    console.log(labwareDef.parameters.loadName)
                     const isFiltered = getIsLabwareFiltered(labwareDef)
                     if (!isFiltered) {
                       return (

--- a/protocol-designer/src/components/LiquidsSidebar/index.tsx
+++ b/protocol-designer/src/components/LiquidsSidebar/index.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { i18n } from '../../localization'
-import { DeprecatedPrimaryButton, SidePanel } from '@opentrons/components'
+import {
+  DeprecatedPrimaryButton,
+  SidePanel,
+  truncateString,
+} from '@opentrons/components'
 import { PDTitledList } from '../lists'
 import { swatchColors } from '../swatchColors'
 import listButtonStyles from '../listButtons.css'
@@ -43,7 +47,10 @@ function LiquidsSidebarComponent(props: Props): JSX.Element {
               className: styles.liquid_icon_container,
             },
           }}
-          title={name || `Unnamed Ingredient ${ingredientId}`} // fallback, should not happen
+          title={
+            truncateString(name ?? '', 25) ??
+            `Unnamed Ingredient ${ingredientId}`
+          } // fallback, should not happen
         />
       ))}
       <div className={listButtonStyles.list_item_button}>

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
@@ -35,7 +35,6 @@ export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: tooltipPlacement,
   })
-  console.log(value)
   return (
     <>
       {tooltipContent && (

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
@@ -35,7 +35,7 @@ export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: tooltipPlacement,
   })
-
+  console.log(value)
   return (
     <>
       {tooltipContent && (
@@ -54,7 +54,7 @@ export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
             updateValue(!value)
           }
-          value={Boolean(value)}
+          value={disabled ? false : Boolean(value)}
         />
         {value && !disabled && !isIndeterminate ? children : null}
       </div>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -14,18 +14,21 @@ import { MixFields } from '../../fields/MixFields'
 import {
   getBlowoutLocationOptionsForForm,
   getLabwareFieldForPositioningField,
+  getTouchTipNotSupportedLabware,
 } from '../../utils'
-
-import { FormData } from '../../../../form-types'
-import { StepFieldName } from '../../../../steplist/fieldLevel'
-import { FieldPropsByName } from '../../types'
 import styles from '../../StepEditForm.css'
+
+import type { FormData } from '../../../../form-types'
+import type { StepFieldName } from '../../../../steplist/fieldLevel'
+import type { LabwareDefByDefURI } from '../../../../labware-defs'
+import type { FieldPropsByName } from '../../types'
 
 interface SourceDestFieldsProps {
   className?: string | null
   prefix: 'aspirate' | 'dispense'
   propsForFields: FieldPropsByName
   formData: FormData
+  allLabware: LabwareDefByDefURI
 }
 
 const makeAddFieldNamePrefix = (prefix: string) => (
@@ -33,10 +36,9 @@ const makeAddFieldNamePrefix = (prefix: string) => (
 ): StepFieldName => `${prefix}_${fieldName}`
 
 export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
-  const { className, formData, prefix, propsForFields } = props
+  const { className, formData, prefix, propsForFields, allLabware } = props
 
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
-
   const getDelayFields = (): JSX.Element => (
     <DelayFields
       checkboxFieldName={addFieldNamePrefix('delay_checkbox')}
@@ -115,10 +117,32 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
             {getMixFields()}
           </React.Fragment>
         )}
+
         <CheckboxRowField
           {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
+          tooltipContent={
+            getTouchTipNotSupportedLabware(
+              allLabware,
+              formData[
+                getLabwareFieldForPositioningField(
+                  addFieldNamePrefix('touchTip_mmFromBottom')
+                )
+              ]
+            )
+              ? i18n.t('tooltip.step_fields.touchTip.disabled')
+              : propsForFields[addFieldNamePrefix('touchTip_checkbox')]
+                  .tooltipContent
+          }
           label={i18n.t('form.step_edit_form.field.touchTip.label')}
           className={styles.small_field}
+          disabled={getTouchTipNotSupportedLabware(
+            allLabware,
+            formData[
+              getLabwareFieldForPositioningField(
+                addFieldNamePrefix('touchTip_mmFromBottom')
+              )
+            ]
+          )}
         >
           <TipPositionField
             {...propsForFields[addFieldNamePrefix('touchTip_mmFromBottom')]}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -39,14 +39,6 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
   const { className, formData, prefix, propsForFields, allLabware } = props
 
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
-  const isTouchTipNotSupportedLabware = getTouchTipNotSupportedLabware(
-    allLabware,
-    formData[
-      getLabwareFieldForPositioningField(
-        addFieldNamePrefix('touchTip_checkBox')
-      )
-    ]
-  )
   const getDelayFields = (): JSX.Element => (
     <DelayFields
       checkboxFieldName={addFieldNamePrefix('delay_checkbox')}
@@ -129,14 +121,28 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
         <CheckboxRowField
           {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
           tooltipContent={
-            isTouchTipNotSupportedLabware
+            getTouchTipNotSupportedLabware(
+              allLabware,
+              formData[
+                getLabwareFieldForPositioningField(
+                  addFieldNamePrefix('touchTip_mmFromBottom')
+                )
+              ]
+            )
               ? i18n.t('tooltip.step_fields.touchTip.disabled')
               : propsForFields[addFieldNamePrefix('touchTip_checkbox')]
                   .tooltipContent
           }
           label={i18n.t('form.step_edit_form.field.touchTip.label')}
           className={styles.small_field}
-          disabled={isTouchTipNotSupportedLabware}
+          disabled={getTouchTipNotSupportedLabware(
+            allLabware,
+            formData[
+              getLabwareFieldForPositioningField(
+                addFieldNamePrefix('touchTip_mmFromBottom')
+              )
+            ]
+          )}
         >
           <TipPositionField
             {...propsForFields[addFieldNamePrefix('touchTip_mmFromBottom')]}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -39,6 +39,14 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
   const { className, formData, prefix, propsForFields, allLabware } = props
 
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
+  const isTouchTipNotSupportedLabware = getTouchTipNotSupportedLabware(
+    allLabware,
+    formData[
+      getLabwareFieldForPositioningField(
+        addFieldNamePrefix('touchTip_checkBox')
+      )
+    ]
+  )
   const getDelayFields = (): JSX.Element => (
     <DelayFields
       checkboxFieldName={addFieldNamePrefix('delay_checkbox')}
@@ -121,28 +129,14 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
         <CheckboxRowField
           {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
           tooltipContent={
-            getTouchTipNotSupportedLabware(
-              allLabware,
-              formData[
-                getLabwareFieldForPositioningField(
-                  addFieldNamePrefix('touchTip_mmFromBottom')
-                )
-              ]
-            )
+            isTouchTipNotSupportedLabware
               ? i18n.t('tooltip.step_fields.touchTip.disabled')
               : propsForFields[addFieldNamePrefix('touchTip_checkbox')]
                   .tooltipContent
           }
           label={i18n.t('form.step_edit_form.field.touchTip.label')}
           className={styles.small_field}
-          disabled={getTouchTipNotSupportedLabware(
-            allLabware,
-            formData[
-              getLabwareFieldForPositioningField(
-                addFieldNamePrefix('touchTip_mmFromBottom')
-              )
-            ]
-          )}
+          disabled={isTouchTipNotSupportedLabware}
         >
           <TipPositionField
             {...propsForFields[addFieldNamePrefix('touchTip_mmFromBottom')]}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import cx from 'classnames'
+import { useSelector } from 'react-redux'
 import { i18n } from '../../../../localization'
+import { getLabwareDefsByURI } from '../../../../labware-defs/selectors'
 import {
   VolumeField,
   PipetteField,
@@ -18,6 +20,7 @@ import { SourceDestHeaders } from './SourceDestHeaders'
 
 export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
   const [collapsed, _setCollapsed] = React.useState<boolean>(true)
+  const allLabware = useSelector(getLabwareDefsByURI)
 
   const toggleCollapsed = (): void => _setCollapsed(!collapsed)
 
@@ -69,12 +72,14 @@ export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
             prefix="aspirate"
             propsForFields={propsForFields}
             formData={formData}
+            allLabware={allLabware}
           />
           <SourceDestFields
             className={styles.section_column}
             prefix="dispense"
             propsForFields={propsForFields}
             formData={formData}
+            allLabware={allLabware}
           />
         </div>
       )}

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
+import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
+import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
 import { CheckboxRowField, DelayFields, WellOrderField } from '../../fields'
 import { SourceDestFields } from '../MoveLiquidForm/SourceDestFields'
-import { FormData } from '../../../../form-types'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { FormData } from '../../../../form-types'
 
 jest.mock('../../../../step-forms')
 jest.mock('../../utils')
@@ -32,7 +35,18 @@ jest.mock('../../fields/', () => {
     WellSelectionField: () => <div></div>,
   }
 })
+const fixtureTipRack10ul = {
+  ...fixture_tiprack_10_ul,
+  version: 2,
+} as LabwareDefinition2
 
+const fixtureTipRack300uL = {
+  ...fixture_tiprack_300_ul,
+  version: 2,
+} as LabwareDefinition2
+const ten = '10uL'
+const threeHundred = '300uL'
+const sourceLab = 'sourceLabware'
 describe('SourceDestFields', () => {
   let store: any
   let props: React.ComponentProps<typeof SourceDestFields>
@@ -173,6 +187,11 @@ describe('SourceDestFields', () => {
         },
       },
       prefix: 'aspirate',
+      allLabware: {
+        [ten]: fixtureTipRack10ul,
+        [threeHundred]: fixtureTipRack300uL,
+        [sourceLab]: { parameters: { quirks: ['touchTipDisabled'] } } as any,
+      },
     }
     store = {
       dispatch: jest.fn(),

--- a/protocol-designer/src/components/StepEditForm/utils.ts
+++ b/protocol-designer/src/components/StepEditForm/utils.ts
@@ -18,7 +18,9 @@ import { getDefaultsForStepType } from '../../steplist/formLevel/getDefaultsForS
 import { Options } from '@opentrons/components'
 import { ProfileFormError } from '../../steplist/formLevel/profileErrors'
 import { FormWarning } from '../../steplist/formLevel/warnings'
-import { StepFormErrors } from '../../steplist/types'
+import type { StepFormErrors } from '../../steplist/types'
+import type { LabwareDefByDefURI } from '../../labware-defs'
+
 export function getBlowoutLocationOptionsForForm(args: {
   stepType: StepType
   path?: PathOption | null | undefined
@@ -197,4 +199,16 @@ export function getLabwareFieldForPositioningField(
     mix_touchTip_mmFromBottom: 'labware',
   }
   return fieldMap[name]
+}
+
+export function getTouchTipNotSupportedLabware(
+  allLabware: LabwareDefByDefURI,
+  labwareId?: string
+): boolean {
+  const labwareDefURI = labwareId?.split(':')[1] ?? ''
+  const test =
+    allLabware[labwareDefURI]?.parameters?.quirks?.includes(
+      'touchTipDisabled'
+    ) ?? false
+  return test
 }

--- a/protocol-designer/src/components/StepEditForm/utils.ts
+++ b/protocol-designer/src/components/StepEditForm/utils.ts
@@ -206,9 +206,9 @@ export function getTouchTipNotSupportedLabware(
   labwareId?: string
 ): boolean {
   const labwareDefURI = labwareId?.split(':')[1] ?? ''
-  const test =
+  const isTouchTipNotSupported =
     allLabware[labwareDefURI]?.parameters?.quirks?.includes(
       'touchTipDisabled'
     ) ?? false
-  return test
+  return isTouchTipNotSupported
 }

--- a/protocol-designer/src/components/TitledListNotes.tsx
+++ b/protocol-designer/src/components/TitledListNotes.tsx
@@ -1,16 +1,18 @@
 import { i18n } from '../localization'
 import * as React from 'react'
 import styles from './TitledListNotes.css'
+import { truncateString } from '@opentrons/components'
 
 interface Props {
   notes?: string | null
 }
 
 export function TitledListNotes(props: Props): JSX.Element | null {
+  const truncatedNotes = truncateString(props.notes ?? '', 25)
   return props.notes ? (
     <div className={styles.notes}>
       <header>{i18n.t('card.notes')}</header>
-      {props.notes}
+      {truncatedNotes}
     </div>
   ) : null
 }

--- a/protocol-designer/src/components/modules/GripperRow.tsx
+++ b/protocol-designer/src/components/modules/GripperRow.tsx
@@ -7,6 +7,8 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   ALIGN_CENTER,
   DIRECTION_COLUMN,
+  LabeledValue,
+  SPACING,
 } from '@opentrons/components'
 import gripperImage from '../../images/flex_gripper.svg'
 import styles from './styles.css'
@@ -26,6 +28,17 @@ export function GripperRow(props: GripperRowProps): JSX.Element {
         <h4 className={styles.row_title}>Flex Gripper</h4>
         <AdditionalItemImage src={gripperImage} alt="Opentrons Flex Gripper" />
       </Flex>
+      <div
+        className={styles.module_col}
+        style={{ marginLeft: SPACING.spacing32 }}
+      >
+        {isGripperAdded && (
+          <LabeledValue
+            label="Model"
+            value={i18n.t(`modules.model_display_name.gripperV1`)}
+          />
+        )}
+      </div>
       <div
         className={styles.modules_button_group}
         style={{ alignSelf: ALIGN_CENTER }}

--- a/protocol-designer/src/components/steplist/MoveLabwareHeader.tsx
+++ b/protocol-designer/src/components/steplist/MoveLabwareHeader.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import cx from 'classnames'
+import {
+  Icon,
+  Tooltip,
+  useHoverTooltip,
+  TOOLTIP_FIXED,
+} from '@opentrons/components'
+import { PDListItem } from '../lists'
+import { LabwareTooltipContents } from './LabwareTooltipContents'
+
+import styles from './StepItem.css'
+
+interface MoveLabwareHeaderProps {
+  sourceLabwareNickname?: string | null
+  destinationSlot?: string | null
+  useGripper: boolean
+}
+
+//  TODO(jr, 7/31/23): add text to i18n
+export function MoveLabwareHeader(props: MoveLabwareHeaderProps): JSX.Element {
+  const { sourceLabwareNickname, destinationSlot, useGripper } = props
+
+  const [sourceTargetProps, sourceTooltipProps] = useHoverTooltip({
+    placement: 'bottom-start',
+    strategy: TOOLTIP_FIXED,
+  })
+
+  const [destTargetProps, destTooltipProps] = useHoverTooltip({
+    placement: 'bottom',
+    strategy: TOOLTIP_FIXED,
+  })
+
+  const destSlot = destinationSlot === 'offDeck' ? 'off deck' : destinationSlot
+  return (
+    <>
+      <li className={styles.substep_header}>
+        <span>Method: {useGripper ? 'With gripper' : 'Manually'} </span>
+      </li>
+      <li className={styles.substep_header}>
+        <span>LABWARE</span>
+        <span className={styles.spacer} />
+        <span>DESTINATION SLOT</span>
+      </li>
+
+      <Tooltip {...sourceTooltipProps}>
+        <LabwareTooltipContents labwareNickname={sourceLabwareNickname} />
+      </Tooltip>
+
+      <Tooltip {...destTooltipProps}>
+        <LabwareTooltipContents labwareNickname={destinationSlot} />
+      </Tooltip>
+
+      <PDListItem
+        className={cx(
+          styles.step_subitem_column_header,
+          styles.emphasized_cell
+        )}
+      >
+        <span {...sourceTargetProps} className={styles.labware_display_name}>
+          {sourceLabwareNickname}
+        </span>
+
+        <Icon className={styles.step_subitem_spacer} name="ot-transfer" />
+
+        <span {...destTargetProps} className={styles.labware_display_name}>
+          {destSlot}
+        </span>
+      </PDListItem>
+    </>
+  )
+}

--- a/protocol-designer/src/components/steplist/MoveLabwareHeader.tsx
+++ b/protocol-designer/src/components/steplist/MoveLabwareHeader.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react'
 import cx from 'classnames'
-import {
-  Icon,
-  Tooltip,
-  useHoverTooltip,
-  TOOLTIP_FIXED,
-} from '@opentrons/components'
+import { Tooltip, useHoverTooltip, TOOLTIP_FIXED } from '@opentrons/components'
 import { PDListItem } from '../lists'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 
@@ -61,8 +56,7 @@ export function MoveLabwareHeader(props: MoveLabwareHeaderProps): JSX.Element {
           {sourceLabwareNickname}
         </span>
 
-        <Icon className={styles.step_subitem_spacer} name="ot-transfer" />
-
+        <div className={styles.spacer} />
         <span {...destTargetProps} className={styles.labware_display_name}>
           {destSlot}
         </span>

--- a/protocol-designer/src/components/steplist/MoveLabwareHeader.tsx
+++ b/protocol-designer/src/components/steplist/MoveLabwareHeader.tsx
@@ -30,7 +30,7 @@ export function MoveLabwareHeader(props: MoveLabwareHeaderProps): JSX.Element {
   return (
     <>
       <li className={styles.substep_header}>
-        <span>Method: {useGripper ? 'With gripper' : 'Manually'} </span>
+        <span>{useGripper ? 'With gripper' : 'Manually'} </span>
       </li>
       <li className={styles.substep_header}>
         <span>LABWARE</span>

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -40,6 +40,7 @@ import {
   ThermocyclerProfileSubstepItem,
   WellIngredientNames,
 } from '../../steplist/types'
+import { MoveLabwareHeader } from './MoveLabwareHeader'
 
 export interface StepItemProps {
   description?: string | null
@@ -505,6 +506,19 @@ export const StepItemContents = (
         volume={rawForm.volume}
         times={rawForm.times}
         labwareNickname={labwareNicknamesById[mixLabwareId]}
+      />
+    )
+  }
+
+  if (stepType === 'moveLabware') {
+    const gripper = rawForm.useGripper
+    const labware = rawForm.labware
+    result.push(
+      <MoveLabwareHeader
+        key="moveLabware-header"
+        sourceLabwareNickname={labwareNicknamesById[labware]}
+        useGripper={gripper}
+        destinationSlot={rawForm.newLocation}
       />
     )
   }

--- a/protocol-designer/src/containers/ConnectedTitleBar.tsx
+++ b/protocol-designer/src/containers/ConnectedTitleBar.tsx
@@ -51,14 +51,13 @@ function TitleWithIcon(props: TitleWithIconProps): JSX.Element {
   )
 }
 
-interface TitleWithBetaTagProps {
+interface TitleProps {
   text: string | null | undefined
 }
 
-const TitleWithBetaTag = (props: TitleWithBetaTagProps): JSX.Element => (
+const Title = (props: TitleProps): JSX.Element => (
   <div className={styles.title_wrapper}>
     <div className={styles.icon_inline_text}>{props.text}</div>
-    <div className={styles.beta_tag}>{i18n.t('application.beta')}</div>
   </div>
 )
 
@@ -98,9 +97,7 @@ function mapStateToProps(state: BaseState): SP {
     case 'settings-app':
       return {
         _page,
-        title: (
-          <TitleWithBetaTag text={i18n.t([`nav.title.${_page}`, fileName])} />
-        ),
+        title: <Title text={i18n.t([`nav.title.${_page}`, fileName])} />,
         subtitle: i18n.t([`nav.subtitle.${_page}`, '']),
       }
     case 'steplist':

--- a/protocol-designer/src/containers/TitleBar.css
+++ b/protocol-designer/src/containers/TitleBar.css
@@ -20,14 +20,3 @@
   display: flex;
   align-items: center;
 }
-
-.beta_tag {
-  font-size: 1rem;
-  font-weight: 500;
-  margin-left: 0.75rem;
-  padding: 0.4rem 0.5rem;
-  color: var(--c-font-light);
-  background-color: var(--c-med-gray);
-  letter-spacing: 0.5px;
-  border-radius: 0.3125rem;
-}

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -112,7 +112,7 @@ export const duplicateLabware: (
       payload: {
         duplicateLabwareNickname,
         templateLabwareId,
-        duplicateLabwareId: uuid(),
+        duplicateLabwareId: uuid() + ':' + templateLabwareDefURI,
         slot: duplicateSlot,
       },
     })

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -87,6 +87,7 @@ export const duplicateLabware: (
   getState
 ) => {
   const state = getState()
+  const robotType = state.fileData.robotType
   const templateLabwareDefURI = stepFormSelectors.getLabwareEntities(state)[
     templateLabwareId
   ].labwareDefURI
@@ -95,7 +96,7 @@ export const duplicateLabware: (
     `no labwareDefURI for labware ${templateLabwareId}, cannot run duplicateLabware thunk`
   )
   const initialDeckSetup = stepFormSelectors.getInitialDeckSetup(state)
-  const duplicateSlot = getNextAvailableDeckSlot(initialDeckSetup)
+  const duplicateSlot = getNextAvailableDeckSlot(initialDeckSetup, robotType)
   if (!duplicateSlot)
     console.warn('no slots available, cannot duplicate labware')
   const allNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -9,7 +9,7 @@ import { DeckSlot } from '../types'
 
 export function getNextAvailableDeckSlot(
   initialDeckSetup: InitialDeckSetup,
-  robotType: RobotType = OT2_ROBOT_TYPE
+  robotType: RobotType
 ): DeckSlot | null | undefined {
   const deckDef = getDeckDefFromRobotType(robotType)
   return deckDef.locations.orderedSlots.find(slot =>

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -1,8 +1,4 @@
-import {
-  OT2_ROBOT_TYPE,
-  RobotType,
-  getDeckDefFromRobotType,
-} from '@opentrons/shared-data'
+import { RobotType, getDeckDefFromRobotType } from '@opentrons/shared-data'
 import { getSlotIsEmpty } from '../step-forms/utils'
 import { InitialDeckSetup } from '../step-forms/types'
 import { DeckSlot } from '../types'

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -193,12 +193,12 @@
     "unused_pipette_and_module": {
       "heading": "Unused pipette and module",
       "body1": "The {{pipettesDetails}} and {{modulesDetails}} in your protocol are not currently used in any step. In order to run this protocol you will need to attach this pipette as well as power up and connect the module to your robot.",
-      "body2": "If you don't intend to use them, please consider removing them from your protocol."
+      "body2": "If you don't intend to use them, please consider removing them from your protocol.  Keep in mind that all JSON protocols must specify at least one pipette."
     },
     "unused_pipette": {
       "heading": "Unused pipette",
       "body1": "The {{pipettesDetails}} specified in your protocol is currently not used in any step. In order to run this protocol you will need to attach this pipette to your robot.",
-      "body2": "If you don't intend to use the pipette, please consider removing it from your protocol."
+      "body2": "If you don’t intend to use the pipette, remove it on the File tab. Keep in mind that all JSON protocols must specify at least one pipette."
     },
     "unused_module": {
       "heading": "Unused module",

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -25,7 +25,6 @@
     "rpm": "rpm"
   },
   "version": "Protocol Designer Version",
-  "beta": "beta",
   "networking": {
     "generic_verification_failure": "Something went wrong with your unique link. Fill out the form below to have a new one sent to your email. Please contact the Opentrons Support team if you require further help.",
     "unauthorized_verification_failure": "This unique link has expired and is no longer valid, to have a new link sent to your email, fill out the form below.",

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -21,7 +21,8 @@
     "thermocyclerModuleV1": "GEN1",
     "thermocyclerModuleV2": "GEN2",
     "heaterShakerModuleV1": "GEN1",
-    "magneticBlockV1": "GEN1"
+    "magneticBlockV1": "GEN1",
+    "gripperV1": "GEN1"
   },
   "status": {
     "engaged": "engaged",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -94,6 +94,9 @@
       "disabled": {
         "latchOpen": "Labware Latch cannot be open while the module is shaking"
       }
+    },
+    "touchTip": {
+      "disabled": "Touch tip is not supported with this labware"
     }
   },
   "edit_module_card": {

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -47,6 +47,7 @@ const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
     'usascientific_96_wellplate_2.4ml_deep',
     'nest_96_wellplate_100ul_pcr_full_skirt',
     'nest_96_wellplate_2ml_deep',
+    'armadillo_96_wellplate_200ul_pcr_full_skirt',
   ],
   [THERMOCYCLER_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',
@@ -61,6 +62,8 @@ const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
   [MAGNETIC_BLOCK_TYPE]: [
     'armadillo_96_wellplate_200ul_pcr_full_skirt',
     'nest_96_wellplate_100ul_pcr_full_skirt',
+    'nest_96_wellplate_2ml_deep',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
 }
 export const getLabwareIsCompatible = (


### PR DESCRIPTION
closes  RQA-1080, RQA-1125, RQA-1102, RQA-1109, RAUT-589, RAUT-590, RQA-1110, RQA-1122, RQA-1100, RQA-1141, RQA-1148, RQA-1151

# Overview

Addresses a handful of bugs

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_bug-fixes-7.0/

On the sandbox build, test that each bug got addressed;
1. add a magnetic module for OT-2 protocol, adding labware on top of it, make sure the correct labware is available and make sure the help link goes to the correct place (RAUT-589, RAUT-590)
2. when editing the pipettes, make sure the arrow icon moves up and down when the dropdown is expanded or not (RQA-1080)
3. make sure you can duplicate labware successfully on a flex and Ot-2 protocol (RQA-1125)
4. add a labware to the deck and give it a verrry long nickname, make sure it truncates after ~3 lines (RQA-1102)
5. add a liquid with a verrry long nickname, make sure it truncates properly both on the liquid tab and when you add the liquid to the labware (RQA-1109, RQA-1110)
6. protocol name should truncate on design tab, but the subtitle to the right of it should not (RQA-1122)
7. removal of the `beta` tag. See Linda's comment in RQA-1100 
8. `touch_tip` option should be disabled in advanced settings in the transfer step when you try to touch tip with a labware that doesn't support it. Hovering over it should show a tooltip explaining why its disabled (RQA-1148)
9. the `moveLabware` step in the timeline should have the correct information shown (should display labware, new location, and if gripper is used or manual intervention is required) RQA-1151
10. when you export a protocol with an unused pipette, the modal copy should be updated (RQA-1141)

# Changelog

- various components in `protocol-designer` directory - adding truncated strings, labware to recommended labware list, fixing a url, duplicate labware bug

# Review requests

see test plan

# Risk assessment

low