### PR TITLE
fix(protocol-engine): Propagate errors during cleanup phase

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -55,7 +55,7 @@ class StopAction:
 
 @dataclass(frozen=True)
 class FinishErrorDetails:
-    """Error details for the payload of a FinishAction."""
+    """Error details for the payload of a FinishAction or HardwareStoppedAction."""
 
     error: Exception
     error_id: str
@@ -64,21 +64,27 @@ class FinishErrorDetails:
 
 @dataclass(frozen=True)
 class FinishAction:
-    """Gracefully stop processing commands in the engine.
-
-    After a FinishAction, the engine status will be marked as `succeeded` or `failed`
-    if `set_run_status` is True. If False, status will be `stopped`.
-    """
+    """Gracefully stop processing commands in the engine."""
 
     set_run_status: bool = True
+    """Whether to set the engine status depending on `error_details`.
+
+    If True, the engine status will be marked `succeeded` or `failed`, depending on `error_details`.
+    If False, the engine status will be marked `stopped`.
+    """
+
     error_details: Optional[FinishErrorDetails] = None
+    """The fatal error that caused the run to fail."""
 
 
 @dataclass(frozen=True)
 class HardwareStoppedAction:
-    """An action dispatched after hardware has successfully been stopped."""
+    """An action dispatched after hardware has been stopped for good, for this engine instance."""
 
     completed_at: datetime
+
+    finish_error_details: Optional[FinishErrorDetails]
+    """The error that happened while doing post-run finish steps (homing and dropping tips)."""
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -291,10 +291,7 @@ class ProtocolEngine:
         # to robustly clean up all these resources
         # instead of try/finally, which can't scale without making indentation silly.
         finally:
-            # Note: After we stop listening, straggling events might be processed
-            # concurrently to the below lines in this .finish() call,
-            # or even after this .finish() call completes.
-            self._door_watcher.stop_soon()
+            self._door_watcher.stop()
 
             await self._hardware_stopper.do_stop_and_recover(drop_tips_and_home)
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -253,9 +253,9 @@ class ProtocolEngine:
         and then shut down. After an engine has been `finished`'ed, it cannot
         be restarted.
 
-        This method should not raise, but if any exceptions happen during
-        execution that are not properly caught by the CommandExecutor, they
-        will be raised here.
+        This method should not raise. If any exceptions happened during execution that were not
+        properly caught by the CommandExecutor, or if any exceptions happen during this
+        `finish()` call, they should be saved as `.state_view.get_summary().errors`.
 
         Arguments:
             error: An error that caused the stop, if applicable.

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -1,5 +1,5 @@
 """ProtocolEngine class definition."""
-from contextlib import AsyncExitStack, ExitStack
+from contextlib import AsyncExitStack
 from typing import Dict, Optional
 
 from opentrons.protocols.models import LabwareDefinition

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -1,5 +1,6 @@
 """ProtocolEngine class definition."""
 from contextlib import AsyncExitStack
+from logging import getLogger
 from typing import Dict, Optional
 
 from opentrons.protocols.models import LabwareDefinition
@@ -48,6 +49,9 @@ from .actions import (
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
 )
+
+
+_log = getLogger(__name__)
 
 
 class ProtocolEngine:
@@ -302,6 +306,7 @@ class ProtocolEngine:
             # If any teardown steps failed, this will raise something.
             await exit_stack.aclose()
         except Exception as hardware_stopped_exception:
