### PR TITLE
docs(api,robot-server): Update readmes to avoid overspecifying as "OT-2"

### DIFF
--- a/api/README.rst
+++ b/api/README.rst
@@ -16,13 +16,13 @@ Opentrons
 Introduction
 ------------
 
-This is the Opentrons library, the Python module that runs the Opentrons OT-2. It contains the code that interprets and executes protocols; code that controls the hardware both during and outside of protocols; and all the other small tasks and capabilities that the robot fulfills.
+This is the Opentrons library, the Python module that runs Opentrons robots. It contains the code that interprets and executes protocols; code that controls the hardware both during and outside of protocols; and all the other small tasks and capabilities that the robot fulfills.
 
 This document is about the structure and purpose of the source code. For information on how to use the Opentrons library or the robot in general, please refer to our  `Full API Documentation`_ for detailed instructions.
 
 The Opentrons library has two purposes:
 
-1. **Control an Opentrons OT-2 robot.**  The API server uses the Opentrons library when controlling a robot. We boot up a server for the robot’s HTTP endpoints, and a server for its WebSockets-based RPC system for control during protocols. We are configured by files in the robot’s filesystem in ``/data``.
+1. **Control an Opentrons robot.**  The API server uses the Opentrons library when controlling a robot. We boot up a server for the robot’s HTTP endpoints, and a server for its WebSockets-based RPC system for control during protocols. We are configured by files in the robot’s filesystem in ``/data``.
 
 2. **Simulate protocols on users’ computers.** When simulating a protocol on a user’s computer, we use the entry point in `opentrons.simulate <https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/simulate.py>`_. We set up simulators for the protocol, but do not run any kind of web servers. We are configured by files in the user’s home directory (for more information see configuration_).
 
@@ -85,4 +85,4 @@ The module has a lot of configuration, some of which is only relevant when runni
 Dealing With Robot Versions
 ---------------------------
 
-The OT2 does not use the ``hardware`` subdirectory or the ``opentrons_hardware`` package. This can be a problem to work around. Please keep imports of ``opentrons_hardware`` to limited places inside the hardware_control submodule and tests of that submodule, and ensure that anything outside these safe areas conditionally imports ``opentrons_hardware`` or imports it inside a non-file scope in a place used only outside an OT2. In tests, any test that uses the OT3 hardware controller will be skipped in the ``test-ot2`` Makefile recipe.
+The OT-2 does not use the ``hardware`` subdirectory or the ``opentrons_hardware`` package. This can be a problem to work around. Please keep imports of ``opentrons_hardware`` to limited places inside the hardware_control submodule and tests of that submodule, and ensure that anything outside these safe areas conditionally imports ``opentrons_hardware`` or imports it inside a non-file scope in a place used only outside an OT2. In tests, any test that uses the OT3 hardware controller will be skipped in the ``test-ot2`` Makefile recipe.

--- a/api/pypi-readme.rst
+++ b/api/pypi-readme.rst
@@ -1,10 +1,10 @@
 .. _Full API Documentation: http://docs.opentrons.com
 
-The Opentrons API is a simple framework designed to make writing automated biology lab protocols for the Opentrons OT-2 easy.
+The Opentrons API is a simple framework designed to make it easy to write automated biology lab protocols for Opentrons robots.
 
 This package can be used to simulate protocols on your computer without connecting to a robot. Please refer to our `Full API Documentation`_ for detailed instructions on how to write and simulate your first protocol.
 
-This package is now for use with the Opentrons OT-2 only. For the software needed to run an Opentrons OT-1, please see versions_.
+This package is now for use with the Opentrons Flex and Opentrons OT-2 only. For the software needed to run an Opentrons OT-One, please see versions_.
 
 .. _simulating:
 
@@ -40,9 +40,9 @@ The module has a lot of configuration, some of which is only relevant when runni
 Note On Versions
 ----------------
 
-This API is for locally simulating protocols for the OT 2 without connecting to a robot. It no longer controls an OT 1.
+This API is for locally simulating protocols for the Flex or OT-2 without connecting to a robot. It no longer controls an OT-One.
 
-`Version 2.5.2 <https://pypi.org/project/opentrons/2.5.2/>`_ was the final release of this API for the OT 1. If you want to download this API to use the OT 1, you should download it with
+`Version 2.5.2 <https://pypi.org/project/opentrons/2.5.2/>`_ was the final release of this API for the OT-One. If you want to download this API to use the OT-One, you should download it with
 
 .. code-block:: shell
 

--- a/robot-server/README.rst
+++ b/robot-server/README.rst
@@ -10,7 +10,7 @@ Opentrons OT-2 HTTP API
 Introduction
 ------------
 
-This is the Opentrons HTTP Server, the webservice that runs the Opentrons OT-2. It contains endpoints for executing protocols, controlling the hardware, and various other small tasks and capabilities that the robot fulfills.
+This is the Opentrons HTTP Server, the webservice that runs the Opentrons Flex and Opentrons OT-2. It contains endpoints for executing protocols, controlling the hardware, and various other small tasks and capabilities that the robot fulfills.
 
 This document is about the structure and purpose of the source code of the HTTP Server.
 
@@ -54,7 +54,7 @@ Developer Modes
 
 The robot server can be run on a PC in one of two development modes.
 
-These can be useful when an OT-2 and modules are not available.
+These can be useful when a physical robot and modules are not available.
 
 The **Opentrons** application will automatically discover a locally running robot server as **dev**.
 


### PR DESCRIPTION
# Changelog

* Update `api` and `robot-server` readmes to mention Flex, not just OT-2.
* Fix up product names to use their official spelling. "OT-2" instead of "OT 2", "OT-One" instead of "OT-1", etc.

# Review requests

None in particular.

# Risk assessment

No risk. Docs only.