### PR TITLE
feat(shared-data): Modify shared data to support low volume on the p50

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -200,8 +200,6 @@ class PipetteHandlerProvider(Generic[MountType]):
         if instr:
             configs = [
                 "name",
-                "min_volume",
-                "max_volume",
                 "aspirate_flow_rate",
                 "dispense_flow_rate",
                 "pipette_id",
@@ -254,6 +252,8 @@ class PipetteHandlerProvider(Generic[MountType]):
                 alvl: self.plunger_speed(instr, fr, "aspirate")
                 for alvl, fr in instr.aspirate_flow_rates_lookup.items()
             }
+            result["min_volume"] = instr.volumes.min_volume
+            result["max_volume"] = instr.volumes.max_volume
         return cast(PipetteDict, result)
 
     @property
@@ -451,13 +451,13 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plunger_speed(
         self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.config.max_volume, action)
+        mm_per_s = ul_per_s / instr.ul_per_mm(instr.volumes.max_volume, action)
         return round(mm_per_s, 6)
 
     def plunger_flowrate(
         self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
+        ul_per_s = mm_per_s * instr.ul_per_mm(instr.volumes.max_volume, action)
         return round(ul_per_s, 6)
 
     @overload

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -212,8 +212,6 @@ class PipetteHandlerProvider:
         if instr:
             configs = [
                 "name",
-                "min_volume",
-                "max_volume",
                 "aspirate_flow_rate",
                 "dispense_flow_rate",
                 "pipette_id",
@@ -268,6 +266,8 @@ class PipetteHandlerProvider:
             result[
                 "default_blow_out_volume"
             ] = instr.active_tip_settings.default_blowout_volume
+            result["min_volume"] = instr.volumes.min_volume
+            result["max_volume"] = instr.volumes.max_volume
         return cast(PipetteDict, result)
 
     @property
@@ -462,13 +462,13 @@ class PipetteHandlerProvider:
     def plunger_speed(
         self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.config.max_volume, action)
+        mm_per_s = ul_per_s / instr.ul_per_mm(instr.volumes.max_volume, action)
         return round(mm_per_s, 6)
 
     def plunger_flowrate(
         self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
+        ul_per_s = mm_per_s * instr.ul_per_mm(instr.volumes.max_volume, action)
         return round(ul_per_s, 6)
 
     def plunger_acceleration(self, instr: Pipette, ul_per_s_per_s: float) -> float:

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -45,13 +45,13 @@ def get_virtual_pipette_static_config(
     )
 
     tip_configuration = config.supported_tips[
-        pip_types.PipetteTipType(config.max_volume)
+        pip_types.PipetteTipType(config.volume_breakpoints.default.max_volume)
     ]
     return LoadedStaticPipetteData(
         model=str(pipette_model),
         display_name=config.display_name,
-        min_volume=config.min_volume,
-        max_volume=config.max_volume,
+        min_volume=config.volume_breakpoints.default.min_volume,
+        max_volume=config.volume_breakpoints.default.max_volume,
         channels=config.channels,
         home_position=config.mount_configurations.homePosition,
         nozzle_offset_z=config.nozzle_offset[2],

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -376,10 +376,10 @@ def test_use_filter_tips(ctx, get_labware_def):
     instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
     pipette: Pipette = ctx._core.get_hardware().hardware_instruments[mount]
 
-    assert pipette.available_volume == pipette.config.max_volume
+    assert pipette.available_volume == pipette.volumes.max_volume
 
     instr.pick_up_tip()
-    assert pipette.available_volume < pipette.config.max_volume
+    assert pipette.available_volume < pipette.volumes.max_volume
 
 
 @pytest.mark.parametrize("pipette_model", ["p10_single", "p20_single_gen2"])

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -286,10 +286,10 @@ class CheckCalibrationUserFlow:
                 info = PipetteInfo(
                     channels=pip.config.channels,
                     rank=PipetteRank.first,
-                    max_volume=pip.config.max_volume,
+                    max_volume=pip.volumes.max_volume,
                     mount=mount,
                     tip_rack=self._get_tiprack_by_pipette_volume(
-                        pip.config.max_volume, pip_calibration
+                        pip.volumes.max_volume, pip_calibration
                     ),
                     default_tipracks=uf.get_default_tipracks(
                         pip.config.default_tipracks
@@ -303,26 +303,26 @@ class CheckCalibrationUserFlow:
         l_calibration = self._get_stored_pipette_offset_cal(left_pip, Mount.LEFT)
         r_info = PipetteInfo(
             channels=right_pip.config.channels,
-            max_volume=right_pip.config.max_volume,
+            max_volume=right_pip.volumes.max_volume,
             rank=PipetteRank.first,
             mount=Mount.RIGHT,
             tip_rack=self._get_tiprack_by_pipette_volume(
-                right_pip.config.max_volume, r_calibration
+                right_pip.volumes.max_volume, r_calibration
             ),
             default_tipracks=uf.get_default_tipracks(right_pip.config.default_tipracks),
         )
         l_info = PipetteInfo(
             channels=left_pip.config.channels,
-            max_volume=left_pip.config.max_volume,
+            max_volume=left_pip.volumes.max_volume,
             rank=PipetteRank.first,
             mount=Mount.LEFT,
             tip_rack=self._get_tiprack_by_pipette_volume(
-                left_pip.config.max_volume, l_calibration
+                left_pip.volumes.max_volume, l_calibration
             ),
             default_tipracks=uf.get_default_tipracks(left_pip.config.default_tipracks),
         )
         if (
-            left_pip.config.max_volume > right_pip.config.max_volume
+            left_pip.volumes.max_volume > right_pip.volumes.max_volume
             or right_pip.config.channels > left_pip.config.channels
         ):
             r_info.rank = PipetteRank.second

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -209,7 +209,7 @@ class DeckCalibrationUserFlow:
 
         right_pip = pips[Mount.RIGHT]
         left_pip = pips[Mount.LEFT]
-        if right_pip.config.max_volume == left_pip.config.max_volume:
+        if right_pip.volumes.max_volume == left_pip.volumes.max_volume:
             if right_pip.config.channels == left_pip.config.channels:
                 return right_pip, Mount.RIGHT
             else:
@@ -220,7 +220,7 @@ class DeckCalibrationUserFlow:
         else:
             return sorted(
                 [(right_pip, Mount.RIGHT), (left_pip, Mount.LEFT)],
-                key=lambda p_m: p_m[0].config.max_volume,
+                key=lambda p_m: p_m[0].volumes.max_volume,
             )[0]
 
     def _get_tip_rack_lw(
@@ -231,7 +231,7 @@ class DeckCalibrationUserFlow:
                 tiprack_definition, self._deck.position_for(TIP_RACK_SLOT)
             )
         else:
-            pip_vol = self._hw_pipette.config.max_volume
+            pip_vol = self._hw_pipette.volumes.max_volume
             lw_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
             return labware.load(lw_load_name, self._deck.position_for(TIP_RACK_SLOT))
 

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -215,7 +215,7 @@ class PipetteOffsetCalibrationUserFlow:
         self._has_calibration_block = hasBlock
 
     def _get_tip_rack_lw(self) -> labware.Labware:
-        pip_vol = self._hw_pipette.config.max_volume
+        pip_vol = self._hw_pipette.volumes.max_volume
         lw_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
         return labware.load(lw_load_name, self._deck.position_for(TIP_RACK_SLOT))
 
@@ -380,7 +380,7 @@ class PipetteOffsetCalibrationUserFlow:
         self._using_default_tiprack, self._tip_rack = self._get_tr_lw(
             tip_rack_def,
             existing_calibration,
-            self._hw_pipette.config.max_volume,
+            self._hw_pipette.volumes.max_volume,
             self._deck.position_for(TIP_RACK_SLOT),
         )
         if self._deck[TIP_RACK_SLOT]:

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -244,7 +244,7 @@ class TipCalibrationUserFlow:
     ) -> labware.Labware:
         position = self._deck.position_for(TIP_RACK_SLOT)
         if tip_rack_def is None:
-            pip_vol = self._hw_pipette.config.max_volume
+            pip_vol = self._hw_pipette.volumes.max_volume
             tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
             return labware.load(tr_load_name, position)
         try:
@@ -253,7 +253,7 @@ class TipCalibrationUserFlow:
             raise RobotServerError(definition=CalibrationError.BAD_LABWARE_DEF)
 
     def _get_alt_tip_racks(self) -> Set[str]:
-        pip_vol = self._hw_pipette.config.max_volume
+        pip_vol = self._hw_pipette.volumes.max_volume
         return set(TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].alternatives)
 
     def _initialize_deck(self):

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": -1.0,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 0.5,
+    "bottomLowVolume": 0.5,
     "blowout": -2.5,
     "drop": -5.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": -1.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": -1.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": -1.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 91.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_5.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 91.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -8.5,
+    "bottomLowVolume": -8.5,
     "blowout": -13.0,
     "drop": -31.6
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -8.5,
+    "bottomLowVolume": -8.5,
     "blowout": -13.0,
     "drop": -31.6
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.5,
+    "bottomLowVolume": 3.5,
     "blowout": 3.0,
     "drop": -2.0
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.5,
+    "bottomLowVolume": 3.5,
     "blowout": 1.5,
     "drop": -3.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.5,
+    "bottomLowVolume": 3.5,
     "blowout": 1.5,
     "drop": -3.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.5,
+    "bottomLowVolume": 3.5,
     "blowout": 1.5,
     "drop": -3.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -14.5,
+    "bottomLowVolume": -14.5,
     "blowout": -19.0,
     "drop": -33.4
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -14.5,
+    "bottomLowVolume": -14.5,
     "blowout": -19.0,
     "drop": -33.4
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.5,
+    "bottomLowVolume": 2.5,
     "blowout": 2.0,
     "drop": -3.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": 0.5,
     "drop": -5.0
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": 0.5,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": 0.5,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 92.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 91.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 91.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 91.5
   },

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 91.5
   },

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0,
     "bottom": 66,
+    "bottomLowVolume": 66,
     "blowout": 71,
     "drop": 80
   },

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0,
     "bottom": 66,
+    "bottomLowVolume": 66,
     "blowout": 71,
     "drop": 80
   },

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0,
     "bottom": 66,
