### PR TITLE
docs(api): docstring for new `del deck` behavior

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -924,16 +924,16 @@ class ProtocolContext(CommandPublisher):
         and :py:attr:`loaded_modules` to get a dict of modules.
 
         For :ref:`advanced-control` *only*, you can delete an element of the ``deck`` dict.
-        This only works for deck slots that contain labware objects. For example, if slot 
-        1 contains a labware, ``del protocol.deck['1']`` will free the slot so you can 
+        This only works for deck slots that contain labware objects. For example, if slot
+        1 contains a labware, ``del protocol.deck['1']`` will free the slot so you can
         load another labware there.
-        
+
         .. warning::
-            Deleting labware from a deck slot does not pause the protocol. Subsequent 
-            commands continue immediately. If you need to physically move the labware to 
-            reflect the new deck state, add a :py:meth:`.pause` or use 
-            :py:meth:`.move_labware` instead. 
-        
+            Deleting labware from a deck slot does not pause the protocol. Subsequent
+            commands continue immediately. If you need to physically move the labware to
+            reflect the new deck state, add a :py:meth:`.pause` or use
+            :py:meth:`.move_labware` instead.
+
         .. versionchanged:: 2.15
            ``del`` sets the corresponding labware's location to ``OFF_DECK``.
         """

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -923,22 +923,19 @@ class ProtocolContext(CommandPublisher):
         you can also use :py:attr:`loaded_labwares` to get a dict of labwares
         and :py:attr:`loaded_modules` to get a dict of modules.
 
-        For :ref:`advanced-control` `only`, you can delete an element of the ``deck`` dict.
+        For :ref:`advanced-control` *only*, you can delete an element of the ``deck`` dict.
         This only works for deck slots that contain labware objects. For example, if slot 
         1 contains a labware, ``del protocol.deck['1']`` will free the slot so you can 
         load another labware there.
         
         .. warning::
-            Do not delete labware from a deck slot for protocols run in the Opentrons App 
-            or on the Flex touchscreen. The protocol will continue immediately without 
-            giving you a chance to physically remove the labware. 
-            Use :py:meth:`.move_labware` instead.
+            Deleting labware from a deck slot does not pause the protocol. Subsequent 
+            commands continue immediately. If you need to physically move the labware to 
+            reflect the new deck state, add a :py:meth:`.pause` or use 
+            :py:meth:`.move_labware` instead. 
         
-        .. versionchanged:: 2.14
-           Deleting deck elements raises an error.
-
         .. versionchanged:: 2.15
-           ``del`` sets the labware location to ``OFF_DECK`` instead of deleting it.
+           ``del`` sets the corresponding labware's location to ``OFF_DECK``.
         """
         return self._deck
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -909,6 +909,7 @@ class ProtocolContext(CommandPublisher):
     @requires_version(2, 0)
     def deck(self) -> Deck:
         """An interface to provide information about what's currently loaded on the deck.
+        This object is useful for determining if a slot in the deck is free.
 
         This object behaves like a dictionary whose keys are the deck slot names.
         For instance, ``protocol.deck[1]``, ``protocol.deck["1"]``, and ``protocol.deck["D1"]``
@@ -918,14 +919,26 @@ class ProtocolContext(CommandPublisher):
         labware, a :py:obj:`~opentrons.protocol_api.ModuleContext` if the slot contains a hardware
         module, or ``None`` if the slot doesn't contain anything.
 
-        This object is useful for determining if a slot in the deck is free.
-
         Rather than filtering the objects in the deck map yourself,
-        you can also use :py:attr:`loaded_labwares` to see a dict of labwares
-        and :py:attr:`loaded_modules` to see a dict of modules.
+        you can also use :py:attr:`loaded_labwares` to get a dict of labwares
+        and :py:attr:`loaded_modules` to get a dict of modules.
 
-        For advanced control, you can delete an item of labware from the deck
-        with e.g. ``del protocol.deck['1']`` to free a slot for new labware.
+        For :ref:`advanced-control` `only`, you can delete an element of the ``deck`` dict.
+        This only works for deck slots that contain labware objects. For example, if slot 
+        1 contains a labware, ``del protocol.deck['1']`` will free the slot so you can 
+        load another labware there.
+        
+        .. warning::
+            Do not delete labware from a deck slot for protocols run in the Opentrons App 
+            or on the Flex touchscreen. The protocol will continue immediately without 
+            giving you a chance to physically remove the labware. 
+            Use :py:meth:`.move_labware` instead.
+        
+        .. versionchanged:: 2.14
+           Deleting deck elements raises an error.
+
+        .. versionchanged:: 2.15
+           ``del`` sets the labware location to ``OFF_DECK`` instead of deleting it.
         """
         return self._deck
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Adds description, a warning, and version changed notices to the `deck` entry of the API Reference. This explains things changing w.r.t #13239 

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Check the API Reference in the sandbox.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- description of new behavior
- new warning not to do this in regular protocols
- two `.. versionchanged::` notices

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Is this accurate for planned behavior? Is the notice for v2.14 proper?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

None, docs. (Negative if you include warning people against making their robot go 💥 )