### PR TITLE
fix(api): update estimation before homing if encoder pos is good, regardless of stepper status

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1209,17 +1209,12 @@ class OT3API(
         # G, Q should be handled in the backend through `self._home()`
         assert axis not in [Axis.G, Axis.Q]
 
+        # ensure stepper position can be updated after boot
+        await self.engage_axes([axis])
+        await self._update_position_estimation([axis])
+        # refresh motor and encoder statuses after position estimation update
         motor_ok = self._backend.check_motor_status([axis])
         encoder_ok = self._backend.check_encoder_status([axis])
-
-        # we can update the motor position if the encoder position is valid
-        if encoder_ok and not motor_ok:
-            # ensure stepper position can be updated after boot
-            await self.engage_axes([axis])
-            await self._update_position_estimation([axis])
-            # refresh motor and encoder statuses after position estimation update
-            motor_ok = self._backend.check_motor_status([axis])
-            encoder_ok = self._backend.check_encoder_status([axis])
 
         # we can move to safe home distance!
         if encoder_ok and motor_ok:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1209,12 +1209,16 @@ class OT3API(
         # G, Q should be handled in the backend through `self._home()`
         assert axis not in [Axis.G, Axis.Q]
 
-        # ensure stepper position can be updated after boot
-        await self.engage_axes([axis])
-        await self._update_position_estimation([axis])
-        # refresh motor and encoder statuses after position estimation update
-        motor_ok = self._backend.check_motor_status([axis])
         encoder_ok = self._backend.check_encoder_status([axis])
+        motor_ok = self._backend.check_motor_status([axis])
+
+        if encoder_ok:
+            # ensure stepper position can be updated after boot
+            await self.engage_axes([axis])
+            await self._update_position_estimation([axis])
+            # refresh motor and encoder statuses after position estimation update
+            motor_ok = self._backend.check_motor_status([axis])
+            encoder_ok = self._backend.check_encoder_status([axis])
 
         # we can move to safe home distance!
         if encoder_ok and motor_ok:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When stall detection is disabled, homing an axis might be an impossible task because the hardware controller is tricked into thinking that the motor position is valid. If the motor is actually much further away from the limit switch than the value the firmware reports, the home command will time out and the move will fail. If the motor is much closer to the limit switch, the home command would most definitely cause the axis to crash into the limit switch. 

Since there are safe guards already on the firmware side (we _only_ update the stepper position if the encoder position is good and the motor is not current moving and/or does not have any queued up moves), we should be able to just update the position based on the encoder value whenever we are about to **home** because the stepper & encoder positions will be subsequently reset anyway.