### PR TITLE
fix(app): display trash name on droptip command text

### DIFF
--- a/api-client/src/instruments/types.ts
+++ b/api-client/src/instruments/types.ts
@@ -2,7 +2,7 @@ export type InstrumentData = PipetteData | GripperData | BadPipette | BadGripper
 export interface GripperData {
   data: {
     jawState: string
-    calibratedOffset: {
+    calibratedOffset?: {
       offset: { x: number; y: number; z: number }
       source: string
       last_modified?: string
@@ -21,7 +21,7 @@ export interface PipetteData {
     channels: number
     min_volume: number
     max_volume: number
-    calibratedOffset: {
+    calibratedOffset?: {
       offset: { x: number; y: number; z: number }
       source: string
       last_modified?: string

--- a/app/src/organisms/CommandText/utils/getLabwareName.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareName.ts
@@ -7,7 +7,11 @@ import {
 } from '@opentrons/shared-data'
 import { getLabwareDefinitionsFromCommands } from '../../LabwarePositionCheck/utils/labware'
 
-const FIXED_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+const FIXED_TRASH_DEF_URIS = [
+  'opentrons/opentrons_1_trash_850ml_fixed/1',
+  'opentrons/opentrons_1_trash_1100ml_fixed/1',
+  'opentrons/opentrons_1_trash_3200ml_fixed/1',
+]
 export function getLabwareName(
   analysis: CompletedProtocolAnalysis,
   labwareId: string
@@ -15,7 +19,7 @@ export function getLabwareName(
   const loadedLabware = getLoadedLabware(analysis, labwareId)
   if (loadedLabware == null) {
     return ''
-  } else if (loadedLabware.definitionUri === FIXED_TRASH_DEF_URI) {
+  } else if (FIXED_TRASH_DEF_URIS.includes(loadedLabware.definitionUri)) {
     return 'Fixed Trash'
   } else if (loadedLabware.displayName != null) {
     return loadedLabware.displayName

--- a/app/src/organisms/InterventionModal/utils/getLabwareNameFromRunData.ts
+++ b/app/src/organisms/InterventionModal/utils/getLabwareNameFromRunData.ts
@@ -8,7 +8,11 @@ import { getLabwareDefinitionsFromCommands } from '../../LabwarePositionCheck/ut
 
 import type { RunData } from '@opentrons/api-client'
 
-const FIXED_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+const FIXED_TRASH_DEF_URIS = [
+  'opentrons/opentrons_1_trash_850ml_fixed/1',
+  'opentrons/opentrons_1_trash_1100ml_fixed/1',
+  'opentrons/opentrons_1_trash_3200ml_fixed/1',
+]
 export function getLabwareNameFromRunData(
   protocolData: RunData,
   labwareId: string,
@@ -17,7 +21,7 @@ export function getLabwareNameFromRunData(
   const loadedLabware = getLoadedLabware(protocolData, labwareId)
   if (loadedLabware == null) {
     return ''
-  } else if (loadedLabware.definitionUri === FIXED_TRASH_DEF_URI) {
+  } else if (FIXED_TRASH_DEF_URIS.includes(loadedLabware.definitionUri)) {
     return 'Fixed Trash'
   } else if (loadedLabware.displayName != null) {
     return loadedLabware.displayName

--- a/app/src/organisms/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ProtocolSetupInstruments/utils.ts
@@ -57,7 +57,7 @@ export function getAreInstrumentsReady(
   })
   const isExtensionMountReady = getProtocolUsesGripper(analysis)
     ? getAttachedGripper(attachedInstruments)?.data.calibratedOffset
-        .last_modified != null
+        ?.last_modified != null
     : true
 
   return allSpeccedPipettesReady && isExtensionMountReady

--- a/app/src/organisms/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ProtocolSetupInstruments/utils.ts
@@ -53,7 +53,7 @@ export function getAreInstrumentsReady(
       loadedPipette,
       attachedInstruments
     )
-    return attachedPipetteMatch?.data.calibratedOffset.last_modified != null
+    return attachedPipetteMatch?.data.calibratedOffset?.last_modified != null
   })
   const isExtensionMountReady = getProtocolUsesGripper(analysis)
     ? getAttachedGripper(attachedInstruments)?.data.calibratedOffset

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
@@ -67,7 +67,7 @@ export function CalibrationDataDownload({
     isOT3 &&
     attachedInstruments?.data.some(
       instrument =>
-        instrument.ok && instrument.data.calibratedOffset.last_modified != null
+        instrument.ok && instrument.data.calibratedOffset?.last_modified != null
     )
 
   const onClickSaveAs: React.MouseEventHandler = e => {


### PR DESCRIPTION
# Overview
fix [RAUT-355](https://opentrons.atlassian.net/browse/RLAB-355)

Drop tip display text in the run log currently does not support trash labware other than the OT-2's `opentrons_1_trash_1100ml_fixed`. The command text is incorrectly displayed as "Dropping tip into A1 of ".

Note that the checks for displaying "fixed trash" in the protocol run log  references a hard-coded subset of labware URIs. This is a workaround for the current state in which trash labwares are listed as `loadedLabwares` but not in `loadLabware` commands of protocol analysis. In the future, we will reference the trash's labware display name directly from the `loadLabware` command, as is done with all other labware types.

# Test Plan
- Ensure drop tip command text in run log can display "Dropping tip into A1 of Fixed Trash" for all current trash options (in both App and ODD)

# Changelog
- added all current fixed trash definition URIs when getting labware name from run data

# Review requests
General

# Risk assessment
low

[RAUT-355]: https://opentrons.atlassian.net/browse/RAUT-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