### PR TITLE
fix(app-shell-odd): fix the brightness with sleep touchscreen

### DIFF
--- a/app-shell-odd/src/config/index.ts
+++ b/app-shell-odd/src/config/index.ts
@@ -106,8 +106,10 @@ export function registerConfig(dispatch: Dispatch): (action: Action) => void {
         }
 
         log().debug('Updating config', { path, nextValue })
-        store().set(path, nextValue)
-        dispatch(Cfg.configValueUpdated(path, nextValue))
+        if (path !== 'onDeviceDisplaySettings.brightness' || nextValue !== 7) {
+          store().set(path, nextValue)
+          dispatch(Cfg.configValueUpdated(path, nextValue))
+        }
       } else {
         log().debug(`config path in overrides; not updating`, { path })
       }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This pr avoids updating brightness config value when the app sleeps
Add condition before updating the config value. When path is brightness and value is 7, app-shell-odd skips storing the value.

The current implementation isn't good and it should be temporary since changing the brightness needs to edge the file that we should be via endpoint.

I could not reproduce the issue that when tapping the display, display stays off on my end.

RAUT-592
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
0. Check config.json brightness
1. Go to Settings
2. Tap Touchscreen sleep and set sleep time 3min
3. After 3 min, display is off and config.json brightness is the same as step 0
4. /sbin/reboot or reboot the robot via desktop app
5. Check display is on
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
