### PR TITLE
fix(app): ensure current run id is one created before issuing commands

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -90,12 +90,14 @@ export function GripperWizardFlows(
   // this will close the modal in case the run was deleted by the terminate
   // activity modal on the ODD
   React.useEffect(() => {
-    if (maintenanceRunData?.data.id === createdMaintenanceRunId) {
+    if (
+      createdMaintenanceRunId !== null &&
+      maintenanceRunData?.data.id === createdMaintenanceRunId
+    ) {
       setMonitorMaintenanceRunForDeletion(true)
     }
     if (
-      maintenanceRunData?.data.id == null &&
-      createdMaintenanceRunId != null &&
+      maintenanceRunData?.data.id !== createdMaintenanceRunId &&
       monitorMaintenanceRunForDeletion
     ) {
       closeFlow()
@@ -155,7 +157,6 @@ export function GripperWizardFlows(
       errorMessage={errorMessage}
       setErrorMessage={setErrorMessage}
       isExiting={isExiting}
-      createdMaintenanceRunId={createdMaintenanceRunId}
     />
   )
 }
@@ -182,7 +183,6 @@ interface GripperWizardProps {
   createRunCommand: ReturnType<
     typeof useCreateMaintenanceCommandMutation
   >['createMaintenanceCommand']
-  createdMaintenanceRunId: string | null
 }
 
 export const GripperWizard = (
@@ -201,7 +201,6 @@ export const GripperWizard = (
     setErrorMessage,
     errorMessage,
     isExiting,
-    createdMaintenanceRunId,
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('gripper_wizard_flows')

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -235,10 +235,7 @@ export const GripperWizard = (
 
   let chainMaintenanceRunCommands
 
-  if (
-    maintenanceRunId != null &&
-    createdMaintenanceRunId === maintenanceRunId
-  ) {
+  if (maintenanceRunId != null) {
     chainMaintenanceRunCommands = (
       commands: CreateCommand[],
       continuePastCommandFailure: boolean

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -155,10 +155,7 @@ export const ModuleWizardFlows = (
 
   let chainMaintenanceRunCommands
 
-  if (
-    maintenanceRunData?.data.id != null &&
-    maintenanceRunData.data.id === createdMaintenanceRunId
-  ) {
+  if (maintenanceRunData?.data.id != null) {
     chainMaintenanceRunCommands = (
       commands: CreateCommand[],
       continuePastCommandFailure: boolean

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -62,18 +62,26 @@ export const ModuleWizardFlows = (
     isCommandMutationLoading,
   } = useChainMaintenanceCommands()
 
+  const [createdRunId, setCreatedRunId] = React.useState<string | null>(null)
   const {
     createMaintenanceRun,
     isLoading: isCreateLoading,
-  } = useCreateMaintenanceRunMutation()
-
+  } = useCreateMaintenanceRunMutation({
+    onSuccess: response => {
+      setCreatedRunId(response.data.id)
+    },
+  })
   const prevMaintenanceRunId = React.useRef<string | undefined>(
     maintenanceRunData?.data.id
   )
   // this will close the modal in case the run was deleted by the terminate
   // activity modal on the ODD
   React.useEffect(() => {
-    if (maintenanceRunData?.data.id == null && prevMaintenanceRunId != null) {
+    if (
+      maintenanceRunData?.data.id == null &&
+      prevMaintenanceRunId != null &&
+      createdRunId != null
+    ) {
       closeFlow()
     }
   }, [maintenanceRunData, closeFlow])
@@ -131,7 +139,10 @@ export const ModuleWizardFlows = (
 
   let chainMaintenanceRunCommands
 
-  if (maintenanceRunData?.data.id != null) {
+  if (
+    maintenanceRunData?.data.id != null &&
+    maintenanceRunData.data.id === createdRunId
+  ) {
     chainMaintenanceRunCommands = (
       commands: CreateCommand[],
       continuePastCommandFailure: boolean

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -85,12 +85,14 @@ export const ModuleWizardFlows = (
   // this will close the modal in case the run was deleted by the terminate
   // activity modal on the ODD
   React.useEffect(() => {
-    if (maintenanceRunData?.data.id === createdMaintenanceRunId) {
+    if (
+      createdMaintenanceRunId !== null &&
+      maintenanceRunData?.data.id === createdMaintenanceRunId
+    ) {
       setMonitorMaintenanceRunForDeletion(true)
     }
     if (
-      maintenanceRunData?.data.id == null &&
-      createdMaintenanceRunId != null &&
+      maintenanceRunData?.data.id !== createdMaintenanceRunId &&
       monitorMaintenanceRunForDeletion
     ) {
       closeFlow()

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -54,37 +54,53 @@ export const ModuleWizardFlows = (
       currentStepIndex !== totalStepCount ? 0 : currentStepIndex
     )
   }
+  const [createdMaintenanceRunId, setCreatedMaintenanceRunId] = React.useState<
+    string | null
+  >(null)
+  // we should start checking for run deletion only after the maintenance run is created
+  // and the useCurrentRun poll has returned that created id
+  const [
+    monitorMaintenanceRunForDeletion,
+    setMonitorMaintenanceRunForDeletion,
+  ] = React.useState<boolean>(false)
+
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
     refetchInterval: RUN_REFETCH_INTERVAL,
+    enabled: createdMaintenanceRunId != null,
   })
   const {
     chainRunCommands,
     isCommandMutationLoading,
   } = useChainMaintenanceCommands()
 
-  const [createdRunId, setCreatedRunId] = React.useState<string | null>(null)
   const {
     createMaintenanceRun,
     isLoading: isCreateLoading,
   } = useCreateMaintenanceRunMutation({
     onSuccess: response => {
-      setCreatedRunId(response.data.id)
+      setCreatedMaintenanceRunId(response.data.id)
     },
   })
-  const prevMaintenanceRunId = React.useRef<string | undefined>(
-    maintenanceRunData?.data.id
-  )
+
   // this will close the modal in case the run was deleted by the terminate
   // activity modal on the ODD
   React.useEffect(() => {
+    if (maintenanceRunData?.data.id === createdMaintenanceRunId) {
+      setMonitorMaintenanceRunForDeletion(true)
+    }
     if (
       maintenanceRunData?.data.id == null &&
-      prevMaintenanceRunId != null &&
-      createdRunId != null
+      createdMaintenanceRunId != null &&
+      monitorMaintenanceRunForDeletion
     ) {
       closeFlow()
     }
-  }, [maintenanceRunData, closeFlow])
+  }, [
+    maintenanceRunData?.data.id,
+    createdMaintenanceRunId,
+    monitorMaintenanceRunForDeletion,
+    closeFlow,
+  ])
 
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
@@ -141,7 +157,7 @@ export const ModuleWizardFlows = (
 
   if (
     maintenanceRunData?.data.id != null &&
-    maintenanceRunData.data.id === createdRunId
+    maintenanceRunData.data.id === createdMaintenanceRunId
   ) {
     chainMaintenanceRunCommands = (
       commands: CreateCommand[],

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -138,12 +138,14 @@ export const PipetteWizardFlows = (
   // this will close the modal in case the run was deleted by the terminate
   // activity modal on the ODD
   React.useEffect(() => {
-    if (maintenanceRunData?.data.id === createdMaintenanceRunId) {
+    if (
+      createdMaintenanceRunId !== null &&
+      maintenanceRunData?.data.id === createdMaintenanceRunId
+    ) {
       setMonitorMaintenanceRunForDeletion(true)
     }
     if (
-      maintenanceRunData?.data.id == null &&
-      createdMaintenanceRunId != null &&
+      maintenanceRunData?.data.id !== createdMaintenanceRunId &&
       monitorMaintenanceRunForDeletion
     ) {
       closeFlow()

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -98,6 +98,7 @@ export const PipetteWizardFlows = (
     attachedPipettes: memoizedAttachedPipettes,
     pipetteInfo: memoizedPipetteInfo,
   })
+  const [createdRunId, setCreatedRunId] = React.useState<string | null>(null)
 
   const goBack = (): void => {
     setCurrentStepIndex(
@@ -122,12 +123,23 @@ export const PipetteWizardFlows = (
   const {
     createMaintenanceRun,
     isLoading: isCreateLoading,
-  } = useCreateMaintenanceRunMutation({}, host)
+  } = useCreateMaintenanceRunMutation(
+    {
+      onSuccess: response => {
+        setCreatedRunId(response.data.id)
+      },
+    },
+    host
+  )
 
   // this will close the modal in case the run was deleted by the terminate
   // activity modal on the ODD
   React.useEffect(() => {
-    if (maintenanceRunData?.data.id == null && prevMaintenanceRunId != null) {
+    if (
+      maintenanceRunData?.data.id == null &&
+      prevMaintenanceRunId.current != null &&
+      createdRunId != null
+    ) {
       closeFlow()
     }
   }, [maintenanceRunData, closeFlow])
@@ -192,7 +204,10 @@ export const PipetteWizardFlows = (
 
   let chainMaintenanceRunCommands
 
-  if (maintenanceRunData?.data.id != null) {
+  if (
+    maintenanceRunData?.data.id != null &&
+    maintenanceRunData.data.id === createdRunId
+  ) {
     chainMaintenanceRunCommands = (
       commands: CreateCommand[],
       continuePastCommandFailure: boolean

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -214,11 +214,7 @@ export const PipetteWizardFlows = (
   }, [isCommandMutationLoading, isExiting])
 
   let chainMaintenanceRunCommands
-
-  if (
-    maintenanceRunData?.data.id != null &&
-    maintenanceRunData.data.id === createdMaintenanceRunId
-  ) {
+  if (maintenanceRunData?.data.id != null) {
     chainMaintenanceRunCommands = (
       commands: CreateCommand[],
       continuePastCommandFailure: boolean


### PR DESCRIPTION
fix RLIQ-1377

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We are often seeing a few second mismatch between the returned `currentMaintenanceRun` id and the maintenance run that is created within a flow. This is causing a number of issues including the flow closing when the previous run id gets deleted and attempting to issue commands to a non-existent maintenance run.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Try to launch a pipette flow and a gripper flow. See that the flow doesn't close right away and that no commands get a 404 error
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Ensure `currentMaintenanceRunId` is equal to the resulting id of the `createMaintenanceRun` mutation before proceeding to issue any commands
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Run through test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
