### PR TITLE
refactor(app): button positioning in pipette flow modals

### DIFF
--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -16,13 +16,22 @@ import {
   JUSTIFY_CENTER,
   PrimaryButton,
   RESPONSIVENESS,
-  ALIGN_FLEX_END,
   DISPLAY_INLINE_BLOCK,
+  ALIGN_CENTER,
+  ALIGN_FLEX_END,
 } from '@opentrons/components'
 import { getIsOnDevice } from '../../redux/config'
 import { StyledText } from '../../atoms/text'
 import { NeedHelpLink } from '../../organisms/CalibrationPanels'
 import { SmallButton } from '../../atoms/buttons'
+
+const ALIGN_BUTTONS = css`
+  align-items: ${ALIGN_FLEX_END};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    align-items: ${ALIGN_CENTER};
+  }
+`
 
 const CAPITALIZE_FIRST_LETTER_STYLE = css`
   &:first-letter {
@@ -130,7 +139,7 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
           {rightHandBody}
         </Flex>
       </Flex>
-      <Flex justifyContent={buttonPositioning} alignItems={ALIGN_FLEX_END}>
+      <Flex justifyContent={buttonPositioning} css={ALIGN_BUTTONS}>
         {back != null ? (
           <Btn onClick={back} disabled={backIsDisabled} aria-label="back">
             <StyledText

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -45,7 +45,7 @@ const MODAL_STYLE = css`
   padding: ${SPACING.spacing32};
   height: 24.625rem;
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    height: 29.5625rem;
+    height: 29.5rem;
   }
 `
 const SPINNER_STYLE = css`
@@ -67,7 +67,7 @@ export function InProgressModal(props: Props): JSX.Element {
         <Icon
           name="ot-spinner"
           aria-label="spinner"
-          size={isOnDevice ? '5.25rem' : '5.125rem'}
+          size={isOnDevice ? '6.25rem' : '5.125rem'}
           css={SPINNER_STYLE}
           spin
         />

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -45,7 +45,7 @@ const MODAL_STYLE = css`
   padding: ${SPACING.spacing32};
   height: 24.625rem;
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    height: 31.5625rem;
+    height: 29.5625rem;
   }
 `
 const SPINNER_STYLE = css`
@@ -67,7 +67,7 @@ export function InProgressModal(props: Props): JSX.Element {
         <Icon
           name="ot-spinner"
           aria-label="spinner"
-          size={isOnDevice ? '6.25rem' : '5.125rem'}
+          size={isOnDevice ? '5.25rem' : '5.125rem'}
           css={SPINNER_STYLE}
           spin
         />

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -27,7 +27,14 @@ interface Props extends StyleProps {
   children?: React.ReactNode
   subHeader?: string | JSX.Element
   isPending?: boolean
+  /**
+   *  change justifyContent of OnDeviceDisplay buttons
+   *  TODO(jr, 8/9/23): this should really be refactored though so the
+   *  buttons' justifyContent is specified at the parent level
+   */
+  justifyContentForOddButton?: string
 }
+
 const BACKGROUND_SIZE = '47rem'
 
 const HEADER_STYLE = css`
@@ -90,7 +97,8 @@ export function SimpleWizardBody(props: Props): JSX.Element {
     padding-bottom: ${SPACING.spacing32};
 
     @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-      justify-content: ${props.justifyContent ?? JUSTIFY_SPACE_BETWEEN};
+      justify-content: ${props.justifyContentForOddButton ??
+      JUSTIFY_SPACE_BETWEEN};
       padding-bottom: ${SPACING.spacing32};
       padding-left: ${SPACING.spacing32};
     }

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -55,18 +55,6 @@ const SUBHEADER_STYLE = css`
     margin-right: 4.5rem;
   }
 `
-const BUTTON_STYLE = css`
-  width: 100%;
-  justify-content: ${JUSTIFY_FLEX_END};
-  padding-right: ${SPACING.spacing32};
-  padding-bottom: ${SPACING.spacing32};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    justify-content: ${JUSTIFY_SPACE_BETWEEN};
-    padding-bottom: ${SPACING.spacing32};
-    padding-left: ${SPACING.spacing32};
-  }
-`
 const WIZARD_CONTAINER_STYLE = css`
   min-height: 394px;
   flex-direction: ${DIRECTION_COLUMN};
@@ -94,6 +82,19 @@ export function SimpleWizardBody(props: Props): JSX.Element {
     ...styleProps
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
+
+  const BUTTON_STYLE = css`
+    width: 100%;
+    justify-content: ${JUSTIFY_FLEX_END};
+    padding-right: ${SPACING.spacing32};
+    padding-bottom: ${SPACING.spacing32};
+
+    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+      justify-content: ${props.justifyContent ?? JUSTIFY_SPACE_BETWEEN};
+      padding-bottom: ${SPACING.spacing32};
+      padding-left: ${SPACING.spacing32};
+    }
+  `
 
   return (
     <Flex css={WIZARD_CONTAINER_STYLE} {...styleProps}>

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -14,6 +14,7 @@ import {
   StyleProps,
   JUSTIFY_SPACE_BETWEEN,
   POSITION_ABSOLUTE,
+  JUSTIFY_FLEX_START,
 } from '@opentrons/components'
 import SuccessIcon from '../../assets/images/icon_success.png'
 import { getIsOnDevice } from '../../redux/config'
@@ -104,12 +105,21 @@ export function SimpleWizardBody(props: Props): JSX.Element {
     }
   `
 
