### PR TITLE
feat(hardware-testing): CSV report's Device-ID can pass/fail if doesn't match barcode

### DIFF
--- a/hardware-testing/hardware_testing/data/csv_report.py
+++ b/hardware-testing/hardware_testing/data/csv_report.py
@@ -41,6 +41,8 @@ META_DATA_TITLE = "META_DATA"
 META_DATA_TEST_NAME = "test_name"
 META_DATA_TEST_TAG = "test_tag"
 META_DATA_TEST_RUN_ID = "test_run_id"
+META_DATA_TEST_DEVICE_ID = "test_device_id"
+META_DATA_TEST_ROBOT_ID = "test_robot_id"
 META_DATA_TEST_TIME_UTC = "test_time_utc"
 META_DATA_TEST_OPERATOR = "test_operator"
 META_DATA_TEST_VERSION = "test_version"
@@ -260,8 +262,10 @@ def _generate_meta_data_section() -> CSVSection:
             CSVLine(tag=META_DATA_TEST_NAME, data=[str]),
             CSVLine(tag=META_DATA_TEST_TAG, data=[str]),
             CSVLine(tag=META_DATA_TEST_RUN_ID, data=[str]),
+            CSVLine(tag=META_DATA_TEST_DEVICE_ID, data=[str, CSVResult]),
+            CSVLine(tag=META_DATA_TEST_ROBOT_ID, data=[str]),
             CSVLine(tag=META_DATA_TEST_TIME_UTC, data=[str]),
-            CSVLine(tag=META_DATA_TEST_OPERATOR, data=[str]),
+            CSVLine(tag=META_DATA_TEST_OPERATOR, data=[str, CSVResult]),
             CSVLine(tag=META_DATA_TEST_VERSION, data=[str]),
             CSVLine(tag=META_DATA_TEST_FIRMWARE, data=[str]),
         ],
@@ -291,7 +295,7 @@ class CSVReport:
         self._tag: Optional[str] = None
         self._file_name: Optional[str] = None
         _section_meta = _generate_meta_data_section()
-        _section_titles = [s.title for s in sections]
+        _section_titles = [META_DATA_TITLE] + [s.title for s in sections]
         _section_results = _generate_results_overview_section(_section_titles)
         self._sections = [_section_meta, _section_results] + sections
         self._cache_start_time(start_time)  # must happen before storing any data
@@ -330,9 +334,11 @@ class CSVReport:
         raise ValueError(f"unexpected section title: {item}")
 
     def _refresh_results_overview_values(self) -> None:
-        for s in self._sections[2:]:
-            section = self[RESULTS_OVERVIEW_TITLE]
-            line = section[f"RESULT_{s.title}"]
+        results_section = self[RESULTS_OVERVIEW_TITLE]
+        for s in self._sections:
+            if s == results_section:
+                continue
+            line = results_section[f"RESULT_{s.title}"]
             assert isinstance(line, CSVLine)
             line.store(CSVResult.PASS, print_results=False)
             if s.result_passed:
@@ -382,9 +388,18 @@ class CSVReport:
         )
         self.save_to_disk()
 
+    def set_device_id(self, device_id: str, result: CSVResult) -> None:
+        """Store DUT serial number."""
+        self(META_DATA_TITLE, META_DATA_TEST_DEVICE_ID, [device_id, result])
+
+    def set_robot_id(self, robot_id: str) -> None:
+        """Store robot serial number."""
+        self(META_DATA_TITLE, META_DATA_TEST_ROBOT_ID, [robot_id])
+
     def set_operator(self, operator: str) -> None:
         """Set operator."""
