### PR TITLE
refactor(shared-data): p1000 flex minimum volumes

### DIFF
--- a/shared-data/pipette/definitions/1/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteNameSpecs.json
@@ -529,7 +529,7 @@
       }
     },
     "channels": 1,
-    "minVolume": 100,
+    "minVolume": 5,
     "maxVolume": 1000,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,
@@ -574,7 +574,7 @@
       }
     },
     "channels": 8,
-    "minVolume": 1,
+    "minVolume": 5,
     "maxVolume": 1000,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,
@@ -660,7 +660,7 @@
       }
     },
     "channels": 96,
-    "minVolume": 1,
+    "minVolume": 5,
     "maxVolume": 1000,
     "smoothieConfigs": {
       "stepsPerMM": 2133.33,

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/1_0.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_0.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_3.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_4.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_5.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_0.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_3.json
@@ -365,7 +365,7 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_4.json
@@ -291,7 +291,7 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_5.json
@@ -291,7 +291,7 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
   "maxVolume": 1000,
-  "minVolume": 1,
+  "minVolume": 5,
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",


### PR DESCRIPTION
closes RAUT-578

# Overview

Change `p1000` pipette minimum volumes to 5uL

# Test Plan

just review code. you can also verify that a move liquid step in PD volume doesn't error if you put a volume down to 5uL when using a p1000 single or multi pipette.

# Changelog

- change `minVolume` key values to `5` in `pipetteNameSpecs`

# Review requests

I only changed this in `pipetteNameSpecs`. Does anywhere else need changing?

# Risk assessment

low