+  const ICON_POSITION_STYLE = css`
+    justify-content: ${JUSTIFY_CENTER};
+
+    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+      justify-content: ${JUSTIFY_FLEX_START};
+      margin-top: ${isSuccess ? SPACING.spacing32 : '8.1875rem'};
+    }
+  `
+
   return (
     <Flex css={WIZARD_CONTAINER_STYLE} {...styleProps}>
       <Flex
         width="100%"
         alignItems={ALIGN_CENTER}
-        justifyContent={JUSTIFY_CENTER}
+        css={ICON_POSITION_STYLE}
         flexDirection={DIRECTION_COLUMN}
         flex="1 0 auto"
       >

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -28,8 +28,8 @@ interface Props extends StyleProps {
   subHeader?: string | JSX.Element
   isPending?: boolean
   /**
-   *  change justifyContent of OnDeviceDisplay buttons
-   *  TODO(jr, 8/9/23): this should really be refactored though so the
+   *  this prop is to change justifyContent of OnDeviceDisplay buttons
+   *  TODO(jr, 8/9/23): this SHOULD be refactored so the
    *  buttons' justifyContent is specified at the parent level
    */
   justifyContentForOddButton?: string

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -9,6 +9,7 @@ import {
   RESPONSIVENESS,
   PrimaryButton,
   ALIGN_FLEX_END,
+  ALIGN_CENTER,
 } from '@opentrons/components'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { css } from 'styled-components'
@@ -28,6 +29,7 @@ import type { BadGripper, GripperData } from '@opentrons/api-client'
 const GO_BACK_BUTTON_STYLE = css`
   ${TYPOGRAPHY.pSemiBold};
   color: ${COLORS.darkGreyEnabled};
+  padding-left: ${SPACING.spacing32};
 
   &:hover {
     opacity: 70%;
@@ -36,10 +38,18 @@ const GO_BACK_BUTTON_STYLE = css`
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
     font-size: ${TYPOGRAPHY.fontSize22};
-
+    padding-left: 0rem;
     &:hover {
       opacity: 100%;
     }
+  }
+`
+
+const ALIGN_BUTTONS = css`
+  align-items: ${ALIGN_FLEX_END};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    align-items: ${ALIGN_CENTER};
   }
 `
 
@@ -86,7 +96,7 @@ export const MountGripper = (
       <Flex
         width="100%"
         justifyContent={JUSTIFY_SPACE_BETWEEN}
-        alignItems={ALIGN_FLEX_END}
+        css={ALIGN_BUTTONS}
         gridGap={SPACING.spacing8}
       >
         <Btn onClick={() => setShowUnableToDetect(false)}>

--- a/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
@@ -55,7 +55,7 @@ export function AttachedInstrumentMountItem(
         flowType: GRIPPER_FLOW_TYPES.ATTACH,
         attachedGripper: attachedInstrument,
         onComplete: () => {
-          history.push(`/instruments/${mount}`)
+          history.push(`/instruments`)
         },
         closeFlow: () => setWizardProps(null),
       })
@@ -98,7 +98,7 @@ export function AttachedInstrumentMountItem(
                 setShowChoosePipetteModal(false)
               },
               onComplete: () => {
-                history.push(`/instruments/${mount}`)
+                history.push(`/instruments`)
               },
             })
             setODDMaintenanceFlowInProgress()

--- a/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
@@ -55,7 +55,9 @@ export function AttachedInstrumentMountItem(
         flowType: GRIPPER_FLOW_TYPES.ATTACH,
         attachedGripper: attachedInstrument,
         onComplete: () => {
-          history.push(`/instruments`)
+          history.push(
+            attachedInstrument == null ? `/instruments` : `/instrument/${mount}`
+          )
         },
         closeFlow: () => setWizardProps(null),
       })
@@ -98,7 +100,11 @@ export function AttachedInstrumentMountItem(
                 setShowChoosePipetteModal(false)
               },
               onComplete: () => {
-                history.push(`/instruments`)
+                history.push(
+                  attachedInstrument == null
+                    ? `/instruments`
+                    : `/instrument/${mount}`
+                )
               },
             })
             setODDMaintenanceFlowInProgress()

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -80,11 +80,13 @@ describe('ProtocolInstrumentMountItem', () => {
   })
 
   it('renders the correct information when there is no pipette attached', () => {
-    const { getByText } = render(props)
+    const { getByText, getByLabelText } = render(props)
     getByText('Left Mount')
     getByText('No data')
     getByText('Flex 8-Channel 1000 μL')
     getByText('Attach')
+    getByLabelText('SmallButton_primary').click()
+    getByText('pipette wizard flow')
   })
   it('renders the correct information when there is no pipette attached for 96 channel', () => {
     props = {

--- a/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { COLORS, PrimaryButton } from '@opentrons/components'
+import { COLORS, JUSTIFY_FLEX_END, PrimaryButton } from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import type { CreateCommand, PipetteMount } from '@opentrons/shared-data'
@@ -52,6 +52,7 @@ export function CalibrationErrorModal(
       header={i18n.format(t('pip_cal_failed'), 'capitalize')}
       subHeader={errorMessage}
       isSuccess={false}
+      justifyContent={JUSTIFY_FLEX_END}
     >
       {isOnDevice ? (
         <SmallButton

--- a/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { COLORS, JUSTIFY_FLEX_END, PrimaryButton } from '@opentrons/components'
+import { COLORS, PrimaryButton } from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import type { CreateCommand, PipetteMount } from '@opentrons/shared-data'
@@ -52,7 +52,6 @@ export function CalibrationErrorModal(
       header={i18n.format(t('pip_cal_failed'), 'capitalize')}
       subHeader={errorMessage}
       isSuccess={false}
-      justifyContentForOddButton={JUSTIFY_FLEX_END}
     >
       {isOnDevice ? (
         <SmallButton

--- a/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/CalibrationErrorModal.tsx
@@ -52,7 +52,7 @@ export function CalibrationErrorModal(
       header={i18n.format(t('pip_cal_failed'), 'capitalize')}
       subHeader={errorMessage}
       isSuccess={false}
-      justifyContent={JUSTIFY_FLEX_END}
+      justifyContentForOddButton={JUSTIFY_FLEX_END}
     >
       {isOnDevice ? (
         <SmallButton

--- a/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next'
 import {
   COLORS,
   SPACING,
-  Flex,
   TYPOGRAPHY,
   SecondaryButton,
   AlertPrimaryButton,
+  JUSTIFY_FLEX_END,
 } from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
@@ -46,16 +46,17 @@ export function ExitModal(props: ExitModalProps): JSX.Element {
       header={t('progress_will_be_lost', { flow: flowTitle })}
       subHeader={t('are_you_sure_exit', { flow: flowTitle })}
       isSuccess={false}
+      justifyContent={JUSTIFY_FLEX_END}
     >
       {isOnDevice ? (
         <>
-          <Flex marginRight={SPACING.spacing8}>
-            <SmallButton
-              onClick={proceed}
-              buttonText={capitalize(t('shared:exit'))}
-              buttonType="alert"
-            />
-          </Flex>
+          <SmallButton
+            marginRight={SPACING.spacing8}
+            onClick={proceed}
+            buttonText={capitalize(t('shared:exit'))}
+            buttonType="alert"
+          />
+
           <SmallButton buttonText={t('shared:go_back')} onClick={goBack} />
         </>
       ) : (

--- a/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
@@ -46,7 +46,7 @@ export function ExitModal(props: ExitModalProps): JSX.Element {
       header={t('progress_will_be_lost', { flow: flowTitle })}
       subHeader={t('are_you_sure_exit', { flow: flowTitle })}
       isSuccess={false}
-      justifyContent={JUSTIFY_FLEX_END}
+      justifyContentForOddButton={JUSTIFY_FLEX_END}
     >
       {isOnDevice ? (
         <>

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -9,6 +9,7 @@ import {
   SPACING,
   PrimaryButton,
   SecondaryButton,
+  ALIGN_FLEX_END,
 } from '@opentrons/components'
 import {
   getPipetteNameSpecs,
@@ -191,6 +192,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       proceed()
     }
   }
+  let justifyContentForOddButton: undefined | string = undefined
   let button: JSX.Element = isOnDevice ? (
     <SmallButton
       textTransform={TYPOGRAPHY.textTransformCapitalize}
@@ -206,6 +208,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
       {buttonText}
     </PrimaryButton>
   )
+
   if (
     flowType === FLOWS.ATTACH &&
     requiredPipette != null &&
@@ -287,6 +290,9 @@ export const Results = (props: ResultsProps): JSX.Element => {
       subHeader={subHeader}
       isPending={isFetching}
       width="100%"
+      justifyContentForOddButton={
+        isOnDevice && isSuccess ? ALIGN_FLEX_END : undefined
+      }
     >
       {button}
     </SimpleWizardBody>

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -192,7 +192,6 @@ export const Results = (props: ResultsProps): JSX.Element => {
       proceed()
     }
   }
-  let justifyContentForOddButton: undefined | string = undefined
   let button: JSX.Element = isOnDevice ? (
     <SmallButton
       textTransform={TYPOGRAPHY.textTransformCapitalize}


### PR DESCRIPTION
closes RQA-1165 and RQA-1166 and RQA-1233 and RAUT-623

# Overview

Button positioning for the on device display modals in the pipette flows

Also, make sure early exiting out of the flows goes to the correct page on ODD

# Test Plan

Verify that the screenshots match the tickets. Make sure both the odd and the desktop version look correct

on odd:
<img width="1020" alt="Screen Shot 2023-08-10 at 4 02 09 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/09cd281d-ecbe-4fb8-bffd-65497af56ee2">
<img width="1029" alt="Screen Shot 2023-08-09 at 10 31 03 AM" src="https://github.com/Opentrons/opentrons/assets/66035149/bf02c4d2-05da-4778-ae55-4d34cde88122">

on desktop:
<img width="785" alt="Screen Shot 2023-08-10 at 1 22 29 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/1cf1e579-4442-48b6-b6a6-04625d7239c4">

Also, make sure the loading screen has no scroll and if you early exit out of a flow in the ODD make sure it goes to the correct instruments page.

<img width="1029" alt="Screen Shot 2023-08-10 at 4 08 12 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/1bc990f4-2863-4c17-97f1-7e235346083d">


# Changelog

- added stylings to the different buttons and made sure it only affected the onDeviceDisplay modal
- tweak onClose logic for early exiting out of flows

# Review requests

see test plan

# Risk assessment
low