### PR TITLE
feat(api): reduce unused mount currents with 96

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -216,9 +216,20 @@ def get_current_settings(
     for axis_kind in conf_by_pip["hold_current"].keys():
         for axis in Axis.of_kind(axis_kind):
             currents[axis] = CurrentConfig(
-                conf_by_pip["hold_current"][axis_kind],
-                conf_by_pip["run_current"][axis_kind],
+                hold_current=conf_by_pip["hold_current"][axis_kind],
+                run_current=conf_by_pip["run_current"][axis_kind],
             )
+    if gantry_load == GantryLoad.HIGH_THROUGHPUT:
+        # In high-throughput configuration, the right mount doesn't do anything: the
+        # lead screw nut is disconnected from the carriage, and it just hangs out
+        # up at the top of the axis. We should therefore not give it a lot of current.
+        # TODO: think of a better way to do this
+        lt_config = config.by_gantry_load(GantryLoad.LOW_THROUGHPUT)
+        currents[Axis.Z_R] = CurrentConfig(
+            hold_current=lt_config["hold_current"][OT3AxisKind.Z],
+            # not a typo: keep that current low
+            run_current=lt_config["hold_current"][OT3AxisKind.Z],
+        )
     return currents
 
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -59,7 +59,7 @@ class OT3AxisKind(enum.Enum):
     #: Gripper Z axis
     Q = 5
     #: High-throughput tip grabbing axis
-    OTHER = 5
+    OTHER = 6
     #: The internal axes of high throughput pipettes, for instance
 
     def __str__(self) -> str:
@@ -165,6 +165,7 @@ class Axis(enum.Enum):
             OT3AxisKind.Y: [cls.Y],
             OT3AxisKind.Z: [cls.Z_L, cls.Z_R],
             OT3AxisKind.Z_G: [cls.Z_G],
+            OT3AxisKind.Q: [cls.Q],
             OT3AxisKind.OTHER: [cls.Q, cls.G],
         }
         return kind_map[kind]


### PR DESCRIPTION
This will make the hold and run currents for the unused right mount be much lower when the 96 is attached.
