### PR TITLE
chore: deploy app to new infra

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -289,7 +289,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID }}
           HOST_PYTHON: python
-          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && robot-stack) || 'ot3' }}
+          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && 'robot-stack') || 'ot3' }}
           OT_APP_DEPLOY_BUCKET: ${{ ((matrix.variant == 'release') && env._APP_DEPLOY_BUCKET_ROBOTSTACK) || env._APP_DEPLOY_BUCKET_OT3   }}
           OT_APP_DEPLOY_FOLDER: ${{ ((matrix.variant == 'release') && env._APP_DEPLOY_FOLDER_ROBOTSTACK ) || env._APP_DEPLOY_FOLDER_OT3 }}
 

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -175,7 +175,7 @@ jobs:
             echo "internal-release develop builds for internal-release branches"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true"]] ; then
+          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true" ]] ; then
             echo "Release develop builds for release branches"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
@@ -187,7 +187,7 @@ jobs:
             echo "internal-release builds for app-build-internal suffixes"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build')) }}" = "true"]] ; then
+          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build')) }}" = "true" ]] ; then
             echo "release develop builds for app-build suffixes"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -208,13 +208,30 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
         variant: ${{fromJSON(needs.determine-build-type.outputs.variants)}}
-        is-odd: [false]
-        include:
-          - os: 'ubuntu-22.04'
-            is-odd: true
+        target: ['desktop', 'odd']
+        exclude:
+          - os: 'windows-2022'
+            target: 'odd'
+          - os: 'macos-11'
+            target: 'odd'
+
     runs-on: ${{ matrix.os }}
-    name: 'Build ${{matrix.variant}} app on ${{matrix.os}}'
+    name: 'Build ${{matrix.variant}} ${{matrix.target}} app on ${{matrix.os}}'
     steps:
+      - name: 'Get project name for variant'
+        id: project
+        run: |
+          if [[ ${{matrix.variant}} = "release" ]] ; then
+             echo "Configuring project, bucket, and folder for robot-stack"
+             echo "project=robot-stack" >> $GITHUB_OUTPUT
+             echo "bucket=${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}" >> $GITHUB_OUTPUT
+             echo "folder=${{env._APP_DEPLOY_FOLDER_ROBOTSTACK}}" >> $GITHUB_OUTPUT
+          else
+             echo "Configuring project, bucket, and folder for ot3"
+             echo "project=ot3" >> $GITHUB_OUTPUT
+             echo "bucket=${{env._APP_DEPLOY_BUCKET_OT3}}" >> $GITHUB_OUTPUT
+             echo "folder=${{env._APP_DEPLOY_BUCKET_OT3}}" >> $GITHUB_OUTPUT
+          fi
       - uses: 'actions/checkout@v3'
         with:
           fetch-depth: 0
@@ -258,7 +275,7 @@ jobs:
           make setup-js
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
-        if: ${{!matrix.is-odd}}
+        if: matrix.target == 'desktop'
         timeout-minutes: 60
         env:
           OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
@@ -271,26 +288,26 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID }}
           HOST_PYTHON: python
-          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && 'robot-stack') || 'ot3' }}
-          OT_APP_DEPLOY_BUCKET: ${{ ((matrix.variant == 'release') && env._APP_DEPLOY_BUCKET_ROBOTSTACK) || env._APP_DEPLOY_BUCKET_OT3   }}
-          OT_APP_DEPLOY_FOLDER: ${{ ((matrix.variant == 'release') && env._APP_DEPLOY_FOLDER_ROBOTSTACK ) || env._APP_DEPLOY_FOLDER_OT3 }}
+          OPENTRONS_PROJECT: ${{ steps.project.outputs.project }}
+          OT_APP_DEPLOY_BUCKET: ${{ steps.project.outputs.bucket }}
+          OT_APP_DEPLOY_FOLDER: ${{ steps.project.outputs.folder }}
 
         run: |
           make -C app-shell dist-${{ matrix.os }}
 
       - name: 'upload github artifact'
-        if: ${{!matrix.is-odd}}
+        if: matrix.target == 'desktop'
         uses: actions/upload-artifact@v3
         with:
           name: 'opentrons-${{matrix.variant}}-${{ matrix.os }}'
           path: app-shell/dist/publish
 
       # build the ODD app
-      - if: matrix.is-odd
-        name: 'build ODD app for linux'
+      - if: matrix.target == 'odd'
+        name: 'build ${{matrix.variant}} ODD app'
         timeout-minutes: 60
         env:
-          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && 'robot-stack') || 'ot3' }}
+          OPENTRONS_PROJECT: ${{ steps.project.outputs.project }}
         run: |
           make -C app-shell-odd dist-ot3
 

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -46,8 +46,8 @@ concurrency:
 
 env:
   CI: true
-  _APP_DEPLOY_BUCKET_ROBOTSTACK: opentrons-app
-  _APP_DEPLOY_FOLDER_ROBOTSTACK: builds
+  _APP_DEPLOY_BUCKET_ROBOTSTACK: builds.opentrons.com
+  _APP_DEPLOY_FOLDER_ROBOTSTACK: app
   _APP_DEPLOY_BUCKET_OT3: ot3-development.builds.opentrons.com
   _APP_DEPLOY_FOLDER_OT3: app
 
@@ -92,14 +92,11 @@ jobs:
           files: ./coverage/lcov.info
           flags: app
 
-  build-app-test-backend:
-    # since js tests for "backend" projects (app-shell, discovery-client) need
-    # to run cross-platform just like builds, might as well do them in the same job
+  backend-unit-test:
     strategy:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
