### PR TITLE
fix(app): navigate to run preview tab after starting run

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -560,6 +560,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
         confirmAttachment()
       } else {
         play()
+        history.push(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
         trackProtocolRunEvent({
           name:
             runStatus === RUN_STATUS_IDLE


### PR DESCRIPTION
# Overview

after clicking start run, users should be routed to the run preview tab on the protocol run page. this is necessary in order to show intervention modals. fixes a regression from prior desktop app behavior

# Test Plan

 - manually confirmed navigation to run preview tab after start, and intervention modals rendering

# Changelog

 - Navigates to run preview tab after starting run

# Review requests


# Risk assessment

low
