### PR TITLE
fix(components): if a labware has no wells, labels should default properly

### DIFF
--- a/components/src/hardware-sim/Labware/labwareInternals/WellLabels.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/WellLabels.tsx
@@ -85,7 +85,7 @@ export function WellLabelsComponent(props: WellLabelsProps): JSX.Element {
     highlightedWellLabels,
     wellLabelColor,
   } = props
-  const letterColumn = definition.ordering[0]
+  const letterColumn = definition.ordering[0] ?? []
   // TODO(bc, 2021-03-08): replace types here with real ones once shared data is in TS
   const numberRow = definition.ordering.map((wellCol: any[]) => wellCol[0])
 


### PR DESCRIPTION
# Overview

Instead of iterating over undefined, default label column to an empty array if no wells on the targeted labware.

Closes RQA-1350

# Risk assessment
low