### PR TITLE
fix(app): Fix white screen on RobotDashboard when clicking protocol

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -171,7 +171,7 @@ export function ProtocolWithLastRun({
             aria-label="icon_ot-spinner"
             spin={true}
             size="2.5rem"
-            color={COLORS.darkBlackEnabled}
+            color={COLORS.darkBlack100}
           />
         )}
       </Flex>

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -6,11 +6,13 @@ import { formatDistance } from 'date-fns'
 
 import {
   Flex,
+  Icon,
   COLORS,
   SPACING,
   TYPOGRAPHY,
   DIRECTION_COLUMN,
   BORDERS,
+  JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 import { useProtocolQuery } from '@opentrons/react-api-client'
 
@@ -74,8 +76,9 @@ export function ProtocolWithLastRun({
   const trackEvent = useTrackEvent()
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runData.id)
   const onResetSuccess = (createRunResponse: Run): void =>
-    history.push(`protocols/${createRunResponse.data.id}/setup`)
+    history.push(`runs/${createRunResponse.data.id}/setup`)
   const { cloneRun } = useCloneRun(runData.id, onResetSuccess)
+  const [showSpinner, setShowSpinner] = React.useState<boolean>(false)
 
   const protocolName =
     protocolData.metadata.protocolName ?? protocolData.files[0].name
@@ -92,6 +95,16 @@ export function ProtocolWithLastRun({
     }
   `
 
+  const PROTOCOL_CARD_CLICKED_STYLE = css`
+    flex: 1 0 0;
+    background-color: ${isReadyToBeReRun
+      ? COLORS.green3Pressed
+      : COLORS.yellow3Pressed};
+    &:focus-visible {
+      box-shadow: ${ODD_FOCUS_VISIBLE};
+    }
+  `
+
   const PROTOCOL_TEXT_STYLE = css`
     display: -webkit-box;
     -webkit-box-orient: vertical;
@@ -102,6 +115,7 @@ export function ProtocolWithLastRun({
   `
 
   const handleCardClick = (): void => {
+    setShowSpinner(true)
     cloneRun()
     trackEvent({
       name: 'proceedToRun',
@@ -134,7 +148,7 @@ export function ProtocolWithLastRun({
   ) : (
     <Flex
       aria-label="RecentRunProtocolCard"
-      css={PROTOCOL_CARD_STYLE}
+      css={!showSpinner ? PROTOCOL_CARD_STYLE : PROTOCOL_CARD_CLICKED_STYLE}
       flexDirection={DIRECTION_COLUMN}
       padding={SPACING.spacing24}
       gridGap={SPACING.spacing24}
@@ -144,13 +158,22 @@ export function ProtocolWithLastRun({
       borderRadius={BORDERS.borderRadiusSize4}
       onClick={handleCardClick}
     >
-      <Flex>
+      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
         <Chip
           paddingLeft="0"
           type={isReadyToBeReRun ? 'success' : 'warning'}
           background={false}
           text={i18n.format(chipText, 'capitalize')}
         />
+        {showSpinner && (
+          <Icon
+            name="ot-spinner"
+            aria-label="icon_ot-spinner"
+            spin={true}
+            size="2.5rem"
+            color={COLORS.darkBlackEnabled}
+          />
+        )}
       </Flex>
       <Flex width="100%" height="14rem">
         <StyledText

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
+import { COLORS, renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { formatDistance } from 'date-fns'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { MemoryRouter } from 'react-router-dom'
 
 import { RUN_STATUS_FAILED } from '@opentrons/api-client'
-import { renderWithProviders } from '@opentrons/components'
+
 import { useAllRunsQuery, useProtocolQuery } from '@opentrons/react-api-client'
 
 import { i18n } from '../../../../i18n'
@@ -191,15 +192,18 @@ describe('RecentRunProtocolCard', () => {
     getByText('Missing hardware')
   })
 
-  it('when tapping a card, mock functions is called', () => {
+  it('when tapping a card, mock functions is called and loading state is activated', () => {
     const [{ getByLabelText }] = render(props)
     const button = getByLabelText('RecentRunProtocolCard')
+    expect(button).toHaveStyle(`background-color: ${COLORS.green3}`)
     fireEvent.click(button)
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: 'proceedToRun',
       properties: { sourceLocation: 'RecentRunProtocolCard' },
     })
     expect(mockTrackProtocolRunEvent).toBeCalledWith({ name: 'runAgain' })
+    getByLabelText('icon_ot-spinner')
+    expect(button).toHaveStyle(`background-color: ${COLORS.green3Pressed}`)
   })
 
   it('should render the skeleton when react query is loading', () => {

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react'
-import { COLORS, renderWithProviders } from '@opentrons/components'
 import { fireEvent } from '@testing-library/react'
 import { formatDistance } from 'date-fns'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { MemoryRouter } from 'react-router-dom'
 
-import { RUN_STATUS_FAILED } from '@opentrons/api-client'
-
 import { useAllRunsQuery, useProtocolQuery } from '@opentrons/react-api-client'
+import { RUN_STATUS_FAILED } from '@opentrons/api-client'
+import { COLORS, renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../../i18n'
 import { Skeleton } from '../../../../atoms/Skeleton'


### PR DESCRIPTION
closes RQA-1235

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Addresses white screening and non-responsive clicks when selecting a protocol from the "Run Again" menu on RobotDashboard. 

While PR #13303 added loading state when the /runs/:runId/setup route was hit, the request logic for accessing this screen when clicking on a recently run protocol is different. There are two issues: 

1. A recently run protocol requires that the previous run record be fetched before routing to the ProtocolSetup page. This period takes 1-2 seconds usually, and the lack of user feedback requires addressing.
2. There is a bug in the routing where a non-existent route is hit before the ProtocolSetup route is hit. This causes the temporary white screen.

Although it seems superfluous to have the onSuccessCallback direct to the same route as useCreateRunMutation, there are bizzare rendering issues prior to the second redirect if it's not included. The route is hit twice, but this seems necessary without further investigation.

### Fix

https://github.com/Opentrons/opentrons/assets/64858653/925f0ee9-5d35-471b-8114-27f9b0288a49

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Verified fix on physical ODD testing several different protocols. 

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Added a pressed state to RecentRunProtocolCard.
- Corrected callback route to the correct route.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low