### PR TITLE
fix(app-shell-odd, discovery-client): add option for MDNS in discovery client for use in odd

### DIFF
--- a/app-shell-odd/src/discovery.ts
+++ b/app-shell-odd/src/discovery.ts
@@ -115,7 +115,7 @@ export function registerDiscovery(
   client = createDiscoveryClient({
     onListChange: handleRobotListChange,
     logger: log,
-    enableMDNS: false
+    enableMDNS: false,
   })
 
   client.start({

--- a/app-shell-odd/src/discovery.ts
+++ b/app-shell-odd/src/discovery.ts
@@ -115,6 +115,7 @@ export function registerDiscovery(
   client = createDiscoveryClient({
     onListChange: handleRobotListChange,
     logger: log,
+    enableMDNS: false
   })
 
   client.start({

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -339,7 +339,8 @@ function PrepareToRun({
   const { data: attachedInstruments } = useInstrumentsQuery()
   const protocolName =
     protocolRecord?.data.metadata.protocolName ??
-    protocolRecord?.data.files[0].name ?? ''
+    protocolRecord?.data.files[0].name ??
+    ''
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
   const { launchLPC, LPCWizard } = useLaunchLPC(runId)
   const { setODDMaintenanceFlowInProgress } = useMaintenanceRunTakeover()

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -339,7 +339,7 @@ function PrepareToRun({
   const { data: attachedInstruments } = useInstrumentsQuery()
   const protocolName =
     protocolRecord?.data.metadata.protocolName ??
-    protocolRecord?.data.files[0].name
+    protocolRecord?.data.files[0].name ?? ''
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
   const { launchLPC, LPCWizard } = useLaunchLPC(runId)
   const { setODDMaintenanceFlowInProgress } = useMaintenanceRunTakeover()
@@ -512,7 +512,7 @@ function PrepareToRun({
                   fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                   overflowWrap="anywhere"
                 >
-                  {truncateString(protocolName as string, 100)}
+                  {truncateString(protocolName, 100)}
                 </StyledText>
               </>
             ) : (

--- a/discovery-client/src/discovery-client.ts
+++ b/discovery-client/src/discovery-client.ts
@@ -15,7 +15,7 @@ import type {
 export function createDiscoveryClient(
   options: DiscoveryClientOptions
 ): DiscoveryClient {
-  const { onListChange, logger } = options
+  const { onListChange, logger, enableMDNS = true } = options
   const { getState, dispatch, subscribe } = Store.createStore()
   const getAddresses = (): Address[] => Store.getAddresses(getState())
   const getRobots = (): DiscoveryClientRobot[] => Store.getRobots(getState())
@@ -45,7 +45,7 @@ export function createDiscoveryClient(
     let prevRobots = getRobots()
 
     healthPoller.start({ list: prevAddrs, interval: healthPollInterval })
-    mdnsBrowser.start()
+    enableMDNS && mdnsBrowser.start()
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!unsubscribe) {
@@ -63,7 +63,7 @@ export function createDiscoveryClient(
   }
 
   const stop = (): void => {
-    mdnsBrowser.stop()
+    enableMDNS && mdnsBrowser.stop()
     healthPoller.stop()
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (unsubscribe) {

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -169,7 +169,7 @@ export interface DiscoveryClientOptions {
   onListChange: (robots: DiscoveryClientRobot[]) => unknown
   /** Optional logger */
   logger?: Logger
-  /** Optional logger */
+  /** Whether to enable discovering robots over MDNS (defaults to true) */
   enableMDNS?: boolean
 }
 

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -169,6 +169,8 @@ export interface DiscoveryClientOptions {
   onListChange: (robots: DiscoveryClientRobot[]) => unknown
   /** Optional logger */
   logger?: Logger
+  /** Optional logger */
+  enableMDNS?: boolean
 }
 
 export interface DiscoveryClient {


### PR DESCRIPTION
# Overview

Because the ODD app shell is only interacting with the local robot, allow it to configure it's discovery client instance to ignore the MDNS poll.

# Changelog

- add `enableMDNS` option to discovery client (defaults to true)
- pass `false` to `enableMDNS` option when app-shell-odd constructs its discovery client instance

# Review requests

- confirm desktop app behaves as expected when discovery robots
- confirm ODD behaves as expected by finding robot at localhost and not polling MDNS for others 

# Risk assessment
med
