### PR TITLE
fix(app):  Fix ODD pressed state CSS

### DIFF
--- a/app/src/atoms/buttons/RadioButton.tsx
+++ b/app/src/atoms/buttons/RadioButton.tsx
@@ -6,9 +6,9 @@ import {
   SPACING,
   BORDERS,
   Flex,
+  RESPONSIVENESS,
 } from '@opentrons/components'
 import { StyledText } from '../text'
-import { ODD_FOCUS_VISIBLE } from './constants'
 
 import type { StyleProps } from '@opentrons/components'
 
@@ -73,8 +73,8 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     ${isSelected ? SELECTED_BUTTON_STYLE : AVAILABLE_BUTTON_STYLE}
     ${disabled && DISABLED_BUTTON_STYLE}
 
-    &:focus-visible {
-      box-shadow: ${ODD_FOCUS_VISIBLE};
+    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+      cursor: default;
     }
   `
 

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -49,9 +49,11 @@ const GO_BACK_BUTTON_STYLE = css`
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
     font-size: ${TYPOGRAPHY.fontSize22};
-
     &:hover {
       opacity: 100%;
+    }
+    &:active {
+      opacity: 70%;
     }
   }
 `

--- a/app/src/molecules/UploadInput/index.tsx
+++ b/app/src/molecules/UploadInput/index.tsx
@@ -86,7 +86,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element | null {
 
   const onChange: React.ChangeEventHandler<HTMLInputElement> = event => {
     const { files = [] } = event.target ?? {}
-    files?.[0] && props.onUpload(files?.[0])
+    files?.[0] != null && props.onUpload(files?.[0])
     if ('value' in event.currentTarget) event.currentTarget.value = ''
   }
 

--- a/app/src/molecules/WizardHeader/index.tsx
+++ b/app/src/molecules/WizardHeader/index.tsx
@@ -37,6 +37,12 @@ const EXIT_BUTTON_STYLE = css`
     margin-right: 1.75rem;
     font-size: ${TYPOGRAPHY.fontSize22};
     font-weight: ${TYPOGRAPHY.fontWeightBold};
+    &:hover {
+      opacity: 100%;
+    }
+    &:active {
+      opacity: 70%;
+    }
   }
 `
 const BOX_STYLE = css`

--- a/app/src/organisms/ChildNavigation/index.tsx
+++ b/app/src/organisms/ChildNavigation/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
+import styled from 'styled-components'
 
 import {
   ALIGN_CENTER,
-  Btn,
   COLORS,
   Flex,
   Icon,
@@ -10,7 +10,9 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   TYPOGRAPHY,
+  RESPONSIVENESS,
 } from '@opentrons/components'
+import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
 
 import { SmallButton } from '../../atoms/buttons'
 import { InlineNotification } from '../../atoms/InlineNotification'
