### PR TITLE
fix(api): update status bar colors for compliance

### DIFF
--- a/api/src/opentrons/hardware_control/status_bar_state.py
+++ b/api/src/opentrons/hardware_control/status_bar_state.py
@@ -31,7 +31,7 @@ class StatusBarStateController:
     async def _status_bar_running(self) -> None:
         self._status_bar_state = StatusBarState.RUNNING
         if self._enabled:
-            await self._controller.static_color(status_bar.BLUE)
+            await self._controller.static_color(status_bar.GREEN)
 
     async def _status_bar_paused(self) -> None:
         self._status_bar_state = StatusBarState.PAUSED
@@ -46,7 +46,7 @@ class StatusBarStateController:
     async def _status_bar_software_error(self) -> None:
         self._status_bar_state = StatusBarState.SOFTWARE_ERROR
         if self._enabled:
-            await self._controller.static_color(status_bar.RED)
+            await self._controller.static_color(status_bar.YELLOW)
 
     async def _status_bar_confirm(self) -> None:
         # Confirm should revert to IDLE
@@ -57,7 +57,7 @@ class StatusBarStateController:
     async def _status_bar_run_complete(self) -> None:
         self._status_bar_state = StatusBarState.RUN_COMPLETED
         if self._enabled:
-            await self._controller.static_color(status_bar.GREEN)
+            await self._controller.pulse_color(status_bar.GREEN)
 
     async def _status_bar_updating(self) -> None:
         self._status_bar_state = StatusBarState.UPDATING

--- a/hardware/opentrons_hardware/hardware_control/status_bar.py
+++ b/hardware/opentrons_hardware/hardware_control/status_bar.py
@@ -49,7 +49,7 @@ BLUE = Color(r=0, g=189, b=255, w=0)
 WHITE = Color(r=0, g=0, b=0, w=255)
 ORANGE = Color(r=255, g=165, b=0, w=0)
 PURPLE = Color(r=192, g=0, b=255, w=0)
-YELLOW = Color(r=248, g=255, b=0, w=0)
+YELLOW = Color(r=255, g=255, b=0, w=0)
 OFF = Color(r=0, g=0, b=0, w=0)
 
 


### PR DESCRIPTION
Machinery directive requires specific color patterns for semantic actions. Update our status bar to be in line with the requirements.

Closes RCORE-819

## Testing
- [x] check the colors