### PR TITLE
fix(api): Do not move/home RIGHT mount when 96ch is attached

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -998,8 +998,14 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
         axes_moving = [Axis.X, Axis.Y, Axis.by_mount(mount)]
 
-        if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and realmount == OT3Mount.RIGHT:
-            raise RuntimeError("unable to move RIGHT mount while 96CH is attached")
+        if (
+            self.gantry_load == GantryLoad.HIGH_THROUGHPUT
+            and realmount == OT3Mount.RIGHT
+        ):
+            raise RuntimeError(
+                f"unable to move {realmount.name} "
+                f"with {self.gantry_load.name} gantry load"
+            )
 
         # Cache current position from backend
         if not self._current_position:
@@ -1109,8 +1115,14 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
         axes_moving = [Axis.X, Axis.Y, Axis.by_mount(mount)]
 
-        if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and realmount == OT3Mount.RIGHT:
-            raise RuntimeError("unable to move RIGHT mount while 96CH is attached")
+        if (
+            self.gantry_load == GantryLoad.HIGH_THROUGHPUT
+            and realmount == OT3Mount.RIGHT
+        ):
+            raise RuntimeError(
+                f"unable to move {realmount.name} "
+                f"with {self.gantry_load.name} gantry load"
+            )
 
         if not self._backend.check_encoder_status(axes_moving):
             await self.home()
@@ -1345,7 +1357,10 @@ class OT3API(
             if not axes:
                 checked_axes.remove(Axis.Z_R)
             elif Axis.Z_R in axes:
-                raise RuntimeError("unable to home RIGHT mount while 96CH is attached")
+                raise RuntimeError(
+                    f"unable to home {Axis.Z_R.name} axis"
+                    f"with {self.gantry_load.name} gantry load"
+                )
         self._log.info(f"Homing {axes}")
 
         home_seq = [
@@ -1395,7 +1410,10 @@ class OT3API(
         will call home if the stepper position is inaccurate.
         """
         if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and axis == Axis.Z_R:
-            raise RuntimeError("unable to retract RIGHT mount while 96CH is attached")
+            raise RuntimeError(
+                f"unable to retract {Axis.Z_R.name} axis"
+                f"with {self.gantry_load.name} gantry load"
+            )
 
         motor_ok = self._backend.check_motor_status([axis])
         encoder_ok = self._backend.check_encoder_status([axis])

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -998,6 +998,9 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
         axes_moving = [Axis.X, Axis.Y, Axis.by_mount(mount)]
 
+        if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and realmount == OT3Mount.RIGHT:
+            raise RuntimeError("unable to move RIGHT mount while 96CH is attached")
+
         # Cache current position from backend
         if not self._current_position:
             await self.refresh_positions()
@@ -1105,6 +1108,9 @@ class OT3API(
 
         realmount = OT3Mount.from_mount(mount)
         axes_moving = [Axis.X, Axis.Y, Axis.by_mount(mount)]
+
+        if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and realmount == OT3Mount.RIGHT:
+            raise RuntimeError("unable to move RIGHT mount while 96CH is attached")
 
         if not self._backend.check_encoder_status(axes_moving):
             await self.home()
@@ -1334,6 +1340,12 @@ class OT3API(
             checked_axes = [ax for ax in Axis if ax != Axis.Q]
         if self.gantry_load == GantryLoad.HIGH_THROUGHPUT:
             checked_axes.append(Axis.Q)
+            # NOTE: Z_R current is dropped very low when 96CH attached,
+            #       so trying to home it would cause timeout error
+            if not axes:
+                checked_axes.remove(Axis.Z_R)
+            elif Axis.Z_R in axes:
+                raise RuntimeError("unable to home RIGHT mount while 96CH is attached")
         self._log.info(f"Homing {axes}")
 
         home_seq = [
@@ -1382,6 +1394,9 @@ class OT3API(
         the behaviors between the two robots similar, retract_axis on the FLEX
         will call home if the stepper position is inaccurate.
         """
+        if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and axis == Axis.Z_R:
+            raise RuntimeError("unable to retract RIGHT mount while 96CH is attached")
+
         motor_ok = self._backend.check_motor_status([axis])
         encoder_ok = self._backend.check_encoder_status([axis])
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR checks if the RIGHT mount is being commanded to move/home while 96ch is attached.

Both the hold and run currents for the right mount are set to a very low value when a 96ch is attached, both because it is not safe to move it and because higher currents would unnecessarily increase heat build-up. However, the hardware-controller would still allow moving and homing, for example when calling `api.home()` with no axes specified.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Low risk, this would primarily just make it so our test scripts run more seamlessly.