### PR TITLE
feat(api): leave home-after-drop-tip to hw

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -96,10 +96,14 @@ class HardwareTipHandler(TipHandler):
         """Drop a tip at the current location using the Hardware API."""
         hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()
 
-        await self._hardware_api.drop_tip(
-            mount=hw_mount,
-            home_after=True if home_after is None else home_after,
-        )
+        # Let the hardware controller handle defaulting home_after since its behavior
+        # differs between machines
+        if home_after is not None:
+            kwargs = {"home_after": home_after}
+        else:
+            kwargs = {}
+
+        await self._hardware_api.drop_tip(mount=hw_mount, **kwargs)
 
     async def add_tip(self, pipette_id: str, tip: TipGeometry) -> None:
         """Tell the Hardware API that a tip is attached."""


### PR DESCRIPTION
The OT-2 and the Flex have different default behaviors in hardware for how they should handle homing after drop tip. That was getting overridden by behavior in the protocol engine itself. Leave the defaults to the hardware. This will let the flex avoid homing after dropping a tip, which should certainly be possible and will speed up protocol execution a lot.

# Risk: Medium
This is pretty central to correct protocol execution but also that means it's pretty easy to test! And we have stall detection! So we should put this on a robot and run it through a protocol and see if it works.