### PR TITLE
fix(app-shell): remove usb-detection build process special casing

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -125,7 +125,7 @@ dist-win: package-deps
 
 .PHONY: dist-ot3
 dist-ot3: package-deps
-	NO_PYTHON=true NO_USB_DETECTION=true $(builder) --linux --arm64 --dir
+	NO_PYTHON=true $(builder) --linux --arm64 --dir
 	cd dist/linux-arm64-unpacked
 
 # Aliases matching github actions OS names for easier calling in

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -5,7 +5,6 @@ const { versionForProject } = require('../scripts/git-version')
 const { OT_APP_DEPLOY_BUCKET, OT_APP_DEPLOY_FOLDER } = process.env
 const DEV_MODE = process.env.NODE_ENV !== 'production'
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
-const NO_USB_DETECTION = process.env.NO_USB_DETECTION === 'true'
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
 
 const ot3PublishConfig =
@@ -41,17 +40,6 @@ module.exports = async () => ({
     'build/br-premigration-wheels',
     '!Makefile',
     '!python',
-    ...(NO_USB_DETECTION
-      ? ['!node_modules/usb-detection']
-      : // this detail with node modules makes sure that any byproducts from the build process
-        // of the usb-detection submodule - which should only exist anyway if we don't get a
-        // prebuild - won't get packed into the app. If they are, they'll prevent the app
-        // from running on OSX, because they intern paths on the action runner in their binaries
-        // sometimes and gatekeeper will scan them, notice, and fail us.
-        [
-          '!node_modules/usb-detection/build',
-          'node_modules/usb-detection/build/Release',
-        ]),
     {
       from: '../app/dist',
       to: './ui',

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -2,8 +2,6 @@
 import { app, ipcMain } from 'electron'
 import contextMenu from 'electron-context-menu'
 
-import { fetchSerialPortList } from '@opentrons/usb-bridge/node-client'
-
 import { createUi } from './ui'
 import { initializeMenu } from './menu'
 import { createLogger } from './log'
@@ -72,10 +70,6 @@ function startUp(): void {
 
   initializeMenu()
 
-  // TESTING SERIALPORT LIBRARY:
-  testSerialport()
-  // commit this to trigger a build
-
   // wire modules to UI dispatches
   const dispatch: Dispatch = action => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -104,12 +98,6 @@ function startUp(): void {
   })
 
   log.silly('Global references', { mainWindow, rendererLogger })
-}
-
-function testSerialport(): void {
-  fetchSerialPortList().then((list: any) =>
-    console.log('serialport list', list)
-  )
 }
 
 function createRendererLogger(): Logger {

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -2,6 +2,8 @@
 import { app, ipcMain } from 'electron'
 import contextMenu from 'electron-context-menu'
 
+import { fetchSerialPortList } from '@opentrons/usb-bridge/node-client'
+
 import { createUi } from './ui'
 import { initializeMenu } from './menu'
 import { createLogger } from './log'
@@ -70,6 +72,9 @@ function startUp(): void {
 
   initializeMenu()
 
+  // TESTING SERIALPORT LIBRARY:
+  testSerialport()
+
   // wire modules to UI dispatches
   const dispatch: Dispatch = action => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -98,6 +103,12 @@ function startUp(): void {
   })
 
   log.silly('Global references', { mainWindow, rendererLogger })
+}
+
+function testSerialport(): void {
+  fetchSerialPortList().then((list: any) =>
+    console.log('serialport list', list)
+  )
 }
 
 function createRendererLogger(): Logger {

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -74,6 +74,7 @@ function startUp(): void {
 
   // TESTING SERIALPORT LIBRARY:
   testSerialport()
+  // commit this to trigger a build
 
   // wire modules to UI dispatches
   const dispatch: Dispatch = action => {

--- a/app-shell/src/system-info/__tests__/dispatch.test.ts
+++ b/app-shell/src/system-info/__tests__/dispatch.test.ts
@@ -52,9 +52,7 @@ describe('app-shell::system-info module action tests', () => {
   beforeEach(() => {
     handler = registerSystemInfo(dispatch)
     isWindows.mockReturnValue(false)
-    createUsbDeviceMonitor.mockReturnValue(
-      new Promise(resolve => resolve(usbMonitor))
-    )
+    createUsbDeviceMonitor.mockReturnValue(usbMonitor)
     createNetworkInterfaceMonitor.mockReturnValue(ifaceMonitor)
     getAllDevices.mockResolvedValue([realtek0])
     getActiveInterfaces.mockReturnValue([
@@ -143,7 +141,7 @@ describe('app-shell::system-info module action tests', () => {
     })
   })
 
-  it('stops monitoring on app quit', async () => {
+  it('stops monitoring on app quit', () => {
     handler(uiInitialized())
 
     const appQuitHandler = appOnce.mock.calls.find(
@@ -152,7 +150,7 @@ describe('app-shell::system-info module action tests', () => {
     )?.[1]
 
     expect(typeof appQuitHandler).toBe('function')
-    await (appQuitHandler as Function)()
+    appQuitHandler?.()
     expect(usbMonitor.stop).toHaveBeenCalled()
     expect(ifaceMonitor.stop).toHaveBeenCalled()
   })

--- a/app-shell/src/system-info/__tests__/usb-devices.test.ts
+++ b/app-shell/src/system-info/__tests__/usb-devices.test.ts
@@ -19,14 +19,14 @@ describe('app-shell::system-info::usb-devices', () => {
     jest.resetAllMocks()
   })
 
-  it('can create a usb device monitor', async () => {
+  it('can create a usb device monitor', () => {
     expect(usbDetection.startMonitoring).toHaveBeenCalledTimes(0)
-    await createUsbDeviceMonitor()
+    createUsbDeviceMonitor()
     expect(usbDetection.startMonitoring).toHaveBeenCalledTimes(1)
   })
 
-  it('usb device monitor can be stopped', async () => {
-    const monitor = await createUsbDeviceMonitor()
+  it('usb device monitor can be stopped', () => {
+    const monitor = createUsbDeviceMonitor()
     monitor.stop()
     expect(usbDetection.stopMonitoring).toHaveBeenCalledTimes(1)
   })
@@ -40,24 +40,24 @@ describe('app-shell::system-info::usb-devices', () => {
 
     usbDetectionFind.mockResolvedValueOnce(mockDevices)
 
-    const monitor = await createUsbDeviceMonitor()
+    const monitor = createUsbDeviceMonitor()
     const result = monitor.getAllDevices()
 
     await expect(result).resolves.toEqual(mockDevices)
   })
 
-  it('can notify when devices are added', async () => {
+  it('can notify when devices are added', () => {
     const onDeviceAdd = jest.fn()
-    await createUsbDeviceMonitor({ onDeviceAdd })
+    createUsbDeviceMonitor({ onDeviceAdd })
 
     usbDetection.emit('add', mockDevice)
 
     expect(onDeviceAdd).toHaveBeenCalledWith(mockDevice)
   })
 
-  it('can notify when devices are removed', async () => {
+  it('can notify when devices are removed', () => {
     const onDeviceRemove = jest.fn()
-    await createUsbDeviceMonitor({ onDeviceRemove })
+    createUsbDeviceMonitor({ onDeviceRemove })
 
     usbDetection.emit('remove', mockDevice)
 

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import execa from 'execa'
+import usbDetection from 'usb-detection'
 import { isWindows } from '../os'
 import { createLogger } from '../log'
 
@@ -19,11 +20,9 @@ export interface UsbDeviceMonitor {
 
 const log = createLogger('usb-devices')
 
-export async function createUsbDeviceMonitor(
+export function createUsbDeviceMonitor(
   options: UsbDeviceMonitorOptions = {}
-): Promise<UsbDeviceMonitor> {
-  const { default: usbDetection } = await import('usb-detection')
-
+): UsbDeviceMonitor {
   const { onDeviceAdd, onDeviceRemove } = options
   usbDetection.startMonitoring()
 


### PR DESCRIPTION
# Overview

special casing of the native usb-detection package in the build process was interfering with code signing of the usb-detection binary and breaking the usb device monitor

mac branch build: https://ot3-development.builds.opentrons.com/app/Opentrons-OT3-v0.14.0-alpha.2-mac-b32554-app_usb-debugging-app-build.dmg

# Test Plan

 - downloaded built app image, checked electron main process logs and did not see usb monitor code signing error, plugged into Flex and observed green check for usb connection

# Changelog

 - Removes usb-detection build process special casing

# Review requests

download built image, connect laptop to Flex with usb, check robot settings/networking tab for green check

# Risk assessment

low
