### PR TITLE
fix(app): show applied offset count in ODD protocol setup step

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -131,6 +131,8 @@
   "no_usb_required": "No USB required",
   "not_calibrated": "Not calibrated yet",
   "offset_data": "Offset Data",
+  "offsets_applied": "{{count}} offset applied",
+  "offsets_applied_plural": "{{count}} offsets applied",
   "on-deck_labware": "{{count}} on-deck labware",
   "opening": "Opening...",
   "pipette_mismatch": "Pipette generation mismatch.",

--- a/app/src/organisms/EstopModal/DesktopEstopMissingModal.stories.tsx
+++ b/app/src/organisms/EstopModal/DesktopEstopMissingModal.stories.tsx
@@ -9,7 +9,7 @@ import type { Store } from 'redux'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'App/organisms/EstopMissingModal',
+  title: 'App/Organisms/EstopMissingModal',
   component: EstopMissingModal,
 } as Meta
 

--- a/app/src/organisms/EstopModal/DesktopEstopPressedModal.stories.tsx
+++ b/app/src/organisms/EstopModal/DesktopEstopPressedModal.stories.tsx
@@ -9,7 +9,7 @@ import type { Store } from 'redux'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'App/organisms/EstopPressedModal',
+  title: 'App/Organisms/EstopPressedModal',
   component: EstopPressedModal,
 } as Meta
 

--- a/app/src/organisms/EstopModal/TouchscreenEstopMissingModal.stories.tsx
+++ b/app/src/organisms/EstopModal/TouchscreenEstopMissingModal.stories.tsx
@@ -9,7 +9,7 @@ import type { Store } from 'redux'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'ODD/organisms/EstopMissingModal',
+  title: 'ODD/Organisms/EstopMissingModal',
   component: EstopMissingModal,
 } as Meta
 

--- a/app/src/organisms/EstopModal/TouchscreenEstopPressedModal.stories.tsx
+++ b/app/src/organisms/EstopModal/TouchscreenEstopPressedModal.stories.tsx
@@ -9,7 +9,7 @@ import type { Store } from 'redux'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'ODD/organisms/EstopPressedModal',
+  title: 'ODD/Organisms/EstopPressedModal',
   component: EstopPressedModal,
 } as Meta
 

