### PR TITLE
docs(api): Flex revisions for Advanced Control

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -7,22 +7,22 @@ Advanced Control
 
 As its name implies, the Python Protocol API is primarily designed for creating protocols that you upload via the Opentrons App and execute on the robot as a unit. But sometimes it's more convenient to control the robot outside of the app. For example, you might want to have variables in your code that change based on user input or the contents of a CSV file. Or you might want to only execute part of your protocol at a time, especially when developing or debugging a new protocol.
 
-The OT-2 offers two ways of issuing Python API commands to the robot outside of the app: through Jupyter Notebook or on the command line with ``opentrons_execute``.
+The Python API offers two ways of issuing commands to the robot outside of the app: through Jupyter Notebook or on the command line with ``opentrons_execute``.
 
 Jupyter Notebook
 ----------------
 
-The OT-2 runs a `Jupyter Notebook <https://jupyter.org>`_ server on port 48888, which you can connect to with your web browser. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells and run a single cell at a time.
+The Flex and OT-2 run `Jupyter Notebook <https://jupyter.org>`_ servers on port 48888, which you can connect to with your web browser. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells and run a single cell at a time.
 
 .. note::
-    The Jupyter Notebook server only supports Python Protocol API versions 2.13 and earlier. Use the Opentrons App to run protocols that require functionality added in newer versions.
+    Currently, the Jupyter Notebook server does not work with Python Protocol API versions 2.14 and 2.15. It does work with API versions 2.13 and earlier. Use the Opentrons App to run protocols that require functionality added in newer versions.
 
-Access the OT-2’s Jupyter Notebook by either:
+Access your robot's Jupyter Notebook by either:
 
 - Going to the **Advanced** tab of Robot Settings and clicking **Launch Jupyter Notebook**.
 - Going directly to ``http://<robot-ip>:48888`` in your web browser (if you know your robot's IP address).
 
-Once you've launched Jupyter Notebook, you can create a notebook file or edit an existing one. These notebook files are stored on the OT-2 itself. If you want to save code from a notebook to your computer, go to **File > Download As** in the notebook interface.
+Once you've launched Jupyter Notebook, you can create a notebook file or edit an existing one. These notebook files are stored on the the robot. If you want to save code from a notebook to your computer, go to **File > Download As** in the notebook interface.
 
 Protocol Structure
 ^^^^^^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ You can also use Jupyter to run a protocol that you have already written. To do 
         # the contents of your previously written protocol go here
 
 
-Since a typical protocol only `defines` the ``run`` function but doesn't `call` it, this won't immediately cause the OT-2 to move. To begin the run, instantiate a :py:class:`.ProtocolContext` and pass it to the ``run`` function you just defined:
+Since a typical protocol only `defines` the ``run`` function but doesn't `call` it, this won't immediately cause the robot to move. To begin the run, instantiate a :py:class:`.ProtocolContext` and pass it to the ``run`` function you just defined:
 
 .. code-block:: python
 
@@ -84,8 +84,9 @@ Creating the dummy protocol requires you to:
 For example, the following dummy protocol will use a Flex 50 µL pipette to enable Labware Position Check for a Flex tip rack, NEST reservoir, and NEST flat well plate.
 
 .. code-block:: python
+    :substitutions:
 
-    requirements = {'apiLevel': '|apiLevel|', 'robotType': 'Flex'}
+    requirements = {'robotType': 'Flex','apiLevel': '|apiLevel|'}
 
     def run(protocol):
         tips = protocol.load_labware('opentrons_flex_96_tiprack_50ul', 'D1')
@@ -99,13 +100,13 @@ After importing this protocol to the Opentrons App, run Labware Position Check t
 
 .. code-block:: python
 	
-    labware_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", location="D1")
+    labware_1 = protocol.load_labware('opentrons_flex_96_tiprack_200ul', location='D1')
     labware_1.set_offset(x=0.00, y=0.00, z=0.00)
 
-    labware_2 = protocol.load_labware("nest_12_reservoir_15ml", location="D2")
+    labware_2 = protocol.load_labware('nest_12_reservoir_15ml', location='D2')
     labware_2.set_offset(x=0.10, y=0.20, z=0.30)
 
-    labware_3 = protocol.load_labware("nest_96_wellplate_200ul_flat", location="D3")
+    labware_3 = protocol.load_labware('nest_96_wellplate_200ul_flat', location='D3')
     labware_3.set_offset(x=0.10, y=0.20, z=0.30)
     
 This automatically generated code uses generic names for the loaded labware. If you want to match the labware names already in your protocol, change the labware names to match your original code:
@@ -145,7 +146,7 @@ To disable the robot server, open a Jupyter terminal session by going to **New >
 Command Line
 ------------
 
-The OT-2's command line is accessible either by going to **New > Terminal** in Jupyter or `via SSH <https://support.opentrons.com/s/article/Connecting-to-your-OT-2-with-SSH>`_.
+The robot's command line is accessible either by going to **New > Terminal** in Jupyter or `via SSH <https://support.opentrons.com/s/article/Connecting-to-your-OT-2-with-SSH>`_.
 
 To execute a protocol from the robot's command line, copy the protocol file to the robot with ``scp`` and then run the protocol with ``opentrons_execute``:
 
