### PR TITLE
docs(api): new page on adapting OT-2 protocols for Flex

### DIFF
--- a/api/docs/v2/adapting_ot2_flex.rst
+++ b/api/docs/v2/adapting_ot2_flex.rst
@@ -27,15 +27,18 @@ You also need to specify ``'robotType': 'Flex'``. If you omit ``robotType`` in t
 Pipettes and Tip-rack Load Names
 ================================
 
-Flex uses different types of pipettes and tip racks than OT-2, which have their own load names in the API. Choose pipettes of the same capacity or larger (or whatever you’ve outfitted your Flex with). See the :ref:`list of pipette API load names <new-pipette-models>` for the valid values of ``instrument_name`` in Flex protocols. And check `Labware Library <https://labware.opentrons.com>`_ or the Opentrons App for the list of Flex tip racks.
+Flex uses different types of pipettes and tip racks than OT-2, which have their own load names in the API. If possible, load Flex pipettes of the same capacity or larger than the OT-2 pipettes. See the :ref:`list of pipette API load names <new-pipette-models>` for the valid values of ``instrument_name`` in Flex protocols. And check `Labware Library <https://labware.opentrons.com>`_ or the Opentrons App for the load names of Flex tip racks.
+
+.. note::
+    If you use smaller capacity tips than in the OT-2 protocol, you may need to make further adjustments to avoid running out of tips. Also, the protocol may have more steps and take longer to execute.
 
 This example converts OT-2 code that uses a P300 Single-Channel GEN2 pipette and 300 µL tips to Flex code that uses a Flex 1-Channel 1000 µL pipette and 1000 µL tips.
 
 .. TK code tabs here
 
 
-Deck Slot Names
-===============
+Deck Slot Labels
+================
 
 It's good practice to update numeric labels for :ref:`deck-slots` (which match the labels on an OT-2) to coordinate ones (which match the labels on Flex). This is an optional step, since the two formats are interchangeable.
 
@@ -50,7 +53,7 @@ If your OT-2 protocol uses older generations of the Temperature Module or Thermo
     * ``temperature module gen2``
     * ``thermocycler module gen2`` or ``thermocyclerModuleV2``
     
-The Heater-Shaker Module only has one generation, which is compatible with Flex and OT-2.
+The Heater-Shaker Module only has one generation, ``heaterShakerModuleV1``, which is compatible with Flex and OT-2.
 
 The Magnetic Module is not compatible with Flex. For protocols that load ``magnetic module``, ``magdeck``, or ``magnetic module gen2``, you will need to make further modifications to use the :ref:`magnetic-block` and Flex Gripper instead. This will require reworking some of your protocol steps, and you should verify that your new protocol design achieves similar results.
 

--- a/api/docs/v2/adapting_ot2_flex.rst
+++ b/api/docs/v2/adapting_ot2_flex.rst
@@ -8,7 +8,7 @@ Adapting OT-2 Protocols for Flex
 
 Python protocols designed to run on the OT-2 can't be directly run on Flex without some modifications. This page describes the minimal steps that you need to take to get OT-2 protocols analyzing and running on Flex.
 
-Adapting a protocol for Flex lets you have parity across different Opentrons robots in yoru lab, or you can extend older protocols to take advantage of new features only available on Flex. Depending on your application, you may need to do additional verification of your adapted protocol.
+Adapting a protocol for Flex lets you have parity across different Opentrons robots in your lab, or you can extend older protocols to take advantage of new features only available on Flex. Depending on your application, you may need to do additional verification of your adapted protocol.
 
 Examples on this page are in tabs so you can quickly move back and forth to see the differences between OT-2 and Flex code.
 
@@ -16,6 +16,9 @@ Metadata and Requirements
 =========================
 
 Flex requires you to specify an ``apiLevel`` of 2.15 or higher. If your OT-2 protocol specified ``apiLevel`` in the ``metadata`` dictionary, it's best to move it to the ``requirements`` dictionary. You can't specify it in both places, or the API will raise an error.
+
+.. note::
+    Consult the list of :ref:`version-notes` to see what effect raising the ``apiLevel`` will have. If you increased it by multiple minor versions to get your protocol running on Flex, make sure that your protocol isn't using removed commands or commands whose behavior has changed in a way that may affect your scientific results.
 
 You also need to specify ``'robotType': 'Flex'``. If you omit ``robotType`` in the ``requirements`` dictionary, the API will assume the protocol is designed for the OT-2.
 
@@ -42,13 +45,12 @@ It's good practice to update numeric labels for :ref:`deck-slots` (which match t
 Module Load Names
 =================
 
-If your OT-2 uses older generations of the Temperature Module or Thermocycler Module, 
-update the load names you pass to :py:meth:`.load_module` to ones compatible with Flex:
+If your OT-2 protocol uses older generations of the Temperature Module or Thermocycler Module, update the load names you pass to :py:meth:`.load_module` to ones compatible with Flex:
 
     * ``temperature module gen2``
     * ``thermocycler module gen2`` or ``thermocyclerModuleV2``
     
