### PR TITLE
feat(robot-server): block POSTing runs when estop is not disengaged

### DIFF
--- a/robot-server/robot_server/errors/robot_errors.py
+++ b/robot-server/robot_server/errors/robot_errors.py
@@ -2,6 +2,7 @@
 
 from typing_extensions import Literal
 from .error_responses import ErrorDetails
+from opentrons_shared_data.errors.codes import ErrorCodes
 
 
 class InstrumentNotFound(ErrorDetails):
@@ -38,3 +39,27 @@ class HardwareFailedToInitialize(ErrorDetails):
 
     id: Literal["HardwareFailedToInitialize"] = "HardwareFailedToInitialize"
     title: str = "Hardware Failed to Initialize"
+
+
+class EstopNotAttached(ErrorDetails):
+    """An error if there is no Estop present."""
+
+    id: Literal["EstopNotAttached"] = "EstopNotAttached"
+    title: str = "There is no Estop attached"
+    errorCode: str = ErrorCodes.E_STOP_NOT_PRESENT.value.code
+
+
+class EstopEngaged(ErrorDetails):
+    """An error if there is an Estop engaged."""
+
+    id: Literal["EstopEngaged"] = "EstopEngaged"
+    title: str = "An Estop is physically engaged"
+    errorCode: str = ErrorCodes.E_STOP_ACTIVATED.value.code
+
+
+class EstopNotAcknowledged(ErrorDetails):
+    """An error if a client needs to acknowledge an estop engage event."""
+
+    id: Literal["EstopNotAcknowledged"] = "EstopNotAcknowledged"
+    title: str = "Estop event must be acknowledged"
+    errorCode: str = ErrorCodes.E_STOP_ACTIVATED.value.code

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.service.dependencies import get_current_time, get_unique_id
+from robot_server.robot.control.dependencies import require_estop_in_good_state
 
 from robot_server.service.json_api import (
     RequestModel,
@@ -143,6 +144,7 @@ async def create_run(
     run_id: str = Depends(get_unique_id),
     created_at: datetime = Depends(get_current_time),
     protocol_run_has_been_played: bool = Depends(get_protocol_run_has_been_played),
+    check_estop: bool = Depends(require_estop_in_good_state),
 ) -> PydanticResponse[SimpleBody[MaintenanceRun]]:
     """Create a new maintenance run.
 
@@ -152,6 +154,7 @@ async def create_run(
         run_id: Generated ID to assign to the run.
         created_at: Timestamp to attach to created run.
         protocol_run_has_been_played: Whether a protocol run has been played yet.
+        check_estop: Dependency to verify the estop is in a valid state.
     """
     if protocol_run_has_been_played:
         raise ProtocolRunIsActive(

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -22,6 +22,7 @@ from robot_server.service.json_api import (
     MultiBodyMeta,
     PydanticResponse,
 )
+from robot_server.robot.control.dependencies import require_estop_in_good_state
 
 from ..maintenance_run_models import (
     MaintenanceRunCommandSummary,
@@ -154,6 +155,7 @@ async def create_run_command(
         ),
     ),
     protocol_engine: ProtocolEngine = Depends(get_current_run_engine_from_url),
+    check_estop: bool = Depends(require_estop_in_good_state),
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
     """Enqueue a protocol command.
 
@@ -166,6 +168,7 @@ async def create_run_command(
             Comes from a query parameter in the URL.
         protocol_engine: The run's `ProtocolEngine` on which the new
             command will be enqueued.
+        check_estop: Dependency to verify the estop is in a valid state.
     """
     # TODO(mc, 2022-05-26): increment the HTTP API version so that default
     # behavior is to pass through `command_intent` without overriding it

--- a/robot-server/robot_server/robot/control/dependencies.py
+++ b/robot-server/robot_server/robot/control/dependencies.py
@@ -1,0 +1,54 @@
+"""Dependencies related to /robot/control endpoints."""
+from fastapi import status, Depends
+
+from opentrons.hardware_control import ThreadManagedHardware
+
+from robot_server.errors.error_responses import ApiError
+from robot_server.errors.robot_errors import (
+    EstopNotAttached,
+    EstopEngaged,
+    EstopNotAcknowledged,
+)
+
+from .models import (
+    EstopState,
+)
+from .estop_handler import EstopHandler
+from robot_server.hardware import get_thread_manager, get_ot3_hardware
+
+
+async def require_estop_in_good_state(
+    thread_manager: ThreadManagedHardware = Depends(get_thread_manager),
+) -> bool:
+    """Check that the estop is in a good state.
+
+    This requires that an estop is attached and disengaged. An exception will
+    be raised if any of the following is true:
+      - No estop is connected
+      - An estop is engaged
+      - An estop was engaged and released, but has not been acknowledged yet.
+
+    If the robot does not support Estop, this dependency will never fail.
+
+    Returns True if the Estop state is okay. Raises an exception in any other case.
+    """
+    try:
+        estop_handler = EstopHandler(hw_handle=get_ot3_hardware(thread_manager))
+    except ApiError:
+        # This is an OT-2 and there's no estop, so don't block out the endpoint
+        return True
+    else:
+        state = estop_handler.get_state()
+        if state is EstopState.NOT_PRESENT:
+            raise EstopNotAttached(
+                detail="An estop must be attached to access this endpoint"
+            ).as_error(status.HTTP_403_FORBIDDEN)
+        if state is EstopState.PHYSICALLY_ENGAGED:
+            raise EstopEngaged(
+                detail="Endpoint access is not permitted while estop is engaged"
+            ).as_error(status.HTTP_403_FORBIDDEN)
+        if state is EstopState.LOGICALLY_ENGAGED:
+            raise EstopNotAcknowledged(
+                detail="Must acknowledge estop event to access this endpoint"
+            ).as_error(status.HTTP_403_FORBIDDEN)
+        return True

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -10,6 +10,7 @@ from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.service.dependencies import get_current_time, get_unique_id
 from robot_server.service.json_api import RequestModel, SimpleBody, PydanticResponse
 from robot_server.service.task_runner import TaskRunner, get_task_runner
+from robot_server.robot.control.dependencies import require_estop_in_good_state
 
 from ..engine_store import EngineStore
 from ..run_store import RunStore
@@ -87,6 +88,7 @@ async def create_run_action(
     maintenance_engine_store: MaintenanceEngineStore = Depends(
         get_maintenance_engine_store
     ),
+    check_estop: bool = Depends(require_estop_in_good_state),
 ) -> PydanticResponse[SimpleBody[RunAction]]:
     """Create a run control action.
 
@@ -101,6 +103,7 @@ async def create_run_action(
         action_id: Generated ID to assign to the control action.
         created_at: Timestamp to attach to the control action.
         maintenance_engine_store: The maintenance run's EngineStore
+        check_estop: Dependency to verify the estop is in a valid state.
     """
     action_type = request_body.data.actionType
     if (

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -15,6 +15,7 @@ from opentrons_shared_data.errors import ErrorCodes
 
 from robot_server.errors import ErrorDetails, ErrorBody
 from robot_server.service.dependencies import get_current_time, get_unique_id
+from robot_server.robot.control.dependencies import require_estop_in_good_state
 
 from robot_server.service.json_api import (
     RequestModel,
@@ -133,6 +134,7 @@ async def create_run(
     run_id: str = Depends(get_unique_id),
     created_at: datetime = Depends(get_current_time),
     run_auto_deleter: RunAutoDeleter = Depends(get_run_auto_deleter),
+    check_estop: bool = Depends(require_estop_in_good_state),
 ) -> PydanticResponse[SimpleBody[Run]]:
     """Create a new run.
 
@@ -144,6 +146,7 @@ async def create_run(
         created_at: Timestamp to attach to created run.
         run_auto_deleter: An interface to delete old resources to make room for
             the new run.
+        check_estop: Dependency to verify the estop is in a valid state.
     """
     protocol_id = request_body.data.protocolId if request_body is not None else None
     offsets = request_body.data.labwareOffsets if request_body is not None else []

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -22,6 +22,7 @@ from robot_server.service.json_api import (
     MultiBodyMeta,
     PydanticResponse,
 )
+from robot_server.robot.control.dependencies import require_estop_in_good_state
 
 from ..run_models import RunCommandSummary
 from ..run_data_manager import RunDataManager
@@ -175,6 +176,7 @@ async def create_run_command(
         ),
     ),
     protocol_engine: ProtocolEngine = Depends(get_current_run_engine_from_url),
+    check_estop: bool = Depends(require_estop_in_good_state),
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
     """Enqueue a protocol command.
 
@@ -187,6 +189,7 @@ async def create_run_command(
             Comes from a query parameter in the URL.
         protocol_engine: The run's `ProtocolEngine` on which the new
             command will be enqueued.
+        check_estop: Dependency to verify the estop is in a valid state.
     """
     # TODO(mc, 2022-05-26): increment the HTTP API version so that default
     # behavior is to pass through `command_intent` without overriding it

--- a/robot-server/tests/robot/control/test_estop_lockout.py
+++ b/robot-server/tests/robot/control/test_estop_lockout.py
@@ -1,0 +1,100 @@
+"""Test the dependency for locking endpoints based on Estop."""
+
+from decoy import Decoy
+import pytest
+from typing import TYPE_CHECKING, Optional
+
+from fastapi import status
+
+from opentrons.hardware_control import ThreadManagedHardware
+from opentrons.hardware_control.api import API
+from opentrons.hardware_control.types import (
+    EstopState,
+    EstopPhysicalStatus,
+    EstopOverallStatus,
+)
+
+if TYPE_CHECKING:
+    from opentrons.hardware_control.ot3api import OT3API
+
+
+from opentrons_shared_data.errors.codes import ErrorCodes, ErrorCode
+
+from robot_server.robot.control.dependencies import require_estop_in_good_state
+from robot_server.errors.error_responses import ApiError
+
+
+@pytest.fixture
+async def hardware_ot2(decoy: Decoy) -> API:
+    return decoy.mock(cls=API)
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
+async def hardware_ot3(decoy: Decoy) -> "OT3API":
+    from opentrons.hardware_control.ot3api import OT3API
+
+    return decoy.mock(cls=OT3API)
+
+
+@pytest.fixture
+async def thread_manager_ot2(decoy: Decoy, hardware_ot2: API) -> ThreadManagedHardware:
+    thread_manager = decoy.mock(cls=ThreadManagedHardware)
+    decoy.when(thread_manager.wrapped()).then_return(hardware_ot2)
+    return thread_manager
+
+
+@pytest.mark.ot3_only
+@pytest.fixture
+async def thread_manager_ot3(
+    decoy: Decoy, hardware_ot3: "OT3API"
+) -> ThreadManagedHardware:
+    from opentrons.hardware_control.ot3api import OT3API
+
+    thread_manager = decoy.mock(cls=ThreadManagedHardware)
+    decoy.when(thread_manager.wraps_instance(OT3API)).then_return(True)
+    decoy.when(thread_manager.wrapped()).then_return(hardware_ot3)
+    return thread_manager
+
+
+async def test_estop_ignored_ot2(thread_manager_ot2: ThreadManagedHardware) -> None:
+    """Test that we can use the dependency on OT-2."""
+    assert await require_estop_in_good_state(thread_manager=thread_manager_ot2)
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    ["estop_state", "error_code"],
+    [
+        [EstopState.DISENGAGED, None],
+        [EstopState.NOT_PRESENT, ErrorCodes.E_STOP_NOT_PRESENT.value],
+        [EstopState.PHYSICALLY_ENGAGED, ErrorCodes.E_STOP_ACTIVATED.value],
+        [EstopState.LOGICALLY_ENGAGED, ErrorCodes.E_STOP_ACTIVATED.value],
+    ],
+)
+async def test_estop_ot3(
+    hardware_ot3: "OT3API",
+    thread_manager_ot3: ThreadManagedHardware,
+    decoy: Decoy,
+    estop_state: EstopState,
+    error_code: Optional[ErrorCode],
+) -> None:
+    """Test that ot3 hardware will check estop state."""
+
+    decoy.when(hardware_ot3.estop_status).then_return(
+        EstopOverallStatus(
+            state=estop_state,
+            left_physical_state=EstopPhysicalStatus.NOT_PRESENT,
+            right_physical_state=EstopPhysicalStatus.NOT_PRESENT,
+        )
+    )
+
+    if error_code is None:
+        assert await require_estop_in_good_state(thread_manager=thread_manager_ot3)
+    else:
+        with pytest.raises(ApiError) as details:
+            await require_estop_in_good_state(thread_manager=thread_manager_ot3)
+        err = details.value
+
+        assert err.status_code == status.HTTP_403_FORBIDDEN
+        assert err.content["errors"][0]["errorCode"] == error_code.code

--- a/robot-server/tests/robot/control/test_estop_lockout.py
+++ b/robot-server/tests/robot/control/test_estop_lockout.py
@@ -1,6 +1,6 @@
 """Test the dependency for locking endpoints based on Estop."""
 
-from decoy import Decoy
+from decoy import Decoy, matchers
 import pytest
 from typing import TYPE_CHECKING, Optional
 
@@ -32,9 +32,7 @@ async def hardware_ot2(decoy: Decoy) -> API:
 @pytest.mark.ot3_only
 @pytest.fixture
 async def hardware_ot3(decoy: Decoy) -> "OT3API":
-    from opentrons.hardware_control.ot3api import OT3API
-
-    return decoy.mock(cls=OT3API)
+    return decoy.mock(cls="OT3API")
 
 
 @pytest.fixture
@@ -49,10 +47,8 @@ async def thread_manager_ot2(decoy: Decoy, hardware_ot2: API) -> ThreadManagedHa
 async def thread_manager_ot3(
     decoy: Decoy, hardware_ot3: "OT3API"
 ) -> ThreadManagedHardware:
-    from opentrons.hardware_control.ot3api import OT3API
-
     thread_manager = decoy.mock(cls=ThreadManagedHardware)
-    decoy.when(thread_manager.wraps_instance(OT3API)).then_return(True)
+    decoy.when(thread_manager.wraps_instance(matchers.Anything())).then_return(True)
     decoy.when(thread_manager.wrapped()).then_return(hardware_ot3)
     return thread_manager
 


### PR DESCRIPTION

# Overview

This PR adds a mechanism to return an error whenever a client attempts to POST to the `/runs` or `/maintenance_runs` endpoints if the Estop is not engaged or is not present.

These specific routes are blocked:
- POST `/maintenance_runs`
- POST `/maintenance_runs/{run_id}/commands`
- POST `/runs`
- POST `/runs/{runId}/commands`
- POST `/runs/{runId}/actions`

# Test Plan

Tested on FLEXY:
* Try performing a run with the estop in the normal state - it should work normally
* Try POSTing to the above endpoints with the estop in any of the invalid states, should get an error back


# Changelog

- Added FastAPI dependency to check that estop state is valid - returns True on OT-2 at all times
- Added aforementioned dependency to POST endpoints for runs & maintenance runs
- Added tests for the dependency


# Review requests

Any other endpoints we want to block out? We are specifically not including Module control (stateless commands) or sending protocols.

# Risk assessment

If this improperly blocks functionality that is Not Good.