-
-    name: 'opentrons app backend unit tests and build'
+    name: 'opentrons app backend unit tests on ${{matrix.os}}'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: 'actions/checkout@v3'
@@ -142,8 +139,6 @@ jobs:
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-      - name: setup-js
-        run: |
           make setup-js
       - name: 'test native(er) packages'
         run: |
@@ -154,52 +149,80 @@ jobs:
           files: ./coverage/lcov.info
           flags: app
 
-      # build the desktop app and deploy it
-      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
-        name: 'build app for ${{ matrix.os }}'
-        timeout-minutes: 60
-        env:
-          OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
-          OT_APP_INTERCOM_ID: ${{ secrets.OT_APP_INTERCOM_ID }}
-          WIN_CSC_LINK: ${{ secrets.OT_APP_CSC_WINDOWS }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_WINDOWS }}
-          CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
-          CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
-          APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID }}
-          HOST_PYTHON: python
-          OPENTRONS_PROJECT: robot-stack
-          OT_APP_DEPLOY_BUCKET: ${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}
-          OT_APP_DEPLOY_FOLDER: ${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
-
+  determine-build-type:
+    runs-on: 'ubuntu-latest'
+    name: 'Determine build variant and type'
+    outputs:
+      variants: ${{steps.determine-build-type.outputs.variants}}
+      type: ${{steps.determine-build-type.outputs.type}}
+    steps:
+      determine-build-type:
+        # pull requests do not get app builds
+        if: github.event_name == 'pull_request'
         run: |
-          make -C app-shell dist-${{ matrix.os }}
-
-      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
-        name: 'upload github artifact'
-        uses: actions/upload-artifact@v3
-        with:
-          name: 'opentrons-${{ matrix.os }}'
-          path: app-shell/dist/publish
-
-      # build the ODD app
-      - if: ${{ github.event_name != 'pull_request' && matrix.os == 'ubuntu-22.04' }}
-        name: 'build ODD app for linux'
-        timeout-minutes: 60
+          echo 'variants=[]' >> $GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # internal release tags get internal release release builds only
+        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/ot3')
         run: |
-          make -C app-shell-odd dist-ot3
+          echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
+          echo 'type=release' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # release tags get release release builds only
+        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo 'variants=["release"]' >> $GITHUB_OUTPUT
+          echo 'type=release' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # branches associated with internal releases get internal release develop builds only
+        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/internal-release')
+        run: |
+          echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # branches starting with app-build-internal get internal release develop builds only
+        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-internal')
+        run: |
+          echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # branches associated with release get release develop builds only
+        if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))
+        run: |
+          echo 'variants=["release"]' >> $GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # branches starting with app-build get release develop builds only
+        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build')
+        run: |
+          echo 'variants=["release"]' >> $GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # our default branch gets both variants, develop builds
+        if: $(github.event_name != 'pull_request') && (github.ref == 'refs/heads/edge')
+        run: |
+          echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
+      determine-build-type:
+        # branches beginning with app-build-both get both develop builds
+        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-both')
+        run: |
+          echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
+          echo 'type=develop' >> $GITHUB_OUTPUT
 
-  build-app-ot3:
+  build-app:
+    needs: determine-build-type
     strategy:
       matrix:
-        os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
-        exclude:
-          - os: format('macos-latest{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
-          - os: format('windows-2022{0}', startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build') || null)
-
-    name: 'opentrons app backend unit tests and build for OT3'
+        os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
+        variant: ${{fromJSON(needs.determine-build-type.outputs.variants)}}
+        is-odd: false
+      include:
+        - os: 'ubuntu-22.04'
+          is-odd: true
     runs-on: ${{ matrix.os }}
+    name: 'Build ${{matrix.variant}} app on ${{matrix.os}}'
     steps:
       - uses: 'actions/checkout@v3'
         with:
@@ -220,9 +243,9 @@ jobs:
         run: npm install -g npm@6
       - name: check make version
         run: make --version
-      - name: 'install libudev'
+      - name: 'install libudev and libsystemd'
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get install libudev-dev libsystemd-dev
+        run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'set complex environment variables'
         id: 'set-vars'
         uses: actions/github-script@v6
@@ -242,10 +265,9 @@ jobs:
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
-
-      # build the app and deploy it
-      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
-        name: 'build app for ${{ matrix.os }}'
+      # build the desktop app and deploy it
+      - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
+        if: !matrix.is-odd
         timeout-minutes: 60
         env:
           OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
@@ -258,53 +280,48 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID }}
           HOST_PYTHON: python
-          OPENTRONS_PROJECT: ot3
-          OT_APP_DEPLOY_BUCKET: ${{ env._APP_DEPLOY_BUCKET_OT3 }}
-          OT_APP_DEPLOY_FOLDER: ${{ env._APP_DEPLOY_FOLDER_OT3 }}
+          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && robot-stack) || 'ot3' }}
+          OT_APP_DEPLOY_BUCKET: ${{ ((matrix.variant == 'release') && env._APP_DEPLOY_BUCKET_ROBOTSTACK) || env._APP_DEPLOY_BUCKET_OT3   }}
+          OT_APP_DEPLOY_FOLDER: ${{ ((matrix.variant == 'release') && env._APP_DEPLOY_FOLDER_ROBOTSTACK ) || env._APP_DEPLOY_FOLDER_OT3 }}
 
         run: |
           make -C app-shell dist-${{ matrix.os }}
 