-The Heater-Shaker Module only has one generation,  which is compatible with Flex and OT-2.
+The Heater-Shaker Module only has one generation, which is compatible with Flex and OT-2.
 
 The Magnetic Module is not compatible with Flex. For protocols that load ``magnetic module``, ``magdeck``, or ``magnetic module gen2``, you will need to make further modifications to use the :ref:`magnetic-block` and Flex Gripper instead. This will require reworking some of your protocol steps, and you should verify that your new protocol design achieves similar results.
 

--- a/api/docs/v2/adapting_ot2_flex.rst
+++ b/api/docs/v2/adapting_ot2_flex.rst
@@ -1,0 +1,55 @@
+:og:description: How to adapt an OT-2 Python protocol to run on Opentrons Flex.
+
+.. _adapting-ot2-protocols:
+
+********************************
+Adapting OT-2 Protocols for Flex
+********************************
+
+Python protocols designed to run on the OT-2 can't be directly run on Flex without some modifications. This page describes the minimal steps that you need to take to get OT-2 protocols analyzing and running on Flex.
+
+Adapting a protocol for Flex lets you have parity across different Opentrons robots in yoru lab, or you can extend older protocols to take advantage of new features only available on Flex. Depending on your application, you may need to do additional verification of your adapted protocol.
+
+Examples on this page are in tabs so you can quickly move back and forth to see the differences between OT-2 and Flex code.
+
+Metadata and Requirements
+=========================
+
+Flex requires you to specify an ``apiLevel`` of 2.15 or higher. If your OT-2 protocol specified ``apiLevel`` in the ``metadata`` dictionary, it's best to move it to the ``requirements`` dictionary. You can't specify it in both places, or the API will raise an error.
+
+You also need to specify ``'robotType': 'Flex'``. If you omit ``robotType`` in the ``requirements`` dictionary, the API will assume the protocol is designed for the OT-2.
+
+.. TK code tabs here
+
+Pipettes and Tip-rack Load Names
+================================
+
+Flex uses different types of pipettes and tip racks than OT-2, which have their own load names in the API. Choose pipettes of the same capacity or larger (or whatever you’ve outfitted your Flex with). See the :ref:`list of pipette API load names <new-pipette-models>` for the valid values of ``instrument_name`` in Flex protocols. And check `Labware Library <https://labware.opentrons.com>`_ or the Opentrons App for the list of Flex tip racks.
+
+This example converts OT-2 code that uses a P300 Single-Channel GEN2 pipette and 300 µL tips to Flex code that uses a Flex 1-Channel 1000 µL pipette and 1000 µL tips.
+
+.. TK code tabs here
+
+
+Deck Slot Names
+===============
+
+It's good practice to update numeric labels for :ref:`deck-slots` (which match the labels on an OT-2) to coordinate ones (which match the labels on Flex). This is an optional step, since the two formats are interchangeable.
+
+.. TK code?
+
+
+Module Load Names
+=================
+
+If your OT-2 uses older generations of the Temperature Module or Thermocycler Module, 
+update the load names you pass to :py:meth:`.load_module` to ones compatible with Flex:
+
+    * ``temperature module gen2``
+    * ``thermocycler module gen2`` or ``thermocyclerModuleV2``
+    
+The Heater-Shaker Module only has one generation,  which is compatible with Flex and OT-2.
+
+The Magnetic Module is not compatible with Flex. For protocols that load ``magnetic module``, ``magdeck``, or ``magnetic module gen2``, you will need to make further modifications to use the :ref:`magnetic-block` and Flex Gripper instead. This will require reworking some of your protocol steps, and you should verify that your new protocol design achieves similar results.
+
+.. TK some code from the science team?

--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -19,6 +19,7 @@ Welcome
     robot_position
     new_advanced_running
     new_examples
+    adapting_ot2_flex
     new_protocol_api
 
 The OT-2 Python Protocol API is a Python framework designed to make it easy to write automated biology lab protocols that use the OT-2 robot and optional hardware modules. We've designed the API to be accessible to anyone with basic Python and wet-lab skills. 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

New page of the PAPI docs, explaining the minimal steps to turn an OT-2 protocol into a Flex protocol. Based on some similar material I wrote for the Flex manual, but adjusted to fit into these docs, including cross-references to other pages, methods, etc.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Check prose and formatting in the [sandbox](http://sandbox.docs.opentrons.com/docs-adapt-ot2-protocols/v2/adapting_ot2_flex.html)
- Check that all standalone code snippets pass analysis

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Brand new page, Adapting OT-2 Protocols for Flex
- Insert new page in the TOC

# Review requests

<!--
Describe any requests for your reviewers here.
-->

👍 ❓ 

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

None, docs.