### PR TITLE
feat(api): Add more validation to metadata and requirements dicts

### DIFF
--- a/api/src/opentrons/ordered_set.py
+++ b/api/src/opentrons/ordered_set.py
@@ -1,7 +1,18 @@
 """A set that preserves the order in which elements are added."""
 
+from __future__ import annotations
 
-from typing import Dict, Generic, Hashable, Iterable, Iterator, TypeVar, Union, overload
+from typing import (
+    Dict,
+    Generic,
+    Hashable,
+    Iterable,
+    Iterator,
+    Set,
+    TypeVar,
+    Union,
+    overload,
+)
 from typing_extensions import Literal
 
 
@@ -110,3 +121,12 @@ class OrderedSet(Generic[_SetElementT]):
             return list(self) == list(other)
         else:
             return False
+
+    def __sub__(
+        self, other: Union[OrderedSet[_SetElementT], Set[_SetElementT]]
+    ) -> OrderedSet[_SetElementT]:
+        """Return this set, without any elements that appear in `other`.
+
+        The elements that aren't removed retain their original relative order.
+        """
+        return OrderedSet(e for e in self if e not in other)

--- a/api/src/opentrons/protocol_reader/protocol_reader.py
+++ b/api/src/opentrons/protocol_reader/protocol_reader.py
@@ -71,7 +71,9 @@ class ProtocolReader:
             ProtocolFilesInvalidError: Input file list given to the reader
                 could not be validated as a protocol.
         """
-        identified_files = await self._file_identifier.identify(files)
+        identified_files = await self._file_identifier.identify(
+            files, flex_dev_compat=False
+        )
         role_analysis = self._role_analyzer.analyze(identified_files)
         await self._file_format_validator.validate(role_analysis.all_files)
 
@@ -101,6 +103,7 @@ class ProtocolReader:
         files: Sequence[Path],
         directory: Optional[Path],
         files_are_prevalidated: bool = False,
+        flex_dev_compat: bool = False,
     ) -> ProtocolSource:
         """Compute a `ProtocolSource` from protocol source files on the filesystem.
 
@@ -116,6 +119,8 @@ class ProtocolReader:
                 stuff for the `ProtocolSource`. This can be 10-100x faster, but you
                 should only do it with protocols that have already been validated
                 by this module.
+            flex_dev_compat: See the parameter of the same name in
+                `opentrons.protocols.parse.parse()`.
 
         Returns:
             A `ProtocolSource` describing the validated protocol.
@@ -125,7 +130,10 @@ class ProtocolReader:
                 could not be validated as a protocol.
         """
         buffered_files = await self._file_reader_writer.read(files)
-        identified_files = await self._file_identifier.identify(buffered_files)
+        identified_files = await self._file_identifier.identify(
+            files=buffered_files,
+            flex_dev_compat=flex_dev_compat,
+        )
         role_analysis = self._role_analyzer.analyze(identified_files)
         if not files_are_prevalidated:
             await self._file_format_validator.validate(role_analysis.all_files)

--- a/api/src/opentrons/protocol_reader/protocol_reader.py
+++ b/api/src/opentrons/protocol_reader/protocol_reader.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 from typing import Optional, Sequence
 
+from opentrons.protocols.parse import PythonParseMode
+
 from .file_identifier import (
     FileIdentifier,
     IdentifiedFile,
@@ -72,7 +74,7 @@ class ProtocolReader:
                 could not be validated as a protocol.
         """
         identified_files = await self._file_identifier.identify(
-            files, flex_dev_compat=False
+            files, python_parse_mode=PythonParseMode.NORMAL
         )
         role_analysis = self._role_analyzer.analyze(identified_files)
         await self._file_format_validator.validate(role_analysis.all_files)
@@ -103,7 +105,7 @@ class ProtocolReader:
         files: Sequence[Path],
         directory: Optional[Path],
         files_are_prevalidated: bool = False,
