### PR TITLE
feat(api): gate pre-protocol-home behind check for door status

### DIFF
--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -121,8 +121,7 @@ def test_analysis_deck_definition(
 
     assert exit_code == 0
 
-    [load_labware_command, comment_command] = analysis_output_json["commands"]
-    _ = load_labware_command
+    [_, _, comment_command] = analysis_output_json["commands"]
 
     # todo(mm, 2023-05-12): When protocols emit true Protocol Engine comment commands instead
     # of legacy commands, "legacyCommandText" should change to "message".

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -155,9 +155,19 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     pipette_left_result_captor = matchers.Captor()
     pipette_right_result_captor = matchers.Captor()
 
-    assert len(commands_result) == 31
+    assert len(commands_result) == 32
 
-    assert commands_result[0] == commands.LoadLabware.construct(
+    assert commands_result[0] == commands.Home.construct(
+        id=matchers.IsA(str),
+        key=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=commands.HomeParams(axes=None),
+        result=commands.HomeResult(),
+    )
+    assert commands_result[1] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -172,7 +182,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=tiprack_1_result_captor,
     )
-    assert commands_result[1] == commands.LoadLabware.construct(
+    assert commands_result[2] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -187,7 +197,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=tiprack_2_result_captor,
     )
-    assert commands_result[2] == commands.LoadModule.construct(
+    assert commands_result[3] == commands.LoadModule.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -201,7 +211,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=module_1_result_captor,
     )
-    assert commands_result[3] == commands.LoadLabware.construct(
+    assert commands_result[4] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -216,7 +226,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=well_plate_1_result_captor,
     )
-    assert commands_result[4] == commands.LoadLabware.construct(
+    assert commands_result[5] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -232,7 +242,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         result=module_plate_1_result_captor,
     )
 
-    assert commands_result[5] == commands.LoadPipette.construct(
+    assert commands_result[6] == commands.LoadPipette.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -245,7 +255,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         result=pipette_left_result_captor,
     )
 
-    assert commands_result[6] == commands.LoadPipette.construct(
+    assert commands_result[7] == commands.LoadPipette.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -267,7 +277,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     pipette_left_id = pipette_left_result_captor.value["pipetteId"]
     pipette_right_id = pipette_right_result_captor.value["pipetteId"]
 
-    assert commands_result[7] == commands.PickUpTip.construct(
+    assert commands_result[8] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -283,7 +293,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             tipVolume=300.0, tipLength=51.83, position=DeckPoint(x=0, y=0, z=0)
         ),
     )
-    assert commands_result[8] == commands.PickUpTip.construct(
+    assert commands_result[9] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -300,7 +310,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
     )
 
-    assert commands_result[9] == commands.DropTip.construct(
+    assert commands_result[10] == commands.DropTip.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -315,7 +325,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         result=commands.DropTipResult(position=DeckPoint(x=0, y=0, z=0)),
     )
 
-    assert commands_result[10] == commands.PickUpTip.construct(
+    assert commands_result[11] == commands.PickUpTip.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -331,7 +341,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
             tipVolume=300.0, tipLength=51.83, position=DeckPoint(x=0, y=0, z=0)
         ),
     )