-      - if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
-        name: 'upload github artifact'
+      - name: 'upload github artifact'
+        if: !matrix.is-odd
         uses: actions/upload-artifact@v3
         with:
-          name: 'opentrons-ot3-${{ matrix.os }}'
+          name: 'opentrons-${{matrix.variant}}-${{ matrix.os }}'
           path: app-shell/dist/publish
 
-
-  deploy-app:
-    name: 'Deploy built app artifacts to S3'
-    runs-on: 'ubuntu-22.04'
-    needs: ['js-unit-test', 'build-app-test-backend']
-    if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
-    steps:
-      - name: 'download run app builds'
-        uses: 'actions/download-artifact@v3'
-        with:
-          path: .
-      - name: 'deploy builds to s3'
+      # build the ODD app
+      - if: matrix.is-odd
+        name: 'build ODD app for linux'
+        timeout-minutes: 60
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_APP_DEPLOY_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_APP_DEPLOY_SECRET }}
-          AWS_DEFAULT_REGION: us-east-2
+          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && robot-stack) || 'ot3' }}
         run: |
-          mkdir to_upload
-          rm -rf ./opentrons-ot3-*
-          cp ./opentrons-*/* ./to_upload/
-          aws s3 sync --acl=public-read to_upload/ s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
+          make -C app-shell-odd dist-ot3
 
-  deploy-app-ot3:
-    name: 'Deploy built OT3 app artifacts to S3'
+  deploy-release-app:
+    name: 'Deploy built release-variant app artifacts to S3'
     runs-on: 'ubuntu-22.04'
-    needs: ['js-unit-test', 'build-app-ot3']
-    if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/edge') || startsWith(github.ref, 'refs/heads/internal-release') || startsWith(github.ref, 'refs/heads/release') || endsWith(github.ref, 'app-build'))
+    needs: ['js-unit-test', 'backend-unit-test', 'build-app', 'determine-build-type']
+    if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'release') || contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
     steps:
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'
         with:
-          path: .
-      - name: 'configure ot3 s3 deploy creds'
+          path: ./artifacts
+      - name: 'separate release and internal-release artifacts'
+        runs: |
+          for variant in release internal-release ; do
+              echo "Moving ${variant} builds ./artifacts/opentrons-${variant}-*/* to to_upload_${variant}"
+              mkdir to_upload_${variant}
+              cp ./artifacts/opentrons-${variant}-*/* ./to_upload_${variant}
+              echo "Moved $(ls ./to_upload_${variant})"
+          done
+      - name: 'configure s3 deploy creds'
         run: |
           aws configure set aws_access_key_id ${{ secrets.S3_OT3_APP_DEPLOY_KEY_ID }} --profile identity
           aws configure set aws_secret_access_key ${{ secrets.S3_OT3_APP_DEPLOY_SECRET }} --profile identity
@@ -314,14 +331,23 @@ jobs:
           aws configure set role_arn ${{ secrets.OT_APP_OT3_DEPLOY_ROLE }} --profile deploy
           aws configure set source_profile identity --profile deploy
         shell: bash
-      - name: 'deploy builds to s3'
+      - name: 'deploy release builds to s3'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_APP_DEPLOY_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_APP_DEPLOY_SECRET }}
+          AWS_DEFAULT_REGION: us-east-2
         run: |
-          mkdir to_upload
-          cp ./opentrons-ot3-*/* ./to_upload
-          aws --profile=deploy s3 sync --acl=public-read to_upload s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
+          aws s3 sync --acl=public-read to_upload_release/ s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
+      - name: 'deploy release builds to s3'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_APP_DEPLOY_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_APP_DEPLOY_SECRET }}
+          AWS_DEFAULT_REGION: us-east-2
+        run: |
+          aws s3 sync --acl=public-read to_upload_internal_release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
       - name: 'create GH release'
         uses: 'ncipollo/release-action@v1.12.0'
-        if: startsWith(github.ref, 'refs/tags/ot3@')
+        if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
           replacesArtifacts: true
@@ -329,56 +355,43 @@ jobs:
           omitPrereleaseDuringUpdate: true
       - name: 'upload windows artifact to GH release'
         uses: 'ncipollo/release-action@v1.12.0'
-        if: startsWith(github.ref, 'refs/tags/ot3@')
+        if: needs.determine-build-type.outputs.type == 'release'
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
           omitPrereleaseDuringUpdate: true
-          artifacts: ./to_upload/*.exe
+          artifacts: ./artifacts/**/*.exe ./artifacts/**/*.dmg ./artifacts/**/*.AppImage
           artifactContentType: application/vnd.microsoft.portable-executable
