### PR TITLE
fix(robot-server): move update animation controls to light task

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -51,6 +51,8 @@ from .types import (
     PauseType,
     StatusBarState,
     EstopState,
+    SubSystem,
+    SubSystemState,
 )
 from .errors import (
     MustHomeError,
@@ -325,6 +327,9 @@ class API(
     @property
     def board_revision(self) -> str:
         return str(self._backend.board_revision)
+    
+    def attached_subsystems(self) -> Dict[SubSystem, SubSystemState]:
+        return {}
 
     # Incidentals (i.e. not motion) API
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -327,7 +327,7 @@ class API(
     @property
     def board_revision(self) -> str:
         return str(self._backend.board_revision)
-    
+
     def attached_subsystems(self) -> Dict[SubSystem, SubSystemState]:
         return {}
 

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -16,7 +16,10 @@ from .service.task_runner import (
     clean_up_task_runner,
 )
 from .settings import get_settings
-from .runs.dependencies import start_light_control_task
+from .runs.dependencies import (
+    start_light_control_task,
+    mark_light_control_startup_finished,
+)
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +58,11 @@ async def on_startup() -> None:
     initialize_logging()
     initialize_task_runner(app_state=app.state)
     start_initializing_hardware(
-        app_state=app.state, callbacks=[start_light_control_task]
+        app_state=app.state,
+        callbacks=[
+            (start_light_control_task, True),
+            (mark_light_control_startup_finished, False),
+        ],
     )
     start_initializing_persistence(
         app_state=app.state,

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -3,7 +3,16 @@ import asyncio
 import logging
 from pathlib import Path
 from fastapi import Depends, status
-from typing import Callable, Union, TYPE_CHECKING, cast, Awaitable, Iterator, Iterable
+from typing import (
+    Callable,
+    Union,
+    TYPE_CHECKING,
+    cast,
+    Awaitable,
+    Iterator,
+    Iterable,
+    Tuple,
+)
 from uuid import uuid4  # direct to avoid import cycles in service.dependencies
 from traceback import format_exception_only, TracebackException
 from contextlib import contextmanager
@@ -57,8 +66,14 @@ from .robot.control.estop_handler import EstopHandler
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
 
-# Function that can be called when hardware initialization completes
-PostInitCallback = Callable[[AppState, HardwareControlAPI], Awaitable[None]]
+
+PostInitCallback = Tuple[
+    Callable[[AppState, HardwareControlAPI], Awaitable[None]], bool
+]
+"""Function to be called when hardware init completes.
+    - First item is the callback
+    - Second item is True if this should be called BEFORE the postinit
+    function, or False if this should be called AFTER the postinit function."""
 
 log = logging.getLogger(__name__)
 
@@ -252,7 +267,11 @@ async def get_deck_type() -> DeckType:
     return DeckType(guess_deck_type_from_global_config())
 
 
-async def _postinit_ot2_tasks(hardware: ThreadManagedHardware) -> None:
+async def _postinit_ot2_tasks(
+    hardware: ThreadManagedHardware,
+    app_state: AppState,
+    callbacks: Iterable[PostInitCallback],
+) -> None:
     """Tasks to run on an initialized OT-2 before it is ready to use."""
 
     async def _blink() -> None:
@@ -276,6 +295,9 @@ async def _postinit_ot2_tasks(hardware: ThreadManagedHardware) -> None:
             await blink_task
         except asyncio.CancelledError:
             pass
+        for callback in callbacks:
+            if not callback[1]:
+                await callback[0](app_state, hardware.wrapped())
 
 
 async def _home_on_boot(hardware: HardwareControlAPI) -> None:
@@ -321,7 +343,9 @@ async def _do_updates(
 
 
 async def _postinit_ot3_tasks(
-    hardware_tm: ThreadManagedHardware, app_state: AppState
+    hardware_tm: ThreadManagedHardware,
+    app_state: AppState,
+    callbacks: Iterable[PostInitCallback],
 ) -> None:
     """Tasks to run on an initialized OT-3 before it is ready to use."""
     update_manager = await get_firmware_update_manager(
@@ -336,8 +360,11 @@ async def _postinit_ot3_tasks(
         await _do_updates(hardware, update_manager)
         await hardware.cache_instruments()
         await _home_on_boot(hardware)
-        update_manager.mark_initialized()
         await hardware.set_status_bar_state(StatusBarState.ACTIVATION)
+        for callback in callbacks:
+            if not callback[1]:
+                await callback[0](app_state, hardware_tm.wrapped())
+
     except Exception:
         log.exception("Hardware initialization failure")
         raise
@@ -470,17 +497,18 @@ async def _initialize_hardware_api(
         _hw_api_accessor.set_on(app_state, hardware)
 
         for callback in callbacks:
-            await callback(app_state, hardware.wrapped())
+            if callback[1]:
+                await callback[0](app_state, hardware.wrapped())
 
         _systemd_notify(systemd_available)
 
         if should_use_ot3():
             postinit_task = asyncio.create_task(
-                _wrap_postinit(_postinit_ot3_tasks(hardware, app_state))
+                _wrap_postinit(_postinit_ot3_tasks(hardware, app_state, callbacks))
             )
         else:
             postinit_task = asyncio.create_task(
-                _wrap_postinit(_postinit_ot2_tasks(hardware))
+                _wrap_postinit(_postinit_ot2_tasks(hardware, app_state, callbacks))
             )
 
         postinit_task.add_done_callback(_postinit_done_handler)

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -72,6 +72,21 @@ async def start_light_control_task(
     return None
 
 
+async def mark_light_control_startup_finished(
+    app_state: AppState,
+    hardware_api: HardwareControlAPI,
+) -> None:
+    """Should be called once the hardware initialization finishes.
+
+    The task bar's animations change once the hardware is initialized, so it needs a way
+    to be notified that the hardware init is complete.
+    """
+    light_controller = _light_control_accessor.get_from(app_state)
+    if light_controller is None:
+        raise HardwareNotYetInitialized().as_error(status.HTTP_503_SERVICE_UNAVAILABLE)
+    light_controller.mark_initialization_done()
+
+
 async def get_light_controller(
     app_state: AppState = Depends(get_app_state),
 ) -> LightController:

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -1,5 +1,5 @@
 """Background task to drive the status bar."""
-from typing import Optional
+from typing import Optional, List
 from logging import getLogger
 import asyncio
 from dataclasses import dataclass
@@ -7,7 +7,13 @@ from dataclasses import dataclass
 from .engine_store import EngineStore
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.types import EngineStatus
-from opentrons.hardware_control.types import StatusBarState, EstopState
+from opentrons.hardware_control.types import (
+    StatusBarState,
+    EstopState,
+    SubSystem,
+    UpdateState,
+)
+
 
 log = getLogger(__name__)
 
@@ -16,17 +22,23 @@ log = getLogger(__name__)
 class Status:
     """Class to encapsulate overall status of the system as it pertains to the light control task."""
 
+    active_updates: List[SubSystem]
     estop_status: EstopState
     engine_status: Optional[EngineStatus]
 
 
-def _engine_status_to_status_bar(status: Optional[EngineStatus]) -> StatusBarState:
+def _engine_status_to_status_bar(
+    status: Optional[EngineStatus],
+    initialization_done: bool,
+) -> StatusBarState:
     """Convert an engine status into a status bar status."""
     if status is None:
-        return StatusBarState.IDLE
+        return StatusBarState.IDLE if initialization_done else StatusBarState.OFF
 
     return {
-        EngineStatus.IDLE: StatusBarState.IDLE,
+        EngineStatus.IDLE: StatusBarState.IDLE
+        if initialization_done
+        else StatusBarState.OFF,
         EngineStatus.RUNNING: StatusBarState.RUNNING,
         EngineStatus.PAUSED: StatusBarState.PAUSED,
         EngineStatus.BLOCKED_BY_OPEN_DOOR: StatusBarState.PAUSED,
@@ -38,6 +50,36 @@ def _engine_status_to_status_bar(status: Optional[EngineStatus]) -> StatusBarSta
     }[status]
 
 
+def _active_updates_to_status_bar(
+    previous: List[SubSystem],
+    current: List[SubSystem],
+    initialization_done: bool,
+    force_value: bool,
+) -> Optional[StatusBarState]:
+    """Based on how the set of active updates has changed, see if the status bar should change.
+
+    It is important NOT to re-set the Updating state every time the list of updating subsystems
+    changes, because that will result in the pulsing looking incorrect. Instead, only update if
+    the list changed between empty/not empty, OR if the rear panel just finished updating (because
+    we can only set the status if the rear panel is active!).
+    """
+    if previous == current and not force_value:
+        return None
+    if SubSystem.rear_panel in current:
+        # We cannot set anything if the rear panel is updating
+        return None
+    if len(current) == 0:
+        # We just finished updating, put status bar in normal mode.
+        # Note that if this is the initial set of updates we want to set the bar Off,
+        # so act accordingly.
+        return StatusBarState.IDLE if initialization_done else StatusBarState.OFF
+    elif len(previous) == 0 or SubSystem.rear_panel in previous or force_value:
+        # We either just finished updating the rear panel OR we just started running
+        # updates. Either way, the status bar should (re)start the Updating animation.
+        return StatusBarState.UPDATING
+    return None
+
+
 class LightController:
     """LightController sets the status bar to match the protocol status."""
 
@@ -47,12 +89,17 @@ class LightController:
         """Create a new LightController."""
         self._api = api
         self._engine_store = engine_store
+        self._initialization_done = False
+
+    def mark_initialization_done(self) -> None:
+        """Called once the robot server hardware initialization finishes."""
+        self._initialization_done = True
 
     def update_engine_store(self, engine_store: EngineStore) -> None:
         """Provide a handle to an EngineStore for the light control task."""
         self._engine_store = engine_store
 
-    async def update(self, prev_status: Status, new_status: Status) -> None:
+    async def update(self, prev_status: Optional[Status], new_status: Status) -> None:
         """Update the status bar if the current run status has changed."""
         if prev_status == new_status:
             # No change, don't try to set anything.
@@ -61,9 +108,26 @@ class LightController:
         if new_status.estop_status == EstopState.PHYSICALLY_ENGAGED:
             # Estop takes precedence
             await self._api.set_status_bar_state(state=StatusBarState.SOFTWARE_ERROR)
+        elif len(new_status.active_updates) > 0:
+            # Updates take precedence over the protocol status
+            state = _active_updates_to_status_bar(
+                previous=[] if prev_status is None else prev_status.active_updates,
+                current=new_status.active_updates,
+                initialization_done=self._initialization_done,
+                force_value=True
+                if prev_status is not None
+                and prev_status.estop_status is EstopState.PHYSICALLY_ENGAGED
+                else False,
+            )
+            if state is not None:
+                await self._api.set_status_bar_state(state=state)
         else:
+            # Active engine status
             await self._api.set_status_bar_state(
-                state=_engine_status_to_status_bar(status=new_status.engine_status)
+                state=_engine_status_to_status_bar(
+                    status=new_status.engine_status,
+                    initialization_done=self._initialization_done,
+                )
             )
 
     def _get_current_engine_status(self) -> Optional[EngineStatus]:
@@ -76,9 +140,19 @@ class LightController:
 
         return None
 
+    def _get_active_updates(self) -> List[SubSystem]:
+        """Get any active firmware updates."""
+        return [
+            subsystem
+            for subsystem, status in self._api.attached_subsystems.items()
+            if status.update_state is not None
+            and status.update_state is UpdateState.updating
+        ]
+
     def get_current_status(self) -> Status:
         """Get the overall status of the system for light purposes."""
         return Status(
+            active_updates=self._get_active_updates(),
             estop_status=self._api.get_estop_state(),
             engine_status=self._get_current_engine_status(),
         )
@@ -90,6 +164,7 @@ async def run_light_task(driver: LightController) -> None:
     This is intended to be run as a background task once the EngineStore has been created.
     """
     prev_status = driver.get_current_status()
+    await driver.update(prev_status=None, new_status=prev_status)
     while True:
         await asyncio.sleep(0.1)
         new_status = driver.get_current_status()

--- a/robot-server/robot_server/subsystems/firmware_update_manager.py
+++ b/robot-server/robot_server/subsystems/firmware_update_manager.py
@@ -11,12 +11,10 @@ from typing import (
     Callable,
     Awaitable,
     List,
-    Set,
 )
 
 from opentrons.hardware_control.types import (
     SubSystem as HWSubSystem,
-    StatusBarState,
 )
 from opentrons.hardware_control.errors import UpdateOngoingError
 
@@ -246,84 +244,6 @@ class _UpdateProcess:
                 return packet
 
 
-class AnimationHandler:
-    """Interface to manage animations to represent firmware updates.
-
-    The status bar should be set to the updating animation whenever an update
-    is in progress, but this is complicated by a couple of factors:
-    - When the rear panel firmware is being updated, the status bar will be stuck
-      off because it is controlled by that MCU
-    - When all updates are finished, the next state depends on whether the updates
-      are automatic updates on startup (which should lead into the off status) or
-      the updates are manually requested by a client (in which case we should
-      transition back to the Idle status).
-
-    This class is left public to enable mocking for testing.
-    """
-
-    def __init__(self, hw_handle: "OT3API") -> None:
-        self._hardware_handle = hw_handle
-        self._initialized = False
-        self._in_progress: Set[SubSystem] = set()
-        self._lock = Lock()
-
-    def mark_initialized(self) -> None:
-        """Mark that the on-startup updates have finished.
-
-        Once this has been called, update completion will rever the status bar
-        to `IDLE` instead of `OFF`.
-        """
-        self._initialized = True
-
-    async def update_started(self, subsystem: SubSystem) -> None:
-        """Update status bar when a new update is started.
-
-        If this is the only running update, start the `update` animation ONLY if
-        the rear panel is not currently updating.
-        """
-        async with self._lock:
-            if subsystem in self._in_progress:
-                return
-            self._in_progress.add(subsystem)
-
-            if SubSystem.rear_panel in self._in_progress:
-                # We can't control the status bar
-                return
-            if len(self._in_progress) == 1:
-                # This is the only update running, update the status bar
-                await self._hardware_handle.set_status_bar_state(
-                    StatusBarState.UPDATING
-                )
-
-    async def update_complete(self, subsystem: SubSystem) -> None:
-        """Update status bar when an update finishes (succesfully or not).
-
-        - If the rear panel just finished AND there are other updates running, start
-          the update animation
-        - If the last remaining update just finished, set the status to IDLE or OFF
-          (based on whether the `mark_initialized` function has been called yet).
-        - Otherwise, do nothing.
-        """
-        async with self._lock:
-            if subsystem not in self._in_progress:
-                return
-            self._in_progress.remove(subsystem)
-
-            if SubSystem.rear_panel in self._in_progress:
-                # We can't control the status bar
-                return
-            if len(self._in_progress) > 0 and subsystem == SubSystem.rear_panel:
-                # The rear panel just finished AND we're still updating, so we
-                # have to set the rear panel to go back to blinking
-                await self._hardware_handle.set_status_bar_state(
-                    StatusBarState.UPDATING
-                )
-            elif len(self._in_progress) == 0:
-                # There are no more updates.
-                state = StatusBarState.IDLE if self._initialized else StatusBarState.OFF
-                await self._hardware_handle.set_status_bar_state(state)
-
-
 class UpdateProcessHandle:
     """The external interface to get status notifications from the update process."""
 
@@ -387,22 +307,16 @@ class FirmwareUpdateManager:
     _task_runner: TaskRunner
     _hardware_handle: "OT3API"
 
-    _animation_handler: AnimationHandler
-
     def __init__(
         self,
         task_runner: TaskRunner,
         hw_handle: "OT3API",
-        animation_handler: Optional[AnimationHandler] = None,
     ) -> None:
         self._all_updates_by_id = {}
         self._running_updates_by_subsystem = {}
         self._task_runner = task_runner
         self._management_lock = Lock()
         self._hardware_handle = hw_handle
-        self._animation_handler = animation_handler or AnimationHandler(
-            hw_handle=hw_handle
-        )
 
     async def _get_by_id(self, update_id: str) -> _UpdateProcess:
         async with self._management_lock:
@@ -432,7 +346,6 @@ class FirmwareUpdateManager:
                     # make sure this process gets its progress updated since nothing may
                     # update it from the route handler after this
                     await process.provide_latest_progress()
-                    await self._animation_handler.update_complete(subsystem)
                 except KeyError:
                     log.exception(f"Double pop for update on {subsystem}")
 
@@ -442,7 +355,6 @@ class FirmwareUpdateManager:
         self._running_updates_by_subsystem[hw_subsystem] = self._all_updates_by_id[
             update_id
         ]
-        await self._animation_handler.update_started(subsystem=subsystem)
         self._task_runner.run(self._all_updates_by_id[update_id]._update_task)
         return self._all_updates_by_id[update_id]
 
@@ -507,11 +419,3 @@ class FirmwareUpdateManager:
             process = await self._emplace(update_id, subsystem, created_at)
             await process.provide_latest_progress()
         return process.get_handle()
-
-    def mark_initialized(self) -> None:
-        """Mark that the on-startup updates are complete.
-
-        This is used by the animation handler to dictate what the status bar should do
-        when updates finish, which depends on whether the robot is initializing or not.
-        """
-        self._animation_handler.mark_initialized()

--- a/robot-server/tests/runs/test_light_control_task.py
+++ b/robot-server/tests/runs/test_light_control_task.py
@@ -1,11 +1,18 @@
 """Unit tests for `runs.light_control_task`."""
+from __future__ import annotations
 
 import pytest
-from typing import Optional
+from typing import Optional, List
 from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.types import StatusBarState, EstopState
+from opentrons.hardware_control.types import (
+    StatusBarState,
+    EstopState,
+    SubSystem,
+    SubSystemState,
+    UpdateState,
+)
 from opentrons.protocol_engine.types import EngineStatus
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.light_control_task import LightController, Status
@@ -19,9 +26,10 @@ def engine_store(decoy: Decoy) -> EngineStore:
 
 @pytest.fixture
 def subject(
-    hardware_api: HardwareControlAPI, engine_store: EngineStore
+    hardware_api: HardwareControlAPI, engine_store: EngineStore, decoy: Decoy
 ) -> LightController:
     """Test subject - LightController."""
+    decoy.when(hardware_api.attached_subsystems).then_return({})
     return LightController(api=hardware_api, engine_store=engine_store)
 
 
@@ -38,7 +46,7 @@ def subject(
         [False, EngineStatus.FAILED, EstopState.NOT_PRESENT],
     ],
 )
-async def test_get_current_status(
+async def test_get_current_status_ot2(
     decoy: Decoy,
     engine_store: EngineStore,
     subject: LightController,
@@ -53,6 +61,7 @@ async def test_get_current_status(
     decoy.when(hardware_api.get_estop_state()).then_return(estop)
 
     expected = Status(
+        active_updates=[],
         estop_status=estop,
         engine_status=status if active else None,
     )
@@ -61,23 +70,81 @@ async def test_get_current_status(
 
 
 @pytest.mark.parametrize(
-    ["prev_state", "new_state", "expected"],
+    "active_updates",
     [
-        [None, None, StatusBarState.IDLE],
-        [EngineStatus.IDLE, None, StatusBarState.IDLE],
-        [EngineStatus.IDLE, EngineStatus.IDLE, None],
-        [None, EngineStatus.IDLE, StatusBarState.IDLE],
-        [None, EngineStatus.PAUSED, StatusBarState.PAUSED],
+        [SubSystem.gantry_x, SubSystem.gantry_y, SubSystem.rear_panel],
+        [],
+        [SubSystem.gantry_x],
+    ],
+)
+async def test_get_current_status(
+    decoy: Decoy,
+    subject: LightController,
+    hardware_api: HardwareControlAPI,
+    active_updates: List[SubSystem],
+) -> None:
+    """Primarily tests converting present subsystems to a list of updates."""
+    all_nodes = [
+        SubSystem.gantry_x,
+        SubSystem.gantry_y,
+        SubSystem.rear_panel,
+        SubSystem.head,
+    ]
+
+    mock_ret = {
+        node: SubSystemState(
+            ok=True,
+            current_fw_version=1,
+            next_fw_version=1,
+            fw_update_needed=False,
+            current_fw_sha="abcdefg",
+            pcba_revision="fake_pcb",
+            update_state=UpdateState.updating if node in active_updates else None,
+        )
+        for node in all_nodes
+    }
+    decoy.when(hardware_api.attached_subsystems).then_return(mock_ret)
+
+    result = subject.get_current_status().active_updates
+    assert len(result) == len(active_updates)
+    for subsystem in result:
+        assert subsystem in active_updates
+
+
+@pytest.mark.parametrize(
+    ["prev_state", "new_state", "initialized", "expected"],
+    [
+        [None, None, True, StatusBarState.IDLE],
+        [EngineStatus.IDLE, None, True, StatusBarState.IDLE],
+        [EngineStatus.IDLE, EngineStatus.IDLE, True, None],
+        [None, EngineStatus.IDLE, True, StatusBarState.IDLE],
+        [None, EngineStatus.PAUSED, True, StatusBarState.PAUSED],
         [
             EngineStatus.RUNNING,
             EngineStatus.BLOCKED_BY_OPEN_DOOR,
+            True,
             StatusBarState.PAUSED,
         ],
-        [EngineStatus.RUNNING, EngineStatus.FAILED, StatusBarState.HARDWARE_ERROR],
-        [EngineStatus.RUNNING, EngineStatus.SUCCEEDED, StatusBarState.RUN_COMPLETED],
-        [EngineStatus.RUNNING, EngineStatus.STOP_REQUESTED, StatusBarState.UPDATING],
-        [EngineStatus.STOP_REQUESTED, EngineStatus.STOPPED, StatusBarState.IDLE],
-        [EngineStatus.RUNNING, EngineStatus.FINISHING, StatusBarState.UPDATING],
+        [
+            EngineStatus.RUNNING,
+            EngineStatus.FAILED,
+            True,
+            StatusBarState.HARDWARE_ERROR,
+        ],
+        [
+            EngineStatus.RUNNING,
+            EngineStatus.SUCCEEDED,
+            True,
+            StatusBarState.RUN_COMPLETED,
+        ],
+        [
+            EngineStatus.RUNNING,
+            EngineStatus.STOP_REQUESTED,
+            True,
+            StatusBarState.UPDATING,
+        ],
+        [EngineStatus.STOP_REQUESTED, EngineStatus.STOPPED, True, StatusBarState.IDLE],
+        [EngineStatus.RUNNING, EngineStatus.FINISHING, True, StatusBarState.UPDATING],
     ],
 )
 async def test_light_controller_update(
@@ -87,17 +154,26 @@ async def test_light_controller_update(
     prev_state: Optional[EngineStatus],
     new_state: Optional[EngineStatus],
     expected: StatusBarState,
+    initialized: bool,
 ) -> None:
     """Test LightController.update.
 
     Verifies that the status bar is NOT updated if the state is the same, and
     checks that state mapping is correct.
     """
+    if initialized:
+        subject.mark_initialization_done()
     await subject.update(
         prev_status=Status(
-            estop_status=EstopState.DISENGAGED, engine_status=prev_state
+            active_updates=[],
+            estop_status=EstopState.DISENGAGED,
+            engine_status=prev_state,
         ),
-        new_status=Status(estop_status=EstopState.DISENGAGED, engine_status=new_state),
+        new_status=Status(
+            active_updates=[],
+            estop_status=EstopState.DISENGAGED,
+            engine_status=new_state,
+        ),
     )
 
     call_count = 0 if prev_state == new_state else 1
@@ -111,9 +187,11 @@ async def test_provide_engine_store(
     decoy: Decoy, hardware_api: HardwareControlAPI, engine_store: EngineStore
 ) -> None:
     """Test providing an engine store after initialization."""
+    decoy.when(hardware_api.attached_subsystems).then_return({})
     subject = LightController(api=hardware_api, engine_store=None)
     decoy.when(hardware_api.get_estop_state()).then_return(EstopState.DISENGAGED)
     assert subject.get_current_status() == Status(
+        active_updates=[],
         estop_status=EstopState.DISENGAGED,
         engine_status=None,
     )
@@ -125,6 +203,7 @@ async def test_provide_engine_store(
 
     subject.update_engine_store(engine_store=engine_store)
     assert subject.get_current_status() == Status(
+        active_updates=[],
         estop_status=EstopState.DISENGAGED,
         engine_status=EngineStatus.RUNNING,
     )
@@ -138,18 +217,18 @@ async def test_estop_precedence(
     """Test that the estop is prioritized."""
     # Software error
     await subject.update(
-        prev_status=Status(EstopState.PHYSICALLY_ENGAGED, None),
-        new_status=Status(EstopState.PHYSICALLY_ENGAGED, EngineStatus.RUNNING),
+        prev_status=Status([], EstopState.PHYSICALLY_ENGAGED, None),
+        new_status=Status([], EstopState.PHYSICALLY_ENGAGED, EngineStatus.RUNNING),
     )
     # Running
     await subject.update(
-        prev_status=Status(EstopState.PHYSICALLY_ENGAGED, EngineStatus.RUNNING),
-        new_status=Status(EstopState.LOGICALLY_ENGAGED, EngineStatus.RUNNING),
+        prev_status=Status([], EstopState.PHYSICALLY_ENGAGED, EngineStatus.RUNNING),
+        new_status=Status([], EstopState.LOGICALLY_ENGAGED, EngineStatus.RUNNING),
     )
     # Software error
     await subject.update(
-        prev_status=Status(EstopState.LOGICALLY_ENGAGED, EngineStatus.RUNNING),
-        new_status=Status(EstopState.PHYSICALLY_ENGAGED, EngineStatus.IDLE),
+        prev_status=Status([], EstopState.LOGICALLY_ENGAGED, EngineStatus.RUNNING),
+        new_status=Status([], EstopState.PHYSICALLY_ENGAGED, EngineStatus.IDLE),
     )
 
     decoy.verify(

--- a/robot-server/tests/subsystems/test_firmware_update_manager.py
+++ b/robot-server/tests/subsystems/test_firmware_update_manager.py
@@ -19,7 +19,6 @@ from opentrons.hardware_control.types import (
     SubSystem as HWSubSystem,
     UpdateStatus as HWUpdateStatus,
     SubSystemState,
-    StatusBarState,
 )
 from opentrons.hardware_control.errors import UpdateOngoingError as HWUpdateOngoingError
 
@@ -31,7 +30,6 @@ from robot_server.subsystems.firmware_update_manager import (
     UpdateInProgress,
     SubsystemNotFound,
     NoOngoingUpdate,
-    AnimationHandler,
 )
 
 from robot_server.subsystems.models import UpdateState, SubSystem
@@ -44,12 +42,6 @@ if TYPE_CHECKING:
 def decoy_task_runner(decoy: Decoy) -> TaskRunner:
     """Get a mocked out TaskRunner."""
     return decoy.mock(cls=TaskRunner)
-
-
-@pytest.fixture
-def decoy_animation_handler(decoy: Decoy) -> AnimationHandler:
-    """Get a mocked out AnimationHandler."""
-    return decoy.mock(cls=AnimationHandler)
 
 
 @pytest.fixture
@@ -77,10 +69,9 @@ def ot3_hardware_api(decoy: Decoy) -> OT3API:
 def subject(
     task_runner: TaskRunner,
     ot3_hardware_api: OT3API,
-    decoy_animation_handler: AnimationHandler,
 ) -> FirmwareUpdateManager:
     """Get a FirmwareUpdateManager to test."""
-    return FirmwareUpdateManager(task_runner, ot3_hardware_api, decoy_animation_handler)
+    return FirmwareUpdateManager(task_runner, ot3_hardware_api)
 
 
 def _build_attached_subsystem(
@@ -282,7 +273,6 @@ async def test_complete_updates_leave_ongoing(
     updater: MockUpdater,
     subject: FirmwareUpdateManager,
     ot3_hardware_api: OT3API,
-    decoy_animation_handler: AnimationHandler,
     decoy: Decoy,
 ) -> None:
     """It should move completed updates out of ongoing whether they succeed or fail."""
@@ -304,13 +294,6 @@ async def test_complete_updates_leave_ongoing(
     with pytest.raises(NoOngoingUpdate):
         await subject.get_ongoing_update_process_handle_by_subsystem(SubSystem.gantry_x)
     assert subject.get_update_process_handle_by_id("some-id") == proc
-    decoy.verify(
-        [
-            await decoy_animation_handler.update_started(subsystem=SubSystem.gantry_x),
-            await decoy_animation_handler.update_complete(subsystem=SubSystem.gantry_x),
-        ],
-        times=1,
-    )
 
 
 @pytest.mark.ot3_only
@@ -318,38 +301,3 @@ async def test_correct_exception_for_wrong_id(subject: FirmwareUpdateManager) ->
     """It uses a custom exception for incorrect ids."""
     with pytest.raises(UpdateIdNotFound):
         subject.get_update_process_handle_by_id("blahblah")
-
-
-@pytest.mark.ot3_only
-async def test_animation_handler(ot3_hardware_api: OT3API, decoy: Decoy) -> None:
-    """It sets the lights accordingly."""
-    subject = AnimationHandler(hw_handle=ot3_hardware_api)
-
-    # First group of updates:
-    #   - UPDATING
-    #   - UPDATING again (once rear panel finishes)
-    #   - OFF (once finished)
-    await subject.update_started(SubSystem.gantry_x)
-    await subject.update_started(SubSystem.rear_panel)
-    await subject.update_started(SubSystem.gantry_y)
-
-    await subject.update_complete(SubSystem.gantry_x)
-    await subject.update_complete(SubSystem.rear_panel)
-    await subject.update_complete(SubSystem.gantry_y)
-
-    # Second group of updates - UPDATING and then IDLE
-    subject.mark_initialized()
-    await subject.update_started(SubSystem.head)
-    await subject.update_complete(SubSystem.head)
-
-    decoy.verify(
-        [
-            # First group
-            await ot3_hardware_api.set_status_bar_state(StatusBarState.UPDATING),
-            await ot3_hardware_api.set_status_bar_state(StatusBarState.UPDATING),
-            await ot3_hardware_api.set_status_bar_state(StatusBarState.OFF),
-            await ot3_hardware_api.set_status_bar_state(StatusBarState.UPDATING),
-            await ot3_hardware_api.set_status_bar_state(StatusBarState.IDLE),
-        ],
-        times=1,
-    )


### PR DESCRIPTION


# Overview

The original implementation of the status bar animations during firmware updates was in the Firmware Update Manager because the light control task didn't start up until the engine store was created by an HTTP request. Now that the light control task is kicked off on startup, we can move all of the status bar animations to it.

This fixes an issue where pressing an Estop during an update would override the Firmware Update Manager animation; once the estop was released, the status bar would go back to IDLE instead of UPDATING.

# Test Plan

Restarted the protocol engine after pushing new firmware. While the firmware was updating I pressed & released the estop a few times. The status bar changed animations as expected, turning red while the estop was activate and going back to pulsing once it was released. At the end of the firmware updates, the startup animation (quick flash of blue) played as expected and the status bar changed to IDLE.

Also tested running a firmware update after attaching a gripper, same thing worked fine.

# Changelog

- Added the ability to differentiate post-init callbacks as either before or after the `hardware.py`-post-init task, in order to tell the light control task that the hardware is fully done initializing.
- Added logic in the Light Control task to indicate firmware updates on the status bar
- Removed all status bar functionality from the Firmware Update Manager
- Added a stub implementation of `attached_subsystems` for the OT2 API, since it's included in the base Hardware Controller api spec
- Added tests for new light controller functionality

# Review requests


# Risk assessment

Medium but it's very easy to test that this is working correctly by looking at the status bar.