--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -288,7 +288,7 @@ const OffsetTable = (props: OffsetTableProps): JSX.Element => {
 
 // Very similar to the OffsetTable, but abbreviates certain things to be optimized
 // for smaller screens
-const TerseOffsetTable = (props: OffsetTableProps): JSX.Element => {
+export const TerseOffsetTable = (props: OffsetTableProps): JSX.Element => {
   const { offsets, labwareDefinitions } = props
   const { i18n, t } = useTranslation('labware_position_check')
   return (

--- a/app/src/organisms/LabwarePositionCheck/TerseOffsetTable.stories.tsx
+++ b/app/src/organisms/LabwarePositionCheck/TerseOffsetTable.stories.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import {
+  ALIGN_FLEX_END,
+  DIRECTION_COLUMN,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+} from '@opentrons/components'
+import { TerseOffsetTable } from './ResultsSummary'
+import type { Story, Meta } from '@storybook/react'
+
+import fixture_12_trough from '@opentrons/shared-data/labware/fixtures/2/fixture_12_trough.json'
+import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
+import { LabwareDefinition2, getLabwareDefURI } from '@opentrons/shared-data'
+import { SmallButton } from '../../atoms/buttons'
+
+export default {
+  title: 'ODD/Organisms/TerseOffsetTable',
+  component: TerseOffsetTable,
+} as Meta
+
+// Note: 59rem(944px) is the size of ODD
+const Template: Story<React.ComponentProps<typeof TerseOffsetTable>> = ({
+  ...args
+}) => (
+  <Flex padding={SPACING.spacing16} width="59rem">
+    <Flex
+      flex="1"
+      flexDirection={DIRECTION_COLUMN}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      padding={SPACING.spacing32}
+      minHeight="29.5rem"
+    >
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        maxHeight="20rem"
+        overflowY="scroll"
+      >
+        <h1>new labware offset data</h1>
+        <TerseOffsetTable {...args} />
+      </Flex>
+      <SmallButton
+        alignSelf={ALIGN_FLEX_END}
+        onClick={() => console.log('FAKE BUTTON')}
+        buttonText="Apply offsets"
+      />
+    </Flex>
+  </Flex>
+)
+
+export const Basic = Template.bind({})
+Basic.args = {
+  offsets: [
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'A1' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'A2' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'A3' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'B1' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'B2' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'B3' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'C1' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'C2' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+    {
+      definitionUri: getLabwareDefURI(fixture_12_trough as LabwareDefinition2),
+      location: { slotName: 'C3' },
+      vector: { x: 1, y: 2, z: 3 },
+    },
+  ],
+  labwareDefinitions: [fixture_12_trough, fixture_tiprack_10_ul],
+}

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -177,6 +177,13 @@ const mockLiquids = [
 ]
 
 const mockPlay = jest.fn()
+const mockOffset = {
+  id: 'fake_labware_offset',
+  createdAt: 'timestamp',
+  definitionUri: 'fake_def_uri',
+  location: { slotName: 'A1' },
+  vector: { x: 1, y: 2, z: 3 },
+}
 
 describe('ProtocolSetup', () => {
   let mockLaunchLPC: jest.Mock
@@ -223,7 +230,14 @@ describe('ProtocolSetup', () => {
       .mockReturnValue(ot3StandardDeckDef as any)
     when(mockUseRunQuery)
       .calledWith(RUN_ID, { staleTime: Infinity })
-      .mockReturnValue({ data: { data: { protocolId: PROTOCOL_ID } } } as any)
+      .mockReturnValue({
+        data: {
+          data: {
+            protocolId: PROTOCOL_ID,
+            labwareOffsets: [mockOffset],
+          },
+        },
+      } as any)
     when(mockUseProtocolQuery)
       .calledWith(PROTOCOL_ID, { staleTime: Infinity })
       .mockReturnValue({
@@ -321,7 +335,8 @@ describe('ProtocolSetup', () => {
   it('should launch LPC when clicked', () => {
     mockUseLPCDisabledReason.mockReturnValue(null)
     const [{ getByText }] = render(`/runs/${RUN_ID}/setup/`)
-    getByText('Recommended')
+    getByText(/Recommended/)
+    getByText(/1 offset applied/)
     getByText('Labware Position Check').click()
     expect(mockLaunchLPC).toHaveBeenCalled()
     getByText('mock LPC Wizard')

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -75,6 +75,7 @@ import { ConfirmAttachedModal } from './ConfirmAttachedModal'
 
 import type { OnDeviceRouteParams } from '../../../App/types'
 import type { HeaterShakerModule } from '../../../redux/modules/types'
+import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
 
 interface ProtocolSetupStepProps {
   onClickSetupStep: () => void
@@ -90,7 +91,7 @@ interface ProtocolSetupStepProps {
   disabledReason?: string | null
 }
 
-function ProtocolSetupStep({
+export function ProtocolSetupStep({
   onClickSetupStep,
   status,
   title,
@@ -448,6 +449,10 @@ function PrepareToRun({
       ? t('additional_labware', { count: additionalLabwareCount })
       : null
 
+  const latestCurrentOffsets = getLatestCurrentOffsets(
+    runRecord?.data?.labwareOffsets ?? []
+  )
+
   // Liquids information
   const liquidsInProtocol = mostRecentAnalysis?.liquids ?? []
 
@@ -529,6 +534,11 @@ function PrepareToRun({
           detail={t(
             lpcDisabledReason != null ? 'currently_unavailable' : 'recommended'
           )}
+          subDetail={
+            latestCurrentOffsets.length > 0
+              ? t('offsets_applied', { count: latestCurrentOffsets.length })
+              : null
+          }
           status="general"
           disabled={lpcDisabledReason != null}
           disabledReason={lpcDisabledReason}


### PR DESCRIPTION


# Overview

Expose the number of applied offsets on a given run within the Labware Position Check setup step
<img width="996" alt="Screen Shot 2023-07-28 at 5 54 56 PM" src="https://github.com/Opentrons/opentrons/assets/4731953/6608c1dd-61a7-49f9-a435-278fc1c47803">
<img width="974" alt="Screen Shot 2023-07-28 at 5 54 47 PM" src="https://github.com/Opentrons/opentrons/assets/4731953/2b65b5f0-83b3-4e1b-9f5c-bbde699faae6">

# Review requests

Run LPC on ODD, confirm that the number of offsets present is visible on the Labware Position Check setup step

# Risk assessment
low