+    "bottomLowVolume": 66,
     "blowout": 71,
     "drop": 80
   },

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
@@ -22,6 +22,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 68.5,
+    "bottomLowVolume": 68.5,
     "blowout": 73.5,
     "drop": 80
   },

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
@@ -22,6 +22,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 68.5,
+    "bottomLowVolume": 68.5,
     "blowout": 73.5,
     "drop": 80
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": -1.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 0.5,
+    "bottomLowVolume": 0.5,
     "blowout": -2.5,
     "drop": -6.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.5,
+    "bottomLowVolume": 2.5,
     "blowout": -0.5,
     "drop": -5.2
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.5,
+    "bottomLowVolume": 2.5,
     "blowout": -0.5,
     "drop": -5.2
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.0,
+    "bottomLowVolume": 3.0,
     "blowout": 1.0,
     "drop": -2.2
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.5,
+    "bottomLowVolume": 2.5,
     "blowout": 0.5,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.5,
+    "bottomLowVolume": 2.5,
     "blowout": 0.5,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.5,
+    "bottomLowVolume": 2.5,
     "blowout": 0.5,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -18.5,
+    "bottomLowVolume": -18.5,
     "blowout": -23.0,
     "drop": -37.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -18.5,
+    "bottomLowVolume": -18.5,
     "blowout": -23.0,
     "drop": -37.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -18.5,