-      - name: 'upload mac artifact to GH release'
-        uses: 'ncipollo/release-action@v1.12.0'
-        if: startsWith(github.ref, 'refs/tags/ot3@')
-        with:
-          allowUpdates: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
-          omitPrereleaseDuringUpdate: true
-          artifacts: ./to_upload/*.dmg
-          artifactContentType: application/octet-stream
-      - name: 'upload linux artifact to GH release'
-        uses: 'ncipollo/release-action@v1.12.0'
-        if: startsWith(github.ref, 'refs/tags/ot3@')
-        with:
-          allowUpdates: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitNameDuringUpdate: true
-          omitPrereleaseDuringUpdate: true
-          artifacts: ./to_upload/*.AppImage
-          artifactContentType: application/octet-stream
-      - name: 'detect build data for notification'
+      - name: 'detect internal-release build data for notification'
         id: names
+        if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
+        shell: bash
         run: |
-          ls ./to_upload
-          _windows_build=$(basename $(ls ./to_upload/Opentrons-OT3*.exe))
-          _mac_build=$(basename $(ls ./to_upload/Opentrons-OT3*.dmg))
-          _linux_build=$(basename $(ls ./to_upload/Opentrons-OT3*.AppImage))
-          if [[ -e latest.yml ]] ; then
-              echo "TYPE=release" >> $GITHUB_OUTPUT
-          else
-              echo "TYPE=branch" >> $GITHUB_OUTPUT
-          fi
-          echo "WINDOWS=$_windows_build">>$GITHUB_OUTPUT
-          echo "MAC=$_mac_build">>$GITHUB_OUTPUT
-          echo "LINUX=$_linux_build">>$GITHUB_OUTPUT
-      - name: 'slack notify for ot3 builds'
+          for variant in release internal-release ; do
+              dir=./to_upload_${variant}
+              echo "Checking for ${variant} builds in ${dir}: $(ls to_upload_${variant})"
+              _windows_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.exe))
+              _mac_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.dmg))
+              _linux_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.AppImage))
+              echo "windows-${variant}=$_windows_build">>$GITHUB_OUTPUT
+              echo "mac-${variant}=$_mac_build">>$GITHUB_OUTPUT
+              echo "linux-${variant}=$_linux_build">>$GITHUB_OUTPUT
+          done
+      - name: 'slack notify internal-release'
         uses: slackapi/slack-github-action@v1.14.0
+        if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         with:
-          payload: "{\"branch_or_tag\":\"${{ github.ref_name }}\",\"build_type\":\"${{ steps.names.outputs.TYPE }}\", \"gh_linkback\":\"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}\", \"windows_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.WINDOWS}}\", \"mac_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.MAC}}\", \"linux_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.LINUX}}\"}"
+          payload: "{\"branch_or_tag\":\"${{ github.ref_name }}\",\"build_type\":\"${{ needs.determine-build-type.outputs.type }}\", \"gh_linkback\":\"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}\", \"windows_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.windows-internal-release}}\", \"mac_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.mac-internal-release}}\", \"linux_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.linux-internal-release}}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_OT3_SLACK_NOTIFICATION_WEBHOOK_URL }}
           _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_OT3}}/${{env._APP_DEPLOY_FOLDER_OT3}}
+      - name: 'slack notify release'
+        uses: slackapi/slack-github-action@v1.14.0
+        if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
+        with:
+          payload: "{\"branch_or_tag\":\"${{ github.ref_name }}\",\"build_type\":\"${{ needs.determine-build-type.outputs.type }}\", \"gh_linkback\":\"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}\", \"windows_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.windows-release}}\", \"mac_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.mac-release}}\", \"linux_build\":\"${{ env._ACCESS_URL }}/${{steps.names.outputs.linux-release}}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_ROBOTSTACK_SLACK_NOTIFICATION_WEBHOOK_URL }}
+          _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}/${{env._APP_DEPLOY_FOLDER_ROBOTSTACK}}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -203,6 +203,7 @@ jobs:
 
   build-app:
     needs: [determine-build-type]
+    if: needs.determine-build-type.outputs.variants != '[]'
     strategy:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -374,6 +374,7 @@ jobs:
         run: |
           for variant in release internal-release ; do
               dir=./to_upload_${variant}
+              ls ${dir} 2>/dev/null 1>/dev/null || continue
               echo "Checking for ${variant} builds in ${dir}: $(ls to_upload_${variant})"
               _windows_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.exe))
               _mac_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.dmg))

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -374,8 +374,8 @@ jobs:
         run: |
           for variant in release internal-release ; do
               dir=./to_upload_${variant}
-              ls ${dir} 2>/dev/null 1>/dev/null || continue
-              echo "Checking for ${variant} builds in ${dir}: $(ls to_upload_${variant})"
+              echo "Checking for ${variant} builds in ${dir}"
+              ls ${dir}/Opentrons* || continue
               _windows_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.exe))
               _mac_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.dmg))
               _linux_build=$(basename $(ls ./to_upload_${variant}/Opentrons*.AppImage))

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -165,7 +165,7 @@ jobs:
             echo 'variants=[]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
           elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/tags/ot3')) }}" = "true" ]] ; then
-            echo "internal-release release builds for ot3@ tags"
+            echo "internal-release release builds for ot3 tags"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
           elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/tags/v')) }}" = "true" ]] ; then
@@ -176,7 +176,7 @@ jobs:
             echo "internal-release develop builds for internal-release branches"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))" }} = "true"]] ; then
+          elif [[ "${{ format('{0}', (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true"]] ; then
             echo "Release develop builds for release branches"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -345,7 +345,7 @@ jobs:
           aws --profile=deploy s3 sync --acl=public-read to_upload_release/ s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
       - name: 'deploy internal-release release builds to s3'
         run: |
-          aws s3 --profile=deploy sync --acl=public-read to_upload_internal_release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
+          aws s3 --profile=deploy sync --acl=public-read to_upload_internal-release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
       - name: 'create GH release'
         uses: 'ncipollo/release-action@v1.12.0'
         if: needs.determine-build-type.outputs.type == 'release'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -329,7 +329,7 @@ jobs:
               variant_pattern="./artifacts/opentrons-${variant}-*"
               ls ${variant_pattern}/ 2>/dev/null 1>/dev/null || continue
               echo "Moving ${variant} builds ${variant_pattern}/* to to_upload_${variant}"
-              cp ./artifacts/${variant_pattern}/* ./to_upload_${variant}/
+              cp ${variant_pattern}/* ./to_upload_${variant}/
               echo "Moved $(ls ./to_upload_${variant})"
           done
       - name: 'configure s3 deploy creds'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -160,7 +160,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
-          if [[ "${{format('{0}', github.event_name == 'pull_request)}}" = "true" ]] ; then
+          if [[ "${{format('{0}', github.event_name == 'pull_request')}}" = "true" ]] ; then
             echo "No builds for pull requests"
             echo 'variants=[]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -226,7 +226,7 @@ jobs:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
         variant: ${{fromJSON(needs.determine-build-type.outputs.variants)}}
-        is-odd: false
+        is-odd: [false]
         include:
           - os: 'ubuntu-22.04'
             is-odd: true

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -156,63 +156,63 @@ jobs:
       variants: ${{steps.determine-build-type.outputs.variants}}
       type: ${{steps.determine-build-type.outputs.type}}
     steps:
-      determine-build-type:
+      - id: determine-build-type
         name: 'No app builds for pull requests'
         # pull requests do not get app builds
         if: github.event_name == 'pull_request'
         run: |
           echo 'variants=[]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id:  determine-build-type
         name: 'Internal release builds for internal release tag ${{github.ref_name}}'
         # internal release tags get internal release release builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/ot3')
         run: |
           echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
           echo 'type=release' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: 'Release build for release tag ${{github.ref_name}}'
         # release tags get release release builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/v')
         run: |
           echo 'variants=["release"]' >> $GITHUB_OUTPUT
           echo 'type=release' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: 'Internal release builds for internal-release branch ${{github.ref_name}}'
         # branches associated with internal releases get internal release develop builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/internal-release')
         run: |
           echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: "Internal release build requested by branch name ${{github.ref_name}}"
         # branches starting with app-build-internal get internal release develop builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-internal')
         run: |
           echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: "Release build for release branch ${{github.ref_name}}"
         # branches associated with release get release develop builds only
         if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))
         run: |
           echo 'variants=["release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: "Release build requested by branch name ${{github.ref_name}}"
         # branches starting with app-build get release develop builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build')
         run: |
           echo 'variants=["release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: "Release and internal-release builds because this is edge"
         # our default branch gets both variants, develop builds
-        if: $(github.event_name != 'pull_request') && (github.ref == 'refs/heads/edge')
+        if: (github.event_name != 'pull_request') && (github.ref == 'refs/heads/edge')
         run: |
           echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
-      determine-build-type:
+      - id: determine-build-type
         name: "Release and internal-release builds requested by branch name ${{github.ref_name}}"
         # branches beginning with app-build-both get both develop builds
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-both')
@@ -221,15 +221,15 @@ jobs:
           echo 'type=develop' >> $GITHUB_OUTPUT
 
   build-app:
-    needs: determine-build-type
+    needs: [determine-build-type]
     strategy:
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
         variant: ${{fromJSON(needs.determine-build-type.outputs.variants)}}
         is-odd: false
-      include:
-        - os: 'ubuntu-22.04'
-          is-odd: true
+        include:
+          - os: 'ubuntu-22.04'
+            is-odd: true
     runs-on: ${{ matrix.os }}
     name: 'Build ${{matrix.variant}} app on ${{matrix.os}}'
     steps:
@@ -276,7 +276,7 @@ jobs:
           make setup-js
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
-        if: !matrix.is-odd
+        if: ${{!matrix.is-odd}}
         timeout-minutes: 60
         env:
           OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
@@ -297,7 +297,7 @@ jobs:
           make -C app-shell dist-${{ matrix.os }}
 
       - name: 'upload github artifact'
-        if: !matrix.is-odd
+        if: ${{!matrix.is-odd}}
         uses: actions/upload-artifact@v3
         with:
           name: 'opentrons-${{matrix.variant}}-${{ matrix.os }}'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -160,39 +160,39 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
-          if [[ "${{format('{0}', github.event_name == 'pull_request')}}" = "true" ]] ; then
+          if [[ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ]] ; then
             echo "No builds for pull requests"
             echo 'variants=[]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}'', startsWith(github.ref, 'refs/tags/ot3'))}}" = "true" ]] ; then
+          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/tags/ot3')) }}" = "true" ]] ; then
             echo "internal-release release builds for ot3@ tags"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', startsWith(github.ref, 'refs/tags/v'))}}" = "true" ]] ; then
+          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/tags/v')) }}" = "true" ]] ; then
             echo "release release builds for v tags"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', startsWith(github.ref, 'refs/heads/internal-release'))}}" = "true" ]] ; then
+          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/heads/internal-release')) }}" = "true" ]] ; then
             echo "internal-release develop builds for internal-release branches"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))" }} = "true"]] ; then
+          elif [[ "${{ format('{0}', (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))" }} = "true"]] ; then
             echo "Release develop builds for release branches"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', github.ref == 'refs/heads/edge')}}" = "true" ]] ; then
+          elif [[ "${{ format('{0}', github.ref == 'refs/heads/edge') }}" = "true" ]] ; then
             echo "both develop builds for edge"
             echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', endsWith(github.ref, 'app-build-internal'))}}" = "true" ]] ; then
+          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build-internal')) }}" = "true" ]] ; then
             echo "internal-release builds for app-build-internal suffixes"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', endsWith(github.ref, 'app-build'))}}" = "true"]] ; then
+          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build')) }}" = "true"]] ; then
             echo "release develop builds for app-build suffixes"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{format('{0}', endsWith(github.ref, 'app-build-both'))}}" = "true" ]] ; then
+          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build-both')) }}" = "true" ]] ; then
             echo "Both develop builds for app-build-both suffixes"
             echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -157,68 +157,49 @@ jobs:
       type: ${{steps.determine-build-type.outputs.type}}
     steps:
       - id: determine-build-type
-        name: 'No app builds for pull requests'
-        # pull requests do not get app builds
         if: github.event_name == 'pull_request'
         run: |
-          echo 'variants=[]' >> $GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
-      - id:  determine-build-type
-        name: 'Internal release builds for internal release tag ${{github.ref_name}}'
-        # internal release tags get internal release release builds only
-        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/ot3')
-        run: |
-          echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
-          echo 'type=release' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: 'Release build for release tag ${{github.ref_name}}'
-        # release tags get release release builds only
-        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo 'variants=["release"]' >> $GITHUB_OUTPUT
-          echo 'type=release' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: 'Internal release builds for internal-release branch ${{github.ref_name}}'
-        # branches associated with internal releases get internal release develop builds only
-        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/internal-release')
-        run: |
-          echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: "Internal release build requested by branch name ${{github.ref_name}}"
-        # branches starting with app-build-internal get internal release develop builds only
-        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-internal')
-        run: |
-          echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: "Release build for release branch ${{github.ref_name}}"
-        # branches associated with release get release develop builds only
-        if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))
-        run: |
-          echo 'variants=["release"]' >> $GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: "Release build requested by branch name ${{github.ref_name}}"
-        # branches starting with app-build get release develop builds only
-        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build')
-        run: |
-          echo 'variants=["release"]' >> $GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: "Release and internal-release builds because this is edge"
-        # our default branch gets both variants, develop builds
-        if: (github.event_name != 'pull_request') && (github.ref == 'refs/heads/edge')
-        run: |
-          echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
-      - id: determine-build-type
-        name: "Release and internal-release builds requested by branch name ${{github.ref_name}}"
-        # branches beginning with app-build-both get both develop builds
-        if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-both')
-        run: |
-          echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
-          echo 'type=develop' >> $GITHUB_OUTPUT
+          echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
+          if [[ ${{github.event_name == 'pull_request' && "true" || "false"}} = "true" ]] ; then
+            echo "No builds for pull requests"
+            echo 'variants=[]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          elif [[ ${{startsWith(github.ref, 'refs/tags/ot3') && "true" || "false"}} = "true" ]] ; then
+            echo "internal-release release builds for ot3@ tags"
+            echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
+            echo 'type=release' >> $GITHUB_OUTPUT
+          elif [[ ${{startsWith(github.ref, 'refs/tags/v') && "true" || "false"}} = "true" ]] ; then
+            echo "release release builds for v tags"
+            echo 'variants=["release"]' >> $GITHUB_OUTPUT
+            echo 'type=release' >> $GITHUB_OUTPUT
+          elif [[ ${{startsWith(github.ref, 'refs/heads/internal-release') && "true" || "false"}} ]] ; then
+            echo "internal-release develop builds for internal-release branches"
+            echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          elif [[ ${{ ((startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) && "true" || "false" }} = "true"]] ; then
+            echo "Release develop builds for release branches"
+            echo 'variants=["release"]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          elif [[ ${{ (github.ref == 'refs/heads/edge') && "true" || "false" }} = "true" ]] ; then
+            echo "both develop builds for edge"
+            echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          elif [[ ${{endsWith(github.ref, 'app-build-internal') && "true" || "false"}} = "true" ]] ; then
+            echo "internal-release builds for app-build-internal suffixes"
+            echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          elif [[ ${{ endsWith(github.ref, 'app-build') && "true" || "false" }} = "true"]] ; then
+            echo "release develop builds for app-build suffixes"
+            echo 'variants=["release"]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          elif [[ ${{ endsWith(github.ref, 'app-build-both') && "true" || "false" }} = "true" ]] ; then
+            echo "Both develop builds for app-build-both suffixes"
+            echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
+          else
+            echo "::error Cannot determine builds for ref ${{github.ref}} and event ${{github.event_name}}, not building"
+            exit 1
+          fi
 
   build-app:
     needs: [determine-build-type]

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -325,9 +325,11 @@ jobs:
       - name: 'separate release and internal-release artifacts'
         run: |
           for variant in release internal-release ; do
-              echo "Moving ${variant} builds ./artifacts/opentrons-${variant}-*/* to to_upload_${variant}"
+              variant_pattern="./artifacts/opentrons-${variant}-*"
+              ls ${variant_pattern}/ 2>/dev/null 1>/dev/null || break
+              echo "Moving ${variant} builds ${variant_pattern}/* to to_upload_${variant}"
               mkdir to_upload_${variant}
