### PR TITLE
fix(api): Fix issue where previous cal offsets are used when calibrating the instruments.

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -242,9 +242,7 @@ def _reload_gripper(
     # are similar enough that we might skip, see if the configs
     # match closely enough.
     # Returns a gripper object
-    if (
-        new_config == attached_instr.config
-    ):
+    if new_config == attached_instr.config:
         # Same config, good enough
         return attached_instr, True
     else:

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -244,7 +244,6 @@ def _reload_gripper(
     # Returns a gripper object
     if (
         new_config == attached_instr.config
-        and cal_offset == attached_instr._calibration_offset
     ):
         # Same config, good enough
         return attached_instr, True

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -567,7 +567,6 @@ def _reload_and_check_skip(
     # TODO this can potentially be removed in a follow-up refactor.
     if (
         new_config == attached_instr.config
-        and pipette_offset == attached_instr._pipette_offset
     ):
         # Same config, good enough
         return attached_instr, True

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -565,9 +565,7 @@ def _reload_and_check_skip(
     # match closely enough.
     # Returns a pipette object and True if we may skip hw reconfig
     # TODO this can potentially be removed in a follow-up refactor.
-    if (
-        new_config == attached_instr.config
-    ):
+    if new_config == attached_instr.config:
         # Same config, good enough
         return attached_instr, True
     else:

--- a/api/tests/opentrons/hardware_control/test_gripper.py
+++ b/api/tests/opentrons/hardware_control/test_gripper.py
@@ -88,5 +88,3 @@ def test_reload_instrument_cal_ot3(fake_offset: "GripperCalibrationOffset") -> N
     assert new_gripper == old_gripper
     # we said upstream could skip
     assert skip
-    # only pipette offset has been updated
-    assert new_gripper._calibration_offset == new_cal

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -399,5 +399,3 @@ def test_reload_instrument_cal_ot3(
     assert skipped
     # it's the same pipette
     assert new_pip == old_pip
-    # only pipette offset has been updated
-    assert new_pip._pipette_offset == new_cal


### PR DESCRIPTION
# Overview

Closes: [RQA-1309](https://opentrons.atlassian.net/browse/RQA-1309)

When we perform an instrument offset calibration, the assumption is that we start from a known nominal position without any previously calculated offsets that would add a margin of error to the calibration. However, this is not the case since we use the previously generated calibration data stored on disk whenever we do a calibration. This would produce calibration offset values that were off by a significant amount and would alternate between the newly calibrated value and the old one with + a slight variation. Look at the calibration data from subsequent instrument calibration on the same pipette from the same mount, and notice that they are alternating.

```
(0.5390625, -0.3984375, 0.9637499999999903)           <----
(0.2109375, 0.1640625, 0.03074999999995498)
(0.5390625, -0.3515625, 1.0322500000000048)           <----
(0.2109375, 0.1640625, -0.003500000000002501)
(0.5390625, -0.3515625, 1.0420000000000016)           <----
(0.1640625, 0.1640625, -0.049500000000051614)
(0.5390625, -0.3515625, 1.0735000000000525)           <----
(0.1640625, 0.1640625, -0.08800000000012176)
(0.5859375, -0.3984375, 1.1077500000001237)           <----
(0.1640625, 0.0703125, -0.11750000000014893)
```

This happened because the `cache_instrument` function would ultimately call `cache_pipette/cache_gripper` which calls into `load_from_config_and_check_skip` to check if the same data could be re-used instead of needing to re-create the object. Since this is not a new pipette, we would check to see if it needed to be reconfigured, and since the offset data in memory gets cleared when we start the instrument calibration the pipette would use the old calibration data and assign it to the newly created object.

After making the below change the instrument calibration offset data varies slightly which is to be expected, but it no longer has wild swings like we've seen above.
```
(0.3046875, -1.8046875, 1.2767499999999643)
(0.3046875, -1.8046875, 1.2527499999999634)
(0.3046875, -1.8046875, 1.2709999999999582)
(0.2109375, -1.8046875, 1.2604999999999649)
(0.3046875, -1.8046875, 1.2652499999999662)
```


# Test Plan

- [x] Test that subsequent instrument calibration no longer uses the previous offset data


# Changelog

- Don't re-use the calibration offset data when caching instruments


# Review requests



[RQA-1309]: https://opentrons.atlassian.net/browse/RQA-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