### PR TITLE
fix(api): Include axis names in MustHomeError message

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -445,17 +445,29 @@ class OT3Controller:
     def _get_motor_status(self, ax: Sequence[Axis]) -> Iterator[Optional[MotorStatus]]:
         return (self._motor_status.get(axis_to_node(a)) for a in ax)
 
+    def get_invalid_motor_axes(self, axes: Sequence[Axis]) -> List[Axis]:
+        """Get axes that currently do not have the motor-ok flag."""
+        ret: List[Axis] = []
+        for axis in axes:
+            status = self._get_motor_status([axis])
+            if isinstance(status, MotorStatus) and status.motor_ok:
+                ret.append(axis)
+        return ret
+
+    def get_invalid_encoder_axes(self, axes: Sequence[Axis]) -> List[Axis]:
+        """Get axes that currently do not have the encoder-ok flag."""
+        ret: List[Axis] = []
+        for axis in axes:
+            status = self._get_motor_status([axis])
+            if isinstance(status, MotorStatus) and status.encoder_ok:
+                ret.append(axis)
+        return ret
+
     def check_motor_status(self, axes: Sequence[Axis]) -> bool:
-        return all(
-            isinstance(status, MotorStatus) and status.motor_ok
-            for status in self._get_motor_status(axes)
-        )
+        return len(self.get_invalid_motor_axes(axes)) == 0
 
     def check_encoder_status(self, axes: Sequence[Axis]) -> bool:
-        return all(
-            isinstance(status, MotorStatus) and status.encoder_ok
-            for status in self._get_motor_status(axes)
-        )
+        return len(self.get_invalid_encoder_axes(axes)) == 0
 
     async def update_position(self) -> OT3AxisMap[float]:
         """Get the current position."""

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -442,26 +442,26 @@ class OT3Controller:
         """Set the module controls"""
         self._module_controls = module_controls
 
-    def _get_motor_status(self, ax: Sequence[Axis]) -> Iterator[Optional[MotorStatus]]:
-        return (self._motor_status.get(axis_to_node(a)) for a in ax)
+    def _get_motor_status(
+        self, axes: Sequence[Axis]
+    ) -> Dict[Axis, Optional[MotorStatus]]:
+        return {ax: self._motor_status.get(axis_to_node(ax)) for ax in axes}
 
     def get_invalid_motor_axes(self, axes: Sequence[Axis]) -> List[Axis]:
         """Get axes that currently do not have the motor-ok flag."""
-        ret: List[Axis] = []
-        for axis in axes:
-            status = self._get_motor_status([axis])
-            if isinstance(status, MotorStatus) and status.motor_ok:
-                ret.append(axis)
-        return ret
+        return [
+            ax
+            for ax, status in self._get_motor_status(axes).items()
+            if not status or not status.motor_ok
+        ]
 
     def get_invalid_encoder_axes(self, axes: Sequence[Axis]) -> List[Axis]:
         """Get axes that currently do not have the encoder-ok flag."""
-        ret: List[Axis] = []
-        for axis in axes:
-            status = self._get_motor_status([axis])
-            if isinstance(status, MotorStatus) and status.encoder_ok:
-                ret.append(axis)
-        return ret
+        return [
+            ax
+            for ax, status in self._get_motor_status(axes).items()
+            if not status or not status.encoder_ok
+        ]
 
     def check_motor_status(self, axes: Sequence[Axis]) -> bool:
         return len(self.get_invalid_motor_axes(axes)) == 0

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -15,7 +15,6 @@ from typing import (
     Set,
     Union,
     Mapping,
-    Iterator,
 )
 
 from opentrons.config.types import OT3Config, GantryLoad

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -255,26 +255,26 @@ class OT3Simulator:
         # Simulate conditions as if there are no stalls, aka do nothing
         return None
 
