### PR TITLE
fix(api): handle unknown working volumes

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -117,10 +117,9 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self.ready_to_aspirate = False
         #: True if ready to aspirate
 
-        self._default_active_tip_settings = self._config.supported_tips[
-            pip_types.PipetteTipType(self._working_volume)
+        self._active_tip_settings = self._config.supported_tips[
+            pip_types.PipetteTipType(self._config.max_volume)
         ]
-        self._active_tip_settings = self._default_active_tip_settings
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
         self._aspirate_flow_rates_lookup = (
             self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
@@ -431,10 +430,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def working_volume(self, tip_volume: float) -> None:
         """The working volume is the current tip max volume"""
         self._working_volume = min(self.config.max_volume, tip_volume)
-        self._active_tip_settings = self._config.supported_tips.get(
-            pip_types.PipetteTipType(int(self._working_volume)),
-            self._default_active_tip_settings,
+        tip_size_type = pip_types.PipetteTipType.check_and_return_type(
+            int(self._working_volume), self.config.max_volume
         )
+        self._active_tip_settings = self._config.supported_tips[tip_size_type]
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -116,11 +116,11 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         )
         self.ready_to_aspirate = False
         #: True if ready to aspirate
-        # TODO Clean this lookup up!
-        self._active_tip_settings = self._config.supported_tips.get(
-            pip_types.PipetteTipType(self._working_volume),
-            self._config.supported_tips[list(self._config.supported_tips.keys())[0]],
-        )
+
+        self._default_active_tip_settings = self._config.supported_tips[
+            pip_types.PipetteTipType(self._working_volume)
+        ]
+        self._active_tip_settings = self._default_active_tip_settings
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
         self._aspirate_flow_rates_lookup = (
             self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
@@ -431,9 +431,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def working_volume(self, tip_volume: float) -> None:
         """The working volume is the current tip max volume"""
         self._working_volume = min(self.config.max_volume, tip_volume)
-        self._active_tip_settings = self._config.supported_tips[
-            pip_types.PipetteTipType(int(self._working_volume))
-        ]
+        self._active_tip_settings = self._config.supported_tips.get(
+            pip_types.PipetteTipType(int(self._working_volume)),
+            self._default_active_tip_settings,
+        )
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -102,11 +102,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         )
         self.ready_to_aspirate = False
 
-        self._default_active_tip_settings = self._config.supported_tips[
-            pip_types.PipetteTipType(self._working_volume)
-        ]
         #: True if ready to aspirate
-        self._active_tip_settings = self._default_active_tip_settings
+        self._active_tip_settings = self._config.supported_tips[
+            pip_types.PipetteTipType(self._config.max_volume)
+        ]
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
         self._aspirate_flow_rates_lookup = (
@@ -217,7 +216,9 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._has_tip = False
         self.ready_to_aspirate = False
         #: True if ready to aspirate
-        self._active_tip_settings = self._default_active_tip_settings
+        self._active_tip_settings = self._config.supported_tips[
+            pip_types.PipetteTipType(self._config.max_volume)
+        ]
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
         self._aspirate_flow_rate = (
@@ -422,10 +423,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def working_volume(self, tip_volume: float) -> None:
         """The working volume is the current tip max volume"""
         self._working_volume = min(self.config.max_volume, tip_volume)
-        self._active_tip_settings = self._config.supported_tips.get(
-            pip_types.PipetteTipType(int(self._working_volume)),
-            self._default_active_tip_settings,
+        tip_size_type = pip_types.PipetteTipType.check_and_return_type(
+            int(self._working_volume), self.config.max_volume
         )
+        self._active_tip_settings = self._config.supported_tips[tip_size_type]
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
         self._tip_overlap_lookup = self._config.tip_overlap_dictionary
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -101,10 +101,12 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             )
         )
         self.ready_to_aspirate = False
-        #: True if ready to aspirate
-        self._active_tip_settings = self._config.supported_tips[
+
+        self._default_active_tip_settings = self._config.supported_tips[
             pip_types.PipetteTipType(self._working_volume)
         ]
+        #: True if ready to aspirate
+        self._active_tip_settings = self._default_active_tip_settings
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
         self._aspirate_flow_rates_lookup = (
@@ -215,9 +217,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._has_tip = False
         self.ready_to_aspirate = False
         #: True if ready to aspirate
-        self._active_tip_settings = self._config.supported_tips[
-            pip_types.PipetteTipType(self._working_volume)
-        ]
+        self._active_tip_settings = self._default_active_tip_settings
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
         self._aspirate_flow_rate = (
@@ -422,9 +422,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def working_volume(self, tip_volume: float) -> None:
         """The working volume is the current tip max volume"""
         self._working_volume = min(self.config.max_volume, tip_volume)
-        self._active_tip_settings = self._config.supported_tips[
-            pip_types.PipetteTipType(int(self._working_volume))
-        ]
+        self._active_tip_settings = self._config.supported_tips.get(
+            pip_types.PipetteTipType(int(self._working_volume)),
+            self._default_active_tip_settings,
+        )
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
         self._tip_overlap_lookup = self._config.tip_overlap_dictionary
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -134,7 +134,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             )
             self._state.flow_rates_by_id[action.pipette_id] = config.flow_rates
 
-    def _handle_command(self, command: Command) -> None:
+    def _handle_command(self, command: Command) -> None:  # noqa: ANN101, C901
         self._update_current_well(command)
         self._update_deck_point(command)
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -176,9 +176,14 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             static_config = self._state.static_config_by_id.get(pipette_id)
             if static_config:
-                tip_configuration = static_config.tip_configuration_lookup_table[
-                    attached_tip.volume
-                ]
+                try:
+                    tip_configuration = static_config.tip_configuration_lookup_table[
+                        attached_tip.volume
+                    ]
+                except KeyError:
+                    tip_configuration = static_config.tip_configuration_lookup_table[
+                        static_config.max_volume
+                    ]
                 self._state.flow_rates_by_id[pipette_id] = FlowRates(
                     default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
                     default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,
@@ -539,7 +544,7 @@ class PipetteView(HasState[PipetteState]):
             ]
         else:
             tip_lookup = self.get_config(pipette_id).tip_configuration_lookup_table[
-                working_volume
+                max_volume
             ]
         return tip_lookup.default_return_tip_height
 

--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -27,12 +27,13 @@ class PipetteTipType(enum.Enum):
     t1000 = 1000
 
     @classmethod
-    def check_and_return_type(cls, working_volume: int, maximum_volume: int) -> "PipetteTipType":
+    def check_and_return_type(
+        cls, working_volume: int, maximum_volume: int
+    ) -> "PipetteTipType":
         try:
             return cls(working_volume)
         except ValueError:
             return cls(maximum_volume)
-        
 
 
 class PipetteChannelType(int, enum.Enum):

--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -26,6 +26,14 @@ class PipetteTipType(enum.Enum):
     t300 = 300
     t1000 = 1000
 
+    @classmethod
+    def check_and_return_type(cls, working_volume: int, maximum_volume: int) -> "PipetteTipType":
+        try:
+            return cls(working_volume)
+        except ValueError:
+            return cls(maximum_volume)
+        
+
 
 class PipetteChannelType(int, enum.Enum):
     SINGLE_CHANNEL = 1


### PR DESCRIPTION
## Overview

We should fall back to the max volume of a pipette if the working volume does not exist in the pipette configurations.

## Test

- [ ] Throw on an OT2, make sure custom tip racks work now.