### PR TITLE
refactor(app): adapter split test coverage and cleanup components

### DIFF
--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -1,4 +1,3 @@
-import { RunTimeCommand } from '@opentrons/shared-data'
 import {
   parsePipetteEntity,
   parseInitialPipetteNamesByMount,
@@ -10,9 +9,11 @@ import {
   parseInitialLoadedModulesBySlot,
   parseLiquidsInLoadOrder,
   parseLabwareInfoByLiquidId,
+  parseInitialLoadedLabwareByAdapter,
 } from '../utils'
-
 import { simpleAnalysisFileFixture } from '../__fixtures__'
+
+import type { RunTimeCommand } from '@opentrons/shared-data'
 
 const mockRunTimeCommands: RunTimeCommand[] = simpleAnalysisFileFixture.commands as any
 const mockLoadLiquidRunTimeCommands = [
@@ -187,6 +188,76 @@ describe('parseRequiredModulesEntity', () => {
       },
     ]
     expect(parseRequiredModulesEntity(mockRunTimeCommands)).toEqual(expected)
+  })
+})
+describe('parseInitialLoadedLabwareByAdapter', () => {
+  it('returns only labware loaded in adapters', () => {
+    const mockCommandsWithAdapter = ([
+      {
+        id: 'commands.LOAD_LABWARE-2',
+        createdAt: '2022-04-01T15:46:01.745870+00:00',
+        commandType: 'loadLabware',
+        key: 'commands.LOAD_LABWARE-2',
+        status: 'succeeded',
+        params: {
+          location: {
+            moduleId: 'module-0',
+          },
+          loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+          namespace: 'opentrons',
+          version: 1,
+          labwareId: null,
+          displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        },
+        result: {
+          labwareId: 'labware-2',
+          definition: {},
+          offsetId: null,
+        },
+        error: null,
+        startedAt: '2022-04-01T15:46:01.745870+00:00',
+        completedAt: '2022-04-01T15:46:01.745870+00:00',
+      },
+      {
+        id: 'commands.LOAD_LABWARE-3',
+        createdAt: '2022-04-01T15:46:01.745870+00:00',
+        commandType: 'loadLabware',
+        key: 'commands.LOAD_LABWARE-3',
+        status: 'succeeded',
+        params: {
+          location: {
+            labwareId: 'labware-2',
+          },
+          loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+          namespace: 'opentrons',
+          version: 1,
+          labwareId: null,
+          displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        },
+        result: {
+          labwareId: 'labware-3',
+          definition: {},
+          offsetId: null,
+        },
+        error: null,
+        startedAt: '2022-04-01T15:46:01.745870+00:00',
+        completedAt: '2022-04-01T15:46:01.745870+00:00',
+      },
+    ] as any) as RunTimeCommand[]
+    const labware2 = 'labware-2'
+
+    const expected = {
+      [labware2]: mockCommandsWithAdapter.find(
+        c =>
+          c.commandType === 'loadLabware' &&
+          typeof c.params.location === 'object' &&
+          'labwareId' in c.params?.location &&
+          c.params?.location?.labwareId === 'labware-2'
+      ),
+    }
+    expect(parseInitialLoadedLabwareByAdapter(mockCommandsWithAdapter)).toEqual(
+      expected
+    )
   })
 })
 describe('parseInitialLoadedLabwareBySlot', () => {

--- a/app/src/organisms/ApplyHistoricOffsets/LabwareOffsetTable.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/LabwareOffsetTable.tsx
@@ -40,7 +40,7 @@ export function LabwareOffsetTable(
   props: LabwareOffsetTableProps
 ): JSX.Element | null {
   const { offsetCandidates, labwareDefinitions } = props
-  const { t } = useTranslation('labware_position_check')
+  const { t, i18n } = useTranslation('labware_position_check')
   return (
     <OffsetTable>
       <thead>
@@ -55,7 +55,7 @@ export function LabwareOffsetTable(
         {offsetCandidates.map(offset => (
           <OffsetTableRow key={offset.id}>
             <OffsetTableDatum>
-              {getDisplayLocation(offset.location, labwareDefinitions, t, true)}
+              {getDisplayLocation(offset.location, labwareDefinitions, t, i18n)}
             </OffsetTableDatum>
             <OffsetTableDatum>
               {formatTimestamp(offset.runCreatedAt)}

--- a/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
@@ -1,16 +1,26 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
-
+import fixture_adapter from '@opentrons/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json'
+import fixture_96_wellplate from '@opentrons/shared-data/labware/definitions/2/opentrons_96_wellplate_200ul_pcr_full_skirt/1.json'
 import { i18n } from '../../../i18n'
 import { ApplyHistoricOffsets } from '..'
 import { getIsLabwareOffsetCodeSnippetsOn } from '../../../redux/config'
+import { getLabwareDefinitionsFromCommands } from '../../LabwarePositionCheck/utils/labware'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { OffsetCandidate } from '../hooks/useOffsetCandidatesForAnalysis'
 
 jest.mock('../../../redux/config')
+jest.mock('../../LabwarePositionCheck/utils/labware')
 
 const mockGetIsLabwareOffsetCodeSnippetsOn = getIsLabwareOffsetCodeSnippetsOn as jest.MockedFunction<
   typeof getIsLabwareOffsetCodeSnippetsOn
 >
+const mockGetLabwareDefinitionsFromCommands = getLabwareDefinitionsFromCommands as jest.MockedFunction<
+  typeof getLabwareDefinitionsFromCommands
+>
+
+const mockLabwareDef = fixture_96_wellplate as LabwareDefinition2
+const mockAdapterDef = fixture_adapter as LabwareDefinition2
 
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',
@@ -39,6 +49,19 @@ const mockThirdCandidate: OffsetCandidate = {
   createdAt: '2022-05-11T13:34:51.012179+00:00',
   runCreatedAt: '2022-05-11T13:33:51.012179+00:00',
 }
+const mockFourthCandidate: OffsetCandidate = {
+  id: 'fourth_offset_id',
+  labwareDisplayName: 'Fourth Fake Labware Display Name',
+  location: {
+    slotName: '3',
+    moduleModel: 'heaterShakerModuleV1',
+    definitionUri: 'opentrons/opentrons_96_pcr_adapter/1',
+  },
+  vector: { x: 7.1, y: 8.1, z: 7.2 },
+  definitionUri: 'fourthFakeDefURI',
+  createdAt: '2022-05-12T13:34:51.012179+00:00',
+  runCreatedAt: '2022-05-12T13:33:51.012179+00:00',
+}
 
 describe('ApplyHistoricOffsets', () => {
   let render: (
@@ -54,6 +77,7 @@ describe('ApplyHistoricOffsets', () => {
             mockFirstCandidate,
             mockSecondCandidate,
             mockThirdCandidate,
+            mockFourthCandidate,
           ]}
           setShouldApplyOffsets={mockSetShouldApplyOffsets}
           shouldApplyOffsets
@@ -83,6 +107,10 @@ describe('ApplyHistoricOffsets', () => {
   })
 
   it('renders view data modal when link clicked, with correct copy and table row for each candidate', () => {
+    mockGetLabwareDefinitionsFromCommands.mockReturnValue([
+      mockLabwareDef,
+      mockAdapterDef,
+    ])
     const [{ getByText, getByRole, queryByText, getByTestId }] = render()
     getByText('View data').click()
 
@@ -101,10 +129,11 @@ describe('ApplyHistoricOffsets', () => {
     getByText('Slot 1')
     // second candidate table row
     getByText('Slot 2')
+    //  4th candidate a labware on adapter on module
+    getByText('Opentrons 96 PCR Adapter in Heater-Shaker Module GEN1 in Slot 3')
     // third candidate on module table row
-    getByText('Heater-Shaker Module GEN1 in slot 3')
+    getByText('Heater-Shaker Module GEN1 in Slot 3')
     getByTestId('ModalHeader_icon_close_Stored Labware Offset data').click()
-
     expect(queryByText('Stored Labware Offset data')).toBeNull()
   })
 
@@ -134,6 +163,10 @@ describe('ApplyHistoricOffsets', () => {
   })
 
   it('renders tabbed offset data with snippets when config option is selected', () => {
+    mockGetLabwareDefinitionsFromCommands.mockReturnValue([
+      mockLabwareDef,
+      mockAdapterDef,
+    ])
     mockGetIsLabwareOffsetCodeSnippetsOn.mockReturnValue(true)
     const [{ getByText }] = render()
     getByText('View data').click()
@@ -141,5 +174,4 @@ describe('ApplyHistoricOffsets', () => {
     expect(getByText('Jupyter Notebook')).toBeTruthy()
     expect(getByText('Command Line Interface (SSH)')).toBeTruthy()
   })
-  it.todo('add test coverage for adapters')
 })

--- a/app/src/organisms/ApplyHistoricOffsets/__tests__/LabwareOffsetTable.test.tsx
+++ b/app/src/organisms/ApplyHistoricOffsets/__tests__/LabwareOffsetTable.test.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
-
+import fixture_adapter from '@opentrons/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json'
+import fixture_96_wellplate from '@opentrons/shared-data/labware/definitions/2/opentrons_96_wellplate_200ul_pcr_full_skirt/1.json'
 import { i18n } from '../../../i18n'
 import { LabwareOffsetTable } from '../LabwareOffsetTable'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { OffsetCandidate } from '../hooks/useOffsetCandidatesForAnalysis'
+
+const mockLabwareDef = fixture_96_wellplate as LabwareDefinition2
+const mockAdapterDef = fixture_adapter as LabwareDefinition2
 
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',
@@ -33,6 +38,20 @@ const mockThirdCandidate: OffsetCandidate = {
   runCreatedAt: '2022-05-11T13:33:51.012179+00:00',
 }
 
+const mockFourthCandidate: OffsetCandidate = {
+  id: 'fourth_offset_id',
+  labwareDisplayName: 'Fourth Fake Labware Display Name',
+  location: {
+    slotName: '3',
+    moduleModel: 'heaterShakerModuleV1',
+    definitionUri: 'opentrons/opentrons_96_pcr_adapter/1',
+  },
+  vector: { x: 7.1, y: 8.1, z: 7.2 },
+  definitionUri: 'fourthFakeDefURI',
+  createdAt: '2022-05-12T13:34:51.012179+00:00',
+  runCreatedAt: '2022-05-12T13:33:51.012179+00:00',
+}
+
 describe('LabwareOffsetTable', () => {
   let render: (
     props?: Partial<React.ComponentProps<typeof LabwareOffsetTable>>
@@ -42,11 +61,12 @@ describe('LabwareOffsetTable', () => {
     render = () =>
       renderWithProviders<React.ComponentProps<typeof LabwareOffsetTable>>(
         <LabwareOffsetTable
-          labwareDefinitions={[]}
+          labwareDefinitions={[mockLabwareDef, mockAdapterDef]}
           offsetCandidates={[
             mockFirstCandidate,
             mockSecondCandidate,
             mockThirdCandidate,
+            mockFourthCandidate,
           ]}
         />,
         { i18nInstance: i18n }
@@ -64,9 +84,9 @@ describe('LabwareOffsetTable', () => {
     getByText('Run')
     getByText('labware')
     getByText('labware offset data')
-    expect(queryAllByText('X')).toHaveLength(3)
-    expect(queryAllByText('Y')).toHaveLength(3)
-    expect(queryAllByText('Z')).toHaveLength(3)
+    expect(queryAllByText('X')).toHaveLength(4)
+    expect(queryAllByText('Y')).toHaveLength(4)
+    expect(queryAllByText('Z')).toHaveLength(4)
     // first candidate
     getByText('Slot 1')
     getByText(/7\/11\/2022/i)
@@ -81,13 +101,18 @@ describe('LabwareOffsetTable', () => {
     getByText('4.00')
     getByText('5.00')
     getByText('6.00')
-    // third candidate on module
-    getByText('Heater-Shaker Module GEN1 in slot 3')
+    // third candidate is adapter on module
+    getByText('Heater-Shaker Module GEN1 in Slot 3')
     getByText(/5\/11\/2022/i)
     getByText('Third Fake Labware Display Name')
     getByText('7.00')
     getByText('8.00')
     getByText('9.00')
+    //  fourth candidate is labware on adapter on module
+    getByText('Opentrons 96 PCR Adapter in Heater-Shaker Module GEN1 in Slot 3')
+    getByText('Fourth Fake Labware Display Name')
+    getByText('7.20')
+    getByText('8.10')
+    getByText('7.10')
   })
-  it.todo('add test coverage for labware offset on adapters')
 })

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/getLabwareLocationCombos.test.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/__tests__/getLabwareLocationCombos.test.ts
@@ -1,13 +1,14 @@
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
-
-import { getLabwareLocationCombos } from '../getLabwareLocationCombos'
+import fixture_adapter from '@opentrons/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json'
 import {
   getLabwareDefURI,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
+import { getLabwareLocationCombos } from '../getLabwareLocationCombos'
 
 import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
 
+const mockAdapterDef = fixture_adapter as LabwareDefinition2
 const mockLabwareDef = fixture_tiprack_300_ul as LabwareDefinition2
 const mockLoadLabwareCommands: RunTimeCommand[] = [
   {
@@ -85,17 +86,44 @@ const mockLoadLabwareCommands: RunTimeCommand[] = [
     params: {
       labwareId: 'onModuleLabwareId',
       location: { moduleId: 'firstModuleId', slotName: '3' },
-      displayName: 'duplicate labware nickname',
+      displayName: 'adapter labware nickname',
       version: 1,
       loadName: 'mockLoadname',
       namespace: 'mockNamespace',
     },
     result: {
       labwareId: 'onModuleLabwareId',
-      definition: mockLabwareDef,
+      definition: mockAdapterDef,
       offset: { x: 0, y: 0, z: 0 },
     },
     id: 'CommandId3',
+    status: 'succeeded',
+    error: null,
+    createdAt: 'fakeCreatedAtTimestamp',
+    startedAt: 'fakeStartedAtTimestamp',
+    completedAt: 'fakeCompletedAtTimestamp',
+  },
+  {
+    key: 'CommandKey4',
+    commandType: 'loadLabware',
+    params: {
+      labwareId: 'onAdapterOnModuleLabwareId',
+      location: {
+        moduleId: 'firstModuleId',
+        slotName: '3',
+        labwareId: 'noModuleLabwareId',
+      },
+      displayName: 'duplicate labware nickname',
+      version: 1,
+      loadName: 'mockLoadname',
+      namespace: 'mockNamespace',
+    },
+    result: {
+      labwareId: 'onAdapterOnModuleLabwareId',
+      definition: mockLabwareDef,
+      offset: { x: 0, y: 0, z: 0 },
+    },
+    id: 'CommandId4',
     status: 'succeeded',
     error: null,
     createdAt: 'fakeCreatedAtTimestamp',
@@ -135,9 +163,20 @@ const mockLabwareEntities: ProtocolAnalysisOutput['labware'] = [
   },
   {
     id: 'onModuleLabwareId',
+    loadName: mockAdapterDef.parameters.loadName,
+    definitionUri: getLabwareDefURI(mockAdapterDef),
+    location: { moduleId: 'firstModuleId', slotName: '3' },
+    displayName: 'on module labware nickname',
+  },
+  {
+    id: 'onAdapterOnModuleLabwareId',
     loadName: mockLabwareDef.parameters.loadName,
     definitionUri: getLabwareDefURI(mockLabwareDef),
-    location: { moduleId: 'firstModuleId', slotName: '3' },
+    location: {
+      moduleId: 'firstModuleId',
+      slotName: '3',
+      labwareId: 'onModuleLabwareId',
+    },
     displayName: 'on module labware nickname',
   },
 ]
@@ -174,6 +213,15 @@ describe('getLabwareLocationCombos', () => {
       {
         location: { slotName: '3', moduleModel: 'heaterShakerModuleV1' },
         labwareId: 'onModuleLabwareId',
+        moduleId: 'firstModuleId',
+        definitionUri: getLabwareDefURI(mockAdapterDef),
+      },
+      {
+        location: {
+          slotName: '3',
+          moduleModel: 'heaterShakerModuleV1',
+        },
+        labwareId: 'onAdapterOnModuleLabwareId',
         moduleId: 'firstModuleId',
         definitionUri: getLabwareDefURI(mockLabwareDef),
       },
@@ -283,6 +331,15 @@ describe('getLabwareLocationCombos', () => {
       {
         location: { slotName: '3', moduleModel: 'heaterShakerModuleV1' },
         labwareId: 'onModuleLabwareId',
+        moduleId: 'firstModuleId',
+        definitionUri: getLabwareDefURI(mockAdapterDef),
+      },
+      {
+        location: {
+          slotName: '3',
+          moduleModel: 'heaterShakerModuleV1',
+        },
+        labwareId: 'onAdapterOnModuleLabwareId',
         moduleId: 'firstModuleId',
         definitionUri: getLabwareDefURI(mockLabwareDef),
       },

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/CurrentOffsetsTable.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/CurrentOffsetsTable.tsx
@@ -66,7 +66,7 @@ export function CurrentOffsetsTable(
   props: CurrentOffsetsTableProps
 ): JSX.Element {
   const { currentOffsets, commands, labware, modules } = props
-  const { t } = useTranslation(['labware_position_check', 'shared'])
+  const { t, i18n } = useTranslation(['labware_position_check', 'shared'])
   const defsByURI = getLoadedLabwareDefinitionsByUri(commands)
   const isLabwareOffsetCodeSnippetsOn = useSelector(
     getIsLabwareOffsetCodeSnippetsOn
@@ -95,7 +95,7 @@ export function CurrentOffsetsTable(
                   offset.location,
                   getLabwareDefinitionsFromCommands(commands),
                   t,
-                  true // capitalize Slot
+                  i18n
                 )}
               </OffsetTableDatum>
               <OffsetTableDatum>{labwareDisplayName}</OffsetTableDatum>

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/CurrentOffsetsTable.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/CurrentOffsetsTable.test.tsx
@@ -160,5 +160,4 @@ describe('CurrentOffsetsTable', () => {
     expect(getByText('Jupyter Notebook')).toBeTruthy()
     expect(getByText('Command Line Interface (SSH)')).toBeTruthy()
   })
-  it.todo('add test coverage for labware offset on adapters')
 })

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareOffsetLocation.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareOffsetLocation.test.tsx
@@ -9,8 +9,8 @@ import type {
   LoadedLabware,
   LoadedModule,
   ProtocolAnalysisFile,
+  LabwareDefinition2,
 } from '@opentrons/shared-data'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 jest.mock('../getLabwareLocation')
 jest.mock('../getModuleInitialLoadInfo')

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareOffsetLocation.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareOffsetLocation.test.tsx
@@ -1,14 +1,27 @@
 import { when, resetAllWhenMocks } from 'jest-when'
 import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
+import fixture_adapter from '@opentrons/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json'
 import { getLabwareOffsetLocation } from '../getLabwareOffsetLocation'
 import { getLabwareLocation } from '../getLabwareLocation'
 import { getModuleInitialLoadInfo } from '../getModuleInitialLoadInfo'
-import type { LoadedModule, ProtocolAnalysisFile } from '@opentrons/shared-data'
+import {
+  getLabwareDefURI,
+  LoadedLabware,
+  LoadedModule,
+  ProtocolAnalysisFile,
+} from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 jest.mock('../getLabwareLocation')
 jest.mock('../getModuleInitialLoadInfo')
 
 const protocolWithTC = (_uncastedProtocolWithTC as unknown) as ProtocolAnalysisFile
+const mockAdapterDef = fixture_adapter as LabwareDefinition2
+const mockAdapterId = 'mockAdapterId'
+const TCModelInProtocol = 'thermocyclerModuleV1'
+const MOCK_SLOT = '2'
+const TCIdInProtocol =
+  '18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType' // this is just taken from the protocol fixture
 
 const mockGetLabwareLocation = getLabwareLocation as jest.MockedFunction<
   typeof getLabwareLocation
@@ -21,15 +34,25 @@ describe('getLabwareOffsetLocation', () => {
   let MOCK_LABWARE_ID: string
   let MOCK_COMMANDS: ProtocolAnalysisFile['commands']
   let MOCK_MODULES: LoadedModule[]
+  let MOCK_LABWARE: LoadedLabware[]
   beforeEach(() => {
     MOCK_LABWARE_ID = 'some_labware'
     MOCK_COMMANDS = protocolWithTC.commands
     MOCK_MODULES = [
       {
-        id: '18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType',
+        id: TCIdInProtocol,
         model: 'thermocyclerModuleV1',
       },
     ] as LoadedModule[]
+    MOCK_LABWARE = [
+      {
+        id: mockAdapterId,
+        loadName: mockAdapterDef.parameters.loadName,
+        definitionUri: getLabwareDefURI(mockAdapterDef),
+        location: { moduleId: TCIdInProtocol },
+        displayName: 'adapter nickname',
+      },
+    ]
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -55,10 +78,6 @@ describe('getLabwareOffsetLocation', () => {
     ).toEqual(null)
   })
   it('should return the slot name and module model if the labware is on top of a module', () => {
-    const TCIdInProtocol =
-      '18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType' // this is just taken from the protocol fixture
-    const TCModelInProtocol = 'thermocyclerModuleV1'
-    const MOCK_SLOT = '2'
     when(mockGetLabwareLocation)
       .calledWith(MOCK_LABWARE_ID, MOCK_COMMANDS)
       .mockReturnValue({ moduleId: TCIdInProtocol })
@@ -71,5 +90,47 @@ describe('getLabwareOffsetLocation', () => {
     ).toEqual({ slotName: MOCK_SLOT, moduleModel: TCModelInProtocol })
   })
 
-  it.todo('TODO(jr, 8/7/23): add test cases for labware on adapter')
+  it('should return the slot name, module model and definition uri for labware on adapter on mod', () => {
+    mockGetLabwareLocation.mockReturnValue({ labwareId: mockAdapterId })
+    mockGetModuleInitialLoadInfo.mockReturnValue({
+      location: { slotName: MOCK_SLOT },
+    } as any)
+    expect(
+      getLabwareOffsetLocation(
+        MOCK_LABWARE_ID,
+        MOCK_COMMANDS,
+        MOCK_MODULES,
+        MOCK_LABWARE
+      )
+    ).toEqual({
+      slotName: MOCK_SLOT,
+      moduleModel: TCModelInProtocol,
+      definitionUri: getLabwareDefURI(mockAdapterDef),
+    })
+  })
+
+  it('should return the slot name and definition uri for labware on adapter on deck', () => {
+    MOCK_LABWARE = [
+      {
+        id: mockAdapterId,
+        loadName: mockAdapterDef.parameters.loadName,
+        definitionUri: getLabwareDefURI(mockAdapterDef),
+        location: { slotName: MOCK_SLOT },
+        displayName: 'adapter nickname',
+      },
+    ]
+    MOCK_MODULES = []
+    mockGetLabwareLocation.mockReturnValue({ labwareId: mockAdapterId })
+    expect(
+      getLabwareOffsetLocation(
+        MOCK_LABWARE_ID,
+        MOCK_COMMANDS,
+        MOCK_MODULES,
+        MOCK_LABWARE
+      )
+    ).toEqual({
+      slotName: MOCK_SLOT,
+      definitionUri: getLabwareDefURI(mockAdapterDef),
+    })
+  })
 })

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareOffsetLocation.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLabwareOffsetLocation.test.tsx
@@ -1,11 +1,11 @@
 import { when, resetAllWhenMocks } from 'jest-when'
+import { getLabwareDefURI } from '@opentrons/shared-data'
 import _uncastedProtocolWithTC from '@opentrons/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json'
 import fixture_adapter from '@opentrons/shared-data/labware/definitions/2/opentrons_96_pcr_adapter/1.json'
 import { getLabwareOffsetLocation } from '../getLabwareOffsetLocation'
 import { getLabwareLocation } from '../getLabwareLocation'
 import { getModuleInitialLoadInfo } from '../getModuleInitialLoadInfo'
-import {
-  getLabwareDefURI,
+import type {
   LoadedLabware,
   LoadedModule,
   ProtocolAnalysisFile,

--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -70,7 +70,7 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
     setFatalError,
   } = props
   const goldenLPC = useFeatureFlag('lpcWithProbe')
-  const { t } = useTranslation(['labware_position_check', 'shared'])
+  const { t, i18n } = useTranslation(['labware_position_check', 'shared'])
   const labwareDef = getLabwareDef(labwareId, protocolData)
   const pipette = protocolData.pipettes.find(
     pipette => pipette.id === pipetteId
@@ -138,7 +138,7 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
   const pipetteZMotorAxis: 'leftZ' | 'rightZ' =
     pipetteMount === 'left' ? 'leftZ' : 'rightZ'
   const isTiprack = getIsTiprack(labwareDef)
-  const displayLocation = getDisplayLocation(location, labwareDefs, t)
+  const displayLocation = getDisplayLocation(location, labwareDefs, t, i18n)
   const labwareDisplayName = getLabwareDisplayName(labwareDef)
 
   let placeItemInstruction: JSX.Element = (
@@ -178,7 +178,8 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
           location: getDisplayLocation(
             omit(location, ['definitionUri']), // only want the adapter's location here
             labwareDefs,
-            t
+            t,
+            i18n
           ),
         }}
         components={{

--- a/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PickUpTip.tsx
@@ -46,7 +46,7 @@ interface PickUpTipProps extends PickUpTipStep {
   isRobotMoving: boolean
 }
 export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
-  const { t } = useTranslation(['labware_position_check', 'shared'])
+  const { t, i18n } = useTranslation(['labware_position_check', 'shared'])
   const {
     labwareId,
     pipetteId,
@@ -76,7 +76,8 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
   const displayLocation = getDisplayLocation(
     location,
     getLabwareDefinitionsFromCommands(protocolData.commands),
-    t
+    t,
+    i18n
   )
   const labwareDisplayName = getLabwareDisplayName(labwareDef)
   const instructions = [

--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -113,13 +113,11 @@ export const ResultsSummary = (
     <TerseOffsetTable
       offsets={offsetsToApply}
       labwareDefinitions={labwareDefinitions}
-      protocolData={protocolData}
     />
   ) : (
     <OffsetTable
       offsets={offsetsToApply}
       labwareDefinitions={labwareDefinitions}
-      protocolData={protocolData}
     />
   )
   const JupyterSnippet = (
@@ -224,12 +222,11 @@ const Header = styled.h1`
 interface OffsetTableProps {
   offsets: LabwareOffsetCreateData[]
   labwareDefinitions: LabwareDefinition2[]
-  protocolData: CompletedProtocolAnalysis
 }
 
 const OffsetTable = (props: OffsetTableProps): JSX.Element => {
-  const { offsets, labwareDefinitions, protocolData } = props
-  const { t } = useTranslation('labware_position_check')
+  const { offsets, labwareDefinitions } = props
+  const { t, i18n } = useTranslation('labware_position_check')
   return (
     <Table>
       <thead>
@@ -255,11 +252,7 @@ const OffsetTable = (props: OffsetTableProps): JSX.Element => {
                   as="p"
                   textTransform={TYPOGRAPHY.textTransformCapitalize}
                 >
-                  {getDisplayLocation(
-                    location,
-                    getLabwareDefinitionsFromCommands(protocolData.commands),
-                    t
-                  )}
+                  {getDisplayLocation(location, labwareDefinitions, t, i18n)}
                 </StyledText>
               </TableDatum>
               <TableDatum>

--- a/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
@@ -31,7 +31,7 @@ interface ReturnTipProps extends ReturnTipStep {
   isRobotMoving: boolean
 }
 export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
-  const { t } = useTranslation(['labware_position_check', 'shared'])
+  const { t, i18n } = useTranslation(['labware_position_check', 'shared'])
   const {
     pipetteId,
     labwareId,
@@ -50,7 +50,8 @@ export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
   const displayLocation = getDisplayLocation(
     location,
     getLabwareDefinitionsFromCommands(protocolData.commands),
-    t
+    t,
+    i18n
   )
   const labwareDisplayName = getLabwareDisplayName(labwareDef)
 

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
-import type { MatcherFunction } from '@testing-library/react'
-import { renderWithProviders } from '@opentrons/components'
+import { renderWithProviders, nestedTextMatcher } from '@opentrons/components'
 import {
   HEATERSHAKER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
@@ -12,6 +11,7 @@ import { useProtocolMetadata } from '../../Devices/hooks'
 import { CheckItem } from '../CheckItem'
 import { SECTIONS } from '../constants'
 import { mockCompletedAnalysis, mockExistingOffsets } from '../__fixtures__'
+import type { MatcherFunction } from '@testing-library/react'
 
 jest.mock('../../../redux/config')
 jest.mock('../../Devices/hooks')
@@ -75,10 +75,10 @@ describe('CheckItem', () => {
   })
   it('renders correct copy when preparing space with tip rack', () => {
     const { getByText, getByRole } = render(props)
-    getByRole('heading', { name: 'Prepare tip rack in slot D1' })
+    getByRole('heading', { name: 'Prepare tip rack in Slot D1' })
     getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
-      matchTextWithSpans('Place a full Mock TipRack Definition into slot D1')
+      matchTextWithSpans('Place a full Mock TipRack Definition into Slot D1')
     )
     getByRole('link', { name: 'Need help?' })
     getByRole('button', { name: 'Confirm placement' })
@@ -91,10 +91,10 @@ describe('CheckItem', () => {
     }
 
     const { getByText, getByRole } = render(props)
-    getByRole('heading', { name: 'Prepare labware in slot D2' })
+    getByRole('heading', { name: 'Prepare labware in Slot D2' })
     getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
-      matchTextWithSpans('Place a Mock Labware Definition into slot D2')
+      matchTextWithSpans('Place a Mock Labware Definition into Slot D2')
     )
     getByRole('link', { name: 'Need help?' })
     getByRole('button', { name: 'Confirm placement' })
@@ -146,6 +146,113 @@ describe('CheckItem', () => {
           params: {
             labwareId: 'labwareId1',
             newLocation: { slotName: 'D1' },
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: 'pipetteId1',
+            labwareId: 'labwareId1',
+            wellName: 'A1',
+            wellLocation: { origin: 'top', offset: { x: 0, y: 0, z: 0 } },
+          },
+        },
+        {
+          commandType: 'savePosition',
+          params: { pipetteId: 'pipetteId1' },
+        },
+      ],
+      false
+    )
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(1, {
+      type: 'initialPosition',
+      labwareId: 'labwareId1',
+      location: { slotName: 'D1' },
+      position: mockStartPosition,
+    })
+  })
+  it('renders the correct copy for moving a labware onto an adapter', () => {
+    props = {
+      ...props,
+      labwareId: mockCompletedAnalysis.labware[1].id,
+      adapterId: 'labwareId2',
+    }
+    const { getByText } = render(props)
+    getByText('Prepare labware in Slot D1')
+    getByText(
+      nestedTextMatcher(
+        'Place a Mock Labware Definition followed by a Mock Labware Definition into Slot D1'
+      )
+    )
+  })
+  it('executes correct chained commands when confirm placement CTA is clicked for when there is an adapter', async () => {
+    props = {
+      ...props,
+      adapterId: 'labwareId2',
+    }
+    when(mockChainRunCommands)
+      .calledWith(
+        [
+          {
+            commandType: 'moveLabware',
+            params: {
+              labwareId: 'labwareId2',
+              newLocation: { slotName: 'D1' },
+              strategy: 'manualMoveWithoutPause',
+            },
+          },
+          {
+            commandType: 'moveLabware',
+            params: {
+              labwareId: 'labwareId1',
+              newLocation: { labwareId: 'labwareId2' },
+              strategy: 'manualMoveWithoutPause',
+            },
+          },
+          {
+            commandType: 'moveToWell',
+            params: {
+              pipetteId: 'pipetteId1',
+              labwareId: 'labwareId1',
+              wellName: 'A1',
+              wellLocation: { origin: 'top', offset: { x: 0, y: 0, z: 0 } },
+            },
+          },
+          { commandType: 'savePosition', params: { pipetteId: 'pipetteId1' } },
+        ],
+        false
+      )
+      .mockImplementation(() =>
+        Promise.resolve([
+          {},
+          {},
+          {
+            data: {
+              commandType: 'savePosition',
+              result: { position: mockStartPosition },
+            },
+          },
+        ])
+      )
+    const { getByRole } = render(props)
+    await getByRole('button', { name: 'Confirm placement' }).click()
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId2',
+            newLocation: { slotName: 'D1' },
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: { labwareId: 'labwareId2' },
             strategy: 'manualMoveWithoutPause',
           },
         },
@@ -496,6 +603,4 @@ describe('CheckItem', () => {
       position: mockStartPosition,
     })
   })
-
-  it.todo('TODO(jr, 8/17/23): add test coverage for when there is an adapter')
 })

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -64,10 +64,10 @@ describe('PickUpTip', () => {
   })
   it('renders correct copy when preparing space', () => {
     const { getByText, getByRole } = render(props)
-    getByRole('heading', { name: 'Prepare tip rack in slot D1' })
+    getByRole('heading', { name: 'Prepare tip rack in Slot D1' })
     getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
-      matchTextWithSpans('Place a full Mock TipRack Definition into slot D1')
+      matchTextWithSpans('Place a full Mock TipRack Definition into Slot D1')
     )
     getByRole('link', { name: 'Need help?' })
     getByRole('button', { name: 'Confirm placement' })
@@ -84,7 +84,7 @@ describe('PickUpTip', () => {
         },
       ],
     })
-    getByRole('heading', { name: 'Pick up tip from tip rack in slot D1' })
+    getByRole('heading', { name: 'Pick up tip from tip rack in Slot D1' })
     getByText(
       "Ensure that the pipette nozzle furthest from you is centered above and level with the top of the tip in the A1 position. If it isn't, use the controls below or your keyboard to jog the pipette until it is properly aligned."
     )

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ResultsSummary.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ResultsSummary.test.tsx
@@ -61,8 +61,8 @@ describe('ResultsSummary', () => {
         name: mockTipRackDefinition.metadata.displayName,
       })
     ).toHaveLength(2)
-    getByRole('cell', { name: 'slot 1' })
-    getByRole('cell', { name: 'slot 3' })
+    getByRole('cell', { name: 'Slot 1' })
+    getByRole('cell', { name: 'Slot 3' })
     getByRole('cell', { name: 'X 1.0 Y 1.0 Z 1.0' })
     getByRole('cell', { name: 'X 3.0 Y 3.0 Z 3.0' })
   })

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
@@ -56,11 +56,11 @@ describe('ReturnTip', () => {
   })
   it('renders correct copy', () => {
     const { getByText, getByRole } = render(props)
-    getByRole('heading', { name: 'Return tip rack to slot D1' })
+    getByRole('heading', { name: 'Return tip rack to Slot D1' })
     getByText('Clear all deck slots of labware, leaving modules in place')
     getByText(
       matchTextWithSpans(
-        'Place the Mock TipRack Definition that you used before back into slot D1. The pipette will return tips to their original location in the rack.'
+        'Place the Mock TipRack Definition that you used before back into Slot D1. The pipette will return tips to their original location in the rack.'
       )
     )
     getByRole('link', { name: 'Need help?' })

--- a/app/src/organisms/LabwarePositionCheck/utils/getDisplayLocation.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getDisplayLocation.ts
@@ -1,4 +1,3 @@
-import capitalize from 'lodash/capitalize'
 import {
   getModuleDisplayName,
   getModuleType,
@@ -6,18 +5,19 @@ import {
   getLabwareDefURI,
   LabwareDefinition2,
 } from '@opentrons/shared-data'
+import type { i18n, TFunction } from 'i18next'
 import type { LabwareOffsetLocation } from '@opentrons/api-client'
-import type { TFunction } from 'i18next'
 
 export function getDisplayLocation(
   location: LabwareOffsetLocation,
   labwareDefinitions: LabwareDefinition2[],
   t: TFunction,
-  //  TODO: (jr, 8/18/23): perhaps find a new route here and refactor this,
-  //  only some instances of slot need to be capitalized depending on the parent component
-  capitalizeSlot?: boolean
+  i18n: i18n
 ): string {
-  const slotDisplayLocation = t('slot_name', { slotName: location.slotName })
+  const slotDisplayLocation = i18n.format(
+    t('slot_name', { slotName: location.slotName }),
+    'titleCase'
+  )
 
   if ('definitionUri' in location && location.definitionUri != null) {
     const adapterDisplayName = labwareDefinitions.find(
@@ -57,8 +57,6 @@ export function getDisplayLocation(
       })
     }
   } else {
-    return capitalizeSlot
-      ? capitalize(slotDisplayLocation)
-      : slotDisplayLocation
+    return slotDisplayLocation
   }
 }


### PR DESCRIPTION
closes RAUT-624

# Overview

This is a follow up PR to the adapter split work. This PR does a few things:
1. increase test coverage of app adapter split components
2. cleans up `offsetTable` in `ResultSummary` to not have `protocolData` as a prop
3. cleans up `getDisplayLocation` to not have that optional boolean and instead pass down `i18n` to `titleCase` locations that are only `slotName`

# Test Plan

- review the tests
- does my change to `getDisplayLocation` make sense?

# Changelog

- add test coverage through the app adapter split components
- remove `protocolData` as as prop in `offsetTable`
- refactor `getDisplayLocation` to not have an optional prop and pass down `i18n` as a prop to capitalize the slot name locations

# Review requests

see test plan

# Risk assessment

low