### PR TITLE
fix(app): generify update robot message

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/InstallModalContents.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/InstallModalContents.tsx
@@ -52,7 +52,7 @@ export function InstallModalContents(
     title = `Robot ${
       robotSystemType === 'balena' ? 'system ' : ''
     } update in progress…`
-    restartMessage = 'Your OT-2 will restart once the update is complete.'
+    restartMessage = 'Your robot will restart once the update is complete.'
   }
 
   if (


### PR DESCRIPTION
# Overview
When updating a flex via the desktop app we still show "OT-2" as the robot name. This PR uses "robot" instead to make it generic.
# Risk assessment
Low