### PR TITLE
chore(api): fix flex camera endpoint

### DIFF
--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -3,11 +3,17 @@ import os
 from pathlib import Path
 from opentrons.config import ARCHITECTURE, SystemArchitecture
 from opentrons_shared_data.errors.exceptions import CommunicationError
+from opentrons_shared_data.errors.codes import ErrorCodes
 
 
 class CameraException(CommunicationError):
     def __init__(self, message: str, system_error: str) -> None:
-        super().__init__(self, message, {'internal-error-message': system_error})
+        super().__init__(
+            ErrorCodes.COMMUNICATION_ERROR,
+            message,
+            {"internal-error-message": system_error},
+        )
+
 
 async def take_picture(filename: Path) -> None:
     """Take a picture and save it to filename
@@ -23,7 +29,7 @@ async def take_picture(filename: Path) -> None:
         pass
 
     if ARCHITECTURE == SystemArchitecture.YOCTO:
-        cmd = f'v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=720,pixelformat=MJPG --stream-mmap --stream-to={str(filename)} --stream-count=1'
+        cmd = f"v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=720,pixelformat=MJPG --stream-mmap --stream-to={str(filename)} --stream-count=1"
     elif ARCHITECTURE == SystemArchitecture.BUILDROOT:
         cmd = f"ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1 {str(filename)}"
     else:  # HOST
@@ -39,6 +45,6 @@ async def take_picture(filename: Path) -> None:
     await proc.wait()
 
     if proc.returncode != 0:
-        raise CameraException('Failed to communicate with camera', res)
+        raise CameraException("Failed to communicate with camera", res)
     if not filename.exists():
-        raise CameraException("Failed to save image", '')
+        raise CameraException("Failed to save image", "")

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -1,12 +1,13 @@
 import asyncio
 import os
 from pathlib import Path
-from opentrons.config import IS_OSX
+from opentrons.config import ARCHITECTURE, SystemArchitecture
+from opentrons_shared_data.errors.exceptions import CommunicationError
 
 
-class CameraException(Exception):
-    pass
-
+class CameraException(CommunicationError):
+    def __init__(self, message: str, system_error: str) -> None:
+        super().__init__(self, message, {'internal-error-message': system_error})
 
 async def take_picture(filename: Path) -> None:
     """Take a picture and save it to filename
@@ -21,14 +22,15 @@ async def take_picture(filename: Path) -> None:
     except OSError:
         pass
 
-    cmd = "ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1"
-
-    if IS_OSX:
-        # Purely for development on macos
-        cmd = 'ffmpeg -f avfoundation -framerate 1  -s 640x480  -i "0" -ss 0:0:1 -frames 1'
+    if ARCHITECTURE == SystemArchitecture.YOCTO:
+        cmd = f'v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=720,pixelformat=MJPG --stream-mmap --stream-to={str(filename)} --stream-count=1'
+    elif ARCHITECTURE == SystemArchitecture.BUILDROOT:
+        cmd = f"ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1 {str(filename)}"
+    else:  # HOST
+        cmd = f'ffmpeg -f avfoundation -framerate 1  -s 640x480  -i "0" -ss 0:0:1 -frames 1 {str(filename)}'
 
     proc = await asyncio.create_subprocess_shell(
-        f"{cmd} {filename}",
+        cmd,
         stderr=asyncio.subprocess.PIPE,
     )
 
@@ -37,6 +39,6 @@ async def take_picture(filename: Path) -> None:
     await proc.wait()
 
     if proc.returncode != 0:
-        raise CameraException(res)
+        raise CameraException('Failed to communicate with camera', res)
     if not filename.exists():
-        raise CameraException("picture not saved")
+        raise CameraException("Failed to save image", '')

--- a/robot-server/tests/service/legacy/routers/test_camera.py
+++ b/robot-server/tests/service/legacy/routers/test_camera.py
@@ -15,7 +15,7 @@ def mock_take_picture():
 
 def test_camera_exception(mock_take_picture, api_client):
     async def raise_it(filename, loop=None):
-        raise camera.CameraException("No")
+        raise camera.CameraException("No", "sorry")
 
     mock_take_picture.side_effect = raise_it
 


### PR DESCRIPTION
The flex doesn't have ffmpeg but does have v4l2-ctl which works just as well.

## Risk
Low

## Testing
`curl -X POST -H 'opentrons-version: 4' $robotip:31950/camera/picture > image.jpg ; open image.jpg `

Closes RCORE-818