@@ -42,9 +44,9 @@ export function ChildNavigation({
       paddingY={SPACING.spacing32}
     >
       <Flex gridGap={SPACING.spacing16} justifyContent={JUSTIFY_FLEX_START}>
-        <Btn onClick={onClickBack}>
+        <IconButton onClick={onClickBack}>
           <Icon name="back" size="3rem" color={COLORS.darkBlack100} />
-        </Btn>
+        </IconButton>
         <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightBold}>
           {header}
         </StyledText>
@@ -66,3 +68,20 @@ export function ChildNavigation({
     </Flex>
   )
 }
+
+const IconButton = styled('button')`
+  border-radius: ${SPACING.spacing4};
+  max-height: 100%;
+  background-color: ${COLORS.white};
+
+  &:focus-visible {
+    box-shadow: ${ODD_FOCUS_VISIBLE};
+    background-color: ${COLORS.darkBlack20};
+  }
+  &:disabled {
+    background-color: transparent;
+  }
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    cursor: default;
+  }
+`

--- a/app/src/organisms/InstrumentMountItem/LabeledMount.tsx
+++ b/app/src/organisms/InstrumentMountItem/LabeledMount.tsx
@@ -26,9 +26,7 @@ const MountButton = styled.button<{ isAttached: boolean }>`
   border-radius: ${BORDERS.borderRadiusSize3};
   background-color: ${({ isAttached }) =>
     isAttached ? COLORS.green3 : COLORS.light1};
-  &:hover,
-  &:active,
-  &:focus {
+  &:active {
     background-color: ${({ isAttached }) =>
       isAttached ? COLORS.green3Pressed : COLORS.light1Pressed};
   }

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -45,9 +45,7 @@ export const MountItem = styled.div<{ isReady: boolean }>`
   border-radius: ${BORDERS.borderRadiusSize3};
   background-color: ${({ isReady }) =>
     isReady ? COLORS.green3 : COLORS.yellow3};
-  &:hover,
-  &:active,
-  &:focus {
+  &:active {
     background-color: ${({ isReady }) =>
       isReady ? COLORS.green3Pressed : COLORS.yellow3Pressed};
   }

--- a/app/src/organisms/Navigation/index.tsx
+++ b/app/src/organisms/Navigation/index.tsx
@@ -20,6 +20,7 @@ import {
   BORDERS,
   RESPONSIVENESS,
 } from '@opentrons/components'
+import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
 
 import { useNetworkConnection } from '../../pages/OnDeviceDisplay/hooks'
 import { getLocalRobot } from '../../redux/discovery'
@@ -168,10 +169,16 @@ const IconButton = styled('button')`
   max-height: 100%;
   background-color: ${COLORS.white};
 
+  &:active {
+    background-color: ${COLORS.darkBlack20};
+  }
+  &:focus-visible {
+    box-shadow: ${ODD_FOCUS_VISIBLE};
+    background-color: ${COLORS.darkBlack20};
+  }
   &:disabled {
     background-color: transparent;
   }
-
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     cursor: default;
   }

--- a/app/src/organisms/Navigation/index.tsx
+++ b/app/src/organisms/Navigation/index.tsx
@@ -18,9 +18,9 @@ import {
   POSITION_STICKY,
   POSITION_STATIC,
   BORDERS,
+  RESPONSIVENESS,
 } from '@opentrons/components'
 
-import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
 import { useNetworkConnection } from '../../pages/OnDeviceDisplay/hooks'
 import { getLocalRobot } from '../../redux/discovery'
 import { NavigationMenu } from './NavigationMenu'
@@ -157,6 +157,14 @@ const TouchNavLink = styled(NavLink)`
   &.active > div {
     background-color: ${COLORS.highlightPurple1};
   }
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    cursor: default;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
 `
 
 const IconButton = styled('button')`
@@ -164,18 +172,15 @@ const IconButton = styled('button')`
   max-height: 100%;
   background-color: ${COLORS.white};
 
-  &:hover {
-    background-color: ${COLORS.darkBlack20};
-  }
-  &:active,
-  &:focus {
-    background-color: ${COLORS.darkBlack20};
-  }
-  &:focus-visible {
-    box-shadow: ${ODD_FOCUS_VISIBLE};
-    background-color: ${COLORS.darkBlack20};
-  }
   &:disabled {
     background-color: transparent;
+  }
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    cursor: default;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 `

--- a/app/src/organisms/Navigation/index.tsx
+++ b/app/src/organisms/Navigation/index.tsx
@@ -160,10 +160,6 @@ const TouchNavLink = styled(NavLink)`
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     cursor: default;
-
-    &:hover {
-      cursor: pointer;
-    }
   }
 `
 
@@ -178,9 +174,5 @@ const IconButton = styled('button')`
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     cursor: default;
-
-    &:hover {
-      cursor: pointer;
-    }
   }
 `

--- a/app/src/organisms/RobotSettingsDashboard/NetworkSettings/index.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/NetworkSettings/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -97,6 +98,14 @@ function NetworkSettingButton({
   networkName,
   onClick,
 }: NetworkSettingButtonProps): JSX.Element {
+  const PUSHED_STATE_STYLING = css`
+    &:active {
+      background-color: ${chipText === 'connected'
+        ? COLORS.green3Pressed
+        : COLORS.darkBlack40};
+    }
+  `
+
   return (
     <Btn
       width="100%"
@@ -104,6 +113,7 @@ function NetworkSettingButton({
       paddingY={SPACING.spacing20}
       backgroundColor={backgroundColor}
       borderRadius={BORDERS.borderRadiusSize3}
+      css={PUSHED_STATE_STYLING}
       onClick={onClick}
     >
       <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing24}>

--- a/app/src/organisms/RobotSettingsDashboard/NetworkSettings/index.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/NetworkSettings/index.tsx
@@ -98,7 +98,7 @@ function NetworkSettingButton({
   networkName,
   onClick,
 }: NetworkSettingButtonProps): JSX.Element {
-  const PUSHED_STATE_STYLING = css`
+  const PUSHED_STATE_STYLE = css`
     &:active {
       background-color: ${chipType === 'success'
         ? COLORS.green3Pressed
@@ -113,7 +113,7 @@ function NetworkSettingButton({
       paddingY={SPACING.spacing20}
       backgroundColor={backgroundColor}
       borderRadius={BORDERS.borderRadiusSize3}
-      css={PUSHED_STATE_STYLING}
+      css={PUSHED_STATE_STYLE}
       onClick={onClick}
     >
       <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing24}>

--- a/app/src/organisms/RobotSettingsDashboard/NetworkSettings/index.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/NetworkSettings/index.tsx
@@ -100,7 +100,7 @@ function NetworkSettingButton({
 }: NetworkSettingButtonProps): JSX.Element {
   const PUSHED_STATE_STYLING = css`
     &:active {
-      background-color: ${chipText === 'connected'
+      background-color: ${chipType === 'success'
         ? COLORS.green3Pressed
         : COLORS.darkBlack40};
     }

--- a/app/src/organisms/RobotSettingsDashboard/TouchscreenBrightness.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/TouchscreenBrightness.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import clamp from 'lodash/clamp'
 
 import {
@@ -18,7 +18,6 @@ import {
   SPACING,
 } from '@opentrons/components'
 
-import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
 import { ChildNavigation } from '../../organisms/ChildNavigation'
 import {
   getOnDeviceDisplaySettings,
@@ -27,16 +26,6 @@ import {
 
 import type { Dispatch } from '../../redux/types'
 import type { SetSettingOption } from '../../pages/OnDeviceDisplay/RobotSettingsDashboard'
-
-const BUTTON_STYLE = css`
-  &:focus-visible {
-    box-shadow: ${ODD_FOCUS_VISIBLE};
-  }
-
-  &:active {
-    color: ${COLORS.darkBlack40};
-  }
-`
 
 interface BrightnessTileProps {
   isActive: boolean
@@ -100,7 +89,6 @@ export function TouchscreenBrightness({
           disabled={brightness === LOWEST_BRIGHTNESS}
           onClick={() => handleClick('down')}
           data-testid="TouchscreenBrightness_decrease"
-          css={BUTTON_STYLE}
         >
           <Icon size="5rem" name="minus" />
         </Btn>
@@ -121,7 +109,6 @@ export function TouchscreenBrightness({
           disabled={brightness === HIGHEST_BRIGHTNESS}
           onClick={() => handleClick('up')}
           data-testid="TouchscreenBrightness_increase"
-          css={BUTTON_STYLE}
         >
           <Icon size="5rem" name="plus" />
         </Btn>

--- a/app/src/organisms/RobotSettingsDashboard/TouchscreenBrightness.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/TouchscreenBrightness.tsx
@@ -8,7 +8,6 @@ import {
   ALIGN_CENTER,
   BORDERS,
   Box,
-  Btn,
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
@@ -16,7 +15,9 @@ import {
   Icon,
   JUSTIFY_CENTER,
   SPACING,
+  RESPONSIVENESS,
 } from '@opentrons/components'
+import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
 
 import { ChildNavigation } from '../../organisms/ChildNavigation'
 import {
@@ -85,13 +86,13 @@ export function TouchscreenBrightness({
         paddingX={SPACING.spacing60}
         paddingY={SPACING.spacing120}
       >
-        <Btn
+        <IconButton
           disabled={brightness === LOWEST_BRIGHTNESS}
           onClick={() => handleClick('down')}
           data-testid="TouchscreenBrightness_decrease"
         >
           <Icon size="5rem" name="minus" />
-        </Btn>
+        </IconButton>
         <Flex
           flexDirection={DIRECTION_ROW}
           gridGap={SPACING.spacing8}
@@ -105,14 +106,34 @@ export function TouchscreenBrightness({
           ))}
         </Flex>
 
-        <Btn
+        <IconButton
           disabled={brightness === HIGHEST_BRIGHTNESS}
           onClick={() => handleClick('up')}
           data-testid="TouchscreenBrightness_increase"
         >
           <Icon size="5rem" name="plus" />
-        </Btn>
+        </IconButton>
       </Flex>
     </Flex>
   )
 }
+
+const IconButton = styled('button')`
+  border-radius: 50%;
+  max-height: 100%;
+  background-color: ${COLORS.white};
+
+  &:active {
+    background-color: ${COLORS.darkBlack20};
+  }
+  &:focus-visible {
+    box-shadow: ${ODD_FOCUS_VISIBLE};
+    background-color: ${COLORS.darkBlack20};
+  }
+  &:disabled {
+    background-color: transparent;
+  }
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    cursor: default;
+  }
+`

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -113,6 +113,18 @@ export function ProtocolSetupStep({
     }
   }
 
+  const PUSHED_STATE_STYLING = css`
+    &:active {
+      background-color: ${!disabled
+        ? status === 'general'
+          ? COLORS.darkBlack40
+          : status === 'ready'
+          ? COLORS.green3Pressed
+          : COLORS.yellow3Pressed
+        : ''};
+    }
+  `
+
   return (
     <Btn
       onClick={() =>
@@ -128,6 +140,7 @@ export function ProtocolSetupStep({
         borderRadius={BORDERS.borderRadiusSize4}
         gridGap={SPACING.spacing16}
         padding={`${SPACING.spacing20} ${SPACING.spacing24}`}
+        css={PUSHED_STATE_STYLING}
       >
         {status !== 'general' && !disabled ? (
           <Icon
@@ -299,7 +312,7 @@ function PrepareToRun({
   const observer = new IntersectionObserver(([entry]) => {
     setIsScrolled(!entry.isIntersecting)
   })
-  if (scrollRef.current) {
+  if (scrollRef.current != null) {
     observer.observe(scrollRef.current)
   }
 

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -113,15 +113,23 @@ export function ProtocolSetupStep({
     }
   }
 
+  let backgroundColor: string
+  if (!disabled) {
+    switch (status) {
+      case 'general':
+        backgroundColor = COLORS.darkBlack40
+        break
+      case 'ready':
+        backgroundColor = COLORS.green3Pressed
+        break
+      default:
+        backgroundColor = COLORS.yellow3Pressed
+    }
+  } else backgroundColor = ''
+
   const PUSHED_STATE_STYLING = css`
     &:active {
-      background-color: ${!disabled
-        ? status === 'general'
-          ? COLORS.darkBlack40
-          : status === 'ready'
-          ? COLORS.green3Pressed
-          : COLORS.yellow3Pressed
-        : ''};
+      background-color: ${backgroundColor};
     }
   `
 

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -127,7 +127,7 @@ export function ProtocolSetupStep({
     }
   } else backgroundColor = ''
 
-  const PUSHED_STATE_STYLING = css`
+  const PUSHED_STATE_STYLE = css`
     &:active {
       background-color: ${backgroundColor};
     }
@@ -148,7 +148,7 @@ export function ProtocolSetupStep({
         borderRadius={BORDERS.borderRadiusSize4}
         gridGap={SPACING.spacing16}
         padding={`${SPACING.spacing20} ${SPACING.spacing24}`}
-        css={PUSHED_STATE_STYLING}
+        css={PUSHED_STATE_STYLE}
       >
         {status !== 'general' && !disabled ? (
           <Icon

--- a/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotSettingsDashboard/RobotSettingButton.tsx
@@ -34,6 +34,10 @@ const SETTING_BUTTON_STYLE = css`
   background-color: ${COLORS.light1};
   padding: ${SPACING.spacing20} ${SPACING.spacing24};
   border-radius: ${BORDERS.borderRadiusSize4};
+
+  &:active {
+    background-color: ${COLORS.darkBlack40};
+  }
 `
 
 interface RobotSettingButtonProps {

--- a/app/src/pages/ProtocolDashboard/PinnedProtocol.tsx
+++ b/app/src/pages/ProtocolDashboard/PinnedProtocol.tsx
@@ -85,7 +85,7 @@ export function PinnedProtocol(props: {
     }
   }, [longpress.isLongPressed, longPress])
 
-  const PUSHED_STATE_STYLING = css`
+  const PUSHED_STATE_STYLE = css`
     &:active {
       background-color: ${longpress.isLongPressed ? '' : COLORS.darkBlack40};
     }
@@ -96,7 +96,7 @@ export function PinnedProtocol(props: {
       alignItems={ALIGN_FLEX_START}
       backgroundColor={COLORS.light1}
       borderRadius={BORDERS.borderRadiusSize4}
-      css={PUSHED_STATE_STYLING}
+      css={PUSHED_STATE_STYLE}
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing24}
       height={cardStyleBySize[cardSize].height}

--- a/app/src/pages/ProtocolDashboard/PinnedProtocol.tsx
+++ b/app/src/pages/ProtocolDashboard/PinnedProtocol.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
 import { format, formatDistance } from 'date-fns'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import {
   ALIGN_FLEX_START,
@@ -85,11 +85,18 @@ export function PinnedProtocol(props: {
     }
   }, [longpress.isLongPressed, longPress])
 
+  const PUSHED_STATE_STYLING = css`
+    &:active {
+      background-color: ${longpress.isLongPressed ? '' : COLORS.darkBlack40};
+    }
+  `
+
   return (
     <Flex
       alignItems={ALIGN_FLEX_START}
       backgroundColor={COLORS.light1}
       borderRadius={BORDERS.borderRadiusSize4}
+      css={PUSHED_STATE_STYLING}
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing24}
       height={cardStyleBySize[cardSize].height}
@@ -127,7 +134,7 @@ export function PinnedProtocol(props: {
           {format(new Date(protocol.createdAt), 'M/d/yy HH:mm')}
         </StyledText>
       </Flex>
-      {longpress.isLongPressed === true && (
+      {longpress.isLongPressed && (
         <LongPressModal
           longpress={longpress}
           protocolId={protocol.id}

--- a/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
@@ -126,7 +126,7 @@ export function ProtocolCard(props: {
     }
   }
 
-  const PUSHED_STATE_STYLING = css`
+  const PUSHED_STATE_STYLE = css`
     &:active {
       background-color: ${longpress.isLongPressed
         ? ''
@@ -146,7 +146,7 @@ export function ProtocolCard(props: {
       onClick={() => handleProtocolClick(longpress, protocol.id)}
       padding={SPACING.spacing24}
       ref={longpress.ref}
-      css={PUSHED_STATE_STYLING}
+      css={PUSHED_STATE_STYLE}
     >
       <Flex
         width="30.75rem"

--- a/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
@@ -74,7 +74,7 @@ export function ProtocolCard(props: {
   ): void => {
     if (isFailedAnalysis) {
       setShowFailedAnalysisModal(true)
-    } else if (longpress.isLongPressed !== true) {
+    } else if (!longpress.isLongPressed) {
       history.push(`/protocols/${protocolId}`)
     }
   }
@@ -125,6 +125,17 @@ export function ProtocolCard(props: {
       )
     }
   }
+
+  const PUSHED_STATE_STYLING = css`
+    &:active {
+      background-color: ${longpress.isLongPressed
+        ? ''
+        : isFailedAnalysis
+        ? COLORS.red3Pressed
+        : COLORS.darkBlack40};
+    }
+  `
+
   return (
     <Flex
       alignItems={isFailedAnalysis ? ALIGN_END : ALIGN_CENTER}
@@ -135,6 +146,7 @@ export function ProtocolCard(props: {
       onClick={() => handleProtocolClick(longpress, protocol.id)}
       padding={SPACING.spacing24}
       ref={longpress.ref}
+      css={PUSHED_STATE_STYLING}
     >
       <Flex
         width="30.75rem"

--- a/components/src/primitives/Btn.tsx
+++ b/components/src/primitives/Btn.tsx
@@ -4,6 +4,7 @@ import * as Styles from '../styles'
 import { styleProps, isntStyleProp } from './style-props'
 
 import type { PrimitiveComponent } from './types'
+import { RESPONSIVENESS } from '../ui-style-constants'
 
 export const BUTTON_TYPE_SUBMIT: 'submit' = 'submit'
 export const BUTTON_TYPE_RESET: 'reset' = 'reset'
@@ -19,6 +20,10 @@ const BUTTON_BASE_STYLE = css`
 
   &:disabled,
   &.disabled {
+    cursor: default;
+  }
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     cursor: default;
   }
 `


### PR DESCRIPTION
closes RAUT-520
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This PR harmonizes the pressed state CSS styling various ODD buttons. Dark gray bounding boxes no longer appear, and pressed state is added to several pages that were missing it. There are also a couple of CSS fixes, like the long press ProtocolDashboard menu also showing pressed state for buttons not on the modal, and touchscreen sleep buttons having bounding boxes that did not fit the shape of the button. Additionally, the inconsistent UI behavior of pressed state for existing routes is fixed.

Note that certain hover effects will no longer appear when emulating the ODD on a computer. Also, I removed some .focus-visible properties, as these could not be triggered previously on the physical ODD and were causing UI bugs (rendered boxes not fitting the shape of the buttons).

### What Causes Grey Bounding Boxes?

The behavior occurs when the bounding box does not perfectly fit the size of the text, and any psuedoclass container other than active changes the cursor property to anything but default. Ex: `&.hover: {cursor: pointer;}`

The major culprit is the Btn primitive, which is now wrapped in a media query to prevent misuse, however, there are other custom buttons on various pages. These have been changed as well. 

In order to implement bounding boxes on icons (or anything else), active properties with cursor: default seem to work.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Must be tested on a physical ODD.
1. Long pressing the navbar links and overflow button on RobotDashboard should not cause grey bounding boxes to appear.
2. Navigating to Settings > Touchscreen Brightness and clicking the +/- should not cause grey bounding boxes to appear.
3. Settings > Touchscreen Sleep. Long pressing these buttons should not cause a visible gray bounding box that doesn't fit the dimensions of the buttons.
4. All Protocols. These buttons now have pressed state. Pinned protocols should also have pressed state.
5. All Protocols > Protocol (details page) > Start Setup (setup page). These buttons now have pressed state.
6.  Instruments Page. Pressed state is now consistent with other pressed state (previously was pressed for too long).
7. Start setup and then click instrument calibration. The wizard exit and back buttons should have state when pressed.
8. Network settings page now has pressed state for connected (green) networks and gray for unconnected networks.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Fixed grey bounding boxes on existing pressed state.
- Harmonized behavior for existing pressed state.
- Created new pressed state behavior for buttons without it.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low
