### PR TITLE
fix(shared-data): add cornerOffsetFromSlot to center h/s adapters

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_96_deep_well_adapter/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_deep_well_adapter/1.json
@@ -34,8 +34,8 @@
   "schemaVersion": 2,
   "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {
-    "x": 0,
-    "y": 0,
+    "x": 6.9,
+    "y": 3.9,
     "z": 0
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_96_flat_bottom_adapter/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_flat_bottom_adapter/1.json
@@ -34,8 +34,8 @@
   "schemaVersion": 2,
   "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {
-    "x": 0,
-    "y": 0,
+    "x": 8.5,
+    "y": 5.5,
     "z": 0
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json
@@ -1011,8 +1011,8 @@
   "schemaVersion": 2,
   "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {
-    "x": 0,
-    "y": 0,
+    "x": 8.5,
+    "y": 5.5,
     "z": 0
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_universal_flat_adapter/1.json
+++ b/shared-data/labware/definitions/2/opentrons_universal_flat_adapter/1.json
@@ -34,8 +34,8 @@
   "schemaVersion": 2,
   "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {
-    "x": 0,
-    "y": 0,
+    "x": 8.5,
+    "y": 5.5,
     "z": 0
   },
   "gripperOffsets": {


### PR DESCRIPTION
# Overview

This PR fixes an issue where adapters that sit on the heater-shaker had a `cornerOffsetFromSlot` offset of all zeroes, which made both labware rendering and Protocol Engine assume that the adapter's bottom left corner was flush with the bottom left corner of the slot, instead of being centered as it is on the heater-shaker.

In practice this did not cause any issues since we disallow liquid operations to adapters, and when labware is loaded on top of them their dimensions and lack of offset are accurate. This does fix rendering the labware in the right position for the frontend, as well as gives a more accurate location to PE of where the adapters are actually sitting.

# Test Plan

Tested using postman to load adapters and ensure that PE had a more accurate position for them, and that adding the offset did not improperly offset any labware loaded on top.

# Changelog

- added `cornerOffsetFromSlot` values for `opentrons_96_deep_well_adapter`, `opentrons_96_flat_bottom_adapter`, `opentrons_96_pcr_adapter`, and `opentrons_universal_flat_adapter`

# Review requests

Someone on App&UI should check to ensure that the updated adapter definitions render properly.

# Risk assessment

Low, in the vast majority of use cases the adapter's geometry is not accessed directly in Protocol Engine, and these changes do not affect the geometry calculations of moving the pipette to labware loaded on top or moving the labware on or off the adapter.