### PR TITLE
fix(app): labware setup renders and location fixes

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -104,8 +104,8 @@ export const LabwareInfoOverlay = (
   const height = definition.dimensions.yDimension
   return (
     <RobotCoordsForeignDiv
-      x={0}
-      y={0}
+      x={definition.cornerOffsetFromSlot.x}
+      y={definition.cornerOffsetFromSlot.y}
       {...{ width, height }}
       innerDivProps={{
         display: DISPLAY_FLEX,

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -121,7 +121,7 @@ export function LabwareListItem(
         const module = commands.find(
           (command): command is LoadModuleRunTimeCommand =>
             command.commandType === 'loadModule' &&
-            command.params.moduleId === loadedAdapterLocation.moduleId
+            command.result?.moduleId === loadedAdapterLocation.moduleId
         )
         if (module != null) {
           slotInfo = t('adapter_slot_location_module', {

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -105,7 +105,6 @@ export function SetupLabwareMap({
                         }
                       >
                         {topLabwareDefinition != null &&
-                        topLabwareDisplayName != null &&
                         topLabwareId != null ? (
                           <React.Fragment
                             key={`LabwareSetup_Labware_${topLabwareId}_${x}${y}`}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -226,6 +226,9 @@ describe('LabwareListItem', () => {
         location: { slotName: 7 },
         model: 'temperatureModuleV2',
       },
+      result: {
+        moduleId: mockModuleId,
+      },
     } as any
 
     const { getByText } = render({


### PR DESCRIPTION
closes RQA-1385 closes RQA-1383

# Overview

PR fixes 2 bugs found in alpha 4:
1. the location of a labware on an adapter on a module
2. labware rendered on top of a module for protocols that don't specify the `displayName` of the nested labware

# Test Plan

Test on the protocol mentioned in the ticket. Look at the labware list view and the labware map view on the desktop/odd, should should correct information now.

# Changelog

- change `labwareListView` to match the moduleId from` results` instead of `params`. TBH idk how i missed this, must be that PD protocols render those `moduleId`s as the same? 
- don't assume every labware has a `displayName` - so i changed `SetupLabwareMap` to not have that extra check
- fix test
- fix `LabwareInfoOverlay` to account for the offset

# Review requests

see test plan

# Risk assessment

low