-        self(META_DATA_TITLE, META_DATA_TEST_OPERATOR, [operator])
+        result = CSVResult.from_bool(bool(operator))
+        self(META_DATA_TITLE, META_DATA_TEST_OPERATOR, [operator, result])
 
     def set_version(self, version: str) -> None:
         """Set version."""

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import List, Tuple, Any
 
 from hardware_testing.data.csv_report import (
+    CSVResult,
     CSVReport,
     CSVSection,
     CSVLine,
@@ -310,6 +311,8 @@ def store_serial_numbers(
     liquid: str,
 ) -> None:
     """Report serial numbers."""
+    report.set_robot_id(robot)
+    report.set_device_id(pipette, CSVResult.PASS)
     report("SERIAL-NUMBERS", "robot", [robot])
     report("SERIAL-NUMBERS", "pipette", [pipette])
     report("SERIAL-NUMBERS", "tips", [tips])

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -976,6 +976,16 @@ def get_pipette_serial_ot3(pipette: Union[PipetteOT2, PipetteOT3]) -> str:
     return f"P{volume}{channels}V{version}{id}"
 
 
+def get_robot_serial_ot3(api: OT3API) -> str:
+    """Get robot serial number."""
+    if api.is_simulator:
+        return "FLXA1000000000000"
+    robot_id = api._backend.eeprom_data.serial_number
+    if not robot_id:
+        robot_id = "None"
+    return robot_id
+
+
 def clear_pipette_ul_per_mm(api: OT3API, mount: OT3Mount) -> None:
     """Clear pipette ul-per-mm."""
 

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/__main__.py
@@ -4,7 +4,7 @@ import asyncio
 from pathlib import Path
 
 from hardware_testing.data import ui, get_git_description
-from hardware_testing.data.csv_report import RESULTS_OVERVIEW_TITLE
+from hardware_testing.data.csv_report import RESULTS_OVERVIEW_TITLE, CSVResult
 from hardware_testing.opentrons_api import helpers_ot3
 from hardware_testing.opentrons_api.types import OT3Mount, Axis
 
@@ -12,6 +12,18 @@ from .config import TestSection, TestConfig, build_report, TESTS, TESTS_INCREMEN
 
 
 async def _main(cfg: TestConfig) -> None:
+    # BUILD REPORT
+    test_name = Path(__file__).parent.name
+    ui.print_title(test_name.replace("_", " ").upper())
+    report = build_report(test_name.replace("_", "-"))
+    version = get_git_description()
+    report.set_version(version)
+    print(f"version: {version}")
+    if not cfg.simulate:
+        report.set_operator(input("enter operator name: "))
+    else:
+        report.set_operator("simulation")
+
     # BUILD API
     api = await helpers_ot3.build_async_ot3_hardware_api(
         is_simulating=cfg.simulate,
@@ -19,6 +31,25 @@ async def _main(cfg: TestConfig) -> None:
         pipette_right="p1000_single_v3.3",
         gripper="GRPV1120230323A01",
     )
+    report.set_firmware(api.fw_version)
+    robot_id = helpers_ot3.get_robot_serial_ot3(api)
+    print(f"robot serial: {robot_id}")
+    report.set_robot_id(robot_id)
+
+    # GRIPPER SERIAL NUMBER
+    gripper = api.attached_gripper
+    assert gripper
+    gripper_id = str(gripper["gripper_id"])
+    report.set_tag(gripper_id)
+    if not api.is_simulator:
+        barcode = input("SCAN gripper serial number: ").strip()
+    else:
+        barcode = str(gripper_id)
+    barcode_pass = CSVResult.from_bool(barcode == gripper_id)
+    print(f"barcode: {barcode} ({barcode_pass})")
+    report.set_device_id(gripper_id, result=barcode_pass)
+
+    # HOME and ATTACH
     await api.home_z(OT3Mount.GRIPPER)
     await api.home()
     home_pos = await api.gantry_position(OT3Mount.GRIPPER)
@@ -29,22 +60,6 @@ async def _main(cfg: TestConfig) -> None:
         while not api.has_gripper():
             ui.get_user_ready("attach a gripper")
             await api.reset()
-
-    gripper = api.attached_gripper
-    assert gripper
-    gripper_id = str(gripper["gripper_id"])
-
-    # BUILD REPORT
-    test_name = Path(__file__).parent.name
-    ui.print_title(test_name.replace("_", " ").upper())
-    report = build_report(test_name.replace("_", "-"))
-    report.set_tag(gripper_id)
-    if not cfg.simulate:
-        report.set_operator(input("enter operator name: "))
-    else:
-        report.set_operator("simulation")
-    report.set_version(get_git_description())
-    report.set_firmware(api.fw_version)
 
     # RUN TESTS
     for section, test_run in cfg.tests.items():

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_force.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_force.py
@@ -33,7 +33,7 @@ WARMUP_SECONDS = 10
 FORCE_GAUGE_TRIAL_SAMPLE_INTERVAL = 0.25  # seconds
 FORCE_GAUGE_TRIAL_SAMPLE_COUNT = 20  # 20 samples = 5 seconds @ 4Hz
 
-GAUGE_OFFSET = Point(x=2, y=42, z=75)
+GAUGE_OFFSET = Point(x=2, y=-42, z=75)
 
 
 def _get_test_tag(
@@ -151,7 +151,7 @@ async def _setup(api: OT3API) -> Union[Mark10, SimMark10]:
     await helpers_ot3.move_to_arched_ot3(api, mount, target_pos + Point(z=15))
     if not api.is_simulator:
         ui.get_user_ready("please make sure the gauge in the middle of the gripper")
-    await api.move_to(mount, target_pos)
+    await helpers_ot3.jog_mount_ot3(api, OT3Mount.GRIPPER)
     if not api.is_simulator:
         ui.get_user_ready("about to grip")
     await api.grip(20)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

As requested by SZ team, all devices under test should have their ready SN compared to the one scanned by the barcode, and the CSV report should pass/fail depending on if these two SNs match or not.

This change affected all of the production QC scripts, because they all use the same CSV report class.

Also includes two small changes to the Gripper diagnostics script, from SZ feedback as well:

1. Jog to the force gauge, so operator can align it by eye
2. Flip the force fixture's orientation along Y axis, because they build theirs backwards from how we did it in NYC

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