+    "bottomLowVolume": -18.5,
     "blowout": -23.0,
     "drop": -37.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_5.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -8.5,
+    "bottomLowVolume": -8.5,
     "blowout": -13.0,
     "drop": -27.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -8.5,
+    "bottomLowVolume": -8.5,
     "blowout": -13.0,
     "drop": -27.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -8.5,
+    "bottomLowVolume": -8.5,
     "blowout": -13.0,
     "drop": -27.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 1.5,
+    "bottomLowVolume": 1.5,
     "blowout": 0.0,
     "drop": -4.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 1.5,
+    "bottomLowVolume": 1.5,
     "blowout": -1.5,
     "drop": -5.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.0,
+    "bottomLowVolume": 3.0,
     "blowout": 0.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 3.0,
+    "bottomLowVolume": 3.0,
     "blowout": 0.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -14.5,
+    "bottomLowVolume": -14.5,
     "blowout": -19.0,
     "drop": -37.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": -14.5,
+    "bottomLowVolume": -14.5,
     "blowout": -19.0,
     "drop": -37.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.01,
+    "bottomLowVolume": 2.01,
     "blowout": 2.0,
     "drop": -4.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": 0.5,
     "drop": -6.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
@@ -21,6 +21,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": 0.5,
     "drop": -5.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