+            _log.exception("Exception during post-run finish steps.")
             finish_error_details: Optional[FinishErrorDetails] = FinishErrorDetails(
                 error_id=self._model_utils.generate_id(),
                 created_at=self._model_utils.get_timestamp(),

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Mapping, Optional, Union
 
-from opentrons_shared_data.errors.exceptions import EnumeratedError
+from opentrons_shared_data.errors import EnumeratedError, ErrorCodes
 
 from opentrons.ordered_set import OrderedSet
 
@@ -140,15 +140,20 @@ class CommandState:
     run_result: Optional[RunResult]
     """Whether the run is done and succeeded, failed, or stopped.
 
-    Once set, this status cannot be unset.
+    This doesn't include the post-run finish steps (homing and dropping tips).
+
+    Once set, this status is immutable.
     """
 
-    errors_by_id: Dict[str, ErrorOccurrence]
-    """All fatal error occurrences, mapped by their unique IDs.
+    run_error: Optional[ErrorOccurrence]
+    """The run's fatal error occurrence, if there was one.
 
     Individual command errors, which may or may not be fatal,
     are stored on the individual commands themselves.
     """
+
+    finish_error: Optional[ErrorOccurrence]
+    """The error that happened during the post-run finish steps (homing & dropping tips), if any."""
 
     latest_command_hash: Optional[str]
     """The latest hash value received in a QueueCommandAction.
@@ -179,7 +184,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
             queued_command_ids=OrderedSet(),
             queued_setup_command_ids=OrderedSet(),
             commands_by_id=OrderedDict(),
-            errors_by_id={},
+            run_error=None,
+            finish_error=None,
             run_completed_at=None,
             run_started_at=None,
             latest_command_hash=None,
@@ -332,34 +338,11 @@ class CommandStore(HasState[CommandState], HandlesActions):
                     self._state.run_result = RunResult.STOPPED
 
                 if action.error_details:
-                    error_id = action.error_details.error_id
-                    created_at = action.error_details.created_at
-                    if (
-                        isinstance(
-                            action.error_details.error, ProtocolCommandFailedError
-                        )
-                        and action.error_details.error.original_error is not None
-                    ):
-                        self._state.errors_by_id[
-                            error_id
-                        ] = action.error_details.error.original_error
-                    else:
-                        if isinstance(
-                            action.error_details.error,
-                            EnumeratedError,
-                        ):
-                            error = action.error_details.error
-                        else:
-                            error = UnexpectedProtocolError(
-                                message=str(action.error_details.error),
-                                wrapping=[action.error_details.error],
-                            )
-
-                        self._state.errors_by_id[
-                            error_id
-                        ] = ErrorOccurrence.from_failed(
-                            id=error_id, createdAt=created_at, error=error
-                        )
+                    self._state.run_error = self._map_exception_to_error_occurrence(
+                        action.error_details.error_id,
+                        action.error_details.created_at,
+                        action.error_details.error,
+                    )
 
         elif isinstance(action, HardwareStoppedAction):
             self._state.queue_status = QueueStatus.PAUSED
@@ -367,6 +350,13 @@ class CommandStore(HasState[CommandState], HandlesActions):
             self._state.run_completed_at = (
                 self._state.run_completed_at or action.completed_at
             )
+
+            if action.finish_error_details:
+                self._state.finish_error = self._map_exception_to_error_occurrence(
+                    action.finish_error_details.error_id,
+                    action.finish_error_details.created_at,
+                    action.finish_error_details.error,
+                )
 
         elif isinstance(action, DoorChangeAction):
             if self._config.block_on_door_open:
@@ -376,6 +366,28 @@ class CommandStore(HasState[CommandState], HandlesActions):
                         self._state.queue_status = QueueStatus.PAUSED
                 elif action.door_state == DoorState.CLOSED:
                     self._state.is_door_blocking = False
+
+    @staticmethod
+    def _map_exception_to_error_occurrence(
+        error_id: str, created_at: datetime, exception: Exception
+    ) -> ErrorOccurrence:
+        if (
+            isinstance(exception, ProtocolCommandFailedError)
+            and exception.original_error is not None
+        ):
+            return exception.original_error
+        elif isinstance(exception, EnumeratedError):
+            return ErrorOccurrence.from_failed(
+                id=error_id, createdAt=created_at, error=exception
+            )
+        else:
+            enumerated_wrapper = UnexpectedProtocolError(
+                message=str(exception),
+                wrapping=[exception],
+            )
+            return ErrorOccurrence.from_failed(
+                id=error_id, createdAt=created_at, error=enumerated_wrapper
+            )
 
 
 class CommandView(HasState[CommandState]):
@@ -445,9 +457,31 @@ class CommandView(HasState[CommandState]):
             total_length=total_length,
         )
 
