### PR TITLE
refactor(app): do not show firmware update modal if maintenance run in progress

### DIFF
--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -24,7 +24,7 @@ export function FirmwareUpdateTakeover(): JSX.Element {
     if (subsystemUpdateInstrument != null && maintenanceRunData == null) {
       setShowUpdateNeededModal(true)
     }
-  }, [subsystemUpdateInstrument])
+  }, [subsystemUpdateInstrument, maintenanceRunData])
 
   return (
     <>


### PR DESCRIPTION
# Overview

The useEffect that triggers showing the update modal on the ODD didn't take in the current maintenance run query as a dependency. This PR just adds the maintenance run query's data to the dependency list


# Risk assessment

Low