### PR TITLE
feat(shared-data): aluminum block split adapter definition

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -7,7 +7,8 @@ from opentrons.protocol_engine.state.labware import LabwareLoadParams
 # Default versions of Opentrons standard labware definitions in Python Protocol API
 # v2.14 and above. Labware not explicitly listed here default to 1.
 #
-# This will need to be extended t
+# TODO(jbl 2023-08-01) this needs to be done more holistically, both to find the version and make sure that
+#   it corresponds to the API level is was released with
 _APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
     # v1 of many labware definitions have wrong `zDimension`s. (Jira RSS-202.)
     # For "opentrons_96_aluminumblock_generic_pcr_strip_200ul" and
@@ -22,6 +23,8 @@ _APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
     "nest_96_wellplate_100ul_pcr_full_skirt": 2,
     "nest_96_wellplate_200ul_flat": 2,
     "nest_96_wellplate_2ml_deep": 2,
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": 2,
+    "biorad_96_wellplate_200ul_pcr": 2,
 }
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
@@ -80,6 +80,8 @@ def test_resolve_load_labware_params(
         "nest_96_wellplate_100ul_pcr_full_skirt",
         "nest_96_wellplate_200ul_flat",
         "nest_96_wellplate_2ml_deep",
+        "opentrons_96_wellplate_200ul_pcr_full_skirt",
+        "biorad_96_wellplate_200ul_pcr",
     ],
 )
 @pytest.mark.parametrize("namespace", [OPENTRONS_NAMESPACE, None])

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -2369,7 +2369,8 @@
       "schemaVersion": 2,
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 },
       "stackingOffsetWithLabware": {
-        "opentrons_96_pcr_adapter": { "x": 0, "y": 0, "z": 10.2 }
+        "opentrons_96_pcr_adapter": { "x": 0, "y": 0, "z": 10.2 },
+        "opentrons_96_well_aluminum_block": { "x": 0, "y": 0, "z": 12.66 }
       }
     },
     "opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1": {

--- a/robot-server/tests/integration/http_api/runs/test_lpc_loads_do_not_cause_conflicts_in_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_lpc_loads_do_not_cause_conflicts_in_run.tavern.yaml
@@ -129,7 +129,7 @@ stages:
                 slotName: '1'
               loadName: biorad_96_wellplate_200ul_pcr
               namespace: opentrons
-              version: 1
+              version: 2
           - id: !anystr
             key: !anystr
             commandType: loadModule

--- a/shared-data/labware/definitions/2/biorad_96_wellplate_200ul_pcr/2.json
+++ b/shared-data/labware/definitions/2/biorad_96_wellplate_200ul_pcr/2.json
@@ -1,0 +1,1027 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "schemaVersion": 2,
+  "version": 2,
+  "namespace": "opentrons",
+  "metadata": {
+    "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
+    "displayCategory": "wellPlate",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "yDimension": 85.48,
+    "xDimension": 127.76,
+    "zDimension": 16.06
+  },
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": false,
+    "loadName": "biorad_96_wellplate_200ul_pcr",
+    "isMagneticModuleCompatible": true,
+    "magneticModuleEngageHeight": 18
+  },
+  "wells": {
+    "H1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 74.24,
+      "z": 1.25
+    }
+  },
+  "brand": {
+    "brand": "Bio-Rad",
+    "brandId": ["hsp9601"],
+    "links": [
+      "http://www.bio-rad.com/en-us/sku/hsp9601-hard-shell-96-well-pcr-plates-low-profile-thin-wall-skirted-white-clear?ID=hsp9601"
+    ]
+  },
+  "groups": [
+    {
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ],
+      "metadata": {
+        "wellBottomShape": "v"
+      }
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "stackingOffsetWithLabware": {
+    "opentrons_96_well_aluminum_block": {
+      "x": 0,
+      "y": 0,
+      "z": 15.41
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/opentrons_96_well_aluminum_block/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_well_aluminum_block/1.json
@@ -14,885 +14,884 @@
     ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
   ],
   "brand": {
-    "brand": "NEST",
-    "brandId": ["402501"],
-    "links": ["https://www.nest-biotech.com/pcr-plates/58773587.html"]
+    "brand": "Opentrons",
+    "brandId": []
   },
   "metadata": {
-    "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
-    "displayCategory": "wellPlate",
-    "displayVolumeUnits": "µL",
+    "displayName": "Opentrons 96 Well Aluminum Block",
+    "displayCategory": "adapter",
+    "displayVolumeUnits": "\u00b5L",
     "tags": []
   },
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 15.7
+    "zDimension": 18.16
   },
   "wells": {
     "A1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H1": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 14.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H2": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 23.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H3": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 32.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H4": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 41.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H5": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 50.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H6": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 59.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H7": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 68.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H8": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 77.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H9": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 86.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H10": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 95.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H11": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 104.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     },
     "A12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 74.24,
-      "z": 0.92
+      "z": 3.38
     },
     "B12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 65.24,
