### PR TITLE
fix(hardware-testing): various fixture updates

### DIFF
--- a/hardware-testing/fixture_overrides/hardware_fixtures.patch
+++ b/hardware-testing/fixture_overrides/hardware_fixtures.patch
@@ -1,5 +1,5 @@
 diff --git a/api/src/opentrons/config/feature_flags.py b/api/src/opentrons/config/feature_flags.py
-index f46674fb56..f59f3826de 100644
+index f46674fb5..f59f3826d 100644
 --- a/api/src/opentrons/config/feature_flags.py
 +++ b/api/src/opentrons/config/feature_flags.py
 @@ -76,6 +76,4 @@ def tip_presence_detection_enabled() -> bool:
@@ -10,8 +10,45 @@ index f46674fb56..f59f3826de 100644
 -        "estopNotRequired", RobotTypeEnum.FLEX
 -    )
 +    return False
+diff --git a/api/src/opentrons/hardware_control/backends/ot3controller.py b/api/src/opentrons/hardware_control/backends/ot3controller.py
+index 8a82c2ad9..24b43028a 100644
+--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
++++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
+@@ -198,19 +198,19 @@ def requires_estop(func: Wrapped) -> Wrapped:
+ 
+     @wraps(func)
+     async def wrapper(self: OT3Controller, *args: Any, **kwargs: Any) -> Any:
+-        state = self._estop_state_machine.state
+-        if state == EstopState.NOT_PRESENT and ff.require_estop():
+-            raise EStopNotPresentError(
+-                message="An Estop must be plugged in to move the robot."
+-            )
+-        if state == EstopState.LOGICALLY_ENGAGED:
+-            raise EStopActivatedError(
+-                message="Estop must be acknowledged and cleared to move the robot."
+-            )
+-        if state == EstopState.PHYSICALLY_ENGAGED:
+-            raise EStopActivatedError(
+-                message="Estop is currently engaged, robot cannot move."
+-            )
++        # state = self._estop_state_machine.state
++        # if state == EstopState.NOT_PRESENT and ff.require_estop():
++        #     raise EStopNotPresentError(
++        #         message="An Estop must be plugged in to move the robot."
++        #     )
++        # if state == EstopState.LOGICALLY_ENGAGED:
++        #     raise EStopActivatedError(
++        #         message="Estop must be acknowledged and cleared to move the robot."
++        #     )
++        # if state == EstopState.PHYSICALLY_ENGAGED:
++        #     raise EStopActivatedError(
++        #         message="Estop is currently engaged, robot cannot move."
++        #     )
+         return await func(self, *args, **kwargs)
+ 
+     return cast(Wrapped, wrapper)
 diff --git a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
