### PR TITLE
fix(app, shared-data): return tip in LPC to default wellLocation

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -153,7 +153,7 @@ export const LabwarePositionCheckComponent = (
         pipetteId: pip.id,
         labwareId: FIXED_TRASH_ID,
         wellName: 'A1',
-        wellLocation: { origin: 'top' as const },
+        wellLocation: { origin: 'default' as const },
       },
     }))
     chainRunCommands(

--- a/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ReturnTip.tsx
@@ -115,7 +115,7 @@ export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
             labwareId: labwareId,
             wellName: 'A1',
             wellLocation: {
-              origin: 'top' as const,
+              origin: 'default' as const,
               offset: tipPickUpOffset ?? undefined,
             },
           },

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
@@ -94,7 +94,7 @@ describe('ReturnTip', () => {
             pipetteId: 'pipetteId1',
             labwareId: 'labwareId1',
             wellName: 'A1',
-            wellLocation: { origin: 'top', offset: undefined },
+            wellLocation: { origin: 'default', offset: undefined },
           },
         },
         {
@@ -145,7 +145,7 @@ describe('ReturnTip', () => {
             labwareId: 'labwareId1',
             wellName: 'A1',
             wellLocation: {
-              origin: 'top',
+              origin: 'default',
               offset: { x: 10, y: 11, z: 12 },
             },
           },
@@ -223,7 +223,7 @@ describe('ReturnTip', () => {
             labwareId: 'labwareId1',
             wellName: 'A1',
             wellLocation: {
-              origin: 'top',
+              origin: 'default',
               offset: { x: 10, y: 11, z: 12 },
             },
           },

--- a/shared-data/protocol/types/schemaV7/command/pipetting.ts
+++ b/shared-data/protocol/types/schemaV7/command/pipetting.ts
@@ -20,7 +20,7 @@ export interface AspirateCreateCommand extends CommonCommandCreateInfo {
 }
 export interface AspirateRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    AspirateCreateCommand {
+  AspirateCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface DispenseCreateCommand extends CommonCommandCreateInfo {
@@ -29,7 +29,7 @@ export interface DispenseCreateCommand extends CommonCommandCreateInfo {
 }
 export interface DispenseRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    DispenseCreateCommand {
+  DispenseCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
@@ -38,7 +38,7 @@ export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
 }
 export interface BlowoutRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    BlowoutCreateCommand {
+  BlowoutCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
@@ -47,7 +47,7 @@ export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TouchTipRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    TouchTipCreateCommand {
+  TouchTipCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
@@ -56,7 +56,7 @@ export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
 }
 export interface PickUpTipRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    PickUpTipCreateCommand {
+  PickUpTipCreateCommand {
   result?: any
 }
 export interface DropTipCreateCommand extends CommonCommandCreateInfo {
@@ -65,7 +65,7 @@ export interface DropTipCreateCommand extends CommonCommandCreateInfo {
 }
 export interface DropTipRunTimeCommand
   extends CommonCommandRunTimeInfo,
-    DropTipCreateCommand {
+  DropTipCreateCommand {
   result?: any
 }
 
@@ -77,7 +77,17 @@ export type BlowoutParams = FlowRateParams &
   PipetteAccessParams &
   WellLocationParam
 export type TouchTipParams = PipetteAccessParams & WellLocationParam
-export type DropTipParams = TouchTipParams
+export type DropTipParams = PipetteAccessParams & {
+  wellLocation?: {
+    origin?: 'default' | 'top' | 'center' | 'bottom'
+    offset?: {
+      // mm values all default to 0
+      x?: number
+      y?: number
+      z?: number
+    }
+  }
+}
 export type PickUpTipParams = TouchTipParams
 
 interface FlowRateParams {

--- a/shared-data/protocol/types/schemaV7/command/pipetting.ts
+++ b/shared-data/protocol/types/schemaV7/command/pipetting.ts
@@ -20,7 +20,7 @@ export interface AspirateCreateCommand extends CommonCommandCreateInfo {
 }
 export interface AspirateRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  AspirateCreateCommand {
+    AspirateCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface DispenseCreateCommand extends CommonCommandCreateInfo {
@@ -29,7 +29,7 @@ export interface DispenseCreateCommand extends CommonCommandCreateInfo {
 }
 export interface DispenseRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  DispenseCreateCommand {
+    DispenseCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
@@ -38,7 +38,7 @@ export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
 }
 export interface BlowoutRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  BlowoutCreateCommand {
+    BlowoutCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
@@ -47,7 +47,7 @@ export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
 }
 export interface TouchTipRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  TouchTipCreateCommand {
+    TouchTipCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
@@ -56,7 +56,7 @@ export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
 }
 export interface PickUpTipRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  PickUpTipCreateCommand {
+    PickUpTipCreateCommand {
   result?: any
 }
 export interface DropTipCreateCommand extends CommonCommandCreateInfo {
@@ -65,7 +65,7 @@ export interface DropTipCreateCommand extends CommonCommandCreateInfo {
 }
 export interface DropTipRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  DropTipCreateCommand {
+    DropTipCreateCommand {
   result?: any
 }
 


### PR DESCRIPTION
closes RAUT-638

# Overview

During the schemav7 migration, I changed the wellLocation type to not include `default` but this is only the case for pipetting commands that are NOT `dropTip`. So this resulted in issues with LPC. But this PR fixes it and allows the `dropTip` `wellLocation` to be `default`

# Test Plan

Test on LPC, test early exit and completion when you return the tip.

# Changelog

- add `default` type to `wellLocation` for `dropTip` commands
- change well location in `ReturnTip` and early exit in LPC to be `default`, fix test

# Review requests

see test plan

# Risk assessment

low