-      "z": 0.92
+      "z": 3.38
     },
     "C12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 56.24,
-      "z": 0.92
+      "z": 3.38
     },
     "D12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 47.24,
-      "z": 0.92
+      "z": 3.38
     },
     "E12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 38.24,
-      "z": 0.92
+      "z": 3.38
     },
     "F12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 29.24,
-      "z": 0.92
+      "z": 3.38
     },
     "G12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 20.24,
-      "z": 0.92
+      "z": 3.38
     },
     "H12": {
       "depth": 14.78,
       "shape": "circular",
       "diameter": 5.34,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 0,
       "x": 113.38,
       "y": 11.24,
-      "z": 0.92
+      "z": 3.38
     }
   },
   "groups": [
@@ -1002,29 +1001,18 @@
   ],
   "parameters": {
     "format": "96Standard",
+    "quirks": [],
     "isTiprack": false,
-    "isMagneticModuleCompatible": true,
-    "magneticModuleEngageHeight": 20,
-    "loadName": "nest_96_wellplate_100ul_pcr_full_skirt"
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_96_well_aluminum_block"
   },
   "namespace": "opentrons",
-  "version": 2,
+  "version": 1,
   "schemaVersion": 2,
+  "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
     "z": 0
-  },
-  "stackingOffsetWithLabware": {
-    "opentrons_96_pcr_adapter": {
-      "x": 0,
-      "y": 0,
-      "z": 10.2
-    },
-    "opentrons_96_well_aluminum_block": {
-      "x": 0,
-      "y": 0,
-      "z": 12.66
-    }
   }
 }


### PR DESCRIPTION
# Overview

This PR adds the `Opentrons 96 Well Aluminum Block` adapter definition to shared data, in addition to adding stacking overlaps for the `Bio-Rad 96 Well Plate 200 µL PCR` and the `NEST 96 Well Plate 100 µL PCR Full Skirt`, allowing both of those to be loaded on top of the aluminum block.

# Test Plan

Loading the compatible plates onto the aluminum block was tested with Postman, to check the command responses and ensure that when a pipette was moved to a well, the resulting `Point` it moved to was identical to moving to the joint definitions loaded onto the same deck slot with the same pipette.

# Changelog

- Added `Opentrons 96 Well Aluminum Block` adapter definition
- Added adapter to `stackingOffsetWithLabware` for `Bio-Rad 96 Well Plate 200 µL PCR` and the `NEST 96 Well Plate 100 µL PCR Full Skirt`
- Updated load labware logic so `biorad_96_wellplate_200ul_pcr` and `opentrons_96_wellplate_200ul_pcr_full_skirt` automatically load version 2 of the labware if no version is explicitly provided.

# Review requests

Just a general check that the name is good and that theirs nothing out of place in the new definition.

# Risk assessment

Low, just adding a new definition. The only API changes are automatically loading `2.json` for the new biorad definition, and fixing not loading the version 2 of `opentrons_96_wellplate_200ul_pcr_full_skirt`. In the future a more holistic way of loading these will be added, hence the TODO statement also included.