-index 318deea522..8d351e4a77 100644
+index 318deea52..8d351e4a7 100644
 --- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
 +++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_utils.py
 @@ -24,7 +24,7 @@ log = logging.getLogger(__name__)

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -1166,6 +1166,7 @@ async def _test_liquid_probe(
     assert CALIBRATED_LABWARE_LOCATIONS.plate is not None
     target_z = CALIBRATED_LABWARE_LOCATIONS.plate.z
     for trial in range(trials):
+        await api.home()
         await _pick_up_tip_for_tip_volume(api, mount, tip_volume)
         await _move_to_above_plate_liquid(api, mount, height_mm=hover_mm)
         start_pos = await api.gantry_position(mount)

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -19,7 +19,11 @@ from opentrons_hardware.firmware_bindings.messages.messages import MessageDefini
 from opentrons_hardware.firmware_bindings.constants import SensorType
 
 from opentrons.config.types import LiquidProbeSettings
-from opentrons.hardware_control.types import TipStateType, FailedTipStateCheck
+from opentrons.hardware_control.types import (
+    TipStateType,
+    FailedTipStateCheck,
+    SubSystem,
+)
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.ot3_calibration import (
     calibrate_pipette,
@@ -59,7 +63,7 @@ DEFAULT_SLOT_RESERVOIR = 8
 DEFAULT_SLOT_PLATE = 2
 DEFAULT_SLOT_TRASH = 12
 
-PROBING_DECK_PRECISION_MM = 0.1
+PROBING_DECK_PRECISION_MM = 0.3
 
 TRASH_HEIGHT_MM: Final = 45
 LEAK_HOVER_ABOVE_LIQUID_MM: Final = 50
@@ -800,15 +804,18 @@ async def _test_diagnostics_capacitive(
         not api.is_simulator
         and len(offsets) > 1
         and (
-            abs(offsets[0].x - offsets[1].x) < PROBING_DECK_PRECISION_MM
-            and abs(offsets[0].x - offsets[1].x) < PROBING_DECK_PRECISION_MM
-            and abs(offsets[0].x - offsets[1].x) < PROBING_DECK_PRECISION_MM
+            abs(offsets[0].x - offsets[1].x) <= PROBING_DECK_PRECISION_MM
+            and abs(offsets[0].y - offsets[1].y) <= PROBING_DECK_PRECISION_MM
+            and abs(offsets[0].z - offsets[1].z) <= PROBING_DECK_PRECISION_MM
         )
     ):
-        probe_slot_result = _bool_to_pass_fail(True)
+        probe_slot_pass = True
+
     else:
-        probe_slot_result = _bool_to_pass_fail(False)
+        probe_slot_pass = False
+    probe_slot_result = _bool_to_pass_fail(probe_slot_pass)
     print(f"probe-slot-result: {probe_slot_result}")
+    write_cb(["capacitive-probe-slot-result", probe_slot_result])
 
     probe_pos = helpers_ot3.get_slot_calibration_square_position_ot3(5)
     probe_pos += Point(13, 13, 0)
@@ -847,6 +854,7 @@ async def _test_diagnostics_capacitive(
         and capacitive_probe_attached_pass
         and capacitive_probing_pass
         and capacitive_square_pass
+        and probe_slot_pass
     )
 
 
@@ -1359,6 +1367,13 @@ async def _main(test_config: TestConfig) -> None:  # noqa: C901
         # cache the pressure-data header
         csv_cb.pressure(PRESSURE_DATA_HEADER, first_row_value="")
 
+        if api.is_simulator:
+            pcba_version = "C2"
+        else:
+            subsystem = SubSystem.of_mount(mount)
+            pcba_version = api.attached_subsystems[subsystem].pcba_revision
+
+        print(f"PCBA version: {pcba_version}")
         # add metadata to CSV
         # FIXME: create a set of CSV helpers, such that you can define a test-report
         #        schema/format/line-length/etc., before having to fill its contents.
@@ -1373,6 +1388,7 @@ async def _main(test_config: TestConfig) -> None:  # noqa: C901
         csv_cb.write(["simulating" if test_config.simulate else "live"])
         csv_cb.write(["version", data.get_git_description()])
         csv_cb.write(["firmware", api.fw_version])
+        csv_cb.write(["pcba-revision", pcba_version])
         # add test configurations to CSV
         csv_cb.write(["-------------------"])
         csv_cb.write(["TEST-CONFIGURATIONS"])

--- a/hardware-testing/hardware_testing/production_qc/pipette_current_speed_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_current_speed_qc_ot3.py
@@ -20,52 +20,77 @@ from hardware_testing.opentrons_api import types
 from hardware_testing.opentrons_api import helpers_ot3
 from hardware_testing.data import ui
 
-TEST_TAG = "CURRENTS-SPEEDS"
+DEFAULT_TRIALS = 5
+STALL_THRESHOLD_MM = 0.1
+TEST_ACCELERATION = 1500  # used during gravimetric tests
 
 DEFAULT_ACCELERATION = DEFAULT_ACCELERATIONS.low_throughput[types.OT3AxisKind.P]
 DEFAULT_CURRENT = DEFAULT_RUN_CURRENT.low_throughput[types.OT3AxisKind.P]
 DEFAULT_SPEED = DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P]
 
-MUST_PASS_CURRENT = DEFAULT_CURRENT * 0.6  # the target spec (must pass here)
-STALL_THRESHOLD_MM = 0.1
-TEST_SPEEDS = [DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P]]
+MUST_PASS_CURRENT = 0.4  # the target spec (must pass here)
+assert (
+    MUST_PASS_CURRENT < DEFAULT_CURRENT
+), "must-pass current must be less than default current"
+TEST_SPEEDS = [
+    DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P],
+    DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P] + 10,
+    DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P] + 20,
+]
 PLUNGER_CURRENTS_SPEED = {
-    round(MUST_PASS_CURRENT - 0.3, 1): TEST_SPEEDS,
-    round(MUST_PASS_CURRENT - 0.2, 1): TEST_SPEEDS,
-    round(MUST_PASS_CURRENT - 0.1, 1): TEST_SPEEDS,
-    round(MUST_PASS_CURRENT, 1): TEST_SPEEDS,
+    0.3: TEST_SPEEDS,
+    0.4: TEST_SPEEDS,
+    0.5: TEST_SPEEDS,
+    0.75: TEST_SPEEDS,
     DEFAULT_CURRENT: TEST_SPEEDS,
 }
