### PR TITLE
fix(shared-data): update flex tip rack definitions with DVT/PVT measurements

### DIFF
--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -370,874 +370,874 @@
         "tags": []
       },
       "dimensions": {
-        "xDimension": 127.76,
-        "yDimension": 85.48,
+        "xDimension": 127.75,
+        "yDimension": 85.75,
         "zDimension": 99
       },
       "wells": {
         "A1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H1": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 14.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H2": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 23.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H3": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 32.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H4": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 41.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H5": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 50.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H6": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 59.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H7": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 68.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H8": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 77.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H9": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 86.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H10": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 95.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H11": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 104.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         },
         "A12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 74.1,
-          "z": 41.1
+          "y": 74.38,
+          "z": 1.5
         },
         "B12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 65.1,
-          "z": 41.1
+          "y": 65.38,
+          "z": 1.5
         },
         "C12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 56.1,
-          "z": 41.1
+          "y": 56.38,
+          "z": 1.5
         },
         "D12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 47.1,
-          "z": 41.1
+          "y": 47.38,
+          "z": 1.5
         },
         "E12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 38.1,
-          "z": 41.1
+          "y": 38.38,
+          "z": 1.5
         },
         "F12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 29.1,
-          "z": 41.1
+          "y": 29.38,
+          "z": 1.5
         },
         "G12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 20.1,
-          "z": 41.1
+          "y": 20.38,
+          "z": 1.5
         },
         "H12": {
-          "depth": 57.9,
-          "totalLiquidVolume": 50,
+          "depth": 97.5,
           "shape": "circular",
           "diameter": 5.58,
+          "totalLiquidVolume": 50,
           "x": 113.38,
-          "y": 11.1,
-          "z": 41.1
+          "y": 11.38,
+          "z": 1.5
         }
       },
       "groups": [

--- a/shared-data/labware/definitions/2/opentrons_flex_96_filtertiprack_1000ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_filtertiprack_1000ul/1.json
@@ -24,874 +24,874 @@
     "tags": []
   },
   "dimensions": {
-    "xDimension": 127.76,
-    "yDimension": 85.48,
+    "xDimension": 127.75,
+    "yDimension": 85.75,
     "zDimension": 99
   },
   "wells": {
     "A1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     }
   },
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_flex_96_filtertiprack_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_filtertiprack_200ul/1.json
@@ -24,874 +24,874 @@
     "tags": []
   },
   "dimensions": {
-    "xDimension": 127.76,
-    "yDimension": 85.48,
+    "xDimension": 127.75,
+    "yDimension": 85.75,
     "zDimension": 99
   },
   "wells": {
     "A1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     }
   },
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_flex_96_filtertiprack_50ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_filtertiprack_50ul/1.json
@@ -24,874 +24,874 @@
     "tags": []
   },
   "dimensions": {
-    "xDimension": 127.76,
-    "yDimension": 85.48,
+    "xDimension": 127.75,
+    "yDimension": 85.75,
     "zDimension": 99
   },
   "wells": {
     "A1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     }
   },
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_1000ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_1000ul/1.json
@@ -24,874 +24,874 @@
     "tags": []
   },
   "dimensions": {
-    "xDimension": 127.76,
-    "yDimension": 85.48,
+    "xDimension": 127.75,
+    "yDimension": 85.75,
     "zDimension": 99
   },
   "wells": {
     "A1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H1": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 14.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H2": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 23.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H3": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 32.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H4": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 41.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H5": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 50.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H6": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 59.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H7": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 68.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H8": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 77.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H9": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 86.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H10": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 95.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H11": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 104.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     },
     "A12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 74.1,
-      "z": 3.4
+      "y": 74.38,
+      "z": 1.5
     },
     "B12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 65.1,
-      "z": 3.4
+      "y": 65.38,
+      "z": 1.5
     },
     "C12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 56.1,
-      "z": 3.4
+      "y": 56.38,
+      "z": 1.5
     },
     "D12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 47.1,
