### PR TITLE
fix(hardware): Increase data ack timeout to 5s for firmware update transfers.

### DIFF
--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -266,7 +266,7 @@ class SubsystemManager:
                 usb_messenger=self._usb_messenger,
                 update_details=update_details,
                 retry_count=60,
-                timeout_seconds=1,
+                timeout_seconds=5,
                 erase=True,
             )
 


### PR DESCRIPTION
# Overview

The firmware update transfer can fail sometimes when all subsystems are updating at the same time because we are handling a lot of data and our data ack timeout is set to 1s. So let's increase the timeout from 1s to 5s to give enough time for data acks to be handled before giving up on the update.

Closes: [RQA-1257](https://opentrons.atlassian.net/browse/RQA-1257)

# Test Plan
- [x] Run all subsystem updates at the same time and make sure they don't fail because of a <5s data ack timeout.

# Changelog
- Increase the data ack timeout from 1s to 5s for firmware updates.

# Review requests

# Risk assessment

[RQA-1257]: https://opentrons.atlassian.net/browse/RQA-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