@@ -23,6 +23,7 @@
   "plungerPositionsConfigurations": {
     "top": 19.5,
     "bottom": 2.0,
+    "bottomLowVolume": 2.0,
     "blowout": 0.5,
     "drop": -5.0
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.5,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_5.json
@@ -15,7 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
-    "bottomLowVolume": 71.5,
+    "bottomLowVolume": 57.0,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_5.json
@@ -15,6 +15,7 @@
   "plungerPositionsConfigurations": {
     "top": 0.0,
     "bottom": 71.5,
+    "bottomLowVolume": 71.5,
     "blowout": 76.5,
     "drop": 90.5
   },

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_0.json
@@ -48,8 +48,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_3.json
@@ -48,8 +48,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_4.json
@@ -48,8 +48,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_5.json
@@ -39,8 +39,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_6.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p10/1_6.json
@@ -47,8 +47,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/1_0.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_0.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_3.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_4.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p1000/3_5.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p20/2_0.json
@@ -311,8 +311,16 @@
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 8.4,
     "opentrons/geb_96_tiprack_10ul/1": 8.3
   },
-  "maxVolume": 20,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_20ul/1",
     "opentrons/opentrons_96_filtertiprack_20ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p20/2_1.json
@@ -191,8 +191,16 @@
     "opentrons/opentrons_96_tiprack_20ul/1": 8.25,
     "opentrons/opentrons_96_filtertiprack_20ul/1": 8.25
   },
-  "maxVolume": 20,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_20ul/1",
     "opentrons/opentrons_96_filtertiprack_20ul/1",

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_0.json
@@ -66,8 +66,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_3.json
@@ -68,6 +68,16 @@
   },
   "maxVolume": 300,
   "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_4.json
@@ -66,8 +66,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p300/1_5.json
@@ -66,8 +66,16 @@
     "opentrons/tipone_96_tiprack_200ul/1": 6.1,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p300/2_0.json
@@ -193,8 +193,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2,
     "opentrons/opentrons_96_tiprack_300ul/1": 8.2
   },
-  "maxVolume": 300,
-  "minVolume": 20.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 200,
+      "minVolume": 20.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p300/2_1.json
@@ -195,6 +195,16 @@
   },
   "maxVolume": 300,
   "minVolume": 20.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_0.json
@@ -119,8 +119,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_3.json
@@ -119,8 +119,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_4.json
@@ -119,8 +119,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/1_5.json
@@ -109,8 +109,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_0.json
@@ -92,7 +92,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_0.json
@@ -95,10 +95,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_3.json
@@ -92,7 +92,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_3.json
@@ -95,10 +95,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_4.json
@@ -92,7 +92,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_4.json
@@ -95,10 +95,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_5.json
@@ -92,7 +92,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/3_5.json
@@ -95,10 +95,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/1_0.json
@@ -366,6 +366,16 @@
   },
   "maxVolume": 1000,
   "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_0.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_3.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_4.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/3_5.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_0.json
