### PR TITLE
feat(hardware): add can message to get gripper jaw state from firmware

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -152,6 +152,8 @@ class MessageId(int, Enum):
     brushed_motor_conf_request = 0x45
     brushed_motor_conf_response = 0x46
     set_gripper_error_tolerance = 0x47
+    gripper_jaw_state_request = 0x48
+    gripper_jaw_state_response = 0x49
 
     acknowledgement = 0x50
 
@@ -364,3 +366,13 @@ class MoveAckId(int, Enum):
     stopped_by_condition = 0x2
     timeout = 0x3
     position_error = 0x4
+
+
+@unique
+class GripperJawState(int, Enum):
+    """Gripper jaw states."""
+
+    unhomed = 0x0
+    force_controlling_home = 0x1
+    force_controlling = 0x2
+    position_controlling = 0x3

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -623,6 +623,24 @@ class BrushedMotorConfResponse(BaseMessage):  # noqa: D101
 
 
 @dataclass
+class GripperJawStateRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[
+        MessageId.gripper_jaw_state_request
+    ] = MessageId.gripper_jaw_state_request
+
+
+@dataclass
+class GripperJawStateResponse(BaseMessage):  # noqa: D101
+    payload: payloads.GripperMoveRequestPayload
+    payload_type: Type[
+        payloads.GripperJawStatePayload
+    ] = payloads.GripperJawStatePayload
+    message_id: Literal[
+        MessageId.gripper_jaw_state_response
+    ] = MessageId.gripper_jaw_state_response
+
+
+@dataclass
 class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -521,6 +521,13 @@ class GripperInfoResponsePayload(EmptyPayload):
 
 
 @dataclass(eq=False)
+class GripperJawStatePayload(EmptyPayload):
+    """A respones carrying info about the jaw state of a gripper."""
+
+    state: utils.UInt8Field
+
+
+@dataclass(eq=False)
 class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     """A request to move gripper."""
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The new can message allows us to get the firmware to report the real-time actual brushed motor state. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