-    assert commands_result[11] == commands.Aspirate.construct(
+    assert commands_result[12] == commands.Aspirate.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -347,7 +357,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.AspirateResult(volume=40, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[12] == commands.Dispense.construct(
+    assert commands_result[13] == commands.Dispense.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -363,7 +373,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.DispenseResult(volume=35, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[13] == commands.Aspirate.construct(
+    assert commands_result[14] == commands.Aspirate.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -379,7 +389,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.AspirateResult(volume=40, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[14] == commands.Dispense.construct(
+    assert commands_result[15] == commands.Dispense.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -395,7 +405,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.DispenseResult(volume=35, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[15] == commands.BlowOut.construct(
+    assert commands_result[16] == commands.BlowOut.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -410,7 +420,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.BlowOutResult(position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[16] == commands.Aspirate.construct(
+    assert commands_result[17] == commands.Aspirate.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -426,7 +436,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.AspirateResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[17] == commands.Dispense.construct(
+    assert commands_result[18] == commands.Dispense.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -442,7 +452,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.DispenseResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[18] == commands.BlowOut.construct(
+    assert commands_result[19] == commands.BlowOut.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -457,7 +467,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.BlowOutResult(position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[19] == commands.Aspirate.construct(
+    assert commands_result[20] == commands.Aspirate.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -473,7 +483,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.AspirateResult(volume=300, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[20] == commands.Dispense.construct(
+    assert commands_result[21] == commands.Dispense.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -489,7 +499,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.DispenseResult(volume=300, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[21] == commands.BlowOut.construct(
+    assert commands_result[22] == commands.BlowOut.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -505,7 +515,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         result=commands.BlowOutResult(position=DeckPoint(x=0, y=0, z=0)),
     )
     #   TODO:(jr, 15.08.2022): this should map to move_to when move_to is mapped in a followup ticket RSS-62
-    assert commands_result[22] == commands.Custom.construct(
+    assert commands_result[23] == commands.Custom.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -520,7 +530,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     )
     #   TODO:(jr, 15.08.2022): aspirate commands with no labware get filtered
     #   into custom. Refactor this in followup legacy command mapping
-    assert commands_result[23] == commands.Custom.construct(
+    assert commands_result[24] == commands.Custom.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -535,7 +545,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     )
     #   TODO:(jr, 15.08.2022): dispense commands with no labware get filtered
     #   into custom. Refactor this in followup legacy command mapping
-    assert commands_result[24] == commands.Custom.construct(
+    assert commands_result[25] == commands.Custom.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -550,7 +560,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     )
     #   TODO:(jr, 15.08.2022): blow_out commands with no labware get filtered
     #   into custom. Refactor this in followup legacy command mapping
-    assert commands_result[25] == commands.Custom.construct(
+    assert commands_result[26] == commands.Custom.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -563,7 +573,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.CustomResult(),
     )
-    assert commands_result[26] == commands.Aspirate.construct(
+    assert commands_result[27] == commands.Aspirate.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -579,7 +589,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.AspirateResult(volume=50, position=DeckPoint(x=0, y=0, z=0)),
     )
-    assert commands_result[27] == commands.Dispense.construct(
+    assert commands_result[28] == commands.Dispense.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -597,7 +607,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     )
     #   TODO:(jr, 15.08.2022): aspirate commands with no labware get filtered
     #   into custom. Refactor this in followup legacy command mapping
-    assert commands_result[28] == commands.Custom.construct(
+    assert commands_result[29] == commands.Custom.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -612,7 +622,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
     )
     #   TODO:(jr, 15.08.2022): dispense commands with no labware get filtered
     #   into custom. Refactor this in followup legacy command mapping
-    assert commands_result[29] == commands.Custom.construct(
+    assert commands_result[30] == commands.Custom.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -625,7 +635,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         ),
         result=commands.CustomResult(),
     )
-    assert commands_result[30] == commands.DropTip.construct(
+    assert commands_result[31] == commands.DropTip.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -681,6 +691,7 @@ async def test_zero_volume_dispense_commands(
     )
 
     [
+        initial_home,
         load_tip_rack,
         load_well_plate,
         load_pipette,
@@ -689,6 +700,7 @@ async def test_zero_volume_dispense_commands(
         aspirate_1,
         aspirate_2_as_move_to_well,
     ] = result_commands
+    assert isinstance(initial_home, commands.Home)
     assert isinstance(load_tip_rack, commands.LoadLabware)
     assert isinstance(load_well_plate, commands.LoadLabware)
     assert isinstance(load_pipette, commands.LoadPipette)

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_module_commands.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_module_commands.py
@@ -67,14 +67,24 @@ async def test_runner_with_modules_in_legacy_python(
     result = await subject.run(protocol_source)
     commands_result = result.commands
 
-    assert len(commands_result) == 5
+    assert len(commands_result) == 6
 
     temp_module_result_captor = matchers.Captor()
     mag_module_result_captor = matchers.Captor()
     thermocycler_result_captor = matchers.Captor()
     heater_shaker_result_captor = matchers.Captor()
 
-    assert commands_result[0] == commands.LoadLabware.construct(
+    assert commands_result[0] == commands.Home.construct(
+        id=matchers.IsA(str),
+        key=matchers.IsA(str),
+        status=commands.CommandStatus.SUCCEEDED,
+        createdAt=matchers.IsA(datetime),
+        startedAt=matchers.IsA(datetime),
+        completedAt=matchers.IsA(datetime),
+        params=commands.HomeParams(axes=None),
+        result=commands.HomeResult(),
+    )
+    assert commands_result[1] == commands.LoadLabware.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -85,7 +95,7 @@ async def test_runner_with_modules_in_legacy_python(
         result=matchers.Anything(),
     )
 
-    assert commands_result[1] == commands.LoadModule.construct(
+    assert commands_result[2] == commands.LoadModule.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -96,7 +106,7 @@ async def test_runner_with_modules_in_legacy_python(
         result=temp_module_result_captor,
     )
 
-    assert commands_result[2] == commands.LoadModule.construct(
+    assert commands_result[3] == commands.LoadModule.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -107,7 +117,7 @@ async def test_runner_with_modules_in_legacy_python(
         result=mag_module_result_captor,
     )
 
-    assert commands_result[3] == commands.LoadModule.construct(
+    assert commands_result[4] == commands.LoadModule.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,
@@ -118,7 +128,7 @@ async def test_runner_with_modules_in_legacy_python(
         result=thermocycler_result_captor,
     )
 
-    assert commands_result[4] == commands.LoadModule.construct(
+    assert commands_result[5] == commands.LoadModule.construct(
         id=matchers.IsA(str),
         key=matchers.IsA(str),
         status=commands.CommandStatus.SUCCEEDED,

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -296,7 +296,6 @@ async def test_run_json_runner(
     assert json_runner_subject.was_started() is True
 
     decoy.verify(
-        await hardware_api.home(),
         protocol_engine.play(),
         task_queue.start(),
         await task_queue.join(),
@@ -364,6 +363,9 @@ async def test_load_json_runner(
         protocol_engine.add_labware_definition(labware_definition),
         protocol_engine.add_liquid(
             id="water-id", name="water", description="water desc", color=None
+        ),
+        protocol_engine.add_command(
+            request=pe_commands.HomeCreate(params=pe_commands.HomeParams(axes=None))
         ),
         protocol_engine.add_command(
             request=pe_commands.WaitForResumeCreate(
@@ -447,6 +449,9 @@ async def test_load_legacy_python(
     decoy.verify(
         protocol_engine.add_labware_definition(labware_definition),
         protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)),
+        protocol_engine.add_command(
+            request=pe_commands.HomeCreate(params=pe_commands.HomeParams(axes=None))
+        ),
         task_queue.set_run_func(
             func=legacy_executor.execute,
             protocol=legacy_protocol,
@@ -563,6 +568,9 @@ async def test_load_legacy_json(
     decoy.verify(
         protocol_engine.add_labware_definition(labware_definition),
         protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)),
+        protocol_engine.add_command(
+            request=pe_commands.HomeCreate(params=pe_commands.HomeParams(axes=None))
+        ),
         task_queue.set_run_func(
             func=legacy_executor.execute,
             protocol=legacy_protocol,
@@ -588,7 +596,6 @@ async def test_run_python_runner(
     assert legacy_python_runner_subject.was_started() is True
 
     decoy.verify(
-        await hardware_api.home(),
         protocol_engine.play(),
         task_queue.start(),
         await task_queue.join(),

--- a/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
@@ -117,10 +117,12 @@ async def test_python_custom_labware_upload(
         ok_analysis_response = await poll_until_analysis_returns_ok(
             robot_client=robot_client, protocol_id=protocol_id, analysis_id=analysis_id
         )
-    [analysis_command] = ok_analysis_response["data"]["commands"]
-    assert analysis_command["commandType"] == "loadLabware"
-    assert analysis_command["params"]["loadName"] == EXPECTED_LABWARE_LOAD_NAME
+    analysis_commands = ok_analysis_response["data"]["commands"]
     assert (
-        analysis_command["result"]["definition"]["parameters"]["loadName"]
+        analysis_commands[1]["commandType"] == "loadLabware"
+    )  # Zeroth command is Home command
+    assert analysis_commands[1]["params"]["loadName"] == EXPECTED_LABWARE_LOAD_NAME
+    assert (
+        analysis_commands[1]["result"]["definition"]["parameters"]["loadName"]
         == EXPECTED_LABWARE_LOAD_NAME
     )

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -125,6 +125,16 @@ stages:
                 location:
                   slotName: '1'
             commands:
+              # Initial home
+              - id: !anystr
+                createdAt: !anystr
+                commandType: home
+                key: !anystr
+                status: succeeded
+                params: { }
+                result: { }
+                startedAt: !anystr
+                completedAt: !anystr
               - id: !anystr
                 createdAt: !anystr
                 commandType: loadPipette

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -92,11 +92,18 @@ stages:
               commandId: '{setup_command_id}'
               key: '{setup_command_key}'
               createdAt: '{setup_command_created_at}'
-              index: 14
+              index: 15
         meta:
           cursor: 0
-          totalLength: 15
+          totalLength: 16
         data:
+          # Initial home
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            status: queued
+            params: { }
           - id: !anystr
             key: !anystr
             commandType: loadPipette
@@ -338,8 +345,16 @@ stages:
           current: !anydict
         meta:
           cursor: 0
-          totalLength: 15
+          totalLength: 16
         data:
+          - id: !anystr
+            createdAt: !anystr
+            commandType: home
+            key: !anystr
+            status: succeeded
+            params: { }
+            startedAt: !anystr
+            completedAt: !anystr
           - id: !anystr
             key: !anystr
             commandType: loadPipette

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -70,8 +70,17 @@ stages:
           current: !anydict
         meta:
           cursor: 0
-          totalLength: 4
+          totalLength: 5
         data:
+          # Initial home
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: { }
           - id: !anystr
             key: !anystr
             commandType: loadLabware

--- a/robot-server/tests/integration/http_api/runs/test_json_v7_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v7_protocol_run.tavern.yaml
@@ -92,11 +92,18 @@ stages:
               commandId: '{setup_command_id}'
               key: '{setup_command_key}'
               createdAt: '{setup_command_created_at}'
-              index: 14
+              index: 15
         meta:
           cursor: 0
-          totalLength: 15
+          totalLength: 16
         data:
+          # Initial home
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            status: queued
+            params: { }
           - id: !anystr
             key: !anystr
             commandType: loadPipette
@@ -338,8 +345,16 @@ stages:
           current: !anydict
         meta:
           cursor: 0
-          totalLength: 15
+          totalLength: 16
         data:
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: { }
           - id: !anystr
             key: !anystr
             commandType: loadPipette

--- a/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
+++ b/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
@@ -149,7 +149,7 @@ async def test_labware_offsets_on_compatible_modules(
 
     # Retrieve details about the protocol's completed commands.
     commands = (await robot_client.get_run_commands(run_id=run_id)).json()
-    [load_module_command_summary, load_labware_command_summary] = commands["data"]
+    [_, load_module_command_summary, load_labware_command_summary] = commands["data"]
     assert load_module_command_summary["commandType"] == "loadModule"
     load_module_command = (
         await robot_client.get_run_command(

--- a/robot-server/tests/integration/http_api/runs/test_lpc_loads_do_not_cause_conflicts_in_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_lpc_loads_do_not_cause_conflicts_in_run.tavern.yaml
@@ -99,8 +99,17 @@ stages:
         links: !anydict
         meta:
           cursor: 0
-          totalLength: 3
+          totalLength: 4
         data:
+          # Initial home
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: { }
           # The labware load from our simulated Labware Position Check:
           - id: !anystr
             key: lpcLoadLabwareKey

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -72,8 +72,16 @@ stages:
           current: !anydict
         meta:
           cursor: 0
-          totalLength: 3
+          totalLength: 4
         data:
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: { }
           - id: !anystr
             key: !anystr
             commandType: loadLabware

--- a/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
@@ -154,8 +154,16 @@ stages:
           current: !anydict
         meta:
           cursor: 0
-          totalLength: 1
+          totalLength: 2
         data:
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: { }
           - id: !anystr
             key: !anystr
             commandType: loadLabware
@@ -171,7 +179,7 @@ stages:
             completedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
       save:
         json:
-          load_labware_command_id: data[0].id
+          load_labware_command_id: data[1].id
 
   - name: Get full details of the load labware command and make sure the offset applied
     request:


### PR DESCRIPTION
Closes RSS-135

# Overview

Removes the call to `hardware.home` at the beginning of a protocol run and instead, adds a home command to the command queue during protocol load, before any protocol commands are queued. This makes the initial homing follow the same rules as any protocol command and will pause when the robot door is opened.

# Test Plan

On an OT2/ Flex, test with a python and a json protocol. Make sure the home command shows up as the first command in the run command view. With the 'Pause on door open' setting enabled for the robot, verify that the homing pauses when door is opened and is able to be resumed after closing the door and clicking resume. Check that the run statuses are updated correctly.

# Review requests

- I've implemented this as the ticket says i.e, by adding an engine command instead of using hardware home. It's been a while since that ticket was written so want to make sure that it's still the recommended approach.
- A side-effect of this approach is that the run commands list will now always have homing as the first command in the protocol. Pros of this effect- the homing action will be documented and visible in the run log so one does not have to assume that the robot homed (or did not home) before starting a protocol. Cons- having an implicit home command as the first command of a protocol might confuse users. We could make the app/ ODD omit this first command from view but that might create additional problems.
- Should we be extending this pause-on-door-open behavior to the post-protocol cleanup procedure (homing and maybe dropping tips) as well? If yes, how do we implement it? And what would 'pausing' and 'resuming' mean for commands after the run has been told to stop? 

# Risk assessment

- Medium. Has a risk of protocols not running if implemented wrongly. But it's a simple change and easy to test.
