### PR TITLE
fix(protocol-designer): get labware dropdown from current deck state

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -235,7 +235,7 @@
   margin-top: 0.5rem;
   font-size: var(--fs-body-1);
   overflow: hidden;
-  white-space: nowrap;
+  white-space: pre-wrap;
   text-overflow: ellipsis;
 }
 

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -114,11 +114,11 @@
       "touchTip": { "label": "touch tip" },
       "moduleActionLabware": { "label": "module" },
       "moduleLabwarePrefix": {
-        "magneticModuleType": "MAG",
-        "temperatureModuleType": "TEMP",
-        "thermocyclerModuleType": "THERMO",
-        "heaterShakerModuleType": "HS",
-        "magneticBlockType": "MAG"
+        "magneticModuleType": "Magnetic Module",
+        "temperatureModuleType": "Temperature Module",
+        "thermocyclerModuleType": "Thermocycler",
+        "heaterShakerModuleType": "Heater-Shaker",
+        "magneticBlockType": "Magnetic Block"
       },
       "magnetAction": {
         "label": "Magnet action",

--- a/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
+++ b/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
@@ -150,6 +150,7 @@ describe('labware selectors', () => {
           labwareEntities,
           names,
           initialDeckSetup,
+          {},
           {}
         )
       ).toEqual([
@@ -179,7 +180,8 @@ describe('labware selectors', () => {
           labwareEntities,
           names,
           initialDeckSetup,
-          presavedStepForm
+          presavedStepForm,
+          {}
         )
       ).toEqual([
         { name: 'Opentrons Tip Rack 10 µL', value: 'tiprack10Id' },
@@ -259,6 +261,7 @@ describe('labware selectors', () => {
           labwareEntities,
           nicknames,
           initialDeckSetup,
+          {},
           {}
         )
       ).toEqual([
@@ -318,7 +321,7 @@ describe('labware selectors', () => {
           savedStep
         )
       ).toEqual([
-        { name: 'Well Plate', value: 'wellPlateId' },
+        { name: 'Well Plate in Magnetic Module', value: 'wellPlateId' },
         { name: 'Trash', value: 'fixedTrash' },
       ])
     })

--- a/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
+++ b/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
@@ -1,4 +1,6 @@
 import {
+  HEATERSHAKER_MODULE_TYPE,
+  HEATERSHAKER_MODULE_V1,
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
   TEMPERATURE_MODULE_TYPE,
@@ -144,7 +146,12 @@ describe('labware selectors', () => {
       }
       expect(
         // @ts-expect-error(sa, 2021-6-15): resultFunc
-        getLabwareOptions.resultFunc(labwareEntities, names, initialDeckSetup)
+        getLabwareOptions.resultFunc(
+          labwareEntities,
+          names,
+          initialDeckSetup,
+          {}
+        )
       ).toEqual([
         { name: 'Source Plate', value: 'wellPlateId' },
         { name: 'Trash', value: 'fixedTrash' },
@@ -197,6 +204,11 @@ describe('labware selectors', () => {
           id: 'tcPlateId',
           slot: 'thermocyclerId', // On thermocycler
         },
+        hsPlateId: {
+          ...otherLabware.wellPlateId,
+          id: 'hsPlateId',
+          slot: 'heaterShakerId', // On heater-shaker
+        },
       }
       const labwareEntities = { ...trash, ...labware }
       const initialDeckSetup = {
@@ -224,6 +236,12 @@ describe('labware selectors', () => {
             model: THERMOCYCLER_MODULE_V1,
             slot: SPAN7_8_10_11_SLOT,
           },
+          heaterShakerId: {
+            id: 'heaterShakerId',
+            type: HEATERSHAKER_MODULE_TYPE,
+            model: HEATERSHAKER_MODULE_V1,
+            slot: '6',
+          },
         },
       }
 
@@ -232,6 +250,7 @@ describe('labware selectors', () => {
         wellPlateId: 'Well Plate',
         tempPlateId: 'Temp Plate',
         tcPlateId: 'TC Plate',
+        hsPlateId: 'HS Plate',
       }
 
       expect(
@@ -239,12 +258,67 @@ describe('labware selectors', () => {
         getLabwareOptions.resultFunc(
           labwareEntities,
           nicknames,
-          initialDeckSetup
+          initialDeckSetup,
+          {}
         )
       ).toEqual([
-        { name: 'MAG Well Plate', value: 'wellPlateId' },
-        { name: 'TEMP Temp Plate', value: 'tempPlateId' },
-        { name: 'THERMO TC Plate', value: 'tcPlateId' },
+        { name: 'HS Plate in Heater-Shaker', value: 'hsPlateId' },
+        { name: 'TC Plate in Thermocycler', value: 'tcPlateId' },
+        { name: 'Temp Plate in Temperature Module', value: 'tempPlateId' },
+        { name: 'Well Plate in Magnetic Module', value: 'wellPlateId' },
+        { name: 'Trash', value: 'fixedTrash' },
+      ])
+    })
+
+    it('should return labware options with a labware moved off of the initial module slot', () => {
+      const labware = {
+        wellPlateId: {
+          ...otherLabware.wellPlateId,
+          slot: 'magModuleId', // On magnetic module
+        },
+      }
+      const labwareEntities = { ...trash, ...labware }
+      const initialDeckSetup = {
+        pipettes: {},
+        labware: {
+          ...trash,
+          ...labware,
+        },
+        modules: {
+          magModuleId: {
+            id: 'magModuleId',
+            type: MAGNETIC_MODULE_TYPE,
+            model: MAGNETIC_MODULE_V1,
+            slot: '1',
+          },
+        },
+      }
+
+      const nicknames: Record<string, string> = {
+        ...names,
+        wellPlateId: 'Well Plate',
+      }
+      const mockId = 'mockId'
+
+      const savedStep = {
+        [mockId]: {
+          stepType: 'moveLabware',
+          id: mockId,
+          labware: 'wellPlateId',
+          newLocation: '2',
+        },
+      }
+
+      expect(
+        // @ts-expect-error(sa, 2021-6-15): resultFunc
+        getLabwareOptions.resultFunc(
+          labwareEntities,
+          nicknames,
+          initialDeckSetup,
+          savedStep
+        )
+      ).toEqual([
+        { name: 'Well Plate', value: 'wellPlateId' },
         { name: 'Trash', value: 'fixedTrash' },
       ])
     })

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -68,13 +68,13 @@ export const getLabwareOptions: Selector<Options> = createSelector(
           savedStepForms,
           labwareId
         )
-        const prefix = moduleOnDeck
+        const module = moduleOnDeck
           ? i18n.t(
               `form.step_edit_form.field.moduleLabwarePrefix.${moduleOnDeck.type}`
             )
           : null
-        const nickName = prefix
-          ? `${nicknamesById[labwareId]} in ${prefix}`
+        const nickName = module
+          ? `${nicknamesById[labwareId]} in ${module}`
           : nicknamesById[labwareId]
 
         if (!moveLabwarePresavedStep) {

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -65,7 +65,7 @@ export const getLabwareOptions: Selector<Options> = createSelector(
           labwareEntity.def.metadata.displayCategory === 'aluminumBlock'
         const moduleOnDeck = getModuleUnderLabware(
           initialDeckSetup,
-          savedStepForms,
+          savedStepForms ?? {},
           labwareId
         )
         const module =

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -68,14 +68,16 @@ export const getLabwareOptions: Selector<Options> = createSelector(
           savedStepForms,
           labwareId
         )
-        const module = moduleOnDeck
-          ? i18n.t(
-              `form.step_edit_form.field.moduleLabwarePrefix.${moduleOnDeck.type}`
-            )
-          : null
-        const nickName = module
-          ? `${nicknamesById[labwareId]} in ${module}`
-          : nicknamesById[labwareId]
+        const module =
+          moduleOnDeck != null
+            ? i18n.t(
+                `form.step_edit_form.field.moduleLabwarePrefix.${moduleOnDeck.type}`
+              )
+            : null
+        const nickName =
+          module != null
+            ? `${nicknamesById[labwareId]} in ${module}`
+            : nicknamesById[labwareId]
 
         if (!moveLabwarePresavedStep) {
           return getIsTiprack(labwareEntity.def) || isAdapter

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -43,7 +43,14 @@ export const getLabwareOptions: Selector<Options> = createSelector(
   getLabwareNicknamesById,
   stepFormSelectors.getInitialDeckSetup,
   stepFormSelectors.getPresavedStepForm,
-  (labwareEntities, nicknamesById, initialDeckSetup, presavedStepForm) => {
+  stepFormSelectors.getSavedStepForms,
+  (
+    labwareEntities,
+    nicknamesById,
+    initialDeckSetup,
+    presavedStepForm,
+    savedStepForms
+  ) => {
     const moveLabwarePresavedStep = presavedStepForm?.stepType === 'moveLabware'
     const options = reduce(
       labwareEntities,
@@ -56,14 +63,18 @@ export const getLabwareOptions: Selector<Options> = createSelector(
         const isAdapterOrAluminumBlock =
           isAdapter ||
           labwareEntity.def.metadata.displayCategory === 'aluminumBlock'
-        const moduleOnDeck = getModuleUnderLabware(initialDeckSetup, labwareId)
+        const moduleOnDeck = getModuleUnderLabware(
+          initialDeckSetup,
+          savedStepForms,
+          labwareId
+        )
         const prefix = moduleOnDeck
           ? i18n.t(
               `form.step_edit_form.field.moduleLabwarePrefix.${moduleOnDeck.type}`
             )
           : null
         const nickName = prefix
-          ? `${prefix} ${nicknamesById[labwareId]}`
+          ? `${nicknamesById[labwareId]} in ${prefix}`
           : nicknamesById[labwareId]
 
         if (!moveLabwarePresavedStep) {

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -11,7 +11,7 @@ import type {
   LabwareOnDeck,
   InitialDeckSetup,
 } from '../../step-forms/types'
-import { SavedStepFormState } from '../../step-forms'
+import type { SavedStepFormState } from '../../step-forms'
 
 export function getModuleOnDeckByType(
   initialDeckSetup: InitialDeckSetup,

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -60,21 +60,21 @@ export function getModuleLabwareOptions(
   const moduleOnDeck = getModuleOnDeckByType(initialDeckSetup, type)
   const labware =
     moduleOnDeck && getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
-  const prefix = i18n.t(`form.step_edit_form.field.moduleLabwarePrefix.${type}`)
+  const module = i18n.t(`form.step_edit_form.field.moduleLabwarePrefix.${type}`)
   let options: Options = []
 
   if (moduleOnDeck) {
     if (labware) {
       options = [
         {
-          name: `${nicknamesById[labware.id]} in ${prefix}`,
+          name: `${nicknamesById[labware.id]} in ${module}`,
           value: moduleOnDeck.id,
         },
       ]
     } else {
       options = [
         {
-          name: `${prefix} No labware on module`,
+          name: `${module} No labware on module`,
           value: moduleOnDeck.id,
         },
       ]


### PR DESCRIPTION
closes RQA-1276

# Overview

When you move a labware that is originally on top of a module to a new location, the labware dropdown info still shows the module in the prefix. And vice versa, if you move a labware to be on top of a module, the module prefix never shows up. This PR fixes that and gets the labware location from the current state instead of the starting deck state.

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_labware_dropdown_mod-prefix/

Follow the steps outlined in the ticket. But basically, add a labware on top of a module in the initial deck state and move it to a deck slot location. Then move the labware again and notice that the labware's module location is no longer there.

Also, make an ot-2 protocol and add a magnetic module. add a magnet form step and make sure the whole labware with module is shown - since the prefix change also affected this area as well

# Changelog

- modify module prefixes and rename to module since it isn't a prefix anymore
- modify `getModuleUnderLabware` util to update the labware's current location instead of only getting the starting location
- update tests

# Review requests

see test plan

# Risk assessment

low