### PR TITLE
refactor(api): split backend tip_action into two functions

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -40,7 +40,7 @@ from .ot3utils import (
     create_gripper_jaw_home_group,
     create_gripper_jaw_hold_group,
     create_tip_action_group,
-    create_gear_motor_home_group,
+    create_tip_motor_home_group,
     motor_nodes,
     LIMIT_SWITCH_OVERTRAVEL_DISTANCE,
     map_pipette_type_to_sensor_id,
@@ -641,7 +641,7 @@ class OT3Controller:
             positions = await asyncio.gather(*coros)
         # TODO(CM): default gear motor homing routine to have some acceleration
         if Axis.Q in checked_axes:
-            await self.home_gear_motors(
+            await self.home_tip_motors(
                 distance=self.axis_bounds[Axis.Q][1] - self.axis_bounds[Axis.Q][0],
                 velocity=self._configuration.motion_settings.max_speed_discontinuity.high_throughput[
                     Axis.to_kind(Axis.Q)
@@ -663,15 +663,13 @@ class OT3Controller:
             )
         return new_group
 
-    async def home_gear_motors(
+    async def home_tip_motors(
         self,
         distance: float,
         velocity: float,
         back_off: bool = True,
     ) -> None:
-        move_group = create_gear_motor_home_group(
-            float(distance), float(velocity), back_off
-        )
+        move_group = create_tip_motor_home_group(distance, velocity, back_off)
 
         runner = MoveGroupRunner(
             move_groups=[move_group],

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -641,12 +641,11 @@ class OT3Controller:
             positions = await asyncio.gather(*coros)
         # TODO(CM): default gear motor homing routine to have some acceleration
         if Axis.Q in checked_axes:
-            await self.tip_action(
+            await self.home_gear_motors(
                 distance=self.axis_bounds[Axis.Q][1] - self.axis_bounds[Axis.Q][0],
                 velocity=self._configuration.motion_settings.max_speed_discontinuity.high_throughput[
                     Axis.to_kind(Axis.Q)
                 ],
-                tip_action="home",
             )
         for position in positions:
             self._handle_motor_status_response(position)
@@ -664,26 +663,33 @@ class OT3Controller:
             )
         return new_group
 
+    async def home_gear_motors(
+        self,
+        distance: float,
+        velocity: float,
+        back_off: bool = True,
+    ) -> None:
+        move_group = create_gear_motor_home_group(
+            float(distance), float(velocity), back_off
+        )
+
+        runner = MoveGroupRunner(
+            move_groups=[move_group],
+            ignore_stalls=True if not ff.stall_detection_enabled() else False,
+        )
+        positions = await runner.run(can_messenger=self._messenger)
+        if NodeId.pipette_left in positions:
+            self._gear_motor_position = {
+                NodeId.pipette_left: positions[NodeId.pipette_left][0]
+            }
+        else:
+            log.debug("no position returned from NodeId.pipette_left")
+
     async def tip_action(
         self,
-        moves: Optional[List[Move[Axis]]] = None,
-        distance: Optional[float] = None,
-        velocity: Optional[float] = None,
-        tip_action: str = "home",
-        back_off: Optional[bool] = False,
+        moves: List[Move[Axis]],
     ) -> None:
-        # TODO: split this into two functions for homing and 'clamp'
-        move_group = []
-        # make sure either moves or distance and velocity is not None
-        assert bool(moves) ^ (bool(distance) and bool(velocity))
-        if moves is not None:
-            move_group = create_tip_action_group(
-                moves, [NodeId.pipette_left], tip_action
-            )
-        elif distance is not None and velocity is not None:
-            move_group = create_gear_motor_home_group(
-                float(distance), float(velocity), back_off
-            )
+        move_group = create_tip_action_group(moves, [NodeId.pipette_left], "clamp")
 
         runner = MoveGroupRunner(
             move_groups=[move_group],

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -393,11 +393,15 @@ class OT3Simulator:
 
     async def tip_action(
         self,
-        moves: Optional[List[Move[Axis]]] = None,
-        distance: Optional[float] = None,
-        velocity: Optional[float] = None,
-        tip_action: str = "home",
-        back_off: Optional[bool] = False,
+        moves: List[Move[Axis]],
+    ) -> None:
+        pass
+
+    async def home_gear_motors(
+        self,
+        distance: float,
+        velocity: float,
+        back_off: bool = True,
     ) -> None:
         pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -397,7 +397,7 @@ class OT3Simulator:
     ) -> None:
         pass
 
-    async def home_gear_motors(
+    async def home_tip_motors(
         self,
         distance: float,
         velocity: float,

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -435,7 +435,7 @@ def create_tip_action_group(
     return move_group
 
 
-def create_gear_motor_home_group(
+def create_tip_motor_home_group(
     distance: float,
     velocity: float,
     backoff: Optional[bool] = False,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -821,7 +821,7 @@ class OT3API(
 
         # if position is not known, move toward limit switch at a constant velocity
         if not any(self._backend.gear_motor_position):
-            await self._backend.home_gear_motors(
+            await self._backend.home_tip_motors(
                 distance=self._backend.axis_bounds[Axis.Q][1],
                 velocity=homing_velocity,
             )
@@ -844,7 +844,7 @@ class OT3API(
             ]
 
         # move until the limit switch is triggered, with no acceleration
-        await self._backend.home_gear_motors(
+        await self._backend.home_tip_motors(
             distance=(current_pos_float + self._config.safe_home_distance),
             velocity=homing_velocity,
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -819,6 +819,7 @@ class OT3API(
             GantryLoad.HIGH_THROUGHPUT
         ][OT3AxisKind.Q]
 
+        # if position is not known, move toward limit switch at a constant velocity
         if not any(self._backend.gear_motor_position):
             await self._backend.home_gear_motors(
                 distance=self._backend.axis_bounds[Axis.Q][1],
@@ -1832,7 +1833,6 @@ class OT3API(
             gear_origin_float = axis_convert(self._backend.gear_motor_position, 0.0)[
                 pipette_axis
             ]
-
             clamp_move_target = pipette_spec.pick_up_distance
             clamp_moves = self._build_moves(
                 {Axis.Q: gear_origin_float}, {Axis.Q: clamp_move_target}

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1833,27 +1833,11 @@ class OT3API(
                 pipette_axis
             ]
 
-            prep_move_speed_mm_sec = 10
-            clamp_move_speed_mm_sec = 5
-
-            prep_move_target = {Axis.Q: pipette_spec.pick_up_distance - 10}
-            clamp_move_target = {Axis.Q: pipette_spec.pick_up_distance}
-
-            #
-            move_target_start = MoveTarget.build(
-                position=prep_move_target,
-                max_speed=prep_move_speed_mm_sec,
+            clamp_move_target = pipette_spec.pick_up_distance
+            clamp_moves = self._build_moves(
+                {Axis.Q: gear_origin_float}, {Axis.Q: clamp_move_target}
             )
-            move_target_finish = MoveTarget.build(
-                position=clamp_move_target,
-                max_speed=clamp_move_speed_mm_sec,
-            )
-            _, moves = self._move_manager.plan_motion(
-                origin={Axis.Q: gear_origin_float}, target_list=[move_target_start, move_target_finish]
-            )
-
-            #
-            await self._backend.tip_action(moves=moves[0])
+            await self._backend.tip_action(moves=clamp_moves[0])
 
             await self.home_gear_motors()
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -700,7 +700,7 @@ async def test_tip_action(
     controller: OT3Controller,
     mock_move_group_run: mock.AsyncMock,
 ) -> None:
-    await controller.tip_action(distance=33, velocity=-5.5, tip_action="home")
+    await controller.home_gear_motors(distance=33, velocity=-5.5, back_off=False)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:
@@ -713,9 +713,7 @@ async def test_tip_action(
 
     mock_move_group_run.reset_mock()
 
-    await controller.tip_action(
-        distance=33, velocity=-5.5, tip_action="home", back_off=True
-    )
+    await controller.home_gear_motors(distance=33, velocity=-5.5, back_off=True)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         move_groups = move_group_runner._move_groups

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -700,7 +700,7 @@ async def test_tip_action(
     controller: OT3Controller,
     mock_move_group_run: mock.AsyncMock,
 ) -> None:
-    await controller.home_gear_motors(distance=33, velocity=-5.5, back_off=False)
+    await controller.home_tip_motors(distance=33, velocity=-5.5, back_off=False)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         for move_group in move_group_runner._move_groups:
@@ -713,7 +713,7 @@ async def test_tip_action(
 
     mock_move_group_run.reset_mock()
 
-    await controller.home_gear_motors(distance=33, velocity=-5.5, back_off=True)
+    await controller.home_tip_motors(distance=33, velocity=-5.5, back_off=True)
     for call in mock_move_group_run.call_args_list:
         move_group_runner = call[0][0]
         move_groups = move_group_runner._move_groups

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -609,10 +609,7 @@ async def move_tip_motor_relative_ot3(
 
     tip_motor_move = api._build_moves(current_gear_pos_dict, target_pos_dict)
 
-    _move_coro = api._backend.tip_action(
-        moves=tip_motor_move[0],
-        tip_action="clamp",
-    )
+    _move_coro = api._backend.tip_action(moves=tip_motor_move[0])
     if motor_current is None:
         await _move_coro
     else:


### PR DESCRIPTION
## Overview
Currently, the backend `tip_action` function is used both for regular tip action moves, as well as for homing the gear motors at a constant velocity. This makes the code a little bit cluttered, as the backend function takes in either a list of moves or a distance and velocity to accommodate this, and then needs to determine which one it's received. 

Instead, the api can just use two separate functions- one for homing, and one for all other moves involving the gear motor.


## Changelog
- create a `home_gear_motors` function in `ot3api.py` that fast homes the gear motors if possible, or homes at constant velocity if not
- create a `home_gear_motors` function in `ot3controller.py` that is used only for homing at constant velocity
- `ot3controller.py::tip_action` will only take in a list of moves 