-TEST_ACCELERATION = 1500  # used during gravimetric tests
 
-MAX_CURRENT = max(max(list(PLUNGER_CURRENTS_SPEED.keys())), 1.0)
 MAX_SPEED = max(TEST_SPEEDS)
+MAX_CURRENT = max(max(list(PLUNGER_CURRENTS_SPEED.keys())), 1.0)
+assert MAX_CURRENT == DEFAULT_CURRENT, (
+    f"do not test current ({MAX_CURRENT}) "
+    f"above the software's default current ({DEFAULT_CURRENT})"
+)
 
 
-def _get_test_tag(current: float, speed: float, direction: str, pos: str) -> str:
-    return f"current-{current}-speed-{speed}-{direction}-{pos}"
+def _get_test_tag(
+    current: float, speed: float, trial: int, direction: str, pos: str
+) -> str:
+    return f"current-{current}-speed-trial-{trial}-{speed}-{direction}-{pos}"
 
 
-def _build_csv_report() -> CSVReport:
+def _get_section_tag(current: float) -> str:
+    return f"CURRENT-{current}-AMPS"
+
+
+def _includes_result(current: float, speed: float) -> bool:
+    # TODO: figure out the current/speed thresholds
+    #       for what should be considered an overall PASS or FAIL.
+    #       Until then, give everything a PASS or FAIL, so we can
+    #       review the results more easily
+    return True
+
+
+def _build_csv_report(trials: int) -> CSVReport:
     _report = CSVReport(
         test_name="pipette-current-speed-qc-ot3",
         sections=[
             CSVSection(
-                title="OVERALL", lines=[CSVLine("failing-current", [float, CSVResult])]
-            ),
-            CSVSection(
-                title=TEST_TAG,
+                title=_get_section_tag(current),
                 lines=[
                     CSVLine(
-                        _get_test_tag(current, speed, direction, pos),
-                        [float, float, float, float, CSVResult],
+                        _get_test_tag(current, speed, trial, direction, pos),
+                        [float, float, float, float, CSVResult]
+                        if _includes_result(current, speed)
+                        else [float, float, float, float],
                     )
-                    for current, speeds in PLUNGER_CURRENTS_SPEED.items()
-                    for speed in speeds
+                    for speed in sorted(PLUNGER_CURRENTS_SPEED[current], reverse=False)
+                    for trial in range(trials)
                     for direction in ["down", "up"]
                     for pos in ["start", "end"]
                 ],
-            ),
+            )
+            for current in sorted(list(PLUNGER_CURRENTS_SPEED.keys()), reverse=False)
         ],
     )
     return _report
@@ -75,10 +100,13 @@ async def _home_plunger(api: OT3API, mount: types.OT3Mount) -> None:
     # restore default current/speed before homing
     pipette_ax = types.Axis.of_main_tool_actuator(mount)
     await helpers_ot3.set_gantry_load_per_axis_current_settings_ot3(
-        api, pipette_ax, run_current=DEFAULT_CURRENT
+        api, pipette_ax, run_current=1.0
     )
     await helpers_ot3.set_gantry_load_per_axis_motion_settings_ot3(
-        api, pipette_ax, default_max_speed=DEFAULT_SPEED
+        api,
+        pipette_ax,
+        default_max_speed=DEFAULT_SPEED / 2,
+        acceleration=DEFAULT_ACCELERATION,
     )
     await api.home([pipette_ax])
 
