### PR TITLE
fix(protocol-designer): error handling in top-selector for switching …

### DIFF
--- a/protocol-designer/src/top-selectors/well-contents/index.ts
+++ b/protocol-designer/src/top-selectors/well-contents/index.ts
@@ -73,9 +73,15 @@ export const getAllWellContentsForActiveItem: Selector<WellContentsByLabware | n
       (
         labwareLiquids: StepGeneration.SingleLabwareLiquidState,
         labwareId: string
-      ) =>
-        _wellContentsForLabware(labwareLiquids, labwareEntities[labwareId].def)
+      ) => {
+        if (labwareEntities[labwareId] == null) return null
+        return _wellContentsForLabware(
+          labwareLiquids,
+          labwareEntities[labwareId].def
+        )
+      }
     )
+
     return wellContentsByLabwareId
   }
 )


### PR DESCRIPTION
…between robot types

closes RQA-1206

# Overview

When you create a protocol with 1 robot and then go back and make a new protocol with the other robot, when you go to the `design` tab, PD will white screen. But this PR fixes that by ensuring that the labwareId isn't null. 

# Test Plan

follow the steps in the ticket to replicate the white screen (the ticket identifies a timeline error but i wasn't able to replicate that) - make sure PD doesn't white screen though!

# Changelog

return null if `labwareId` is not in the `labwareEntities`

# Review requests

see test plan

# Risk assessment

low