### PR TITLE
feat(robot-server): Sort robot settings by robot type

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -259,6 +259,17 @@ def get_adv_setting(setting: str, robot_type: RobotTypeEnum) -> Optional[Setting
     return s.get(setting, None)
 
 
+def _filtered_key(
+    definition: SettingDefinition,
+    robot_type: RobotTypeEnum,
+    include_internal: bool,
+) -> bool:
+    if include_internal:
+        return robot_type in definition.robot_type
+    else:
+        return robot_type in definition.robot_type and not definition.internal_only
+
+
 @lru_cache(maxsize=1)
 def get_all_adv_settings(
     robot_type: RobotTypeEnum, include_internal: bool = False
@@ -271,9 +282,7 @@ def get_all_adv_settings(
     return {
         key: Setting(value=value, definition=settings_by_id[key])
         for key, value in values.items()
-        if key in settings_by_id
-        and robot_type in settings_by_id[key].robot_type
-        and not (include_internal and settings_by_id[key].internal_only)
+        if key in settings_by_id and _filtered_key(settings_by_id[key], robot_type, include_internal)
     }
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -77,7 +77,10 @@ class SettingDefinition:
         """
         if not self.show_if:
             return True
-        return get_setting_with_env_overload(self.show_if[0], self.robot_type[0]) == self.show_if[1]
+        return (
+            get_setting_with_env_overload(self.show_if[0], self.robot_type[0])
+            == self.show_if[1]
+        )
 
     async def on_change(self, value: Optional[bool]) -> None:
         """
@@ -96,6 +99,7 @@ class DisableLogIntegrationSettingDefinition(SettingDefinition):
             description="Prevent the robot from sending its logs to Opentrons"
             " for analysis. Opentrons uses these logs to"
             " troubleshoot robot issues and spot error trends.",
+            robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
         )
 
     async def on_change(self, value: Optional[bool]) -> None:
@@ -129,7 +133,7 @@ settings = [
         old_id="short-fixed-trash",
         title="Short (55mm) fixed trash",
         description="Trash box is 55mm tall (rather than the 77mm default)",
-        robot_type=[RobotTypeEnum.OT2]
+        robot_type=[RobotTypeEnum.OT2],
     ),
     SettingDefinition(
         _id="deckCalibrationDots",
@@ -137,14 +141,14 @@ settings = [
         title="Deck calibration to dots",
         description="Perform deck calibration to dots rather than crosses, for"
         " robots that do not have crosses etched on the deck",
-        robot_type=[RobotTypeEnum.OT2]
+        robot_type=[RobotTypeEnum.OT2],
     ),
     SettingDefinition(
         _id="disableHomeOnBoot",
         old_id="disable-home-on-boot",
         title="Disable home on boot",
         description="Prevent robot from homing motors on boot",
-        robot_type=[RobotTypeEnum.OT2]
+        robot_type=[RobotTypeEnum.OT2],
     ),
     SettingDefinition(
         _id="useOldAspirationFunctions",
@@ -153,7 +157,7 @@ settings = [
         " that were used before version 3.7.0. Use this if you"
         " need consistency with pre-v3.7.0 results. This only"
         " affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.",
-        robot_type=[RobotTypeEnum.OT2]
+        robot_type=[RobotTypeEnum.OT2],
     ),
     SettingDefinition(
         _id="enableDoorSafetySwitch",
@@ -162,7 +166,7 @@ settings = [
         "Opening the robot door during a run will "
         "pause your robot only after it has completed its "
         "current motion.",
-        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="disableFastProtocolUpload",
@@ -175,7 +179,7 @@ settings = [
             "problems with the newer, faster protocol analysis method."
         ),
         restart_required=False,
-        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="enableOT3HardwareController",
@@ -185,25 +189,25 @@ settings = [
             "new hardware."
         ),
         restart_required=True,
-        robot_type=[RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="rearPanelIntegration",
         title="Enable robots with the new usb connected rear-panel board.",
         description="This is an Opentrons-internal setting to test new rear-panel.",
-        robot_type=[RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="disableStallDetection",
         title="Disable stall detection on the Flex.",
         description="This is an Opentrons-internal setting for hardware-testing.",
-        robot_type=[RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="disableStatusBar",
         title="Disable the LED status bar on the Flex.",
         description="This setting disables the LED status bar on the Flex.",
-        robot_type=[RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="estopNotRequired",
@@ -213,20 +217,20 @@ settings = [
             "estopNotRequired",
             True,
         ),  # Configured so this only shows if it has been set by a user
-        robot_type=[RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="disableOverpressureDetection",
         title="Disable overpressure detection on pipettes.",
         description="This setting disables overpressure detection on pipettes, do not turn this feature off unless recommended.",
-        robot_type=[RobotTypeEnum.FLEX]
+        robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(
         _id="disableTipPresenceDetection",
         title="Disable tip presence detection on pipettes.",
         description="This setting disables tip presence detection on pipettes, do not turn this feature off unless recommended.",
-        robot_type=[RobotTypeEnum.FLEX]
-    )
+        robot_type=[RobotTypeEnum.FLEX],
+    ),
 ]
 
 if (

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -50,7 +50,7 @@ class SettingDefinition:
         old_id: Optional[str] = None,
         restart_required: bool = False,
         show_if: Optional[Tuple[str, bool]] = None,
-        interal_only: bool = False,
+        internal_only: bool = False,
     ):
         self.id = _id
         #: The id of the setting for programmatic access through
@@ -68,7 +68,7 @@ class SettingDefinition:
         #: to show this setting in http endpoints
         self.robot_type = robot_type
         #: A list of RobotTypeEnums that are compatible with this feature flag.
-        self.internal_only = interal_only
+        self.internal_only = internal_only
         #: A flag determining whether this setting is user-facing.
 
     def __repr__(self) -> str:
@@ -194,14 +194,14 @@ settings = [
         ),
         restart_required=True,
         robot_type=[RobotTypeEnum.FLEX],
-        interal_only=True,
+        internal_only=True,
     ),
     SettingDefinition(
         _id="rearPanelIntegration",
         title="Enable robots with the new usb connected rear-panel board.",
         description="This is an Opentrons-internal setting to test new rear-panel.",
         robot_type=[RobotTypeEnum.FLEX],
-        interal_only=True,
+        internal_only=True,
     ),
     SettingDefinition(
         _id="disableStallDetection",
@@ -224,7 +224,7 @@ settings = [
             True,
         ),  # Configured so this only shows if it has been set by a user
         robot_type=[RobotTypeEnum.FLEX],
-        interal_only=True,
+        internal_only=True,
     ),
     SettingDefinition(
         _id="disableOverpressureDetection",

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -282,7 +282,8 @@ def get_all_adv_settings(
     return {
         key: Setting(value=value, definition=settings_by_id[key])
         for key, value in values.items()
-        if key in settings_by_id and _filtered_key(settings_by_id[key], robot_type, include_internal)
+        if key in settings_by_id
+        and _filtered_key(settings_by_id[key], robot_type, include_internal)
     }
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -255,12 +255,14 @@ settings_by_old_id: Dict[str, SettingDefinition] = {
 
 def get_adv_setting(setting: str, robot_type: RobotTypeEnum) -> Optional[Setting]:
     setting = _clean_id(setting)
-    s = get_all_adv_settings(robot_type)
+    s = get_all_adv_settings(robot_type, include_internal=True)
     return s.get(setting, None)
 
 
 @lru_cache(maxsize=1)
-def get_all_adv_settings(robot_type: RobotTypeEnum) -> Dict[str, Setting]:
+def get_all_adv_settings(
+    robot_type: RobotTypeEnum, include_internal: bool = False
+) -> Dict[str, Setting]:
     """Get all the advanced setting values and definitions"""
     settings_file = CONFIG["feature_flags_file"]
 
@@ -271,7 +273,7 @@ def get_all_adv_settings(robot_type: RobotTypeEnum) -> Dict[str, Setting]:
         for key, value in values.items()
         if key in settings_by_id
         and robot_type in settings_by_id[key].robot_type
-        and not settings_by_id[key].internal_only
+        and not (include_internal and settings_by_id[key].internal_only)
     }
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -13,10 +13,12 @@ from typing import (
     Optional,
     NamedTuple,
     cast,
+    List,
 )
 
 from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 from opentrons.system import log_control
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -44,6 +46,7 @@ class SettingDefinition:
         _id: str,
         title: str,
         description: str,
+        robot_type: List[RobotTypeEnum],
         old_id: Optional[str] = None,
         restart_required: bool = False,
         show_if: Optional[Tuple[str, bool]] = None,
@@ -62,6 +65,7 @@ class SettingDefinition:
         self.show_if = show_if
         #: A tuple of (other setting id, setting value) that must match reality
         #: to show this setting in http endpoints
+        self.robot_type = robot_type
 
     def __repr__(self) -> str:
         return "{}: {}".format(self.__class__, self.id)
@@ -73,7 +77,7 @@ class SettingDefinition:
         """
         if not self.show_if:
             return True
-        return get_setting_with_env_overload(self.show_if[0]) == self.show_if[1]
+        return get_setting_with_env_overload(self.show_if[0], self.robot_type[0]) == self.show_if[1]
 
     async def on_change(self, value: Optional[bool]) -> None:
         """
@@ -125,6 +129,7 @@ settings = [
         old_id="short-fixed-trash",
         title="Short (55mm) fixed trash",
         description="Trash box is 55mm tall (rather than the 77mm default)",
+        robot_type=[RobotTypeEnum.OT2]
     ),
     SettingDefinition(
         _id="deckCalibrationDots",
@@ -132,12 +137,14 @@ settings = [
         title="Deck calibration to dots",
         description="Perform deck calibration to dots rather than crosses, for"
         " robots that do not have crosses etched on the deck",
+        robot_type=[RobotTypeEnum.OT2]
     ),
     SettingDefinition(
         _id="disableHomeOnBoot",
         old_id="disable-home-on-boot",
         title="Disable home on boot",
         description="Prevent robot from homing motors on boot",
+        robot_type=[RobotTypeEnum.OT2]
     ),
     SettingDefinition(
         _id="useOldAspirationFunctions",
@@ -146,6 +153,7 @@ settings = [
         " that were used before version 3.7.0. Use this if you"
         " need consistency with pre-v3.7.0 results. This only"
         " affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.",
+        robot_type=[RobotTypeEnum.OT2]
     ),
     SettingDefinition(
         _id="enableDoorSafetySwitch",
@@ -154,6 +162,7 @@ settings = [
         "Opening the robot door during a run will "
         "pause your robot only after it has completed its "
         "current motion.",
+        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX]
     ),
     SettingDefinition(
         _id="disableFastProtocolUpload",
@@ -166,6 +175,7 @@ settings = [
             "problems with the newer, faster protocol analysis method."
         ),
         restart_required=False,
+        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX]
     ),
     SettingDefinition(
         _id="enableOT3HardwareController",
@@ -175,21 +185,25 @@ settings = [
             "new hardware."
         ),
         restart_required=True,
+        robot_type=[RobotTypeEnum.FLEX]
     ),
     SettingDefinition(
         _id="rearPanelIntegration",
         title="Enable robots with the new usb connected rear-panel board.",
         description="This is an Opentrons-internal setting to test new rear-panel.",
+        robot_type=[RobotTypeEnum.FLEX]
     ),
     SettingDefinition(
         _id="disableStallDetection",
         title="Disable stall detection on the Flex.",
         description="This is an Opentrons-internal setting for hardware-testing.",
+        robot_type=[RobotTypeEnum.FLEX]
     ),
     SettingDefinition(
         _id="disableStatusBar",
         title="Disable the LED status bar on the Flex.",
         description="This setting disables the LED status bar on the Flex.",
+        robot_type=[RobotTypeEnum.FLEX]
     ),
     SettingDefinition(
         _id="estopNotRequired",
@@ -199,7 +213,20 @@ settings = [
             "estopNotRequired",
             True,
         ),  # Configured so this only shows if it has been set by a user
+        robot_type=[RobotTypeEnum.FLEX]
     ),
+    SettingDefinition(
+        _id="disableOverpressureDetection",
+        title="Disable overpressure detection on pipettes.",
+        description="This setting disables overpressure detection on pipettes, do not turn this feature off unless recommended.",
+        robot_type=[RobotTypeEnum.FLEX]
+    ),
+    SettingDefinition(
+        _id="disableTipPresenceDetection",
+        title="Disable tip presence detection on pipettes.",
+        description="This setting disables tip presence detection on pipettes, do not turn this feature off unless recommended.",
+        robot_type=[RobotTypeEnum.FLEX]
+    )
 ]
 
 if (
@@ -215,14 +242,14 @@ settings_by_old_id: Dict[str, SettingDefinition] = {
 }
 
 
-def get_adv_setting(setting: str) -> Optional[Setting]:
+def get_adv_setting(setting: str, robot_type: RobotTypeEnum) -> Optional[Setting]:
     setting = _clean_id(setting)
-    s = get_all_adv_settings()
+    s = get_all_adv_settings(robot_type)
     return s.get(setting, None)
 
 
 @lru_cache(maxsize=1)
-def get_all_adv_settings() -> Dict[str, Setting]:
+def get_all_adv_settings(robot_type: RobotTypeEnum) -> Dict[str, Setting]:
     """Get all the advanced setting values and definitions"""
     settings_file = CONFIG["feature_flags_file"]
 
@@ -231,7 +258,7 @@ def get_all_adv_settings() -> Dict[str, Setting]:
     return {
         key: Setting(value=value, definition=settings_by_id[key])
         for key, value in values.items()
-        if key in settings_by_id
+        if key in settings_by_id and robot_type in settings_by_id[key].robot_type
     }
 
 
@@ -695,12 +722,12 @@ def _ensure(data: Mapping[str, Any]) -> SettingsMap:
     return newdata
 
 
-def get_setting_with_env_overload(setting_name: str) -> bool:
+def get_setting_with_env_overload(setting_name: str, robot_type: RobotTypeEnum) -> bool:
     env_name = "OT_API_FF_" + setting_name
     if env_name in os.environ:
         return os.environ[env_name].lower() in {"1", "true", "on"}
     else:
-        s = get_adv_setting(setting_name)
+        s = get_adv_setting(setting_name, robot_type)
         return s.value is True if s is not None else False
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -50,6 +50,7 @@ class SettingDefinition:
         old_id: Optional[str] = None,
         restart_required: bool = False,
         show_if: Optional[Tuple[str, bool]] = None,
+        interal_only: bool = False,
     ):
         self.id = _id
         #: The id of the setting for programmatic access through
@@ -66,6 +67,9 @@ class SettingDefinition:
         #: A tuple of (other setting id, setting value) that must match reality
         #: to show this setting in http endpoints
         self.robot_type = robot_type
+        #: A list of RobotTypeEnums that are compatible with this feature flag.
+        self.internal_only = interal_only
+        #: A flag determining whether this setting is user-facing.
 
     def __repr__(self) -> str:
         return "{}: {}".format(self.__class__, self.id)
@@ -166,7 +170,7 @@ settings = [
         "Opening the robot door during a run will "
         "pause your robot only after it has completed its "
         "current motion.",
-        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
+        robot_type=[RobotTypeEnum.OT2],
     ),
     SettingDefinition(
         _id="disableFastProtocolUpload",
@@ -190,12 +194,14 @@ settings = [
         ),
         restart_required=True,
         robot_type=[RobotTypeEnum.FLEX],
+        interal_only=True,
     ),
     SettingDefinition(
         _id="rearPanelIntegration",
         title="Enable robots with the new usb connected rear-panel board.",
         description="This is an Opentrons-internal setting to test new rear-panel.",
         robot_type=[RobotTypeEnum.FLEX],
+        interal_only=True,
     ),
     SettingDefinition(
         _id="disableStallDetection",
@@ -218,6 +224,7 @@ settings = [
             True,
         ),  # Configured so this only shows if it has been set by a user
         robot_type=[RobotTypeEnum.FLEX],
+        interal_only=True,
     ),
     SettingDefinition(
         _id="disableOverpressureDetection",
@@ -262,7 +269,9 @@ def get_all_adv_settings(robot_type: RobotTypeEnum) -> Dict[str, Setting]:
     return {
         key: Setting(value=value, definition=settings_by_id[key])
         for key, value in values.items()
-        if key in settings_by_id and robot_type in settings_by_id[key].robot_type
+        if key in settings_by_id
+        and robot_type in settings_by_id[key].robot_type
+        and not settings_by_id[key].internal_only
     }
 
 

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,64 +1,81 @@
 from opentrons.config import advanced_settings as advs
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 
 def short_fixed_trash() -> bool:
-    return advs.get_setting_with_env_overload("shortFixedTrash")
+    return advs.get_setting_with_env_overload("shortFixedTrash", RobotTypeEnum.OT2)
 
 
 def dots_deck_type() -> bool:
-    return advs.get_setting_with_env_overload("deckCalibrationDots")
+    return advs.get_setting_with_env_overload("deckCalibrationDots", RobotTypeEnum.OT2)
 
 
 def disable_home_on_boot() -> bool:
-    return advs.get_setting_with_env_overload("disableHomeOnBoot")
+    return advs.get_setting_with_env_overload("disableHomeOnBoot", RobotTypeEnum.OT2)
 
 
 def use_old_aspiration_functions() -> bool:
-    return advs.get_setting_with_env_overload("useOldAspirationFunctions", RobotTypeEnum.OT2)
+    return advs.get_setting_with_env_overload(
+        "useOldAspirationFunctions", RobotTypeEnum.OT2
+    )
 
 
 def enable_door_safety_switch() -> bool:
-    return advs.get_setting_with_env_overload("enableDoorSafetySwitch", RobotTypeEnum.FLEX)
+    return advs.get_setting_with_env_overload(
+        "enableDoorSafetySwitch", RobotTypeEnum.FLEX
+    )
 
 
 def disable_fast_protocol_upload() -> bool:
-    return advs.get_setting_with_env_overload("disableFastProtocolUpload", RobotTypeEnum.FLEX)
+    return advs.get_setting_with_env_overload(
+        "disableFastProtocolUpload", RobotTypeEnum.FLEX
+    )
 
 
 def enable_ot3_hardware_controller() -> bool:
     """Get whether to use the OT-3 hardware controller."""
 
-    return advs.get_setting_with_env_overload("enableOT3HardwareController", RobotTypeEnum.FLEX)
+    return advs.get_setting_with_env_overload(
+        "enableOT3HardwareController", RobotTypeEnum.FLEX
+    )
 
 
 def rear_panel_integration() -> bool:
     """Whether to enable usb connected rear_panel for the OT-3."""
 
-    return advs.get_setting_with_env_overload("rearPanelIntegration", RobotTypeEnum.FLEX)
+    return advs.get_setting_with_env_overload(
+        "rearPanelIntegration", RobotTypeEnum.FLEX
+    )
 
 
 def stall_detection_enabled() -> bool:
-    return not advs.get_setting_with_env_overload("disableStallDetection", RobotTypeEnum.FLEX)
+    return not advs.get_setting_with_env_overload(
+        "disableStallDetection", RobotTypeEnum.FLEX
+    )
 
 
 def overpressure_detection_enabled() -> bool:
-    return not advs.get_setting_with_env_overload("disableOverpressureDetection", RobotTypeEnum.FLEX)
+    return not advs.get_setting_with_env_overload(
+        "disableOverpressureDetection", RobotTypeEnum.FLEX
+    )
 
 
 def status_bar_enabled() -> bool:
     """Whether the status bar is enabled."""
-<<<<<<< HEAD
-    return not advs.get_setting_with_env_overload("disableStatusBar")
+    return not advs.get_setting_with_env_overload(
+        "disableStatusBar", RobotTypeEnum.FLEX
+    )
 
 
 def tip_presence_detection_enabled() -> bool:
     """Whether tip presence is enabled on the Flex"""
-    return not advs.get_setting_with_env_overload("disableTipPresenceDetection")
+    return not advs.get_setting_with_env_overload(
+        "disableTipPresenceDetection", RobotTypeEnum.FLEX
+    )
 
 
 def require_estop() -> bool:
     """Whether the OT3 should allow gantry movements with no Estop plugged in."""
-    return not advs.get_setting_with_env_overload("estopNotRequired")
-=======
-    return not advs.get_setting_with_env_overload("disableStatusBar", RobotTypeEnum.FLEX)
->>>>>>> feat(robot-server): filter robot advanced settings based on robot type
+    return not advs.get_setting_with_env_overload(
+        "estopNotRequired", RobotTypeEnum.FLEX
+    )

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -14,39 +14,40 @@ def disable_home_on_boot() -> bool:
 
 
 def use_old_aspiration_functions() -> bool:
-    return advs.get_setting_with_env_overload("useOldAspirationFunctions")
+    return advs.get_setting_with_env_overload("useOldAspirationFunctions", RobotTypeEnum.OT2)
 
 
 def enable_door_safety_switch() -> bool:
-    return advs.get_setting_with_env_overload("enableDoorSafetySwitch")
+    return advs.get_setting_with_env_overload("enableDoorSafetySwitch", RobotTypeEnum.FLEX)
 
 
 def disable_fast_protocol_upload() -> bool:
-    return advs.get_setting_with_env_overload("disableFastProtocolUpload")
+    return advs.get_setting_with_env_overload("disableFastProtocolUpload", RobotTypeEnum.FLEX)
 
 
 def enable_ot3_hardware_controller() -> bool:
     """Get whether to use the OT-3 hardware controller."""
 
-    return advs.get_setting_with_env_overload("enableOT3HardwareController")
+    return advs.get_setting_with_env_overload("enableOT3HardwareController", RobotTypeEnum.FLEX)
 
 
 def rear_panel_integration() -> bool:
     """Whether to enable usb connected rear_panel for the OT-3."""
 
-    return advs.get_setting_with_env_overload("rearPanelIntegration")
+    return advs.get_setting_with_env_overload("rearPanelIntegration", RobotTypeEnum.FLEX)
 
 
 def stall_detection_enabled() -> bool:
-    return not advs.get_setting_with_env_overload("disableStallDetection")
+    return not advs.get_setting_with_env_overload("disableStallDetection", RobotTypeEnum.FLEX)
 
 
 def overpressure_detection_enabled() -> bool:
-    return not advs.get_setting_with_env_overload("disableOverpressureDetection")
+    return not advs.get_setting_with_env_overload("disableOverpressureDetection", RobotTypeEnum.FLEX)
 
 
 def status_bar_enabled() -> bool:
     """Whether the status bar is enabled."""
+<<<<<<< HEAD
     return not advs.get_setting_with_env_overload("disableStatusBar")
 
 
@@ -58,3 +59,6 @@ def tip_presence_detection_enabled() -> bool:
 def require_estop() -> bool:
     """Whether the OT3 should allow gantry movements with no Estop plugged in."""
     return not advs.get_setting_with_env_overload("estopNotRequired")
+=======
+    return not advs.get_setting_with_env_overload("disableStatusBar", RobotTypeEnum.FLEX)
+>>>>>>> feat(robot-server): filter robot advanced settings based on robot type

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -12,7 +12,7 @@ def mock_settings_values_ot2() -> Dict[str, Optional[bool]]:
     return {
         s.id: False
         for s in advanced_settings.settings
-        if RobotTypeEnum.OT2 in s.robot_type
+        if RobotTypeEnum.OT2 in s.robot_type and not s.internal_only
     }
 
 
@@ -21,7 +21,7 @@ def mock_settings_values_flex() -> Dict[str, Optional[bool]]:
     return {
         s.id: False
         for s in advanced_settings.settings
-        if RobotTypeEnum.FLEX in s.robot_type
+        if RobotTypeEnum.FLEX in s.robot_type and not s.internal_only
     }
 
 

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -1,13 +1,28 @@
 import pytest
+from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 from typing import Any, Dict, Generator, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 from opentrons.config import advanced_settings, ARCHITECTURE, CONFIG
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 
 @pytest.fixture
-def mock_settings_values() -> Dict[str, Optional[bool]]:
-    return {s.id: False for s in advanced_settings.settings}
+def mock_settings_values_ot2() -> Dict[str, Optional[bool]]:
+    return {
+        s.id: False
+        for s in advanced_settings.settings
+        if RobotTypeEnum.OT2 in s.robot_type
+    }
+
+
+@pytest.fixture
+def mock_settings_values_flex() -> Dict[str, Optional[bool]]:
+    return {
+        s.id: False
+        for s in advanced_settings.settings
+        if RobotTypeEnum.FLEX in s.robot_type
+    }
 
 
 @pytest.fixture
@@ -17,21 +32,38 @@ def mock_settings_version() -> int:
 
 @pytest.fixture
 def mock_settings(
-    mock_settings_values: Dict[str, Optional[bool]],
+    mock_settings_values_ot2: Dict[str, Optional[bool]],
     mock_settings_version: int,
 ) -> advanced_settings.SettingsData:
     return advanced_settings.SettingsData(
-        settings_map=mock_settings_values,
+        settings_map=mock_settings_values_ot2,
         version=mock_settings_version,
     )
 
 
 @pytest.fixture
-def mock_read_settings_file(
-    mock_settings: advanced_settings.SettingsData,
+def mock_read_settings_file_ot2(
+    mock_settings_values_ot2: Dict[str, Optional[bool]],
+    mock_settings_version: int,
 ) -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.advanced_settings._read_settings_file") as p:
-        p.return_value = mock_settings
+        p.return_value = advanced_settings.SettingsData(
+            settings_map=mock_settings_values_ot2,
+            version=mock_settings_version,
+        )
+        yield p
+
+
+@pytest.fixture
+def mock_read_settings_file_flex(
+    mock_settings_values_flex: Dict[str, Optional[bool]],
+    mock_settings_version: int,
+) -> Generator[MagicMock, None, None]:
+    with patch("opentrons.config.advanced_settings._read_settings_file") as p:
+        p.return_value = advanced_settings.SettingsData(
+            settings_map=mock_settings_values_flex,
+            version=mock_settings_version,
+        )
         yield p
 
 
@@ -53,29 +85,45 @@ def clear_cache() -> None:
 
 
 def test_get_advanced_setting_not_found(
-    clear_cache: None, mock_read_settings_file: MagicMock
+    clear_cache: None, mock_read_settings_file_ot2: MagicMock
 ) -> None:
-    assert advanced_settings.get_adv_setting("unknown") is None
+    assert advanced_settings.get_adv_setting("unknown", RobotTypeEnum.OT2) is None
 
 
 def test_get_advanced_setting_found(
     clear_cache: None,
-    mock_read_settings_file: MagicMock,
-    mock_settings_values: Dict[str, Optional[bool]],
+    mock_read_settings_file_ot2: MagicMock,
+    mock_settings_values_ot2: Dict[str, Optional[bool]],
 ) -> None:
-    for k, v in mock_settings_values.items():
-        s = advanced_settings.get_adv_setting(k)
+    for k, v in mock_settings_values_ot2.items():
+        s = advanced_settings.get_adv_setting(k, RobotTypeEnum.OT2)
         assert s is not None
         assert s.value == v
         assert s.definition == advanced_settings.settings_by_id[k]
 
 
+@pytest.mark.parametrize(
+    "robot_type, mock_settings_values, mock_read_settings_file",
+    [
+        [
+            RobotTypeEnum.OT2,
+            lazy_fixture("mock_settings_values_ot2"),
+            lazy_fixture("mock_read_settings_file_ot2"),
+        ],
+        [
+            RobotTypeEnum.FLEX,
+            lazy_fixture("mock_settings_values_flex"),
+            lazy_fixture("mock_read_settings_file_flex"),
+        ],
+    ],
+)
 def test_get_all_adv_settings(
     clear_cache: None,
     mock_read_settings_file: MagicMock,
     mock_settings_values: MagicMock,
+    robot_type: RobotTypeEnum,
 ) -> None:
-    s = advanced_settings.get_all_adv_settings()
+    s = advanced_settings.get_all_adv_settings(robot_type)
     assert s.keys() == mock_settings_values.keys()
     for k, v in s.items():
         assert v.value == mock_settings_values[k]
@@ -84,68 +132,71 @@ def test_get_all_adv_settings(
 
 def test_get_all_adv_settings_empty(
     clear_cache: None,
-    mock_read_settings_file: MagicMock,
+    mock_read_settings_file_ot2: MagicMock,
 ) -> None:
-    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
-    s = advanced_settings.get_all_adv_settings()
+    mock_read_settings_file_ot2.return_value = advanced_settings.SettingsData({}, 1)
+    s = advanced_settings.get_all_adv_settings(RobotTypeEnum.OT2)
     assert s == {}
 
 
 async def test_set_adv_setting(
-    mock_read_settings_file: MagicMock,
-    mock_settings_values: MagicMock,
+    mock_read_settings_file_ot2: MagicMock,
+    mock_settings_values_ot2: MagicMock,
     mock_write_settings_file: MagicMock,
     mock_settings_version: int,
     restore_restart_required: None,
 ) -> None:
-    for k, v in mock_settings_values.items():
+    for k, v in mock_settings_values_ot2.items():
         # Toggle the advanced setting
         await advanced_settings.set_adv_setting(k, not v)
         mock_write_settings_file.assert_called_with(
             # Only the current key is toggled
-            {nk: nv if nk != k else not v for nk, nv in mock_settings_values.items()},
+            {
+                nk: nv if nk != k else not v
+                for nk, nv in mock_settings_values_ot2.items()
+            },
             mock_settings_version,
             CONFIG["feature_flags_file"],
         )
 
 
 async def test_set_adv_setting_unknown(
-    mock_read_settings_file: MagicMock,
+    mock_read_settings_file_ot2: MagicMock,
     mock_write_settings_file: MagicMock,
 ) -> None:
-    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
+    mock_read_settings_file_ot2.return_value = advanced_settings.SettingsData({}, 1)
     with pytest.raises(ValueError, match="is not recognized"):
         await advanced_settings.set_adv_setting("no", False)
 
 
 async def test_get_all_adv_settings_lru_cache(
     clear_cache: None,
-    mock_read_settings_file: MagicMock,
+    mock_read_settings_file_ot2: MagicMock,
     mock_write_settings_file: MagicMock,
 ) -> None:
     # Cache should not be used.
-    advanced_settings.get_all_adv_settings()
-    mock_read_settings_file.assert_called_once()
-    mock_read_settings_file.reset_mock()
+    advanced_settings.get_all_adv_settings(RobotTypeEnum.OT2)
+    mock_read_settings_file_ot2.assert_called_once()
+    mock_read_settings_file_ot2.reset_mock()
     # Should use cache
-    advanced_settings.get_all_adv_settings()
-    mock_read_settings_file.assert_not_called()
-    mock_read_settings_file.reset_mock()
+    advanced_settings.get_all_adv_settings(RobotTypeEnum.OT2)
+    mock_read_settings_file_ot2.assert_not_called()
+    mock_read_settings_file_ot2.reset_mock()
     # Updating will invalidate cache
     await advanced_settings.set_adv_setting("enableDoorSafetySwitch", True)
-    mock_read_settings_file.reset_mock()
+    mock_read_settings_file_ot2.reset_mock()
     # Cache should not be used
-    advanced_settings.get_all_adv_settings()
-    mock_read_settings_file.assert_called_once()
-    mock_read_settings_file.reset_mock()
+    advanced_settings.get_all_adv_settings(RobotTypeEnum.OT2)
+    mock_read_settings_file_ot2.assert_called_once()
+    mock_read_settings_file_ot2.reset_mock()
     # Should use cache
-    advanced_settings.get_all_adv_settings()
-    mock_read_settings_file.assert_not_called()
+    advanced_settings.get_all_adv_settings(RobotTypeEnum.OT2)
+    mock_read_settings_file_ot2.assert_not_called()
 
 
 async def test_restart_required(
     restore_restart_required: None,
-    mock_read_settings_file: MagicMock,
+    mock_read_settings_file_ot2: MagicMock,
     mock_write_settings_file: MagicMock,
     mock_settings_version: int,
 ) -> None:
@@ -153,7 +204,11 @@ async def test_restart_required(
     # Mock out the available settings
     available_settings = [
         advanced_settings.SettingDefinition(
-            _id=_id, title="", description="", restart_required=True
+            _id=_id,
+            title="",
+            description="",
+            restart_required=True,
+            robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
         )
     ]
     with patch.object(advanced_settings, "settings", new=available_settings):
@@ -162,7 +217,7 @@ async def test_restart_required(
         with patch.object(
             advanced_settings, "settings_by_id", new=available_settings_by_id
         ):
-            mock_read_settings_file.return_value = advanced_settings.SettingsData(
+            mock_read_settings_file_ot2.return_value = advanced_settings.SettingsData(
                 settings_map={_id: None}, version=mock_settings_version
             )
 

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -17,6 +17,15 @@ def mock_settings_values_ot2() -> Dict[str, Optional[bool]]:
 
 
 @pytest.fixture
+def mock_settings_values_ot2_all() -> Dict[str, Optional[bool]]:
+    return {
+        s.id: False
+        for s in advanced_settings.settings
+        if RobotTypeEnum.OT2 in s.robot_type
+    }
+
+
+@pytest.fixture
 def mock_settings_values_flex() -> Dict[str, Optional[bool]]:
     return {
         s.id: False
@@ -93,9 +102,9 @@ def test_get_advanced_setting_not_found(
 def test_get_advanced_setting_found(
     clear_cache: None,
     mock_read_settings_file_ot2: MagicMock,
-    mock_settings_values_ot2: Dict[str, Optional[bool]],
+    mock_settings_values_ot2_all: Dict[str, Optional[bool]],
 ) -> None:
-    for k, v in mock_settings_values_ot2.items():
+    for k, v in mock_settings_values_ot2_all.items():
         s = advanced_settings.get_adv_setting(k, RobotTypeEnum.OT2)
         assert s is not None
         assert s.value == v

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -483,4 +483,6 @@ def test_ensures_config() -> None:
         "disableStallDetection": None,
         "disableStatusBar": None,
         "estopNotRequired": None,
+        "disableTipPresenceDetection": None,
+        "disableOverpressureDetection": None,
     }

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -56,7 +56,9 @@ router = APIRouter()
     },
 )
 async def post_settings(
-    update: AdvancedSettingRequest, hardware: HardwareControlAPI = Depends(get_hardware)
+    update: AdvancedSettingRequest,
+    hardware: HardwareControlAPI = Depends(get_hardware),
+    robot_type: str = Depends(get_robot_type),
 ) -> AdvancedSettingsResponse:
     """Update advanced setting (feature flag)"""
     try:
@@ -69,7 +71,7 @@ async def post_settings(
         raise LegacyErrorResponse.from_exc(e).as_error(
             status.HTTP_500_INTERNAL_SERVER_ERROR
         )
-    return _create_settings_response()
+    return _create_settings_response(robot_type)
 
 
 @router.get(
@@ -79,7 +81,9 @@ async def post_settings(
     response_model=AdvancedSettingsResponse,
     response_model_exclude_unset=True,
 )
-async def get_settings(robot_type: str = Depends(get_robot_type)) -> AdvancedSettingsResponse:
+async def get_settings(
+    robot_type: str = Depends(get_robot_type),
+) -> AdvancedSettingsResponse:
     """Get advanced setting (feature flags)"""
     return _create_settings_response(robot_type)
 

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -48,30 +48,6 @@ stages:
             description: !re_search 'Use an older, slower method of analyzing uploaded protocols'
             restart_required: false
             value: !anything
-          - id: enableOT3HardwareController
-            old_id: Null
-            title: Enable experimental OT-3 hardware controller
-            description: !re_search 'Opentrons-internal setting to test new hardware'
-            restart_required: true
-            value: !anything
-          - id: rearPanelIntegration
-            old_id: Null
-            title: 'Enable robots with the new usb connected rear-panel board.'
-            description: !re_search 'This is an Opentrons-internal setting to test new rear-panel.'
-            restart_required: false
-            value: !anything
-          - id: disableStallDetection
-            old_id: Null
-            title: 'Disable stall detection on the Flex.'
-            description: !re_search 'This is an Opentrons-internal setting for hardware-testing.'
-            restart_required: false
-            value: !anything
-          - id: disableStatusBar
-            old_id: Null
-            title: 'Disable the LED status bar on the Flex.'
-            description: !re_search 'This setting disables the LED status bar on the Flex.'
-            restart_required: false
-            value: !anything
         links: !anydict
 
 ---

--- a/shared-data/python/opentrons_shared_data/robot/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/robot/dev_types.py
@@ -1,4 +1,5 @@
 """opentrons_shared_data.robot.dev_types: types for robot def."""
+import enum
 from typing import NewType, List, Dict, Any
 from typing_extensions import Literal, TypedDict
 
@@ -7,6 +8,10 @@ RobotSchemaVersion1 = Literal[1]
 RobotSchema = NewType("RobotSchema", Dict[str, Any])
 
 RobotType = Literal["OT-2 Standard", "OT-3 Standard"]
+
+class RobotTypeEnum(enum.Enum):
+    OT2 = enum.auto()
+    FLEX = enum.auto()
 
 
 class RobotDefinition(TypedDict):

--- a/shared-data/python/opentrons_shared_data/robot/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/robot/dev_types.py
@@ -11,6 +11,11 @@ RobotType = Literal["OT-2 Standard", "OT-3 Standard"]
 
 
 class RobotTypeEnum(enum.Enum):
+    """An enum representing the active robot type."""
+
+    # TODO we should switch over to using Enums fully (if possible)
+    # to represent our robot types in code -- rather than having
+    # to string match everywhere.
     OT2 = enum.auto()
     FLEX = enum.auto()
 

--- a/shared-data/python/opentrons_shared_data/robot/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/robot/dev_types.py
@@ -9,6 +9,7 @@ RobotSchema = NewType("RobotSchema", Dict[str, Any])
 
 RobotType = Literal["OT-2 Standard", "OT-3 Standard"]
 
+
 class RobotTypeEnum(enum.Enum):
     OT2 = enum.auto()
     FLEX = enum.auto()


### PR DESCRIPTION
# Overview

We should sort feature flags by robot type instead of constantly displaying the list.

# Test Plan
Throw this PR on both a FLEX and OT2. See that the feature flags for each respective robot show. Ensure that restart for certain feature flags still works (like disabling home on boot)

# Changelog

- Add a robot type to the SettingsDefinition
- Filter robot type by endpoint

# Review requests

Test on a robot. Check that implementation is OK.

# Risk assessment

Low. Only dealing with advanced feature flags.