@@ -154,4 +155,4 @@ To execute a protocol from the robot's command line, copy the protocol file to t
    opentrons_execute /data/my_protocol.py
 
 
-By default, ``opentrons_execute`` will print out the same run log shown in the Opentrons App, as the protocol executes. It also prints out internal logs at the level ``warning`` or above. Both of these behaviors can be changed; for further details, run ``opentrons_execute --help``. 
+By default, ``opentrons_execute`` will print out the same run log shown in the Opentrons App, as the protocol executes. It also prints out internal logs at the level ``warning`` or above. Both of these behaviors can be changed. Run ``opentrons_execute --help`` for more information. 

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -34,7 +34,7 @@ Rather than writing a  ``run`` function and embedding commands within it, start 
 .. code-block:: python
 
     import opentrons.execute
-    protocol = opentrons.execute.get_protocol_api('2.13')
+    protocol = opentrons.execute.get_protocol_api("2.13")
     protocol.home()
 
 The first command you execute should always be :py:meth:`~opentrons.protocol_api.ProtocolContext.home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
@@ -58,7 +58,7 @@ Since a typical protocol only `defines` the ``run`` function but doesn't `call` 
 
 .. code-block:: python
 
-    protocol = opentrons.execute.get_protocol_api('2.13')
+    protocol = opentrons.execute.get_protocol_api("2.13")
     run(protocol)  # your protocol will now run
 
 .. _using_lpc:
@@ -81,39 +81,38 @@ Creating the dummy protocol requires you to:
     4. Load your smallest capacity pipette and specify its ``tipracks``.
     5. Call ``pick_up_tip()``. Labware Position Check can't run if you don't pick up a tip.
     
-For example, the following dummy protocol will use a Flex 50 µL pipette to enable Labware Position Check for a Flex tip rack, NEST reservoir, and NEST flat well plate.
+For example, the following dummy protocol will use a P300 Single-Channel GEN2 pipette to enable Labware Position Check for an OT-2 tip rack, NEST reservoir, and NEST flat well plate.
 
 .. code-block:: python
-    :substitutions:
 
-    requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
-
-    def run(protocol):
-        tips = protocol.load_labware('opentrons_flex_96_tiprack_50ul', 'D1')
-        reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
-        plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
-        pipette = protocol.load_instrument('flex_1channel_50', 'left', tip_racks=[tips])
-        pipette.pick_up_tip()
-        pipette.return_tip()
+    metadata = {"apiLevel": "2.13"} 
+  
+     def run(protocol): 
+         tiprack = protocol.load_labware("opentrons_96_tiprack_300ul", 1) 
+         reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2) 
+         plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3) 
+         p300 = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tiprack]) 
+         p300.pick_up_tip() 
+         p300.return_tip()
 
 After importing this protocol to the Opentrons App, run Labware Position Check to get the x, y, and z offsets for the tip rack and labware. When complete, you can click **Get Labware Offset Data** to view automatically generated code that uses :py:meth:`.set_offset` to apply the offsets to each piece of labware.
 
 .. code-block:: python
 	
-    labware_1 = protocol.load_labware('opentrons_flex_96_tiprack_200ul', location='D1')
+    labware_1 = protocol.load_labware("opentrons_96_tiprack_300ul", location="1")
     labware_1.set_offset(x=0.00, y=0.00, z=0.00)
 
-    labware_2 = protocol.load_labware('nest_12_reservoir_15ml', location='D2')
+    labware_2 = protocol.load_labware("nest_12_reservoir_15ml", location="2")
     labware_2.set_offset(x=0.10, y=0.20, z=0.30)
 
-    labware_3 = protocol.load_labware('nest_96_wellplate_200ul_flat', location='D3')
+    labware_3 = protocol.load_labware("nest_96_wellplate_200ul_flat", location="3")
     labware_3.set_offset(x=0.10, y=0.20, z=0.30)
     
 This automatically generated code uses generic names for the loaded labware. If you want to match the labware names already in your protocol, change the labware names to match your original code:
 
 .. code-block:: python
 
-    reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
+    reservoir = protocol.load_labware("nest_12_reservoir_15ml", "2")
     reservoir.set_offset(x=0.10, y=0.20, z=0.30)
     
 .. versionadded:: 2.12

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -86,7 +86,7 @@ For example, the following dummy protocol will use a Flex 50 µL pipette to enab
 .. code-block:: python
     :substitutions:
 
-    requirements = {'robotType': 'Flex','apiLevel': '|apiLevel|'}
+    requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
 
     def run(protocol):
         tips = protocol.load_labware('opentrons_flex_96_tiprack_50ul', 'D1')


### PR DESCRIPTION
# Overview

This is for revisions to the API doc, [Advanced Control](https://docs.opentrons.com/v2/new_advanced_running.html) (`new_advanced_running.rst`). Changes make this less OT-2 specific, incorporate Flex into the doc, and are very light.


# Test Plan

* Our usual review process.

* Sandbox:  http://sandbox.docs.opentrons.com/advanced-controls-revisions/v2/new_advanced_running.html

# Changelog

Changes include removing single OT-2 mentions and including both robots in text. Also, we're using generic terms for both like "robots".

Some minor text changes.

# Review requests

No specific requests.

# Risk assessment

Low. Changes are trivial.
