### PR TITLE
fix(app): Remove home, change to extension mount for gripper cal

### DIFF
--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { UseMutateFunction } from 'react-query'
 import { Trans, useTranslation } from 'react-i18next'
 import { COLORS } from '@opentrons/components'
-import { LEFT } from '@opentrons/shared-data'
+import { EXTENSION } from '@opentrons/shared-data'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
@@ -80,7 +80,7 @@ export const BeforeBeginning = (
     {
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
-        mount: LEFT,
+        mount: EXTENSION,
       },
     },
   ]

--- a/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -70,7 +70,7 @@ describe('BeforeBeginning', () => {
         },
         {
           commandType: 'calibration/moveToMaintenancePosition',
-          params: { mount: 'left' },
+          params: { mount: 'extension' },
         },
       ],
       false
@@ -99,7 +99,7 @@ describe('BeforeBeginning', () => {
         { commandType: 'home', params: {} },
         {
           commandType: 'calibration/moveToMaintenancePosition',
-          params: { mount: 'left' },
+          params: { mount: 'extension' },
         },
       ],
       false
@@ -132,7 +132,7 @@ describe('BeforeBeginning', () => {
         },
         {
           commandType: 'calibration/moveToMaintenancePosition',
-          params: { mount: 'left' },
+          params: { mount: 'extension' },
         },
       ],
       false

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -63,12 +63,19 @@ describe('MovePin', () => {
     await getByRole('button', { name: 'Begin calibration' }).click()
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(1, {
       command: {
+        commandType: 'home',
+        params: { axes: ['extensionZ', 'extensionJaw'] },
+      },
+      waitUntilComplete: true,
+    })
+    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
+      command: {
         commandType: 'calibration/calibrateGripper',
         params: { jaw: 'front' },
       },
       waitUntilComplete: true,
     })
-    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
+    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
         params: { mount: 'extension' },
@@ -110,6 +117,13 @@ describe('MovePin', () => {
 
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(1, {
       command: {
+        commandType: 'home',
+        params: { axes: ['extensionZ', 'extensionJaw'] },
+      },
+      waitUntilComplete: true,
+    })
+    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
+      command: {
         commandType: 'calibration/calibrateGripper',
         params: {
           jaw: 'rear',
@@ -118,7 +132,7 @@ describe('MovePin', () => {
       },
       waitUntilComplete: true,
     })
-    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
+    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
         params: { mount: 'extension' },

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -62,20 +62,16 @@ describe('MovePin', () => {
     const { getByRole } = render()[0]
     await getByRole('button', { name: 'Begin calibration' }).click()
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(1, {
-      command: { commandType: 'home', params: { axes: [] } },
-      waitUntilComplete: true,
-    })
-    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
       command: {
         commandType: 'calibration/calibrateGripper',
         params: { jaw: 'front' },
       },
       waitUntilComplete: true,
     })
-    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
+    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
-        params: { mount: 'left' },
+        params: { mount: 'extension' },
       },
       waitUntilComplete: true,
     })
@@ -113,10 +109,6 @@ describe('MovePin', () => {
     await getByRole('button', { name: 'Continue' }).click()
 
     await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(1, {
-      command: { commandType: 'home', params: { axes: [] } },
-      waitUntilComplete: true,
-    })
-    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
       command: {
         commandType: 'calibration/calibrateGripper',
         params: {
@@ -126,10 +118,10 @@ describe('MovePin', () => {
       },
       waitUntilComplete: true,
     })
-    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(3, {
+    await expect(mockCreateRunCommand).toHaveBeenNthCalledWith(2, {
       command: {
         commandType: 'calibration/moveToMaintenancePosition',
-        params: { mount: 'left' },
+        params: { mount: 'extension' },
       },
       waitUntilComplete: true,
     })

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -472,6 +472,8 @@ export type MotorAxis =
   | 'rightZ'
   | 'leftPlunger'
   | 'rightPlunger'
+  | 'extensionZ'
+  | 'extensionJaw'
 
 export type MotorAxes = MotorAxis[]
 


### PR DESCRIPTION
fix [RQA-1256](https://opentrons.atlassian.net/browse/RQA-1256)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We need to use the `extension` mount param when calling `moveToMaintenancePosition` for the gripper. We can also update the `home` command we send directly before calibration to use the `extensionZ` and `extensionJaw` commands instead of homing the whole gantry.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Run through gripper calibration, ensure left pipette doesn't drop and gripper doesn't lower

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Change mount from `left` to `extension`
2. Update `home` params before `calibrateGripper`
3. Update tests

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-1256]: https://opentrons.atlassian.net/browse/RQA-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