### PR TITLE
refactor(step-generation): moveLabware error handling for adapters

### DIFF
--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -111,8 +111,7 @@ export const getIsAdapter = (
   labwareId: string,
   labwareEntities: LabwareEntities
 ): boolean => {
-  if (labwareEntities[labwareId]) return false
-
+  if (labwareEntities[labwareId] == null) return false
   return (
     labwareEntities[labwareId].def.allowedRoles?.includes('adapter') ?? false
   )

--- a/step-generation/src/__tests__/moveLabware.test.ts
+++ b/step-generation/src/__tests__/moveLabware.test.ts
@@ -165,6 +165,45 @@ describe('moveLabware', () => {
       type: 'HEATER_SHAKER_LATCH_CLOSED',
     })
   })
+  it('should return an error when trying to move labware to an adapter on the heater-shaker when its latch is closed', () => {
+    const state = getInitialRobotStateStandard(invariantContext)
+    const HEATER_SHAKER_ID = 'heaterShakerId'
+    const HEATER_SHAKER_SLOT = 'A1'
+    const ADAPTER_ID = 'adapterId'
+
+    robotState = {
+      ...state,
+      labware: {
+        ...state.labware,
+        [ADAPTER_ID]: {
+          slot: HEATER_SHAKER_ID,
+        },
+      },
+      modules: {
+        ...state.modules,
+        [HEATER_SHAKER_ID]: {
+          slot: HEATER_SHAKER_SLOT,
+          moduleState: {
+            type: HEATERSHAKER_MODULE_TYPE,
+            latchOpen: false,
+            targetSpeed: null,
+          },
+        } as any,
+      },
+    }
+    const params = {
+      commandCreatorFnName: 'moveLabware',
+      labware: SOURCE_LABWARE,
+      useGripper: true,
+      newLocation: { labwareId: ADAPTER_ID },
+    } as MoveLabwareArgs
+
+    const result = moveLabware(params, invariantContext, robotState)
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'HEATER_SHAKER_LATCH_CLOSED',
+    })
+  })
   it('should return an error when trying to move labware to the heater-shaker when its shaking', () => {
     const state = getInitialRobotStateStandard(invariantContext)
     const HEATER_SHAKER_ID = 'heaterShakerId'

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -64,14 +64,15 @@ export const moveLabware: CommandCreator<MoveLabwareArgs> = (
       : null
   const destModuleIdUnderAdapter =
     destAdapterId != null ? prevRobotState.labware[destAdapterId].slot : null
-  const destId =
+  const destinationModuleId =
     destModuleIdUnderAdapter != null ? destModuleIdUnderAdapter : destModuleId
 
   if (newLocation === 'offDeck' && useGripper) {
     errors.push(errorCreators.labwareOffDeck())
   }
-  if (destId != null) {
-    const destModuleState = prevRobotState.modules[destId].moduleState
+  if (destinationModuleId != null) {
+    const destModuleState =
+      prevRobotState.modules[destinationModuleId].moduleState
     if (
       destModuleState.type === THERMOCYCLER_MODULE_TYPE &&
       destModuleState.lidOpen !== true


### PR DESCRIPTION
closes RAUT-641 and RQA-1442

# Overview

The error handling for moving labware in and out of a H-S with the latch closed wasn't wired up for adapters since I completely forgot to wire it up. This PR fixes that

# Test Plan

PD sandbox: https://sandbox.designer.opentrons.com/sg_moveLabware-error-handling-adapters/

Test 2 things:
1. add a H-S, an adapter and a labware on top of it to the deck map in PD. Add a `moveLabware` step to move the labware to a new destination. There should be an error saying the Heater-shaker latch is closed
2. add a H-S, an adapter and then the labware that matches the adapter to a different slot. Add a `moveLabware` step to move the labware to be on top of the adatper. There should be an error saying the Heater-shaker latch is closed.

# Changelog

- extend logic in `MoveLabware` to accommodate adapters, add test case
- fix small error in `getIsAdapter` that was making it always return false (RQA-1442)

# Review requests

see test plan

# Risk assessment

low