@@ -42,8 +42,16 @@
       "defaultBlowoutVolume": 2.356
     }
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipOverlapDictionary": {
     "default": 3.29,
     "opentrons/opentrons_96_tiprack_10ul/1": 3.29,

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_3.json
@@ -49,8 +49,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_4.json
@@ -49,8 +49,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p10/1_5.json
@@ -48,8 +48,16 @@
     "opentrons/geb_96_tiprack_10ul/1": 6.2,
     "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 1.0
   },
-  "maxVolume": 10,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 10,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_10ul/1",
     "opentrons/opentrons_96_filtertiprack_10ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_0.json
@@ -40,8 +40,16 @@
     "opentrons/geb_96_tiprack_1000ul/1": 11.2,
     "opentrons/eppendorf_96_tiprack_1000ul_eptips/1": 0.0
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_3.json
@@ -42,8 +42,16 @@
     "opentrons/geb_96_tiprack_1000ul/1": 11.2,
     "opentrons/eppendorf_96_tiprack_1000ul_eptips/1": 0.0
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_4.json
@@ -42,8 +42,16 @@
     "opentrons/geb_96_tiprack_1000ul/1": 11.2,
     "opentrons/eppendorf_96_tiprack_1000ul_eptips/1": 0.0
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/1_5.json
@@ -40,8 +40,16 @@
     "opentrons/geb_96_tiprack_1000ul/1": 11.2,
     "opentrons/eppendorf_96_tiprack_1000ul_eptips/1": 0.0
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/2_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/2_0.json
@@ -104,8 +104,16 @@
     "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
     "opentrons/geb_96_tiprack_1000ul/1": 9.5
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/2_1.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/2_1.json
@@ -106,8 +106,16 @@
     "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
     "opentrons/geb_96_tiprack_1000ul/1": 9.5
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/2_2.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/2_2.json
@@ -106,8 +106,16 @@
     "opentrons/opentrons_96_filtertiprack_1000ul/1": 11.5,
     "opentrons/geb_96_tiprack_1000ul/1": 9.5
   },
-  "maxVolume": 1000,
-  "minVolume": 100.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 100.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_1000ul/1",
     "opentrons/opentrons_96_filtertiprack_1000ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_0.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_3.json
@@ -364,8 +364,16 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_4.json
@@ -290,8 +290,16 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/3_5.json
@@ -242,8 +242,16 @@
     "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 1000,
-  "minVolume": 5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 1000,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p20/2_0.json
@@ -437,8 +437,16 @@
     "opentrons/opentrons_96_tiprack_20ul/1": 8.25,
     "opentrons/opentrons_96_filtertiprack_20ul/1": 8.25
   },
-  "maxVolume": 20,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_20ul/1",
     "opentrons/opentrons_96_filtertiprack_20ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p20/2_1.json
@@ -248,8 +248,16 @@
       "defaultBlowoutVolume": 3.534
     }
   },
-  "maxVolume": 20,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipOverlapDictionary": {
     "default": 8.25,
     "opentrons/opentrons_96_tiprack_10ul/1": 8.25,

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p20/2_2.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p20/2_2.json
@@ -317,8 +317,16 @@
     "opentrons/opentrons_96_tiprack_20ul/1": 8.25,
     "opentrons/opentrons_96_filtertiprack_20ul/1": 8.25
   },
-  "maxVolume": 20,
-  "minVolume": 1.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 20,
+      "minVolume": 1.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_20ul/1",
     "opentrons/opentrons_96_filtertiprack_20ul/1",

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_0.json
@@ -90,8 +90,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_3.json
@@ -90,8 +90,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_4.json
@@ -90,8 +90,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p300/1_5.json
@@ -74,8 +74,16 @@
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47,
     "opentrons/opentrons_96_tiprack_300ul/1": 7.47
   },
-  "maxVolume": 300,
-  "minVolume": 30.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 30.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p300/2_0.json
@@ -197,8 +197,16 @@
     "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2
   },
-  "maxVolume": 300,
-  "minVolume": 20.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p300/2_1.json
@@ -197,8 +197,16 @@
     "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2
   },
