### PR TITLE
fix(api, hardware): Only monitor overpressure if plunger axis is actually moving

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -44,6 +44,7 @@ from .ot3utils import (
     motor_nodes,
     LIMIT_SWITCH_OVERTRAVEL_DISTANCE,
     map_pipette_type_to_sensor_id,
+    moving_axes_in_move_group,
 )
 
 try:
@@ -485,8 +486,7 @@ class OT3Controller:
         )
         mounts_moving = [
             k
-            for g in move_group
-            for k in g.keys()
+            for k in moving_axes_in_move_group(move_group)
             if k in [NodeId.pipette_left, NodeId.pipette_right]
         ]
         async with self._monitor_overpressure(mounts_moving):

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -464,6 +464,16 @@ def create_gripper_jaw_hold_group(encoder_position_um: int) -> MoveGroup:
     return move_group
 
 
+def moving_axes_in_move_group(group: MoveGroup) -> Set[NodeId]:
+    """Utility function to get only the moving nodes in a move group."""
+    ret: Set[NodeId] = set()
+    for step in group:
+        for node, node_step in step.items():
+            if node_step.is_moving_step():
+                ret.add(node)
+    return ret
+
+
 AxisMapPayload = TypeVar("AxisMapPayload")
 
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -1,4 +1,7 @@
 from opentrons_hardware.hardware_control.motion_planning import Move
+from opentrons_hardware.hardware_control.motion import (
+    create_step,
+)
 from opentrons.hardware_control.backends import ot3utils
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons.hardware_control.types import Axis
@@ -30,6 +33,31 @@ def test_create_step() -> None:
     assert len(move_group) == 3
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
+
+
+def test_get_moving_nodes() -> None:
+    """Test that we can filter out the nonmoving nodes."""
+    # Create a dummy group where X has velocity but no accel, and Y has accel but no velocity.
+    present_nodes = [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l, NodeId.head_r]
+    move_group = [
+        create_step(
+            distance={NodeId.gantry_x: f64(100), NodeId.gantry_y: f64(100)},
+            velocity={NodeId.gantry_x: f64(100), NodeId.gantry_y: f64(0)},
+            acceleration={NodeId.gantry_x: f64(0), NodeId.gantry_y: f64(100)},
+            duration=f64(1),
+            present_nodes=present_nodes,
+        )
+    ]
+    assert len(move_group[0]) == 4
+
+    print(move_group)
+
+    moving_nodes = ot3utils.moving_axes_in_move_group(move_group)
+    assert len(moving_nodes) == 2
+    assert NodeId.gantry_x in moving_nodes
+    assert NodeId.gantry_y in moving_nodes
+    assert NodeId.head_l not in moving_nodes
+    assert NodeId.head_r not in moving_nodes
 
 
 def test_filter_zero_duration_step() -> None:

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -52,7 +52,11 @@ class MoveGroupSingleAxisStep:
     move_type: MoveType = MoveType.linear
 
     def is_moving_step(self) -> bool:
-        return self.velocity_mm_sec != np.float64(0) or self.acceleration_mm_sec_sq != np.float64(0)
+        """Check if this step involves any actual movement."""
+        return bool(
+            self.velocity_mm_sec != np.float64(0)
+            or self.acceleration_mm_sec_sq != np.float64(0)
+        )
 
 
 @dataclass(frozen=True)
@@ -66,7 +70,11 @@ class MoveGroupTipActionStep:
     acceleration_mm_sec_sq: np.float64
 
     def is_moving_step(self) -> bool:
-        return self.velocity_mm_sec != np.float64(0) or self.acceleration_mm_sec_sq != np.float64(0)
+        """Check if this step involves any actual movement."""
+        return bool(
+            self.velocity_mm_sec != np.float64(0)
+            or self.acceleration_mm_sec_sq != np.float64(0)
+        )
 
 
 @dataclass(frozen=True)
@@ -82,7 +90,11 @@ class MoveGroupSingleGripperStep:
     move_type: MoveType = MoveType.grip
 
     def is_moving_step(self) -> bool:
-        return self.pwm_duty_cycle != np.float32(0) or self.encoder_position_um != np.int32(0)
+        """Check if this step involves any actual movement."""
+        return bool(
+            self.pwm_duty_cycle != np.float32(0)
+            or self.encoder_position_um != np.int32(0)
+        )
 
 
 SingleMoveStep = Union[

--- a/hardware/opentrons_hardware/hardware_control/motion.py
+++ b/hardware/opentrons_hardware/hardware_control/motion.py
@@ -51,6 +51,9 @@ class MoveGroupSingleAxisStep:
     stop_condition: MoveStopCondition = MoveStopCondition.none
     move_type: MoveType = MoveType.linear
 
+    def is_moving_step(self) -> bool:
+        return self.velocity_mm_sec != np.float64(0) or self.acceleration_mm_sec_sq != np.float64(0)
+
 
 @dataclass(frozen=True)
 class MoveGroupTipActionStep:
@@ -61,6 +64,9 @@ class MoveGroupTipActionStep:
     action: PipetteTipActionType
     stop_condition: MoveStopCondition
     acceleration_mm_sec_sq: np.float64
+
+    def is_moving_step(self) -> bool:
+        return self.velocity_mm_sec != np.float64(0) or self.acceleration_mm_sec_sq != np.float64(0)
 
 
 @dataclass(frozen=True)
@@ -74,6 +80,9 @@ class MoveGroupSingleGripperStep:
     stay_engaged: bool = False
     stop_condition: MoveStopCondition = MoveStopCondition.gripper_force
     move_type: MoveType = MoveType.grip
+
+    def is_moving_step(self) -> bool:
+        return self.pwm_duty_cycle != np.float32(0) or self.encoder_position_um != np.int32(0)
 
 
 SingleMoveStep = Union[


### PR DESCRIPTION


# Overview

The OT3Controller is configured monitor overpressure on a pipette if it's in a move group's set of nodes. Unfortunately, because the move group generator creates zero-velocity move groups for present nodes that are not moving in a group, the controller would monitor overpressure on every call to `move` when pipettes are attached to the system.

This posed a problem in some internal testing cases where the pipettes would mash tips against a plate and throw an overpressure error. Once the gantry tries to home the Z axes, it fails yet again due to an overpressure even though it should be ignored.

This PR adds filtering to be able to discern whether a node in a move group is actually moving, and we only monitor overpressure if the plunger is actually moving.

The OT3Controller home function didn't need any changes because it already filters based on the axes passed in directly.

# Test Plan

Compared homing with two pipettes attached, with the gantry in the middle of the deck and encoders valid so the API would call `move` to get the axes near the home switches.

Before this change, there were `bind_sensor_output_request` messages when the X and Y axes were commanded to move to the "safe-home" position. After this PR, the `bind_sensor_output_request` messages only occur when homing the plunger axes.


# Changelog

- Add member function to check if a move group step is nonmoving
- Add function to get all moving nodes in a move group
- When setting up overpressure monitoring, only monitor based on _moving_ nodes


# Review requests


# Risk assessment


