### PR TITLE
feat(api): Alias `del deck[...]` to `moveLabware(..., OFF_DECK)`

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -256,17 +256,20 @@ class ProtocolCore(
             DeckSlotName, LabwareCore, ModuleCore, NonConnectedModuleCore, OffDeckType
         ],
         use_gripper: bool,
+        pause_for_manual_move: bool,
         pick_up_offset: Optional[Tuple[float, float, float]],
         drop_offset: Optional[Tuple[float, float, float]],
     ) -> None:
         """Move the given labware to a new location."""
         to_location = self._convert_labware_location(location=new_location)
 
-        strategy = (
-            LabwareMovementStrategy.USING_GRIPPER
-            if use_gripper
-            else LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE
-        )
+        if use_gripper:
+            strategy = LabwareMovementStrategy.USING_GRIPPER
+        elif pause_for_manual_move:
+            strategy = LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE
+        else:
+            strategy = LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE
+
         _pick_up_offset = (
             LabwareOffsetVector(
                 x=pick_up_offset[0], y=pick_up_offset[1], z=pick_up_offset[2]

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -254,6 +254,7 @@ class LegacyProtocolCore(
             OffDeckType,
         ],
         use_gripper: bool,
+        pause_for_manual_move: bool,
         pick_up_offset: Optional[Tuple[float, float, float]],
         drop_offset: Optional[Tuple[float, float, float]],
     ) -> None:

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -36,6 +36,7 @@ class AbstractModuleCore(ABC):
     def get_deck_slot_id(self) -> str:
         """Get the module's deck slot in a robot accurate format."""
 
+    @abstractmethod
     def get_display_name(self) -> str:
         """Get the module's display name."""
 

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -86,6 +86,7 @@ class AbstractProtocol(
         labware_core: LabwareCoreType,
         new_location: Union[DeckSlotName, LabwareCoreType, ModuleCoreType, OffDeckType],
         use_gripper: bool,
+        pause_for_manual_move: bool,
         pick_up_offset: Optional[Tuple[float, float, float]],
         drop_offset: Optional[Tuple[float, float, float]],
     ) -> None:

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -113,6 +113,7 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
         if item_core is None:
             raise TypeError(f"Slot {repr(key)} doesn't contain anything to delete.")
         elif isinstance(item_core, AbstractModuleCore):
+            # Protocol Engine does not support removing modules from the deck.
             raise TypeError(
                 f"Slot {repr(key)} contains a module, {item_core.get_display_name()}."
                 f" You can only delete labware, not modules."
@@ -122,6 +123,7 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
                 item_core,
                 new_location=OFF_DECK,
                 use_gripper=False,
+                pause_for_manual_move=False,
                 pick_up_offset=None,
                 drop_offset=None,
             )

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -597,6 +597,7 @@ class ProtocolContext(CommandPublisher):
             labware_core=labware._core,
             new_location=location,
             use_gripper=use_gripper,
+            pause_for_manual_move=True,
             pick_up_offset=_pick_up_offset,
             drop_offset=_drop_offset,
         )

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -546,10 +546,12 @@ def test_load_adapter(
 
 
 @pytest.mark.parametrize(
-    argnames=["use_gripper", "expected_strategy"],
+    argnames=["use_gripper", "pause_for_manual_move", "expected_strategy"],
     argvalues=[
-        (True, LabwareMovementStrategy.USING_GRIPPER),
-        (False, LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE),
+        (True, False, LabwareMovementStrategy.USING_GRIPPER),
+        (True, True, LabwareMovementStrategy.USING_GRIPPER),
+        (False, False, LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE),
+        (False, True, LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE),
     ],
 )
 @pytest.mark.parametrize(
@@ -566,6 +568,7 @@ def test_move_labware(
     mock_engine_client: EngineClient,
     expected_strategy: LabwareMovementStrategy,
     use_gripper: bool,
+    pause_for_manual_move: bool,
     pick_up_offset: Optional[Tuple[float, float, float]],
     drop_offset: Optional[Tuple[float, float, float]],
 ) -> None:
@@ -580,6 +583,7 @@ def test_move_labware(
         labware_core=labware,
         new_location=DeckSlotName.SLOT_5,
         use_gripper=use_gripper,
+        pause_for_manual_move=pause_for_manual_move,
         pick_up_offset=pick_up_offset,
         drop_offset=drop_offset,
     )
@@ -618,6 +622,7 @@ def test_move_labware_on_non_connected_module(
         labware_core=labware,
         new_location=non_connected_module_core,
         use_gripper=False,
+        pause_for_manual_move=True,
         pick_up_offset=None,
         drop_offset=None,
     )
@@ -650,6 +655,7 @@ def test_move_labware_off_deck(
         labware_core=labware,
         new_location=OFF_DECK,
         use_gripper=False,
+        pause_for_manual_move=True,
         pick_up_offset=None,
         drop_offset=None,
     )

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -173,31 +173,28 @@ def test_delitem_aliases_to_move_labware(
 
 
 @pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
-def test_delitem_raises_on_old_api_version(
+def test_delitem_raises_on_api_2_14(
     subject: Deck,
 ) -> None:
+    """It should raise on apiLevel 2.14."""
     with pytest.raises(APIVersionError):
         del subject[1]
 
 
-def test_delitem_raises_if_slot_is_empty(
+def test_delitem_noops_if_slot_is_empty(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     api_version: APIVersion,
     subject: Deck,
 ) -> None:
-    """It should raise a descriptive error if you try to delete from an empty slot."""
+    """It should do nothing, and not raise anything, if you try to delete from an empty slot."""
     decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
         mock_validation.ensure_and_convert_deck_slot(1, api_version, "OT-3 Standard")
     ).then_return(DeckSlotName.SLOT_1)
     decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_1)).then_return(None)
 
-    with pytest.raises(
-        TypeError,
-        match=("Slot 1 doesn't contain anything to delete."),
-    ):
-        del subject[1]
+    del subject[1]
 
 
 def test_delitem_raises_if_slot_has_module(

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -147,6 +147,7 @@ def test_delitem_aliases_to_move_labware(
     api_version: APIVersion,
     subject: Deck,
 ) -> None:
+    """It should be equivalent to a manual labware move to off-deck, without pausing."""
     mock_labware_core = decoy.mock(cls=LabwareCore)
 
     decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
@@ -164,6 +165,7 @@ def test_delitem_aliases_to_move_labware(
             mock_labware_core,
             OFF_DECK,
             use_gripper=False,
+            pause_for_manual_move=False,
             pick_up_offset=None,
             drop_offset=None,
         )
@@ -184,6 +186,7 @@ def test_delitem_raises_if_slot_is_empty(
     api_version: APIVersion,
     subject: Deck,
 ) -> None:
+    """It should raise a descriptive error if you try to delete from an empty slot."""
     decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
         mock_validation.ensure_and_convert_deck_slot(1, api_version, "OT-3 Standard")
@@ -203,6 +206,7 @@ def test_delitem_raises_if_slot_has_module(
     api_version: APIVersion,
     subject: Deck,
 ) -> None:
+    """It should raise a descriptive error if you try to delete a module."""
     decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
     mock_module_core = decoy.mock(cls=ModuleCore)
     decoy.when(mock_module_core.get_display_name()).then_return("<module display name>")

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -9,9 +9,15 @@ from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 
 from opentrons.motion_planning import adjacent_slots_getters as mock_adjacent_slots
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocol_api.core.common import ProtocolCore, LabwareCore
+from opentrons.protocols.api_support.util import APIVersionError
+from opentrons.protocol_api.core.common import ProtocolCore, LabwareCore, ModuleCore
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
-from opentrons.protocol_api import Deck, Labware, validation as mock_validation
+from opentrons.protocol_api import (
+    Deck,
+    Labware,
+    OFF_DECK,
+    validation as mock_validation,
+)
 from opentrons.protocol_api.deck import CalibrationPosition
 from opentrons.types import DeckSlotName, Point
 
@@ -133,6 +139,88 @@ def test_get_slot_item(
     decoy.when(mock_core_map.get(mock_labware_core)).then_return(mock_labware)
 
     assert subject[42] is mock_labware
+
+
+def test_delitem_aliases_to_move_labware(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    api_version: APIVersion,
+    subject: Deck,
+) -> None:
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_2)
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_2)).then_return(
+        mock_labware_core
+    )
+
+    del subject[42]
+
+    decoy.verify(
+        mock_protocol_core.move_labware(
+            mock_labware_core,
+            OFF_DECK,
+            use_gripper=False,
+            pick_up_offset=None,
+            drop_offset=None,
+        )
+    )
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 14)])
+def test_delitem_raises_on_old_api_version(
+    subject: Deck,
+) -> None:
+    with pytest.raises(APIVersionError):
+        del subject[1]
+
+
+def test_delitem_raises_if_slot_is_empty(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    api_version: APIVersion,
+    subject: Deck,
+) -> None:
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(1, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_1)
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_1)).then_return(None)
+
+    with pytest.raises(
+        TypeError,
+        match=("Slot 1 doesn't contain anything to delete."),
+    ):
+        del subject[1]
+
+
+def test_delitem_raises_if_slot_has_module(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    api_version: APIVersion,
+    subject: Deck,
+) -> None:
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    mock_module_core = decoy.mock(cls=ModuleCore)
+    decoy.when(mock_module_core.get_display_name()).then_return("<module display name>")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(2, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_2)
+    decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_2)).then_return(
+        mock_module_core
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Slot 2 contains a module, <module display name>."
+            " You can only delete labware, not modules."
+        ),
+    ):
+        del subject[2]
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -517,6 +517,7 @@ def test_move_labware_to_slot(
             labware_core=mock_labware_core,
             new_location=DeckSlotName.SLOT_1,
             use_gripper=False,
+            pause_for_manual_move=True,
             pick_up_offset=None,
             drop_offset=(1, 2, 3),
         )
