### PR TITLE
fix(app): ui changes to moduleInfo and liquid color icon

### DIFF
--- a/app/src/organisms/Devices/ModuleInfo.tsx
+++ b/app/src/organisms/Devices/ModuleInfo.tsx
@@ -17,6 +17,9 @@ import {
   getModuleDisplayName,
   getModuleDef2,
   MAGNETIC_BLOCK_V1,
+  THERMOCYCLER_MODULE_V2,
+  getModuleType,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { StyledText } from '../../atoms/text'
@@ -58,7 +61,13 @@ export const ModuleInfo = (props: ModuleInfoProps): JSX.Element => {
       y={0}
       height={labwareInterfaceYDimension ?? yDimension}
       width={labwareInterfaceXDimension ?? xDimension}
-      flexProps={{ padding: SPACING.spacing16 }}
+      flexProps={{
+        padding: SPACING.spacing16,
+        backgroundColor:
+          moduleDef.moduleType === THERMOCYCLER_MODULE_TYPE
+            ? COLORS.white
+            : COLORS.transparent,
+      }}
     >
       <Flex
         flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/ModuleInfo.tsx
+++ b/app/src/organisms/Devices/ModuleInfo.tsx
@@ -17,8 +17,6 @@ import {
   getModuleDisplayName,
   getModuleDef2,
   MAGNETIC_BLOCK_V1,
-  THERMOCYCLER_MODULE_V2,
-  getModuleType,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -49,6 +49,13 @@ const HIDE_SCROLLBAR = css`
   }
 `
 
+const LIQUID_BORDER_STYLE = css`
+  border-style: ${BORDERS.styleSolid};
+  border-width: 1px;
+  border-color: ${COLORS.medGreyEnabled};
+  border-radius: ${BORDERS.radiusSoftCorners};
+`
+
 export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
   const { runId } = props
   const protocolData = useMostRecentCompletedAnalysis(runId)
@@ -261,7 +268,7 @@ export const LiquidsListItemDetails = (
   return (
     <Flex flexDirection={DIRECTION_ROW}>
       <Flex
-        css={BORDERS.cardOutlineBorder}
+        css={LIQUID_BORDER_STYLE}
         padding={SPACING.spacing12}
         height="max-content"
         backgroundColor={COLORS.white}


### PR DESCRIPTION
closes RQA-1301 and RQA-1298

# Overview

This PR does a few things
1. adds a white background color to the module info only for thermocyclers.
2. remove the hover from the liquid icon in Protocol details liquids and Setup liquids (I removed it from both places since that icon doesn't actually act like a button in either of those areas)

# Test Plan

in the app, can do this in a dev environment/dev kit, upload a protocol with a thermocycler gen2 and liquids, in the liquid details, hover over the liquid icon and it shouldn't have a hover state. Then go to protocol setup and go to the liquid setup and hover over the liquid icons again, there shouldn't be a hover state.

then go to module setup, check the thermocycler module info, it should be legible now. **Note:** I changed it for both thermocyclers because we might change the thermocycler gen1 render to be an open thermocycler svg so it doesn't hurt to change it in both places

# Changelog

- change css state in `SetupLiquidsList` for the liquids icon
- add a background color to thermocycler modules in `ModuleInfo`

# Review requests

see test plan

# Risk assessment

low