-    def _get_motor_status(self, ax: Sequence[Axis]) -> Iterator[Optional[MotorStatus]]:
-        return (self._motor_status.get(axis_to_node(a)) for a in ax)
+    def _get_motor_status(
+        self, axes: Sequence[Axis]
+    ) -> Dict[Axis, Optional[MotorStatus]]:
+        return {ax: self._motor_status.get(axis_to_node(ax)) for ax in axes}
 
     def get_invalid_motor_axes(self, axes: Sequence[Axis]) -> List[Axis]:
         """Get axes that currently do not have the motor-ok flag."""
-        ret: List[Axis] = []
-        for axis in axes:
-            status = self._get_motor_status([axis])
-            if isinstance(status, MotorStatus) and status.motor_ok:
-                ret.append(axis)
-        return ret
+        return [
+            ax
+            for ax, status in self._get_motor_status(axes).items()
+            if not status or not status.motor_ok
+        ]
 
     def get_invalid_encoder_axes(self, axes: Sequence[Axis]) -> List[Axis]:
         """Get axes that currently do not have the encoder-ok flag."""
-        ret: List[Axis] = []
-        for axis in axes:
-            status = self._get_motor_status([axis])
-            if isinstance(status, MotorStatus) and status.encoder_ok:
-                ret.append(axis)
-        return ret
+        return [
+            ax
+            for ax, status in self._get_motor_status(axes).items()
+            if not status or not status.encoder_ok
+        ]
 
     def check_motor_status(self, axes: Sequence[Axis]) -> bool:
         return len(self.get_invalid_motor_axes(axes)) == 0

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -258,18 +258,29 @@ class OT3Simulator:
     def _get_motor_status(self, ax: Sequence[Axis]) -> Iterator[Optional[MotorStatus]]:
         return (self._motor_status.get(axis_to_node(a)) for a in ax)
 
+    def get_invalid_motor_axes(self, axes: Sequence[Axis]) -> List[Axis]:
+        """Get axes that currently do not have the motor-ok flag."""
+        ret: List[Axis] = []
+        for axis in axes:
+            status = self._get_motor_status([axis])
+            if isinstance(status, MotorStatus) and status.motor_ok:
+                ret.append(axis)
+        return ret
+
+    def get_invalid_encoder_axes(self, axes: Sequence[Axis]) -> List[Axis]:
+        """Get axes that currently do not have the encoder-ok flag."""
+        ret: List[Axis] = []
+        for axis in axes:
+            status = self._get_motor_status([axis])
+            if isinstance(status, MotorStatus) and status.encoder_ok:
+                ret.append(axis)
+        return ret
+
     def check_motor_status(self, axes: Sequence[Axis]) -> bool:
-        return all(
-            isinstance(status, MotorStatus) and status.motor_ok
-            for status in self._get_motor_status(axes)
-        )
+        return len(self.get_invalid_motor_axes(axes)) == 0
 
     def check_encoder_status(self, axes: Sequence[Axis]) -> bool:
-        """If any of the encoder statuses is ok, parking can proceed."""
-        return all(
-            isinstance(status, MotorStatus) and status.encoder_ok
-            for status in self._get_motor_status(axes)
-        )
+        return len(self.get_invalid_encoder_axes(axes)) == 0
 
     async def update_position(self) -> OT3AxisMap[float]:
         """Get the current position."""

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -34,7 +34,8 @@ class EnumeratedError(Exception):
 
     def __str__(self) -> str:
         """Get a human-readable string."""
-        return f'Error {self.code.value.code} {self.code.name} ({self.__class__.__name__}){f": {self.message}" if self.message else ""}'
+        _node = self.detail.get("node")
+        return f'Error {self.code.value.code} {self.code.name} ({self.__class__.__name__}){f": {self.message}" if self.message else ""}{f" ({_node})" if _node else ""}'
 
     def __eq__(self, other: object) -> bool:
         """Compare if two enumerated errors match."""


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Random stalls can happen during factory tests, and an error message that includes which axes stalled is very helpful when debugging.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