-  "maxVolume": 300,
-  "minVolume": 20.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 300,
+      "minVolume": 20.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_0.json
@@ -119,8 +119,16 @@
     "opentrons/tipone_96_tiprack_200ul/1": 6.1,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_3.json
@@ -119,8 +119,16 @@
     "opentrons/tipone_96_tiprack_200ul/1": 6.1,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_4.json
@@ -119,8 +119,16 @@
     "opentrons/tipone_96_tiprack_200ul/1": 6.1,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/1_5.json
@@ -107,8 +107,16 @@
     "opentrons/tipone_96_tiprack_200ul/1": 6.1,
     "opentrons/opentrons_96_filtertiprack_200ul/1": 7.47
   },
-  "maxVolume": 50,
-  "minVolume": 5.0,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 5.0
+    }
+  },
   "defaultTipracks": [
     "opentrons/opentrons_96_tiprack_300ul/1",
     "opentrons/opentrons_96_filtertiprack_200ul/1"

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_0.json
@@ -92,7 +92,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_0.json
@@ -95,10 +95,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_3.json
@@ -92,7 +92,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_3.json
@@ -95,10 +95,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_4.json
@@ -94,7 +94,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_4.json
@@ -97,10 +97,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_5.json
@@ -94,7 +94,15 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "volumeBreakpoints": {
+    "default": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    },
+    "bottomLowVolume": {
+      "maxVolume": 50,
+      "minVolume": 0.5
+    }
+  },
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/3_5.json
@@ -97,10 +97,10 @@
   "volumeBreakpoints": {
     "default": {
       "maxVolume": 50,
-      "minVolume": 0.5
+      "minVolume": 5
     },
     "bottomLowVolume": {
-      "maxVolume": 50,
+      "maxVolume": 45,
       "minVolume": 0.5
     }
   },

--- a/shared-data/python/opentrons_shared_data/pipette/load_data.py
+++ b/shared-data/python/opentrons_shared_data/pipette/load_data.py
@@ -157,6 +157,10 @@ def update_pipette_configuration(
                     # all tips.
                     for k in dict_of_base_model[new_names["top_level_name"]].keys():
                         dict_of_base_model[top_name][k][nested_name] = v
+                elif lookup_key == "minVolume" or lookup_key == "maxVolume":
+                    # TODO we should be able to update this value by
+                    # default or some other configuration value.
+                    dict_of_base_model[top_name]["default"][nested_name] = v
                 else:
                     # isinstances are needed for type checking.
                     dict_of_base_model[top_name][nested_name] = v

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -98,6 +98,8 @@ _MAP_KEY_TO_V2: Dict[str, Dict[str, str]] = {
     },
     "dropTipSpeed": {"top_level_name": "dropTipConfigurations", "nested_name": "speed"},
     "tipLength": {"top_level_name": "supportedTips", "nested_name": "defaultTipLength"},
+    "minVolume": {"top_level_name": "volumeBreakpoints", "nested_name": "minVolume"},
+    "maxVolume": {"top_level_name": "volumeBreakpoints", "nested_name": "maxVolume"},
 }
 
 

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -132,7 +132,7 @@ class PlungerPositions(BaseModel):
     bottom_low_volume: float = Field(
         ...,
         description="The plunger position required for certain pipettes to dispense low volumes. Most of the time, this value should match the bottom position.",
-        alias="bottomLowVolume"
+        alias="bottomLowVolume",
     )
     blow_out: float = Field(
         ...,
@@ -188,8 +188,10 @@ class PartialTipDefinition(BaseModel):
         alias="perTipPickupCurrent",
     )
 
+
 class Volumes(BaseModel):
     """A definition containing the min and max volume of a pipette for a given volume constraint."""
