### PR TITLE
fix(app): poll instrument info for desktop protocol setup

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -74,9 +74,9 @@ export function InstrumentsAndModules({
     setSubsystemToUpdate,
   ] = React.useState<Subsystem | null>(null)
 
-  const { data: attachedInstruments } = useInstrumentsQuery()
-  // TODO(bc, 2023-03-20): reintroduce this poll, once it is safe to call cache_instruments during sensor reads on CAN bus
-  // { refetchInterval: EQUIPMENT_POLL_MS, },
+  const { data: attachedInstruments } = useInstrumentsQuery({
+    refetchInterval: EQUIPMENT_POLL_MS,
+  })
   const attachedGripper =
     (attachedInstruments?.data ?? []).find(
       (i): i is GripperData => i.instrumentType === 'gripper' && i.ok

--- a/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
@@ -34,7 +34,9 @@ export function SetupInstrumentCalibration({
   const { t } = useTranslation('protocol_setup')
   const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
 
-  const { data: instrumentsQueryData, refetch } = useInstrumentsQuery({refetchInterval: EQUIPMENT_POLL_MS})
+  const { data: instrumentsQueryData, refetch } = useInstrumentsQuery({
+    refetchInterval: EQUIPMENT_POLL_MS,
+  })
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const usesGripper = isGripperInCommands(

--- a/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
@@ -21,6 +21,7 @@ import { isGripperInCommands } from '../../../resources/protocols/utils'
 import type { GripperData } from '@opentrons/api-client'
 import { i18n } from '../../../i18n'
 
+const EQUIPMENT_POLL_MS = 5000
 interface SetupInstrumentCalibrationProps {
   robotName: string
   runId: string
@@ -33,7 +34,7 @@ export function SetupInstrumentCalibration({
   const { t } = useTranslation('protocol_setup')
   const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
 
-  const { data: instrumentsQueryData, refetch } = useInstrumentsQuery()
+  const { data: instrumentsQueryData, refetch } = useInstrumentsQuery({refetchInterval: EQUIPMENT_POLL_MS})
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const usesGripper = isGripperInCommands(

--- a/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -206,6 +206,8 @@ describe('InstrumentsAndModules', () => {
       { refetchInterval: 5000 }
     )
     expect(mockUseModulesQuery).toHaveBeenCalledWith({ refetchInterval: 5000 })
-    expect(mockUseInstrumentsQuery).toHaveBeenCalledWith()
+    expect(mockUseInstrumentsQuery).toHaveBeenCalledWith({
+      refetchInterval: 5000,
+    })
   })
 })

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -42,6 +42,7 @@ const GO_BACK_BUTTON_STYLE = css`
     }
   }
 `
+const QUICK_GRIPPER_POLL_MS = 3000
 
 export const MountGripper = (
   props: GripperWizardStepProps
@@ -51,9 +52,8 @@ export const MountGripper = (
   const isOnDevice = useSelector(getIsOnDevice)
   const [showUnableToDetect, setShowUnableToDetect] = React.useState(false)
   const [isPending, setIsPending] = React.useState(false)
-  // TODO(bc, 2023-03-23): remove this temporary local poll in favor of the single top level poll in InstrumentsAndModules
   const { data: instrumentsQueryData, refetch } = useInstrumentsQuery({
-    refetchInterval: 3000,
+    refetchInterval: QUICK_GRIPPER_POLL_MS,
   })
   const isGripperAttached = (instrumentsQueryData?.data ?? []).some(
     (i): i is GripperData | BadGripper => i.instrumentType === 'gripper'

--- a/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
@@ -45,6 +45,8 @@ const GO_BACK_BUTTON_TEXT_STYLE = css`
   }
 `
 
+const QUICK_GRIPPER_POLL_MS = 3000
+
 export const UnmountGripper = (
   props: GripperWizardStepProps
 ): JSX.Element | null => {
@@ -52,10 +54,8 @@ export const UnmountGripper = (
   const { t } = useTranslation(['gripper_wizard_flows', 'shared'])
   const isOnDevice = useSelector(getIsOnDevice)
   const [isPending, setIsPending] = React.useState<boolean>(false)
-
-  // TODO(bc, 2023-03-23): remove this temporary local poll in favor of the single top level poll in InstrumentsAndModules
   const { data: instrumentsQueryData, refetch } = useInstrumentsQuery({
-    refetchInterval: 3000,
+    refetchInterval: QUICK_GRIPPER_POLL_MS,
   })
   const isGripperStillAttached = (instrumentsQueryData?.data ?? []).some(
     (i): i is GripperData => i.instrumentType === 'gripper' && i.ok


### PR DESCRIPTION
# Overview

To avoid scenarios where users complete a wizard flow launched from the protocol setup steps only to return to a list item that still shows the old value, employ a background poll of the instruments endpoint in addition to the on complete refetches.  this way updates are visible regardless of whether ODD or Desktop was  used to complete the wizard.

Closes RQA-1139

# Review requests

- Complete any required attach or calibrate flows from the desktop protocol setup robot calibration step on Desktop. Upon completion, when the wizard closes, the list items should update to reflect the completed action. 

# Risk assessment
low
