### PR TITLE
fix(app-shell): match opentrons usb devices on Windows

### DIFF
--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -115,8 +115,12 @@ function startUsbHttpRequests(dispatch: Dispatch): void {
     .then((list: PortInfo[]) => {
       const ot3UsbSerialPort = list.find(
         port =>
-          port.productId === DEFAULT_PRODUCT_ID &&
-          port.vendorId === DEFAULT_VENDOR_ID
+          port.productId?.localeCompare(DEFAULT_PRODUCT_ID, 'en-US', {
+            sensitivity: 'base',
+          }) === 0 &&
+          port.vendorId?.localeCompare(DEFAULT_VENDOR_ID, 'en-US', {
+            sensitivity: 'base',
+          }) === 0
       )
 
       // retry if no OT-3 serial port found - usb-detection and serialport packages have race condition


### PR DESCRIPTION
# Overview
This PR fixes usb interaction between an Opentrons app running on an Windows machine and a Flex.

Serialport exposes vendor ids and product ids as string casted hex digits with letters lowercased on Mac and Linux. For Windows, vendor ids and product ids get exposed as string casted hex digits with letters uppercased 🙃 

closes RQA-1317

# Changelog

- Match Opentrons usb devices on Windows

# Review requests


I verified this works, but if you've got a windows machine handy go ahead and try to connect it to a flex and see that the robot shows up in the app and you can interact with it. 


# Risk assessment

Low, its already broken
