### PR TITLE
fix(app): filter for duplicate defUri after filtering for tipracks usedx

### DIFF
--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/getLabwareLocationCombos.test.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/getLabwareLocationCombos.test.ts
@@ -120,6 +120,13 @@ const mockLabwareEntities: ProtocolAnalysisOutput['labware'] = [
     displayName: 'second labware nickname',
   },
   {
+    id: 'secondLabwareId',
+    loadName: mockLabwareDef.parameters.loadName,
+    definitionUri: getLabwareDefURI(mockLabwareDef),
+    location: { slotName: '2' },
+    displayName: 'second labware nickname',
+  },
+  {
     id: 'duplicateLabwareId',
     loadName: mockLabwareDef.parameters.loadName,
     definitionUri: getLabwareDefURI(mockLabwareDef),
@@ -157,6 +164,11 @@ describe('getLabwareLocationCombos', () => {
       {
         location: { slotName: '2' },
         labwareId: 'secondLabwareId',
+        definitionUri: getLabwareDefURI(mockLabwareDef),
+      },
+      {
+        location: { slotName: '2' },
+        labwareId: 'duplicateLabwareId',
         definitionUri: getLabwareDefURI(mockLabwareDef),
       },
       {
@@ -264,6 +276,11 @@ describe('getLabwareLocationCombos', () => {
         definitionUri: getLabwareDefURI(mockLabwareDef),
       },
       {
+        location: { slotName: '2' },
+        labwareId: 'duplicateLabwareId',
+        definitionUri: getLabwareDefURI(mockLabwareDef),
+      },
+      {
         location: { slotName: '3', moduleModel: 'heaterShakerModuleV1' },
         labwareId: 'onModuleLabwareId',
         moduleId: 'firstModuleId',
@@ -277,6 +294,11 @@ describe('getLabwareLocationCombos', () => {
       {
         location: { slotName: '5' },
         labwareId: 'secondLabwareId',
+        definitionUri: getLabwareDefURI(mockLabwareDef),
+      },
+      {
+        location: { slotName: '5' },
+        labwareId: 'duplicateLabwareId',
         definitionUri: getLabwareDefURI(mockLabwareDef),
       },
     ])

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
@@ -6,7 +6,7 @@ import type {
 } from '@opentrons/shared-data'
 import { LabwareOffsetLocation } from '@opentrons/api-client'
 
-interface LabwareLocationCombo {
+export interface LabwareLocationCombo {
   location: LabwareOffsetLocation
   definitionUri: string
   labwareId: string
@@ -84,6 +84,7 @@ function appendLocationComboIfUniq(
 ): LabwareLocationCombo[] {
   const locationComboAlreadyExists = acc.some(
     combo =>
+      combo.labwareId === locationCombo.labwareId &&
       isEqual(combo.location, locationCombo.location) &&
       combo.definitionUri === locationCombo.definitionUri
   )

--- a/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getCheckSteps.ts
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash'
 import { SECTIONS } from '../constants'
 import { getLabwareDefinitionsFromCommands } from './labware'
 import {
@@ -18,7 +19,8 @@ import type {
   RunTimeCommand,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
-import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/pipetting'
+import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
+import type { LabwareLocationCombo } from '../../ApplyHistoricOffsets/hooks/getLabwareLocationCombos'
 
 interface LPCArgs {
   primaryPipetteId: string
@@ -109,9 +111,23 @@ function getCheckTipRackSectionSteps(args: LPCArgs): CheckTipRacksStep[] {
     ...onlySecondaryPipettePickUpTipCommands,
     ...uniqPrimaryPipettePickUpTipCommands,
   ].reduce<CheckTipRacksStep[]>((acc, { params }) => {
-    const labwareLocations = labwareLocationCombos.filter(
-      combo => combo.labwareId === params.labwareId
-    )
+    const labwareLocations = labwareLocationCombos.reduce<
+      LabwareLocationCombo[]
+    >((acc, labwareLocationCombo) => {
+      // remove labware that isn't accessed by a pickup tip command
+      if (labwareLocationCombo.labwareId !== params.labwareId) {
+        return acc
+      }
+      // remove duplicate definitionUri in same location
+      const comboAlreadyExists = acc.some(
+        accLocationCombo =>
+          labwareLocationCombo.definitionUri ===
+            accLocationCombo.definitionUri &&
+          isEqual(labwareLocationCombo.location, accLocationCombo.location)
+      )
+      return comboAlreadyExists ? acc : [...acc, labwareLocationCombo]
+    }, [])
+
     return [
       ...acc,
       ...labwareLocations.map(({ location }) => ({


### PR DESCRIPTION
Fix RQA-1119

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In LPC we were comparing a list of unique labware definitionUri's and locations present in a protocol with a list of labware that was visited by pipettes. If there were multiples of the same loaded labware, some of which were visited and some that wasn't used by a pipette, it was possible for labware to be missing in LPC. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Upload the protocol linked in the above ticket and ensure the tiprack that was missing is now present in LPC.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Move filtering for duplicate definitionUri/location combos from `appendLocationComboIfUniq` to later in the matching process in `getCheckSteps`
2. Update tests

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
