### PR TITLE
build: robot builds for all release types

### DIFF
--- a/.github/workflows/start-flex-build.yaml
+++ b/.github/workflows/start-flex-build.yaml
@@ -1,11 +1,14 @@
-name: 'Start Internal-Release OT-2 build'
+name: 'Start Flex build'
 on:
   push:
     branches:
       - edge
       - '*internal-release*'
+      - 'release'
+      - 'chore_release*'
     tags:
       - ot3@*
+      - v*
   pull_request:
     types:
       - opened
@@ -16,21 +19,21 @@ jobs:
   handle-push:
     runs-on: 'ubuntu-latest'
     if: github.event_name == 'push'
-    name: "Start an OT-2 build for a branch/tag push"
+    name: "Start a Flex build for a branch/tag push"
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OT2_BUILD_CROSSREPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
-          repo: buildroot
-          workflow-id: build.yml
-          ref: opentrons-develop
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: main
           inputs: |
             {
-              "buildroot-ref": "-",
+              "oe-core-ref": "-",
               "monorepo-ref": "${{ github.ref }}",
               "infra-stage": "stage-prod"
             }
@@ -38,22 +41,22 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot2-build')
-    name: "Start an OT-2 build for a requested PR"
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
+    name: "Start a Flex build for a requested PR"
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OT2_BUILD_CROSSREPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
-          repo: buildroot
-          workflow-id: build.yml
-          ref: opentrons-develop
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: main
           inputs: |
             {
-              "buildroot-ref": "-",
+              "oe-core-ref": "-",
               "monorepo-ref": "refs/heads/${{ github.head_ref }}",
               "infra-stage": "stage-prod"
             }

--- a/.github/workflows/start-flex-build.yaml
+++ b/.github/workflows/start-flex-build.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - edge
       - '*internal-release*'
-      - 'release'
+      - 'release*'
       - 'chore_release*'
     tags:
       - ot3@*

--- a/.github/workflows/start-ot2-build.yaml
+++ b/.github/workflows/start-ot2-build.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - edge
       - '*internal-release*'
-      - 'release'
+      - 'release*'
       - 'chore_release*'
     tags:
       - ot3@*

--- a/.github/workflows/start-ot2-build.yaml
+++ b/.github/workflows/start-ot2-build.yaml
@@ -1,11 +1,14 @@
-name: 'Start Internal-Release OT-3 build'
+name: 'Start OT-2 build'
 on:
   push:
     branches:
       - edge
       - '*internal-release*'
+      - 'release'
+      - 'chore_release*'
     tags:
       - ot3@*
+      - v*
   pull_request:
     types:
       - opened
@@ -16,21 +19,21 @@ jobs:
   handle-push:
     runs-on: 'ubuntu-latest'
     if: github.event_name == 'push'
-    name: "Start an OT-3 build for a branch/tag push"
+    name: "Start an OT-2 build for a branch/tag push"
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.OT2_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
-          repo: oe-core
-          workflow-id: build-ot3-actions.yml
-          ref: main
+          repo: buildroot
+          workflow-id: build.yml
+          ref: opentrons-develop
           inputs: |
             {
-              "oe-core-ref": "-",
+              "buildroot-ref": "-",
               "monorepo-ref": "${{ github.ref }}",
               "infra-stage": "stage-prod"
             }
@@ -38,22 +41,22 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
-    name: "Start an OT-3 build for a requested PR"
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot2-build')
+    name: "Start an OT-2 build for a requested PR"
     steps:
       - name: 'start build'
         uses: octokit/request-action@v2.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.OT2_BUILD_CROSSREPO_ACCESS }}
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
           owner: opentrons
-          repo: oe-core
-          workflow-id: build-ot3-actions.yml
-          ref: main
+          repo: buildroot
+          workflow-id: build.yml
+          ref: opentrons-develop
           inputs: |
             {
-              "oe-core-ref": "-",
+              "buildroot-ref": "-",
               "monorepo-ref": "refs/heads/${{ github.head_ref }}",
               "infra-stage": "stage-prod"
             }

--- a/scripts/deploy/create-release.js
+++ b/scripts/deploy/create-release.js
@@ -177,6 +177,15 @@ async function createRelease(token, tag, project, version, changelog, deploy) {
   }
 }
 
+function truncateAndAnnotate(changelog, limit, prevtag, thistag) {
+  if (changelog.length < limit) {
+    return changelog
+  }
+  const truncated = changelog.substring(0, limit)
+  const linkmessage = `...and more! Log link: https://github.com/${REPO_DETAILS.owner}/${REPO_DETAILS.repo}/compare/${prevtag}...${thistag}`
+  return truncated + linkmessage
+}
+
 async function main() {
   const { args, flags } = parseArgs(process.argv.slice(2))
 
@@ -197,12 +206,18 @@ async function main() {
     currentVersion,
     previousVersion
   )
+  const truncatedChangelog = truncateAndAnnotate(
+    changelog,
+    10000,
+    prefixForProject(project) + previousVersion,
+    prefixForProject(project) + currentVersion
+  )
   return await createRelease(
     token,
     tag,
     project,
     currentVersion,
-    changelog,
+    truncatedChangelog,
     deploy
   )
 }

--- a/scripts/deploy/create-release.js
+++ b/scripts/deploy/create-release.js
@@ -178,11 +178,13 @@ async function createRelease(token, tag, project, version, changelog, deploy) {
 }
 
 function truncateAndAnnotate(changelog, limit, prevtag, thistag) {
-  if (changelog.length < limit) {
+  const linkmessage = `\n...and more! Log link: https://github.com/${REPO_DETAILS.owner}/${REPO_DETAILS.repo}/compare/${prevtag}...${thistag}`
+  const limitWithMessage = limit - linkmessage.length
+  if (changelog.length < limitWithMessage) {
     return changelog
   }
-  const truncated = changelog.substring(0, limit)
-  const linkmessage = `...and more! Log link: https://github.com/${REPO_DETAILS.owner}/${REPO_DETAILS.repo}/compare/${prevtag}...${thistag}`
+  const truncated = changelog.substring(0, limitWithMessage)
+
   return truncated + linkmessage
 }
 


### PR DESCRIPTION
Fix a couple build issues in the release branch:
- Some failures in the app yaml that were evident in the cold light of day, like incorrect glob patterns and bad step `if`s (this commit is in the release branch already unfortunately, you can see it here: https://github.com/Opentrons/opentrons/commit/59a588959c924567538bceb58bcfba00d0e3dec8 )
- robot builds actually need to be triggered on regular release branches and tags