### PR TITLE
fix(engine): fix calculation for labware height on modules

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -439,10 +439,13 @@ class GeometryView:
         )
         location_slot: DeckSlotName
 
-        if isinstance(location, (ModuleLocation, OnLabwareLocation)):
+        if isinstance(location, DeckSlotLocation):
+            location_slot = location.slotName
+            offset = LabwareOffsetVector(x=0, y=0, z=0)
+        else:
             if isinstance(location, ModuleLocation):
                 location_slot = self._modules.get_location(location.moduleId).slotName
-            else:
+            else:  # OnLabwareLocation
                 location_slot = self.get_ancestor_slot_name(location.labwareId)
             labware_offset = self._get_labware_position_offset(labware_id, location)
             # Get the calibrated offset if the on labware location is on top of a module, otherwise return empty one
@@ -452,9 +455,6 @@ class GeometryView:
                 y=labware_offset.y + cal_offset.y,
                 z=labware_offset.z + cal_offset.z,
             )
-        else:
-            location_slot = location.slotName
-            offset = LabwareOffsetVector(x=0, y=0, z=0)
 
         slot_center = self._labware.get_slot_center_position(location_slot)
         return Point(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -139,6 +139,15 @@ class GeometryView:
         """Gets the offset vector of a labware on the given location.
 
         NOTE: Not to be confused with LPC offset.
+        - For labware on Deck Slot: returns an offset of (0, 0, 0)
+        - For labware on a Module: returns the nominal offset for the labware's position
+          when placed on the specified module (using slot-transformed labwareOffset
+          from the module's definition with any stacking overlap).
+          Does not include module calibration offset or LPC offset.
+        - For labware on another labware: returns the nominal offset for the labware
+          as placed on the specified labware, taking into account any offsets for labware
+          on modules as well as stacking overlaps.
+          Does not include module calibration offset or LPC offset.
         """
         if isinstance(labware_location, DeckSlotLocation):
             return LabwareOffsetVector(x=0, y=0, z=0)

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -1075,13 +1075,6 @@ def test_ensure_location_not_occupied_raises(
     )
 
 
-@pytest.mark.parametrize(
-    argnames=["location", "expected_center_point"],
-    argvalues=[
-        (DeckSlotLocation(slotName=DeckSlotName.SLOT_1), Point(101.0, 102.0, 203)),
-        (ModuleLocation(moduleId="module-id"), Point(111.0, 122.0, 233)),
-    ],
-)
 def test_get_labware_grip_point(
     decoy: Decoy,
     labware_view: LabwareView,
@@ -1096,20 +1089,6 @@ def test_get_labware_grip_point(
         labware_view.get_grip_height_from_labware_bottom("labware-id")
     ).then_return(100)
 
-    if isinstance(location, ModuleLocation):
-        decoy.when(labware_view.get_deck_definition()).then_return(
-            ot2_standard_deck_def
-        )
-        decoy.when(
-            module_view.get_module_offset(
-                module_id="module-id", deck_type=DeckType.OT2_STANDARD
-            )
-        ).then_return(LabwareOffsetVector(x=10, y=20, z=30))
-
-        decoy.when(module_view.get_location("module-id")).then_return(
-            DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
-        )
-
     decoy.when(labware_view.get_slot_center_position(DeckSlotName.SLOT_1)).then_return(
         Point(x=101, y=102, z=103)
     )
@@ -1120,30 +1099,43 @@ def test_get_labware_grip_point(
     assert labware_center == expected_center_point
 
 
+@pytest.mark.parametrize(
+    argnames=["location", "expected_center_point"],
+    argvalues=[
+        (OnLabwareLocation(labwareId="labware-id"), Point(5, 10, 115.0)),
+        (ModuleLocation(moduleId="module-id"), Point(111.0, 122.0, 233)),
+    ],
+)
 def test_get_labware_grip_point_on_labware(
     decoy: Decoy,
     labware_view: LabwareView,
     module_view: ModuleView,
     ot2_standard_deck_def: DeckDefinitionV3,
     subject: GeometryView,
+    location: Union[ModuleLocation, OnLabwareLocation],
+    expected_center_point: Point,
 ) -> None:
     """It should get the grip point of a labware on another labware."""
-    decoy.when(labware_view.get(labware_id="labware-id")).then_return(
-        LoadedLabware(
-            id="labware-id",
-            loadName="above-name",
-            definitionUri="1234",
-            location=OnLabwareLocation(labwareId="below-id"),
+    if isinstance(location, ModuleLocation):
+        decoy.when(module_view.get_location("module-id")).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_4))
+    else:
+
+        decoy.when(labware_view.get(labware_id="labware-id")).then_return(
+            LoadedLabware(
+                id="labware-id",
+                loadName="above-name",
+                definitionUri="1234",
+                location=OnLabwareLocation(labwareId="below-id"),
+            )
         )
-    )
-    decoy.when(labware_view.get(labware_id="below-id")).then_return(
-        LoadedLabware(
-            id="below-id",
-            loadName="below-name",
-            definitionUri="1234",
-            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+        decoy.when(labware_view.get(labware_id="below-id")).then_return(
+            LoadedLabware(
+                id="below-id",
+                loadName="below-name",
+                definitionUri="1234",
+                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+            )
         )
-    )
 
     decoy.when(labware_view.get_dimensions("below-id")).then_return(
         Dimensions(x=1000, y=1001, z=11)
@@ -1163,7 +1155,7 @@ def test_get_labware_grip_point_on_labware(
         labware_id="labware-id", location=OnLabwareLocation(labwareId="below-id")
     )
 
-    assert grip_point == Point(5, 10, 115.0)
+    assert grip_point == expected_center_point
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

I had forgotten to account for stacking overlap during calculation of the grip point when moving labware from/ to modules. This PR fixes that and adds a test to check for it.

# Test Plan

Check that the gripping point of the same labware is same no matter if it's being moved to/ from:
- [ ] a slot 
- [ ] a module with stacking overlap
- [ ] a module without stacking overlap
- [ ] a module with adapter
- [ ] a module without adapter.

# Changelog

- updated the grip point calculation to fetch the labware origin coordinates from the existing geometry getter (instead of duplicating the logic, which I was wrongly doing before)
- updated tests

# Review requests

- make sure I'm not missing anything else
- @thassyopinto has tested on a mag block and confirmed that it fixed the issue being seen before. Testing on thermocycler was pending (did it complete yet?) 

# Risk assessment

None if done correctly.