-      "z": 3.4
+      "y": 47.38,
+      "z": 1.5
     },
     "E12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 38.1,
-      "z": 3.4
+      "y": 38.38,
+      "z": 1.5
     },
     "F12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 29.1,
-      "z": 3.4
+      "y": 29.38,
+      "z": 1.5
     },
     "G12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 20.1,
-      "z": 3.4
+      "y": 20.38,
+      "z": 1.5
     },
     "H12": {
-      "depth": 95.6,
-      "totalLiquidVolume": 1000,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.47,
+      "totalLiquidVolume": 1000,
       "x": 113.38,
-      "y": 11.1,
-      "z": 3.4
+      "y": 11.38,
+      "z": 1.5
     }
   },
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_200ul/1.json
@@ -24,874 +24,874 @@
     "tags": []
   },
   "dimensions": {
-    "xDimension": 127.76,
-    "yDimension": 85.48,
+    "xDimension": 127.75,
+    "yDimension": 85.75,
     "zDimension": 99
   },
   "wells": {
     "A1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H1": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 14.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H2": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 23.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H3": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 32.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H4": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 41.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H5": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 50.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H6": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 59.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H7": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 68.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H8": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 77.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H9": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 86.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H10": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 95.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H11": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 104.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     },
     "A12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 74.1,
-      "z": 40.65
+      "y": 74.38,
+      "z": 1.5
     },
     "B12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 65.1,
-      "z": 40.65
+      "y": 65.38,
+      "z": 1.5
     },
     "C12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 56.1,
-      "z": 40.65
+      "y": 56.38,
+      "z": 1.5
     },
     "D12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 47.1,
-      "z": 40.65
+      "y": 47.38,
+      "z": 1.5
     },
     "E12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 38.1,
-      "z": 40.65
+      "y": 38.38,
+      "z": 1.5
     },
     "F12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 29.1,
-      "z": 40.65
+      "y": 29.38,
+      "z": 1.5
     },
     "G12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 20.1,
-      "z": 40.65
+      "y": 20.38,
+      "z": 1.5
     },
     "H12": {
-      "depth": 58.35,
-      "totalLiquidVolume": 200,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.59,
+      "totalLiquidVolume": 200,
       "x": 113.38,
-      "y": 11.1,
-      "z": 40.65
+      "y": 11.38,
+      "z": 1.5
     }
   },
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_50ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_50ul/1.json
@@ -24,874 +24,874 @@
     "tags": []
   },
   "dimensions": {
-    "xDimension": 127.76,
-    "yDimension": 85.48,
+    "xDimension": 127.75,
+    "yDimension": 85.75,
     "zDimension": 99
   },
   "wells": {
     "A1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H1": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 14.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H2": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 23.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H3": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 32.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H4": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 41.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H5": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 50.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H6": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 59.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H7": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 68.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H8": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 77.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H9": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 86.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H10": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 95.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H11": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 104.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     },
     "A12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 74.1,
-      "z": 41.1
+      "y": 74.38,
+      "z": 1.5
     },
     "B12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 65.1,
-      "z": 41.1
+      "y": 65.38,
+      "z": 1.5
     },
     "C12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 56.1,
-      "z": 41.1
+      "y": 56.38,
+      "z": 1.5
     },
     "D12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 47.1,
-      "z": 41.1
+      "y": 47.38,
+      "z": 1.5
     },
     "E12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 38.1,
-      "z": 41.1
+      "y": 38.38,
+      "z": 1.5
     },
     "F12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 29.1,
-      "z": 41.1
+      "y": 29.38,
+      "z": 1.5
     },
     "G12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 20.1,
