### PR TITLE
refactor(robot-server): Followups to GET /protocols/ids

### DIFF
--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -307,7 +307,14 @@ async def get_protocols(
 
 @protocols_router.get(
     path="/protocols/ids",
-    summary="Get uploaded protocol ids",
+    summary="[Internal] Get uploaded protocol ids",
+    description=(
+        "Get the IDs of all protocols stored on the server."
+        "\n\n"
+        "**Warning:**"
+        " This is an experimental endpoint and is only meant for internal use by Opentrons."
+        " We might remove it or change its behavior without warning."
+    ),
     responses={status.HTTP_200_OK: {"model": SimpleMultiBody[str]}},
 )
 async def get_protocol_ids(

--- a/robot-server/tests/integration/http_api/protocols/test_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload.tavern.yaml
@@ -33,6 +33,32 @@ stages:
           analysisSummaries:
             - id: !anystr
               status: pending
+  - name: Make sure the new protocol is present in GET /protocols
+    request:
+      url: '{ot2_server_base_url}/protocols'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          - id: '{protocol_id}'
+        meta:
+          cursor: 0
+          totalLength: 1
+  - name: Make sure the new protocol is present in GET /protocols/ids
+    request:
+      url: '{ot2_server_base_url}/protocols/ids'
+      method: GET
+    response:
+      status_code: 200
+      json:
+        data:
+          - '{protocol_id}'
+        meta:
+          cursor: 0
+          totalLength: 1
   - name: Retry until analyses status is completed and result is ok.
     max_retries: 5
     delay_after: 1


### PR DESCRIPTION
# Overview

Some low-priority follow-ups to the `GET /protocols/ids` endpoint, from the discussion in #12725.

# Test Plan

None needed. Changes are just to docs and tests.

# Changelog

The public-facing documentation of `GET /protocols/ids` was accidentally showing an internal Python thing. Replace it with something that says this endpoint is only meant for internal use. https://github.com/Opentrons/opentrons/pull/12725#discussion_r1200693447. I suspect we should replace this endpoint with a [partial](https://philsturgeon.com/a-happy-compromise-between-customization-and-cacheability/) on `GET /protocols` someday, so I'd rather not have external people start to depend on it. (Though it wouldn't be too hard to add a redirect, I guess.)

Also add an integration test. `GET /protocols/ids` has an ambiguity with `GET /protocols/{id}`. For `GET /protocols/ids` to take precedence, we need to define the endpoint functions in a particular order. It's only possible to cover this with a Tavern test. https://github.com/Opentrons/opentrons/pull/12725#discussion_r1200673851

# Review requests

None in particular.

# Risk assessment

No risk.