-        flex_dev_compat: bool = False,
+        python_parse_mode: PythonParseMode = PythonParseMode.NORMAL,
     ) -> ProtocolSource:
         """Compute a `ProtocolSource` from protocol source files on the filesystem.
 
@@ -119,8 +121,7 @@ class ProtocolReader:
                 stuff for the `ProtocolSource`. This can be 10-100x faster, but you
                 should only do it with protocols that have already been validated
                 by this module.
-            flex_dev_compat: See the parameter of the same name in
-                `opentrons.protocols.parse.parse()`.
+            python_parse_mode: See the documentation in `PythonParseMode`.
 
         Returns:
             A `ProtocolSource` describing the validated protocol.
@@ -132,7 +133,7 @@ class ProtocolReader:
         buffered_files = await self._file_reader_writer.read(files)
         identified_files = await self._file_identifier.identify(
             files=buffered_files,
-            flex_dev_compat=flex_dev_compat,
+            python_parse_mode=python_parse_mode,
         )
         role_analysis = self._role_analyzer.analyze(identified_files)
         if not files_are_prevalidated:

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -68,6 +68,7 @@ class LegacyFileReader:
     def read(
         protocol_source: ProtocolSource,
         labware_definitions: Iterable[LabwareDefinition],
+        flex_dev_compat: bool,
     ) -> LegacyProtocol:
         """Read a PAPIv2 protocol into a data structure."""
         protocol_file_path = protocol_source.main_file
@@ -93,6 +94,7 @@ class LegacyFileReader:
             extra_data={
                 data_path.name: data_path.read_bytes() for data_path in data_file_paths
             },
+            flex_dev_compat=flex_dev_compat,
         )
 
 

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -39,7 +39,7 @@ from opentrons.protocol_api.core.legacy.load_info import (
     ModuleLoadInfo as LegacyModuleLoadInfo,
 )
 
-from opentrons.protocols.parse import parse
+from opentrons.protocols.parse import PythonParseMode, parse
 from opentrons.protocols.execution.execute import run_protocol
 from opentrons.protocols.types import (
     Protocol as LegacyProtocol,
@@ -68,7 +68,7 @@ class LegacyFileReader:
     def read(
         protocol_source: ProtocolSource,
         labware_definitions: Iterable[LabwareDefinition],
-        flex_dev_compat: bool,
+        python_parse_mode: PythonParseMode,
     ) -> LegacyProtocol:
         """Read a PAPIv2 protocol into a data structure."""
         protocol_file_path = protocol_source.main_file
@@ -94,7 +94,7 @@ class LegacyFileReader:
             extra_data={
                 data_path.name: data_path.read_bytes() for data_path in data_file_paths
             },
-            flex_dev_compat=flex_dev_compat,
+            python_parse_mode=python_parse_mode,
         )
 
 

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -116,7 +116,9 @@ class PythonAndLegacyRunner(AbstractRunner):
         # of runner interface
         self._task_queue = task_queue or TaskQueue(cleanup_func=protocol_engine.finish)
 
-    async def load(self, protocol_source: ProtocolSource) -> None:
+    async def load(
+        self, protocol_source: ProtocolSource, flex_dev_compat: bool
+    ) -> None:
         """Load a Python or JSONv5(& older) ProtocolSource into managed ProtocolEngine."""
         labware_definitions = await protocol_reader.extract_labware_definitions(
             protocol_source=protocol_source
@@ -128,7 +130,9 @@ class PythonAndLegacyRunner(AbstractRunner):
 
         # fixme(mm, 2022-12-23): This does I/O and compute-bound parsing that will block
         # the event loop. Jira RSS-165.
-        protocol = self._legacy_file_reader.read(protocol_source, labware_definitions)
+        protocol = self._legacy_file_reader.read(
+            protocol_source, labware_definitions, flex_dev_compat
+        )
         broker = None
         equipment_broker = None
 
@@ -159,11 +163,14 @@ class PythonAndLegacyRunner(AbstractRunner):
     async def run(  # noqa: D102
         self,
         protocol_source: Optional[ProtocolSource] = None,
+        flex_dev_compat: bool = False,
     ) -> RunResult:
         # TODO(mc, 2022-01-11): move load to runner creation, remove from `run`
         # currently `protocol_source` arg is only used by tests
         if protocol_source:
-            await self.load(protocol_source=protocol_source)
+            await self.load(
+                protocol_source=protocol_source, flex_dev_compat=flex_dev_compat
+            )
 
         self.play()
         self._task_queue.start()

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -21,6 +21,7 @@ from opentrons.protocol_engine import (
     Command,
     commands as pe_commands,
 )
+from opentrons.protocols.parse import PythonParseMode
 
 from .task_queue import TaskQueue
 from .json_file_reader import JsonFileReader
@@ -117,7 +118,7 @@ class PythonAndLegacyRunner(AbstractRunner):
         self._task_queue = task_queue or TaskQueue(cleanup_func=protocol_engine.finish)
 
     async def load(
-        self, protocol_source: ProtocolSource, flex_dev_compat: bool
+        self, protocol_source: ProtocolSource, python_parse_mode: PythonParseMode
     ) -> None:
         """Load a Python or JSONv5(& older) ProtocolSource into managed ProtocolEngine."""
         labware_definitions = await protocol_reader.extract_labware_definitions(
@@ -131,7 +132,7 @@ class PythonAndLegacyRunner(AbstractRunner):
         # fixme(mm, 2022-12-23): This does I/O and compute-bound parsing that will block
         # the event loop. Jira RSS-165.
         protocol = self._legacy_file_reader.read(
-            protocol_source, labware_definitions, flex_dev_compat
+            protocol_source, labware_definitions, python_parse_mode
         )
         broker = None
         equipment_broker = None
@@ -163,13 +164,13 @@ class PythonAndLegacyRunner(AbstractRunner):
     async def run(  # noqa: D102
         self,
         protocol_source: Optional[ProtocolSource] = None,
-        flex_dev_compat: bool = False,
+        python_parse_mode: PythonParseMode = PythonParseMode.NORMAL,
     ) -> RunResult:
         # TODO(mc, 2022-01-11): move load to runner creation, remove from `run`
         # currently `protocol_source` arg is only used by tests
         if protocol_source:
             await self.load(
-                protocol_source=protocol_source, flex_dev_compat=flex_dev_compat
+                protocol_source=protocol_source, python_parse_mode=python_parse_mode
             )
 
         self.play()

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -50,6 +50,10 @@ MAX_SUPPORTED_JSON_SCHEMA_VERSION = 5
 API_VERSION_FOR_JSON_V5_AND_BELOW = APIVersion(2, 8)
 
 
+# Matches the minimum version for the Protocol Engine PAPI core.
+_MIN_API_VERSION_FOR_FLEX = APIVersion(2, 14)
+
+
 class JSONSchemaVersionTooNewError(RuntimeError):
     def __init__(self, attempted_schema_version: int) -> None:
         super().__init__(attempted_schema_version)
@@ -119,6 +123,16 @@ def _validate_v2_static_info(static_info: StaticPythonInfo) -> None:
         # version that only knows about the metadata dict, not the requirements dict.
         raise MalformedPythonProtocolError(
             "You may only put apiLevel in the metadata dict or the requirements dict, not both."
+        )
+
+
+def _validate_robot_type_at_version(robot_type: RobotType, version: APIVersion) -> None:
+    if robot_type == "OT-3 Standard" and version < _MIN_API_VERSION_FOR_FLEX:
+        raise MalformedPythonProtocolError(
+            short_message=(
+                f"The Opentrons Flex only supports apiLevel"
+                f" {_MIN_API_VERSION_FOR_FLEX} or newer."
+            )
         )
 
 
@@ -199,6 +213,7 @@ def _parse_python(
         _validate_v2_ast(parsed)
         if not flex_dev_compat:
             _validate_v2_static_info(static_info)
+            _validate_robot_type_at_version(robot_type, version)
     else:
         raise ApiDeprecationError(version)
 

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -426,17 +426,6 @@ def _version_from_static_python_info(
     If the protocol doesn't declare apiLevel at all, return None.
     If the protocol declares apiLevel incorrectly, raise a ValueError.
     """
