### PR TITLE
docs(api,robot-server): Document errors list as having no more than 1 element

### DIFF
--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -140,7 +140,10 @@ class PythonConfig(BaseModel):
 
 
 class AnalyzeResults(BaseModel):
-    """Results of a protocol analysis."""
+    """Results of a protocol analysis.
+
+    See robot-server's analysis models for field documentation.
+    """
 
     createdAt: datetime
     files: List[ProtocolFile]
@@ -152,5 +155,4 @@ class AnalyzeResults(BaseModel):
     pipettes: List[LoadedPipette]
     modules: List[LoadedModule]
     liquids: List[Liquid]
-    # errors is a list for historical reasons. It will only have up to one element.
     errors: List[ErrorOccurrence]

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -152,4 +152,5 @@ class AnalyzeResults(BaseModel):
     pipettes: List[LoadedPipette]
     modules: List[LoadedModule]
     liquids: List[Liquid]
+    # errors is a list for historical reasons. It will only have up to one element.
     errors: List[ErrorOccurrence]

--- a/api/src/opentrons/protocol_engine/state/state_summary.py
+++ b/api/src/opentrons/protocol_engine/state/state_summary.py
@@ -19,7 +19,7 @@ class StateSummary(BaseModel):
 
     status: EngineStatus
     # errors is a list for historical reasons. (This model needs to stay compatible with
-    # the database.) It shouldn't have more than 1 element.
+    # robot-server's database.) It shouldn't have more than 1 element.
     errors: List[ErrorOccurrence]
     labware: List[LoadedLabware]
     pipettes: List[LoadedPipette]

--- a/api/src/opentrons/protocol_engine/state/state_summary.py
+++ b/api/src/opentrons/protocol_engine/state/state_summary.py
@@ -18,7 +18,8 @@ class StateSummary(BaseModel):
     """Data from a protocol run."""
 
     status: EngineStatus
-    # errors is a list for historical reasons. It will only have up to one element.
+    # errors is a list for historical reasons. (This model needs to stay compatible with
+    # the database.) It shouldn't have more than 1 element.
     errors: List[ErrorOccurrence]
     labware: List[LoadedLabware]
     pipettes: List[LoadedPipette]

--- a/api/src/opentrons/protocol_engine/state/state_summary.py
+++ b/api/src/opentrons/protocol_engine/state/state_summary.py
@@ -18,6 +18,7 @@ class StateSummary(BaseModel):
     """Data from a protocol run."""
 
     status: EngineStatus
+    # errors is a list for historical reasons. It will only have up to one element.
     errors: List[ErrorOccurrence]
     labware: List[LoadedLabware]
     pipettes: List[LoadedPipette]

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
@@ -76,7 +76,11 @@ class MaintenanceRun(ResourceModel):
     )
     errors: List[ErrorOccurrence] = Field(
         ...,
-        description="Any errors that have occurred during the run.",
+        description=(
+            "The protocol's fatal error, if there was one."
+            " For historical reasons, this is an array,"
+            " but it will only have up to one element."
+        ),
     )
     pipettes: List[LoadedPipette] = Field(
         ...,

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
@@ -77,7 +77,7 @@ class MaintenanceRun(ResourceModel):
     errors: List[ErrorOccurrence] = Field(
         ...,
         description=(
-            "The protocol's fatal error, if there was one."
+            "The run's fatal error, if there was one."
             " For historical reasons, this is an array,"
             " but it won't have more than one element."
         ),

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
@@ -79,7 +79,7 @@ class MaintenanceRun(ResourceModel):
         description=(
             "The protocol's fatal error, if there was one."
             " For historical reasons, this is an array,"
-            " but it will only have up to one element."
+            " but it won't have more than one element."
         ),
     )
     pipettes: List[LoadedPipette] = Field(

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -111,7 +111,7 @@ class CompletedAnalysis(BaseModel):
         description=(
             "The protocol's fatal error, if there was one."
             " For historical reasons, this is an array,"
-            " but it will only have up to one element."
+            " but it won't have more than one element."
         ),
     )
     liquids: List[Liquid] = Field(

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -108,7 +108,11 @@ class CompletedAnalysis(BaseModel):
     )
     errors: List[ErrorOccurrence] = Field(
         ...,
-        description="Any errors the protocol run produced",
+        description=(
+            "The protocol's fatal error, if there was one."
+            " For historical reasons, this is an array,"
+            " but it will only have up to one element."
+        ),
     )
     liquids: List[Liquid] = Field(
         default_factory=list,

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -77,7 +77,11 @@ class Run(ResourceModel):
     )
     errors: List[ErrorOccurrence] = Field(
         ...,
-        description="Any errors that have occurred during the run.",
+        description=(
+            "The run's fatal error, if there was one."
+            " For historical reasons, this is an array,"
+            " but it will only have up to one element."
+        ),
     )
     pipettes: List[LoadedPipette] = Field(
         ...,

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -80,7 +80,7 @@ class Run(ResourceModel):
         description=(
             "The run's fatal error, if there was one."
             " For historical reasons, this is an array,"
-            " but it will only have up to one element."
+            " but it won't have more than one element."
         ),
     )
     pipettes: List[LoadedPipette] = Field(


### PR DESCRIPTION
# Overview

In the public (HTTP-facing) models for runs and analyses, you can access the errors of individual commands. In addition, there's an array of top-level errors. That top-level array is used to indicate fatal errors, including those that happen in between commands.

This documents, officially, that the top-level array will only ever have zero elements or one element. It will never contain multiple errors. The fact that it's an array, instead of a nullable object, is just a historical quirk.

This goes towards RSS-146 by clarifying how we should expose different kinds of run failures.

# Rationale

* There is no use for `errors` to have multiple elements today.

  This array is left over from a time before individual commands held their own errors. Today, commands have a self-contained `error` field, but in þe olden tymes, they had an `errorId` reference that pointed into this array. This was problematic for a few reasons, such as [inherent duplication](https://github.com/Opentrons/opentrons/issues/9436).

  [PR #9715](https://github.com/Opentrons/opentrons/pull/9715) fixed this. Since then, `errors` has only had up to 1 element.

* Having multiple elements is confusing, and muddies what the field is supposed to be doing, conceptually. One internal comment describes it as "a list of fatal errors." But there can only be one fatal error, by definition.

* For the case where multiple things contributed to a run's failure, and we want to convey them all, we now have @sfoster1's `EnumeratedError` architecture. We should commit to that tree-based API instead of keeping around a competing array-based API.

* According to @shlokamin, the app just does, and has always just done, something like `errors[0]`.

* If we really need to have multiple elements in this list later on, we can just revert this documentation change. We can do that revert without breaking any clients.

# Test Plan

None needed.

# Changelog

Update the public HTTP documentation in run and analysis models, and internal comments.

# Review requests

Do we agree with this?

# Risk assessment

No risk.
