### PR TITLE
fix(app): update api support version display format

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotInformation.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotInformation.tsx
@@ -33,10 +33,16 @@ export function RobotInformation({
     robot?.status != null ? getRobotProtocolApiVersion(robot) : null
   const minProtocolApiVersion = protocolApiVersions?.min ?? null
   const maxProtocolApiVersion = protocolApiVersions?.max ?? null
-  const apiVersionMinMax =
-    minProtocolApiVersion != null && maxProtocolApiVersion != null
-      ? `v${minProtocolApiVersion} - v${maxProtocolApiVersion}`
-      : t('robot_settings_advanced_unknown')
+
+  const formatApiVersionMinMax = (): string => {
+    if (minProtocolApiVersion === maxProtocolApiVersion) {
+      return `v${minProtocolApiVersion}`
+    } else {
+      return minProtocolApiVersion != null && maxProtocolApiVersion != null
+        ? `v${minProtocolApiVersion} - v${maxProtocolApiVersion}`
+        : t('robot_settings_advanced_unknown')
+    }
+  }
 
   return (
     <Box>
@@ -70,8 +76,8 @@ export function RobotInformation({
             {t('supported_protocol_api_versions')}
           </StyledText>
           <StyledText as="p">
-            {apiVersionMinMax != null
-              ? apiVersionMinMax
+            {formatApiVersionMinMax() != null
+              ? formatApiVersionMinMax()
               : t('robot_settings_advanced_unknown')}
           </StyledText>
         </Flex>

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotInformation.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotInformation.tsx
@@ -37,10 +37,10 @@ export function RobotInformation({
   const formatApiVersionMinMax = (): string => {
     if (minProtocolApiVersion === maxProtocolApiVersion) {
       return `v${minProtocolApiVersion}`
+    } else if (minProtocolApiVersion != null && maxProtocolApiVersion != null) {
+      return `v${minProtocolApiVersion} - v${maxProtocolApiVersion}`
     } else {
-      return minProtocolApiVersion != null && maxProtocolApiVersion != null
-        ? `v${minProtocolApiVersion} - v${maxProtocolApiVersion}`
-        : t('robot_settings_advanced_unknown')
+      return t('robot_settings_advanced_unknown')
     }
   }
 
@@ -75,11 +75,7 @@ export function RobotInformation({
           <StyledText css={TYPOGRAPHY.pSemiBold}>
             {t('supported_protocol_api_versions')}
           </StyledText>
-          <StyledText as="p">
-            {formatApiVersionMinMax() != null
-              ? formatApiVersionMinMax()
-              : t('robot_settings_advanced_unknown')}
-          </StyledText>
+          <StyledText as="p">{formatApiVersionMinMax()}</StyledText>
         </Flex>
       </Flex>
     </Box>

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotInformation.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotInformation.test.tsx
@@ -69,10 +69,14 @@ describe('RobotSettings RobotInformation', () => {
   })
 
   it('should not render serial number, firmware version and supported protocol api versions without ViewableRobot', () => {
-    mockUseRobot.mockReturnValue(null)
-    const [{ queryByText }] = render()
-    expect(queryByText('0.0.0')).not.toBeInTheDocument()
-    expect(queryByText('4.5.6')).not.toBeInTheDocument()
-    expect(queryByText('v0.0 - v5.1')).not.toBeInTheDocument()
+    mockGetRobotProtocolApiVersion.mockReturnValue({
+      min: '2.15',
+      max: '2.15',
+    })
+    const [{ getByText, queryByText }] = render()
+    getByText('v2.15')
+    expect(queryByText('v2.15 - v2.15')).not.toBeInTheDocument()
   })
+
+  it('should render only one version when min supported protocol version and max supported protocol version are equal', () => {})
 })

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotInformation.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotInformation.test.tsx
@@ -69,6 +69,14 @@ describe('RobotSettings RobotInformation', () => {
   })
 
   it('should not render serial number, firmware version and supported protocol api versions without ViewableRobot', () => {
+    mockUseRobot.mockReturnValue(null)
+    const [{ queryByText }] = render()
+    expect(queryByText('0.0.0')).not.toBeInTheDocument()
+    expect(queryByText('4.5.6')).not.toBeInTheDocument()
+    expect(queryByText('v0.0 - v5.1')).not.toBeInTheDocument()
+  })
+
+  it('should render only one version when min supported protocol version and max supported protocol version are equal', () => {
     mockGetRobotProtocolApiVersion.mockReturnValue({
       min: '2.15',
       max: '2.15',
@@ -77,6 +85,4 @@ describe('RobotSettings RobotInformation', () => {
     getByText('v2.15')
     expect(queryByText('v2.15 - v2.15')).not.toBeInTheDocument()
   })
-
-  it('should render only one version when min supported protocol version and max supported protocol version are equal', () => {})
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
For Flex, the min support version is 2.15 and currently the min version and the max version is the same. For that case,
Desktop App only shows the min version.

close RAUT-633

#### OT-2
![Screenshot 2023-08-18 at 12 57 48 PM](https://github.com/Opentrons/opentrons/assets/474225/067818e2-654c-4040-87ab-3f39c9724ac1)


#### Flex
![Screenshot 2023-08-18 at 12 57 19 PM](https://github.com/Opentrons/opentrons/assets/474225/c1583d4c-c20a-49ee-9bd3-6ee6657eb74e)


thread
For Flex, the min suppor version is 2.15 and currently the min version and the max version is the same. For that case,
Desktop App only shows the min version.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1.  pull the latest 7.0.0 branch and run robot-server or push the latest 7.0.0 branch to a dev kit/Flex
2. open Desktop App and go to RobotSettings AdvancedTab
Flex: v2.15
OT-2 v2.0 - v2.15
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update RobotInformation component and test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
