### PR TITLE
fix(app): do not call direction control handlers if disabled

### DIFF
--- a/app/src/molecules/JogControls/DirectionControl.tsx
+++ b/app/src/molecules/JogControls/DirectionControl.tsx
@@ -282,14 +282,16 @@ export function DirectionControl(props: DirectionControlProps): JSX.Element {
             handlers={[
               ...CONTROLS_CONTENTS_BY_PLANE.vertical.controls,
               ...CONTROLS_CONTENTS_BY_PLANE.horizontal.controls,
-            ].map(({ keyName, shiftKey, axis, sign }) => ({
-              key: keyName,
-              shiftKey,
-              onPress: () => {
-                setCurrentPlane(shiftKey ? 'vertical' : 'horizontal')
-                jog(axis, sign, stepSize)
-              },
-            }))}
+            ]
+              .filter(control => !control.disabled)
+              .map(({ keyName, shiftKey, axis, sign }) => ({
+                key: keyName,
+                shiftKey,
+                onPress: () => {
+                  setCurrentPlane(shiftKey ? 'vertical' : 'horizontal')
+                  jog(axis, sign, stepSize)
+                },
+              }))}
           >
             <ArrowKeys plane={currentPlane} jog={jog} stepSize={stepSize} />
           </HandleKeypress>


### PR DESCRIPTION
# Overview

This PR fixes an issue where horizontal direction controls in the app here getting called twice via keypress.

# Test Plan

- Ran LPC, verified jog commands via key press work as expected


# Changelog

- Do not call direction control handlers if disabled


# Review requests
Run through LPC and verify that key presses work as expected when issuing jog commands

# Risk assessment

Low
