### PR TITLE
docs(api): add more gripper-supported labware

### DIFF
--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -98,12 +98,12 @@ You can manually move any standard or custom labware. Using the gripper to move 
           * ``nest_96_wellplate_2ml_deep``
     * - All Opentrons Flex 96 Tip Racks 
       - 
-          * ``opentrons_flex_96_filtertiprack_1000ul``
-          * ``opentrons_flex_96_filtertiprack_200ul``
-          * ``opentrons_flex_96_filtertiprack_50ul``
-          * ``opentrons_flex_96_tiprack_1000ul``
-          * ``opentrons_flex_96_tiprack_200ul``
           * ``opentrons_flex_96_tiprack_50ul``
+          * ``opentrons_flex_96_tiprack_200ul``
+          * ``opentrons_flex_96_tiprack_1000ul``
+          * ``opentrons_flex_96_filtertiprack_50ul``
+          * ``opentrons_flex_96_filtertiprack_200ul``
+          * ``opentrons_flex_96_filtertiprack_1000ul``
     
 The gripper may work with other ANSI/SLAS standard labware, but this is not recommended.
 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -75,21 +75,35 @@ You can manually move any standard or custom labware. Using the gripper to move 
     :header-rows: 1
 
     * - Labware Type
-      - API Load Name
-    * - NEST 96 Deep Well Plate 2mL
-      - ``nest_96_wellplate_2ml_deep``
-    * - Armadillo 96 well plate 200 µL Full Skirt
-      - ``armadillo_96_wellplate_200ul_pcr_full_skirt``
-    * - NEST 96 Well Plate 200 µL Flat
-      - ``nest_96_wellplate_200ul_flat``
+      - API Load Names
+    * - Full-skirt PCR plates
+      - 
+          * ``armadillo_96_wellplate_200ul_pcr_full_skirt``
+          * ``biorad_96_wellplate_200ul_pcr``
+          * ``nest_96_wellplate_100ul_pcr_full_skirt``
+          * ``opentrons_96_wellplate_200ul_pcr_full_skirt``
+    * - Bio-Rad 384-well plate 
+      - 
+          * ``biorad_384_wellplate_50ul``
+    * - Most Corning flat well plates 
+      - 
+          * ``corning_12_wellplate_6.9ml_flat``
+          * ``corning_48_wellplate_1.6ml_flat``
+          * ``corning_96_wellplate_360ul_flat``
+          * ``corning_384_wellplate_112ul_flat``
+    * - Certain NEST reservoirs and plates
+      - 
+          * ``nest_1_reservoir_195ml``
+          * ``nest_96_wellplate_200ul_flat``
+          * ``nest_96_wellplate_2ml_deep``
     * - All Opentrons Flex 96 Tip Racks 
       - 
-          * ``opentrons_flex_96_tiprack_50ul``
-          * ``opentrons_flex_96_tiprack_200ul``
-          * ``opentrons_flex_96_tiprack_1000ul``
-          * ``opentrons_flex_96_filtertiprack_50ul``
-          * ``opentrons_flex_96_filtertiprack_200ul``
           * ``opentrons_flex_96_filtertiprack_1000ul``
+          * ``opentrons_flex_96_filtertiprack_200ul``
+          * ``opentrons_flex_96_filtertiprack_50ul``
+          * ``opentrons_flex_96_tiprack_1000ul``
+          * ``opentrons_flex_96_tiprack_200ul``
+          * ``opentrons_flex_96_tiprack_50ul``
     
 The gripper may work with other ANSI/SLAS standard labware, but this is not recommended.
 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -69,7 +69,7 @@ If you attempt to use the gripper to move labware in an OT-2 protocol, the API w
 Supported Labware
 =================
 
-You can manually move any standard or custom labware. Using the gripper to move the following types of labware is fully supported by Opentrons:
+You can manually move any standard or custom labware. Using the gripper to move the following labware is fully supported by Opentrons:
 
 .. list-table::
     :header-rows: 1
