### PR TITLE
fix(app): change desktop network icon priority

### DIFF
--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -109,12 +109,12 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
 
   let iconName: IconName | null = null
   let tooltipTranslationKey = null
-  if (isOT3ConnectedViaWifi) {
-    iconName = 'wifi'
-    tooltipTranslationKey = 'device_settings:wifi'
-  } else if (isOT3ConnectedViaEthernet) {
+  if (isOT3ConnectedViaEthernet) {
     iconName = 'ethernet'
     tooltipTranslationKey = 'device_settings:ethernet'
+  } else if (isOT3ConnectedViaWifi) {
+    iconName = 'wifi'
+    tooltipTranslationKey = 'device_settings:wifi'
   } else if ((local != null && local) || isOT3ConnectedViaUSB) {
     iconName = 'usb'
     tooltipTranslationKey = 'device_settings:wired_usb'

--- a/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
@@ -177,7 +177,7 @@ describe('RobotStatusHeader', () => {
     )
   })
 
-  it('renders a wifi icon when connected by wifi and ethernet', () => {
+  it('renders an ethernet icon when connected by wifi and ethernet', () => {
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, 'otie')
       .mockReturnValue({
@@ -187,20 +187,20 @@ describe('RobotStatusHeader', () => {
 
     const [{ getByLabelText }] = render(props)
 
-    getByLabelText('wifi')
+    getByLabelText('ethernet')
   })
 
-  it('renders an ethernet icon when only connected by ethernet', () => {
+  it('renders a wifi icon when only connected by wifi', () => {
     when(mockGetNetworkInterfaces)
       .calledWith({} as State, 'otie')
       .mockReturnValue({
-        wifi: null,
-        ethernet: { ipAddress: ETHERNET_IP } as SimpleInterfaceStatus,
+        wifi: { ipAddress: WIFI_IP } as SimpleInterfaceStatus,
+        ethernet: null,
       })
 
     const [{ getByLabelText }] = render(props)
 
-    getByLabelText('ethernet')
+    getByLabelText('wifi')
   })
 
   it('renders a usb icon when only connected locally', () => {


### PR DESCRIPTION
# Overview

changes the desktop network icon priority to ethernet > wifi > usb

closes RQA-1204

# Test Plan

 - updated unit tests
 - manually verified desktop/ODD icon match

# Changelog

 - Changes desktop network icon priority

# Review requests



# Risk assessment

low