-              cp ./artifacts/opentrons-${variant}-*/* ./to_upload_${variant}
+              cp ./artifacts/${variant_pattern}/* ./to_upload_${variant}/
               echo "Moved $(ls ./to_upload_${variant})"
           done
       - name: 'configure s3 deploy creds'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -160,39 +160,39 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
-          if [[ ${{github.event_name == 'pull_request' && "true" || "false"}} = "true" ]] ; then
+          if [[ "${{format('{0}', github.event_name == 'pull_request)}}" = "true" ]] ; then
             echo "No builds for pull requests"
             echo 'variants=[]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ ${{startsWith(github.ref, 'refs/tags/ot3') && "true" || "false"}} = "true" ]] ; then
+          elif [[ "${{format('{0}'', startsWith(github.ref, 'refs/tags/ot3'))}}" = "true" ]] ; then
             echo "internal-release release builds for ot3@ tags"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
-          elif [[ ${{startsWith(github.ref, 'refs/tags/v') && "true" || "false"}} = "true" ]] ; then
+          elif [[ "${{format('{0}', startsWith(github.ref, 'refs/tags/v'))}}" = "true" ]] ; then
             echo "release release builds for v tags"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
-          elif [[ ${{startsWith(github.ref, 'refs/heads/internal-release') && "true" || "false"}} ]] ; then
+          elif [[ "${{format('{0}', startsWith(github.ref, 'refs/heads/internal-release'))}}" = "true" ]] ; then
             echo "internal-release develop builds for internal-release branches"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ ${{ ((startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) && "true" || "false" }} = "true"]] ; then
+          elif [[ "${{format('{0}', (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))" }} = "true"]] ; then
             echo "Release develop builds for release branches"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ ${{ (github.ref == 'refs/heads/edge') && "true" || "false" }} = "true" ]] ; then
+          elif [[ "${{format('{0}', github.ref == 'refs/heads/edge')}}" = "true" ]] ; then
             echo "both develop builds for edge"
             echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ ${{endsWith(github.ref, 'app-build-internal') && "true" || "false"}} = "true" ]] ; then
+          elif [[ "${{format('{0}', endsWith(github.ref, 'app-build-internal'))}}" = "true" ]] ; then
             echo "internal-release builds for app-build-internal suffixes"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ ${{ endsWith(github.ref, 'app-build') && "true" || "false" }} = "true"]] ; then
+          elif [[ "${{format('{0}', endsWith(github.ref, 'app-build'))}}" = "true"]] ; then
             echo "release develop builds for app-build suffixes"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ ${{ endsWith(github.ref, 'app-build-both') && "true" || "false" }} = "true" ]] ; then
+          elif [[ "${{format('{0}', endsWith(github.ref, 'app-build-both'))}}" = "true" ]] ; then
             echo "Both develop builds for app-build-both suffixes"
             echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -159,39 +159,39 @@ jobs:
       - id: determine-build-type
         run: |
           echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
-          if [[ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ]] ; then
+          if [ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ] ; then
             echo "No builds for pull requests"
             echo 'variants=[]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/tags/ot3')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/tags/ot3')) }}" = "true" ] ; then
             echo "internal-release release builds for ot3 tags"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/tags/v')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/tags/v')) }}" = "true" ] ; then
             echo "release release builds for v tags"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=release' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/heads/internal-release')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/internal-release')) }}" = "true" ] ; then
             echo "internal-release develop builds for internal-release branches"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true" ] ; then
             echo "Release develop builds for release branches"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', github.ref == 'refs/heads/edge') }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', github.ref == 'refs/heads/edge') }}" = "true" ] ; then
             echo "both develop builds for edge"
             echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build-internal')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', endsWith(github.ref, 'app-build-internal')) }}" = "true" ] ; then
             echo "internal-release builds for app-build-internal suffixes"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', endsWith(github.ref, 'app-build')) }}" = "true" ] ; then
             echo "release develop builds for app-build suffixes"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', endsWith(github.ref, 'app-build-both')) }}" = "true" ]] ; then
+          elif [ "${{ format('{0}', endsWith(github.ref, 'app-build-both')) }}" = "true" ] ; then
             echo "Both develop builds for app-build-both suffixes"
             echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
@@ -221,7 +221,7 @@ jobs:
       - name: 'Get project name for variant'
         id: project
         run: |
-          if [[ ${{matrix.variant}} = "release" ]] ; then
+          if [ "${{matrix.variant}}" = "release" ] ; then
              echo "Configuring project, bucket, and folder for robot-stack"
              echo "project=robot-stack" >> $GITHUB_OUTPUT
              echo "bucket=${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -196,8 +196,9 @@ jobs:
             echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
           else
-            echo "::error Cannot determine builds for ref ${{github.ref}} and event ${{github.event_name}}, not building"
-            exit 1
+            echo "No build for ref ${{github.ref}} and event ${{github.event_type}}"
+            echo 'variants=[]' >> $GITHUB_OUTPUT
+            echo 'type=develop' >> $GITHUB_OUTPUT
           fi
 
   build-app:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -157,54 +157,63 @@ jobs:
       type: ${{steps.determine-build-type.outputs.type}}
     steps:
       determine-build-type:
+        name: 'No app builds for pull requests'
         # pull requests do not get app builds
         if: github.event_name == 'pull_request'
         run: |
           echo 'variants=[]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: 'Internal release builds for internal release tag ${{github.ref_name}}'
         # internal release tags get internal release release builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/ot3')
         run: |
           echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
           echo 'type=release' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: 'Release build for release tag ${{github.ref_name}}'
         # release tags get release release builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/tags/v')
         run: |
           echo 'variants=["release"]' >> $GITHUB_OUTPUT
           echo 'type=release' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: 'Internal release builds for internal-release branch ${{github.ref_name}}'
         # branches associated with internal releases get internal release develop builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/internal-release')
         run: |
           echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: "Internal release build requested by branch name ${{github.ref_name}}"
         # branches starting with app-build-internal get internal release develop builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-internal')
         run: |
           echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: "Release build for release branch ${{github.ref_name}}"
         # branches associated with release get release develop builds only
         if: (github.event_name != 'pull_request') && (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release'))
         run: |
           echo 'variants=["release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: "Release build requested by branch name ${{github.ref_name}}"
         # branches starting with app-build get release develop builds only
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build')
         run: |
           echo 'variants=["release"]' >> $GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: "Release and internal-release builds because this is edge"
         # our default branch gets both variants, develop builds
         if: $(github.event_name != 'pull_request') && (github.ref == 'refs/heads/edge')
         run: |
           echo 'variants=["release", "internal-release"]' >> GITHUB_OUTPUT
           echo 'type=develop' >> $GITHUB_OUTPUT
       determine-build-type:
+        name: "Release and internal-release builds requested by branch name ${{github.ref_name}}"
         # branches beginning with app-build-both get both develop builds
         if: (github.event_name != 'pull_request') && startsWith(github.ref, 'refs/heads/app-build-both')
         run: |
@@ -314,7 +323,7 @@ jobs:
         with:
           path: ./artifacts
       - name: 'separate release and internal-release artifacts'
-        runs: |
+        run: |
           for variant in release internal-release ; do
               echo "Moving ${variant} builds ./artifacts/opentrons-${variant}-*/* to to_upload_${variant}"
               mkdir to_upload_${variant}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -220,6 +220,7 @@ jobs:
     steps:
       - name: 'Get project name for variant'
         id: project
