### PR TITLE
fix(app): get Flex calibration data from instruments to download

### DIFF
--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
@@ -12,7 +12,7 @@ import {
   TYPOGRAPHY,
   DIRECTION_COLUMN,
 } from '@opentrons/components'
-
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { TertiaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import {
@@ -54,6 +54,7 @@ export function CalibrationDataDownload({
   const deckCalibrationData = useDeckCalibrationData(robot?.name)
   const pipetteOffsetCalibrations = usePipetteOffsetCalibrations()
   const tipLengthCalibrations = useTipLengthCalibrations()
+  const { data: attachedInstruments } = useInstrumentsQuery({ enabled: isOT3 })
 
   const downloadIsPossible =
     deckCalibrationData.isDeckCalibrated &&
@@ -64,8 +65,10 @@ export function CalibrationDataDownload({
 
   const ot3DownloadIsPossible =
     isOT3 &&
-    pipetteOffsetCalibrations != null &&
-    pipetteOffsetCalibrations.length > 0
+    attachedInstruments?.data.some(
+      instrument =>
+        instrument.ok && instrument.data.calibratedOffset.last_modified != null
+    )
 
   const onClickSaveAs: React.MouseEventHandler = e => {
     e.preventDefault()
@@ -77,7 +80,7 @@ export function CalibrationDataDownload({
       new Blob([
         isOT3
           ? JSON.stringify({
-              pipetteOffset: pipetteOffsetCalibrations,
+              instrumentData: attachedInstruments,
             })
           : JSON.stringify({
               deck: deckCalibrationData,

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -85,7 +85,7 @@ export function OverflowMenu({
   const isFlexPipette = isOT3Pipette(pipetteName as PipetteName)
   const ot3PipCal =
     useAttachedPipettesFromInstrumentsQuery()[mount]?.data?.calibratedOffset
-      ?.offset ?? null
+      ?.last_modified ?? null
 
   const applicablePipetteOffsetCal = pipetteOffsetCalibrations?.find(
     p => p.mount === mount && p.pipette === serialNumber


### PR DESCRIPTION
fix RQA-1249

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
For Device Settings/Calibration the download calibration button should be enabled if any instrument has calibration data and the downloaded JSON blob should contain the instruments response.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

1. Look at robot settings of a Flex with no calibrated instruments, see that the button is disabled
2. Look at settings for a Flex with 1 or more calibrated instruments, see button enabled, upon pressing the button see that the json file downloaded contains the instruments response including `calibratedOffset` information
 <!--

Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

1. Grab `instruments` data for Flex robots and check for any calibrated instrument
2. Return instruments response for downloaded file
3. Add test case
<!--

List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
