### PR TITLE
fix(app): find previous labware location from all commands for run preview text

### DIFF
--- a/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
+++ b/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
@@ -4,8 +4,8 @@ import type {
   MoveLabwareRunTimeCommand,
 } from '@opentrons/shared-data/'
 import { getLabwareName } from './utils'
-import { getLoadedLabware } from './utils/accessors'
 import { getLabwareDisplayLocation } from './utils/getLabwareDisplayLocation'
+import { getFinalLabwareLocation } from './utils/getFinalLabwareLocation'
 
 interface MoveLabwareCommandTextProps {
   command: MoveLabwareRunTimeCommand
@@ -17,7 +17,12 @@ export function MoveLabwareCommandText(
   const { t } = useTranslation('protocol_command_text')
   const { command, robotSideAnalysis } = props
   const { labwareId, newLocation, strategy } = command.params
-  const oldLocation = getLoadedLabware(robotSideAnalysis, labwareId)?.location
+
+  const allPreviousCommands = robotSideAnalysis.commands.slice(
+    0,
+    robotSideAnalysis.commands.findIndex(c => c.id === command.id)
+  )
+  const oldLocation = getFinalLabwareLocation(labwareId, allPreviousCommands)
   const newDisplayLocation = getLabwareDisplayLocation(
     robotSideAnalysis,
     newLocation,

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -875,7 +875,7 @@ describe('CommandText', () => {
           params: {
             strategy: 'manualMoveWithPause',
             labwareId: mockRobotSideAnalysis.labware[3].id,
-            newLocation: { moduleId: mockRobotSideAnalysis.modules[0].id },
+            newLocation: { slotName: 'A3' },
           },
           id: 'def456',
           result: { offsetId: 'fake_offset_id' },
@@ -892,7 +892,7 @@ describe('CommandText', () => {
       }
     )[0]
     getByText(
-      'Manually move NEST 96 Well Plate 100 µL PCR Full Skirt (1) from Magnetic Module GEN2 in Slot 1 to Magnetic Module GEN2 in Slot 1'
+      'Manually move NEST 96 Well Plate 100 µL PCR Full Skirt (1) from Magnetic Module GEN2 in Slot 1 to Slot A3'
     )
   })
   it('renders correct text for move labware with gripper off deck', () => {

--- a/app/src/organisms/CommandText/utils/__tests__/getFinalLabwareLocation.test.ts
+++ b/app/src/organisms/CommandText/utils/__tests__/getFinalLabwareLocation.test.ts
@@ -1,0 +1,129 @@
+import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
+import { getFinalLabwareLocation } from '../getFinalLabwareLocation'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+describe('getFinalLabwareLocation', () => {
+  it('calculates labware location after only load_labware', () => {
+    const labwareId = 'fakeLabwareId'
+    const location = { slotName: 'C3' }
+    expect(
+      getFinalLabwareLocation(labwareId, [
+        {
+          id: 'fakeId1',
+          commandType: 'loadLabware',
+          params: {
+            location,
+            loadName: 'fakeLoadname',
+            namespace: 'opentrons',
+            version: 1,
+          },
+          result: {
+            labwareId,
+            definition: fixture_tiprack_10_ul as LabwareDefinition2,
+            offset: { x: 1, y: 2, z: 3 },
+          },
+          status: 'succeeded',
+          createdAt: 'fake_timestamp',
+          startedAt: 'fake_timestamp',
+          completedAt: 'fake_timestamp',
+        },
+      ])
+    ).toBe(location)
+  })
+  it('calculates labware location after only load_labware and move_labware', () => {
+    const labwareId = 'fakeLabwareId'
+    const initialLocation = { slotName: 'C3' }
+    const finalLocation = { slotName: 'D1' }
+    expect(
+      getFinalLabwareLocation(labwareId, [
+        {
+          id: 'fakeId1',
+          commandType: 'loadLabware',
+          params: {
+            location: initialLocation,
+            loadName: 'fakeLoadname',
+            namespace: 'opentrons',
+            version: 1,
+          },
+          result: {
+            labwareId,
+            definition: fixture_tiprack_10_ul as LabwareDefinition2,
+            offset: { x: 1, y: 2, z: 3 },
+          },
+          status: 'succeeded',
+          createdAt: 'fake_timestamp',
+          startedAt: 'fake_timestamp',
+          completedAt: 'fake_timestamp',
+        },
+        {
+          id: 'fakeId2',
+          commandType: 'moveLabware',
+          params: {
+            labwareId,
+            newLocation: finalLocation,
+            strategy: 'usingGripper',
+          },
+          status: 'succeeded',
+          createdAt: 'fake_timestamp',
+          startedAt: 'fake_timestamp',
+          completedAt: 'fake_timestamp',
+        },
+      ])
+    ).toBe(finalLocation)
+  })
+  it('calculates labware location after multiple moves', () => {
+    const labwareId = 'fakeLabwareId'
+    const initialLocation = { slotName: 'C3' }
+    const secondLocation = { slotName: 'D1' }
+    const finalLocation = { slotName: 'A2' }
+    expect(
+      getFinalLabwareLocation(labwareId, [
+        {
+          id: 'fakeId1',
+          commandType: 'loadLabware',
+          params: {
+            location: initialLocation,
+            loadName: 'fakeLoadname',
+            namespace: 'opentrons',
+            version: 1,
+          },
+          result: {
+            labwareId,
+            definition: fixture_tiprack_10_ul as LabwareDefinition2,
+            offset: { x: 1, y: 2, z: 3 },
+          },
+          status: 'succeeded',
+          createdAt: 'fake_timestamp',
+          startedAt: 'fake_timestamp',
+          completedAt: 'fake_timestamp',
+        },
+        {
+          id: 'fakeId2',
+          commandType: 'moveLabware',
+          params: {
+            labwareId,
+            newLocation: secondLocation,
+            strategy: 'usingGripper',
+          },
+          status: 'succeeded',
+          createdAt: 'fake_timestamp',
+          startedAt: 'fake_timestamp',
+          completedAt: 'fake_timestamp',
+        },
+        {
+          id: 'fakeId3',
+          commandType: 'moveLabware',
+          params: {
+            labwareId,
+            newLocation: finalLocation,
+            strategy: 'usingGripper',
+          },
+          status: 'succeeded',
+          createdAt: 'fake_timestamp',
+          startedAt: 'fake_timestamp',
+          completedAt: 'fake_timestamp',
+        },
+      ])
+    ).toBe(finalLocation)
+  })
+})

--- a/app/src/organisms/CommandText/utils/getFinalLabwareLocation.ts
+++ b/app/src/organisms/CommandText/utils/getFinalLabwareLocation.ts
@@ -11,7 +11,7 @@ export function getFinalLabwareLocation(
   labwareId: string,
   commands: RunTimeCommand[]
 ): LabwareLocation | null {
-  return commands.reduce<LabwareLocation | null>((acc, c) => {
+  for (const c of commands.reverse()) {
     if (c.commandType === 'loadLabware' && c.result?.labwareId === labwareId) {
       return c.params.location
     } else if (
@@ -19,8 +19,7 @@ export function getFinalLabwareLocation(
       c.params.labwareId === labwareId
     ) {
       return c.params.newLocation
-    } else {
-      return acc
     }
-  }, null)
+  }
+  return null
 }

--- a/app/src/organisms/CommandText/utils/getFinalLabwareLocation.ts
+++ b/app/src/organisms/CommandText/utils/getFinalLabwareLocation.ts
@@ -1,11 +1,11 @@
-import type { LabwareLocation, RunTimeCommand } from '@opentrons/shared-data/'
+import type { LabwareLocation, RunTimeCommand } from '@opentrons/shared-data'
 
 /**
  * given a list of commands and a labwareId, calculate the resulting location
  * of the corresponding labware after all given commands are executed
  * @param labwareId target labware
  * @param commands list of commands to search within
- * @returns string in format hh:mm:ss, e.g. 03:15:45
+ * @returns LabwareLocation object of the resulting location of the target labware after all commands execute
  */
 export function getFinalLabwareLocation(
   labwareId: string,

--- a/app/src/organisms/CommandText/utils/getFinalLabwareLocation.ts
+++ b/app/src/organisms/CommandText/utils/getFinalLabwareLocation.ts
@@ -1,0 +1,26 @@
+import type { LabwareLocation, RunTimeCommand } from '@opentrons/shared-data/'
+
+/**
+ * given a list of commands and a labwareId, calculate the resulting location
+ * of the corresponding labware after all given commands are executed
+ * @param labwareId target labware
+ * @param commands list of commands to search within
+ * @returns string in format hh:mm:ss, e.g. 03:15:45
+ */
+export function getFinalLabwareLocation(
+  labwareId: string,
+  commands: RunTimeCommand[]
+): LabwareLocation | null {
+  return commands.reduce<LabwareLocation | null>((acc, c) => {
+    if (c.commandType === 'loadLabware' && c.result?.labwareId === labwareId) {
+      return c.params.location
+    } else if (
+      c.commandType === 'moveLabware' &&
+      c.params.labwareId === labwareId
+    ) {
+      return c.params.newLocation
+    } else {
+      return acc
+    }
+  }, null)
+}


### PR DESCRIPTION
# Overview

In the absence of a way to request timeline-based location information from the protocol engine, search through all previous commands to reduce labware location by duplicating PE concerns on the front end. 

Note: This is a brittle duplication of information that is already managed (but not exposed) by the Protocol Engine.

re RSS-301

Before: 
![Screen Shot 2023-08-23 at 12 17 57 PM](https://github.com/Opentrons/opentrons/assets/4731953/60ad5eb9-0fac-42d4-bffa-46cc8f568f95)


After:
![Screen Shot 2023-08-23 at 12 18 16 PM](https://github.com/Opentrons/opentrons/assets/4731953/dad6f230-b208-4932-a68c-4c810eebe3c1)

# Review requests

- Run Preview on Desktop and Running Protocol screen on ODD should render the correct "old location"
 when describing a `moveLabware` command. 
  
# Risk assessment
low