-      "z": 41.1
+      "y": 20.38,
+      "z": 1.5
     },
     "H12": {
-      "depth": 57.9,
-      "totalLiquidVolume": 50,
+      "depth": 97.5,
       "shape": "circular",
       "diameter": 5.58,
+      "totalLiquidVolume": 50,
       "x": 113.38,
-      "y": 11.1,
-      "z": 41.1
+      "y": 11.38,
+      "z": 1.5
     }
   },
   "groups": [


### PR DESCRIPTION
# Overview

While working on RLAB-358 on the 96 channel tip rack adapter split, it was discovered that the existing flex tip rack adapters had slight discerpancies in the geometry of their definition when compared to the schematics in the DVT Robot Extents spreadsheet. In order from most to least important:

- the `y` property of the wells was set to to `11.1` offset from the well edge instead of `11.38`. The spacing was proper so this did not compound but was still off by `.28`.
- the x and y dimensions of the tip racks themselves were set to `127.76` and `85.48` instead of `127.75` and `85.75`
- the well depth of each tip rack was set to its tip length, with the `z` property different for each so that the two added together to `99`, the z height of the tip rack. In practice this did not cause any issue since the pipette only moves to the tops of the wells for tip racks, and as long as these added to the correct height there was no noticeable change in behavior. In an effort to be more accurate though, these values were changed to the accurate uniform well `depth` of `97.5` and well `z` of `1.5`.

With these changes there should be a small reduction in the y-dimension LPC offsets for the tip racks.

# Test Plan

LPC using the same robot and pipette and tip rack location was used with both the old and the newly updated definitions and confirmed to have less offset needed for the new definitions. Overall correctness in tip pick up behavior for single and multi channel pipettes with all 3 tip lengths was tested using this protocol.

```
metadata = {
    'protocolName': 'Tip Rack Definition Change Test',
}

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.15"
}

def run(context):
    pipette_single = context.load_instrument("p50_single_flex", mount="left")
    pipette_multi = context.load_instrument("p1000_multi_flex", mount="right")

    tip_rack_50 = context.load_labware('opentrons_flex_96_tiprack_50ul', location="C1")
    tip_rack_200 = context.load_labware('opentrons_flex_96_tiprack_200ul', location="C2")
    tip_rack_1000 = context.load_labware('opentrons_flex_96_tiprack_1000ul', location="C3")

    labware = context.load_labware('armadillo_96_wellplate_200ul_pcr_full_skirt', location="D2")
    labware_well = labware.wells()[0].top()

    # Test picking up and dropping off in column 1
    for well in tip_rack_50.columns_by_name()['1']:
        pipette_single.pick_up_tip(well)
        pipette_single.move_to(labware_well)
        pipette_single.drop_tip(well)


    # Test picking up and dropping off in row A
    for well in tip_rack_50.rows_by_name()['A']:
        pipette_single.pick_up_tip(well)
        pipette_single.move_to(labware_well)
        pipette_single.drop_tip(well)


    # Test picking up four corners
    wells_by_name_200 = tip_rack_200.wells_by_name()

    for well_name in ['A1', 'H1', 'A12', 'H12']:
        well = wells_by_name_200[well_name]
        pipette_single.pick_up_tip(well)
        pipette_single.move_to(labware_well)
        pipette_single.drop_tip(well)


    # Test multi pipette pick up
    wells_by_name_1000 = tip_rack_1000.wells_by_name()
    for well_name in ['A1', 'A6', 'A7', 'A12']:
        well = wells_by_name_1000[well_name]
        pipette_multi.pick_up_tip(well)
        pipette_multi.move_to(labware_well)
        pipette_multi.drop_tip(well)
```

# Changelog

- Updated the definitions for the six tip flex tip racks (50uL, 200uL, and 1000uL for filter and non-filter tips)

# Review requests

Double check that the measurements compare properly to the DVT/PVT schematics. Also, in keeping with the amount of precision in other definitions, the decimal points of `.375` were rounded up to `.38`.

# Risk assessment

Medium-low, the definitions have been changed but by small amounts. There will still be a need for LPC but this PR should be reducing that amount on a properly calibrated robot.

Importantly:
**NEW LPC OFFSETS WILL NEED TO BE CALCULATED. USING OLD OFFSETS MIGHT CAUSE THE PIPETTE TO BE MISALIGNED AND CRASH INTO THE TIPS!**