### PR TITLE
refactor(api): clean up labware movement error strings

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -230,7 +230,7 @@ class LabwareMovementHandler:
             location, (DeckSlotLocation, ModuleLocation, OnLabwareLocation)
         ):
             raise LabwareMovementNotAllowedError(
-                "Cannot move labware off-deck using the gripper."
+                "Cannot perform off-deck labware movements with the gripper."
             )
         return location
 

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -97,7 +97,7 @@ class LabwareMovementHandler:
             return
         ot3api = ensure_ot3_hardware(
             hardware_api=self._hardware_api,
-            error_msg="Gripper is only available on the OT-3",
+            error_msg="Gripper is only available on Opentrons Flex",
         )
 
         if not ot3api.has_gripper():
@@ -230,7 +230,7 @@ class LabwareMovementHandler:
             location, (DeckSlotLocation, ModuleLocation, OnLabwareLocation)
         ):
             raise LabwareMovementNotAllowedError(
-                "Off-deck labware movements are not supported using the gripper."
+                "Cannot move labware off-deck using the gripper."
             )
         return location
 
@@ -260,10 +260,10 @@ class LabwareMovementHandler:
                 )
             except ThermocyclerNotOpenError:
                 raise LabwareMovementNotAllowedError(
-                    "Cannot move labware from/to a thermocycler with closed lid."
+                    "Cannot move labware to or from a Thermocycler with its lid closed."
                 )
             except HeaterShakerLabwareLatchNotOpenError:
                 raise LabwareMovementNotAllowedError(
-                    "Cannot move labware from/to a heater-shaker"
+                    "Cannot move labware to or from a Heater-Shaker"
                     " with its labware latch closed."
                 )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Small PR to clean up some user-facing error copy for labware movement. 

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Read words. Words good?

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- excised a user-facing mention of "OT-3"
- capitalized module product names
- general prose cleanup

# Review requests

<!--
Describe any requests for your reviewers here.
-->

The only edits in this PR are within strings, but they are code, not docs. Is there anything preventing us from making these changes, and is `edge` the right target branch?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

low.