-    # TODO(mm, 2022-10-21):
-    #
-    # This logic is quick and dirty, and might allow things that we don't want.
-    #
-    # - Require protocols with new `apiLevel`s to specify `apiLevel` in `requirements`
-    #   and not in `metadata`?
-    # - Forbid protocols from specifying `apiLevel` in both `requirements` and
-    #   `metadata`?
-    # - Be more careful with falsey values, like `"apiLevel": ""`?
-    # - Forbid unrecognized keys in `requirements`?
-
     from_requirements = (static_python_info.requirements or {}).get("apiLevel", None)
     from_metadata = (static_python_info.metadata or {}).get("apiLevel", None)
     requested_level = from_requirements or from_metadata

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -50,8 +50,7 @@ MAX_SUPPORTED_JSON_SCHEMA_VERSION = 5
 API_VERSION_FOR_JSON_V5_AND_BELOW = APIVersion(2, 8)
 
 
-# Matches the minimum version for the Protocol Engine PAPI core.
-_MIN_API_VERSION_FOR_FLEX = APIVersion(2, 14)
+_MIN_API_VERSION_FOR_FLEX = APIVersion(2, 15)
 
 
 class JSONSchemaVersionTooNewError(RuntimeError):

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -22,6 +22,8 @@ from opentrons_shared_data.protocol import (
 )
 from opentrons_shared_data.robot.dev_types import RobotType
 
+from opentrons.ordered_set import OrderedSet
+
 from .api_support.types import APIVersion
 from .types import (
     RUN_FUNCTION_MESSAGE,
@@ -97,7 +99,8 @@ def _validate_v2_static_info(static_info: StaticPythonInfo) -> None:
         # NOTE(mm, 2023-08-08): If we add new allowed keys to this dict in the future,
         # we should probably gate them behind new apiLevels.
     }
