### PR TITLE
feat(hardware-testing): Adds first line to CSV reports helping operators copy data

### DIFF
--- a/hardware-testing/hardware_testing/data/csv_report.py
+++ b/hardware-testing/hardware_testing/data/csv_report.py
@@ -92,6 +92,11 @@ class CSVLine:
         """Line stored."""
         return self._stored
 
+    @property
+    def num_data_points(self) -> int:
+        """Get the number of data points saved in this line."""
+        return len(self._data_types)
+
     def cache_start_time(self, start_time: float) -> None:
         """Line cache start time."""
         self._start_time = start_time
@@ -349,7 +354,17 @@ class CSVReport:
 
     def __str__(self) -> str:
         """CSV Report string."""
-        return "\n".join([str(s) for s in self._sections])
+        max_cols = max(
+            [
+                line.num_data_points
+                for section in self._sections
+                for line in section.lines
+            ]
+        )
+        max_cols += 2  # all lines are prepended with the timestamp and tag
+        # the first line in the CSV should be populated with "copy"
+        first_line = ",".join(["copy"] * max_cols)
+        return f"{first_line}\n" + "\n".join([str(s) for s in self._sections])
 
     @property
     def completed(self) -> bool:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

As requested by SZ team, the first line in all of our CSV reports should include a single row with the word `copy` populating each column of the CSV where data is present. This will help operators know how many columns they should be copy/pasting into our templates.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
