### PR TITLE
fix(app): show robot network connection in app if able to communicate via that connection

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -63,19 +63,30 @@ export function RobotSettingsNetworking({
 
   const canDisconnect = useCanDisconnect(robotName)
 
-  const addresses = useSelector((state: State) =>
-    getRobotAddressesByName(state, robotName)
-  )
-  const usbAddress = addresses.find(addr => addr.ip === OPENTRONS_USB)
-  const isOT3ConnectedViaUSB =
-    usbAddress != null && usbAddress.healthStatus === HEALTH_STATUS_OK
-
   const { wifi, ethernet } = useSelector((state: State) =>
     getNetworkInterfaces(state, robotName)
   )
   const activeNetwork = wifiList?.find(network => network.active)
 
   const ssid = activeNetwork?.ssid ?? null
+
+  const addresses = useSelector((state: State) =>
+    getRobotAddressesByName(state, robotName)
+  )
+
+  const wifiAddress = addresses.find(addr => addr.ip === wifi?.ipAddress)
+  const isOT3ConnectedViaWifi =
+    wifiAddress != null && wifiAddress.healthStatus === HEALTH_STATUS_OK
+
+  const ethernetAddress = addresses.find(
+    addr => addr.ip === ethernet?.ipAddress
+  )
+  const isOT3ConnectedViaEthernet =
+    ethernetAddress != null && ethernetAddress.healthStatus === HEALTH_STATUS_OK
+
+  const usbAddress = addresses.find(addr => addr.ip === OPENTRONS_USB)
+  const isOT3ConnectedViaUSB =
+    usbAddress != null && usbAddress.healthStatus === HEALTH_STATUS_OK
 
   useInterval(() => dispatch(fetchStatus(robotName)), STATUS_REFRESH_MS, true)
 
@@ -95,7 +106,7 @@ export function RobotSettingsNetworking({
       </Portal>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
         <Flex alignItems={ALIGN_CENTER}>
-          {wifi?.ipAddress != null ? (
+          {isOT3ConnectedViaWifi ? (
             <Icon
               size="1.25rem"
               name="ot-check"
@@ -120,7 +131,7 @@ export function RobotSettingsNetworking({
           </StyledText>
         </Flex>
         <Box paddingLeft="3.75rem">
-          {wifi?.ipAddress != null ? (
+          {isOT3ConnectedViaWifi ? (
             <>
               <Flex marginBottom={SPACING.spacing24}>
                 <Flex marginRight={SPACING.spacing8}>
@@ -180,7 +191,7 @@ export function RobotSettingsNetworking({
         </Box>
         <Divider />
         <Flex alignItems={ALIGN_CENTER}>
-          {ethernet?.ipAddress != null ? (
+          {isOT3ConnectedViaEthernet ? (
             <Icon
               size="1.25rem"
               name="ot-check"
@@ -203,7 +214,7 @@ export function RobotSettingsNetworking({
         </Flex>
         <Box paddingLeft="3.75rem">
           <Flex gridGap={SPACING.spacing16}>
-            {ethernet?.ipAddress != null ? (
+            {isOT3ConnectedViaEthernet ? (
               <>
                 <Flex
                   flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -24,6 +24,11 @@ import { StyledText } from '../../atoms/text'
 import { Tooltip } from '../../atoms/Tooltip'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
+import {
+  getRobotAddressesByName,
+  HEALTH_STATUS_OK,
+  OPENTRONS_USB,
+} from '../../redux/discovery'
 import { getNetworkInterfaces, fetchStatus } from '../../redux/networking'
 
 import type { IconName, StyleProps } from '@opentrons/components'
@@ -84,15 +89,33 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
     getNetworkInterfaces(state, name)
   )
 
+  const addresses = useSelector((state: State) =>
+    getRobotAddressesByName(state, name)
+  )
+
+  const wifiAddress = addresses.find(addr => addr.ip === wifi?.ipAddress)
+  const isOT3ConnectedViaWifi =
+    wifiAddress != null && wifiAddress.healthStatus === HEALTH_STATUS_OK
+
+  const ethernetAddress = addresses.find(
+    addr => addr.ip === ethernet?.ipAddress
+  )
+  const isOT3ConnectedViaEthernet =
+    ethernetAddress != null && ethernetAddress.healthStatus === HEALTH_STATUS_OK
+
+  const usbAddress = addresses.find(addr => addr.ip === OPENTRONS_USB)
+  const isOT3ConnectedViaUSB =
+    usbAddress != null && usbAddress.healthStatus === HEALTH_STATUS_OK
+
   let iconName: IconName | null = null
   let tooltipTranslationKey = null
-  if (wifi?.ipAddress != null) {
+  if (isOT3ConnectedViaWifi) {
     iconName = 'wifi'
     tooltipTranslationKey = 'device_settings:wifi'
-  } else if (ethernet?.ipAddress != null) {
+  } else if (isOT3ConnectedViaEthernet) {
     iconName = 'ethernet'
     tooltipTranslationKey = 'device_settings:ethernet'
-  } else if (local != null && local) {
+  } else if ((local != null && local) || isOT3ConnectedViaUSB) {
     iconName = 'usb'
     tooltipTranslationKey = 'device_settings:wired_usb'
   }

--- a/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
@@ -9,16 +9,23 @@ import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
 import { useCurrentRunId } from '../../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../../organisms/RunTimeControl/hooks'
+import {
+  getRobotAddressesByName,
+  HEALTH_STATUS_OK,
+  OPENTRONS_USB,
+} from '../../../redux/discovery'
 import { getNetworkInterfaces } from '../../../redux/networking'
 
 import { RobotStatusHeader } from '../RobotStatusHeader'
 
+import type { DiscoveryClientRobotAddress } from '../../../redux/discovery/types'
 import type { SimpleInterfaceStatus } from '../../../redux/networking/types'
 import type { State } from '../../../redux/types'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../organisms/ProtocolUpload/hooks')
 jest.mock('../../../organisms/RunTimeControl/hooks')
+jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/networking')
 jest.mock('../hooks')
 
@@ -35,6 +42,23 @@ const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
 const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
   typeof getNetworkInterfaces
 >
+const mockGetRobotAddressesByName = getRobotAddressesByName as jest.MockedFunction<
+  typeof getRobotAddressesByName
+>
+
+const MOCK_OTIE = {
+  name: 'otie',
+  local: true,
+  robotModel: 'OT-2',
+}
+const MOCK_BUZZ = {
+  name: 'buzz',
+  local: true,
+  robotModel: 'Opentrons Flex',
+}
+
+const WIFI_IP = 'wifi-ip'
+const ETHERNET_IP = 'ethernet-ip'
 
 const render = (props: React.ComponentProps<typeof RobotStatusHeader>) => {
   return renderWithProviders(
@@ -50,11 +74,7 @@ describe('RobotStatusHeader', () => {
   let props: React.ComponentProps<typeof RobotStatusHeader>
 
   beforeEach(() => {
-    props = {
-      name: 'otie',
-      local: true,
-      robotModel: 'OT-2',
-    }
+    props = MOCK_OTIE
     when(mockUseCurrentRunId).calledWith().mockReturnValue(null)
     when(mockUseCurrentRunStatus).calledWith().mockReturnValue(null)
     when(mockUseRunQuery)
@@ -82,6 +102,22 @@ describe('RobotStatusHeader', () => {
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, 'otie')
       .mockReturnValue({ wifi: null, ethernet: null })
+    when(mockGetRobotAddressesByName)
+      .calledWith({} as State, 'otie')
+      .mockReturnValue([
+        {
+          ip: WIFI_IP,
+          healthStatus: HEALTH_STATUS_OK,
+        } as DiscoveryClientRobotAddress,
+        {
+          ip: ETHERNET_IP,
+          healthStatus: HEALTH_STATUS_OK,
+        } as DiscoveryClientRobotAddress,
+        {
+          ip: OPENTRONS_USB,
+          healthStatus: HEALTH_STATUS_OK,
+        } as DiscoveryClientRobotAddress,
+      ])
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -94,12 +130,26 @@ describe('RobotStatusHeader', () => {
   })
 
   it('renders the model of robot and robot name - OT-3', () => {
-    props.name = 'buzz'
-    props.robotModel = 'Opentrons Flex'
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, 'buzz')
       .mockReturnValue({ wifi: null, ethernet: null })
-    const [{ getByText }] = render(props)
+    when(mockGetRobotAddressesByName)
+      .calledWith({} as State, 'buzz')
+      .mockReturnValue([
+        {
+          ip: WIFI_IP,
+          healthStatus: HEALTH_STATUS_OK,
+        } as DiscoveryClientRobotAddress,
+        {
+          ip: ETHERNET_IP,
+          healthStatus: HEALTH_STATUS_OK,
+        } as DiscoveryClientRobotAddress,
+        {
+          ip: OPENTRONS_USB,
+          healthStatus: HEALTH_STATUS_OK,
+        } as DiscoveryClientRobotAddress,
+      ])
+    const [{ getByText }] = render(MOCK_BUZZ)
     getByText('Opentrons Flex')
     getByText('buzz')
   })
@@ -131,8 +181,8 @@ describe('RobotStatusHeader', () => {
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, 'otie')
       .mockReturnValue({
-        wifi: { ipAddress: 'wifi-ip' } as SimpleInterfaceStatus,
-        ethernet: { ipAddress: 'ethernet-ip' } as SimpleInterfaceStatus,
+        wifi: { ipAddress: WIFI_IP } as SimpleInterfaceStatus,
+        ethernet: { ipAddress: ETHERNET_IP } as SimpleInterfaceStatus,
       })
 
     const [{ getByLabelText }] = render(props)
@@ -145,7 +195,7 @@ describe('RobotStatusHeader', () => {
       .calledWith({} as State, 'otie')
       .mockReturnValue({
         wifi: null,
-        ethernet: { ipAddress: 'ethernet-ip' } as SimpleInterfaceStatus,
+        ethernet: { ipAddress: ETHERNET_IP } as SimpleInterfaceStatus,
       })
 
     const [{ getByLabelText }] = render(props)
@@ -157,5 +207,21 @@ describe('RobotStatusHeader', () => {
     const [{ getByLabelText }] = render(props)
 
     getByLabelText('usb')
+  })
+
+  it('does not render a wifi or ethernet icon when discovery client cannot find a healthy robot at its network connection ip addresses', () => {
+    when(mockGetNetworkInterfaces)
+      .calledWith({} as State, 'otie')
+      .mockReturnValue({
+        wifi: { ipAddress: WIFI_IP } as SimpleInterfaceStatus,
+        ethernet: { ipAddress: ETHERNET_IP } as SimpleInterfaceStatus,
+      })
+    when(mockGetRobotAddressesByName)
+      .calledWith({} as State, 'otie')
+      .mockReturnValue([])
+    const [{ queryByLabelText }] = render(props)
+
+    expect(queryByLabelText('wifi')).toBeNull()
+    expect(queryByLabelText('ethernet')).toBeNull()
   })
 })


### PR DESCRIPTION
# Overview

adds a check to ensure a connected network status ip reported by a robot has a healthy response from the desktop app discovery-client. for example, robots connected to a different wifi network than the client app should not show a wifi connection in the app, because the app cannot communicate with that robot via wifi. updated robot settings networking tab, and robot status header rendered on devices and device details pages.

closes RQA-1150

example robot settings networking tab when robot connected to a different wifi network:

<img width="1134" alt="Screen Shot 2023-07-31 at 5 15 50 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/5849d4a7-833d-44ce-b36c-db5b6b766521">


# Test Plan

 - manually verified app behavior for robot connected to a different wifi network
 - updated unit tests

# Changelog

 -  Show robot network connection in app if able to communicate via that connection

# Review requests

confirm on robot connected to different wifi network than app

# Risk assessment

low
