### PR TITLE
feat(shared-data): add a current scale for partial tip configurations

### DIFF
--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -174,6 +174,11 @@ class PartialTipDefinition(BaseModel):
         description="A list of the types of partial tip configurations supported, listed by channel ints",
         alias="availableConfigurations",
     )
+    current_scale: float = Field(
+        default=0.5,
+        description="A current scale for pick up tip in a parital tip configuration",
+        alias="currentScale",
+    )
 
 
 class PipettePhysicalPropertiesDefinition(BaseModel):

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -174,10 +174,10 @@ class PartialTipDefinition(BaseModel):
         description="A list of the types of partial tip configurations supported, listed by channel ints",
         alias="availableConfigurations",
     )
-    current_scale: float = Field(
+    per_tip_pickup_current: float = Field(
         default=0.5,
-        description="A current scale for pick up tip in a parital tip configuration",
-        alias="currentScale",
+        description="A current scale for pick up tip in a partial tip configuration",
+        alias="perTipPickupCurrent",
     )
 
 


### PR DESCRIPTION
## Overview

Once we have concrete data for a current scale on different pipette models, we can add those values to the configuration file. For now, we can load everything in with a default value.

RLIQ-423

# Risk assessment

None. Un-used parameter right now.
