### PR TITLE
feat(protocol-designer, step-generation): wire up hover labware and remove duplicate btn

### DIFF
--- a/protocol-designer/src/components/steplist/ContextMenu.tsx
+++ b/protocol-designer/src/components/steplist/ContextMenu.tsx
@@ -11,6 +11,7 @@ import { actions as steplistActions } from '../../steplist'
 import { Portal } from '../portals/TopPortal'
 import styles from './StepItem.css'
 import { StepIdType } from '../../form-types'
+import { getSavedStepForms } from '../../step-forms/selectors'
 
 const MENU_OFFSET_PX = 5
 
@@ -47,6 +48,9 @@ export const ContextMenu = (props: Props): JSX.Element => {
   const menuRoot = React.useRef<HTMLDivElement | null>(null)
 
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
+  const allSavedSteps = useSelector(getSavedStepForms)
+  const isMoveLabwareStepType =
+    stepId != null ? allSavedSteps[stepId].stepType === 'moveLabware' : null
 
   React.useEffect(() => {
     global.addEventListener('click', handleClick)
@@ -78,7 +82,6 @@ export const ContextMenu = (props: Props): JSX.Element => {
     setStepId(stepId)
     setPosition({ left, top })
   }
-
   const handleClick = (event: MouseEvent): void => {
     const wasOutside = !(
       event.target instanceof Node && menuRoot.current?.contains(event.target)
@@ -128,24 +131,24 @@ export const ContextMenu = (props: Props): JSX.Element => {
       })}
       {!showDeleteConfirmation && visible && (
         <Portal>
-          <React.Fragment>
-            <div
-              ref={menuRoot}
-              // @ts-expect-error(sa, 2021-7-5): position cannot be null, cast to undefined
-              style={{ left: position.left, top: position.top }}
-              className={styles.context_menu}
-            >
+          <div
+            ref={menuRoot}
+            // @ts-expect-error(sa, 2021-7-5): position cannot be null, cast to undefined
+            style={{ left: position.left, top: position.top }}
+            className={styles.context_menu}
+          >
+            {isMoveLabwareStepType ? null : (
               <div
                 onClick={handleDuplicate}
                 className={styles.context_menu_item}
               >
                 {i18n.t('context_menu.step.duplicate')}
               </div>
-              <div onClick={confirmDelete} className={styles.context_menu_item}>
-                {i18n.t('context_menu.step.delete')}
-              </div>
+            )}
+            <div onClick={confirmDelete} className={styles.context_menu_item}>
+              {i18n.t('context_menu.step.delete')}
             </div>
-          </React.Fragment>
+          </div>
         </Portal>
       )}
     </div>

--- a/protocol-designer/src/ui/steps/selectors.ts
+++ b/protocol-designer/src/ui/steps/selectors.ts
@@ -143,6 +143,11 @@ export const getHoveredStepLabware: Selector<string[]> = createSelector(
       return labware ? [labware.id] : []
     }
 
+    if (stepArgs.commandCreatorFnName === 'moveLabware') {
+      const src = stepArgs.labware
+      return [src]
+    }
+
     // step types that have no labware that gets highlighted
     if (!(stepArgs.commandCreatorFnName === 'delay')) {
       // TODO Ian 2018-05-08 use assert here

--- a/protocol-designer/src/ui/steps/test/selectors.test.ts
+++ b/protocol-designer/src/ui/steps/test/selectors.test.ts
@@ -40,6 +40,7 @@ function createArgsForStepId(
 const hoveredStepId = 'hoveredStepId'
 const labware = 'well plate'
 const mixCommand = 'mix'
+const moveLabwareCommand = 'moveLabware'
 describe('getHoveredStepLabware', () => {
   let initialDeckState: any
   beforeEach(() => {
@@ -119,6 +120,22 @@ describe('getHoveredStepLabware', () => {
   it('labware is returned when command is mix', () => {
     const stepArgs = {
       commandCreatorFnName: mixCommand,
+      labware,
+    }
+    const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
+    const result = getHoveredStepLabware.resultFunc(
+      argsByStepId,
+      hoveredStepId,
+      initialDeckState
+    )
+
+    expect(result).toEqual([labware])
+  })
+
+  it('correct labware is returned when command is moveLabware', () => {
+    const stepArgs = {
+      commandCreatorFnName: moveLabwareCommand,
       labware,
     }
     const argsByStepId = createArgsForStepId(hoveredStepId, stepArgs)

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -43,7 +43,7 @@ export const moveLabware: CommandCreator<MoveLabwareArgs> = (
     ) {
       errors.push(errorCreators.thermocyclerLidClosed())
     } else if (initialModuleState.type === HEATERSHAKER_MODULE_TYPE) {
-      if (initialModuleState.latchOpen === false) {
+      if (initialModuleState.latchOpen !== true) {
         errors.push(errorCreators.heaterShakerLatchClosed())
       } else if (initialModuleState.targetSpeed !== null) {
         errors.push(errorCreators.heaterShakerIsShaking())


### PR DESCRIPTION
closes RQA-1273 and RQA-1272

# Overview

This PR wires up a few things related to the `MoveLabware` timeline step

# Test Plan

Sandbox: https://sandbox.designer.opentrons.com/pd_movelabware-timeline-fixes/

Check these 2 things:

- Create a Move Labware step in PD. When you highlight it in the timeline, make sure the correct labware is highlighted on the deck map
- right click on the Move Labware step in the timeline, there should only be the option to "delete" and **no** option to "duplicate" the step.

Bonus:
- if you add a H-S to the deck and then move a labware in/out of the H-S, there should be a timeline error that pops up saying the latch is closed. Previously, my logic was a bit wrong and didn't account for if the latch was null

In the screenshot, notice that only the Delete step option is available and in the deckmap, notice that the labware that is being moved is highlighted

<img width="1130" alt="Screen Shot 2023-08-11 at 1 45 17 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/2bc6e20f-ac13-4ca1-b069-0f8bf2a638db">

# Changelog

- add logic to tell what the step type is for the selected step in the timeline to remove the duplicate option if its a move labware step - this is done in `ContextMenu`
- add the highlighted labware to the deck map by adding a `moveLabware` step condition in the `getHoveredStepLabware` selector, add a test case
- tiny logic fix in `MoveLabware` atomic command

# Review requests

see test plan

# Risk assessment

low