### PR TITLE
fix(app): oDD Run Setup reflect calibration requirements

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useLPCDisabledReason.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useLPCDisabledReason.test.tsx
@@ -88,7 +88,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )
@@ -100,7 +100,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: true,
-          hasMissingPipCalForOdd: true,
+          hasMissingCalForOdd: true,
         }),
       { wrapper }
     )
@@ -128,7 +128,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: true,
+          hasMissingCalForOdd: true,
         }),
       { wrapper }
     )
@@ -150,7 +150,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: true,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )
@@ -177,7 +177,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )
@@ -201,7 +201,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )
@@ -227,7 +227,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )
@@ -256,7 +256,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )
@@ -283,7 +283,7 @@ describe('useLPCDisabledReason', () => {
         useLPCDisabledReason({
           runId: RUN_ID_1,
           hasMissingModulesForOdd: false,
-          hasMissingPipCalForOdd: false,
+          hasMissingCalForOdd: false,
         }),
       { wrapper }
     )

--- a/app/src/organisms/Devices/hooks/useLPCDisabledReason.tsx
+++ b/app/src/organisms/Devices/hooks/useLPCDisabledReason.tsx
@@ -14,7 +14,7 @@ interface LPCDisabledReasonProps {
   runId: string
   robotName?: string
   hasMissingModulesForOdd?: boolean
-  hasMissingPipCalForOdd?: boolean
+  hasMissingCalForOdd?: boolean
 }
 export function useLPCDisabledReason(
   props: LPCDisabledReasonProps
@@ -23,7 +23,7 @@ export function useLPCDisabledReason(
     runId,
     robotName,
     hasMissingModulesForOdd,
-    hasMissingPipCalForOdd,
+    hasMissingCalForOdd,
   } = props
   const { t } = useTranslation(['protocol_setup', 'shared'])
   const runHasStarted = useRunHasStarted(runId)
@@ -34,7 +34,7 @@ export function useLPCDisabledReason(
   )
 
   const isCalibrationComplete =
-    robotName != null ? complete : !hasMissingPipCalForOdd
+    robotName != null ? complete : !hasMissingCalForOdd
   const { missingModuleIds } = unmatchedModuleResults
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)

--- a/app/src/organisms/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ProtocolSetupInstruments/utils.ts
@@ -3,13 +3,7 @@ import type {
   LoadedPipette,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
-import {
-  AllPipetteOffsetCalibrations,
-  GripperData,
-  Instruments,
-  PipetteData,
-  PipetteOffsetCalibration,
-} from '@opentrons/api-client'
+import { GripperData, Instruments, PipetteData } from '@opentrons/api-client'
 
 export function getProtocolUsesGripper(
   analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput
@@ -49,23 +43,9 @@ export function getPipetteMatch(
   )
 }
 
-export function getCalibrationDataForPipetteMatch(
-  attachedPipetteMatch: PipetteData,
-  allPipettesCalibrationData: AllPipetteOffsetCalibrations
-): PipetteOffsetCalibration | null {
-  return (
-    allPipettesCalibrationData?.data.find(
-      cal =>
-        cal.mount === attachedPipetteMatch.mount &&
-        cal.pipette === attachedPipetteMatch.instrumentName
-    ) ?? null
-  )
-}
-
 export function getAreInstrumentsReady(
   analysis: CompletedProtocolAnalysis,
-  attachedInstruments: Instruments,
-  allPipettesCalibrationData: AllPipetteOffsetCalibrations
+  attachedInstruments: Instruments
 ): boolean {
   const speccedPipettes = analysis?.pipettes ?? []
   const allSpeccedPipettesReady = speccedPipettes.every(loadedPipette => {
@@ -73,18 +53,11 @@ export function getAreInstrumentsReady(
       loadedPipette,
       attachedInstruments
     )
-    // const calibrationData =
-    //   attachedPipetteMatch != null
-    //     ? getCalibrationDataForPipetteMatch(
-    //         attachedPipetteMatch,
-    //         allPipettesCalibrationData
-    //       )
-    //     : null
-    return attachedPipetteMatch != null // TODO: check for presence of calibration data once instruments endpoint
-    // returns calibration data for pipettes
+    return attachedPipetteMatch?.data.calibratedOffset.last_modified != null
   })
   const isExtensionMountReady = getProtocolUsesGripper(analysis)
-    ? getAttachedGripper(attachedInstruments) != null
+    ? getAttachedGripper(attachedInstruments)?.data.calibratedOffset
+        .last_modified != null
     : true
 
   return allSpeccedPipettesReady && isExtensionMountReady

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -28,7 +28,6 @@ import {
 import {
   useProtocolQuery,
   useRunQuery,
-  useAllPipetteOffsetCalibrationsQuery,
   useInstrumentsQuery,
 } from '@opentrons/react-api-client'
 import {
@@ -317,9 +316,6 @@ function PrepareToRun({
   })
 
   const { data: attachedInstruments } = useInstrumentsQuery()
-  const {
-    data: allPipettesCalibrationData,
-  } = useAllPipetteOffsetCalibrationsQuery()
   const protocolName =
     protocolRecord?.data.metadata.protocolName ??
     protocolRecord?.data.files[0].name
@@ -357,12 +353,16 @@ function PrepareToRun({
     attachedModules,
     protocolModulesInfo
   )
+  const areInstrumentsReady =
+    mostRecentAnalysis != null && attachedInstruments != null
+      ? getAreInstrumentsReady(mostRecentAnalysis, attachedInstruments)
+      : false
 
   const isMissingModules = missingModuleIds.length > 0
   const lpcDisabledReason = useLPCDisabledReason({
     runId,
     hasMissingModulesForOdd: isMissingModules,
-    hasMissingPipCalForOdd: allPipettesCalibrationData == null,
+    hasMissingCalForOdd: !areInstrumentsReady,
   })
 
   const [
@@ -374,19 +374,8 @@ function PrepareToRun({
   const isLoading =
     mostRecentAnalysis == null ||
     attachedInstruments == null ||
-    (protocolHasModules && attachedModules == null) ||
-    allPipettesCalibrationData == null
+    (protocolHasModules && attachedModules == null)
 
-  const areInstrumentsReady =
-    mostRecentAnalysis != null &&
-    attachedInstruments != null &&
-    allPipettesCalibrationData != null
-      ? getAreInstrumentsReady(
-          mostRecentAnalysis,
-          attachedInstruments,
-          allPipettesCalibrationData
-        )
-      : false
   const speccedInstrumentCount =
     mostRecentAnalysis !== null
       ? mostRecentAnalysis.pipettes.length +


### PR DESCRIPTION
fix RQA-1268

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Only show instrument section as "Ready" if all instruments are attached and calibrated
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Look at ODD Run Setup screen when one or more required instruments is not calibrated, see that the instruments card is yellow
2. Look at ODD Run Setup screen when all instruments are attached and calibrated, see that the instruments card is green

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Update `getAreInstrumentsReady` util to pull pipette calibration from InstrumentsData
2. Remove references to OT2 pipette cal endpoint from setup for run page

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look at test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
