### PR TITLE
refactor(api): Remove some opentrons.protocols type-checking exceptions

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -14,31 +14,14 @@ warn_untyped_fields = True
 
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
-
-# ~157 errors
-[mypy-opentrons.protocols.*]
+# ~125 errors
+[mypy-opentrons.protocols.advanced_control.*,opentrons.protocols.api_support.*,opentrons.protocols.duration.*,opentrons.protocols.execution.*,opentrons.protocols.geometry.*,opentrons.protocols.models.*,opentrons.protocols.bundle.*,opentrons.protocols.labware.*]
 disallow_any_generics = False
 disallow_untyped_defs = False
 disallow_untyped_calls = False
 disallow_incomplete_defs = False
 no_implicit_optional = False
 warn_return_any = False
-
-[mypy-opentrons.protocols.parse]
-disallow_any_generics = True
-disallow_untyped_defs = True
-disallow_untyped_calls = True
-disallow_incomplete_defs = True
-no_implicit_optional = True
-warn_return_any = True
-
-[mypy-opentrons.protocols.types]
-disallow_any_generics = True
-disallow_untyped_defs = True
-disallow_untyped_calls = True
-disallow_incomplete_defs = True
-no_implicit_optional = True
-warn_return_any = True
 
 # ~30 errors
 [mypy-tests.opentrons.drivers.*]

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -34,10 +34,6 @@ disallow_untyped_defs = False
 disallow_untyped_calls = False
 disallow_incomplete_defs = False
 
-[mypy-tests.opentrons.protocols.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 # ~10 errors
 [mypy-tests.opentrons.system.*]
 disallow_untyped_defs = False

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -15,7 +15,7 @@ warn_untyped_fields = True
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
 # ~125 errors
-[mypy-opentrons.protocols.advanced_control.*,opentrons.protocols.api_support.*,opentrons.protocols.duration.*,opentrons.protocols.execution.*,opentrons.protocols.geometry.*,opentrons.protocols.models.*,opentrons.protocols.bundle.*,opentrons.protocols.labware.*]
+[mypy-opentrons.protocols.advanced_control.*,opentrons.protocols.api_support.*,opentrons.protocols.duration.*,opentrons.protocols.execution.*,opentrons.protocols.geometry.*,opentrons.protocols.models.*,opentrons.protocols.labware.*]
 disallow_any_generics = False
 disallow_untyped_defs = False
 disallow_untyped_calls = False

--- a/api/src/opentrons/protocols/bundle.py
+++ b/api/src/opentrons/protocols/bundle.py
@@ -19,7 +19,7 @@ LABWARE_DIR = "labware"
 DATA_DIR = "data"
 
 
-def _has_files_at_root(zipFile):
+def _has_files_at_root(zipFile: ZipFile) -> bool:
     for zipInfo in zipFile.infolist():
         if zipInfo.filename.count("/") == 0:
             return True
@@ -76,7 +76,7 @@ def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa: C901
     return BundleContents(py_protocol, bundled_labware, bundled_data, bundled_python)
 
 
-def create_bundle(contents: BundleContents, into_file: BinaryIO):
+def create_bundle(contents: BundleContents, into_file: BinaryIO) -> None:
     """Create a bundle from assumed-good contents"""
     with ZipFile(into_file, mode="w") as zf:
         zf.writestr(MAIN_PROTOCOL_FILENAME, contents.protocol)

--- a/api/tests/opentrons/protocols/models/test_json_protocol.py
+++ b/api/tests/opentrons/protocols/models/test_json_protocol.py
@@ -1,4 +1,6 @@
 import pytest
+from typing import Callable
+
 from opentrons.protocols.models import json_protocol
 
 
@@ -12,7 +14,11 @@ from opentrons.protocols.models import json_protocol
         ["3", "testAllAtomicSingleV3"],
     ],
 )
-def test_json_protocol_model(get_json_protocol_fixture, version: str, name: str):
+def test_json_protocol_model(
+    get_json_protocol_fixture: Callable[..., object],
+    version: str,
+    name: str,
+) -> None:
     """It should be parsed and validated correctly."""
     fx = get_json_protocol_fixture(
         fixture_version=version, fixture_name=name, decode=True

--- a/api/tests/opentrons/protocols/test_bundle.py
+++ b/api/tests/opentrons/protocols/test_bundle.py
@@ -1,12 +1,13 @@
 import io
 import zipfile
+from typing import Any, Callable
 
 import pytest
 
 from opentrons.protocols import bundle
 
 
-def test_parse_bundle_no_root_files(get_bundle_fixture):
+def test_parse_bundle_no_root_files(get_bundle_fixture: Callable[..., Any]) -> None:
     fixture = get_bundle_fixture("no_root_files_bundle")
     with pytest.raises(
         RuntimeError, match="No files found in ZIP file's root directory"
@@ -17,7 +18,9 @@ def test_parse_bundle_no_root_files(get_bundle_fixture):
         bundle.extract_bundle(zf)
 
 
-def test_parse_bundle_no_entrypoint_protocol(get_bundle_fixture):
+def test_parse_bundle_no_entrypoint_protocol(
+    get_bundle_fixture: Callable[..., Any]
+) -> None:
     fixture = get_bundle_fixture("no_entrypoint_protocol_bundle")
     with pytest.raises(RuntimeError, match="Bundled protocol should have a"):
         buf = io.BytesIO(fixture["binary_zipfile"])
@@ -26,7 +29,9 @@ def test_parse_bundle_no_entrypoint_protocol(get_bundle_fixture):
         bundle.extract_bundle(zf)
 
 
-def test_parse_bundle_conflicting_labware(get_bundle_fixture):
+def test_parse_bundle_conflicting_labware(
+    get_bundle_fixture: Callable[..., Any]
+) -> None:
     fixture = get_bundle_fixture("conflicting_labware_bundle")
     with pytest.raises(RuntimeError, match="Conflicting labware in bundle"):
         buf = io.BytesIO(fixture["binary_zipfile"])
@@ -35,7 +40,7 @@ def test_parse_bundle_conflicting_labware(get_bundle_fixture):
         bundle.extract_bundle(zf)
 
 
-def test_write_bundle(get_bundle_fixture):
+def test_write_bundle(get_bundle_fixture: Callable[..., Any]) -> None:
     fixture = get_bundle_fixture("simple_bundle")
     buf = io.BytesIO(fixture["binary_zipfile"])
     buf.seek(0)


### PR DESCRIPTION
# Overview

While I'm in the neighborhood for RSS-265, remove some mypy overrides in `opentrons.protocols` so we type-check that whole part of the module tree a bit more strictly.

# Changelog

Attain strict type-checking for:
* `tests/opentrons/protocols/*`
* Any new modules created in `src/opentrons/protocols/*`
* `bundle.py`

# Test Plan

Make sure CI keeps passing.

# Review requests

None in particular.

# Risk assessment

No risk.
