### PR TITLE
fix(app): add loading state to protocol routes

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/ProtocolDetails/ProtocolDetailsSkeleton.tsx
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolDetails/ProtocolDetailsSkeleton.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+
+import { Flex, BORDERS, DIRECTION_COLUMN, SPACING } from '@opentrons/components'
+
+import { Skeleton } from '../../../atoms/Skeleton'
+
+export function ProtocolDetailsHeaderChipSkeleton(): JSX.Element {
+  return (
+    <Skeleton
+      width="12.17875rem"
+      height="2.75rem"
+      backgroundSize="99rem"
+      borderRadius={BORDERS.borderRadiusSize3}
+    />
+  )
+}
+
+export function ProcotolDetailsHeaderTitleSkeleton(): JSX.Element {
+  return (
+    <Skeleton
+      width="42rem"
+      height="3rem"
+      backgroundSize="99rem"
+      borderRadius={BORDERS.borderRadiusSize3}
+    />
+  )
+}
+
+export function ProtocolDetailsSectionContentSkeleton(): JSX.Element {
+  return (
+    <Flex margin={SPACING.spacing16}>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+        <Skeleton
+          width="12rem"
+          height="1.75rem"
+          backgroundSize="99rem"
+          borderRadius={BORDERS.borderRadiusSize5}
+        />
+        <Skeleton
+          width="58rem"
+          height="1.75rem"
+          backgroundSize="99rem"
+          borderRadius={BORDERS.borderRadiusSize5}
+        />
+        <Skeleton
+          width="58rem"
+          height="1.75rem"
+          backgroundSize="99rem"
+          borderRadius={BORDERS.borderRadiusSize5}
+        />
+        <Skeleton
+          width="39rem"
+          height="1.75rem"
+          backgroundSize="99rem"
+          borderRadius={BORDERS.borderRadiusSize5}
+        />
+        <Flex
+          borderRadius={BORDERS.borderRadiusSize1}
+          marginTop={SPACING.spacing24}
+          width="max-content"
+        >
+          <Skeleton
+            width="18rem"
+            height="2.25rem"
+            backgroundSize="99rem"
+            borderRadius={BORDERS.borderRadiusSize3}
+          />
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/organisms/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetailsSkeleton.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetailsSkeleton.test.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+
+import { render } from '@testing-library/react'
+
+import {
+  ProtocolDetailsHeaderChipSkeleton,
+  ProcotolDetailsHeaderTitleSkeleton,
+  ProtocolDetailsSectionContentSkeleton,
+} from '../ProtocolDetailsSkeleton'
+
+describe('ProtocolDetailsSkeleton', () => {
+  it('renders a Skeleton to replace the Chip component', () => {
+    const { getAllByTestId } = render(<ProtocolDetailsHeaderChipSkeleton />)
+    const chipSkeleton = getAllByTestId('Skeleton')
+    expect(chipSkeleton.length).toEqual(1)
+    expect(chipSkeleton[0]).toHaveStyle('background-size: 99rem')
+  })
+
+  it('renders a Skeleton to replace the title section', () => {
+    const { getAllByTestId } = render(<ProcotolDetailsHeaderTitleSkeleton />)
+    const titleSkeleton = getAllByTestId('Skeleton')
+    expect(titleSkeleton.length).toEqual(1)
+    expect(titleSkeleton[0]).toHaveStyle('background-size: 99rem')
+  })
+
+  it('renders Skeletons to replace the ProtocolSectionContent component', () => {
+    const { getAllByTestId } = render(<ProtocolDetailsSectionContentSkeleton />)
+    const contentSkeletons = getAllByTestId('Skeleton')
+    expect(contentSkeletons.length).toEqual(5)
+    contentSkeletons.forEach(contentSkeleton => {
+      expect(contentSkeleton).toHaveStyle('background-size: 99rem')
+    })
+  })
+})

--- a/app/src/organisms/OnDeviceDisplay/ProtocolDetails/index.ts
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolDetails/index.ts
@@ -1,0 +1,1 @@
+export * from './ProtocolDetailsSkeleton'

--- a/app/src/organisms/OnDeviceDisplay/ProtocolSetup/ProtocolSetupSkeleton.tsx
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolSetup/ProtocolSetupSkeleton.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+
+import { BORDERS } from '@opentrons/components'
+
+import { Skeleton } from '../../../atoms/Skeleton'
+
+export function ProtocolSetupTitleSkeleton(): JSX.Element {
+  return (
+    <>
+      <Skeleton
+        height="2.25rem"
+        width="11.937rem"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+      <Skeleton
+        height="2.25rem"
+        width="28rem"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+    </>
+  )
+}
+
+export function ProtocolSetupStepSkeleton(): JSX.Element {
+  return (
+    <>
+      <Skeleton
+        height="5.5rem"
+        width="100%"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+      <Skeleton
+        height="5.5rem"
+        width="100%"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+      <Skeleton
+        height="5.5rem"
+        width="100%"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+      <Skeleton
+        height="5.5rem"
+        width="100%"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+      <Skeleton
+        height="5.5rem"
+        width="100%"
+        backgroundSize="99rem"
+        borderRadius={BORDERS.borderRadiusSize3}
+      />
+    </>
+  )
+}

--- a/app/src/organisms/OnDeviceDisplay/ProtocolSetup/ProtocolSetupSkeleton.tsx
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolSetup/ProtocolSetupSkeleton.tsx
@@ -23,39 +23,25 @@ export function ProtocolSetupTitleSkeleton(): JSX.Element {
   )
 }
 
+const SetupSkeleton = (): JSX.Element => {
+  return (
+    <Skeleton
+      height="5.5rem"
+      width="100%"
+      backgroundSize="99rem"
+      borderRadius={BORDERS.borderRadiusSize3}
+    />
+  )
+}
+
 export function ProtocolSetupStepSkeleton(): JSX.Element {
   return (
     <>
-      <Skeleton
-        height="5.5rem"
-        width="100%"
-        backgroundSize="99rem"
-        borderRadius={BORDERS.borderRadiusSize3}
-      />
-      <Skeleton
-        height="5.5rem"
-        width="100%"
-        backgroundSize="99rem"
-        borderRadius={BORDERS.borderRadiusSize3}
-      />
-      <Skeleton
-        height="5.5rem"
-        width="100%"
-        backgroundSize="99rem"
-        borderRadius={BORDERS.borderRadiusSize3}
-      />
-      <Skeleton
-        height="5.5rem"
-        width="100%"
-        backgroundSize="99rem"
-        borderRadius={BORDERS.borderRadiusSize3}
-      />
-      <Skeleton
-        height="5.5rem"
-        width="100%"
-        backgroundSize="99rem"
-        borderRadius={BORDERS.borderRadiusSize3}
-      />
+      <SetupSkeleton />
+      <SetupSkeleton />
+      <SetupSkeleton />
+      <SetupSkeleton />
+      <SetupSkeleton />
     </>
   )
 }

--- a/app/src/organisms/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetupSkeleton.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetupSkeleton.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+
+import { render } from '@testing-library/react'
+
+import {
+  ProtocolSetupTitleSkeleton,
+  ProtocolSetupStepSkeleton,
+} from '../ProtocolSetupSkeleton'
+
+describe('ProtocolSetupSkeleton', () => {
+  it('renders Skeletons to replace the title section', () => {
+    const { getAllByTestId } = render(<ProtocolSetupTitleSkeleton />)
+    const titleSkeletons = getAllByTestId('Skeleton')
+    expect(titleSkeletons.length).toBe(2)
+
+    titleSkeletons.forEach(titleSkeleton => {
+      expect(titleSkeleton).toHaveStyle('background-size: 99rem')
+    })
+  })
+
+  it('renders Skeletons to replace the SetupStep components', () => {
+    const { getAllByTestId } = render(<ProtocolSetupStepSkeleton />)
+    const titleSkeletons = getAllByTestId('Skeleton')
+    expect(titleSkeletons.length).toBe(5)
+
+    titleSkeletons.forEach(titleSkeleton => {
+      expect(titleSkeleton).toHaveStyle('background-size: 99rem')
+    })
+  })
+})

--- a/app/src/organisms/OnDeviceDisplay/ProtocolSetup/index.ts
+++ b/app/src/organisms/OnDeviceDisplay/ProtocolSetup/index.ts
@@ -1,0 +1,1 @@
+export * from './ProtocolSetupSkeleton'

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -126,6 +126,7 @@ describe('ODDProtocolDetails', () => {
           key: '26ed5a82-502f-4074-8981-57cdda1d066d',
         },
       },
+      isLoading: false,
     } as any)
     mockUseProtocolAnalysesQuery.mockReturnValue({
       data: {

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -81,6 +81,25 @@ const mockUseMissingHardwareText = useMissingHardwareText as jest.MockedFunction
   typeof useMissingHardwareText
 >
 
+const MOCK_DATA = {
+  data: {
+    id: 'mockProtocol1',
+    createdAt: '2022-05-03T21:36:12.494778+00:00',
+    protocolType: 'json',
+    metadata: {
+      protocolName:
+        'Nextera XT DNA Library Prep Kit Protocol: Part 1/4 - Tagment Genomic DNA and Amplify Libraries',
+      author: 'engineering testing division',
+      description: 'A short mock protocol',
+      created: 1606853851893,
+      tags: ['unitTest'],
+    },
+    analysisSummaries: [],
+    files: [],
+    key: '26ed5a82-502f-4074-8981-57cdda1d066d',
+  },
+}
+
 const render = (path = '/protocols/fakeProtocolId') => {
   return renderWithProviders(
     <MemoryRouter initialEntries={[path]} initialIndex={0}>
@@ -108,24 +127,7 @@ describe('ODDProtocolDetails', () => {
       isLoading: false,
     })
     mockUseProtocolQuery.mockReturnValue({
-      data: {
-        data: {
-          id: 'mockProtocol1',
-          createdAt: '2022-05-03T21:36:12.494778+00:00',
-          protocolType: 'json',
-          metadata: {
-            protocolName:
-              'Nextera XT DNA Library Prep Kit Protocol: Part 1/4 - Tagment Genomic DNA and Amplify Libraries',
-            author: 'engineering testing division',
-            description: 'A short mock protocol',
-            created: 1606853851893,
-            tags: ['unitTest'],
-          },
-          analysisSummaries: [],
-          files: [],
-          key: '26ed5a82-502f-4074-8981-57cdda1d066d',
-        },
-      },
+      data: MOCK_DATA,
       isLoading: false,
     } as any)
     mockUseProtocolAnalysesQuery.mockReturnValue({
@@ -218,5 +220,13 @@ describe('ODDProtocolDetails', () => {
     const summaryButton = getByRole('button', { name: 'Summary' })
     summaryButton.click()
     getByText('A short mock protocol')
+  })
+  it('should render a loading skeleton while awaiting a response from the server', () => {
+    mockUseProtocolQuery.mockReturnValue({
+      data: MOCK_DATA,
+      isLoading: true,
+    } as any)
+    const [{ getAllByTestId }] = render()
+    expect(getAllByTestId('Skeleton').length).toBeGreaterThan(0)
   })
 })

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -480,9 +480,7 @@ export function ProtocolDetails(): JSX.Element | null {
             justifyContent={JUSTIFY_SPACE_BETWEEN}
             paddingTop={
               // Skeleton is large. Better UX not to scroll to see buttons while loading.
-              !isProtocolFetching
-                ? SPACING.spacing60
-                : SPACING.spacing24
+              !isProtocolFetching ? SPACING.spacing60 : SPACING.spacing24
             }
             marginX={SPACING.spacing16}
           >

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -57,7 +57,7 @@ import type { OnDeviceRouteParams } from '../../../App/types'
 import { useOffsetCandidatesForAnalysis } from '../../../organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 
 interface ProtocolHeaderProps {
-  title: string | null | undefined
+  title?: string | null
   handleRunProtocol: () => void
   chipText: string
   isScrolled: boolean
@@ -146,7 +146,7 @@ const ProtocolHeader = ({
         buttonText={t('protocol_details:start_setup')}
         disabled={isProtocolFetching}
         iconName={startSetup ? 'ot-spinner' : undefined}
-        iconPlacement={'endIcon'}
+        iconPlacement="endIcon"
       />
     </Flex>
   )
@@ -235,17 +235,17 @@ const Summary = ({ author, description, date }: SummaryProps): JSX.Element => {
 
 interface ProtocolSectionContentProps {
   protocolId: string
-  protocolData: Protocol | null | undefined
+  protocolData?: Protocol | null
   currentOption: TabOption
 }
 const ProtocolSectionContent = ({
   protocolId,
   protocolData,
   currentOption,
-}: ProtocolSectionContentProps): JSX.Element => {
-  if (protocolData === null || protocolData === undefined) return <></>
+}: ProtocolSectionContentProps): JSX.Element | null => {
+  if (protocolData == null) return null
 
-  let protocolSection = null
+  let protocolSection: JSX.Element | null = null
   switch (currentOption) {
     case 'Summary':
       protocolSection = (
@@ -391,7 +391,7 @@ export function ProtocolDetails(): JSX.Element | null {
   }
 
   const displayName =
-    isProtocolFetching === false && protocolRecord !== undefined
+    !isProtocolFetching && protocolRecord != null
       ? protocolRecord?.data.metadata.protocolName ??
         protocolRecord?.data.files[0].name
       : null
@@ -406,7 +406,7 @@ export function ProtocolDetails(): JSX.Element | null {
     <>
       {showConfirmDeleteProtocol ? (
         <Flex alignItems={ALIGN_CENTER}>
-          {isProtocolFetching === false ? (
+          {!isProtocolFetching ? (
             <Modal
               modalSize="medium"
               onOutsideClick={() => setShowConfirmationDeleteProtocol(false)}
@@ -465,7 +465,7 @@ export function ProtocolDetails(): JSX.Element | null {
             currentOption={currentOption}
             setCurrentOption={setCurrentOption}
           />
-          {isProtocolFetching === false ? (
+          {!isProtocolFetching ? (
             <ProtocolSectionContent
               protocolId={protocolId}
               protocolData={protocolRecord}
@@ -480,7 +480,7 @@ export function ProtocolDetails(): JSX.Element | null {
             justifyContent={JUSTIFY_SPACE_BETWEEN}
             paddingTop={
               // Skeleton is large. Better UX not to scroll to see buttons while loading.
-              isProtocolFetching === false
+              !isProtocolFetching
                 ? SPACING.spacing60
                 : SPACING.spacing24
             }

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -74,6 +74,7 @@ const ProtocolHeader = ({
   const history = useHistory()
   const { t } = useTranslation(['protocol_info, protocol_details', 'shared'])
   const [truncate, setTruncate] = React.useState<boolean>(true)
+  const [startSetup, setStartSetup] = React.useState<boolean>(false)
   const toggleTruncate = (): void => setTruncate(value => !value)
 
   let displayedTitle = title ?? null
@@ -138,9 +139,14 @@ const ProtocolHeader = ({
       </Flex>
       <SmallButton
         buttonCategory="rounded"
-        onClick={handleRunProtocol}
+        onClick={() => {
+          setStartSetup(true)
+          handleRunProtocol()
+        }}
         buttonText={t('protocol_details:start_setup')}
         disabled={isProtocolFetching}
+        iconName={startSetup ? 'ot-spinner' : undefined}
+        iconPlacement={'endIcon'}
       />
     </Flex>
   )

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -348,4 +348,9 @@ describe('ProtocolSetup', () => {
     getByRole('button', { name: 'play' }).click()
     getByText('mock ConfirmAttachedModal')
   })
+  it('should render a loading skeleton while awaiting a response from the server', () => {
+    mockUseMostRecentCompletedAnalysis.mockReturnValue(null)
+    const [{ getAllByTestId }] = render(`/runs/${RUN_ID}/setup/`)
+    expect(getAllByTestId('Skeleton').length).toBeGreaterThan(0)
+  })
 })

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -154,9 +154,13 @@ export function ProtocolSetupStep({
             {subDetail}
           </StyledText>
         </Flex>
-        {disabled ? null : (
-          <Icon marginLeft={SPACING.spacing8} name="more" size="3rem" />
-        )}
+        <Icon
+          marginLeft={SPACING.spacing8}
+          name="more"
+          size="3rem"
+          // Required to prevent inconsistent component height.
+          style={{ backgroundColor: disabled ? 'transparent' : 'initial' }}
+        />
       </Flex>
     </Btn>
   )
@@ -299,7 +303,7 @@ function PrepareToRun({
   const observer = new IntersectionObserver(([entry]) => {
     setIsScrolled(!entry.isIntersecting)
   })
-  if (scrollRef.current) {
+  if (scrollRef.current != null) {
     observer.observe(scrollRef.current)
   }
 

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -377,17 +377,21 @@ function PrepareToRun({
     (protocolHasModules && attachedModules == null) ||
     allPipettesCalibrationData == null
 
-  const areInstrumentsReady = !isLoading
-    ? getAreInstrumentsReady(
-        mostRecentAnalysis!,
-        attachedInstruments!,
-        allPipettesCalibrationData!
-      )
-    : false
-  const speccedInstrumentCount = !isLoading
-    ? mostRecentAnalysis!.pipettes.length +
-      (getProtocolUsesGripper(mostRecentAnalysis!) ? 1 : 0)
-    : 0
+  const areInstrumentsReady =
+    mostRecentAnalysis != null &&
+    attachedInstruments != null &&
+    allPipettesCalibrationData != null
+      ? getAreInstrumentsReady(
+          mostRecentAnalysis,
+          attachedInstruments,
+          allPipettesCalibrationData
+        )
+      : false
+  const speccedInstrumentCount =
+    mostRecentAnalysis !== null
+      ? mostRecentAnalysis.pipettes.length +
+        (getProtocolUsesGripper(mostRecentAnalysis) ? 1 : 0)
+      : 0
 
   const instrumentsDetail = t('instruments_connected', {
     count: speccedInstrumentCount,

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -249,7 +249,7 @@ const PLAY_BUTTON_STYLE = css`
 `
 interface PlayButtonProps {
   ready: boolean
-  onPlay: () => void
+  onPlay?: () => void
   disabled?: boolean
 }
 
@@ -519,7 +519,7 @@ function PrepareToRun({
             />
             <PlayButton
               disabled={isLoading}
-              onPlay={!isLoading ? onPlay : () => {}}
+              onPlay={!isLoading ? onPlay : undefined}
               ready={!isLoading ? isReadyToRun : false}
             />
           </Flex>
@@ -573,7 +573,7 @@ function PrepareToRun({
               detail={labwareDetail}
               subDetail={labwareSubDetail}
               status="general"
-              disabled={labwareDetail === null}
+              disabled={labwareDetail == null}
             />
             <ProtocolSetupStep
               onClickSetupStep={() => setSetupScreen('liquids')}

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -491,7 +491,7 @@ function PrepareToRun({
             gridGap={SPACING.spacing2}
             maxWidth="43rem"
           >
-            {isLoading ? (
+            {!isLoading ? (
               <>
                 <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightBold}>
                   {t('prepare_to_run')}
@@ -531,7 +531,7 @@ function PrepareToRun({
         gridGap={SPACING.spacing8}
         paddingX={SPACING.spacing8}
       >
-        {isLoading ? (
+        {!isLoading ? (
           <>
             <ProtocolSetupStep
               onClickSetupStep={() => setSetupScreen('instruments')}

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -38,7 +38,10 @@ import {
 } from '@opentrons/shared-data'
 
 import { StyledText } from '../../../atoms/text'
-import { Skeleton } from '../../../atoms/Skeleton'
+import {
+  ProtocolSetupTitleSkeleton,
+  ProtocolSetupStepSkeleton,
+} from '../../../organisms/OnDeviceDisplay/ProtocolSetup'
 import { ODD_FOCUS_VISIBLE } from '../../../atoms/buttons/constants'
 import { useMaintenanceRunTakeover } from '../../../organisms/TakeoverModal'
 import {
@@ -367,23 +370,25 @@ function PrepareToRun({
     setShowConfirmCancelModal,
   ] = React.useState<boolean>(false)
 
-  if (
+  // True if any sever request is still pending.
+  const isLoading =
     mostRecentAnalysis == null ||
     attachedInstruments == null ||
     (protocolHasModules && attachedModules == null) ||
     allPipettesCalibrationData == null
-  ) {
-    return <ProtocolSetupSkeleton cancelAndClose={onConfirmCancelClose} />
-  }
 
-  const areInstrumentsReady = getAreInstrumentsReady(
-    mostRecentAnalysis,
-    attachedInstruments,
-    allPipettesCalibrationData
-  )
-  const speccedInstrumentCount =
-    mostRecentAnalysis.pipettes.length +
-    (getProtocolUsesGripper(mostRecentAnalysis) ? 1 : 0)
+  const areInstrumentsReady = !isLoading
+    ? getAreInstrumentsReady(
+        mostRecentAnalysis,
+        attachedInstruments,
+        allPipettesCalibrationData
+      )
+    : false
+  const speccedInstrumentCount = !isLoading
+    ? mostRecentAnalysis.pipettes.length +
+      (getProtocolUsesGripper(mostRecentAnalysis) ? 1 : 0)
+    : 0
+
   const instrumentsDetail = t('instruments_connected', {
     count: speccedInstrumentCount,
   })
@@ -482,29 +487,36 @@ function PrepareToRun({
             gridGap={SPACING.spacing2}
             maxWidth="43rem"
           >
-            <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightBold}>
-              {t('prepare_to_run')}
-            </StyledText>
-            <StyledText
-              as="h4"
-              color={COLORS.darkGreyEnabled}
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-              overflowWrap="anywhere"
-            >
-              {truncateString(protocolName as string, 100)}
-            </StyledText>
+            {!isLoading ? (
+              <>
+                <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightBold}>
+                  {t('prepare_to_run')}
+                </StyledText>
+                <StyledText
+                  as="h4"
+                  color={COLORS.darkGreyEnabled}
+                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                  overflowWrap="anywhere"
+                >
+                  {truncateString(protocolName as string, 100)}
+                </StyledText>
+              </>
+            ) : (
+              <ProtocolSetupTitleSkeleton />
+            )}
           </Flex>
           <Flex gridGap={SPACING.spacing16}>
-            <CloseButton onClose={() => setShowConfirmCancelModal(true)} />
-            <PlayButton
-              disabled={
-                mostRecentAnalysis == null ||
-                attachedInstruments == null ||
-                (protocolHasModules && attachedModules == null) ||
-                allPipettesCalibrationData == null
+            <CloseButton
+              onClose={
+                !isLoading
+                  ? () => setShowConfirmCancelModal(true)
+                  : onConfirmCancelClose
               }
-              onPlay={onPlay}
-              ready={isReadyToRun}
+            />
+            <PlayButton
+              disabled={isLoading}
+              onPlay={!isLoading ? onPlay : () => {}}
+              ready={!isLoading ? isReadyToRun : false}
             />
           </Flex>
         </Flex>
@@ -515,59 +527,67 @@ function PrepareToRun({
         gridGap={SPACING.spacing8}
         paddingX={SPACING.spacing8}
       >
-        <ProtocolSetupStep
-          onClickSetupStep={() => setSetupScreen('instruments')}
-          title={t('instruments')}
-          detail={instrumentsDetail}
-          status={instrumentsStatus}
-          disabled={speccedInstrumentCount === 0}
-        />
-        <ProtocolSetupStep
-          onClickSetupStep={() => setSetupScreen('modules')}
-          title={t('modules')}
-          detail={modulesDetail}
-          status={modulesStatus}
-          disabled={protocolModulesInfo.length === 0}
-        />
-        <ProtocolSetupStep
-          onClickSetupStep={() => {
-            setODDMaintenanceFlowInProgress()
-            launchLPC()
-          }}
-          title={t('labware_position_check')}
-          detail={t(
-            lpcDisabledReason != null ? 'currently_unavailable' : 'recommended'
-          )}
-          subDetail={
-            latestCurrentOffsets.length > 0
-              ? t('offsets_applied', { count: latestCurrentOffsets.length })
-              : null
-          }
-          status="general"
-          disabled={lpcDisabledReason != null}
-          disabledReason={lpcDisabledReason}
-        />
-        <ProtocolSetupStep
-          onClickSetupStep={() => setSetupScreen('labware')}
-          title={t('labware')}
-          detail={labwareDetail}
-          subDetail={labwareSubDetail}
-          status="general"
-          disabled={labwareDetail === null}
-        />
-        <ProtocolSetupStep
-          onClickSetupStep={() => setSetupScreen('liquids')}
-          title={t('liquids')}
-          status="general"
-          detail={
-            liquidsInProtocol.length > 0
-              ? t('initial_liquids_num', {
-                  count: liquidsInProtocol.length,
-                })
-              : t('liquids_not_in_setup')
-          }
-          disabled={liquidsInProtocol.length === 0}
-        />
+        {!isLoading ? (
+          <>
+            <ProtocolSetupStep
+              onClickSetupStep={() => setSetupScreen('instruments')}
+              title={t('instruments')}
+              detail={instrumentsDetail}
+              status={instrumentsStatus}
+              disabled={speccedInstrumentCount === 0}
+            />
+            <ProtocolSetupStep
+              onClickSetupStep={() => setSetupScreen('modules')}
+              title={t('modules')}
+              detail={modulesDetail}
+              status={modulesStatus}
+              disabled={protocolModulesInfo.length === 0}
+            />
+            <ProtocolSetupStep
+              onClickSetupStep={() => {
+                setODDMaintenanceFlowInProgress()
+                launchLPC()
+              }}
+              title={t('labware_position_check')}
+              detail={t(
+                lpcDisabledReason != null
+                  ? 'currently_unavailable'
+                  : 'recommended'
+              )}
+              subDetail={
+                latestCurrentOffsets.length > 0
+                  ? t('offsets_applied', { count: latestCurrentOffsets.length })
+                  : null
+              }
+              status="general"
+              disabled={lpcDisabledReason != null}
+              disabledReason={lpcDisabledReason}
+            />
+            <ProtocolSetupStep
+              onClickSetupStep={() => setSetupScreen('labware')}
+              title={t('labware')}
+              detail={labwareDetail}
+              subDetail={labwareSubDetail}
+              status="general"
+              disabled={labwareDetail === null}
+            />
+            <ProtocolSetupStep
+              onClickSetupStep={() => setSetupScreen('liquids')}
+              title={t('liquids')}
+              status="general"
+              detail={
+                liquidsInProtocol.length > 0
+                  ? t('initial_liquids_num', {
+                      count: liquidsInProtocol.length,
+                    })
+                  : t('liquids_not_in_setup')
+              }
+              disabled={liquidsInProtocol.length === 0}
+            />
+          </>
+        ) : (
+          <ProtocolSetupStepSkeleton />
+        )}
       </Flex>
       {LPCWizard}
       {showConfirmCancelModal ? (
@@ -656,35 +676,5 @@ export function ProtocolSetup(): JSX.Element {
         {setupComponentByScreen[setupScreen]}
       </Flex>
     </>
-  )
-}
-
-interface ProtocolSetupSkeletonProps {
-  cancelAndClose: () => void
-}
-function ProtocolSetupSkeleton(props: ProtocolSetupSkeletonProps): JSX.Element {
-  return (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
-      gridGap={SPACING.spacing40}
-      marginTop={SPACING.spacing40}
-    >
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-        <Flex flexDirection={DIRECTION_COLUMN} gridGap="0.25rem">
-          <Skeleton height="2rem" width="7rem" backgroundSize="64rem" />
-          <Skeleton height="2rem" width="28rem" backgroundSize="64rem" />
-        </Flex>
-        <Flex gridGap={SPACING.spacing24}>
-          <CloseButton onClose={() => props.cancelAndClose()} />
-          <PlayButton onPlay={() => {}} ready={false} />
-        </Flex>
-      </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-        <Skeleton height="6rem" width="100%" backgroundSize="64rem" />
-        <Skeleton height="6rem" width="100%" backgroundSize="64rem" />
-        <Skeleton height="6rem" width="100%" backgroundSize="64rem" />
-        <Skeleton height="6rem" width="100%" backgroundSize="64rem" />
-      </Flex>
-    </Flex>
   )
 }

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -379,14 +379,14 @@ function PrepareToRun({
 
   const areInstrumentsReady = !isLoading
     ? getAreInstrumentsReady(
-        mostRecentAnalysis,
-        attachedInstruments,
-        allPipettesCalibrationData
+        mostRecentAnalysis!,
+        attachedInstruments!,
+        allPipettesCalibrationData!
       )
     : false
   const speccedInstrumentCount = !isLoading
-    ? mostRecentAnalysis.pipettes.length +
-      (getProtocolUsesGripper(mostRecentAnalysis) ? 1 : 0)
+    ? mostRecentAnalysis!.pipettes.length +
+      (getProtocolUsesGripper(mostRecentAnalysis!) ? 1 : 0)
     : 0
 
   const instrumentsDetail = t('instruments_connected', {
@@ -487,7 +487,7 @@ function PrepareToRun({
             gridGap={SPACING.spacing2}
             maxWidth="43rem"
           >
-            {!isLoading ? (
+            {isLoading ? (
               <>
                 <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightBold}>
                   {t('prepare_to_run')}
@@ -527,7 +527,7 @@ function PrepareToRun({
         gridGap={SPACING.spacing8}
         paddingX={SPACING.spacing8}
       >
-        {!isLoading ? (
+        {isLoading ? (
           <>
             <ProtocolSetupStep
               onClickSetupStep={() => setSetupScreen('instruments')}


### PR DESCRIPTION
closes RQA-1235 and RAUT-466
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This PR addresses loading state skeletons/fixes/refactoring to the protocol routes.

### ProtocolDetails Route
Adds new loading skeleton to ProtocolDetails route. Adds a spinner to the Start Setup when clicked.

**New Skeleton**

![protocolDetailsSkeleton](https://github.com/Opentrons/opentrons/assets/64858653/8d07d2d0-44cd-4252-9110-e79b11b9592d)
**Make Setup Spinner**
![makeSetupSpinner](https://github.com/Opentrons/opentrons/assets/64858653/f6bbd82e-af1a-405a-9150-28802c85acec)
### ProtocolSetup
Fixes jitter/styling errors with the ProtocolSetup route skeleton to better match existing page components and adds missing testing to the skeleton. Fixes ProtocolSetupStep button sizing issues when enabled/disabled.
**Updated Skeleton**
![updated skeleton](https://github.com/Opentrons/opentrons/assets/64858653/11c0cfb4-b558-45c4-8033-f1c73537e1f7)
**Consistent Button Sizing**
![sizing](https://github.com/Opentrons/opentrons/assets/64858653/560ea3b8-27c3-41d3-bc0e-2014493d0ce1)

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

ProtocolDetails Skeleton
1. Upload a new protocol and click it (ProtocolDetails route).
2. If loading occurs, there should be a skeleton, and the Make Setup button should be disabled.
3. After loading completes, the skeleton should disappear and the make setup button should be selectable.
4. Click Make Setup - there should be a spinner until the redirect occurs.

ProtocolSetup Skeleton
1. If any loading occurs on this page, there should be a skeleton. No jittering should occur. 
2. Disabled setup buttons should be the same size as enabled buttons.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Created ProtocolDetailsSkeleton and testing.
- ProtocolSetupSkeleton refactored to own file and testing added.
- Refactored props within ProtocolDetails to interfaces to promote consistency.
- Added loading spinner on Make Setup button.
- Added a transparent icon in ProtocolSetup for the ProtocolSetupStep buttons.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