+        shell: bash
         run: |
           if [ "${{matrix.variant}}" = "release" ] ; then
              echo "Configuring project, bucket, and folder for robot-stack"

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -341,19 +341,11 @@ jobs:
           aws configure set source_profile identity --profile deploy
         shell: bash
       - name: 'deploy release builds to s3'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_APP_DEPLOY_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_APP_DEPLOY_SECRET }}
-          AWS_DEFAULT_REGION: us-east-2
         run: |
-          aws s3 sync --acl=public-read to_upload_release/ s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
-      - name: 'deploy release builds to s3'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_APP_DEPLOY_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_APP_DEPLOY_SECRET }}
-          AWS_DEFAULT_REGION: us-east-2
+          aws --profile=deploy s3 sync --acl=public-read to_upload_release/ s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}
+      - name: 'deploy internal-release release builds to s3'
         run: |
-          aws s3 sync --acl=public-read to_upload_internal_release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
+          aws s3 --profile=deploy sync --acl=public-read to_upload_internal_release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
       - name: 'create GH release'
         uses: 'ncipollo/release-action@v1.12.0'
         if: needs.determine-build-type.outputs.type == 'release'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -325,10 +325,10 @@ jobs:
       - name: 'separate release and internal-release artifacts'
         run: |
           for variant in release internal-release ; do
