### PR TITLE
fix(app): wire up gripper flow to odd run setup

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -13,6 +13,7 @@ import {
 import {
   useCreateMaintenanceCommandMutation,
   useCreateMaintenanceRunMutation,
+  useDeleteMaintenanceRunMutation,
 } from '@opentrons/react-api-client'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
@@ -69,19 +70,24 @@ export function GripperWizardFlows(
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
 
+  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
+    onSuccess: () => closeFlow(),
+    onError: () => closeFlow(),
+  })
+
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
     chainRunCommands([{ commandType: 'home' as const, params: {} }], true)
       .then(() => {
+        deleteMaintenanceRun(maintenanceRunId)
         setIsExiting(false)
         props.onComplete?.()
-        closeFlow()
       })
       .catch(error => {
         console.error(error.message)
+        deleteMaintenanceRun(maintenanceRunId)
         setIsExiting(false)
         props.onComplete?.()
-        closeFlow()
       })
   }
 

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -26,6 +26,7 @@ import { SmallButton } from '../../atoms/buttons'
 import { useMaintenanceRunTakeover } from '../TakeoverModal'
 import { FLOWS } from '../PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../PipetteWizardFlows'
+import { GripperWizardFlows } from '../GripperWizardFlows'
 
 import type {
   InstrumentData,
@@ -72,6 +73,17 @@ export function ProtocolInstrumentMountItem(
     showPipetteWizardFlow,
     setShowPipetteWizardFlow,
   ] = React.useState<boolean>(false)
+  const [
+    showGripperWizardFlow,
+    setShowGripperWizardFlow,
+  ] = React.useState<boolean>(false)
+  const memoizedAttachedGripper = React.useMemo(
+    () =>
+      attachedInstrument?.instrumentType === 'gripper' && attachedInstrument.ok
+        ? attachedInstrument
+        : null,
+    []
+  )
   const [flowType, setFlowType] = React.useState<string>(FLOWS.ATTACH)
   const selectedPipette =
     speccedName === 'p1000_96' ? NINETY_SIX_CHANNEL : SINGLE_MOUNT_PIPETTES
@@ -79,12 +91,20 @@ export function ProtocolInstrumentMountItem(
   const handleCalibrate: React.MouseEventHandler = () => {
     setODDMaintenanceFlowInProgress()
     setFlowType(FLOWS.CALIBRATE)
-    setShowPipetteWizardFlow(true)
+    if (mount === 'extension') {
+      setShowGripperWizardFlow(true)
+    } else {
+      setShowPipetteWizardFlow(true)
+    }
   }
   const handleAttach: React.MouseEventHandler = () => {
     setODDMaintenanceFlowInProgress()
     setFlowType(FLOWS.ATTACH)
-    setShowPipetteWizardFlow(true)
+    if (mount === 'extension') {
+      setShowGripperWizardFlow(true)
+    } else {
+      setShowPipetteWizardFlow(true)
+    }
   }
   const is96ChannelPipette = speccedName === 'p1000_96'
   const isAttachedWithCal =
@@ -160,6 +180,14 @@ export function ProtocolInstrumentMountItem(
           selectedPipette={selectedPipette}
           mount={mount as Mount}
           pipetteInfo={mostRecentAnalysis?.pipettes}
+          onComplete={props.instrumentsRefetch}
+        />
+      ) : null}
+      {showGripperWizardFlow ? (
+        <GripperWizardFlows
+          attachedGripper={memoizedAttachedGripper}
+          flowType={memoizedAttachedGripper != null ? 'RECALIBRATE' : 'ATTACH'}
+          closeFlow={() => setShowGripperWizardFlow(false)}
           onComplete={props.instrumentsRefetch}
         />
       ) : null}

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -3,14 +3,19 @@ import { LEFT, renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../i18n'
 import { PipetteWizardFlows } from '../../PipetteWizardFlows'
+import { GripperWizardFlows } from '../../GripperWizardFlows'
 import { useMaintenanceRunTakeover } from '../../TakeoverModal'
 import { ProtocolInstrumentMountItem } from '..'
 
 jest.mock('../../PipetteWizardFlows')
+jest.mock('../../GripperWizardFlows')
 jest.mock('../../TakeoverModal')
 
 const mockPipetteWizardFlows = PipetteWizardFlows as jest.MockedFunction<
   typeof PipetteWizardFlows
+>
+const mockGripperWizardFlows = GripperWizardFlows as jest.MockedFunction<
+  typeof GripperWizardFlows
 >
 const mockUseMaintenanceRunTakeover = useMaintenanceRunTakeover as jest.MockedFunction<
   typeof useMaintenanceRunTakeover
@@ -29,7 +34,7 @@ const mockGripperData = {
         z: 4,
       },
       source: 'standard',
-      last_modified: 'date',
+      last_modified: undefined,
     },
   },
   subsystem: 'gripper',
@@ -74,6 +79,7 @@ describe('ProtocolInstrumentMountItem', () => {
       speccedName: 'p1000_multi_flex',
     }
     mockPipetteWizardFlows.mockReturnValue(<div>pipette wizard flow</div>)
+    mockGripperWizardFlows.mockReturnValue(<div>gripper wizard flow</div>)
     mockUseMaintenanceRunTakeover.mockReturnValue({
       setODDMaintenanceFlowInProgress: mockSetODDMaintenanceFlowInProgress,
     })
@@ -152,9 +158,12 @@ describe('ProtocolInstrumentMountItem', () => {
     getByText('Extension Mount')
     getByText('No data')
     getByText('Flex Gripper')
-    getByText('Attach')
+    const button = getByText('Attach')
+    fireEvent.click(button)
+    getByText('gripper wizard flow')
+    expect(mockSetODDMaintenanceFlowInProgress).toHaveBeenCalled()
   })
-  it('renders the correct information when gripper is attached', () => {
+  it('renders the correct information when gripper is attached but not calibrated', () => {
     props = {
       ...props,
       mount: 'extension',
@@ -163,7 +172,10 @@ describe('ProtocolInstrumentMountItem', () => {
     }
     const { getByText } = render(props)
     getByText('Extension Mount')
-    getByText('Calibrated')
     getByText('Flex Gripper')
+    const button = getByText('Calibrate')
+    fireEvent.click(button)
+    getByText('gripper wizard flow')
+    expect(mockSetODDMaintenanceFlowInProgress).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
fix RQA-1266

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Gripper wizard flows were never wired up to ODD run setup step so pipette flows were being launched for the gripper. This PR fixes that and also deletes maintenance runs at the end of gripper flows so the "Remote activity in progress" modal closes when we end a flow on desktop.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Launch gripper attach and calibrate flow from run setup and see that the correct wizard is rendered on ODD
2. Run any gripper wizard flow from desktop, see that remote activity modal on ODD closes shortly after the flow is closed on desktop

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Launch gripper wizard flow for extension mount instrument in `ProtocolInstrumentMountItem`
2.  Delete maintenance run in `handleCleanUpAndClose` gripper wizard function
3.  Update tests accordingly

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
