### PR TITLE
feat(app, components, protocol-designer): trash and slotLabels adjustments

### DIFF
--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -186,6 +186,7 @@ export function ProtocolSetupLabware({
               deckFill={COLORS.light1}
               trashSlotName="A3"
               id="LabwareSetup_deckMap"
+              trashColor={COLORS.darkGreyEnabled}
             >
               {() => (
                 <>

--- a/app/src/organisms/ProtocolSetupModules/index.tsx
+++ b/app/src/organisms/ProtocolSetupModules/index.tsx
@@ -210,6 +210,7 @@ export function ProtocolSetupModules({
               deckFill={COLORS.light1}
               trashSlotName="A3"
               id="ModuleSetup_deckMap"
+              trashColor={COLORS.darkGreyEnabled}
             >
               {() => (
                 <>

--- a/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
@@ -20,6 +20,7 @@ export interface RobotWorkSpaceProps extends StyleProps {
   deckFill?: string
   deckLayerBlocklist?: string[]
   trashSlotName?: TrashSlotName
+  trashColor?: string
   id?: string
 }
 
@@ -33,6 +34,7 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
     deckLayerBlocklist = [],
     trashSlotName,
     viewBox,
+    trashColor,
     id,
     ...styleProps
   } = props
@@ -83,6 +85,7 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
           def={deckDef}
           layerBlocklist={deckLayerBlocklist}
           trashSlotName={trashSlotName}
+          trashColor={trashColor}
         />
       )}
       {children?.({ deckSlotsById, getRobotCoordsFromDOMCoords })}

--- a/components/src/hardware-sim/Deck/SlotLabels.tsx
+++ b/components/src/hardware-sim/Deck/SlotLabels.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { LocationIcon } from '../../molecules'
 import { Flex } from '../../primitives'
 import { ALIGN_CENTER, DIRECTION_COLUMN, JUSTIFY_CENTER } from '../../styles'
@@ -7,8 +8,10 @@ import { RobotCoordsForeignObject } from './RobotCoordsForeignObject'
 
 import type { RobotType } from '@opentrons/shared-data'
 
+export type DisplayType = 'app' | 'protocolDesigner'
 interface SlotLabelsProps {
   robotType: RobotType
+  displayType?: DisplayType
   color?: string
 }
 
@@ -19,8 +22,9 @@ interface SlotLabelsProps {
 export const SlotLabels = ({
   robotType,
   color,
+  displayType = 'app',
 }: SlotLabelsProps): JSX.Element | null => {
-  return robotType === 'OT-3 Standard' ? (
+  return robotType === FLEX_ROBOT_TYPE ? (
     <>
       <RobotCoordsForeignObject
         width="2.5rem"
@@ -73,7 +77,7 @@ export const SlotLabels = ({
         height="2.5rem"
         width="30.375rem"
         x="-15"
-        y="-55"
+        y={displayType === 'protocolDesigner' ? '-65' : '-55'}
       >
         <Flex
           alignItems={ALIGN_CENTER}

--- a/components/src/hardware-sim/Deck/StyledDeck.tsx
+++ b/components/src/hardware-sim/Deck/StyledDeck.tsx
@@ -10,6 +10,7 @@ import type { TrashSlotName } from './FlexTrash'
 
 interface StyledDeckProps {
   deckFill: string
+  trashColor?: string
   trashSlotName?: TrashSlotName
 }
 
@@ -23,7 +24,12 @@ const StyledG = styled.g<StyledDeckProps>`
 export function StyledDeck(
   props: StyledDeckProps & DeckFromDataProps
 ): JSX.Element {
-  const { deckFill, trashSlotName, ...deckFromDataProps } = props
+  const {
+    deckFill,
+    trashSlotName,
+    trashColor = '#757070',
+    ...deckFromDataProps
+  } = props
 
   const robotType = deckFromDataProps.def.robot.model ?? 'OT-2 Standard'
 
@@ -45,7 +51,7 @@ export function StyledDeck(
         <FlexTrash
           robotType={robotType}
           trashIconColor={deckFill}
-          backgroundColor={COLORS.light1}
+          backgroundColor={trashColor}
           trashSlotName={trashSlotName}
         />
       ) : null}

--- a/components/src/hardware-sim/Deck/StyledDeck.tsx
+++ b/components/src/hardware-sim/Deck/StyledDeck.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
 
-import { COLORS } from '../../ui-style-constants'
 import { DeckFromData } from './DeckFromData'
 import { FlexTrash } from './FlexTrash'
 

--- a/protocol-designer/src/components/DeckSetup/SlotLabels.tsx
+++ b/protocol-designer/src/components/DeckSetup/SlotLabels.tsx
@@ -1,24 +1,28 @@
 import * as React from 'react'
 
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
-import { LocationIcon } from '../../molecules'
-import { Flex } from '../../primitives'
-import { ALIGN_CENTER, DIRECTION_COLUMN, JUSTIFY_CENTER } from '../../styles'
-import { RobotCoordsForeignObject } from './RobotCoordsForeignObject'
+import {
+  Flex,
+  JUSTIFY_CENTER,
+  LocationIcon,
+  RobotCoordsForeignObject,
+  ALIGN_CENTER,
+  DIRECTION_COLUMN,
+} from '@opentrons/components'
 
 import type { RobotType } from '@opentrons/shared-data'
+
 interface SlotLabelsProps {
   robotType: RobotType
-  color?: string
 }
 
 /**
- * Component to render Opentrons Flex slot labels
- * For use as a RobotWorkspace child component
+ * This is an almost copy of SlotLabels in @opentrons/components
+ * in order to keep the changes between PD and the rest
+ * of the repo separate
  */
 export const SlotLabels = ({
   robotType,
-  color,
 }: SlotLabelsProps): JSX.Element | null => {
   return robotType === FLEX_ROBOT_TYPE ? (
     <>
@@ -36,36 +40,16 @@ export const SlotLabels = ({
           width="2.5rem"
         >
           <Flex alignItems={ALIGN_CENTER} flex="1">
-            <LocationIcon
-              color={color}
-              slotName="A"
-              height="max-content"
-              width="100%"
-            />
+            <LocationIcon slotName="A" height="max-content" width="100%" />
           </Flex>
           <Flex alignItems={ALIGN_CENTER} flex="1">
-            <LocationIcon
-              color={color}
-              slotName="B"
-              height="max-content"
-              width="100%"
-            />
+            <LocationIcon slotName="B" height="max-content" width="100%" />
           </Flex>
           <Flex alignItems={ALIGN_CENTER} flex="1">
-            <LocationIcon
-              color={color}
-              slotName="C"
-              height="max-content"
-              width="100%"
-            />
+            <LocationIcon slotName="C" height="max-content" width="100%" />
           </Flex>
           <Flex alignItems={ALIGN_CENTER} flex="1">
-            <LocationIcon
-              color={color}
-              slotName="D"
-              height="max-content"
-              width="100%"
-            />
+            <LocationIcon slotName="D" height="max-content" width="100%" />
           </Flex>
         </Flex>
       </RobotCoordsForeignObject>
@@ -73,7 +57,7 @@ export const SlotLabels = ({
         height="2.5rem"
         width="30.375rem"
         x="-15"
-        y="-55"
+        y="-65"
       >
         <Flex
           alignItems={ALIGN_CENTER}
@@ -86,21 +70,21 @@ export const SlotLabels = ({
             justifyContent={JUSTIFY_CENTER}
             flex="1"
           >
-            <LocationIcon color={color} slotName="1" height="100%" />
+            <LocationIcon slotName="1" height="100%" />
           </Flex>
           <Flex
             alignItems={ALIGN_CENTER}
             justifyContent={JUSTIFY_CENTER}
             flex="1"
           >
-            <LocationIcon color={color} slotName="2" height="100%" />
+            <LocationIcon slotName="2" height="100%" />
           </Flex>
           <Flex
             alignItems={ALIGN_CENTER}
             justifyContent={JUSTIFY_CENTER}
             flex="1"
           >
-            <LocationIcon color={color} slotName="3" height="100%" />
+            <LocationIcon slotName="3" height="100%" />
           </Flex>
         </Flex>
       </RobotCoordsForeignObject>

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -12,6 +12,7 @@ import {
   RobotWorkSpaceRenderProps,
   Module,
   SlotLabels,
+  COLORS,
 } from '@opentrons/components'
 import {
   MODULES_WITH_COLLISION_ISSUES,
@@ -461,6 +462,7 @@ export const DeckSetup = (): JSX.Element => {
           width="100%"
           height="100%"
           trashSlotName={FLEX_TRASH_SLOT}
+          trashColor={COLORS.darkGreyEnabled}
         >
           {({ deckSlotsById, getRobotCoordsFromDOMCoords }) => (
             <>
@@ -475,7 +477,10 @@ export const DeckSetup = (): JSX.Element => {
                   showGen1MultichannelCollisionWarnings,
                 }}
               />
-              <SlotLabels robotType={robotType} />
+              <SlotLabels
+                robotType={robotType}
+                displayType="protocolDesigner"
+              />
             </>
           )}
         </RobotWorkSpace>

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -11,7 +11,6 @@ import {
   TEXT_TRANSFORM_UPPERCASE,
   RobotWorkSpaceRenderProps,
   Module,
-  SlotLabels,
   COLORS,
 } from '@opentrons/components'
 import {
@@ -66,6 +65,7 @@ import { LabwareOnDeck } from './LabwareOnDeck'
 import { SlotControls, LabwareControls, DragPreview } from './LabwareOverlays'
 import { FlexModuleTag } from './FlexModuleTag'
 import { Ot2ModuleTag } from './Ot2ModuleTag'
+import { SlotLabels } from './SlotLabels'
 import styles from './DeckSetup.css'
 
 export const DECK_LAYER_BLOCKLIST = [
@@ -477,10 +477,7 @@ export const DeckSetup = (): JSX.Element => {
                   showGen1MultichannelCollisionWarnings,
                 }}
               />
-              <SlotLabels
-                robotType={robotType}
-                displayType="protocolDesigner"
-              />
+              <SlotLabels robotType={robotType} />
             </>
           )}
         </RobotWorkSpace>


### PR DESCRIPTION
closes RQA-1245 closes RQA-1101

# Overview

Fixes the trash slot color depending on if its displayed on the app vs odd vs PD and creates a new `SlotLabels` to adjust the x axis labels for PD

see this slack post for reference: https://opentrons.slack.com/archives/CSCLVUW3C/p1691011895923299

# Test Plan

Look at all the deck maps in Pd, the app and the odd. Make sure they look correct!

PD sandbox: https://sandbox.designer.opentrons.com/app_pd-deck-map-adjustments/

# Changelog

- create new `SlotLabels` in Protocol-designer directory
- extend props in `StyledDeck` to include a trash color and change the color based on where it is being rendered

# Review requests

see test plan

# Risk assessment

low