### PR TITLE
feat(app): update use is robot busy for estop

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -144,7 +144,7 @@ function RobotControlTakeover(): JSX.Element | null {
   const isOT3 = useIsOT3(robotName)
 
   // E-stop is not supported on OT2
-  if (isOT3) return null
+  if (!isOT3) return null
 
   if (deviceRouteMatch == null || robot == null || robotName == null)
     return null

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -26,7 +26,7 @@ import { Navbar } from './Navbar'
 import { EstopTakeover, EmergencyStopContext } from '../organisms/EmergencyStop'
 import { OPENTRONS_USB } from '../redux/discovery'
 import { appShellRequestor } from '../redux/shell/remote'
-import { useRobot } from '../organisms/Devices/hooks'
+import { useRobot, useIsOT3 } from '../organisms/Devices/hooks'
 import { PortalRoot as ModalPortalRoot } from './portal'
 
 import type { RouteProps, DesktopRouteParams } from './types'
@@ -141,6 +141,10 @@ function RobotControlTakeover(): JSX.Element | null {
   const params = deviceRouteMatch?.params as DesktopRouteParams
   const robotName = params?.robotName
   const robot = useRobot(robotName)
+  const isOT3 = useIsOT3(robotName)
+
+  // E-stop is not supported on OT2
+  if (isOT3) return null
 
   if (deviceRouteMatch == null || robot == null || robotName == null)
     return null

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -14,6 +14,7 @@ import { ProtocolRunDetails } from '../../pages/Devices/ProtocolRunDetails'
 import { RobotSettings } from '../../pages/Devices/RobotSettings'
 import { GeneralSettings } from '../../pages/AppSettings/GeneralSettings'
 import { Alerts } from '../../organisms/Alerts'
+import { useIsOT3 } from '../../organisms/Devices/hooks'
 import { useSoftwareUpdatePoll } from '../hooks'
 import { DesktopApp } from '../DesktopApp'
 
@@ -55,6 +56,7 @@ const mockBreadcrumbs = Breadcrumbs as jest.MockedFunction<typeof Breadcrumbs>
 const mockUseSoftwareUpdatePoll = useSoftwareUpdatePoll as jest.MockedFunction<
   typeof useSoftwareUpdatePoll
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -78,6 +80,7 @@ describe('DesktopApp', () => {
     mockAlerts.mockReturnValue(<div>Mock Alerts</div>)
     mockAppSettings.mockReturnValue(<div>Mock AppSettings</div>)
     mockBreadcrumbs.mockReturnValue(<div>Mock Breadcrumbs</div>)
+    mockUseIsOT3.mockReturnValue(true)
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -292,6 +292,7 @@ export function ProtocolRunHeader({
         ) : null}
         {estopStatus?.data.status !== DISENGAGED &&
         estopError == null &&
+        isOT3 &&
         showEmergencyStopRunBanner ? (
           <EmergencyStopRunBanner
             setShowEmergencyStopRunBanner={setShowEmergencyStopRunBanner}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -142,7 +142,7 @@ export function ProtocolRunHeader({
     runRecord?.data?.errors != null
       ? getHighestPriorityError(runRecord?.data?.errors)
       : undefined
-  const { data: estopStatus } = useEstopQuery({
+  const { data: estopStatus, error: estopError } = useEstopQuery({
     refetchInterval: ESTOP_POLL_MS,
   })
   const [
@@ -150,7 +150,7 @@ export function ProtocolRunHeader({
     setShowEmergencyStopRunBanner,
   ] = React.useState<boolean>(false)
   React.useEffect(() => {
-    if (estopStatus?.data.status !== DISENGAGED) {
+    if (estopStatus?.data.status !== DISENGAGED && estopError == null) {
       setShowEmergencyStopRunBanner(true)
     }
   }, [estopStatus?.data.status])
@@ -288,6 +288,7 @@ export function ProtocolRunHeader({
           />
         ) : null}
         {estopStatus?.data.status !== DISENGAGED &&
+        estopError == null &&
         showEmergencyStopRunBanner ? (
           <EmergencyStopRunBanner
             setShowEmergencyStopRunBanner={setShowEmergencyStopRunBanner}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -83,6 +83,7 @@ import {
   useIsRobotViewable,
   useTrackProtocolRunEvent,
   useRobotAnalyticsData,
+  useIsOT3,
 } from '../hooks'
 import { formatTimestamp } from '../utils'
 import { RunTimer } from './RunTimer'
@@ -149,6 +150,8 @@ export function ProtocolRunHeader({
     showEmergencyStopRunBanner,
     setShowEmergencyStopRunBanner,
   ] = React.useState<boolean>(false)
+  const isOT3 = useIsOT3(robotName)
+
   React.useEffect(() => {
     if (estopStatus?.data.status !== DISENGAGED) {
       setShowEmergencyStopRunBanner(true)
@@ -288,7 +291,8 @@ export function ProtocolRunHeader({
           />
         ) : null}
         {estopStatus?.data.status !== DISENGAGED &&
-        showEmergencyStopRunBanner ? (
+        showEmergencyStopRunBanner &&
+        isOT3 ? (
           <EmergencyStopRunBanner
             setShowEmergencyStopRunBanner={setShowEmergencyStopRunBanner}
           />

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -66,6 +66,7 @@ import {
   useRunCreatedAtTimestamp,
   useUnmatchedModulesForProtocol,
   useIsRobotViewable,
+  useIsOT3,
 } from '../../hooks'
 import { useIsHeaterShakerInProtocol } from '../../../ModuleCard/hooks'
 import { ConfirmAttachmentModal } from '../../../ModuleCard/ConfirmAttachmentModal'
@@ -192,6 +193,7 @@ const mockRunFailedModal = RunFailedModal as jest.MockedFunction<
 const mockUseEstopQuery = useEstopQuery as jest.MockedFunction<
   typeof useEstopQuery
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -345,6 +347,7 @@ describe('ProtocolRunHeader', () => {
     when(mockUseRunCalibrationStatus)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({ complete: true })
+    mockUseIsOT3.mockReturnValue(true)
     mockRunFailedModal.mockReturnValue(<div>mock RunFailedModal</div>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
   })

--- a/app/src/organisms/Devices/RobotOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverflowMenu.tsx
@@ -14,6 +14,8 @@ import {
   useHoverTooltip,
 } from '@opentrons/components'
 
+import { useEstopQuery } from '@opentrons/react-api-client'
+
 import { CONNECTABLE, removeRobot } from '../../redux/discovery'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
@@ -25,6 +27,7 @@ import { ChooseProtocolSlideout } from '../ChooseProtocolSlideout'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { ConnectionTroubleshootingModal } from './ConnectionTroubleshootingModal'
 import { useMenuHandleClickOutside } from '../../atoms/MenuList/hooks'
+import { useIsRobotBusy } from './hooks'
 
 import type { StyleProps } from '@opentrons/components'
 import type { DiscoveredRobot } from '../../redux/discovery/types'
@@ -35,6 +38,7 @@ interface RobotOverflowMenuProps extends StyleProps {
 }
 
 export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
+  console.log(useEstopQuery())
   const { robot, ...styleProps } = props
   const { t } = useTranslation(['devices_landing', 'shared'])
   const {
@@ -61,6 +65,8 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
   const isRobotOnWrongVersionOfSoftware =
     autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade'
 
+  const isRobotBusy = useIsRobotBusy()
+
   const handleClickRun: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
@@ -78,14 +84,16 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
   if (robot.status === CONNECTABLE && runId == null) {
     menuItems = (
       <>
-        <MenuItem
-          {...targetProps}
-          onClick={handleClickRun}
-          disabled={isRobotOnWrongVersionOfSoftware}
-          data-testid={`RobotOverflowMenu_${robot.name}_runProtocol`}
-        >
-          {t('run_a_protocol')}
-        </MenuItem>
+        {!isRobotBusy ? (
+          <MenuItem
+            {...targetProps}
+            onClick={handleClickRun}
+            disabled={isRobotOnWrongVersionOfSoftware}
+            data-testid={`RobotOverflowMenu_${robot.name}_runProtocol`}
+          >
+            {t('run_a_protocol')}
+          </MenuItem>
+        ) : null}
         {isRobotOnWrongVersionOfSoftware && (
           <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
             {t('shared:a_software_update_is_available')}

--- a/app/src/organisms/Devices/RobotOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverflowMenu.tsx
@@ -14,8 +14,6 @@ import {
   useHoverTooltip,
 } from '@opentrons/components'
 
-import { useEstopQuery } from '@opentrons/react-api-client'
-
 import { CONNECTABLE, removeRobot } from '../../redux/discovery'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
@@ -38,7 +36,6 @@ interface RobotOverflowMenuProps extends StyleProps {
 }
 
 export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
-  console.log(useEstopQuery())
   const { robot, ...styleProps } = props
   const { t } = useTranslation(['devices_landing', 'shared'])
   const {

--- a/app/src/organisms/Devices/RobotOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverflowMenu.tsx
@@ -62,7 +62,7 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
   const isRobotOnWrongVersionOfSoftware =
     autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade'
 
-  const isRobotBusy = useIsRobotBusy()
+  const isRobotBusy = useIsRobotBusy({ poll: true })
 
   const handleClickRun: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()

--- a/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
@@ -110,7 +110,7 @@ describe('RobotOverflowMenu', () => {
     expect(run).toBeDisabled()
   })
 
-  it('should only render robotsettings when e-stop is pressed or disconnected', () => {
+  it('should only render robot settings when e-stop is pressed or disconnected', () => {
     mockUseCurrentRunId.mockReturnValue(null)
     mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
       autoUpdateAction: 'upgrade',

--- a/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
@@ -9,6 +9,7 @@ import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { ConnectionTroubleshootingModal } from '../ConnectionTroubleshootingModal'
 import { RobotOverflowMenu } from '../RobotOverflowMenu'
 import { getRobotUpdateDisplayInfo } from '../../../redux/robot-update'
+import { useIsRobotBusy } from '../hooks'
 
 import {
   mockUnreachableRobot,
@@ -19,6 +20,7 @@ jest.mock('../../../redux/robot-update/selectors')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../../ChooseProtocolSlideout')
 jest.mock('../ConnectionTroubleshootingModal')
+jest.mock('../hooks')
 
 const mockUseCurrentRunId = useCurrentRunId as jest.MockedFunction<
   typeof useCurrentRunId
@@ -31,6 +33,9 @@ const mockConnectionTroubleshootingModal = ConnectionTroubleshootingModal as jes
 >
 const mockGetBuildrootUpdateDisplayInfo = getRobotUpdateDisplayInfo as jest.MockedFunction<
   typeof getRobotUpdateDisplayInfo
+>
+const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
+  typeof useIsRobotBusy
 >
 
 const render = (props: React.ComponentProps<typeof RobotOverflowMenu>) => {
@@ -60,6 +65,7 @@ describe('RobotOverflowMenu', () => {
       autoUpdateDisabledReason: null,
       updateFromFileDisabledReason: null,
     })
+    mockUseIsRobotBusy.mockReturnValue(false)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -102,5 +108,20 @@ describe('RobotOverflowMenu', () => {
     fireEvent.click(btn)
     const run = getByText('Run a protocol')
     expect(run).toBeDisabled()
+  })
+
+  it('should only render robotsettings when e-stop is pressed or disconnected', () => {
+    mockUseCurrentRunId.mockReturnValue(null)
+    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
+      autoUpdateAction: 'upgrade',
+      autoUpdateDisabledReason: null,
+      updateFromFileDisabledReason: null,
+    })
+    mockUseIsRobotBusy.mockReturnValue(true)
+    const { getByText, getByLabelText, queryByText } = render(props)
+    const btn = getByLabelText('RobotOverflowMenu_button')
+    fireEvent.click(btn)
+    expect(queryByText('Run a protocol')).not.toBeInTheDocument()
+    getByText('Robot settings')
   })
 })

--- a/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
@@ -117,6 +117,7 @@ describe('RobotOverflowMenu', () => {
       autoUpdateDisabledReason: null,
       updateFromFileDisabledReason: null,
     })
+
     mockUseIsRobotBusy.mockReturnValue(true)
     const { getByText, getByLabelText, queryByText } = render(props)
     const btn = getByLabelText('RobotOverflowMenu_button')

--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -4,6 +4,12 @@ import {
   useAllRunsQuery,
   useEstopQuery,
 } from '@opentrons/react-api-client'
+import {
+  DISENGAGED,
+  NOT_PRESENT,
+  PHYSICALLY_ENGAGED,
+  ENGAGED,
+} from '../../../EmergencyStop'
 
 import { useIsRobotBusy } from '../useIsRobotBusy'
 
@@ -12,11 +18,22 @@ import type { Sessions, Runs } from '@opentrons/api-client'
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../ProtocolUpload/hooks')
 
+const mockEstopStatus = {
+  data: {
+    status: DISENGAGED,
+    leftEstopPhysicalStatus: DISENGAGED,
+    rightEstopPhysicalStatus: NOT_PRESENT,
+  },
+}
+
 const mockUseAllSessionsQuery = useAllSessionsQuery as jest.MockedFunction<
   typeof useAllSessionsQuery
 >
 const mockUseAllRunsQuery = useAllRunsQuery as jest.MockedFunction<
   typeof useAllRunsQuery
+>
+const mockUseEstopQuery = useEstopQuery as jest.MockedFunction<
+  typeof useEstopQuery
 >
 
 describe('useIsRobotBusy', () => {
@@ -31,6 +48,7 @@ describe('useIsRobotBusy', () => {
         },
       },
     } as UseQueryResult<Runs, Error>)
+    mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
   })
 
   afterEach(() => {
@@ -67,6 +85,60 @@ describe('useIsRobotBusy', () => {
       ],
       links: {},
     } as unknown) as UseQueryResult<Sessions, Error>)
+    const result = useIsRobotBusy()
+    expect(result).toBe(false)
+  })
+
+  it('returns false when Estop status is disengaged', () => {
+    mockUseAllRunsQuery.mockReturnValue({
+      data: {
+        links: {
+          current: null,
+        },
+      },
+    } as any)
+    mockUseAllSessionsQuery.mockReturnValue(({
+      data: [
+        {
+          id: 'test',
+          createdAt: '2019-08-24T14:15:22Z',
+          details: {},
+          sessionType: 'calibrationCheck',
+          createParams: {},
+        },
+      ],
+      links: {},
+    } as unknown) as UseQueryResult<Sessions, Error>)
+    const result = useIsRobotBusy()
+    expect(result).toBe(false)
+  })
+
+  it('returns true when Estop status is not disengaged', () => {
+    mockUseAllRunsQuery.mockReturnValue({
+      data: {
+        links: {
+          current: null,
+        },
+      },
+    } as any)
+    mockUseAllSessionsQuery.mockReturnValue(({
+      data: [
+        {
+          id: 'test',
+          createdAt: '2019-08-24T14:15:22Z',
+          details: {},
+          sessionType: 'calibrationCheck',
+          createParams: {},
+        },
+      ],
+      links: {},
+    } as unknown) as UseQueryResult<Sessions, Error>)
+    const mockEngagedStatus = {
+      ...mockEstopStatus,
+      status: PHYSICALLY_ENGAGED,
+      leftEstopPhysicalStatus: ENGAGED,
+    }
+    mockUseEstopQuery.mockReturnValue({ data: mockEngagedStatus } as any)
     const result = useIsRobotBusy()
     expect(result).toBe(false)
   })

--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -2,6 +2,7 @@ import { UseQueryResult } from 'react-query'
 import {
   useAllSessionsQuery,
   useAllRunsQuery,
+  useEstopQuery,
 } from '@opentrons/react-api-client'
 
 import { useIsRobotBusy } from '../useIsRobotBusy'

--- a/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
+++ b/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
@@ -1,7 +1,9 @@
 import {
   useAllSessionsQuery,
   useAllRunsQuery,
+  useEstopQuery,
 } from '@opentrons/react-api-client'
+import { DISENGAGED } from '../../EmergencyStop'
 
 const ROBOT_STATUS_POLL_MS = 30000
 
@@ -16,9 +18,12 @@ export function useIsRobotBusy(
   const robotHasCurrentRun =
     useAllRunsQuery({}, queryOptions)?.data?.links?.current != null
   const allSessionsQueryResponse = useAllSessionsQuery(queryOptions)
+  const { data: estopStatus, error: estopError } = useEstopQuery()
+
   return (
     robotHasCurrentRun ||
     (allSessionsQueryResponse?.data?.data != null &&
-      allSessionsQueryResponse?.data?.data?.length !== 0)
+      allSessionsQueryResponse?.data?.data?.length !== 0) ||
+    (estopStatus?.data.status !== DISENGAGED && estopError == null)
   )
 }

--- a/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
+++ b/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
@@ -18,7 +18,7 @@ export function useIsRobotBusy(
   const robotHasCurrentRun =
     useAllRunsQuery({}, queryOptions)?.data?.links?.current != null
   const allSessionsQueryResponse = useAllSessionsQuery(queryOptions)
-  const { data: estopStatus, error: estopError } = useEstopQuery()
+  const { data: estopStatus, error: estopError } = useEstopQuery(queryOptions)
 
   return (
     robotHasCurrentRun ||

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -151,7 +151,6 @@ describe('RobotConfigurationDetails', () => {
       robotType: OT2_STANDARD_MODEL,
     }
     const { queryByText } = render(props)
-    console.log(props.robotType)
     expect(queryByText('extension mount')).not.toBeInTheDocument()
   })
 

--- a/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -14,8 +14,7 @@ import { InstrumentsAndModules } from '../../../organisms/Devices/InstrumentsAnd
 import { RecentProtocolRuns } from '../../../organisms/Devices/RecentProtocolRuns'
 import { EstopBanner } from '../../../organisms/Devices/EstopBanner'
 import { DISENGAGED, useEstopContext } from '../../../organisms/EmergencyStop'
-
-const ESTOP_STATUS_REFETCH_INTERVAL = 10000
+// import { useIsOT3 } from '../../../organisms/Devices/hooks'
 
 interface DeviceDetailsComponentProps {
   robotName: string
@@ -24,10 +23,9 @@ interface DeviceDetailsComponentProps {
 export function DeviceDetailsComponent({
   robotName,
 }: DeviceDetailsComponentProps): JSX.Element {
-  const { data: estopStatus } = useEstopQuery({
-    refetchInterval: ESTOP_STATUS_REFETCH_INTERVAL,
-  })
+  const { data: estopStatus, error: estopError } = useEstopQuery()
   const { isEmergencyStopModalDismissed } = useEstopContext()
+  // const isOT3 = useIsOT3(robotName)
 
   return (
     <Box
@@ -38,6 +36,8 @@ export function DeviceDetailsComponent({
       paddingBottom={SPACING.spacing48}
     >
       {estopStatus?.data.status !== DISENGAGED &&
+      estopError == null &&
+      // isOT3 &&
       isEmergencyStopModalDismissed ? (
         <Flex marginBottom={SPACING.spacing16}>
           <EstopBanner status={estopStatus?.data.status} />

--- a/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -14,6 +14,7 @@ import { InstrumentsAndModules } from '../../../organisms/Devices/InstrumentsAnd
 import { RecentProtocolRuns } from '../../../organisms/Devices/RecentProtocolRuns'
 import { EstopBanner } from '../../../organisms/Devices/EstopBanner'
 import { DISENGAGED, useEstopContext } from '../../../organisms/EmergencyStop'
+import { useIsOT3 } from '../../../organisms/Devices/hooks'
 
 interface DeviceDetailsComponentProps {
   robotName: string
@@ -24,6 +25,7 @@ export function DeviceDetailsComponent({
 }: DeviceDetailsComponentProps): JSX.Element {
   const { data: estopStatus, error: estopError } = useEstopQuery()
   const { isEmergencyStopModalDismissed } = useEstopContext()
+  const isOT3 = useIsOT3(robotName)
 
   return (
     <Box
@@ -35,6 +37,7 @@ export function DeviceDetailsComponent({
     >
       {estopStatus?.data.status !== DISENGAGED &&
       estopError == null &&
+      isOT3 &&
       isEmergencyStopModalDismissed ? (
         <Flex marginBottom={SPACING.spacing16}>
           <EstopBanner status={estopStatus?.data.status} />

--- a/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -14,7 +14,6 @@ import { InstrumentsAndModules } from '../../../organisms/Devices/InstrumentsAnd
 import { RecentProtocolRuns } from '../../../organisms/Devices/RecentProtocolRuns'
 import { EstopBanner } from '../../../organisms/Devices/EstopBanner'
 import { DISENGAGED, useEstopContext } from '../../../organisms/EmergencyStop'
-// import { useIsOT3 } from '../../../organisms/Devices/hooks'
 
 interface DeviceDetailsComponentProps {
   robotName: string
@@ -25,7 +24,6 @@ export function DeviceDetailsComponent({
 }: DeviceDetailsComponentProps): JSX.Element {
   const { data: estopStatus, error: estopError } = useEstopQuery()
   const { isEmergencyStopModalDismissed } = useEstopContext()
-  // const isOT3 = useIsOT3(robotName)
 
   return (
     <Box
@@ -37,7 +35,6 @@ export function DeviceDetailsComponent({
     >
       {estopStatus?.data.status !== DISENGAGED &&
       estopError == null &&
-      // isOT3 &&
       isEmergencyStopModalDismissed ? (
         <Flex marginBottom={SPACING.spacing16}>
           <EstopBanner status={estopStatus?.data.status} />


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This is the last piece for E-stop. 
Update useIsRobotBusy hook for e-stop and fix Banner rendering issue when robotType is OT-2.

close RCORE-801 and fix [RQA-1314](https://opentrons.atlassian.net/browse/RQA-1314) and [RQA-1325](https://opentrons.atlassian.net/browse/RQA-1325)


Currently `useEstopQuery` uses useIsRobotBusy's fetch interval (30sec) so it will take some time to update the overflow menu items.
https://github.com/Opentrons/opentrons/assets/474225/c91dc6c9-7216-49f6-8959-f428d612dde2


https://github.com/Opentrons/opentrons/assets/474225/4a7ff028-0091-456d-840d-678bc91716c7




<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
[Flex]
0. open Desktop app
1. pressed E-stop button
2. click overflow menu in RobotCard and check the menu button only shows robotsettings 
3. click RobotCard and click overflow menu in DeviceDetails page and check the buttons in overflow menu are disabled except robotsettings
4. Twist the Estop button and tap `Resume operation` This will take 30 sec because of useIsRobot fetch interval
5. click RobotCard and click overflow menu in DeviceDetails page and check the buttons in overflow menu are not disabled 

[OT-2]
0. open Desktop app
1. click overflow menu in RobotCard and check the menu button shows `run a protocol` and  `robotsettings`
2. click RobotCard and click overflow menu in DeviceDetails page and check the buttons are not disabled

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-1314]: https://opentrons.atlassian.net/browse/RQA-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-1325]: https://opentrons.atlassian.net/browse/RQA-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