### PR TITLE
docs(api): Document `ProtocolContext.commands()`

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -13,7 +13,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.ProtocolContext
    :members:
-   :exclude-members: location_cache, cleanup, clear_commands, commands
+   :exclude-members: location_cache, cleanup, clear_commands
 
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -232,6 +232,14 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def commands(self) -> List[str]:
+        """Return the run log.
+
+        This is a list of human-readable strings representing what's been done in the protocol so
+        far. For example, "Aspirating 123 µL from well A1 of 96 well plate in slot 1."
+
+        The exact format of these entries is not guaranteed. The format here may differ from other
+        places that show the run log, such as the Opentrons App.
+        """
         return self._commands
 
     @requires_version(2, 0)


### PR DESCRIPTION
11654# Overview

`ProtocolContext.commands()` is not currently listed on docs.opentrons.com. Before #11654, it was listed, but with an empty body.

It turns out that this method is actually public, in that our software team has recommended it to our support team ([1](https://opentrons.slack.com/archives/C0JLZLPL3/p1575922002338300?thread_ts=1575920726.337400&cid=C0JLZLPL3), [2](https://opentrons.slack.com/archives/C03TM47CW/p1590690760242600)) and our support team has recommended it to our customers ([3](https://support.opentrons.com/s/article/Running-the-robot-using-Jupyter-Notebook)). This PR documents and re-publishes it so it's clearer to everyone that it's official.

# Review requests

http://sandbox.docs.opentrons.com/document_protocolcontext_commands_method/v2/new_protocol_api.html#opentrons.protocol_api.ProtocolContext.commands (may still be building)

Does this definition make sense? Is the terminology good? Anything we want to add? Anything we want to leave out?

Note that things like `opentrons_simulate` also have a "run log" concept, so we should be wary of explaining too much here, unless we try to centralize the explanation somewhere.

# Risk assessment

No risk to functional behavior. Changes are just to documentation.