@@ -556,6 +557,7 @@ def test_move_labware_to_module(
             labware_core=mock_labware_core,
             new_location=mock_module_core,
             use_gripper=False,
+            pause_for_manual_move=True,
             pick_up_offset=None,
             drop_offset=None,
         )
@@ -586,6 +588,7 @@ def test_move_labware_off_deck(
             labware_core=mock_labware_core,
             new_location=OFF_DECK,
             use_gripper=False,
+            pause_for_manual_move=True,
             pick_up_offset=None,
             drop_offset=None,
         )


### PR DESCRIPTION
# Overview

Closes RSS-269.

# Changelog

* `del protocol.deck[...]` is now equivalent to `protocol.move_labware(..., OFF_DECK)`. So, for labware, `del protocol.deck[...]` should now work the way it did before PAPIv2.14.
* Deleting *modules* in PAPIv>=2.14 remains unsupported. This is a Protocol Engine limitation. This now raises a descriptive error.
* Trying to use `del` in PAPIv2.14 will now raise an actionable `APIVersionError` error instead of `TypeError: 'Deck' object doesn't support item deletion`.

# Test Plan

Unit tests are probably sufficient. But we can try running this on a robot and make sure it behaves sensibly. It should *not* pause the run or prompt the user to do anything.

```python
requirements = {"apiLevel": "2.15", "robotType": "Flex"}


def run(protocol):
    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
    pipette = protocol.load_instrument(
        "flex_1channel_1000", "left", tip_racks=[tip_rack]
    )

    labware_1 = protocol.load_labware("agilent_1_reservoir_290ml", "D2")

    pipette.pick_up_tip()

    pipette.aspirate(200, labware_1["A1"].top())

    del protocol.deck["D2"]

    labware_2 = protocol.load_labware(
        "armadillo_96_wellplate_200ul_pcr_full_skirt", "D2"
    )
    pipette.dispense(200, labware_2["A1"].top())

    pipette.return_tip()

```

# Review requests

There's now a weird API asymmetry where `protocol.move_labware()` can only do manual moves *with* a pause, whereas `del protocol.deck[...]` can only do manual moves *without* a pause. Does `protocol.move_labware()` need to support manual moves *without* a pause?

Does [the `Deck` documentation](https://docs.opentrons.com/v2/new_protocol_api.html?highlight=deck#opentrons.protocol_api.ProtocolContext.deck) need to be updated to explain all these nuances of what's supported in what versions? @ecormany @jwwojak 

# Risk assessment

Low.