-    def get_all_errors(self) -> List[ErrorOccurrence]:
-        """Get a list of all errors that have occurred."""
-        return list(self._state.errors_by_id.values())
+    def get_error(self) -> Optional[ErrorOccurrence]:
+        """Get the run's fatal error, if there was one."""
+        run_error = self._state.run_error
+        finish_error = self._state.finish_error
+
+        if run_error and finish_error:
+            combined_error = ErrorOccurrence.construct(
+                id=finish_error.id,
+                createdAt=finish_error.createdAt,
+                errorType="RunAndFinishFailed",
+                detail=(
+                    "The run had a fatal error,"
+                    " and another error happened while doing post-run cleanup."
+                ),
+                # TODO(mm, 2023-07-31): Consider adding a low-priority error code so clients can
+                # deemphasize this root node, in favor of its children in wrappedErrors.
+                errorCode=ErrorCodes.GENERAL_ERROR.value.code,
+                wrappedErrors=[
+                    run_error,
+                    finish_error,
+                ],
+            )
+            return combined_error
+        else:
+            return run_error or finish_error
 
     def get_current(self) -> Optional[CurrentCommand]:
         """Return the "current" command, if any.
@@ -625,18 +659,28 @@ class CommandView(HasState[CommandState]):
     def get_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
         if self._state.run_result:
-            if not self.get_is_stopped():
+            # The main part of the run is over, or will be over soon.
+            # Have we also completed the post-run finish steps (homing and dropping tips)?
+            if self.get_is_stopped():
+                # Post-run finish steps have completed. Calculate the engine's final status,
+                # taking into account any failures in the run or the post-run finish steps.
+                if (
+                    self._state.run_result == RunResult.FAILED
+                    or self._state.finish_error is not None
+                ):
+                    return EngineStatus.FAILED
+                elif self._state.run_result == RunResult.SUCCEEDED:
+                    return EngineStatus.SUCCEEDED
+                else:
+                    return EngineStatus.STOPPED
+            else:
+                # Post-run finish steps have not yet completed,
+                # and we may even still be executing commands.
                 return (
                     EngineStatus.STOP_REQUESTED
                     if self._state.run_result == RunResult.STOPPED
                     else EngineStatus.FINISHING
                 )
-            elif self._state.run_result == RunResult.FAILED:
-                return EngineStatus.FAILED
-            elif self._state.run_result == RunResult.SUCCEEDED:
-                return EngineStatus.SUCCEEDED
-            else:
-                return EngineStatus.STOPPED
 
         elif self._state.queue_status == QueueStatus.RUNNING:
             return EngineStatus.RUNNING

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -99,13 +99,14 @@ class StateView(HasState[State]):
 
     def get_summary(self) -> StateSummary:
         """Get protocol run data."""
+        error = self._commands.get_error()
         return StateSummary.construct(
-            status=self.commands.get_status(),
-            errors=self._commands.get_all_errors(),
+            status=self._commands.get_status(),
+            errors=[] if error is None else [error],
             pipettes=self._pipettes.get_all(),
             labware=self._labware.get_all(),
             labwareOffsets=self._labware.get_labware_offsets(),
-            modules=self.modules.get_all(),
+            modules=self._modules.get_all(),
             completedAt=self._state.commands.run_completed_at,
             startedAt=self._state.commands.run_started_at,
             liquids=self._liquid.get_all(),

--- a/api/tests/opentrons/protocol_engine/execution/test_door_watcher.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_door_watcher.py
@@ -113,8 +113,8 @@ async def test_one_subscribe_one_unsubscribe(
 
     subject.start()
     subject.start()
-    subject.stop_soon()
-    subject.stop_soon()
+    subject.stop()
+    subject.stop()
 
     decoy.verify(unsubscribe(), times=1)
     decoy.verify(wrong_unsubscribe(), times=0)

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -43,7 +43,8 @@ def get_command_view(
     running_command_id: Optional[str] = None,
     queued_command_ids: Sequence[str] = (),
     queued_setup_command_ids: Sequence[str] = (),
-    errors_by_id: Optional[Dict[str, errors.ErrorOccurrence]] = None,
+    run_error: Optional[errors.ErrorOccurrence] = None,
+    finish_error: Optional[errors.ErrorOccurrence] = None,
     commands: Sequence[cmd.Command] = (),
     latest_command_hash: Optional[str] = None,
 ) -> CommandView:
@@ -62,7 +63,8 @@ def get_command_view(
         running_command_id=running_command_id,
         queued_command_ids=OrderedSet(queued_command_ids),
         queued_setup_command_ids=OrderedSet(queued_setup_command_ids),
-        errors_by_id=errors_by_id or {},
+        run_error=run_error,
+        finish_error=finish_error,
         all_command_ids=all_command_ids,
         commands_by_id=commands_by_id,
         run_started_at=run_started_at,
@@ -450,14 +452,14 @@ def test_validate_action_allowed(
 
 def test_get_errors() -> None:
     """It should be able to pull all ErrorOccurrences from the store."""
-    error_1 = errors.ErrorOccurrence(
+    run_error = errors.ErrorOccurrence(
         id="error-1",
         createdAt=datetime(year=2021, month=1, day=1),
         errorType="ReallyBadError",
         detail="things could not get worse",
         errorCode="4321",
     )
-    error_2 = errors.ErrorOccurrence(
+    finish_error = errors.ErrorOccurrence(
         id="error-2",
         createdAt=datetime(year=2022, month=2, day=2),
         errorType="EvenWorseError",
@@ -465,9 +467,21 @@ def test_get_errors() -> None:
         errorCode="1234",
     )
 
-    subject = get_command_view(errors_by_id={"error-1": error_1, "error-2": error_2})
+    no_error_subject = get_command_view()
+    assert no_error_subject.get_error() is None
 
-    assert subject.get_all_errors() == [error_1, error_2]
+    just_run_error_subject = get_command_view(run_error=run_error)
+    assert just_run_error_subject.get_error() == run_error
+
+    just_finish_error_subject = get_command_view(finish_error=finish_error)
+    assert just_finish_error_subject.get_error() == finish_error
+
+    both_errors_subject = get_command_view(
+        run_error=run_error, finish_error=finish_error
+    )
+    both_errors_result = both_errors_subject.get_error()
+    assert both_errors_result is not None
+    assert both_errors_result.wrappedErrors == [run_error, finish_error]
 
 
 class GetStatusSpec(NamedTuple):
@@ -512,6 +526,19 @@ get_status_specs: List[GetStatusSpec] = [
         subject=get_command_view(
             run_result=RunResult.FAILED,
             run_completed_at=datetime(year=2021, day=1, month=1),
+        ),
+        expected_status=EngineStatus.FAILED,
+    ),
+    GetStatusSpec(
+        subject=get_command_view(
+            run_result=RunResult.SUCCEEDED,
+            run_completed_at=datetime(year=2021, day=1, month=1),
+            finish_error=errors.ErrorOccurrence(
+                id="finish-error-id",
+                errorType="finish-error-type",
+                createdAt=datetime(year=2021, day=1, month=1),
+                detail="finish-error-detail",
+            ),
         ),
         expected_status=EngineStatus.FAILED,
     ),

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -2,7 +2,7 @@
 import pytest
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime
-from typing import Dict, List, NamedTuple, Optional, Sequence, Type, Union
+from typing import List, NamedTuple, Optional, Sequence, Type, Union
 
 from opentrons.ordered_set import OrderedSet
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -436,10 +436,10 @@ async def test_finish(
         await hardware_stopper.do_stop_and_recover(
             drop_tips_and_home=drop_tips_and_home
         ),
+        await plugin_starter.stop(),
         action_dispatcher.dispatch(
             HardwareStoppedAction(completed_at=completed_at, finish_error_details=None)
         ),
-        await plugin_starter.stop(),
     )
 
 
@@ -490,13 +490,13 @@ async def test_finish_with_error(
         await queue_worker.join(),
         door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
+        await plugin_starter.stop(),
         action_dispatcher.dispatch(
             HardwareStoppedAction(
                 completed_at=datetime(year=2022, month=2, day=2),
                 finish_error_details=None,
             )
         ),
-        await plugin_starter.stop(),
     )
 
 
@@ -538,13 +538,13 @@ async def test_finish_with_estop_error_will_not_drop_tip_and_home(
         await queue_worker.join(),
         door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=False),
+        await plugin_starter.stop(),
         action_dispatcher.dispatch(
             HardwareStoppedAction(
                 completed_at=datetime(year=2022, month=2, day=2),
                 finish_error_details=None,
             )
         ),
-        await plugin_starter.stop(),
     )
 
 
@@ -576,10 +576,10 @@ async def test_finish_stops_hardware_if_queue_worker_join_fails(
         # We can't verify that step in the sequence here because of a Decoy limitation.
         door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
+        await plugin_starter.stop(),
         action_dispatcher.dispatch(
             HardwareStoppedAction(completed_at=completed_at, finish_error_details=None)
         ),
-        await plugin_starter.stop(),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -553,7 +553,7 @@ async def test_finish_stops_hardware_if_queue_worker_join_fails(
         await subject.finish()
 
     decoy.verify(
-        door_watcher.stop_soon(),
+        door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
         action_dispatcher.dispatch(HardwareStoppedAction(completed_at=completed_at)),
         await plugin_starter.stop(),

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -434,7 +434,9 @@ async def test_finish(
         await hardware_stopper.do_stop_and_recover(
             drop_tips_and_home=drop_tips_and_home
         ),
-        action_dispatcher.dispatch(HardwareStoppedAction(completed_at=completed_at)),
+        action_dispatcher.dispatch(
+            HardwareStoppedAction(completed_at=completed_at, finish_error_details=None)
+        ),
         await plugin_starter.stop(),
     )
 
@@ -484,7 +486,10 @@ async def test_finish_with_error(
         await queue_worker.join(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
         action_dispatcher.dispatch(
-            HardwareStoppedAction(completed_at=datetime(year=2022, month=2, day=2))
+            HardwareStoppedAction(
+                completed_at=datetime(year=2022, month=2, day=2),
+                finish_error_details=None,
+            )
         ),
     )
 
@@ -525,7 +530,10 @@ async def test_finish_with_estop_error_will_not_drop_tip_and_home(
         await queue_worker.join(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=False),
         action_dispatcher.dispatch(
-            HardwareStoppedAction(completed_at=datetime(year=2022, month=2, day=2))
+            HardwareStoppedAction(
+                completed_at=datetime(year=2022, month=2, day=2),
+                finish_error_details=None,
+            )
         ),
     )
 
@@ -555,7 +563,9 @@ async def test_finish_stops_hardware_if_queue_worker_join_fails(
     decoy.verify(
         door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
-        action_dispatcher.dispatch(HardwareStoppedAction(completed_at=completed_at)),
+        action_dispatcher.dispatch(
+            HardwareStoppedAction(completed_at=completed_at, finish_error_details=None)
+        ),
         await plugin_starter.stop(),
     )
 


### PR DESCRIPTION
# Overview

When a run ends (either by completing or by erroring out), the robot homes and drops tips in the trash.

This fixes RSS-146, which is a bug where, if something went wrong during those post-run cleanup steps, the run would get stuck permanently in the "finishing" state.

# Changelog

If an error happens during the cleanup phase, treat it basically as if the error happened during the main part of the run. That means returning the error over HTTP in the top-level `errors` field, with our existing `ErrorOccurrence` model. And mark the run's final status as `failed`.

The spicy case is when the main part of the run fails, *and* the post-run cleanup phase fails. We want to propagate *both* errors. From discussions with @sfoster1, we should do this by returning a root `RunAndFinishFailed` error, with both of the real errors as its children:

```
                 RunAndFinishFailed
                /                  \
       Run error                    Finish error
           |                             |
 ...underlying errors...       ...underlying errors...
```

(See #13191 for why we want there to be a single node at the root.)

Here's a real example of what that looks like over HTTP:

<details>

```json
{
  "id": "59482a84-9c17-4bc2-bc3d-e53d73182603",
  "errorType": "RunAndFinishFailed",
  "createdAt": "2023-08-01T13:51:48.997575+00:00",
  "detail": "The run had a fatal error, and another error happened while doing post-run cleanup.",
  "errorCode": "4000",
  "errorInfo": {},
  "wrappedErrors": [
    {
      "id": "62f6b19f-21ae-496c-b1e0-103566969ad5",
      "errorType": "ExceptionInProtocolError",
      "createdAt": "2023-08-01T13:51:30.811210+00:00",
      "detail": "ZeroDivisionError [line 14]: Jesus Christ",
      "errorCode": "4000",
      "errorInfo": {},
      "wrappedErrors": [
        {
          "id": "62f6b19f-21ae-496c-b1e0-103566969ad5",
          "errorType": "PythonException",
          "createdAt": "2023-08-01T13:51:30.811210+00:00",
          "detail": "ZeroDivisionError: Jesus Christ",
          "errorCode": "4000",
          "errorInfo": {
            "args": "('Jesus Christ',)",
            "traceback": "  File \"/opt/opentrons-robot-server/opentrons/protocols/execution/execute_python.py\", line 61, in run_python\n    exec(\"run(__context)\", new_globs)\n\n  File \"<string>\", line 1, in <module>\n\n  File \"raise_after_picking_up.py\", line 14, in run\n",
            "class": "ZeroDivisionError"
          },
          "wrappedErrors": []
        }
      ]
    },
    {
      "id": "59482a84-9c17-4bc2-bc3d-e53d73182603",
      "errorType": "PythonException",
      "createdAt": "2023-08-01T13:51:48.997575+00:00",
      "detail": "opentrons.hardware_control.types.FailedTipStateCheck: Failed to correctly determine tip state for tip ABSENT received True but expected False",
      "errorCode": "4000",
      "errorInfo": {
        "args": "('Failed to correctly determine tip state for tip ABSENT received True but expected False',)",
        "traceback": "  File \"/opt/opentrons-robot-server/opentrons/protocol_engine/protocol_engine.py\", line 298, in finish\n    await exit_stack.aclose()\n\n  File \"/usr/lib/python3.8/contextlib.py\", line 621, in aclose\n    await self.__aexit__(None, None, None)\n\n  File \"/usr/lib/python3.8/contextlib.py\", line 679, in __aexit__\n    raise exc_details[1]\n\n  File \"/usr/lib/python3.8/contextlib.py\", line 662, in __aexit__\n    cb_suppress = await cb(*exc_details)\n\n  File \"/usr/lib/python3.8/contextlib.py\", line 557, in _exit_wrapper\n    await callback(*args, **kwds)\n\n  File \"/opt/opentrons-robot-server/opentrons/protocol_engine/execution/hardware_stopper.py\", line 101, in do_stop_and_recover\n    await self._drop_tip()\n\n  File \"/opt/opentrons-robot-server/opentrons/protocol_engine/execution/hardware_stopper.py\", line 80, in _drop_tip\n    await self._tip_handler.drop_tip(\n\n  File \"/opt/opentrons-robot-server/opentrons/protocol_engine/execution/tip_handler.py\", line 101, in drop_tip\n    await self._hardware_api.drop_tip(\n\n  File \"/opt/opentrons-robot-server/opentrons/hardware_control/thread_manager.py\", line 151, in wrapper\n    return await call_coroutine_threadsafe(loop, attr, *args, **kwargs)\n\n  File \"/opt/opentrons-robot-server/opentrons/hardware_control/thread_manager.py\", line 54, in call_coroutine_threadsafe\n    return await wrapped\n\n  File \"/opt/opentrons-robot-server/opentrons/hardware_control/ot3api.py\", line 1795, in drop_tip\n    await self._backend.get_tip_present(realmount, TipStateType.ABSENT)\n\n  File \"/opt/opentrons-robot-server/opentrons/hardware_control/backends/ot3controller.py\", line 770, in get_tip_present\n    raise FailedTipStateCheck(tip_state, res)\n",
        "class": "FailedTipStateCheck"
      },
      "wrappedErrors": []
    }
  ]
}
```

</details>

And a bonus: Fix an unrelated old concurrency hazard with `DoorWatcher`.

# Test Plan

* [x] Regression test: Induce an error during the main part of the run, and make sure it's still propagated. The run should show up as failed in the app, with some error details. Further error details should be available over HTTP.

  One way is to run a Python protocol that does `raise Exception()`.

* [x] New code test: Induce an error during the post-run finish steps (homing and dropping tips), and make sure it's propagated now just like errors in the main part of the run.

  One way to induce an error like this is to use your finger to press the pipette ejector up into the pipette body immediately after it homes and drops the tip in the trash. The hardware controller will raise an exception because it thinks it failed to eject the tip.

* [x] New code test: Induce an error during the main part of the run *and* the post-run finish steps, and make sure they're *both* propagated.

  I think it's a little up in the air how we want this to show up in the app. But over HTTP, at least, the details from both errors should be present.

  Here's how it currently shows up on the on-device display:

  ![IMG_6516](https://github.com/Opentrons/opentrons/assets/3236864/696e8601-3991-4b31-8158-9d6279b4ccfd)

# Review requests

* I would love opinions on naming. I inconsistently see this called the "finishing steps," "recovery steps," "cleanup steps," etc.
* Do the fixes to `DoorWatcher` make sense?

# Risk assessment

Low. The way we calculate the run state ("failed," "succeeded", etc.) is kind of complicated, but I'm satisfied with the testing.

We could cut the `DoorWatcher` fix out of this if we want to minimize the diff.