### PR TITLE
fix(app): show robot moving loader when exiting gripper calibration

### DIFF
--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -26,6 +26,7 @@ interface MovePinProps extends GripperWizardStepProps, MovePinStep {
   setFrontJawOffset: (offset: Coordinates) => void
   frontJawOffset: Coordinates | null
   createRunCommand: CreateMaintenaceCommand
+  isExiting: boolean
 }
 
 export const MovePin = (props: MovePinProps): JSX.Element | null => {
@@ -39,6 +40,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
     createRunCommand,
     errorMessage,
     setErrorMessage,
+    isExiting,
   } = props
   const { t } = useTranslation(['gripper_wizard_flows', 'shared'])
 
@@ -215,7 +217,9 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
             ? inProgressText
             : t('shared:stand_back_robot_is_in_motion')
         }
-        alternativeSpinner={errorMessage == null ? inProgressImage : undefined}
+        alternativeSpinner={
+          errorMessage == null && !isExiting ? inProgressImage : undefined
+        }
       />
     )
   return errorMessage != null ? (

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -213,7 +213,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
     return (
       <InProgressModal
         description={
-          errorMessage == null
+          errorMessage == null && !isExiting
             ? inProgressText
             : t('shared:stand_back_robot_is_in_motion')
         }

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -170,4 +170,13 @@ describe('MovePin', () => {
     })[0]
     getByText('Stand Back, Robot is in Motion')
   })
+
+  it('renders correct loader for early exiting', () => {
+    const { getByText } = render({
+      isRobotMoving: true,
+      isExiting: true,
+      movement: MOVE_PIN_FROM_FRONT_JAW_TO_REAR_JAW,
+    })[0]
+    getByText('Stand Back, Robot is in Motion')
+  })
 })

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -47,6 +47,7 @@ describe('MovePin', () => {
           createRunCommand={mockCreateRunCommand}
           errorMessage={null}
           setErrorMessage={mockSetErrorMessage}
+          isExiting={false}
           {...props}
         />,
         { i18nInstance: i18n }

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -106,6 +106,7 @@ export function GripperWizardFlows(
       createRunCommand={createMaintenanceCommand}
       errorMessage={errorMessage}
       setErrorMessage={setErrorMessage}
+      isExiting={isExiting}
     />
   )
 }
@@ -122,6 +123,7 @@ interface GripperWizardProps {
   >
   isCreateLoading: boolean
   isRobotMoving: boolean
+  isExiting: boolean
   setErrorMessage: (message: string | null) => void
   errorMessage: string | null
   handleCleanUpAndClose: () => void
@@ -148,6 +150,7 @@ export const GripperWizard = (
     createRunCommand,
     setErrorMessage,
     errorMessage,
+    isExiting,
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('gripper_wizard_flows')
@@ -218,7 +221,7 @@ export const GripperWizard = (
       <MovePin
         {...currentStep}
         {...sharedProps}
-        {...{ setFrontJawOffset, frontJawOffset, createRunCommand }}
+        {...{ setFrontJawOffset, frontJawOffset, createRunCommand, isExiting }}
       />
     )
   } else if (currentStep.section === SECTIONS.MOUNT_GRIPPER) {


### PR DESCRIPTION
fix RQA-753

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When exiting a gripper flow from a pin attach/removal screen the wizard should display the "robot in motion" loader not the calibration in progress loader

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Early exit from gripper calibration on the attach, move, or remove probe screen and confirm you do not see the calibration in progress modal while exiting

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
If `isExiting` is true show the normal spinner
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Review test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
