### PR TITLE
fix(app): bring users to top of setup when they press Back to Top

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
@@ -60,7 +60,7 @@ export function BackToTopButton({
 
   return (
     <Link
-      to={`/devices/${robotName}/protocol-runs/${runId}/run-preview`}
+      to={`/devices/${robotName}/protocol-runs/${runId}/setup`}
       onClick={() => {
         trackEvent({
           name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
@@ -88,7 +88,7 @@ describe('BackToTopButton', () => {
     const button = getByRole('link', { name: 'Back to top' })
     expect(button).not.toBeDisabled()
     expect(button.getAttribute('href')).toEqual(
-      '/devices/otie/protocol-runs/1/run-preview'
+      '/devices/otie/protocol-runs/1/setup'
     )
   })
 


### PR DESCRIPTION
fix RQA-1305

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The "Back to Top" button at the bottom of the run setup step was bringing users to the top of the run preview tab instead of the setup tab
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Go to setup for run for a protocol and press "Back to Top" - you should not be redirected to the run preview tab
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Change redirect to /setup from /run-preview
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
See test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
