### PR TITLE
fix(app): fix error boundary icon

### DIFF
--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -38,7 +38,7 @@ export function OnDeviceDisplayAppFallback({
   }
   const modalHeader: ModalHeaderBaseProps = {
     title: t('error_boundary_title'),
-    iconName: 'information',
+    iconName: 'ot-alert',
     iconColor: COLORS.red2,
   }
 

--- a/app/src/pages/ProtocolDashboard/index.tsx
+++ b/app/src/pages/ProtocolDashboard/index.tsx
@@ -55,7 +55,7 @@ export function ProtocolDashboard(): JSX.Element {
     setTargetProtocol,
   ] = React.useState<ProtocolResource | null>(null)
   const sortBy = useSelector(getProtocolsOnDeviceSortKey) ?? 'alphabetical'
-  const protocolsData = protocols.data?.data != null ? protocols.data?.data : []
+  const protocolsData = protocols.data?.data ?? []
   let unpinnedProtocols: ProtocolResource[] = protocolsData
 
   // The pinned protocols are stored as an array of IDs in config


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The current error boundary uses a wrong icon. This PR fixes that.
Also fix a potential bug in ProtocolDashboard

design
https://www.figma.com/file/AoTLAYuWawlaWItB1umOjr/Release%3A-Opentrons-Flex-Touchscreen?type=design&node-id=17641-406642&mode=design&t=2z80gpYH2pGdrxGB-0

![Screenshot 2023-07-31 at 6 10 37 PM](https://github.com/Opentrons/opentrons/assets/474225/039b96c7-8b1c-4737-9c76-65d20dd481ff)


close RQA-1168

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