@@ -94,7 +122,7 @@ async def _move_plunger(
     # set max currents/speeds, to make sure we're not accidentally limiting ourselves
     pipette_ax = types.Axis.of_main_tool_actuator(mount)
     await helpers_ot3.set_gantry_load_per_axis_current_settings_ot3(
-        api, pipette_ax, run_current=MAX_CURRENT
+        api, pipette_ax, run_current=c
     )
     await helpers_ot3.set_gantry_load_per_axis_motion_settings_ot3(
         api,
@@ -112,6 +140,7 @@ async def _record_plunger_alignment(
     api: OT3API,
     mount: types.OT3Mount,
     report: CSVReport,
+    trial: int,
     current: float,
     speed: float,
     direction: str,
@@ -126,13 +155,19 @@ async def _record_plunger_alignment(
     else:
         enc = est
     _stalled_mm = est - enc
-    print(f"{position}: motor={est}, encoder={enc}")
-    _did_pass = abs(_stalled_mm) < STALL_THRESHOLD_MM
-    _tag = _get_test_tag(current, speed, direction, position)
+    print(f"{position}: motor={round(est, 2)}, encoder={round(enc, 2)}")
+    if not api.is_simulator:
+        _did_pass = abs(_stalled_mm) < STALL_THRESHOLD_MM
+    else:
+        _did_pass = speed < MAX_SPEED
+    # NOTE: only tests that are required to PASS need to show a results in the file
+    data = [round(current, 2), round(speed, 2), round(est, 2), round(enc, 2)]
+    if _includes_result(current, speed):
+        data.append(CSVResult.from_bool(_did_pass))  # type: ignore[arg-type]
     report(
-        TEST_TAG,
-        _tag,
-        [current, speed, est, enc, CSVResult.from_bool(_did_pass)],
+        _get_section_tag(current),
+        _get_test_tag(current, speed, trial, direction, position),
+        data,
     )
     return _did_pass
 
@@ -141,26 +176,27 @@ async def _test_direction(
     api: OT3API,
     mount: types.OT3Mount,
     report: CSVReport,
+    trial: int,
     current: float,
     speed: float,
     acceleration: float,
     direction: str,
 ) -> bool:
     plunger_poses = helpers_ot3.get_plunger_positions_ot3(api, mount)
-    top, bottom, blowout, drop_tip = plunger_poses
+    top, _, bottom, _ = plunger_poses
     # check that encoder/motor align
     aligned = await _record_plunger_alignment(
-        api, mount, report, current, speed, direction, "start"
+        api, mount, report, trial, current, speed, direction, "start"
     )
     if not aligned:
         return False
     # move the plunger
-    _plunger_target = {"down": blowout, "up": top}[direction]
+    _plunger_target = {"down": bottom, "up": top + 1.0}[direction]
     try:
         await _move_plunger(api, mount, _plunger_target, speed, current, acceleration)
         # check that encoder/motor still align
         aligned = await _record_plunger_alignment(
-            api, mount, report, current, speed, direction, "end"
+            api, mount, report, trial, current, speed, direction, "end"
         )
     except StallOrCollisionDetectedError as e:
         print(e)
@@ -169,34 +205,49 @@ async def _test_direction(
     return aligned
 
 
-async def _unstick_plunger(api: OT3API, mount: types.OT3Mount) -> None:
-    plunger_poses = helpers_ot3.get_plunger_positions_ot3(api, mount)
-    top, bottom, blowout, drop_tip = plunger_poses
-    await _move_plunger(api, mount, bottom, 10, 1.0, DEFAULT_ACCELERATION)
-    await _home_plunger(api, mount)
-
-
-async def _test_plunger(api: OT3API, mount: types.OT3Mount, report: CSVReport) -> float:
-    ui.print_header("UNSTICK PLUNGER")
-    await _unstick_plunger(api, mount)
+async def _test_plunger(
+    api: OT3API,
+    mount: types.OT3Mount,
+    report: CSVReport,
+    trials: int,
+    continue_after_stall: bool,
+) -> float:
     # start at HIGHEST (easiest) current
-    currents = sorted(list(PLUNGER_CURRENTS_SPEED.keys()), reverse=True)
+    currents = sorted(list(PLUNGER_CURRENTS_SPEED.keys()), reverse=False)
+    max_failed_current = 0.0
     for current in currents:
+        ui.print_title(f"CURRENT = {current}")
         # start at LOWEST (easiest) speed
         speeds = sorted(PLUNGER_CURRENTS_SPEED[current], reverse=False)
         for speed in speeds:
-            ui.print_header(f"CURRENT = {current}; SPEED = {speed}")
-            await _home_plunger(api, mount)
-            for direction in ["down", "up"]:
-                _pass = await _test_direction(
-                    api, mount, report, current, speed, TEST_ACCELERATION, direction
+            for trial in range(trials):
+                ui.print_header(
+                    f"CURRENT = {current}: "
+                    f"SPEED = {speed}: "
+                    f"TRIAL = {trial + 1}/{trials}"
                 )
-                if not _pass:
-                    ui.print_error(
-                        f"failed moving {direction} at {current} amps and {speed} mm/sec"
+                await _home_plunger(api, mount)
+                for direction in ["down", "up"]:
+                    _pass = await _test_direction(
+                        api,
+                        mount,
+                        report,
+                        trial,
+                        current,
+                        speed,
+                        TEST_ACCELERATION,
+                        direction,
                     )
-                    return current
-    return 0.0
+                    if not _pass:
+                        ui.print_error(
+                            f"failed moving {direction} at {current} amps and {speed} mm/sec"
+                        )
+                        max_failed_current = max(max_failed_current, current)
+                        if continue_after_stall:
+                            break
+                        else:
+                            return max_failed_current
+    return max_failed_current
 
 
 async def _get_next_pipette_mount(api: OT3API) -> types.OT3Mount:
@@ -213,7 +264,14 @@ async def _get_next_pipette_mount(api: OT3API) -> types.OT3Mount:
 
 
 async def _reset_gantry(api: OT3API) -> None:
-    await api.home()
+    await api.home(
+        [
+            types.Axis.Z_L,
+            types.Axis.Z_R,
+            types.Axis.X,
+            types.Axis.Y,
+        ]
+    )
     home_pos = await api.gantry_position(
         types.OT3Mount.RIGHT, types.CriticalPoint.MOUNT
     )
@@ -224,7 +282,7 @@ async def _reset_gantry(api: OT3API) -> None:
     )
 
 
-async def _main(is_simulating: bool) -> None:
+async def _main(is_simulating: bool, trials: int, continue_after_stall: bool) -> None:
     api = await helpers_ot3.build_async_ot3_hardware_api(
         is_simulating=is_simulating,
         pipette_left="p1000_single_v3.4",
@@ -239,16 +297,16 @@ async def _main(is_simulating: bool) -> None:
         if not api.is_simulator and not ui.get_user_answer(f"QC {mount.name} pipette"):
             continue
 
-        report = _build_csv_report()
+        report = _build_csv_report(trials=trials)
         dut = helpers_ot3.DeviceUnderTest.by_mount(mount)
         helpers_ot3.set_csv_report_meta_data_ot3(api, report, dut)
 
-        failing_current = await _test_plunger(api, mount, report)
-        report(
-            "OVERALL",
-            "failing-current",
-            [failing_current, CSVResult.from_bool(failing_current < MUST_PASS_CURRENT)],
+        await _test_plunger(
+            api, mount, report, trials=trials, continue_after_stall=continue_after_stall
         )
+        ui.print_title("DONE")
+        report.save_to_disk()
+        report.print_results()
         if api.is_simulator:
             break
 
@@ -256,5 +314,7 @@ async def _main(is_simulating: bool) -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
+    parser.add_argument("--trials", type=int, default=DEFAULT_TRIALS)
+    parser.add_argument("--continue-after-stall", action="store_true")
     args = parser.parse_args()
-    asyncio.run(_main(args.simulate))
+    asyncio.run(_main(args.simulate, args.trials, args.continue_after_stall))

--- a/hardware-testing/hardware_testing/production_qc/pipette_current_speed_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_current_speed_qc_ot3.py
@@ -33,6 +33,7 @@ assert (
     MUST_PASS_CURRENT < DEFAULT_CURRENT
 ), "must-pass current must be less than default current"
 TEST_SPEEDS = [
+    DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P] - 20,
     DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P],
     DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P] + 10,
     DEFAULT_MAX_SPEEDS.low_throughput[types.OT3AxisKind.P] + 20,

--- a/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
@@ -796,7 +796,7 @@ async def get_test_metadata(
 ) -> Tuple[str, str]:
     """Get the operator name and robot serial number."""
     if arguments.no_input:
-        _operator = "None"
+        _operator = args.operator if isinstance(args.operator, str) else "None"
         _robot_id = api._backend.eeprom_data.serial_number
         if not _robot_id:
             ui.print_error("no serial number saved on this robot")
@@ -810,7 +810,10 @@ async def get_test_metadata(
             if not _robot_id:
                 ui.print_error("no serial number saved on this robot")
                 _robot_id = input("enter ROBOT SERIAL number: ").strip()
-            _operator = input("enter OPERATOR name: ")
+            if isinstance(args.operator, str):
+                _operator = args.operator
+            else:
+                _operator = input("enter OPERATOR name: ")
 
     return (_operator, _robot_id)
 
@@ -927,6 +930,7 @@ async def _main(arguments: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--operator", type=str, default=None)
     parser.add_argument("--simulate", action="store_true")
     parser.add_argument("--cycles", type=int, default=20)
     parser.add_argument("--skip_bowtie", action="store_true")

--- a/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
@@ -648,6 +648,7 @@ async def _run_xy_motion(
     XY_AXIS_SETTINGS = _creat_xy_axis_settings(arguments)
     LOG.info(XY_AXIS_SETTINGS)
     for setting in XY_AXIS_SETTINGS:
+        await api.home()
         print_motion_settings(
             "X",
             setting[Axis.X].max_speed,

--- a/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
@@ -23,6 +23,7 @@ from hardware_testing.data.csv_report import (
 
 from opentrons_shared_data.errors.exceptions import MoveConditionNotMetError
 from opentrons.config.advanced_settings import get_adv_setting, set_adv_setting
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 import logging
 
@@ -364,7 +365,7 @@ if __name__ == "__main__":
     arg_parser.add_argument("--simulate", action="store_true")
     arg_parser.add_argument("--skip_left", action="store_true")
     arg_parser.add_argument("--skip_right", action="store_true")
-    old_stall_setting = get_adv_setting("disableStallDetection")
+    old_stall_setting = get_adv_setting("disableStallDetection", RobotTypeEnum.FLEX)
     try:
         asyncio.run(set_adv_setting("disableStallDetection", True))
         asyncio.run(_main(arg_parser.parse_args()))

--- a/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
@@ -22,6 +22,7 @@ from hardware_testing.data.csv_report import (
 )
 
 from opentrons_shared_data.errors.exceptions import MoveConditionNotMetError
+from opentrons.config.advanced_settings import get_adv_setting, set_adv_setting
 
 import logging
 
@@ -219,9 +220,9 @@ async def _force_gauge(
     await api.home([z_ax])
     home_pos = await api.gantry_position(mount)
     LOG.info(f"Home Position: {home_pos}")
-    pre_test_pos = home_pos._replace(z=home_pos.z - 10)
+    pre_test_pos = home_pos._replace(z=home_pos.z - 110)
     LOG.info(f"Pre-Test Position: {pre_test_pos}")
-    press_pos = home_pos._replace(z=pre_test_pos.z - 12)
+    press_pos = home_pos._replace(z=pre_test_pos.z - 113)
     LOG.info(f"Press Position: {press_pos}")
 
     qc_pass = True
@@ -273,6 +274,7 @@ async def _force_gauge(
             # we expect a stall has happened during pick up, so we want to
             # update the motor estimation
             await api._update_position_estimation([Axis.by_mount(mount)])
+            await api.refresh_positions()
 
             await api.move_to(mount=mount, abs_position=pre_test_pos)
 
@@ -362,4 +364,14 @@ if __name__ == "__main__":
     arg_parser.add_argument("--simulate", action="store_true")
     arg_parser.add_argument("--skip_left", action="store_true")
     arg_parser.add_argument("--skip_right", action="store_true")
-    asyncio.run(_main(arg_parser.parse_args()))
+    old_stall_setting = get_adv_setting("disableStallDetection")
+    try:
+        asyncio.run(set_adv_setting("disableStallDetection", True))
+        asyncio.run(_main(arg_parser.parse_args()))
+    finally:
+        asyncio.run(
+            set_adv_setting(
+                "disableStallDetection",
+                False if old_stall_setting is None else old_stall_setting.value,
+            )
+        )


### PR DESCRIPTION
# Overview

All fixture patches
- Changed ot3api to never block movement based on estop

Z Stage:
- Disable stall detection
- Refresh position after each stall
- Update positions based on fixture in Shenzhen

Robot assembly:
- Refresh position only after estop is released to avoid exceptions

Robot Stress
- Home for each new settings group
- Added ability to run overnight with `nohup` by ignoring input

Pipette assembly:
- Check & Print the PCBA version for operator review
- Probing deck precision loosened to 0.3mm
- Include deck recalibration in final results
- Check XYZ instead of just X
- Current/speed tests many more points, and has 5 trials for each setting

**NOTE that all fixture software must be uploaded with the command `make push-ot3-fixture` in order to include patches for fixture-specific fixes now.**

# Test Plan


# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
