### PR TITLE
refactor(app, protocol-designer, labware-library): adapter render viewbox adjustments

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -331,9 +331,7 @@ function StandaloneLabware(props: {
   const { definition } = props
   return (
     <LabwareThumbnail
-      viewBox={` 0 0 ${String(definition.dimensions.xDimension)} ${String(
-        definition.dimensions.yDimension
-      )}`}
+      viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${definition.dimensions.xDimension} ${definition.dimensions.yDimension}`}
     >
       <LabwareRender
         definition={definition}

--- a/app/src/organisms/LabwareCard/index.tsx
+++ b/app/src/organisms/LabwareCard/index.tsx
@@ -21,7 +21,6 @@ import {
 
 import { StyledText } from '../../atoms/text'
 import { CustomLabwareOverflowMenu } from './CustomLabwareOverflowMenu'
-
 import type { LabwareDefAndDate } from '../../pages/Labware/hooks'
 
 export interface LabwareCardProps {
@@ -36,7 +35,6 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const displayName = definition?.metadata.displayName
   const displayCategory = startCase(definition.metadata.displayCategory)
   const isCustomDefinition = definition.namespace !== 'opentrons'
-
   return (
     <Box
       role="link"
@@ -56,9 +54,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
     >
       <Box id="LabwareCard_labwareImage" marginRight={SPACING.spacing24}>
         <RobotWorkSpace
-          viewBox={`0 0 ${String(definition.dimensions.xDimension)} ${String(
-            definition.dimensions.yDimension
-          )}`}
+          viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${definition.dimensions.xDimension} ${definition.dimensions.yDimension}`}
         >
           {() => <LabwareRender definition={definition} />}
         </RobotWorkSpace>

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -339,9 +339,7 @@ export function ProtocolSetupLabware({
           >
             <Flex alignItems={ALIGN_STRETCH} gridGap={SPACING.spacing48}>
               <LabwareThumbnail
-                viewBox={` 0 0 ${String(
-                  selectedLabware.dimensions.xDimension
-                )} ${String(selectedLabware.dimensions.yDimension)}`}
+                viewBox={`${selectedLabware.cornerOffsetFromSlot.x} ${selectedLabware.cornerOffsetFromSlot.y} ${selectedLabware.dimensions.xDimension} ${selectedLabware.dimensions.yDimension}`}
               >
                 <LabwareRender definition={selectedLabware} />
               </LabwareThumbnail>

--- a/app/src/pages/Labware/index.tsx
+++ b/app/src/pages/Labware/index.tsx
@@ -46,9 +46,9 @@ import type { LabwareFilter, LabwareSort } from './types'
 
 const LABWARE_CREATOR_HREF = 'https://labware.opentrons.com/create/'
 const labwareDisplayCategoryFilters: LabwareFilter[] = [
+  'adapter',
   'all',
   'aluminumBlock',
-  'adapter',
   'customLabware',
   'reservoir',
   'tipRack',

--- a/app/src/pages/Labware/index.tsx
+++ b/app/src/pages/Labware/index.tsx
@@ -46,8 +46,8 @@ import type { LabwareFilter, LabwareSort } from './types'
 
 const LABWARE_CREATOR_HREF = 'https://labware.opentrons.com/create/'
 const labwareDisplayCategoryFilters: LabwareFilter[] = [
-  'adapter',
   'all',
+  'adapter',
   'aluminumBlock',
   'customLabware',
   'reservoir',

--- a/app/src/pages/Labware/index.tsx
+++ b/app/src/pages/Labware/index.tsx
@@ -47,17 +47,20 @@ import type { LabwareFilter, LabwareSort } from './types'
 const LABWARE_CREATOR_HREF = 'https://labware.opentrons.com/create/'
 const labwareDisplayCategoryFilters: LabwareFilter[] = [
   'all',
-  'wellPlate',
+  'aluminumBlock',
+  'adapter',
+  'customLabware',
+  'reservoir',
   'tipRack',
   'tubeRack',
-  'reservoir',
-  'aluminumBlock',
-  'customLabware',
+  'wellPlate',
 ]
 
-const FILTER_OPTIONS: DropdownOption[] = []
-labwareDisplayCategoryFilters.forEach(category =>
-  FILTER_OPTIONS.push({ name: startCase(category), value: category })
+const FILTER_OPTIONS: DropdownOption[] = labwareDisplayCategoryFilters.map(
+  category => ({
+    name: startCase(category),
+    value: category,
+  })
 )
 
 const SORT_BY_BUTTON_STYLE = css`

--- a/app/src/pages/Labware/types.ts
+++ b/app/src/pages/Labware/types.ts
@@ -42,5 +42,6 @@ export type LabwareFilter =
   | 'reservoir'
   | 'aluminumBlock'
   | 'customLabware'
+  | 'adapter'
 
 export type LabwareSort = 'alphabetical' | 'reverse'

--- a/labware-library/src/components/labware-ui/Gallery.tsx
+++ b/labware-library/src/components/labware-ui/Gallery.tsx
@@ -13,12 +13,16 @@ export interface GalleryProps {
 
 export function Gallery(props: GalleryProps): JSX.Element {
   const { definition, className } = props
-  const { parameters: params, dimensions: dims } = definition
+  const {
+    parameters: params,
+    dimensions: dims,
+    cornerOffsetFromSlot,
+  } = definition
   const [currentImage, setCurrentImage] = React.useState(0)
   const render = (
     <RobotWorkSpace
       key="center"
-      viewBox={`0 0 ${dims.xDimension} ${dims.yDimension}`}
+      viewBox={`${cornerOffsetFromSlot.x} ${cornerOffsetFromSlot.y} ${dims.xDimension} ${dims.yDimension}`}
       width="100%"
       height="100%"
     >

--- a/labware-library/src/localization/en.ts
+++ b/labware-library/src/localization/en.ts
@@ -14,6 +14,7 @@ export const CATEGORY_LABELS_BY_CATEGORY = {
 
 export const PLURAL_CATEGORY_LABELS_BY_CATEGORY = {
   all: 'All',
+  adapter: 'Adapter',
   tubeRack: 'Tube Racks',
   tipRack: 'Tip Racks',
   wellPlate: 'Well Plates',

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwarePreview.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwarePreview.tsx
@@ -59,7 +59,7 @@ export const LabwarePreview = (props: Props): JSX.Element | null => {
         <div className={styles.labware_detail_row}>
           <div className={styles.labware_render_wrapper}>
             <RobotWorkSpace
-              viewBox={`0 0 ${labwareDef.dimensions.xDimension} ${labwareDef.dimensions.yDimension}`}
+              viewBox={`${labwareDef.cornerOffsetFromSlot.x} ${labwareDef.cornerOffsetFromSlot.y} ${labwareDef.dimensions.xDimension} ${labwareDef.dimensions.yDimension}`}
             >
               {() => <LabwareRender definition={labwareDef} />}
             </RobotWorkSpace>


### PR DESCRIPTION
 closes RQA-1307 closes RQA-1308 closes RAUT-635

# Overview

This PR does 2 things:
1. fixes the adapter render viewbox to display the whole svg in app, Pd, and LL
2. adds `adapter` as a dropdown category in Labware tab in the app

# Test Plan

Verify that everything looks correct:

App:
- labware list view in labware setup
- adapters in the labware tab, make sure there is an adapter option in the dropdown categories too!

ODD:
- labware list view in labware setup

PD (sandbox: https://sandbox.designer.opentrons.com/app_pd_ll-adapter-render/):
- add a H-S to the protocol and add a labware, look at the labware modal when hovering on the adapters, should display correctly

Labware-Library (`make -C labware-library dev`):
- the adapters in the display, make sure there is an adapter option in the list of categories on the left side bar too!

# Changelog

- change the viewBox for adapters rendered to start at the `cornerOffFromSlot` instead of 0
- add `adapter` to category dropdown in Labware tab in the app
- add `adapter` to labware types

# Review requests

see test plan

# Risk assessment

low