+
     max_volume: int = Field(
         ...,
         description="The maximum supported volume of the pipette.",
@@ -204,8 +206,15 @@ class Volumes(BaseModel):
 
 class VolumeBreakPointsDefinition(BaseModel):
     """A definition of changing volume configurations based on plunger position constraints."""
-    default: Volumes = Field(..., description="The default volume configuration for a pipette.")
-    bottom_low_volume : Volumes = Field(..., description="The volume constraint for bottom low volume position.", alias="bottomLowVolume")
+
+    default: Volumes = Field(
+        ..., description="The default volume configuration for a pipette."
+    )
+    bottom_low_volume: Volumes = Field(
+        ...,
+        description="The volume constraint for bottom low volume position.",
+        alias="bottomLowVolume",
+    )
 
 
 class PipettePhysicalPropertiesDefinition(BaseModel):
@@ -333,9 +342,7 @@ class PipetteLiquidPropertiesDefinition(BaseModel):
         alias="defaultTipracks",
     )
     volume_breakpoints: VolumeBreakPointsDefinition = Field(
-        ...,
-        description="",
-        alias="volumeBreakpoints"
+        ..., description="", alias="volumeBreakpoints"
     )
 
     @validator("supported_tips", pre=True)

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -188,6 +188,25 @@ class PartialTipDefinition(BaseModel):
         alias="perTipPickupCurrent",
     )
 
+class Volumes(BaseModel):
+    """A definition containing the min and max volume of a pipette for a given volume constraint."""
+    max_volume: int = Field(
+        ...,
+        description="The maximum supported volume of the pipette.",
+        alias="maxVolume",
+    )
+    min_volume: float = Field(
+        ...,
+        description="The minimum supported volume of the pipette.",
+        alias="minVolume",
+    )
+
+
+class VolumeBreakPointsDefinition(BaseModel):
+    """A definition of changing volume configurations based on plunger position constraints."""
+    default: Volumes = Field(..., description="The default volume configuration for a pipette.")
+    bottom_low_volume : Volumes = Field(..., description="The volume constraint for bottom low volume position.", alias="bottomLowVolume")
+
 
 class PipettePhysicalPropertiesDefinition(BaseModel):
     """The physical properties definition of a pipette."""
@@ -307,21 +326,16 @@ class PipetteLiquidPropertiesDefinition(BaseModel):
         description="The default tip overlap associated with this tip type.",
         alias="defaultTipOverlapDictionary",
     )
-    max_volume: int = Field(
-        ...,
-        description="The maximum supported volume of the pipette.",
-        alias="maxVolume",
-    )
-    min_volume: float = Field(
-        ...,
-        description="The minimum supported volume of the pipette.",
-        alias="minVolume",
-    )
     default_tipracks: List[str] = Field(
         ...,
         description="A list of default tiprack paths.",
         regex="opentrons/[a-z0-9._]+/[0-9]",
         alias="defaultTipracks",
+    )
+    volume_breakpoints: VolumeBreakPointsDefinition = Field(
+        ...,
+        description="",
+        alias="volumeBreakpoints"
     )
 
     @validator("supported_tips", pre=True)

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -129,6 +129,11 @@ class PlungerPositions(BaseModel):
         ...,
         description="The plunger position that describes min available volume of a pipette in mm.",
     )
+    bottom_low_volume: float = Field(
+        ...,
+        description="The plunger position required for certain pipettes to dispense low volumes. Most of the time, this value should match the bottom position.",
+        alias="bottomLowVolume"
+    )
     blow_out: float = Field(
         ...,
         description="The plunger position past 0 volume to blow out liquid.",


### PR DESCRIPTION
# Overview

Closes RSS-310 & RSS-311. This is the first step in [supporting low volumes](https://opentrons.atlassian.net/browse/RSS-309) on the p50s. Slight modification from the structure described in the [proposal doc](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3778609180/Flex+Low-Volume+Configuration). See the [comment](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3778609180/Flex+Low-Volume+Configuration#Shared-Data-and-Configuration) regarding this change.

# Test Plan

Throw on a robot and make sure things don't break, but should be fairly well tested.

# Changelog

You should be able to follow the commits for the changes.

- Add a new plunger position called `low_volume_bottom`
- Add a new parameter (and remove the top level keys) of min/max volume that changes based on the plunger position.

# Review requests

Maybe throw on a robot and make sure things are still functioning as expected when simulating a protocol.

# Risk assessment

Medium/low. Only changing how we access min/max volume currently.