### PR TITLE
fix(api): Fix protocol.deck not accepting non-native deck slot spellings

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -81,7 +81,7 @@ class ModuleCore(AbstractModuleCore):
 
     def get_deck_slot_id(self) -> str:
         slot_name = self.get_deck_slot()
-        return validation.ensure_deck_slot_string(
+        return validation.internal_slot_to_public_string(
             slot_name, robot_type=self._engine_client.state.config.robot_type
         )
 
@@ -137,7 +137,7 @@ class NonConnectedModuleCore(AbstractModuleCore):
 
     def get_deck_slot_id(self) -> str:
         slot_name = self.get_deck_slot()
-        return validation.ensure_deck_slot_string(
+        return validation.internal_slot_to_public_string(
             slot_name, robot_type=self._engine_client.state.config.robot_type
         )
 

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -579,7 +579,7 @@ class ProtocolCore(
             labware_core.labware_id
         )
         if isinstance(labware_location, DeckSlotLocation):
-            return validation.ensure_deck_slot_string(
+            return validation.internal_slot_to_public_string(
                 labware_location.slotName, self._engine_client.state.config.robot_type
             )
         elif isinstance(labware_location, ModuleLocation):

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -132,11 +132,10 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.
     def get_slot_definition(self, slot: DeckLocation) -> SlotDefV3:
         """Get the geometric definition data of a slot."""
-        slot_name = validation.ensure_deck_slot_string(
-            _get_slot_name(slot, self._api_version, self._protocol_core.robot_type),
-            self._protocol_core.robot_type,
+        slot_name = _get_slot_name(
+            slot, self._api_version, self._protocol_core.robot_type
         )
-        return self._slot_definitions_by_name[slot_name]
+        return self._slot_definitions_by_name[slot_name.id]
 
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.
     def get_slot_center(self, slot: DeckLocation) -> Point:

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -124,10 +124,15 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
     # and remove it from this class. Jira RSS-236.
     def position_for(self, slot: DeckLocation) -> Location:
         """Get the absolute location of a deck slot's front-left corner."""
-        slot_definition = self.get_slot_definition(slot)
+        slot_name = _get_slot_name(
+            slot, self._api_version, self._protocol_core.robot_type
+        )
+        slot_definition = self._slot_definitions_by_name[slot_name.id]
         x, y, z = slot_definition["position"]
-
-        return Location(point=Point(x, y, z), labware=slot_definition["id"])
+        normalized_slot_name = validation.internal_slot_to_public_string(
+            slot_name, self._protocol_core.robot_type
+        )
+        return Location(point=Point(x, y, z), labware=normalized_slot_name)
 
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.
     def get_slot_definition(self, slot: DeckLocation) -> SlotDefV3:

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -37,7 +37,7 @@ def _get_slot_name(slot_key: DeckLocation, api_version: APIVersion) -> DeckSlotN
     try:
         return validation.ensure_deck_slot(slot_key, api_version)
     except (TypeError, ValueError) as error:
-        raise KeyError(str(error)) from error
+        raise KeyError(slot_key) from error
 
 
 class Deck(Mapping[DeckLocation, Optional[DeckItem]]):

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -7,6 +7,7 @@ from opentrons_shared_data.deck.dev_types import SlotDefV3
 from opentrons.motion_planning import adjacent_slots_getters
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import DeckLocation, DeckSlotName, Location, Point
+from opentrons_shared_data.robot.dev_types import RobotType
 
 from .core.common import ProtocolCore
 from .core.core_map import LoadedCoreMap
@@ -33,9 +34,13 @@ class CalibrationPosition:
     displayName: str
 
 
-def _get_slot_name(slot_key: DeckLocation, api_version: APIVersion) -> DeckSlotName:
+def _get_slot_name(
+    slot_key: DeckLocation, api_version: APIVersion, robot_type: RobotType
+) -> DeckSlotName:
     try:
-        return validation.ensure_deck_slot(slot_key, api_version)
+        return validation.ensure_and_convert_deck_slot(
+            slot_key, api_version, robot_type
+        )
     except (TypeError, ValueError) as error:
         raise KeyError(slot_key) from error
 
@@ -55,6 +60,8 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
         self._protocol_core = protocol_core
         self._core_map = core_map
         self._api_version = api_version
+
+        self._protocol_core.robot_type
 
         deck_locations = protocol_core.get_deck_definition()["locations"]
 
@@ -76,7 +83,9 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
 
     def __getitem__(self, key: DeckLocation) -> Optional[DeckItem]:
         """Get the item, if any, located in a given slot."""
-        slot_name = _get_slot_name(key, self._api_version)
+        slot_name = _get_slot_name(
+            key, self._api_version, self._protocol_core.robot_type
+        )
         item_core = self._protocol_core.get_slot_item(slot_name)
         item = self._core_map.get(item_core)
 
@@ -93,7 +102,9 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.
     def right_of(self, slot: DeckLocation) -> Optional[DeckItem]:
         """Get the item directly to the right of the given slot, if any."""
-        slot_name = _get_slot_name(slot, self._api_version)
+        slot_name = _get_slot_name(
+            slot, self._api_version, self._protocol_core.robot_type
+        )
         east_slot = adjacent_slots_getters.get_east_slot(slot_name.as_int())
 
         return self[east_slot] if east_slot is not None else None
@@ -101,7 +112,9 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.
     def left_of(self, slot: DeckLocation) -> Optional[DeckItem]:
         """Get the item directly to the left of the given slot, if any."""
-        slot_name = _get_slot_name(slot, self._api_version)
+        slot_name = _get_slot_name(
+            slot, self._api_version, self._protocol_core.robot_type
+        )
         west_slot = adjacent_slots_getters.get_west_slot(slot_name.as_int())
 
         return self[west_slot] if west_slot is not None else None
@@ -120,14 +133,17 @@ class Deck(Mapping[DeckLocation, Optional[DeckItem]]):
     def get_slot_definition(self, slot: DeckLocation) -> SlotDefV3:
         """Get the geometric definition data of a slot."""
         slot_name = validation.ensure_deck_slot_string(
-            _get_slot_name(slot, self._api_version), self._protocol_core.robot_type
+            _get_slot_name(slot, self._api_version, self._protocol_core.robot_type),
+            self._protocol_core.robot_type,
         )
         return self._slot_definitions_by_name[slot_name]
 
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.
     def get_slot_center(self, slot: DeckLocation) -> Point:
         """Get the absolute coordinates of a slot's center."""
-        slot_name = _get_slot_name(slot, self._api_version)
+        slot_name = _get_slot_name(
+            slot, self._api_version, self._protocol_core.robot_type
+        )
         return self._protocol_core.get_slot_center(slot_name)
 
     # todo(mm, 2023-05-08): This may be internal and removable from this public class. Jira RSS-236.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -365,7 +365,9 @@ class ProtocolContext(CommandPublisher):
         elif isinstance(location, OffDeckType):
             load_location = location
         else:
-            load_location = validation.ensure_deck_slot(location, self._api_version)
+            load_location = validation.ensure_and_convert_deck_slot(
+                location, self._api_version, self._core.robot_type
+            )
 
         labware_core = self._core.load_labware(
             load_name=load_name,
@@ -471,7 +473,9 @@ class ProtocolContext(CommandPublisher):
         if isinstance(location, OffDeckType):
             load_location = location
         else:
-            load_location = validation.ensure_deck_slot(location, self._api_version)
+            load_location = validation.ensure_and_convert_deck_slot(
+                location, self._api_version, self._core.robot_type
+            )
 
         labware_core = self._core.load_adapter(
             load_name=load_name,
@@ -575,7 +579,9 @@ class ProtocolContext(CommandPublisher):
         elif isinstance(new_location, OffDeckType):
             location = new_location
         else:
-            location = validation.ensure_deck_slot(new_location, self._api_version)
+            location = validation.ensure_and_convert_deck_slot(
+                new_location, self._api_version, self._core.robot_type
+            )
 
         _pick_up_offset = (
             validation.ensure_valid_labware_offset_vector(pick_up_offset)
@@ -672,7 +678,9 @@ class ProtocolContext(CommandPublisher):
         deck_slot = (
             None
             if location is None
-            else validation.ensure_deck_slot(location, self._api_version)
+            else validation.ensure_and_convert_deck_slot(
+                location, self._api_version, self._core.robot_type
+            )
         )
 
         module_core = self._core.load_module(

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -160,7 +160,15 @@ def ensure_deck_slot(
     return parsed_slot
 
 
-def ensure_deck_slot_string(slot_name: DeckSlotName, robot_type: RobotType) -> str:
+def internal_slot_to_public_string(
+    slot_name: DeckSlotName, robot_type: RobotType
+) -> str:
+    """Convert an internal `DeckSlotName` to a user-facing Python Protocol API string.
+
+    This normalizes the string to the robot type's native format, like "5" for OT-2s or "C2" for
+    Flexes. This probably won't change anything because the internal `DeckSlotName` should already
+    match the robot's native format, but it's nice to have an explicit interface barrier.
+    """
     return slot_name.to_equivalent_for_robot_type(robot_type).id
 
 

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -125,10 +125,12 @@ def ensure_pipette_name(pipette_name: str) -> PipetteNameType:
         ) from e
 
 
-def ensure_deck_slot(
-    deck_slot: Union[int, str], api_version: APIVersion
+def ensure_and_convert_deck_slot(
+    deck_slot: Union[int, str], api_version: APIVersion, robot_type: RobotType
 ) -> DeckSlotName:
     """Ensure that a primitive value matches a named deck slot.
+
+    Also, convert the deck slot to match the given `robot_type`.
 
     Params:
         deck_slot: The primitive value to validate. Valid values are like `5`, `"5"`, or `"C2"`.
@@ -139,6 +141,10 @@ def ensure_deck_slot(
         TypeError: If you provide something that's not an `int` or `str`.
         ValueError: If the value does not match a known deck slot.
         APIVersionError: If you provide a value like `"C2"`, but `api_version` is too old.
+
+    Returns:
+        A `DeckSlotName` appropriate for the given `robot_type`. For example, given `"5"`,
+        this will return `DeckSlotName.SLOT_C2` on a Flex.
     """
     if not isinstance(deck_slot, (int, str)):
         raise TypeError(f"Deck slot must be a string or integer, but got {deck_slot}")
@@ -157,7 +163,7 @@ def ensure_deck_slot(
             f' Increase your protocol\'s apiLevel, or use slot "{alternative}" instead.'
         )
 
-    return parsed_slot
+    return parsed_slot.to_equivalent_for_robot_type(robot_type)
 
 
 def internal_slot_to_public_string(

--- a/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_module_core.py
@@ -82,7 +82,9 @@ def test_get_deck_slot_id(
     decoy.when(mock_engine_client.state.config.robot_type).then_return("OT-3 Standard")
 
     decoy.when(
-        mock_validation.ensure_deck_slot_string(DeckSlotName.SLOT_1, "OT-3 Standard")
+        mock_validation.internal_slot_to_public_string(
+            DeckSlotName.SLOT_1, "OT-3 Standard"
+        )
     ).then_return("foo")
 
     assert subject.get_deck_slot_id() == "foo"

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -1456,7 +1456,7 @@ def test_get_labware_location_deck_slot(
     )
     decoy.when(mock_engine_client.state.config.robot_type).then_return("OT-2 Standard")
     decoy.when(
-        validation.ensure_deck_slot_string(DeckSlotName.SLOT_1, "OT-2 Standard")
+        validation.internal_slot_to_public_string(DeckSlotName.SLOT_1, "OT-2 Standard")
     ).then_return("777")
 
     assert subject.get_labware_location(mock_labware_core) == "777"

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -173,7 +173,29 @@ def test_slot_keys_iter(subject: Deck) -> None:
         },
     ],
 )
-def test_get_slots(
+def test_slots_property(subject: Deck) -> None:
+    """It should provide slot definitions."""
+    assert subject.slots == [
+        {"id": "fee"},
+        {"id": "foe"},
+        {"id": "fum"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "deck_definition",
+    [
+        {
+            "locations": {
+                "orderedSlots": [
+                    {"id": DeckSlotName.SLOT_2.id, "displayName": "foobar"},
+                ],
+                "calibrationPoints": [],
+            }
+        },
+    ],
+)
+def test_get_slot_definition(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     api_version: APIVersion,
@@ -184,20 +206,11 @@ def test_get_slots(
     decoy.when(
         mock_validation.ensure_and_convert_deck_slot(222, api_version, "OT-3 Standard")
     ).then_return(DeckSlotName.SLOT_2)
-    decoy.when(mock_protocol_core.robot_type).then_return("OT-2 Standard")
-    decoy.when(
-        mock_validation.internal_slot_to_public_string(
-            DeckSlotName.SLOT_2, "OT-2 Standard"
-        )
-    ).then_return("fee")
 
-    assert subject.slots == [
-        {"id": "fee"},
-        {"id": "foe"},
-        {"id": "fum"},
-    ]
-
-    assert subject.get_slot_definition(222) == {"id": "fee"}
+    assert subject.get_slot_definition(222) == {
+        "id": DeckSlotName.SLOT_2.id,
+        "displayName": "foobar",
+    }
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -237,7 +237,6 @@ def test_get_position_for(
     decoy.when(
         mock_validation.ensure_and_convert_deck_slot(333, api_version, "OT-3 Standard")
     ).then_return(DeckSlotName.SLOT_3)
-    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
         mock_validation.internal_slot_to_public_string(
             DeckSlotName.SLOT_3, "OT-3 Standard"

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -182,7 +182,9 @@ def test_get_slots(
     )
     decoy.when(mock_protocol_core.robot_type).then_return("OT-2 Standard")
     decoy.when(
-        mock_validation.ensure_deck_slot_string(DeckSlotName.SLOT_2, "OT-2 Standard")
+        mock_validation.internal_slot_to_public_string(
+            DeckSlotName.SLOT_2, "OT-2 Standard"
+        )
     ).then_return("fee")
 
     assert subject.slots == [
@@ -219,7 +221,9 @@ def test_get_position_for(
     )
     decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
-        mock_validation.ensure_deck_slot_string(DeckSlotName.SLOT_3, "OT-3 Standard")
+        mock_validation.internal_slot_to_public_string(
+            DeckSlotName.SLOT_3, "OT-3 Standard"
+        )
     ).then_return("foo")
 
     result = subject.position_for(333)

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -81,9 +81,10 @@ def test_get_empty_slot(
     subject: Deck,
 ) -> None:
     """It should return None for slots if empty."""
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_2
-    )
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_2)
     decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_2)).then_return(None)
 
     assert subject[42] is None
@@ -96,12 +97,13 @@ def test_get_slot_invalid_key(
     subject: Deck,
 ) -> None:
     """It should map a ValueError from validation to a KeyError."""
-    decoy.when(mock_validation.ensure_deck_slot(1, api_version)).then_raise(
-        TypeError("uh oh")
-    )
-    decoy.when(mock_validation.ensure_deck_slot(2, api_version)).then_raise(
-        ValueError("oh no")
-    )
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(1, api_version, "OT-3 Standard")
+    ).then_raise(TypeError("uh oh"))
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(2, api_version, "OT-3 Standard")
+    ).then_raise(ValueError("oh no"))
 
     with pytest.raises(KeyError, match="1"):
         subject[1]
@@ -121,9 +123,10 @@ def test_get_slot_item(
     mock_labware_core = decoy.mock(cls=LabwareCore)
     mock_labware = decoy.mock(cls=Labware)
 
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_2
-    )
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_2)
     decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_2)).then_return(
         mock_labware_core
     )
@@ -177,9 +180,10 @@ def test_get_slots(
     subject: Deck,
 ) -> None:
     """It should provide slot definitions."""
-    decoy.when(mock_validation.ensure_deck_slot(222, api_version)).then_return(
-        DeckSlotName.SLOT_2
-    )
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(222, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_2)
     decoy.when(mock_protocol_core.robot_type).then_return("OT-2 Standard")
     decoy.when(
         mock_validation.internal_slot_to_public_string(
@@ -216,9 +220,10 @@ def test_get_position_for(
     subject: Deck,
 ) -> None:
     """It should return a `Location` for a deck slot."""
-    decoy.when(mock_validation.ensure_deck_slot(333, api_version)).then_return(
-        DeckSlotName.SLOT_3
-    )
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(333, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_3)
     decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
         mock_validation.internal_slot_to_public_string(
@@ -254,17 +259,19 @@ def test_right_of_and_left_of(
     left_labware = decoy.mock(cls=Labware)
     right_labware = decoy.mock(cls=Labware)
 
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+
     decoy.when(mock_adjacent_slots.get_east_slot(4)).then_return(111)
     decoy.when(mock_adjacent_slots.get_west_slot(4)).then_return(999)
-    decoy.when(mock_validation.ensure_deck_slot(444, api_version)).then_return(
-        DeckSlotName.SLOT_4
-    )
-    decoy.when(mock_validation.ensure_deck_slot(111, api_version)).then_return(
-        DeckSlotName.SLOT_1
-    )
-    decoy.when(mock_validation.ensure_deck_slot(999, api_version)).then_return(
-        DeckSlotName.SLOT_9
-    )
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(444, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_4)
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(111, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_1)
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(999, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_9)
 
     decoy.when(mock_protocol_core.get_slot_item(DeckSlotName.SLOT_1)).then_return(
         right_labware_core
@@ -321,9 +328,10 @@ def test_get_slot_center(
     subject: Deck,
 ) -> None:
     """It should get the geometric center of a slot."""
-    decoy.when(mock_validation.ensure_deck_slot(222, api_version)).then_return(
-        DeckSlotName.SLOT_2
-    )
+    decoy.when(mock_protocol_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(222, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_2)
     decoy.when(mock_protocol_core.get_slot_center(DeckSlotName.SLOT_2)).then_return(
         Point(1, 2, 3)
     )

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -103,10 +103,10 @@ def test_get_slot_invalid_key(
         ValueError("oh no")
     )
 
-    with pytest.raises(KeyError, match="uh oh"):
+    with pytest.raises(KeyError, match="1"):
         subject[1]
 
-    with pytest.raises(KeyError, match="oh no"):
+    with pytest.raises(KeyError, match="2"):
         subject[2]
 
 

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -219,7 +219,7 @@ def test_get_slot_definition(
         {
             "locations": {
                 "orderedSlots": [
-                    {"id": "foo", "position": [1.0, 2.0, 3.0]},
+                    {"id": DeckSlotName.SLOT_3.id, "position": [1.0, 2.0, 3.0]},
                 ],
                 "calibrationPoints": [],
             }

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -219,9 +219,10 @@ def test_load_labware(
     decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
         "lowercase_labware"
     )
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_5
-    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_5)
 
     decoy.when(
         mock_core.load_labware(
@@ -320,9 +321,10 @@ def test_load_labware_from_definition(
     labware_load_params = LabwareLoadParams("you", "are", 1337)
 
     decoy.when(mock_validation.ensure_lowercase_name("are")).then_return("are")
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_1
-    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_1)
     decoy.when(mock_core.add_labware_definition(labware_definition_dict)).then_return(
         labware_load_params
     )
@@ -363,9 +365,10 @@ def test_load_adapter(
     decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_ADAPTER")).then_return(
         "lowercase_adapter"
     )
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_5
-    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_5)
 
     decoy.when(
         mock_core.load_adapter(
@@ -408,9 +411,10 @@ def test_load_labware_on_adapter(
     decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_ADAPTER")).then_return(
         "lowercase_adapter"
     )
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_5
-    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_5)
     decoy.when(
         mock_core.load_adapter(
             load_name="lowercase_adapter",
@@ -487,9 +491,10 @@ def test_move_labware_to_slot(
     drop_offset = {"x": 4, "y": 5, "z": 6}
     mock_labware_core = decoy.mock(cls=LabwareCore)
 
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_1
-    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_1)
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
     movable_labware = Labware(
@@ -623,9 +628,10 @@ def test_load_module(
     decoy.when(mock_validation.ensure_module_model("spline reticulator")).then_return(
         TemperatureModuleModel.TEMPERATURE_V1
     )
-    decoy.when(mock_validation.ensure_deck_slot(42, api_version)).then_return(
-        DeckSlotName.SLOT_3
-    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_3)
 
     decoy.when(
         mock_core.load_module(


### PR DESCRIPTION
# Overview

Fixes RSS-315.

This fixes `protocol.deck["A1"]` on an OT-2 and `protocol.deck[1]` on a Flex. It likewise fixes other methods of `protocol.deck`, like `.position_for()`.

# Test Plan

See the steps to reproduce in RSS-315.

# Changelog

Without this PR, when `protocol.deck` takes a slot as input, it merely validates it as matching *any* slot for *any* robot. This causes lookups to behave weirdly, because lower-level things are expecting the slot to match the robot's native format.

This PR fixes it by adding normalization on all input.

# Review requests

Double-check the `Deck` class. All methods should:

* Accept deck slots in any format—`5`, `"5"`, or `"C2"`. The `"C2"` format requires a recent `apiLevel`.
* Do internal lookups based on the `DeckSlotName` enum, with the robot's native format—like `DeckSlotName.SLOT_5` for OT-2, or `DeckSlotName.SLOT_C2` for Flex.
* Return to the user strings with the robot's native format—like `"5"` for OT-2 or `"C2"` for Flex.

In hindsight, it's possible that this normalization logic should be pushed down into Protocol Engine. That's how we've been doing it for `load_labware()` and `load_module()`. But the `Deck` class is full of cruft and I guess I didn't want to bloat Protocol Engine with supporting it. Any thoughts? 

I guess we know Protocol Engine *commands* should normalize input slots, but there's a question of whether the getters on `ProtocolEngine.state` should normalize input slots.

See also RSS-259. We clearly need more static type-safety here.

# Risk assessment

Medium? We don't really have good infrastructure for integration-testing this kind of thing [anymore](https://github.com/Opentrons/opentrons/blob/8c37860593493bd192d9bb19b53e306a0983be3c/api/tests/opentrons/protocol_api_old/__init__.py#L3-L4). We have plenty of unit tests, but I don't think those are sufficient for catching bugs like this.