-    actual_requirements_keys = set((static_info.requirements or {}).keys())
+    # OrderedSet just to make the error message deterministic and easy to test.
+    actual_requirements_keys = OrderedSet((static_info.requirements or {}).keys())
     unexpected_requirements_keys = actual_requirements_keys - allowed_requirements_keys
     if unexpected_requirements_keys:
         raise MalformedPythonProtocolError(

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -151,10 +151,6 @@ def test_analysis_deck_definition(
 
 # TODO(mm, 2023-08-12): We can remove this test when we remove special handling for these
 # protocols. https://opentrons.atlassian.net/browse/RSS-306
-@pytest.mark.xfail(
-    # TODO(mm, 2023-08-12): Remove xfail when we implement this special handling.
-    strict=True
-)
 def test_strict_metatada_requirements_validation(tmp_path: Path) -> None:
     """It should apply strict validation to the metadata and requirements dicts.
 

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -105,9 +105,9 @@ def _get_deck_definition_test_source(api_level: str, robot_type: str) -> str:
         # The exact values don't matter much for this test, since we're not checking positional
         # accuracy here. They just need to be clearly different between the OT-2 and OT-3.
         ("2.13", "OT-2", "(196.38, 42.785, 44.04)"),
-        ("2.14", "OT-2", "(196.38, 42.785, 44.04)"),
+        ("2.15", "OT-2", "(196.38, 42.785, 44.04)"),
         pytest.param(
-            "2.14",
+            "2.15",
             "OT-3",
             "(227.88, 42.785, 44.04)",
             marks=pytest.mark.ot3_only,  # Analyzing an OT-3 protocol requires an OT-3 hardware API.

--- a/api/tests/opentrons/protocol_reader/test_file_identifier.py
+++ b/api/tests/opentrons/protocol_reader/test_file_identifier.py
@@ -34,13 +34,16 @@ def use_mock_parse(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize("filename", ["protocol.py", "protocol.PY", "protocol.Py"])
+@pytest.mark.parametrize("flex_dev_compat", [True, False])
 async def test_python_parsing(
-    decoy: Decoy, use_mock_parse: None, filename: str
+    decoy: Decoy, use_mock_parse: None, filename: str, flex_dev_compat: bool
 ) -> None:
     """It should use opentrons.protocols.parse() to extract basic ID info out of Python files."""
     input_file = BufferedFile(name=filename, contents=b"contents", path=None)
 
-    decoy.when(parse.parse(b"contents", filename)).then_return(
+    decoy.when(
+        parse.parse(b"contents", filename, flex_dev_compat=flex_dev_compat)
+    ).then_return(
         PythonProtocol(
             api_level=APIVersion(2, 1),
             robot_type="OT-3 Standard",
@@ -56,7 +59,7 @@ async def test_python_parsing(
     )
 
     subject = FileIdentifier()
-    [result] = await subject.identify([input_file])
+    [result] = await subject.identify([input_file], flex_dev_compat=flex_dev_compat)
 
     assert result == IdentifiedPythonMain(
         original_file=input_file,
@@ -185,7 +188,7 @@ async def test_valid_json_protocol(spec: _ValidJsonProtocolSpec) -> None:
         unvalidated_json=json.loads(spec.contents),
     )
     subject = FileIdentifier()
-    [result] = await subject.identify([input_file])
+    [result] = await subject.identify([input_file], flex_dev_compat=False)
     assert result == expected_result
 
 
@@ -219,7 +222,7 @@ async def test_valid_labware_definition(spec: _ValidLabwareDefinitionSpec) -> No
         original_file=input_file, unvalidated_json=json.loads(spec.contents)
     )
     subject = FileIdentifier()
-    [result] = await subject.identify([input_file])
+    [result] = await subject.identify([input_file], flex_dev_compat=False)
     assert result == expected_result
 
 
@@ -270,14 +273,19 @@ async def test_invalid_input(spec: _InvalidInputSpec) -> None:
     )
     subject = FileIdentifier()
     with pytest.raises(FileIdentificationError, match=spec.expected_message):
-        await subject.identify([input_file])
+        await subject.identify(
+            [input_file],
+            flex_dev_compat=False,
+        )
 
 
 async def test_invalid_python_api_level(decoy: Decoy, use_mock_parse: None) -> None:
     """It should check the apiLevel and raise if it's not supported."""
     input_file = BufferedFile(name="filename.py", contents=b"contents", path=None)
 
-    decoy.when(parse.parse(b"contents", "filename.py")).then_return(
+    decoy.when(
+        parse.parse(b"contents", "filename.py", flex_dev_compat=False)
+    ).then_return(
         PythonProtocol(
             api_level=APIVersion(999, 999),
             robot_type="OT-3 Standard",
@@ -295,14 +303,16 @@ async def test_invalid_python_api_level(decoy: Decoy, use_mock_parse: None) -> N
     subject = FileIdentifier()
 
     with pytest.raises(FileIdentificationError, match="999.999 is not supported"):
-        await subject.identify([input_file])
+        await subject.identify([input_file], flex_dev_compat=False)
 
 
 async def test_malformed_python(decoy: Decoy, use_mock_parse: None) -> None:
     """It should propagate errors that mean the Python file was malformed."""
     input_file = BufferedFile(name="filename.py", contents=b"contents", path=None)
 
-    decoy.when(parse.parse(b"contents", "filename.py")).then_raise(
+    decoy.when(
+        parse.parse(b"contents", "filename.py", flex_dev_compat=False)
+    ).then_raise(
         MalformedPythonProtocolError(
             short_message="message 1", long_additional_message="message 2"
         )
@@ -311,7 +321,7 @@ async def test_malformed_python(decoy: Decoy, use_mock_parse: None) -> None:
     subject = FileIdentifier()
 
     with pytest.raises(FileIdentificationError) as exc_info:
-        await subject.identify([input_file])
+        await subject.identify([input_file], flex_dev_compat=False)
 
     # TODO(mm, 2023-08-8): We probably want to propagate the longer message too, if there is one.
     # Align with the app+UI team about how to do this safely.

--- a/api/tests/opentrons/protocol_reader/test_protocol_reader.py
+++ b/api/tests/opentrons/protocol_reader/test_protocol_reader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.parse import PythonParseMode
 
 from opentrons.protocol_reader import (
     ProtocolReader,
@@ -126,7 +127,7 @@ async def test_save(
     decoy.when(
         await file_identifier.identify(
             [buffered_main_file, buffered_labware_file, buffered_data_file],
-            flex_dev_compat=False,
+            python_parse_mode=PythonParseMode.NORMAL,
         )
     ).then_return([main_file, labware_file, data_file])
     decoy.when(role_analyzer.analyze([main_file, labware_file, data_file])).then_return(
@@ -234,7 +235,7 @@ async def test_read_saved(
     decoy.when(
         await file_identifier.identify(
             [buffered_main_file, buffered_labware_file, buffered_data_file],
-            flex_dev_compat=False,
+            python_parse_mode=PythonParseMode.NORMAL,
         )
     ).then_return([main_file, labware_file, data_file])
     decoy.when(role_analyzer.analyze([main_file, labware_file, data_file])).then_return(

--- a/api/tests/opentrons/protocol_reader/test_protocol_reader.py
+++ b/api/tests/opentrons/protocol_reader/test_protocol_reader.py
@@ -125,7 +125,8 @@ async def test_save(
 
     decoy.when(
         await file_identifier.identify(
-            [buffered_main_file, buffered_labware_file, buffered_data_file]
+            [buffered_main_file, buffered_labware_file, buffered_data_file],
+            flex_dev_compat=False,
         )
     ).then_return([main_file, labware_file, data_file])
     decoy.when(role_analyzer.analyze([main_file, labware_file, data_file])).then_return(
@@ -232,7 +233,8 @@ async def test_read_saved(
     ).then_return([buffered_main_file, buffered_labware_file, buffered_data_file])
     decoy.when(
         await file_identifier.identify(
-            [buffered_main_file, buffered_labware_file, buffered_data_file]
+            [buffered_main_file, buffered_labware_file, buffered_data_file],
+            flex_dev_compat=False,
         )
     ).then_return([main_file, labware_file, data_file])
     decoy.when(role_analyzer.analyze([main_file, labware_file, data_file])).then_return(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -12,6 +12,7 @@ from opentrons.broker import Broker
 from opentrons.equipment_broker import EquipmentBroker
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.parse import PythonParseMode
 from opentrons_shared_data.protocol.models import ProtocolSchemaV6, ProtocolSchemaV7
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.protocol_engine import ProtocolEngine, Liquid, commands as pe_commands
@@ -434,7 +435,7 @@ async def test_load_legacy_python(
         legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[labware_definition],
-            flex_dev_compat=True,
+            python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         )
     ).then_return(legacy_protocol)
     decoy.when(
@@ -446,7 +447,8 @@ async def test_load_legacy_python(
     ).then_return(legacy_context)
 
     await legacy_python_runner_subject.load(
-        legacy_protocol_source, flex_dev_compat=True
+        legacy_protocol_source,
+        python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
     )
 
     decoy.verify(
@@ -503,7 +505,7 @@ async def test_load_python_with_pe_papi_core(
         legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[],
-            flex_dev_compat=True,
+            python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         )
     ).then_return(legacy_protocol)
     decoy.when(
@@ -513,7 +515,8 @@ async def test_load_python_with_pe_papi_core(
     ).then_return(legacy_context)
 
     await legacy_python_runner_subject.load(
-        legacy_protocol_source, flex_dev_compat=True
+        legacy_protocol_source,
+        python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
     )
 
     decoy.verify(protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)), times=0)
@@ -560,7 +563,7 @@ async def test_load_legacy_json(
         legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[labware_definition],
-            flex_dev_compat=True,
+            python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         )
     ).then_return(legacy_protocol)
     decoy.when(
@@ -572,7 +575,8 @@ async def test_load_legacy_json(
     ).then_return(legacy_context)
 
     await legacy_python_runner_subject.load(
-        legacy_protocol_source, flex_dev_compat=True
+        legacy_protocol_source,
+        python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
     )
 
     decoy.verify(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -434,6 +434,7 @@ async def test_load_legacy_python(
         legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[labware_definition],
+            flex_dev_compat=True,
         )
     ).then_return(legacy_protocol)
     decoy.when(
@@ -444,7 +445,9 @@ async def test_load_legacy_python(
         )
     ).then_return(legacy_context)
 
-    await legacy_python_runner_subject.load(legacy_protocol_source)
+    await legacy_python_runner_subject.load(
+        legacy_protocol_source, flex_dev_compat=True
+    )
 
     decoy.verify(
         protocol_engine.add_labware_definition(labware_definition),
@@ -498,7 +501,9 @@ async def test_load_python_with_pe_papi_core(
     ).then_return([])
     decoy.when(
         legacy_file_reader.read(
-            protocol_source=legacy_protocol_source, labware_definitions=[]
+            protocol_source=legacy_protocol_source,
+            labware_definitions=[],
+            flex_dev_compat=True,
         )
     ).then_return(legacy_protocol)
     decoy.when(
@@ -507,7 +512,9 @@ async def test_load_python_with_pe_papi_core(
         )
     ).then_return(legacy_context)
 
-    await legacy_python_runner_subject.load(legacy_protocol_source)
+    await legacy_python_runner_subject.load(
+        legacy_protocol_source, flex_dev_compat=True
+    )
 
     decoy.verify(protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)), times=0)
 
@@ -553,6 +560,7 @@ async def test_load_legacy_json(
         legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[labware_definition],
+            flex_dev_compat=True,
         )
     ).then_return(legacy_protocol)
     decoy.when(
@@ -563,7 +571,9 @@ async def test_load_legacy_json(
         )
     ).then_return(legacy_context)
 
-    await legacy_python_runner_subject.load(legacy_protocol_source)
+    await legacy_python_runner_subject.load(
+        legacy_protocol_source, flex_dev_compat=True
+    )
 
     decoy.verify(
         protocol_engine.add_labware_definition(labware_definition),

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -167,7 +167,6 @@ parse_version_cases = [
         APIVersion(10, 23123151),
     ),
     # Explicitly-declared apiLevel with various cases of it being in metadata or requirements:
-    # TODO(mm, 2022-10-21): The expected behavior here is still to be decided.
     (
         """
         requirements = {"apiLevel": "123.456"}
@@ -197,16 +196,6 @@ parse_version_cases = [
         def run(ctx): pass
         """,
         APIVersion(123, 456),
-    ),
-    (
-        # Overriding:
-        # TODO(mm, 2022-10-21): The expected behavior here is still to be decided.
-        """
-        metadata = {"apiLevel": "123.456"}
-        requirements = {"apiLevel": "789.0"}
-        def run(ctx): pass
-        """,
-        APIVersion(789, 0),
     ),
 ]
 
@@ -636,6 +625,24 @@ def test_parse_extra_contents(
                 pass
             """,
             "robotType must be 'OT-2' or 'Flex', not 'flex'.",
+        ),
+        (
+            # apiLevel in both metadata and requirements.
+            """
+            metadata = {"apiLevel": "2.14"}
+            requirements = {"apiLevel": "2.14"}
+            def run(ctx): pass
+            """,
+            "You may only put apiLevel in the metadata dict or the requirements dict, not both.",
+        ),
+        (
+            # apiLevel in both metadata and requirements.
+            """
+            metadata = {"apiLevel": "2.14"}
+            requirements = {"apiLevel": ""}
+            def run(ctx): pass
+            """,
+            "You may only put apiLevel in the metadata dict or the requirements dict, not both.",
         ),
     ],
 )

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -626,6 +626,17 @@ def test_parse_extra_contents(
             """,
             "robotType must be 'OT-2' or 'Flex', not 'flex'.",
         ),
+    ],
+)
+def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
+    with pytest.raises(MalformedPythonProtocolError, match=expected_message):
+        parse(dedent(bad_protocol))
+
+
+@pytest.mark.parametrize("flex_dev_compat", [True, False])
+@pytest.mark.parametrize(
+    ("questionable_protocol", "expected_message"),
+    [
         (
             # apiLevel in both metadata and requirements.
             """
@@ -654,12 +665,18 @@ def test_parse_extra_contents(
                 "RobotType": "Flex",
                 "foo": "bar",
             }
-            def run(cxt): pass
+            def run(ctx): pass
             """,
             "Unrecognized keys in requirements dict: 'APILevel', 'RobotType', 'foo'",
         ),
     ],
 )
-def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
-    with pytest.raises(MalformedPythonProtocolError, match=expected_message):
-        parse(dedent(bad_protocol))
+def test_flex_dev_compat(
+    questionable_protocol: str, flex_dev_compat: bool, expected_message: str
+) -> None:
+    if flex_dev_compat:
+        # Should not raise:
+        parse(dedent(questionable_protocol), flex_dev_compat=True)
+    else:
+        with pytest.raises(MalformedPythonProtocolError, match=expected_message):
+            parse(dedent(questionable_protocol), flex_dev_compat=False)

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -335,7 +335,7 @@ def test_validate_json(
             metadata = {
                 'mk1': 'mv1',
                 'mk2': 'mv2',
-                'apiLevel': '2.0'
+                'apiLevel': '2.123'
             }
             print('wat?')
             def run(cxt): pass
@@ -348,9 +348,9 @@ def test_validate_json(
             {
                 "mk1": "mv1",
                 "mk2": "mv2",
-                "apiLevel": "2.0",
+                "apiLevel": "2.123",
             },
-            APIVersion(2, 0),
+            APIVersion(2, 123),
             "OT-3 Standard",
         ),
         (
@@ -668,6 +668,14 @@ def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
             def run(ctx): pass
             """,
             "Unrecognized keys in requirements dict: 'APILevel', 'RobotType', 'foo'",
+        ),
+        (
+            # apiLevel too old to support the Flex.
+            """
+            requirements = {"apiLevel": "2.13", "robotType": "Flex"}
+            def run(cxt): pass
+            """,
+            "The Opentrons Flex only supports apiLevel 2.14 or newer.",
         ),
     ],
 )

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -633,6 +633,9 @@ def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
         parse(dedent(bad_protocol))
 
 
+# TODO(mm, 2023-08-10): When we remove flex_dev_compat from parse(), remove this
+# flex_dev_compat=True parametrization and merge these tests with the other metadata/requirements
+# validation tests.
 @pytest.mark.parametrize("flex_dev_compat", [True, False])
 @pytest.mark.parametrize(
     ("questionable_protocol", "expected_message"),
@@ -673,13 +676,13 @@ def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
             # apiLevel too old to support the Flex.
             """
             requirements = {"apiLevel": "2.13", "robotType": "Flex"}
-            def run(cxt): pass
+            def run(ctx): pass
             """,
             "The Opentrons Flex only supports apiLevel 2.15 or newer.",
         ),
     ],
 )
-def test_flex_dev_compat(
+def test_flex_dev_compat_conditional_errors(
     questionable_protocol: str, flex_dev_compat: bool, expected_message: str
 ) -> None:
     if flex_dev_compat:

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -659,9 +659,9 @@ def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
             # Unrecognized keys in requirements.
             """
             requirements = {
-                "apiLevel": "2.14",
+                "apiLevel": "2.15",
                 "robotType": "Flex",
-                "APILevel": "2.14",
+                "APILevel": "2.15",
                 "RobotType": "Flex",
                 "foo": "bar",
             }
@@ -675,7 +675,7 @@ def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:
             requirements = {"apiLevel": "2.13", "robotType": "Flex"}
             def run(cxt): pass
             """,
-            "The Opentrons Flex only supports apiLevel 2.14 or newer.",
+            "The Opentrons Flex only supports apiLevel 2.15 or newer.",
         ),
     ],
 )

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -644,6 +644,20 @@ def test_parse_extra_contents(
             """,
             "You may only put apiLevel in the metadata dict or the requirements dict, not both.",
         ),
+        (
+            # Unrecognized keys in requirements.
+            """
+            requirements = {
+                "apiLevel": "2.14",
+                "robotType": "Flex",
+                "APILevel": "2.14",
+                "RobotType": "Flex",
+                "foo": "bar",
+            }
+            def run(cxt): pass
+            """,
+            "Unrecognized keys in requirements dict: 'APILevel', 'RobotType', 'foo'",
+        ),
     ],
 )
 def test_parse_bad_structure(bad_protocol: str, expected_message: str) -> None:

--- a/api/tests/opentrons/test_ordered_set.py
+++ b/api/tests/opentrons/test_ordered_set.py
@@ -137,3 +137,11 @@ def test_head() -> None:
         subject.head()
 
     assert subject.head(default_value=42) == 42
+
+
+def test_difference() -> None:
+    """It should return the set difference, preserving order."""
+    a = OrderedSet([3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9])
+    b = {1, 9}
+
+    assert (a - OrderedSet(b)) == (a - b) == OrderedSet([3, 4, 5, 2, 6, 5, 3, 5, 8, 7])

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -443,6 +443,7 @@ async def _compute_protocol_sources(
             files=protocol_files,
             directory=Path(protocol_subdirectory),
             files_are_prevalidated=True,
+            flex_dev_compat=True,
         )
         sources_by_id[protocol_id] = protocol_source
 

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Set
 from anyio import Path as AsyncPath, create_task_group
 import sqlalchemy
 
+from opentrons.protocols.parse import PythonParseMode
 from opentrons.protocol_reader import ProtocolReader, ProtocolSource
 from robot_server.persistence import (
     analysis_table,
@@ -443,7 +444,7 @@ async def _compute_protocol_sources(
             files=protocol_files,
             directory=Path(protocol_subdirectory),
             files_are_prevalidated=True,
-            flex_dev_compat=True,
+            python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         )
         sources_by_id[protocol_id] = protocol_source
 

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -11,6 +11,7 @@ from opentrons.hardware_control.types import (
     EstopStateNotification,
     HardwareEventHandler,
 )
+from opentrons.protocols.parse import PythonParseMode
 from opentrons.protocol_runner import (
     AnyRunner,
     JsonRunner,
@@ -186,7 +187,7 @@ class EngineStore:
                 # Conservatively assume that we're re-running a protocol that
                 # was uploaded before we added stricter validation, and that
                 # doesn't conform to the new rules.
-                flex_dev_compat=True,
+                python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
             )
         elif isinstance(runner, JsonRunner):
             assert (

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -162,7 +162,7 @@ async def test_rerun_flex_dev_compat() -> None:
     async with RobotClient.make(
         base_url=f"http://localhost:{_PORT}", version="*"
     ) as client:
-        assert await client.wait_until_dead(), "Dev Robot is running and must not be."
+        assert await client.wait_until_dead(), "Dev Robot is running but it should not be."
         with DevServer(persistence_directory=snapshot.get_copy(), port=_PORT) as server:
             server.start()
             await client.wait_until_alive()

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -17,6 +17,12 @@ from .persistence_snapshots_dir import PERSISTENCE_SNAPSHOTS_DIR
 _POLL_INTERVAL = 0.1
 _RUN_TIMEOUT = 5
 
+# Our Tavern tests have servers that stay up for the duration of the test session.
+# We need to pick a different port for our servers to avoid colliding with those.
+# Beware that if there is a collision, these tests' manual DevServer() constructions will currently
+# *not* raise an error--the tests will try to use the preexisting session-scoped servers. :(
+_PORT = "15555"
+
 
 @dataclass
 class Snapshot:
@@ -79,14 +85,13 @@ snapshots: List[(Snapshot)] = [
 async def test_protocols_analyses_and_runs_available_from_older_persistence_dir(
     snapshot: Snapshot,
 ) -> None:
-    port = "15555"
     async with RobotClient.make(
-        base_url=f"http://localhost:{port}", version="*"
+        base_url=f"http://localhost:{_PORT}", version="*"
     ) as robot_client:
         assert (
             await robot_client.wait_until_dead()
         ), "Dev Robot is running and must not be."
-        with DevServer(port=port, persistence_directory=snapshot.get_copy()) as server:
+        with DevServer(port=_PORT, persistence_directory=snapshot.get_copy()) as server:
             server.start()
             assert (
                 await robot_client.wait_until_alive()
@@ -154,12 +159,15 @@ async def test_rerun_flex_dev_compat() -> None:
     during Flex development, so robots used for testing may already have them stored.
     """
     snapshot = flex_dev_compat_snapshot
-    with DevServer(persistence_directory=snapshot.get_copy()) as server:
-        server.start()
-        async with RobotClient.make(
-            base_url=f"http://localhost:{server.port}", version="*"
-        ) as client:
+    async with RobotClient.make(
+        base_url=f"http://localhost:{_PORT}", version="*"
+    ) as client:
+        assert await client.wait_until_dead(), "Dev Robot is running and must not be."
+        with DevServer(persistence_directory=snapshot.get_copy(), port=_PORT) as server:
+            server.start()
             await client.wait_until_alive()
+            assert await client.wait_until_alive(), "Dev Robot never became available."
+
             [protocol] = (await client.get_protocols()).json()["data"]
             new_run = (
                 await client.post_run({"data": {"protocolId": protocol["id"]}})

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -147,10 +147,6 @@ async def test_protocols_analyses_and_runs_available_from_older_persistence_dir(
 
 # TODO(mm, 2023-08-12): We can remove this test when we remove special handling for these
 # protocols. https://opentrons.atlassian.net/browse/RSS-306
-@pytest.mark.xfail(
-    # TODO(mm, 2023-08-12): Remove this xfail when we implement this special handling.
-    strict=True
-)
 async def test_rerun_flex_dev_compat() -> None:
     """Test re-running a stored protocol that has messed up requirements and metadata.
 

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -162,7 +162,9 @@ async def test_rerun_flex_dev_compat() -> None:
     async with RobotClient.make(
         base_url=f"http://localhost:{_PORT}", version="*"
     ) as client:
-        assert await client.wait_until_dead(), "Dev Robot is running but it should not be."
+        assert (
+            await client.wait_until_dead()
+        ), "Dev Robot is running but it should not be."
         with DevServer(persistence_directory=snapshot.get_copy(), port=_PORT) as server:
             server.start()
             await client.wait_until_alive()

--- a/robot-server/tests/integration/http_api/protocols/test_upload_flex_internal_release_compat.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_flex_internal_release_compat.tavern.yaml
@@ -6,8 +6,6 @@ test_name: Make sure the server rejects new uploads of protocols with messed up 
 marks:
   - usefixtures:
     - ot2_server_base_url
-  # TODO(mm, 2023-08-12): Remove this xfail when we implement this special handling.
-  - xfail
 stages:
   - name: Upload the protocol.
     request:

--- a/robot-server/tests/integration/protocols/empty_ot3.py
+++ b/robot-server/tests/integration/protocols/empty_ot3.py
@@ -1,6 +1,6 @@
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.13",
+    "apiLevel": "2.14",
 }
 
 

--- a/robot-server/tests/integration/protocols/empty_ot3.py
+++ b/robot-server/tests/integration/protocols/empty_ot3.py
@@ -1,6 +1,6 @@
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.14",
+    "apiLevel": "2.15",
 }
 
 


### PR DESCRIPTION
# Overview

Closes RSS-264 and RSS-265.

# Changelog

Add additional validation when parsing Python protocol files:

* Forbid putting `apiLevel` in `metadata` and `requirements` simultaneously. Each protocol should choose one or the other. The historical behavior is that `requirements` overrides `metadata`.
* Forbid unrecognized keys in `requirements`.
* Require `"apiLevel": "2.15"` or newer if  `"robotType"` is `"Flex"` or `"OT-3"`.

# ⚠️Compatibility

These are breaking changes, but thankfully, they're only breaking for our internal testing protocols. For example, [according to](https://opentrons.slack.com/archives/C049WNGU22H/p1691613304413849) @nusrat813, some QA and ABR protocols *do* specify `apiLevel` in both `metadata` and `requirements`.

We want to add this validation for launch, but we don't want to cause database problems on all the existing robots and force our internal testers to do factory-resets.

To accomplish that, this PR introduces a temporarily-configurable "strict mode" for Python parsing.

**We *disable* strict mode for protocols that are already on robots.** That means when:

* robot-server parses already-stored protocols to support GET /protocols.
* robot-server runs an already-stored protocol.

**And we *enable* strict mode for protocols that are not.** That means when:

* robot-server receives new protocols over HTTP.
* The local analysis engine analyzes a protocol from the Opentrons App.
* Someone uses opentrons_simulate et. al.

In the future, some time after the Flex launch, we'll always use strict mode. 

# Test Plan

Automated unit tests should be sufficient. We added integration tests in #13295.

# Review requests

Do we agree with the approach in the ⚠️ compatibility section above?

# Risk assessment

See the ⚠️ compatibility section above.
