### PR TITLE
refactor(api): hardware controller use error codes

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -14,7 +14,6 @@ from .api import API
 from .pause_manager import PauseManager
 from .backends import Controller, Simulator
 from .types import CriticalPoint, ExecutionState
-from .errors import ExecutionCancelledError, NoTipAttachedError, TipAttachedError
 from .constants import DROP_TIP_RELEASE_DISTANCE
 from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
@@ -48,13 +47,10 @@ __all__ = [
     "SynchronousAdapter",
     "HardwareControlAPI",
     "CriticalPoint",
-    "NoTipAttachedError",
-    "TipAttachedError",
     "DROP_TIP_RELEASE_DISTANCE",
     "ThreadManager",
     "ExecutionManager",
     "ExecutionState",
-    "ExecutionCancelledError",
     "ThreadedAsyncLock",
     "ThreadedAsyncForbidden",
     "ThreadManagedHardware",

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -763,7 +763,7 @@ class API(
             if fail_on_not_homed:
                 raise PositionUnknownError(
                     message="Cannot make a relative move because absolute position"
-                            " is unknown.",
+                    " is unknown.",
                     detail={
                         "mount": str(mount),
                         "fail_on_not_homed": fail_on_not_homed,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -601,10 +601,13 @@ class API(
         # No internal code passes OT3 axes as arguments on an OT2. But a user/ client
         # can still explicitly specify an OT3 axis even when working on an OT2.
         # Adding this check in order to prevent misuse of axes types.
-        if axes and any(axis not in Axis.ot2_axes() for axis in axes):
-            raise UnsupportedHardwareCommand(
-                message=f"At least one axis in {axes} is not supported on the OT2."
-            )
+        if axes:
+            unsupported = list(axis not in Axis.ot2_axes() for axis in axes)
+            if any(unsupported):
+                raise UnsupportedHardwareCommand(
+                    message=f"At least one axis in {axes} is not supported on the OT2.",
+                    detail={"unsupported_axes": unsupported},
+                )
         self._reset_last_mount()
         # Initialize/update current_position
         checked_axes = axes or [ax for ax in Axis.ot2_axes()]

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -145,11 +145,15 @@ class Controller:
         await self._smoothie_driver.update_position()
         return self._smoothie_driver.position
 
+    def _unhomed_axes(self, axes: Sequence[str]) -> List[str]:
+        return list(
+            axis
+            for axis in axes
+            if not self._smoothie_driver.homed_flags.get(axis, False)
+        )
+
     def is_homed(self, axes: Sequence[str]) -> bool:
-        for axis in axes:
-            if not self._smoothie_driver.homed_flags.get(axis, False):
-                return False
-        return True
+        return not any(self._unhomed_axes(axes))
 
     async def move(
         self,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1095,6 +1095,7 @@ class OT3Controller:
 
     @asynccontextmanager
     async def _monitor_overpressure(self, mounts: List[NodeId]) -> AsyncIterator[None]:
+        msg = "The pressure sensor on the {} mount has exceeded operational limits."
         if ff.overpressure_detection_enabled() and mounts:
             tools_with_id = map_pipette_type_to_sensor_id(
                 mounts, self._subsystem_manager.device_info
@@ -1120,7 +1121,10 @@ class OT3Controller:
                     q_msg = _pop_queue()
                     if q_msg:
                         mount = Axis.to_ot3_mount(node_to_axis(q_msg[0]))
-                        raise PipetteOverpressureError(str(mount))
+                        raise PipetteOverpressureError(
+                            message=msg.format(str(mount)),
+                            detail={"mount": mount},
+                        )
         else:
             yield
 

--- a/api/src/opentrons/hardware_control/backends/simulator.py
+++ b/api/src/opentrons/hardware_control/backends/simulator.py
@@ -187,11 +187,15 @@ class Simulator:
     async def update_position(self) -> Dict[str, float]:
         return self._position
 
+    def _unhomed_axes(self, axes: Sequence[str]) -> List[str]:
+        return list(
+            axis
+            for axis in axes
+            if not self._smoothie_driver.homed_flags.get(axis, False)
+        )
+
     def is_homed(self, axes: Sequence[str]) -> bool:
-        for axis in axes:
-            if not self._smoothie_driver.homed_flags.get(axis, False):
-                return False
-        return True
+        return not any(self._unhomed_axes(axes))
 
     @ensure_yield
     async def move(

--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     AsyncIterator,
     Union,
+    List,
 )
 
 from opentrons_hardware.hardware_control import network, tools
@@ -143,6 +144,10 @@ class SubsystemManager:
     @property
     def update_required(self) -> bool:
         return bool(self._updates_required)
+
+    @property
+    def subsystems_to_update(self) -> List[SubSystem]:
+        return [target_to_subsystem(t) for t in self._updates_required.keys()]
 
     async def start(self) -> None:
         await self._probe_network_and_cache_fw_updates(

--- a/api/src/opentrons/hardware_control/errors.py
+++ b/api/src/opentrons/hardware_control/errors.py
@@ -1,114 +1,43 @@
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
-from .types import OT3Mount
+from typing import Optional, Dict, Any
+from opentrons_shared_data.errors.exceptions import (
+    MotionPlanningFailureError,
+    InvalidInstrumentData,
+    RobotInUseError,
+)
 
 
-class OutOfBoundsMove(RuntimeError):
-    def __init__(self, message: str):
-        self.message = message
-        super().__init__()
-
-    def __str__(self) -> str:
-        return f"OutOfBoundsMove: {self.message}"
-
-    def __repr__(self) -> str:
-        return f"<{str(self.__class__)}: {self.message}>"
+class OutOfBoundsMove(MotionPlanningFailureError):
+    def __init__(self, message: str, detail: Dict[str, Any]):
+        super().__init__(message=message, detail=detail)
 
 
-class ExecutionCancelledError(RuntimeError):
-    pass
-
-
-class MustHomeError(RuntimeError):
-    pass
-
-
-class NoTipAttachedError(RuntimeError):
-    pass
-
-
-class TipAttachedError(RuntimeError):
-    pass
-
-
-class InvalidMoveError(ValueError):
-    pass
-
-
-class NotSupportedByHardware(ValueError):
-    """Error raised when attempting to use arguments and values not supported by the specific hardware."""
-
-
-class GripperNotAttachedError(Exception):
-    """An error raised if a gripper is accessed that is not attached."""
-
-    pass
-
-
-class AxisNotPresentError(Exception):
-    """An error raised if an axis that is not present."""
-
-    pass
-
-
-class FirmwareUpdateRequired(RuntimeError):
-    """An error raised when the firmware of the submodules needs to be updated."""
-
-    pass
-
-
-class FirmwareUpdateFailed(RuntimeError):
-    """An error raised when a firmware update fails."""
-
-    pass
-
-
-class OverPressureDetected(PipetteOverpressureError):
-    """An error raised when the pressure sensor max value is exceeded."""
-
-    def __init__(self, mount: str) -> None:
-        return super().__init__(
-            message=f"The pressure sensor on the {mount} mount has exceeded operational limits.",
-            detail={"mount": mount},
+class InvalidCriticalPoint(MotionPlanningFailureError):
+    def __init__(self, cp_name: str, instr: str, message: Optional[str] = None):
+        super().__init__(
+            message=(message or f"Critical point {cp_name} is invalid for a {instr}."),
+            detail={"instrument": instr, "critical point": cp_name},
         )
 
 
-class InvalidPipetteName(KeyError):
+class InvalidPipetteName(InvalidInstrumentData):
     """Raised for an invalid pipette."""
 
-    def __init__(self, name: int, mount: OT3Mount) -> None:
-        self.name = name
-        self.mount = mount
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: name={self.name} mount={self.mount}>"
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}: Pipette name key {self.name} on mount {self.mount.name} is not valid"
+    def __init__(self, name: int, mount: str) -> None:
+        super().__init__(
+            message=f"Invalid pipette name key {name} on mount {mount}",
+            detail={"mount": mount, "name": name},
+        )
 
 
-class InvalidPipetteModel(KeyError):
+class InvalidPipetteModel(InvalidInstrumentData):
     """Raised for a pipette with an unknown model."""
 
-    def __init__(self, name: str, model: str, mount: OT3Mount) -> None:
-        self.name = name
-        self.model = model
-        self.mount = mount
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: name={self.name}, model={self.model}, mount={self.mount}>"
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}: {self.name} on {self.mount.name} has an unknown model {self.model}"
+    def __init__(self, name: str, model: str, mount: str) -> None:
+        super().__init__(detail={"mount": mount, "name": name, "model": model})
 
 
-class UpdateOngoingError(RuntimeError):
+class UpdateOngoingError(RobotInUseError):
     """Error when an update is already happening."""
 
-    def __init__(self, msg: str) -> None:
-        self.msg = msg
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: msg={self.msg}>"
-
-    def __str__(self) -> str:
-        return self.msg
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 from typing import Set, TypeVar, Type, cast, Callable, Any, Awaitable, overload
 from .types import ExecutionState
-from .errors import ExecutionCancelledError
+from opentrons_shared_data.errors.exceptions import ExecutionCancelledError
 
 TaskContents = TypeVar("TaskContents")
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -45,7 +45,7 @@ from opentrons.hardware_control.types import (
     CriticalPoint,
     BoardRevision,
 )
-from opentrons.hardware_control.errors import InvalidMoveError
+from opentrons.hardware_control.errors import InvalidCriticalPoint
 
 
 from opentrons_shared_data.pipette.dev_types import (
@@ -331,9 +331,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             CriticalPoint.GRIPPER_FRONT_CALIBRATION_PIN,
             CriticalPoint.GRIPPER_REAR_CALIBRATION_PIN,
         ]:
-            raise InvalidMoveError(
-                f"Critical point {cp_override.name} is not valid for a pipette"
-            )
+            raise InvalidCriticalPoint(cp_override.name, "pipette")
 
         if not self.has_tip or cp_override == CriticalPoint.NOZZLE:
             cp_type = CriticalPoint.NOZZLE

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -17,6 +17,10 @@ from typing import (
 )
 import numpy
 
+from opentrons_shared_data.errors.exceptions import (
+    UnexpectedTipRemovalError,
+    UnexpectedTipAttachError,
+)
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction
 from opentrons_shared_data.pipette.types import Quirks
 from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
@@ -27,10 +31,6 @@ from opentrons.hardware_control.types import (
     HardwareAction,
     Axis,
     OT3Mount,
-)
-from opentrons.hardware_control.errors import (
-    TipAttachedError,
-    NoTipAttachedError,
 )
 from opentrons.hardware_control.constants import (
     SHAKE_OFF_TIPS_SPEED,
@@ -432,9 +432,11 @@ class PipetteHandlerProvider(Generic[MountType]):
             # configured such that the end of a p300 single gen1's tip is 0.
             return top_types.Point(0, 0, 30)
 
-    def ready_for_tip_action(self, target: Pipette, action: HardwareAction) -> None:
+    def ready_for_tip_action(
+        self, target: Pipette, action: HardwareAction, mount: MountType
+    ) -> None:
         if not target.has_tip:
-            raise NoTipAttachedError(f"Cannot perform {action} without a tip attached")
+            raise UnexpectedTipRemovalError(action.name, target.name, mount.name)
         if (
             action == HardwareAction.ASPIRATE
             and target.current_volume == 0
@@ -497,7 +499,7 @@ class PipetteHandlerProvider(Generic[MountType]):
         - Plunger distances (possibly calling an overridden plunger_volume)
         """
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.ASPIRATE)
+        self.ready_for_tip_action(instrument, HardwareAction.ASPIRATE, mount)
         if volume is None:
             self._ihp_log.debug(
                 "No aspirate volume defined. Aspirating up to "
@@ -579,7 +581,7 @@ class PipetteHandlerProvider(Generic[MountType]):
         """
 
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.DISPENSE)
+        self.ready_for_tip_action(instrument, HardwareAction.DISPENSE, mount)
 
         if volume is None:
             disp_vol = instrument.current_volume
@@ -660,7 +662,7 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plan_check_blow_out(self, mount):  # type: ignore[no-untyped-def]
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
+        self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT, mount)
         speed = self.plunger_speed(
             instrument, instrument.blow_out_flow_rate, "dispense"
         )
@@ -736,7 +738,7 @@ class PipetteHandlerProvider(Generic[MountType]):
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)
         if instrument.has_tip:
-            raise TipAttachedError("Cannot pick up tip with a tip attached")
+            raise UnexpectedTipAttachError("pick_up_tip", instrument.name, mount.name)
         self._ihp_log.debug(f"Picking up tip on {mount.name}")
 
         if presses is None or presses < 0:
@@ -894,7 +896,7 @@ class PipetteHandlerProvider(Generic[MountType]):
         home_after,
     ):
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.DROPTIP)
+        self.ready_for_tip_action(instrument, HardwareAction.DROPTIP, mount)
 
         bottom = instrument.plunger_positions.bottom
         droptip = instrument.plunger_positions.drop_tip

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -12,7 +12,9 @@ from opentrons.hardware_control.types import (
     CriticalPoint,
     GripperJawState,
 )
-from opentrons.hardware_control.errors import InvalidMoveError
+from opentrons.hardware_control.errors import (
+    InvalidCriticalPoint,
+)
 from .instrument_calibration import (
     GripperCalibrationOffset,
     load_gripper_calibration_offset,
@@ -20,6 +22,7 @@ from .instrument_calibration import (
 )
 from ..instrument_abc import AbstractInstrument
 from opentrons.hardware_control.dev_types import AttachedGripper, GripperDict
+from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
 
 from opentrons_shared_data.gripper import (
     GripperDefinition,
@@ -176,9 +179,21 @@ class Gripper(AbstractInstrument[GripperDefinition]):
 
     def check_calibration_pin_location_is_accurate(self) -> None:
         if not self.attached_probe:
-            raise RuntimeError("must attach a probe before starting calibration")
+            raise CommandPreconditionViolated(
+                "Cannot calibrate gripper without attaching a calibration probe",
+                detail={
+                    "probe": self._attached_probe,
+                    "jaw_state": self.state,
+                },
+            )
         if self.state != GripperJawState.GRIPPING:
-            raise RuntimeError("must grip the jaws before starting calibration")
+            raise CommandPreconditionViolated(
+                "Cannot calibrate gripper if jaw is not in gripping state",
+                detail={
+                    "probe": self._attached_probe,
+                    "jaw_state": self.state,
+                },
+            )
 
     def critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         """
@@ -186,9 +201,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         between the center of the gripper engagement volume and the calibration pins.
         """
         if cp_override in [CriticalPoint.NOZZLE, CriticalPoint.TIP]:
-            raise InvalidMoveError(
-                f"Critical point {cp_override.name} is not valid for a gripper"
-            )
+            raise InvalidCriticalPoint(cp_override.name, "gripper")
 
         if not self._attached_probe:
             cp = cp_override or CriticalPoint.GRIPPER_JAW_CENTER
@@ -215,7 +228,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
                 - Point(y=self.current_jaw_displacement)
             )
         else:
-            raise InvalidMoveError(f"Critical point {cp_override} is not valid")
+            raise InvalidCriticalPoint(cp.name, "gripper")
 
     def duty_cycle_by_force(self, newton: float) -> float:
         return gripper_config.duty_cycle_by_force(newton, self.grip_force_profile)

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -13,26 +13,15 @@ from opentrons.hardware_control.types import (
     GripperJawState,
     GripperProbe,
 )
-from opentrons.hardware_control.errors import (
-    InvalidMoveError,
-    GripperNotAttachedError,
+from opentrons.hardware_control.errors import InvalidCriticalPoint
+from opentrons_shared_data.errors.exceptions import (
+    GripperNotPresentError,
+    CommandPreconditionViolated,
 )
 from .gripper import Gripper
 
 
 MOD_LOG = logging.getLogger(__name__)
-
-
-class GripError(Exception):
-    """An error raised if a gripper action is blocked"""
-
-    pass
-
-
-class CalibrationError(Exception):
-    """An error raised if a gripper calibration is blocked"""
-
-    pass
 
 
 class GripperHandler:
@@ -48,8 +37,8 @@ class GripperHandler:
     def get_gripper(self) -> Gripper:
         gripper = self._gripper
         if not gripper:
-            raise GripperNotAttachedError(
-                "Cannot perform action without gripper attached"
+            raise GripperNotPresentError(
+                message="Cannot perform action without gripper attached"
             )
         return gripper
 
@@ -94,9 +83,13 @@ class GripperHandler:
 
     def get_critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         if not self._gripper:
-            raise GripperNotAttachedError()
+            raise GripperNotPresentError()
         if cp_override == CriticalPoint.MOUNT:
-            raise InvalidMoveError("The gripper mount may not be moved directly.")
+            raise InvalidCriticalPoint(
+                cp_override.name,
+                "gripper",
+                "The gripper mount may not be moved directly.",
+            )
         return self._gripper.critical_point(cp_override)
 
     def get_gripper_dict(self) -> Optional[GripperDict]:
@@ -132,11 +125,17 @@ class GripperHandler:
         gripper = self.get_gripper()
         gripper.check_calibration_pin_location_is_accurate()
 
-    def check_ready_for_jaw_move(self) -> None:
+    def check_ready_for_jaw_move(self, command: str) -> None:
         """Raise an exception if it is not currently valid to move the jaw."""
         gripper = self.get_gripper()
         if gripper.state == GripperJawState.UNHOMED:
-            raise GripError("Gripper jaw must be homed before moving")
+            raise CommandPreconditionViolated(
+                message=f"Cannot {command} gripper jaw before homing",
+                detail={
+                    "command": command,
+                    "jaw_state": gripper.state,
+                },
+            )
 
     def is_ready_for_idle(self) -> bool:
         """Gripper can idle when the jaw is not currently gripping."""

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -45,7 +45,7 @@ from opentrons_shared_data.pipette import (
     types as pip_types,
 )
 from opentrons.hardware_control.types import CriticalPoint, OT3Mount
-from opentrons.hardware_control.errors import InvalidMoveError
+from opentrons.hardware_control.errors import InvalidCriticalPoint
 
 mod_log = logging.getLogger(__name__)
 
@@ -321,9 +321,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             CriticalPoint.GRIPPER_FRONT_CALIBRATION_PIN,
             CriticalPoint.GRIPPER_REAR_CALIBRATION_PIN,
         ]:
-            raise InvalidMoveError(
-                f"Critical point {cp_override.name} is not valid for a pipette"
-            )
+            raise InvalidCriticalPoint(cp_override.name, "pipette")
         if not self.has_tip or cp_override == CriticalPoint.NOZZLE:
             cp_type = CriticalPoint.NOZZLE
             tip_length = 0.0

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -20,6 +20,8 @@ from opentrons_shared_data.pipette.dev_types import UlPerMmAction
 from opentrons_shared_data.errors.exceptions import (
     CommandPreconditionViolated,
     CommandParameterLimitViolated,
+    UnexpectedTipRemovalError,
+    UnexpectedTipAttachError,
 )
 from opentrons_shared_data.pipette.pipette_definition import (
     liquid_class_for_volume_between_default_and_defaultlowvolume,
@@ -31,10 +33,6 @@ from opentrons.hardware_control.types import (
     HardwareAction,
     Axis,
     OT3Mount,
-)
-from opentrons.hardware_control.errors import (
-    TipAttachedError,
-    NoTipAttachedError,
 )
 from opentrons.hardware_control.constants import (
     SHAKE_OFF_TIPS_SPEED,
@@ -487,9 +485,11 @@ class OT3PipetteHandler:
         else:
             return top_types.Point(0, 0, 0)
 
-    def ready_for_tip_action(self, target: Pipette, action: HardwareAction) -> None:
+    def ready_for_tip_action(
+        self, target: Pipette, action: HardwareAction, mount: OT3Mount
+    ) -> None:
         if not target.has_tip:
-            raise NoTipAttachedError(f"Cannot perform {action} without a tip attached")
+            raise UnexpectedTipRemovalError(str(action), target.name, mount.name)
         if (
             action == HardwareAction.ASPIRATE
             and target.current_volume == 0
@@ -545,7 +545,7 @@ class OT3PipetteHandler:
         - Plunger distances (possibly calling an overridden plunger_volume)
         """
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.ASPIRATE)
+        self.ready_for_tip_action(instrument, HardwareAction.ASPIRATE, mount)
         if volume is None:
             self._ihp_log.debug(
                 "No aspirate volume defined. Aspirating up to "
@@ -606,7 +606,7 @@ class OT3PipetteHandler:
         """
 
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.DISPENSE)
+        self.ready_for_tip_action(instrument, HardwareAction.DISPENSE, mount)
 
         if volume is None:
             disp_vol = instrument.current_volume
@@ -674,7 +674,7 @@ class OT3PipetteHandler:
     ) -> LiquidActionSpec:
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT)
+        self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT, mount)
         speed = self.plunger_speed(instrument, instrument.blow_out_flow_rate, "blowout")
         acceleration = self.plunger_acceleration(
             instrument, instrument.flow_acceleration
@@ -734,7 +734,7 @@ class OT3PipetteHandler:
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)
         if instrument.has_tip:
-            raise TipAttachedError("Cannot pick up tip with a tip attached")
+            raise UnexpectedTipAttachError("pick_up_tip", instrument.name, mount.name)
         self._ihp_log.debug(f"Picking up tip on {mount.name}")
 
         def add_tip_to_instr() -> None:
@@ -880,7 +880,7 @@ class OT3PipetteHandler:
         home_after: bool,
     ) -> Tuple[DropTipSpec, Callable[[], None]]:
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.DROPTIP)
+        self.ready_for_tip_action(instrument, HardwareAction.DROPTIP, mount)
 
         is_96_chan = instrument.channels == 96
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -890,15 +890,16 @@ class OT3API(
                 message=f"Cannot return position for {mount} if no gripper is attached",
                 detail={"mount": str(mount)},
             )
-
+        mount_axes = [Axis.X, Axis.Y, Axis.by_mount(mount)]
         if refresh:
             await self.refresh_positions()
         elif not self._current_position:
             raise PositionUnknownError(
-                message=f"Motor positions for {str(mount)} are missing; must first home motors.",
-                detail={"mount": str(mount)},
+                message=f"Motor positions for {str(mount)} mount are missing ("
+                f"{mount_axes}); must first home motors.",
+                detail={"mount": str(mount), "missing_axes": mount_axes},
             )
-        self._assert_motor_ok([Axis.X, Axis.Y, Axis.by_mount(mount)])
+        self._assert_motor_ok(mount_axes)
 
         return self._effector_pos_from_carriage_pos(
             OT3Mount.from_mount(mount), self._current_position, critical_point

--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -90,7 +90,7 @@ class MotionController(Protocol):
         specified mount but `CriticalPoint.TIP` was specified, the position of
         the nozzle will be returned.
 
-        If `fail_on_not_homed` is `True`, this method will raise a `MustHomeError`
+        If `fail_on_not_homed` is `True`, this method will raise a `PositionUnknownError`
         if any of the relavent axes are not homed, regardless of `refresh`.
         """
         ...
@@ -186,7 +186,7 @@ class MotionController(Protocol):
         axes are to be moved, they will do so at the same speed.
 
         If fail_on_not_homed is True (default False), if an axis that is not
-        homed moves it will raise a MustHomeError. Otherwise, it will home the axis.
+        homed moves it will raise a PositionUnknownError. Otherwise, it will home the axis.
         """
         ...
 

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -78,27 +78,29 @@ def check_motion_bounds(
     )
     for ax in target_smoothie.keys():
         if target_smoothie[ax] < bounds[ax][0]:
-            bounds_message = bounds_message_format.format(
-                axis=ax,
-                tsp=target_smoothie[ax],
-                tdp=target_deck.get(ax, "unknown"),
-                dir="low",
-                limsp=bounds.get(ax, ("unknown",))[0],
-            )
+            format_detail = {
+                "axis": ax,
+                "tsp": target_smoothie[ax],
+                "tdp": target_deck.get(ax, "unknown"),
+                "dir": "low",
+                "limsp": bounds.get(ax, ("unknown",))[0],
+            }
+            bounds_message = bounds_message_format.format(**format_detail)
             mod_log.warning(bounds_message)
             if checks.value & MotionChecks.LOW.value:
-                raise OutOfBoundsMove(bounds_message)
+                raise OutOfBoundsMove(bounds_message, format_detail)
         elif target_smoothie[ax] > bounds[ax][1]:
-            bounds_message = bounds_message_format.format(
-                axis=ax,
-                tsp=target_smoothie[ax],
-                tdp=target_deck.get(ax, "unknown"),
-                dir="high",
-                limsp=bounds.get(ax, (None, "unknown"))[1],
-            )
+            format_detail = {
+                "axis": ax,
+                "tsp": target_smoothie[ax],
+                "tdp": target_deck.get(ax, "unknown"),
+                "dir": "high",
+                "limsp": bounds.get(ax, (None, "unknown"))[1],
+            }
+            bounds_message = bounds_message_format.format(**format_detail)
             mod_log.warning(bounds_message)
             if checks.value & MotionChecks.HIGH.value:
-                raise OutOfBoundsMove(bounds_message)
+                raise OutOfBoundsMove(bounds_message, format_detail)
 
 
 def ot2_axis_to_string(axis: Axis) -> str:

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -4,7 +4,6 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from opentrons import types
-from opentrons.hardware_control import NoTipAttachedError, TipAttachedError
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.types import HardwareAction
 from opentrons.protocols.api_support import instrument as instrument_support
@@ -17,6 +16,10 @@ from opentrons.protocols.api_support.util import (
     APIVersionError,
 )
 from opentrons.protocols.geometry import planning
+from opentrons_shared_data.errors.exceptions import (
+    UnexpectedTipRemovalError,
+    UnexpectedTipAttachError,
+)
 
 from ..instrument import AbstractInstrument
 
@@ -409,14 +412,18 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
         self._pipette_dict["blow_out_speed"] = p["blow_out_speed"]
 
     def _raise_if_no_tip(self, action: str) -> None:
-        """Raise NoTipAttachedError if no tip."""
+        """Raise UnexpectedTipRemovalError if no tip."""
         if not self.has_tip():
-            raise NoTipAttachedError(f"Cannot perform {action} without a tip attached")
+            raise UnexpectedTipRemovalError(
+                action, self._instrument_name, self._mount.name
+            )
 
     def _raise_if_tip(self, action: str) -> None:
-        """Raise TipAttachedError if tip."""
+        """Raise UnexpectedTipAttachError if tip."""
         if self.has_tip():
-            raise TipAttachedError(f"Cannot {action} with a tip attached")
+            raise UnexpectedTipAttachError(
+                action, self._instrument_name, self._mount.name
+            )
 
     def configure_for_volume(self, volume: float) -> None:
         """This will never be called because it was added in API 2.15."""

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.errors.exceptions import (
 )
 from opentrons.broker import Broker
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons import types, hardware_control as hc
+from opentrons import types
 from opentrons.commands import commands as cmds
 
 from opentrons.commands import publisher
@@ -25,6 +25,7 @@ from opentrons.protocols.api_support.util import (
     requires_version,
     APIVersionError,
 )
+from opentrons_shared_data.errors.exceptions import UnexpectedTipRemovalError
 
 from .core.common import InstrumentCore, ProtocolCore
 from .core.engine import ENGINE_CORE_API_VERSION
@@ -394,7 +395,7 @@ class InstrumentContext(publisher.CommandPublisher):
                      `rate` * :py:attr:`flow_rate.aspirate <flow_rate>`,
                      and when dispensing, it will be
                      `rate` * :py:attr:`flow_rate.dispense <flow_rate>`.
-        :raises: ``NoTipAttachedError`` -- if no tip is attached to the pipette.
+        :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette.
         :returns: This instance
 
         .. note::
@@ -418,7 +419,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
         )
         if not self._core.has_tip():
-            raise hc.NoTipAttachedError("Pipette has no tip. Aborting mix()")
+            raise UnexpectedTipRemovalError("mix", self.name, self.mount)
 
         c_vol = self._core.get_available_volume() if not volume else volume
 
@@ -539,7 +540,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param speed: The speed for touch tip motion, in mm/s.
                       Default: 60.0 mm/s, Max: 80.0 mm/s, Min: 20.0 mm/s
         :type speed: float
-        :raises: ``NoTipAttachedError`` -- if no tip is attached to the pipette
+        :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette
         :raises RuntimeError: If no location is specified and location cache is
                               None. This should happen if `touch_tip` is called
                               without first calling a method that takes a
@@ -554,7 +555,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         """
         if not self._core.has_tip():
-            raise hc.NoTipAttachedError("Pipette has no tip to touch_tip()")
+            raise UnexpectedTipRemovalError("touch_tip", self.name, self.mount)
 
         checked_speed = self._determine_speed(speed)
 
@@ -612,7 +613,7 @@ class InstrumentContext(publisher.CommandPublisher):
                        to air-gap aspirate. (Default: 5mm above current Well)
         :type height: float
 
-        :raises: ``NoTipAttachedError`` -- if no tip is attached to the pipette
+        :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette
 
         :raises RuntimeError: If location cache is None.
                               This should happen if `touch_tip` is called
@@ -633,7 +634,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         """
         if not self._core.has_tip():
-            raise hc.NoTipAttachedError("Pipette has no tip. Aborting air_gap")
+            raise UnexpectedTipRemovalError("air_gap", self.name, self.mount)
 
         if height is None:
             height = 5

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -398,7 +398,7 @@ class MustHomeError(ProtocolEngineError):
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a MustHomeError."""
-        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+        super().__init__(ErrorCodes.POSITION_UNKNOWN, message, details, wrapping)
 
 
 class SetupCommandNotAllowedError(ProtocolEngineError):
@@ -738,7 +738,9 @@ class FirmwareUpdateRequired(ProtocolEngineError):
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a LocationIsOccupiedError."""
-        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+        super().__init__(
+            ErrorCodes.FIRMWARE_UPDATE_REQUIRED, message, details, wrapping
+        )
 
 
 class PipetteNotReadyToAspirateError(ProtocolEngineError):

--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -6,7 +6,7 @@ from opentrons.types import Point, Mount
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import Axis as HardwareAxis
-from opentrons.hardware_control.errors import MustHomeError as HardwareMustHomeError
+from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
 from opentrons.motion_planning import Waypoint
 
@@ -95,7 +95,7 @@ class HardwareGantryMover(GantryMover):
         Args:
             pipette_id: Pipette ID to get location data for.
             current_well: Optional parameter for getting pipette location data, effects critical point.
-            fail_on_not_homed: Raise HardwareMustHomeError if gantry position is not known.
+            fail_on_not_homed: Raise PositionUnknownError if gantry position is not known.
         """
         pipette_location = self._state_view.motion.get_pipette_location(
             pipette_id=pipette_id,
@@ -107,7 +107,7 @@ class HardwareGantryMover(GantryMover):
                 critical_point=pipette_location.critical_point,
                 fail_on_not_homed=fail_on_not_homed,
             )
-        except HardwareMustHomeError as e:
+        except PositionUnknownError as e:
             raise MustHomeError(str(e)) from e
 
     def get_max_travel_z(self, pipette_id: str) -> float:
@@ -167,7 +167,7 @@ class HardwareGantryMover(GantryMover):
                 critical_point=critical_point,
                 fail_on_not_homed=True,
             )
-        except HardwareMustHomeError as e:
+        except PositionUnknownError as e:
             raise MustHomeError(str(e)) from e
 
         return point

--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -108,7 +108,7 @@ class HardwareGantryMover(GantryMover):
                 fail_on_not_homed=fail_on_not_homed,
             )
         except PositionUnknownError as e:
-            raise MustHomeError(str(e)) from e
+            raise MustHomeError(message=str(e), wrapping=[e])
 
     def get_max_travel_z(self, pipette_id: str) -> float:
         """Get the maximum allowed z-height for pipette movement.
@@ -168,7 +168,7 @@ class HardwareGantryMover(GantryMover):
                 fail_on_not_homed=True,
             )
         except PositionUnknownError as e:
-            raise MustHomeError(str(e)) from e
+            raise MustHomeError(message=str(e), wrapping=[e])
 
         return point
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 
 from opentrons.types import Point, MountType
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.errors import MustHomeError
+from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
 from ..types import (
     WellLocation,
@@ -217,6 +217,6 @@ class MovementHandler:
             await self._hardware_api.gantry_position(
                 mount=mount.to_hw_mount(), fail_on_not_homed=True
             )
-        except MustHomeError:
+        except PositionUnknownError:
             return False
         return True

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -9,7 +9,7 @@ from opentrons.drivers.smoothie_drivers.errors import SmoothieAlarm
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
 from opentrons.protocols.types import PythonProtocol, MalformedPythonProtocolError
-from opentrons.hardware_control import ExecutionCancelledError
+from opentrons_shared_data.errors.exceptions import ExecutionCancelledError
 
 MODULE_LOG = logging.getLogger(__name__)
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -54,7 +54,6 @@ from opentrons.hardware_control.types import (
     EstopState,
 )
 from opentrons.hardware_control.errors import (
-    FirmwareUpdateRequired,
     InvalidPipetteName,
     InvalidPipetteModel,
 )
@@ -80,6 +79,7 @@ from opentrons.hardware_control.estop_state import EstopStateMachine
 from opentrons_shared_data.errors.exceptions import (
     EStopActivatedError,
     EStopNotPresentError,
+    FirmwareUpdateRequiredError,
 )
 
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
@@ -907,7 +907,7 @@ async def test_update_required_flag(
     axes = [Axis.X, Axis.Y]
     decoy.when(mock_subsystem_manager.update_required).then_return(True)
     controller._initialized = True
-    with pytest.raises(FirmwareUpdateRequired):
+    with pytest.raises(FirmwareUpdateRequiredError):
         await controller.home(axes, gantry_load=GantryLoad.LOW_THROUGHPUT)
 
 
@@ -930,7 +930,7 @@ async def test_update_required_bypass_firmware_update(
         pass
     # raise FirmwareUpdateRequired if the _update_required flag is set
     controller._initialized = True
-    with pytest.raises(FirmwareUpdateRequired):
+    with pytest.raises(FirmwareUpdateRequiredError):
         await controller.home([Axis.X], gantry_load=GantryLoad.LOW_THROUGHPUT)
 
 

--- a/api/tests/opentrons/hardware_control/test_execution_manager.py
+++ b/api/tests/opentrons/hardware_control/test_execution_manager.py
@@ -3,8 +3,8 @@ import pytest
 from opentrons.hardware_control import (
     ExecutionManager,
     ExecutionState,
-    ExecutionCancelledError,
 )
+from opentrons_shared_data.errors.exceptions import ExecutionCancelledError
 
 
 async def test_state_machine():

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -17,8 +17,7 @@ from opentrons.hardware_control.types import (
     MotionChecks,
 )
 from opentrons.hardware_control.errors import (
-    MustHomeError,
-    InvalidMoveError,
+    InvalidCriticalPoint,
     OutOfBoundsMove,
 )
 from opentrons.hardware_control.robot_calibration import (
@@ -26,7 +25,10 @@ from opentrons.hardware_control.robot_calibration import (
     DeckCalibration,
 )
 
-from opentrons_shared_data.errors.exceptions import MoveConditionNotMetError
+from opentrons_shared_data.errors.exceptions import (
+    MoveConditionNotMetError,
+    PositionUnknownError,
+)
 
 
 async def test_controller_must_home(hardware_api):
@@ -196,7 +198,7 @@ async def test_gripper_critical_points_fail_on_pipettes(
         types.Mount.RIGHT: {"model": "p10_single_v1", "id": "testyness"},
     }
     await hardware_api.cache_instruments()
-    with pytest.raises(InvalidMoveError):
+    with pytest.raises(InvalidCriticalPoint):
         await hardware_api.move_to(
             types.Mount.RIGHT, types.Point(0, 0, 0), critical_point=critical_point
         )
@@ -494,7 +496,7 @@ async def test_move_rel_homing_failures(hardware_api):
         "C": False,
     }
     # If one axis being used isn't homed, we must get an exception
-    with pytest.raises(MustHomeError):
+    with pytest.raises(PositionUnknownError):
         await hardware_api.move_rel(
             types.Mount.LEFT, types.Point(0, 0, 2000), fail_on_not_homed=True
         )
@@ -517,13 +519,13 @@ async def test_current_position_homing_failures(hardware_api):
     }
 
     # If one axis being used isn't homed, we must get an exception
-    with pytest.raises(MustHomeError):
+    with pytest.raises(PositionUnknownError):
         await hardware_api.current_position(
             mount=types.Mount.LEFT,
             fail_on_not_homed=True,
         )
 
-    with pytest.raises(MustHomeError):
+    with pytest.raises(PositionUnknownError):
         await hardware_api.gantry_position(
             mount=types.Mount.LEFT,
             fail_on_not_homed=True,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -20,10 +20,7 @@ from opentrons.hardware_control.dev_types import (
     GripperDict,
 )
 from opentrons.hardware_control.motion_utilities import target_position_from_plunger
-from opentrons.hardware_control.instruments.ot3.gripper_handler import (
-    GripError,
-    GripperHandler,
-)
+from opentrons.hardware_control.instruments.ot3.gripper_handler import GripperHandler
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
     PipetteOffsetByPipetteMount,
@@ -48,10 +45,7 @@ from opentrons.hardware_control.types import (
     EstopState,
     EstopStateNotification,
 )
-from opentrons.hardware_control.errors import (
-    GripperNotAttachedError,
-    InvalidMoveError,
-)
+from opentrons.hardware_control.errors import InvalidCriticalPoint
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control import ThreadManager
 from opentrons.hardware_control.backends.ot3utils import (
@@ -64,6 +58,11 @@ from opentrons_hardware.hardware_control.motion import MoveStopCondition
 from opentrons_hardware.hardware_control.motion_planning.types import Move
 
 from opentrons.config import gripper_config as gc
+from opentrons_shared_data.errors.exceptions import (
+    GripperNotPresentError,
+    CommandPreconditionViolated,
+    CommandParameterLimitViolated,
+)
 from opentrons_shared_data.gripper.gripper_definition import GripperModel
 from opentrons_shared_data.pipette.types import (
     PipetteModelType,
@@ -74,7 +73,6 @@ from opentrons_shared_data.pipette.types import (
 from opentrons_shared_data.pipette import (
     load_data as load_pipette_data,
 )
-from opentrons_shared_data.errors.exceptions import CommandParameterLimitViolated
 from opentrons.hardware_control.modules import (
     Thermocycler,
     TempDeck,
@@ -924,13 +922,13 @@ async def test_gripper_action_fails_with_no_gripper(
     mock_ungrip: AsyncMock,
 ) -> None:
     with pytest.raises(
-        GripperNotAttachedError, match="Cannot perform action without gripper attached"
+        GripperNotPresentError, match="Cannot perform action without gripper attached"
     ):
         await ot3_hardware.grip(5.0)
     mock_grip.assert_not_called()
 
     with pytest.raises(
-        GripperNotAttachedError, match="Cannot perform action without gripper attached"
+        GripperNotPresentError, match="Cannot perform action without gripper attached"
     ):
         await ot3_hardware.ungrip()
     mock_ungrip.assert_not_called()
@@ -952,7 +950,9 @@ async def test_gripper_action_works_with_gripper(
     }
     await ot3_hardware.cache_gripper(instr_data)
 
-    with pytest.raises(GripError, match="Gripper jaw must be homed before moving"):
+    with pytest.raises(
+        CommandPreconditionViolated, match="Cannot grip gripper jaw before homing"
+    ):
         await ot3_hardware.grip(5.0)
     await ot3_hardware.home_gripper_jaw()
     mock_ungrip.assert_called_once()
@@ -981,7 +981,7 @@ async def test_gripper_move_fails_with_no_gripper(
     ot3_hardware: ThreadManager[OT3API],
 ) -> None:
     assert not ot3_hardware._gripper_handler.gripper
-    with pytest.raises(GripperNotAttachedError):
+    with pytest.raises(GripperNotPresentError):
         await ot3_hardware.move_to(OT3Mount.GRIPPER, Point(0, 0, 0))
 
 
@@ -992,7 +992,7 @@ async def test_gripper_mount_not_movable(
     instr_data = AttachedGripper(config=gripper_config, id="g12345")
     await ot3_hardware.cache_gripper(instr_data)
     assert ot3_hardware._gripper_handler.gripper
-    with pytest.raises(InvalidMoveError):
+    with pytest.raises(InvalidCriticalPoint):
         await ot3_hardware.move_to(
             OT3Mount.GRIPPER, Point(0, 0, 0), critical_point=CriticalPoint.MOUNT
         )
@@ -1013,7 +1013,7 @@ async def test_gripper_fails_for_pipette_cps(
     instr_data = AttachedGripper(config=gripper_config, id="g12345")
     await ot3_hardware.cache_gripper(instr_data)
     assert ot3_hardware._gripper_handler.gripper
-    with pytest.raises(InvalidMoveError):
+    with pytest.raises(InvalidCriticalPoint):
         await ot3_hardware.move_to(
             OT3Mount.GRIPPER, Point(0, 0, 0), critical_point=critical_point
         )

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
@@ -4,12 +4,12 @@ from typing import Callable
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
 
-from opentrons.hardware_control import (
-    NoTipAttachedError,
-    TipAttachedError,
-)
 from opentrons.protocol_api.core.common import InstrumentCore, LabwareCore
 from opentrons.types import Location, Point
+from opentrons_shared_data.errors.exceptions import (
+    UnexpectedTipRemovalError,
+    UnexpectedTipAttachError,
+)
 
 # TODO (lc 12-8-2022) Not sure if we plan to keep these tests, but if we do
 # we should re-write them to be agnostic to the underlying hardware. Otherwise
@@ -40,7 +40,9 @@ def test_same_pipette(
 
 def test_prepare_to_aspirate_no_tip(subject: InstrumentCore) -> None:
     """It should raise an error if a tip is not attached."""
-    with pytest.raises(NoTipAttachedError, match="Cannot perform PREPARE_ASPIRATE"):
+    with pytest.raises(
+        UnexpectedTipRemovalError, match="Cannot perform PREPARE_ASPIRATE"
+    ):
         subject.prepare_for_aspirate()  # type: ignore[attr-defined]
 
 
@@ -48,7 +50,7 @@ def test_dispense_no_tip(subject: InstrumentCore) -> None:
     """It should raise an error if a tip is not attached."""
     subject.home()
     location = Location(point=Point(1, 2, 3), labware=None)
-    with pytest.raises(NoTipAttachedError, match="Cannot perform DISPENSE"):
+    with pytest.raises(UnexpectedTipRemovalError, match="Cannot perform DISPENSE"):
         subject.dispense(
             volume=1,
             rate=1,
@@ -65,13 +67,13 @@ def test_drop_tip_no_tip(subject: InstrumentCore, tip_rack: LabwareCore) -> None
     tip_core = tip_rack.get_well_core("A1")
 
     subject.home()
-    with pytest.raises(NoTipAttachedError, match="Cannot perform DROPTIP"):
+    with pytest.raises(UnexpectedTipRemovalError, match="Cannot perform DROPTIP"):
         subject.drop_tip(location=None, well_core=tip_core, home_after=False)
 
 
 def test_blow_out_no_tip(subject: InstrumentCore, labware: LabwareCore) -> None:
     """It should raise an error if a tip is not attached."""
-    with pytest.raises(NoTipAttachedError, match="Cannot perform BLOWOUT"):
+    with pytest.raises(UnexpectedTipRemovalError, match="Cannot perform BLOWOUT"):
         subject.blow_out(
             location=Location(point=Point(1, 2, 3), labware=None),
             well_core=labware.get_well_core("A1"),
@@ -91,7 +93,7 @@ def test_pick_up_tip_no_tip(subject: InstrumentCore, tip_rack: LabwareCore) -> N
         increment=None,
         prep_after=False,
     )
-    with pytest.raises(TipAttachedError):
+    with pytest.raises(UnexpectedTipAttachError):
         subject.pick_up_tip(
             location=Location(point=tip_core.get_top(z_offset=0), labware=None),
             well_core=tip_core,

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.errors.exceptions import UnexpectedTipRemovalError
 
 import opentrons.protocol_api as papi
 import opentrons.protocols.api_support as papi_support
@@ -17,7 +18,7 @@ from opentrons.protocol_api.module_contexts import (
     HeaterShakerContext,
 )
 from opentrons.types import Mount, Point, Location, TransferTipPolicy
-from opentrons.hardware_control import API, NoTipAttachedError, ThreadManagedHardware
+from opentrons.hardware_control import API, ThreadManagedHardware
 from opentrons.hardware_control.instruments.ot2.pipette import Pipette
 from opentrons.hardware_control.types import Axis
 from opentrons.protocols.advanced_control import transfers as tf
@@ -581,7 +582,7 @@ def test_prevent_liquid_handling_without_tip(ctx):
     plate = ctx.load_labware("corning_384_wellplate_112ul_flat", "2")
     pipR = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tr])
 
-    with pytest.raises(NoTipAttachedError):
+    with pytest.raises(UnexpectedTipRemovalError):
         pipR.aspirate(100, plate.wells()[0])
 
     pipR.pick_up_tip()
@@ -589,7 +590,7 @@ def test_prevent_liquid_handling_without_tip(ctx):
     pipR.aspirate(100, plate.wells()[0])
     pipR.drop_tip()
 
-    with pytest.raises(NoTipAttachedError):
+    with pytest.raises(UnexpectedTipRemovalError):
         pipR.dispense(100, plate.wells()[1])
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -11,7 +11,7 @@ from opentrons.hardware_control.types import (
     CriticalPoint,
     Axis as HardwareAxis,
 )
-from opentrons.hardware_control.errors import MustHomeError as HardwareMustHomeError
+from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
 from opentrons.motion_planning import Waypoint
 
@@ -143,7 +143,7 @@ async def test_get_position_raises(
             critical_point=CriticalPoint.NOZZLE,
             fail_on_not_homed=False,
         )
-    ).then_raise(HardwareMustHomeError("oh no"))
+    ).then_raise(PositionUnknownError("oh no"))
 
     with pytest.raises(MustHomeError, match="oh no"):
         await hardware_subject.get_position("pipette-id")
@@ -266,7 +266,7 @@ async def test_move_relative_must_home(
             fail_on_not_homed=True,
             speed=456.7,
         )
-    ).then_raise(HardwareMustHomeError("oh no"))
+    ).then_raise(PositionUnknownError("oh no"))
 
     with pytest.raises(MustHomeError, match="oh no"):
         await hardware_subject.move_relative(

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -6,7 +6,6 @@ from typing import NamedTuple
 from opentrons.types import MountType, Point, DeckSlotName, Mount
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons.hardware_control.errors import MustHomeError
 from opentrons.motion_planning import Waypoint
 
 from opentrons.protocol_engine.types import (
@@ -31,6 +30,7 @@ from opentrons.protocol_engine.execution.heater_shaker_movement_flagger import (
     HeaterShakerMovementFlagger,
 )
 from opentrons.protocol_engine.execution.gantry_mover import GantryMover
+from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
 
 @pytest.fixture
@@ -445,7 +445,7 @@ async def test_check_valid_position(
     ).then_return(Point(0, 0, 0))
     decoy.when(
         await hardware_api.gantry_position(mount=Mount.RIGHT, fail_on_not_homed=True)
-    ).then_raise(MustHomeError())
+    ).then_raise(PositionUnknownError())
 
     assert await subject.check_for_valid_position(MountType.LEFT)
     assert not await subject.check_for_valid_position(MountType.RIGHT)

--- a/hardware-testing/hardware_testing/scripts/speed_accel_profile.py
+++ b/hardware-testing/hardware_testing/scripts/speed_accel_profile.py
@@ -8,7 +8,7 @@ import os
 from typing import Tuple, Dict
 
 from opentrons.hardware_control.ot3api import OT3API
-from opentrons.hardware_control.errors import MustHomeError
+from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
 from hardware_testing.opentrons_api.types import GantryLoad, OT3Mount, Axis, Point
 from hardware_testing.opentrons_api.helpers_ot3 import (
@@ -247,7 +247,7 @@ async def _single_axis_move(
                     await api.move_rel(
                         mount=MOUNT, delta=move_error_correction, speed=35
                     )
-            except MustHomeError:
+            except PositionUnknownError:
                 await api.home([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R])
 
             if DELAY > 0:

--- a/robot-server/robot_server/errors/exception_handlers.py
+++ b/robot-server/robot_server/errors/exception_handlers.py
@@ -8,6 +8,9 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, Type, Union
 
 from opentrons_shared_data.errors import ErrorCodes, EnumeratedError, PythonException
+from opentrons_shared_data.errors.exceptions import (
+    FirmwareUpdateRequiredError as HWFirmwareUpdateRequired,
+)
 
 from robot_server.versioning import (
     API_VERSION,
@@ -21,10 +24,6 @@ from .global_errors import (
     BadRequest,
     InvalidRequest,
     FirmwareUpdateRequired,
-)
-
-from opentrons.hardware_control.errors import (
-    FirmwareUpdateRequired as HWFirmwareUpdateRequired,
 )
 
 from .error_responses import (

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -56,9 +56,14 @@ stages:
           status: failed
           errors:
             - id: !anystr
-              errorType: PythonException
               createdAt: !anystr
-              detail: 'opentrons.hardware_control.errors.NoTipAttachedError: Cannot perform DROPTIP without a tip attached'
+              errorType: 'UnexpectedTipRemovalError'
+              detail: 'Cannot perform DROPTIP without a tip attached.'
+              errorInfo:
+                mount: 'LEFT'
+                pipette_name: 'p10_single'
+              errorCode: '3005'
+              wrappedErrors: []
   - name: Verify commands contain the expected results
     request:
       url: '{ot2_server_base_url}/runs/{run_id}/commands'
@@ -116,12 +121,14 @@ stages:
             status: failed
             error:
               id: !anystr
-              errorType: PythonException
               createdAt: !anystr
-              detail: 'opentrons.hardware_control.errors.NoTipAttachedError: Cannot perform DROPTIP without a tip attached'
-              errorCode: '4000'
-              errorInfo: !anydict
-              wrappedErrors: !anylist
+              errorType: 'UnexpectedTipRemovalError'
+              detail: 'Cannot perform DROPTIP without a tip attached.'
+              errorInfo:
+                mount: 'LEFT'
+                pipette_name: 'p10_single'
+              errorCode: '3005'
+              wrappedErrors: []
             params:
               pipetteId: pipetteId
               labwareId: tipRackId

--- a/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_papi_v2_run_failure.tavern.yaml
@@ -58,8 +58,9 @@ stages:
             - id: !anystr
               errorType: ExceptionInProtocolError
               createdAt: !anystr
-              detail: 'NoTipAttachedError [line 9]: Cannot perform DROPTIP without a tip attached'
+              detail: 'UnexpectedTipRemovalError [line 9]: Error 3005 UNEXPECTED_TIP_REMOVAL (UnexpectedTipRemovalError): Cannot perform DROPTIP without a tip attached.'
               errorCode: '4000'
+              wrappedErrors: !anylist
 
   - name: Verify commands contain the expected results
     request:
@@ -116,8 +117,8 @@ stages:
               id: !anystr
               errorType: LegacyContextCommandError
               createdAt: !anystr
-              detail: 'Cannot perform DROPTIP without a tip attached'
-              errorCode: '4000'
+              detail: 'Cannot perform DROPTIP without a tip attached.'
+              errorCode: '3005'
               errorInfo: !anydict
               wrappedErrors: !anylist
             params:

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -106,6 +106,14 @@
       "detail": "Unmatched tip presence states",
       "category": "roboticsControlError"
     },
+    "2013": {  
+      "detail": "Position Unknown",
+      "category": "roboticsControlError"
+    },
+    "2014": {
+      "detail": "Execution Cancelled",
+      "category": "roboticsControlError"
+    },
     "3000": {
       "detail": "A robotics interaction error occurred.",
       "category": "roboticsInteractionError"

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -106,7 +106,7 @@
       "detail": "Unmatched tip presence states",
       "category": "roboticsControlError"
     },
-    "2013": {  
+    "2013": {
       "detail": "Position Unknown",
       "category": "roboticsControlError"
     },

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -56,6 +56,8 @@ class ErrorCodes(Enum):
     INACCURATE_NON_CONTACT_SWEEP = _code_from_dict_entry("2010")
     MISALIGNED_GANTRY = _code_from_dict_entry("2011")
     UNMATCHED_TIP_PRESENCE_STATES = _code_from_dict_entry("2012")
+    POSITION_UNKNOWN = _code_from_dict_entry("2013")
+    EXECUTION_CANCELLED = _code_from_dict_entry("2014")
     ROBOTICS_INTERACTION_ERROR = _code_from_dict_entry("3000")
     LABWARE_DROPPED = _code_from_dict_entry("3001")
     LABWARE_NOT_PICKED_UP = _code_from_dict_entry("3002")

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -686,15 +686,12 @@ class PipetteOverpressureError(RoboticsInteractionError):
 
     def __init__(
         self,
-        mount: str,
+        message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an PipetteOverpressureError."""
-        msg = (
-            f"The pressure sensor on the {mount} mount has exceeded operational limits."
-        )
-        super().__init__(ErrorCodes.PIPETTE_OVERPRESSURE, msg, detail, wrapping)
+        super().__init__(ErrorCodes.PIPETTE_OVERPRESSURE, message, detail, wrapping)
 
 
 class EStopActivatedError(RoboticsInteractionError):

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -350,7 +350,7 @@ class MotionFailedError(RoboticsControlError):
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a FirmwareUpdateFailedError."""
+        """Build a MotionFailedError."""
         super().__init__(ErrorCodes.MOTION_FAILED, message, detail, wrapping)
 
 
@@ -363,7 +363,7 @@ class HomingFailedError(RoboticsControlError):
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a FirmwareUpdateFailedError."""
+        """Build a HomingFailedError."""
         super().__init__(ErrorCodes.HOMING_FAILED, message, detail, wrapping)
 
 
@@ -556,6 +556,32 @@ class UnmatchedTipPresenceStates(RoboticsControlError):
         )
 
 
+class PositionUnknownError(RoboticsControlError):
+    """An error indicating that the robot's position is unknown."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a PositionUnknownError."""
+        super().__init__(ErrorCodes.POSITION_UNKNOWN, message, detail, wrapping)
+
+
+class ExecutionCancelledError(RoboticsControlError):
+    """An error indicating that the robot's execution manager has been cancelled."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a ExecutionCancelledError."""
+        super().__init__(ErrorCodes.EXECUTION_CANCELLED, message, detail, wrapping)
+
+
 class LabwareDroppedError(RoboticsInteractionError):
     """An error indicating that the gripper dropped labware it was holding."""
 
@@ -600,12 +626,20 @@ class UnexpectedTipRemovalError(RoboticsInteractionError):
 
     def __init__(
         self,
-        message: Optional[str] = None,
+        action: str,
+        pipette_name: str,
+        mount: str,
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnexpectedTipRemovalError."""
-        super().__init__(ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, detail, wrapping)
+        checked_detail: Dict[str, Any] = detail or {}
+        checked_detail["pipette_name"] = pipette_name
+        checked_detail["mount"] = mount
+        message = f"Cannot perform {action} without a tip attached."
+        super().__init__(
+            ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, checked_detail, wrapping
+        )
 
 
 class UnexpectedTipAttachError(RoboticsInteractionError):
@@ -613,11 +647,18 @@ class UnexpectedTipAttachError(RoboticsInteractionError):
 
     def __init__(
         self,
+        action: str,
+        pipette_name: str,
+        mount: str,
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnexpectedTipAttachError."""
+        checked_detail: Dict[str, Any] = detail or {}
+        checked_detail["pipette_name"] = pipette_name
+        checked_detail["mount"] = mount
+        message = f"Cannot perform {action} with a tip already attached."
         super().__init__(ErrorCodes.UNEXPECTED_TIP_ATTACH, message, detail, wrapping)
 
 
@@ -626,11 +667,17 @@ class FirmwareUpdateRequiredError(RoboticsInteractionError):
 
     def __init__(
         self,
+        action: str,
+        subsystems_to_update: List[Any],
         message: Optional[str] = None,
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FirmwareUpdateRequiredError."""
+        checked_detail: Dict[str, Any] = detail or {}
+        checked_detail["identifier"] = action
+        checked_detail["subsystems_to_update"] = subsystems_to_update
+        message = f"Cannot perform {action} until {subsystems_to_update} are updated."
         super().__init__(ErrorCodes.FIRMWARE_UPDATE_REQUIRED, message, detail, wrapping)
 
 
@@ -639,12 +686,15 @@ class PipetteOverpressureError(RoboticsInteractionError):
 
     def __init__(
         self,
-        message: Optional[str] = None,
+        mount: str,
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an PipetteOverpressureError."""
-        super().__init__(ErrorCodes.PIPETTE_OVERPRESSURE, message, detail, wrapping)
+        msg = (
+            f"The pressure sensor on the {mount} mount has exceeded operational limits."
+        )
+        super().__init__(ErrorCodes.PIPETTE_OVERPRESSURE, msg, detail, wrapping)
 
 
 class EStopActivatedError(RoboticsInteractionError):
@@ -708,7 +758,7 @@ class InvalidActuator(RoboticsInteractionError):
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build an GripperNotPresentError."""
+        """Build an InvalidActuator."""
         super().__init__(ErrorCodes.INVALID_ACTUATOR, message, detail, wrapping)
 
 
@@ -740,7 +790,7 @@ class InvalidInstrumentData(RoboticsInteractionError):
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build an GripperNotPresentError."""
+        """Build an InvalidInstrumentData."""
         super().__init__(ErrorCodes.INVALID_INSTRUMENT_DATA, message, detail, wrapping)
 
 
@@ -824,4 +874,19 @@ class CommandParameterLimitViolated(GeneralError):
                 PythonException(e) if isinstance(e, BaseException) else e
                 for e in wrapping_checked
             ],
+        )
+
+
+class UnsupportedHardwareCommand(GeneralError):
+    """An error indicating that a command being executed is not supported by the hardware."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an UnsupportedHardwareCommand."""
+        super().__init__(
+            ErrorCodes.NOT_SUPPORTED_ON_ROBOT_TYPE, message, detail, wrapping
         )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We are now using the error codes in the hardware controller api. Let me know if i forgot anything!