+              mkdir to_upload_${variant}
               variant_pattern="./artifacts/opentrons-${variant}-*"
               ls ${variant_pattern}/ 2>/dev/null 1>/dev/null || break
               echo "Moving ${variant} builds ${variant_pattern}/* to to_upload_${variant}"
-              mkdir to_upload_${variant}
               cp ./artifacts/${variant_pattern}/* ./to_upload_${variant}/
               echo "Moved $(ls ./to_upload_${variant})"
           done

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -157,7 +157,6 @@ jobs:
       type: ${{steps.determine-build-type.outputs.type}}
     steps:
       - id: determine-build-type
-        if: github.event_name == 'pull_request'
         run: |
           echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
           if [[ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ]] ; then

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -176,7 +176,7 @@ jobs:
             echo "internal-release develop builds for internal-release branches"
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [[ "${{ format('{0}', (startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true"]] ; then
+          elif [[ "${{ format('{0}', startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/chore_release')) }}" = "true"]] ; then
             echo "Release develop builds for release branches"
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -308,7 +308,7 @@ jobs:
         name: 'build ODD app for linux'
         timeout-minutes: 60
         env:
-          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && robot-stack) || 'ot3' }}
+          OPENTRONS_PROJECT: ${{ ((matrix.variant == 'release') && 'robot-stack') || 'ot3' }}
         run: |
           make -C app-shell-odd dist-ot3
 

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -327,7 +327,7 @@ jobs:
           for variant in release internal-release ; do
               mkdir to_upload_${variant}
               variant_pattern="./artifacts/opentrons-${variant}-*"
-              ls ${variant_pattern}/ 2>/dev/null 1>/dev/null || break
+              ls ${variant_pattern}/ 2>/dev/null 1>/dev/null || continue
               echo "Moving ${variant} builds ${variant_pattern}/* to to_upload_${variant}"
               cp ./artifacts/${variant_pattern}/* ./to_upload_${variant}/
               echo "Moved $(ls ./to_upload_${variant})"


### PR DESCRIPTION
This PR changes the app to deploy to builds.opentrons.com instead of the legacy bucket.

It also refactors the app build workflow in some ways that should make it a little more pleasant to deal with:
- Separate backend tests from builds
- Reduce duplication between internal release and release builds
- Make the logic about what kind of build we have clearer

# Risk
Medium - we have time to work this out.

# Testing
The testing is entirely about deploying app builds to various places - both variants, develop and release. All this should now be safe to do because this workflow no longer contains the public release bucket location. You can trigger builds on specific refs via manual dispatch.
- [x] Deploy some internal release develop app builds and check that they go to ot3-development.builds.opentrons.com and get slack notifications
- [x] Deploy some internal release release app builds (this might be tough, may have to debug at a later date unfortuntely) and check that they go to ot3-development.builds.opentrons.com and get slack notifications and get the yml payloads
- [x] Deploy some release develop app builds and check that they go to builds.opentrons.com and get slack notifications
- [x] Deploy some release release app builds and check that they go to builds.opentrons.com and get slack notifications and yml payloads