### PR TITLE
fix(api): Centralize Python parsing logic, and fix syntax error reporting

### DIFF
--- a/api/src/opentrons/protocol_reader/file_identifier.py
+++ b/api/src/opentrons/protocol_reader/file_identifier.py
@@ -204,9 +204,13 @@ def _analyze_python_protocol(
 ) -> IdentifiedPythonMain:
     try:
         parsed = parse.parse(protocol_file=py_file.contents, filename=py_file.name)
-        assert isinstance(parsed, PythonProtocol)
     except MalformedPythonProtocolError as e:
         raise FileIdentificationError(e.short_message) from e
+
+    # We know this should never be a JsonProtocol. Help out the type-checker.
+    assert isinstance(
+        parsed, PythonProtocol
+    ), "Parsing a Python file returned something other than a Python protocol."
 
     if parsed.api_level > MAX_SUPPORTED_VERSION:
         raise FileIdentificationError(

--- a/api/src/opentrons/protocol_reader/file_identifier.py
+++ b/api/src/opentrons/protocol_reader/file_identifier.py
@@ -10,7 +10,7 @@ from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.parse import parse
+from opentrons.protocols import parse
 from opentrons.protocols.types import MalformedPythonError, PythonProtocol
 
 from .file_reader_writer import BufferedFile
@@ -203,7 +203,7 @@ def _analyze_python_protocol(
     py_file: BufferedFile,
 ) -> IdentifiedPythonMain:
     try:
-        parsed = parse(protocol_file=py_file.contents, filename=py_file.name)
+        parsed = parse.parse(protocol_file=py_file.contents, filename=py_file.name)
         assert isinstance(parsed, PythonProtocol)
     except MalformedPythonError as e:
         raise FileIdentificationError(e.short_message) from e

--- a/api/src/opentrons/protocol_reader/file_identifier.py
+++ b/api/src/opentrons/protocol_reader/file_identifier.py
@@ -1,6 +1,5 @@
 """File identifier interface."""
 
-import ast
 import json
 from dataclasses import dataclass
 from typing import Any, Dict, Sequence, Union
@@ -10,13 +9,9 @@ import anyio
 from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocols.parse import (
-    extract_static_python_info,
-    robot_type_from_static_python_info,
-    version_from_static_python_info,
-)
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.types import MalformedPythonError, StaticPythonInfo
+from opentrons.protocols.parse import parse
+from opentrons.protocols.types import MalformedPythonError, PythonProtocol
 
 from .file_reader_writer import BufferedFile
 from .protocol_files_invalid_error import ProtocolFilesInvalidError
@@ -204,62 +199,25 @@ def _analyze_json_protocol(
     )
 
 
-# todo(mm, 2021-09-13): This duplicates opentrons.protocols.parse.parse()
-# and misses some of its functionality. For example, this misses looking at import
-# statements to see if a protocol looks like APIv1, and this misses statically
-# validating the structure of an APIv2 protocol to make sure it has exactly 1 run()
-# function, etc.
 def _analyze_python_protocol(
     py_file: BufferedFile,
 ) -> IdentifiedPythonMain:
     try:
-        # todo(mm, 2021-09-13): Investigate whether it's really appropriate to leave
-        # the Python compilation flags at their defaults. For example, we probably
-        # don't truly want the protocol to inherit our own __future__ features.
-        module_ast = ast.parse(source=py_file.contents, filename=py_file.name)
-    except MalformedPythonError as e:
-        # ast.parse() raises SyntaxError for most errors,
-        # but ValueError if the source contains null bytes.
-        raise FileIdentificationError(f"Unable to parse {py_file.name}.") from e
-
-    try:
-        static_info = extract_static_python_info(module_ast)
+        parsed = parse(protocol_file=py_file.contents, filename=py_file.name)
+        assert isinstance(parsed, PythonProtocol)
     except MalformedPythonError as e:
         raise FileIdentificationError(e.short_message) from e
 
-    api_version = _get_api_version(static_info, py_file.name)
-
-    robot_type = _get_robot_type(static_info)
-
-    return IdentifiedPythonMain(
-        original_file=py_file,
-        metadata=static_info.metadata or {},
-        robot_type=robot_type,
-        api_level=api_version,
-    )
-
-
-def _get_api_version(
-    static_python_info: StaticPythonInfo, file_name_for_error: str
-) -> APIVersion:
-    try:
-        api_version = version_from_static_python_info(static_python_info)
-    except MalformedPythonError as e:
-        raise FileIdentificationError(e.short_message) from e
-    if api_version is None:
-        raise FileIdentificationError(f"apiLevel not declared in {file_name_for_error}")
-    if api_version > MAX_SUPPORTED_VERSION:
+    if parsed.api_level > MAX_SUPPORTED_VERSION:
         raise FileIdentificationError(
-            f"API version {api_version} is not supported by this "
+            f"API version {parsed.api_level} is not supported by this "
             f"robot software. Please either reduce your requested API "
             f"version or update your robot."
         )
 
-    return api_version
-
-
-def _get_robot_type(static_python_info: StaticPythonInfo) -> RobotType:
-    try:
-        return robot_type_from_static_python_info(static_python_info)
-    except MalformedPythonError as e:
-        raise FileIdentificationError(e.short_message) from e
+    return IdentifiedPythonMain(
+        original_file=py_file,
+        metadata=parsed.metadata or {},
+        robot_type=parsed.robot_type,
+        api_level=parsed.api_level,
+    )

--- a/api/src/opentrons/protocol_reader/file_identifier.py
+++ b/api/src/opentrons/protocol_reader/file_identifier.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols import parse
-from opentrons.protocols.types import MalformedPythonError, PythonProtocol
+from opentrons.protocols.types import MalformedPythonProtocolError, PythonProtocol
 
 from .file_reader_writer import BufferedFile
 from .protocol_files_invalid_error import ProtocolFilesInvalidError
@@ -205,7 +205,7 @@ def _analyze_python_protocol(
     try:
         parsed = parse.parse(protocol_file=py_file.contents, filename=py_file.name)
         assert isinstance(parsed, PythonProtocol)
-    except MalformedPythonError as e:
+    except MalformedPythonProtocolError as e:
         raise FileIdentificationError(e.short_message) from e
 
     if parsed.api_level > MAX_SUPPORTED_VERSION:

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from opentrons.drivers.smoothie_drivers.errors import SmoothieAlarm
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
-from opentrons.protocols.types import PythonProtocol, MalformedPythonError
+from opentrons.protocols.types import PythonProtocol, MalformedPythonProtocolError
 from opentrons.hardware_control import ExecutionCancelledError
 from opentrons.protocol_engine.errors import ProtocolCommandFailedError
 
@@ -55,7 +55,7 @@ def run_python(proto: PythonProtocol, context: ProtocolContext):
     try:
         _runfunc_ok(new_globs.get("run"))
     except SyntaxError as se:
-        raise MalformedPythonError(str(se))
+        raise MalformedPythonProtocolError(str(se))
     new_globs["__context"] = context
     try:
         exec("run(__context)", new_globs)

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from opentrons.drivers.smoothie_drivers.errors import SmoothieAlarm
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
-from opentrons.protocols.types import PythonProtocol, MalformedProtocolError
+from opentrons.protocols.types import PythonProtocol, MalformedPythonError
 from opentrons.hardware_control import ExecutionCancelledError
 from opentrons.protocol_engine.errors import ProtocolCommandFailedError
 
@@ -55,7 +55,7 @@ def run_python(proto: PythonProtocol, context: ProtocolContext):
     try:
         _runfunc_ok(new_globs.get("run"))
     except SyntaxError as se:
-        raise MalformedProtocolError(str(se))
+        raise MalformedPythonError(str(se))
     new_globs["__context"] = context
     try:
         exec("run(__context)", new_globs)

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -97,7 +97,7 @@ def version_from_string(vstr: str) -> APIVersion:
     if not matches:
         raise MalformedPythonError(
             short_message=(
-                f"apiLevel {vstr} is incorrectly formatted. It should "
+                f"apiLevel {vstr} is incorrectly formatted. It should be "
                 "major.minor, where both major and minor are numbers."
             )
         )

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -156,7 +156,7 @@ def _parse_python(
     static_info = extract_static_python_info(parsed)
     protocol = compile(parsed, filename=ast_filename, mode="exec")
     version = _get_version(static_info, parsed, filename_checked)
-    robot_type = robot_type_from_static_python_info(static_info)
+    robot_type = _robot_type_from_static_python_info(static_info)
 
     if version >= APIVersion(2, 0):
         _validate_v2_ast(parsed)
@@ -259,6 +259,8 @@ def parse(
             )
 
 
+# TODO(mm, 2023-08-08): This should be made a private implementation detail of this module
+# once its unit tests are ported to go through parse() instead.
 def extract_static_python_info(parsed: ast.Module) -> StaticPythonInfo:
     """Extract statically analyzable info from a Python protocol, like its metadata.
 
@@ -381,6 +383,8 @@ def _has_api_v1_imports(parsed: ast.Module) -> bool:
     return bool(v1_markers.intersection(opentrons_imports))
 
 
+# TODO(mm, 2023-08-08): This should be made a private implementation detail of this module
+# once its unit tests are ported to go through parse() instead.
 def version_from_static_python_info(
     static_python_info: StaticPythonInfo,
 ) -> Optional[APIVersion]:
@@ -426,7 +430,7 @@ def robot_type_from_python_identifier(python_robot_type: str) -> RobotType:
         )
 
 
-def robot_type_from_static_python_info(
+def _robot_type_from_static_python_info(
     static_python_info: StaticPythonInfo,
 ) -> RobotType:
     python_robot_type = (static_python_info.requirements or {}).get("robotType", None)

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -155,7 +155,7 @@ def _parse_python(
 
     static_info = extract_static_python_info(parsed)
     protocol = compile(parsed, filename=ast_filename, mode="exec")
-    version = _get_version(static_info, parsed)
+    version = _get_version(static_info, parsed, filename_checked)
     robot_type = robot_type_from_static_python_info(static_info)
 
     if version >= APIVersion(2, 0):
@@ -437,7 +437,7 @@ def robot_type_from_static_python_info(
 
 
 def _get_version(
-    static_python_info: StaticPythonInfo, parsed: ast.Module
+    static_python_info: StaticPythonInfo, parsed: ast.Module, filename: str
 ) -> APIVersion:
     """
     Infer protocol API version based on a combination of metadata and imports.
@@ -461,9 +461,10 @@ def _get_version(
         if not _has_api_v1_imports(parsed):
             raise MalformedPythonError(
                 short_message=(
-                    "If this is not an API v1 protocol, you must specify the target "
-                    "API version in the apiLevel key of the metadata dict. For instance, "
-                    'metadata={"apiLevel": "2.0"}'
+                    f"apiLevel not declared in {filename}. "
+                    f"You must specify the target API version "
+                    f"in the apiLevel key of the metadata dict. For instance, "
+                    f'metadata={{"apiLevel": "2.0"}}'
                 )
             )
         return APIVersion(1, 0)

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -153,7 +153,7 @@ def _parse_python(
         # but ValueError if the source contains null bytes.
         raise MalformedPythonError(short_message=str(null_bytes_error))
 
-    static_info = extract_static_python_info(parsed)
+    static_info = _extract_static_python_info(parsed)
     protocol = compile(parsed, filename=ast_filename, mode="exec")
     version = _get_version(static_info, parsed, filename_checked)
     robot_type = _robot_type_from_static_python_info(static_info)
@@ -259,9 +259,7 @@ def parse(
             )
 
 
-# TODO(mm, 2023-08-08): This should be made a private implementation detail of this module
-# once its unit tests are ported to go through parse() instead.
-def extract_static_python_info(parsed: ast.Module) -> StaticPythonInfo:
+def _extract_static_python_info(parsed: ast.Module) -> StaticPythonInfo:
     """Extract statically analyzable info from a Python protocol, like its metadata.
 
     Raises:

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -383,9 +383,7 @@ def _has_api_v1_imports(parsed: ast.Module) -> bool:
     return bool(v1_markers.intersection(opentrons_imports))
 
 
-# TODO(mm, 2023-08-08): This should be made a private implementation detail of this module
-# once its unit tests are ported to go through parse() instead.
-def version_from_static_python_info(
+def _version_from_static_python_info(
     static_python_info: StaticPythonInfo,
 ) -> Optional[APIVersion]:
     """Get an explicitly specified apiLevel from static info, if we can.
@@ -457,7 +455,7 @@ def _get_version(
     APIv2 protocol (note that 'labware' is not in this list, as there is a
     valid APIv2 import named 'labware').
     """
-    declared_version = version_from_static_python_info(static_python_info)
+    declared_version = _version_from_static_python_info(static_python_info)
     if declared_version:
         return declared_version
     else:

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -144,7 +144,7 @@ def _parse_python(
             short_message=str(syntax_error),
             # Get Python's nice syntax error message with carets pointing to where in the line
             # had the problem.
-            long_additional_message="".join(
+            long_additional_message="\n".join(
                 traceback.format_exception_only(type(syntax_error), syntax_error)
             ),
         ) from syntax_error

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -98,16 +98,16 @@ through the downgrade process.
 
 # TODO(mm, 2023-08-07): Align with the app team on how to surface errors like this,
 # and probably make this an EnumeratedError.
-class MalformedPythonError(Exception):
+class MalformedPythonProtocolError(Exception):
     def __init__(
         self, short_message: str, long_additional_message: Optional[str] = None
     ) -> None:
         """Raised when a user's Python protocol file is malformed.
 
-        "Malformed" in this case means it doesn't conform to the Python Protocol API's structural
-        requirements, like having a `run()` function and declaring an `apiLevel`. This does not
-        cover runtime or analysis errors such as aspirating from a nonexistent well or running
-        out of tips.
+        "Malformed" in this case means it's either syntactically invalid as standard Python, or it
+        doesn't conform to the Python Protocol API's structural requirements, like having a `run()`
+        function and declaring an `apiLevel`. This does not cover runtime or analysis errors such as
+        aspirating from a nonexistent well or running out of tips.
 
         Params:
             short_message: A short (~1-2 sentences), self-contained message describing what's wrong

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -121,7 +121,7 @@ class MalformedPythonError(Exception):
         super().__init__(short_message, long_additional_message)
 
     def __str__(self) -> str:
-        if self.long_additional_message:
+        if self.long_additional_message is not None:
             return self.short_message + "\n\n" + self.long_additional_message
         else:
             return self.short_message

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -122,10 +122,9 @@ class MalformedPythonError(Exception):
 
     def __str__(self) -> str:
         if self.long_additional_message:
-            to_append = "\n\n" + self.long_additional_message
+            return self.short_message + "\n\n" + self.long_additional_message
         else:
-            to_append = ""
-        return self.short_message + to_append
+            return self.short_message
 
     def __repr__(self) -> str:
         return "<{}: {}>".format(self.__class__.__name__, self.short_message)

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -69,9 +69,8 @@ class BundleContents(NamedTuple):
     bundled_python: Dict[str, str]
 
 
-PROTOCOL_MALFORMED = """
-
-A Python protocol for the OT2 must define a function called 'run' that takes a
+RUN_FUNCTION_MESSAGE = """\
+A Python protocol must define a function called 'run' that takes a
 single argument: the protocol context to call functions on. For instance, a run
 function might look like this:
 
@@ -79,7 +78,6 @@ def run(ctx):
     ctx.comment('hello, world')
 
 This function is called by the robot when the robot executes the protocol.
-This function is not present in the current protocol and must be added.
 """
 
 PYTHON_API_VERSION_DEPRECATED = """
@@ -98,16 +96,39 @@ through the downgrade process.
 """
 
 
-class MalformedProtocolError(Exception):
-    def __init__(self, message: str) -> None:
-        self.message = message
-        super().__init__(message)
+# TODO(mm, 2023-08-07): Align with the app team on how to surface errors like this,
+# and probably make this an EnumeratedError.
+class MalformedPythonError(Exception):
+    def __init__(
+        self, short_message: str, long_additional_message: Optional[str] = None
+    ) -> None:
+        """Raised when a user's Python protocol file is malformed.
+
+        "Malformed" in this case means it doesn't conform to the Python Protocol API's structural
+        requirements, like having a `run()` function and declaring an `apiLevel`. This does not
+        cover runtime or analysis errors such as aspirating from a nonexistent well or running
+        out of tips.
+
+        Params:
+            short_message: A short (~1-2 sentences), self-contained message describing what's wrong
+                with the file. This should not contain internal newlines or indentation.
+
+            long_additional_message: Longer context, in addition to `short_message`. This may
+                contain internal newlines and indentation.
+        """
+        self.short_message = short_message
+        self.long_additional_message = long_additional_message
+        super().__init__(short_message, long_additional_message)
 
     def __str__(self) -> str:
-        return self.message + PROTOCOL_MALFORMED
+        if self.long_additional_message:
+            to_append = "\n\n" + self.long_additional_message
+        else:
+            to_append = ""
+        return self.short_message + to_append
 
     def __repr__(self) -> str:
-        return "<{}: {}>".format(self.__class__.__name__, self.message)
+        return "<{}: {}>".format(self.__class__.__name__, self.short_message)
 
 
 class ApiDeprecationError(Exception):

--- a/api/tests/opentrons/protocol_reader/test_file_identifier.py
+++ b/api/tests/opentrons/protocol_reader/test_file_identifier.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.protocols import parse
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.types import MalformedPythonError, PythonProtocol
+from opentrons.protocols.types import MalformedPythonProtocolError, PythonProtocol
 
 from opentrons.protocol_reader.file_identifier import (
     FileIdentifier,
@@ -303,7 +303,7 @@ async def test_malformed_python(decoy: Decoy, use_mock_parse: None) -> None:
     input_file = BufferedFile(name="filename.py", contents=b"contents", path=None)
 
     decoy.when(parse.parse(b"contents", "filename.py")).then_raise(
-        MalformedPythonError(
+        MalformedPythonProtocolError(
             short_message="message 1", long_additional_message="message 2"
         )
     )

--- a/api/tests/opentrons/protocol_reader/test_file_identifier.py
+++ b/api/tests/opentrons/protocol_reader/test_file_identifier.py
@@ -365,7 +365,7 @@ class _InvalidInputSpec:
                 metadata = {"apiLevel": "123" + ".456"}
                 """
             ),
-            expected_message="Unable to extract metadata from protocol.py",
+            expected_message="Could not read the contents of the metadata dict",
         ),
         _InvalidInputSpec(
             file_name="protocol.py",
@@ -375,10 +375,7 @@ class _InvalidInputSpec:
                 metadata = {"apiLevel": 123.456}
                 """
             ),
-            # TODO(mm, 2021-09-13): bug in opentrons.protocols.parse.extract_metadata.
-            # It errors when a field isn't a string, even though its return type suggests
-            # suggests it should allow ints. This error message should be different.
-            expected_message="Unable to extract metadata from protocol.py",
+            expected_message="must be strings",
         ),
         _InvalidInputSpec(
             file_name="protocol.py",

--- a/api/tests/opentrons/protocol_reader/test_file_identifier.py
+++ b/api/tests/opentrons/protocol_reader/test_file_identifier.py
@@ -4,12 +4,15 @@ import json
 from dataclasses import dataclass
 import textwrap
 
+from decoy import Decoy
 import pytest
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.robot.dev_types import RobotType
 
+from opentrons.protocols import parse
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.types import MalformedPythonError, PythonProtocol
 
 from opentrons.protocol_reader.file_identifier import (
     FileIdentifier,
@@ -20,6 +23,15 @@ from opentrons.protocol_reader.file_identifier import (
 )
 from opentrons.protocol_reader.file_reader_writer import BufferedFile
 from opentrons.protocol_reader.protocol_source import Metadata
+
+
+# TODO(mm, 2023-08-08): Make this autouse=True (apply to all test functions) when
+# FileReaderWriter delegates to opentrons.protocols.parse for JSON files.
+@pytest.fixture
+def use_mock_parse(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace opentrons.protocols.parse.parse() with a mock."""
+    mock_parse = decoy.mock(func=parse.parse)
+    monkeypatch.setattr(parse, "parse", mock_parse)
 
 
 @dataclass
@@ -324,153 +336,10 @@ class _InvalidInputSpec:
 @pytest.mark.parametrize(
     "spec",
     [
-        # Python syntax error:
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                metadata = {
-                    'apiLevel': '123.456'
-                }
-
-                def run()  # Syntax error: missing colon.
-                    pass
-                """
-            ),
-            expected_message="invalid syntax",
-        ),
-        # Python with various kinds of invalid metadata dict or apiLevel:
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # Metadata missing entirely.
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="apiLevel not declared in protocol.py",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # Metadata provided, but not as a dict.
-                metadata = "Hello"
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="apiLevel not declared in protocol.py",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # apiLevel missing from metadata.
-                metadata = {"Hello": "World"}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="apiLevel not declared in protocol.py",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # Metadata not statically parsable.
-                metadata = {"apiLevel": "123" + ".456"}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="Could not read the contents of the metadata dict",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # apiLevel provided, but not as a string.
-                metadata = {"apiLevel": 123.456}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="must be strings",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # apiLevel provided, but not as a well formatted string.
-                metadata = {"apiLevel": "123*456"}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="is incorrectly formatted",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                # apiLevel provided, but not a valid version.
-                metadata = {"apiLevel": "123.456"}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="API version 123.456 is not supported by this robot software. Please either reduce your requested API version or update your robot.",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                metadata = {"apiLevel": "2.11"}
-                # robotType provided, but not a valid string.
-                requirements = {"robotType": "ot2"}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="robotType must be 'OT-2' or 'Flex', not 'ot2'.",
-        ),
-        _InvalidInputSpec(
-            file_name="protocol.py",
-            contents=textwrap.dedent(
-                """
-                metadata = {"apiLevel": "2.11"}
-                # robotType provided, but not a valid string.
-                requirements = {"robotType": "flex"}
-
-                def run():
-                    pass
-                """
-            ),
-            expected_message="robotType must be 'OT-2' or 'Flex', not 'flex'.",
-        ),
         # Unrecognized file extension:
         _InvalidInputSpec(
             file_name="protocol.python",
-            contents=textwrap.dedent(
-                """
-                metadata = {
-                    'apiLevel': '123.456'
-                }
-
-                def run()  # Syntax error: missing colon.
-                    pass
-                """
-            ),
+            contents="",
             expected_message="protocol.python has an unrecognized file extension.",
         ),
         _InvalidInputSpec(
@@ -505,3 +374,81 @@ async def test_invalid_input(spec: _InvalidInputSpec) -> None:
     subject = FileIdentifier()
     with pytest.raises(FileIdentificationError, match=spec.expected_message):
         await subject.identify([input_file])
+
+
+@pytest.mark.parametrize("filename", ["protocol.py", "protocol.PY", "protocol.Py"])
+async def test_python_parsing(
+    decoy: Decoy, use_mock_parse: None, filename: str
+) -> None:
+    """It should use opentrons.protocols.parse() to extract basic ID info out of Python files."""
+    input_file = BufferedFile(name=filename, contents=b"contents", path=None)
+
+    decoy.when(parse.parse(b"contents", filename)).then_return(
+        PythonProtocol(
+            api_level=APIVersion(2, 1),
+            robot_type="OT-3 Standard",
+            metadata={"Hello": "World"},
+            text="",
+            filename="",
+            contents=None,
+            bundled_data=None,
+            bundled_labware=None,
+            bundled_python=None,
+            extra_labware=None,
+        )
+    )
+
+    subject = FileIdentifier()
+    [result] = await subject.identify([input_file])
+
+    assert result == IdentifiedPythonMain(
+        original_file=input_file,
+        api_level=APIVersion(2, 1),
+        robot_type="OT-3 Standard",
+        metadata={"Hello": "World"},
+    )
+
+
+async def test_invalid_python_api_level(decoy: Decoy, use_mock_parse: None) -> None:
+    """It should check the apiLevel and raise if it's not supported."""
+    input_file = BufferedFile(name="filename.py", contents=b"contents", path=None)
+
+    decoy.when(parse.parse(b"contents", "filename.py")).then_return(
+        PythonProtocol(
+            api_level=APIVersion(999, 999),
+            robot_type="OT-3 Standard",
+            metadata=None,
+            text="",
+            filename="",
+            contents=None,
+            bundled_data=None,
+            bundled_labware=None,
+            bundled_python=None,
+            extra_labware=None,
+        )
+    )
+
+    subject = FileIdentifier()
+
+    with pytest.raises(FileIdentificationError, match="999.999 is not supported"):
+        await subject.identify([input_file])
+
+
+async def test_malformed_python(decoy: Decoy, use_mock_parse: None) -> None:
+    """It should propagate errors that mean the Python file was malformed."""
+    input_file = BufferedFile(name="filename.py", contents=b"contents", path=None)
+
+    decoy.when(parse.parse(b"contents", "filename.py")).then_raise(
+        MalformedPythonError(
+            short_message="message 1", long_additional_message="message 2"
+        )
+    )
+
+    subject = FileIdentifier()
+
+    with pytest.raises(FileIdentificationError) as exc_info:
+        await subject.identify([input_file])
+
+    # TODO(mm, 2023-08-8): We probably want to propagate the longer message too, if there is one.
+    # Align with the app+UI team about how to do this safely.
+    assert str(exc_info.value) == "message 1"

--- a/api/tests/opentrons/protocol_reader/test_file_identifier.py
+++ b/api/tests/opentrons/protocol_reader/test_file_identifier.py
@@ -43,6 +43,8 @@ class _ValidPythonProtocolSpec:
                     "author": "Dr. Sy. N. Tist",
                     "apiLevel": "2.11",
                 }
+                def run(protocol):
+                    pass
                 """
             ),
             expected_api_level=APIVersion(2, 11),
@@ -57,6 +59,8 @@ class _ValidPythonProtocolSpec:
                 metadata = {
                     "apiLevel": "2.11",
                 }
+                def run(protocol):
+                    pass
                 """
             ),
             expected_api_level=APIVersion(2, 11),
@@ -74,6 +78,8 @@ class _ValidPythonProtocolSpec:
                 requirements = {
                     "robotType": "OT-2",
                 }
+                def run(protocol):
+                    pass
                 """
             ),
             expected_api_level=APIVersion(2, 11),
@@ -90,6 +96,8 @@ class _ValidPythonProtocolSpec:
                 requirements = {
                     "robotType": "Flex",
                 }
+                def run(protocol):
+                    pass
                 """
             ),
             expected_api_level=APIVersion(2, 11),
@@ -106,6 +114,8 @@ class _ValidPythonProtocolSpec:
                 requirements = {
                     "robotType": "OT-3",
                 }
+                def run(protocol):
+                    pass
                 """
             ),
             expected_api_level=APIVersion(2, 11),
@@ -120,6 +130,8 @@ class _ValidPythonProtocolSpec:
                 requirements = {
                     "apiLevel": "2.11",
                 }
+                def run(protocol):
+                    pass
                 """
             ),
             expected_api_level=APIVersion(2, 11),
@@ -325,7 +337,7 @@ class _InvalidInputSpec:
                     pass
                 """
             ),
-            expected_message="Unable to parse",
+            expected_message="invalid syntax",
         ),
         # Python with various kinds of invalid metadata dict or apiLevel:
         _InvalidInputSpec(
@@ -333,6 +345,9 @@ class _InvalidInputSpec:
             contents=textwrap.dedent(
                 """
                 # Metadata missing entirely.
+
+                def run():
+                    pass
                 """
             ),
             expected_message="apiLevel not declared in protocol.py",
@@ -343,6 +358,9 @@ class _InvalidInputSpec:
                 """
                 # Metadata provided, but not as a dict.
                 metadata = "Hello"
+
+                def run():
+                    pass
                 """
             ),
             expected_message="apiLevel not declared in protocol.py",
@@ -353,6 +371,9 @@ class _InvalidInputSpec:
                 """
                 # apiLevel missing from metadata.
                 metadata = {"Hello": "World"}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="apiLevel not declared in protocol.py",
@@ -363,6 +384,9 @@ class _InvalidInputSpec:
                 """
                 # Metadata not statically parsable.
                 metadata = {"apiLevel": "123" + ".456"}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="Could not read the contents of the metadata dict",
@@ -373,6 +397,9 @@ class _InvalidInputSpec:
                 """
                 # apiLevel provided, but not as a string.
                 metadata = {"apiLevel": 123.456}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="must be strings",
@@ -383,6 +410,9 @@ class _InvalidInputSpec:
                 """
                 # apiLevel provided, but not as a well formatted string.
                 metadata = {"apiLevel": "123*456"}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="is incorrectly formatted",
@@ -393,6 +423,9 @@ class _InvalidInputSpec:
                 """
                 # apiLevel provided, but not a valid version.
                 metadata = {"apiLevel": "123.456"}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="API version 123.456 is not supported by this robot software. Please either reduce your requested API version or update your robot.",
@@ -404,6 +437,9 @@ class _InvalidInputSpec:
                 metadata = {"apiLevel": "2.11"}
                 # robotType provided, but not a valid string.
                 requirements = {"robotType": "ot2"}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="robotType must be 'OT-2' or 'Flex', not 'ot2'.",
@@ -415,6 +451,9 @@ class _InvalidInputSpec:
                 metadata = {"apiLevel": "2.11"}
                 # robotType provided, but not a valid string.
                 requirements = {"robotType": "flex"}
+
+                def run():
+                    pass
                 """
             ),
             expected_message="robotType must be 'OT-2' or 'Flex', not 'flex'.",

--- a/api/tests/opentrons/protocols/execution/test_execute_python.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_python.py
@@ -49,7 +49,7 @@ def run():
     pass
 """
     )
-    with pytest.raises(execute_python.MalformedProtocolError) as e:
+    with pytest.raises(execute_python.MalformedPythonError) as e:
         execute.run_protocol(no_args, context=ctx)
         assert "Function 'run()' does not take any parameters" in str(e.value)
 
@@ -60,7 +60,7 @@ def run(a, b):
     pass
 """
     )
-    with pytest.raises(execute_python.MalformedProtocolError) as e:
+    with pytest.raises(execute_python.MalformedPythonError) as e:
         execute.run_protocol(many_args, context=ctx)
         assert "must be called with more than one argument" in str(e.value)
 

--- a/api/tests/opentrons/protocols/execution/test_execute_python.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_python.py
@@ -49,7 +49,7 @@ def run():
     pass
 """
     )
-    with pytest.raises(execute_python.MalformedPythonError) as e:
+    with pytest.raises(execute_python.MalformedPythonProtocolError) as e:
         execute.run_protocol(no_args, context=ctx)
         assert "Function 'run()' does not take any parameters" in str(e.value)
 
@@ -60,7 +60,7 @@ def run(a, b):
     pass
 """
     )
-    with pytest.raises(execute_python.MalformedPythonError) as e:
+    with pytest.raises(execute_python.MalformedPythonProtocolError) as e:
         execute.run_protocol(many_args, context=ctx)
         assert "must be called with more than one argument" in str(e.value)
 

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -18,7 +18,7 @@ from opentrons.protocols.types import (
     Protocol,
     PythonProtocol,
     PythonProtocolMetadata,
-    MalformedPythonError,
+    MalformedPythonProtocolError,
     ApiDeprecationError,
 )
 from opentrons.protocols.api_support.types import APIVersion
@@ -251,7 +251,7 @@ def test_parse_get_version(proto: str, version: APIVersion) -> None:
 def test_version_from_static_python_info_invalid(
     protocol_source: str, expected_message: str
 ) -> None:
-    with pytest.raises(MalformedPythonError, match=expected_message):
+    with pytest.raises(MalformedPythonProtocolError, match=expected_message):
         parse(dedent(protocol_source), "protocol.py")
 
 
@@ -640,5 +640,5 @@ def test_parse_extra_contents(
     ],
 )
 def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
-    with pytest.raises(MalformedPythonError, match=expected_message):
+    with pytest.raises(MalformedPythonProtocolError, match=expected_message):
         parse(dedent(bad_protocol))

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -115,6 +115,13 @@ def test_extract_static_python_info(
 
 
 parse_version_cases = [
+    # No explicitly-declared apiLevel (infer heuristically from APIv1 imports):
+    (
+        """
+        from opentrons import types, containers
+        """,
+        APIVersion(1, 0),
+    ),
     (
         """
         from opentrons import instruments
@@ -125,7 +132,15 @@ parse_version_cases = [
     ),
     (
         """
-        import opentrons.instruments
+        from opentrons import labware, instruments
+
+        p = instruments.P10_Single(mount='right')
+        """,
+        APIVersion(1, 0),
+    ),
+    (
+        """
+        from opentrons import types, instruments
 
         p = instruments.P10_Single(mount='right')
         """,
@@ -141,6 +156,15 @@ parse_version_cases = [
     ),
     (
         """
+        import opentrons.instruments
+
+        p = instruments.P10_Single(mount='right')
+        """,
+        APIVersion(1, 0),
+    ),
+    # Explicitly-declared APIv1:
+    (
+        """
         from opentrons import instruments
 
         metadata = {
@@ -151,6 +175,21 @@ parse_version_cases = [
         """,
         APIVersion(1, 0),
     ),
+    (
+        # Explicitly-declared APIv1 despite having an APIv2-style run(ctx) function.
+        """
+        from opentrons import types
+
+        metadata = {
+          'apiLevel': '1'
+          }
+
+        def run(ctx):
+            right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
+        """,
+        APIVersion(1, 0),
+    ),
+    # Explicitly-declared APIv2:
     (
         """
         from opentrons import types
@@ -169,19 +208,6 @@ parse_version_cases = [
         from opentrons import types
 
         metadata = {
-          'apiLevel': '1'
-          }
-
-        def run(ctx):
-            right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
-        """,
-        APIVersion(1, 0),
-    ),
-    (
-        """
-        from opentrons import types
-
-        metadata = {
           'apiLevel': '2.0'
           }
 
@@ -189,36 +215,6 @@ parse_version_cases = [
             right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
         """,
         APIVersion(2, 0),
-    ),
-    (
-        """
-        from opentrons import labware, instruments
-
-        p = instruments.P10_Single(mount='right')
-        """,
-        APIVersion(1, 0),
-    ),
-    (
-        """
-        from opentrons import types, containers
-        """,
-        APIVersion(1, 0),
-    ),
-    (
-        """
-        from opentrons import types, instruments
-
-        p = instruments.P10_Single(mount='right')
-        """,
-        APIVersion(1, 0),
-    ),
-    (
-        """
-        from opentrons import instruments as instr
-
-        p = instr.P300_Single('right')
-        """,
-        APIVersion(1, 0),
     ),
 ]
 

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -496,7 +496,7 @@ def test_parse_extra_contents(
             def run(ctx)  # Missing ":".
                 pass
             """,
-            "(invalid syntax)|(missing ':')",  # This error message depends on the Python version.
+            '(invalid syntax)|(Missing ":")',  # This error message depends on the Python version.
         ),
         # Bad Python Protocol API structure:
         (

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -489,6 +489,16 @@ def test_parse_extra_contents(
 @pytest.mark.parametrize(
     ("bad_protocol", "expected_message"),
     [
+        # Bad Python syntax:
+        (
+            """
+            metadata = {"apiLevel": "2.0"}
+            def run(ctx)  # Missing ":".
+                pass
+            """,
+            "(invalid syntax)|(missing ':')",  # This error message depends on the Python version.
+        ),
+        # Bad Python Protocol API structure:
         (
             """
             metadata={"apiLevel": "2.0"}
@@ -515,6 +525,87 @@ def test_parse_extra_contents(
               pass
             """,
             "More than one run function",
+        ),
+        # Various kinds of invalid metadata dict or apiLevel:
+        (
+            # metadata missing entirely.
+            """
+            def run():
+                pass
+            """,
+            "apiLevel not declared",
+        ),
+        (
+            # Metadata provided, but not as a dict.
+            """
+            metadata = "Hello"
+
+            def run():
+                pass
+            """,
+            "apiLevel not declared",
+        ),
+        (
+            # apiLevel missing from metadata dict and requirements dict.
+            """
+            metadata = {"Hello": "World"}
+
+            def run():
+                pass
+            """,
+            "apiLevel not declared",
+        ),
+        (
+            # Metadata not statically parsable.
+            """
+            metadata = {"apiLevel": "123" + ".456"}
+
+            def run():
+                pass
+            """,
+            "Could not read the contents of the metadata dict",
+        ),
+        (
+            # apiLevel provided, but not as a string.
+            """
+            metadata = {"apiLevel": 123.456}
+
+            def run():
+                pass
+            """,
+            "must be strings",
+        ),
+        (
+            # apiLevel provided, but not as a well formatted string.
+            """
+            metadata = {"apiLevel": "123*456"}
+
+            def run():
+                pass
+            """,
+            "is incorrectly formatted",
+        ),
+        (
+            # robotType provided, but not a valid string.
+            """
+            metadata = {"apiLevel": "2.11"}
+            requirements = {"robotType": "ot2"}
+
+            def run():
+                pass
+            """,
+            "robotType must be 'OT-2' or 'Flex', not 'ot2'.",
+        ),
+        (
+            # robotType provided, but not a valid string.
+            """
+            metadata = {"apiLevel": "2.11"}
+            requirements = {"robotType": "flex"}
+
+            def run():
+                pass
+            """,
+            "robotType must be 'OT-2' or 'Flex', not 'flex'.",
         ),
     ],
 )

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -381,6 +381,36 @@ def test_validate_json(
             APIVersion(2, 1),
             "OT-2 Standard",
         ),
+        (
+            # Explicitly-specified robotType.
+            """
+            requirements = {"apiLevel": "2.15", "robotType": "OT-2"}
+            def run(ctx): pass
+            """,
+            None,
+            APIVersion(2, 15),
+            "OT-2 Standard",
+        ),
+        (
+            # Explicitly-specified robotType.
+            """
+            requirements = {"apiLevel": "2.15", "robotType": "Flex"}
+            def run(ctx): pass
+            """,
+            None,
+            APIVersion(2, 15),
+            "OT-3 Standard",
+        ),
+        (
+            # Explicitly-specified robotType.
+            """
+            requirements = {"apiLevel": "2.15", "robotType": "OT-3"}
+            def run(ctx): pass
+            """,
+            None,
+            APIVersion(2, 15),
+            "OT-3 Standard",
+        ),
     ],
 )
 @pytest.mark.parametrize("protocol_text_kind", ["str", "bytes"])


### PR DESCRIPTION
# Overview

`FileIdentifier` and `opentrons.protocols.parse` have had a duplication problem for a while now. This resolves a lot of that duplication for Python protocols, leaving JSON protocols alone for now.

Fixes RSS-161 (unactionable error messages for certain kinds of malformed protocols). [Before](https://github.com/Opentrons/opentrons/assets/3236864/6ba5273b-b446-453f-902d-395f41f8f298) vs. [after](https://github.com/Opentrons/opentrons/assets/3236864/a5c19353-f126-4d3a-9b32-81627b99cc6e).

Helps with RSS-268 (supporting Protocol Engine through `opentrons.execute` etc.).

Helps with RSS-264 and RSS-265 (adding some new validation for Python files).

# Test Plan

I think this is decently covered by automated tests.

One quick manual test that could be helpful is pushing this branch to some random robots in the office and confirming that the robot server still boots up. We've had problems in the past where schema changes make the server think its stored protocols are corrupted, which can block general usability. I don't think that will happen here, but it's good to check.

# Changelog

* Instead of letting `FileIdentifier` do its own `ast.parse()` crap, have it delegate to `opentrons.protocols.parse.parse()`.
* Resolve a lot of the overlap between the two modules' test suites. The `FileIdentifier` tests now mock out `opentrons.protocols.parse.parse()`. 
* Simplify the the public interface of `opentrons.protocols.parse`. There were several public functions that were veering into weedy implementation-detail territory. Now that `FileIdentifier` doesn't rely on those, we can make them private. Their tests have been ported to go through the top-level `parse()` function instead, so we should still be testing the same codepaths.
* When `opentrons.protocols.parse` identifies a user error in a Python file, ensure it raises it with a distinct error type, `MalformedPythonError`. Also ensure it includes a human-readable message that the higher layers can relay to the Opentrons App.

# Review requests

None in particular.

# Risk assessment

I think low, but see my thoughts in the test plan.