### PR TITLE
fix(hardware-testing): Slight spec changes to PVT gripper QC script

### DIFF
--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_probe.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_probe.py
@@ -29,8 +29,8 @@ from hardware_testing.opentrons_api.types import Axis, OT3Mount, Point, GripperP
 TEST_SLOT = 5
 PROBE_PREP_HEIGHT_MM = 5
 PROBE_POS_OFFSET = Point(13, 13, 0)
-JAW_ALIGNMENT_MM_X = 0.5
-JAW_ALIGNMENT_MM_Z = 0.5
+JAW_ALIGNMENT_MM_X = 2.0
+JAW_ALIGNMENT_MM_Z = 2.0
 PROBE_PF_MAX = 6.0
 DECK_PF_MIN = 9.0
 DECK_PF_MAX = 15.0

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_width.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_width.py
@@ -20,7 +20,7 @@ GAUGE_HEIGHT_MM = 40
 GRIP_HEIGHT_MM = 30
 TEST_WIDTHS_MM: List[float] = [60, 85.75, 62]
 SLOT_WIDTH_GAUGE: List[Optional[int]] = [None, 3, 9]
-GRIP_FORCES_NEWTON: List[float] = [5, 15, 20]
+GRIP_FORCES_NEWTON: List[float] = [10, 15, 20]
 
 
 def _get_test_tag(width: float, force: float) -> str:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Two small changes to Gripper QC script:

- Start width test at 10N, not 5N (because some grippers have trouble at 5N)
- Increase probe-alignment spec from `0.5` mm to `2.0` mm

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
