### PR TITLE
fix(robot-server): Advertise a minimum Python Protocol API version of 2.15 from Flex robots

### DIFF
--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -7,6 +7,7 @@ control the OT2.
 from opentrons.protocols.api_support.definitions import (
     MAX_SUPPORTED_VERSION,
     MIN_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION_FOR_FLEX,
 )
 
 from .protocol_context import ProtocolContext
@@ -32,6 +33,7 @@ from .create_protocol_context import (
 __all__ = [
     "MAX_SUPPORTED_VERSION",
     "MIN_SUPPORTED_VERSION",
+    "MIN_SUPPORTED_VERSION_FOR_FLEX",
     "ProtocolContext",
     "Deck",
     "ModuleContext",

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -4,4 +4,15 @@ MAX_SUPPORTED_VERSION = APIVersion(2, 15)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)
-"""The minimum supported protocol API version in this release."""
+"""The minimum supported protocol API version in this release, across all robot types."""
+
+MIN_SUPPORTED_VERSION_FOR_FLEX = APIVersion(2, 15)
+"""The minimum protocol API version supported by the Opentrons Flex.
+
+It's an infrastructural requirement for this to be at least newer than 2.14. Before then,
+the protocol API is backed by the legacy non-Protocol-engine backend, which is not prepared to
+handle anything but OT-2s.
+
+The additional bump to 2.15 is because that's what we tested on, and because it adds all the
+Flex-specific features.
+"""

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -25,6 +25,7 @@ from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.ordered_set import OrderedSet
 
+from .api_support.definitions import MIN_SUPPORTED_VERSION_FOR_FLEX
 from .api_support.types import APIVersion
 from .types import (
     RUN_FUNCTION_MESSAGE,
@@ -49,9 +50,6 @@ MODULE_LOG = logging.getLogger(__name__)
 API_VERSION_RE = re.compile(r"^(\d+)\.(\d+)$")
 MAX_SUPPORTED_JSON_SCHEMA_VERSION = 5
 API_VERSION_FOR_JSON_V5_AND_BELOW = APIVersion(2, 8)
-
-
-_MIN_API_VERSION_FOR_FLEX = APIVersion(2, 15)
 
 
 class JSONSchemaVersionTooNewError(RuntimeError):
@@ -167,11 +165,11 @@ def _validate_v2_static_info(static_info: StaticPythonInfo) -> None:
 
 
 def _validate_robot_type_at_version(robot_type: RobotType, version: APIVersion) -> None:
-    if robot_type == "OT-3 Standard" and version < _MIN_API_VERSION_FOR_FLEX:
+    if robot_type == "OT-3 Standard" and version < MIN_SUPPORTED_VERSION_FOR_FLEX:
         raise MalformedPythonProtocolError(
             short_message=(
                 f"The Opentrons Flex only supports apiLevel"
-                f" {_MIN_API_VERSION_FOR_FLEX} or newer."
+                f" {MIN_SUPPORTED_VERSION_FOR_FLEX} or newer."
             )
         )
 

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -141,9 +141,11 @@ async def get_health(
     )
 
     if robot_type == "OT-3 Standard":
+        minimum_protocol_api_version = protocol_api.MIN_SUPPORTED_VERSION_FOR_FLEX
         logs = FLEX_LOG_PATHS
         health_links.oddLog = "/logs/touchscreen.log"
     else:
+        minimum_protocol_api_version = protocol_api.MIN_SUPPORTED_VERSION
         logs = OT2_LOG_PATHS
 
     return Health(
@@ -154,7 +156,7 @@ async def get_health(
         logs=logs,
         system_version=versions.system_version,
         maximum_protocol_api_version=list(protocol_api.MAX_SUPPORTED_VERSION),
-        minimum_protocol_api_version=list(protocol_api.MIN_SUPPORTED_VERSION),
+        minimum_protocol_api_version=list(minimum_protocol_api_version),
         robot_model=robot_type,
         links=health_links,
     )

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -3,12 +3,13 @@
 
 from box import Box
 from requests import Response
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
+from opentrons.protocol_api import (
+    MAX_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION_FOR_FLEX,
+)
 from opentrons import __version__, config
 from opentrons_shared_data.module.dev_types import ModuleModel
-
-minimum_version = list(MIN_SUPPORTED_VERSION)
-maximum_version = list(MAX_SUPPORTED_VERSION)
 
 
 def check_health_response(response: Response) -> None:
@@ -20,8 +21,8 @@ def check_health_response(response: Response) -> None:
         "logs": ["/logs/serial.log", "/logs/api.log", "/logs/server.log"],
         "system_version": config.OT_SYSTEM_VERSION,
         "robot_model": "OT-2 Standard",
-        "minimum_protocol_api_version": minimum_version,
-        "maximum_protocol_api_version": maximum_version,
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",
@@ -48,8 +49,8 @@ def check_ot3_health_response(response: Response) -> None:
         ],
         "system_version": config.OT_SYSTEM_VERSION,
         "robot_model": "OT-3 Standard",
-        "minimum_protocol_api_version": minimum_version,
-        "maximum_protocol_api_version": maximum_version,
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION_FOR_FLEX),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",


### PR DESCRIPTION
# Overview

Closes RQA-1005.

# Test Plan

* [x] **Robot Settings > Advanced > Supported Protocol API Versions** says **v2.15 - v2.15** on a Flex dev server.
* [x] It still says **v2.0 - v2.15** on an OT-2 dev server. 

# Changelog

Make `GET /health` advertise a minimum Python Protocol API version of 2.15, not 2.0, if the server is running on a Flex.

# Review requests

None in particular.

# Risk assessment

Low.