@@ -79,24 +79,12 @@ You can manually move any standard or custom labware. Using the gripper to move 
     * - Full-skirt PCR plates
       - 
           * ``armadillo_96_wellplate_200ul_pcr_full_skirt``
-          * ``biorad_96_wellplate_200ul_pcr``
-          * ``nest_96_wellplate_100ul_pcr_full_skirt``
           * ``opentrons_96_wellplate_200ul_pcr_full_skirt``
-    * - Bio-Rad 384-well plate 
+    * - NEST well plates
       - 
-          * ``biorad_384_wellplate_50ul``
-    * - Most Corning flat well plates 
-      - 
-          * ``corning_12_wellplate_6.9ml_flat``
-          * ``corning_48_wellplate_1.6ml_flat``
-          * ``corning_96_wellplate_360ul_flat``
-          * ``corning_384_wellplate_112ul_flat``
-    * - Certain NEST reservoirs and plates
-      - 
-          * ``nest_1_reservoir_195ml``
           * ``nest_96_wellplate_200ul_flat``
           * ``nest_96_wellplate_2ml_deep``
-    * - All Opentrons Flex 96 Tip Racks 
+    * - Opentrons Flex 96 Tip Racks 
       - 
           * ``opentrons_flex_96_tiprack_50ul``
           * ``opentrons_flex_96_tiprack_200ul``
@@ -109,7 +97,7 @@ The gripper may work with other ANSI/SLAS standard labware, but this is not reco
 
 .. note::
 
-    The labware definitions listed above include information about the position and force that the gripper uses to pick up the labware. The gripper uses default position and force values for other labware. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
+    The labware definitions listed above include information about the position and force that the gripper uses to pick up the labware. The gripper uses default values for labware definitions that don't include position and force information. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
 
 
 .. _movement-modules: 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -109,7 +109,7 @@ The gripper may work with other ANSI/SLAS standard labware, but this is not reco
 
 .. note::
 
-    Labware definitions don't explicitly declare compatibility or incompatibility with the gripper. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
+    The labware definitions listed above include information about the position and force that the gripper uses to pick up the labware. The gripper uses default position and force values for other labware. The Python Protocol API won’t raise a warning or error if you try to grip and move other types of labware.
 
 
 .. _movement-modules: 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -109,7 +109,7 @@ The gripper may work with other ANSI/SLAS standard labware, but this is not reco
 
 .. note::
 
-    The labware definitions listed above include information about the position and force that the gripper uses to pick up the labware. The gripper uses default position and force values for other labware. The Python Protocol API won’t raise a warning or error if you try to grip and move other types of labware.
+    The labware definitions listed above include information about the position and force that the gripper uses to pick up the labware. The gripper uses default position and force values for other labware. The Python Protocol API won't raise a warning or error if you try to grip and move other types of labware.
 
 
 .. _movement-modules: 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Expands the table in the Supported Labware § of Moving Labware to include all 18 labware whose definitions currently include gripper parameters.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Check formatting [in the sandbox](http://sandbox.docs.opentrons.com/docs-more-grippable-labware/v2/moving_labware.html#supported-labware).
- Check that the table lists all and only the labware that include grip force and offset info added to internal-release in #13233

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- update list-table in `moving_labware.rst`

# Review requests

<!--
Describe any requests for your reviewers here.
-->

@sanni-t @andySigler @ChrisYarka Confirm which labware we want to include in this section _on August 21_:
- [ ] `biorad_96_wellplate_200ul_pcr`
- [ ] `nest_96_wellplate_100ul_pcr_full_skirt`
- [ ] `biorad_384_wellplate_50ul`
- [ ] `corning_12_wellplate_6.9ml_flat`
- [ ] `corning_48_wellplate_1.6ml_flat`
- [ ] `corning_96_wellplate_360ul_flat`
- [ ] `corning_384_wellplate_112ul_flat`
- [ ] `nest_1_reservoir_195ml`
  
 
# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Nil, docs.