### PR TITLE
docs(api): refactor-tip-handling

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -218,18 +218,21 @@ Working With Used Tips
 
 API versions 2.2 or higher consider tips as "used" after they've been picked up, even if you return a tip to the tip rack. For example, if you pick up a tip from rack location A1 and then return it to the same location, the robot will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
 
-    pipette.pick_up_tip()  # picks up tip from rack location A1
-    pipette.return_tip()   # drops tip in rack location A1
-    pipette.pick_up_tip()  # picks up from rack location B1
+    pipette.pick_up_tip()                # picks up tip from rack location A1
+    pipette.return_tip()                 # drops tip in rack location A1
+    pipette.pick_up_tip(tiprack_1['A1']) # picks up tip from rack location A1
+    pipette.drop_tip()                   # drops tip in trash bin
+    pipette.pick_up_tip()                # picks up tip from rack location B1
 
 .. can this be removed?
 Also in API Version 2.2, the return tip height was corrected to utilize values determined by hardware testing. This is more in-line with return tip behavior from Python Protocol API Version 1.
 
-API versions 2.0 and 2.1 treated returned tips as unused items and they could be picked up again. For example:: 
+API versions 2.0 and 2.1 treated returned tips as unused items and they could be picked up again without an explicit argument. For example:: 
 
     pipette.pick_up_tip()  # picks up tip from rack location A1
     pipette.return_tip()   # drops tip in rack location A1
     pipette.pick_up_tip()  # picks up tip from rack location A1
+
 
 ****************
 Liquid Control

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -149,13 +149,14 @@ If you omit the ``tip_rack`` argument from the ``pipette`` variable, then you mu
 
 However, coding the location of each tip is inefficient. Let's use a ``for`` loop to automate a sequential tip pick up process.
 
+Coding the location of each tip is inefficient. Instead, let the API track and manage the tip pickup location for you. Adding a ``for`` loop to  your protocol is a great way to take advantage of API tip tracking.
+
 .. versionadded:: 2.0
 
-.. needs better title?
 Loops and Tip Pick Up
 ---------------------
 
-A ``for`` loop and Python's :py:class:`range` class gives you a better way to automate the tip pickup process. It eliminates the need to call ``pick_up_tip()`` multiple times. For example, this snippet tells the robot to sequentially use all the tips in a 96-tip rack::
+A ``for`` loop and Python's :py:class:`range` class brings automation to the tip pickup and tracking process. It eliminates the need to call ``pick_up_tip()`` multiple times. For example, this snippet tells the robot to sequentially use all the tips in a 96-tip rack::
 
     for i in range(96):
         pipette.pick_up_tip()

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -32,29 +32,35 @@ The examples in this section would be added to the following:
 
 This loads a `Corning 96 Well Plate <https://labware.opentrons.com/corning_96_wellplate_360ul_flat>`_ in slot 2 and a `Opentrons 300 µL Tiprack <https://labware.opentrons.com/opentrons_96_tiprack_300ul>`_ in slot 3, and uses a P300 Single GEN2 pipette.
 
+.. _atomic-tip-manipulation:
 
-************
-Tip Handling
-************
+Manipulating Pipette Tips
+=========================
 
-By default, the robot constantly exchanges old, used tips for new ones to prevent cross-contamination between wells. Tip handling uses the functions :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`.
+The API provides three basic functions that help the robot manipulate pipette tips during a protocol run. These are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. 
+Respectively, they tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions.
 
-Pick Up Tip
-===========
+Picking Up a Tip
+----------------
 
-Before any liquid handling can be done, your pipette must have a tip on it. The command :py:meth:`.InstrumentContext.pick_up_tip` will move the pipette over to the specified tip, then press down into it to create a vacuum seal. The below example picks up the tip at location ``'A1'`` of the tiprack previously loaded in slot 3.
-
-.. code-block:: python
-
-   pipette.pick_up_tip(tiprack['A1'])
-
-If you have associated a tiprack with your pipette such as in the :ref:`new-pipette` or :ref:`protocol_api-protocols-and-instruments` sections, then you can simply call
-
-.. code-block:: python
-
+Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense any liquids. Given sample code above, call the :py:meth:`~.InstrumentContext.pick_up_tip` method without any arguments::
+    
     pipette.pick_up_tip()
 
-This will use the next available tip from the list of tipracks passed in to the ``tip_racks`` argument of :py:meth:`.ProtocolContext.load_instrument`.
+This works because the variable ``tiprack_1`` includes the on-deck location of the tip rack (Flex ``location="D3"``, OT-2 ``location=3``). Next, notice how the ``pipette`` variable includes the argument ``tip_racks=[tiprack_1]``. Given this information, the robot automatically knows where to go and what to do. For example:
+
+- Flex moves the pipette to the tip rack in deck slot D3 and picks up a tip from rack location A1.
+- OT-2 moves the pipette to the tip rack in deck slot 3 and picks up a tip from rack location A1.
+
+On subsequent calls to ``pick_up_tip()``, the robot will use the next available tip in the rack. For example::
+
+    pipette.pick_up_tip()  # picks up tip in rack location A1
+    pipette.drop_tip()     # drops tip in trash bin
+    pipette.pick_up_tip()  # picks up tip in rack location B1 
+
+If you omit the ``tip_rack`` argument from the :py:meth:`~.InstrumentContext.load_instrument` method, then you must pass in the tip rack's location information to ``pick_up_tip`` like this::
+    
+    pipette.pick_up_tip(tiprack_1['A1']) 
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -159,9 +159,12 @@ A ``for`` loop and Python's :py:class:`range` class gives you a better way to au
 
     for i in range(96):
         pipette.pick_up_tip()
+        # liquid handling commands
         pipette.drop_tip()
 
-If your protocol requires a lot of tips, add a second tip rack to the protocol, and sum the tip count in the range. The robot will loop through both racks. For example, let's add another tip rack to the sample protocol::
+If your protocol requires a lot of tips, add a second tip rack to the protocol. Then associate it with your pipette and increase the number of repetitions in the loop. The robot will loop through both racks. 
+
+First, add another tip rack to the sample protocol::
 
     tiprack_2 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul",
@@ -173,7 +176,7 @@ Next, revise the pipette's ``load_instrument()`` method to include the new tip r
     pipette = protocol.load_instrument(
         instrument_name="flex_1channel_1000",
         mount="left",
-        tip_racks=[tiprack_1, tip_rack_2],
+        tip_racks=[tiprack_1, tiprack_2],
     ) 
 
 Finally, sum the tip count in the range::

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -178,7 +178,7 @@ Set the new range in the ``for`` loop to use all the tips in each tip rack::
         pipette.pick_up_tip()
         pipette.drop_tip()
 
-For a more advanced example using a loop, take a moment to review the :ref:`off-deck location protocol <off-deck-location>` on the :ref:`_moving-labware` page. This example uses a ``for`` loop to iterate through a tip rack, but also includes other commands that pause the protocol and let you replace an on-deck tip rack with another rack stored in an off-deck location.
+For a more advanced "real-world" example, take a moment to review the :ref:`off-deck location protocol <off-deck-location>` on the :ref:`_moving-labware` page. This example uses a ``for`` loop to iterate through a tip rack, but also includes other commands that pause the protocol and let you replace an on-deck tip rack with another rack stored in an off-deck location.
 
 Dropping a Tip
 --------------
@@ -190,7 +190,7 @@ To drop a tip in the trash bin, call the :py:meth:`~.InstrumentContext.drop_tip`
 You can also specify where to drop the tip by passing in a location. For example, this code drops a tip in the trash bin and drops another tip in its original tip rack location::
 
     pipette.pick_up_tip()            # picks up tip from rack location A1
-    pipette.drop_tip                 # drops tip in trash bin 
+    pipette.drop_tip()               # drops tip in trash bin 
     pipette.pick_up_tip()            # picks up tip from rack location B1
     pipette.drop_tip(tiprack['B1'])  # drops tip in rack location B1
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -116,15 +116,14 @@ Depending on your robot model and/or API version, the foundation of a basic prot
                 pipette = protocol.load_instrument(
                     instrument_name="p300_single_gen2",
                     mount="left",
-                    tip_racks=[tip_rack_1]
+                    tip_racks=[tip_rack_1],
                 )  
                 # Put other protocol commands here
 
 Manipulating Pipette Tips
 =========================
 
-Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. 
-Respectively, they tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each of these are designed to work with the sample protocols above.
+Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each code snippet is designed to work with the sample protocols above.
 
 Picking Up a Tip
 ----------------
@@ -138,7 +137,7 @@ This simple statement works because the variable ``tiprack_1`` in the sample pro
     pipette.pick_up_tip()  # picks up tip from rack location A1
     pipette.drop_tip()     # drops tip in trash bin
     pipette.pick_up_tip()  # picks up tip from rack location B1
-    pipette.drop_tip()   # drops tip in trash bin 
+    pipette.drop_tip()     # drops tip in trash bin 
 
 If you omit the ``tip_rack`` argument from the ``pipette`` variable, then you must pass in the tip rack location to ``pick_up_tip`` like this::
     
@@ -166,6 +165,7 @@ If your protocol requires a lot of tips, add a second tip rack to the protocol, 
         load_name="opentrons_flex_96_tiprack_1000ul",
         location="C3"
     )
+
 Next, revise the pipette's ``load_instrument()`` method to include the new tip rack in the ``tip_rack`` argument::
 
     pipette = protocol.load_instrument(
@@ -215,7 +215,7 @@ To return a tip to its original location, call the :py:meth:`~.InstrumentContext
 Working With Used Tips
 ----------------------
 
-API versions 2.2 or higher consider tips as "used" after they've been picked up, even if the tip is returned to a tip rack. For example, if you pick up a tip from rack location A1 and then return it to the same location, the robot will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
+API versions 2.2 or higher consider tips as "used" after they've been picked up. For example, if you pick up a tip from rack location A1 and then return it to the same location, the robot will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
 
     pipette.pick_up_tip()                # picks up tip from rack location A1
     pipette.return_tip()                 # drops tip in rack location A1

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -123,7 +123,7 @@ Depending on your robot model and/or API version, the foundation of a basic prot
 Manipulating Pipette Tips
 =========================
 
-Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each code snippet is designed to work with the sample protocol code shown above.
+Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each code snippet works with the sample code shown above.
 
 Picking Up a Tip
 ----------------

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -33,18 +33,16 @@ If you omit the ``tip_rack`` argument from the ``pipette`` variable, then you mu
     
     pipette.pick_up_tip(tiprack_1['A1'])
     pipette.drop_tip()
-    pipette.pick_up_tip(tiprack_1['B1'])
+    pipette.pick_up_tip(tiprack_1['B1']) 
 
-However, coding the location of each tip is inefficient. Let's use a ``for`` loop to automate a sequential tip pick up process.
-
-Coding the location of each tip is inefficient. Instead, let the API track and manage the tip pickup location for you. Adding a ``for`` loop to  your protocol is a great way to take advantage of API tip tracking.
+If coding the location of each tip seems inefficient or tedious, try using a ``for`` loop to automate a sequential tip pick up process. When using a loop, the API tracks and manages the tip pickup locations automatically. But ``pick_up_tip`` is still a powerful feature. It lets you maintain control over tip use when that’s important in your protocol.
 
 .. versionadded:: 2.0
 
-Loops and Tip Pick Up
----------------------
+Automating Tip Pick Up
+----------------------
 
-A ``for`` loop and Python's :py:class:`range` class brings automation to the tip pickup and tracking process. It eliminates the need to call ``pick_up_tip()`` multiple times. For example, this snippet tells the robot to sequentially use all the tips in a 96-tip rack::
+Adding a ``for`` loop to your protocol is a great way to take advantage of API tip tracking. When used with Python's :py:class:`range` class, a loop brings automation to the tip pickup and tracking process. It eliminates the need to call ``pick_up_tip()`` multiple times. For example, this snippet tells the robot to sequentially use all the tips in a 96-tip rack::
 
     for i in range(96):
         pipette.pick_up_tip()
@@ -79,16 +77,16 @@ For a more advanced "real-world" example, take a moment to review the :ref:`off-
 Dropping a Tip
 --------------
 
-To drop a tip in the trash bin, call the :py:meth:`~.InstrumentContext.drop_tip` method without any arguments::
+To drop a tip in the trash bin, call the :py:meth:`~.InstrumentContext.drop_tip` method with no arguments::
     
     pipette.pick_up_tip()
 
-You can also specify where to drop the tip by passing in a location. For example, this code drops a tip in the trash bin and returns another tip to the tip rack::
+You can also specify where to drop the tip by passing in a location. For example, this code drops a tip in the trash bin and returns another tip to to a previously used well in a tip rack::
 
     pipette.pick_up_tip()            # picks up tip from rack location A1
     pipette.drop_tip()               # drops tip in trash bin 
     pipette.pick_up_tip()            # picks up tip from rack location B1
-    pipette.drop_tip(tiprack['B1'])  # drops tip in rack location B1
+    pipette.drop_tip(tiprack['A1'])  # drops tip in rack location A1
 
 .. versionadded:: 2.0
 
@@ -97,14 +95,9 @@ You can also specify where to drop the tip by passing in a location. For example
 Return Tip
 ===========
 
-To return a tip to its original location, call the :py:meth:`~.InstrumentContext.return_tip` method without any arguments::
+To return a tip to its original location, call the :py:meth:`~.InstrumentContext.return_tip` method with no arguments::
 
     pipette.return_tip()
-
-.. this section below was a long note
-.. a lot of info for a call-out
-.. let's try it in a section
-.. important info, let's give it some attention
 
 Working With Used Tips
 ----------------------
@@ -117,15 +110,13 @@ API versions 2.2 or higher consider tips as "used" after being picked up. For ex
     pipette.drop_tip()                   # drops tip in trash bin
     pipette.pick_up_tip(tiprack_1['A1']) # picks up tip from rack location A1
 
-.. can this be removed, is it helpful?
-Also in API Version 2.2, the return tip height was corrected to utilize values determined by hardware testing. This is more in-line with return tip behavior from Python Protocol API Version 1.
-
 API versions 2.0 and 2.1 treated returned tips as unused items. They could be picked up again without an explicit argument. For example:: 
 
     pipette.pick_up_tip()  # picks up tip from rack location A1
     pipette.return_tip()   # drops tip in rack location A1
     pipette.pick_up_tip()  # picks up tip from rack location A1
 
+.. versionchanged: 2.2
 
 ****************
 Liquid Control

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -42,7 +42,7 @@ If coding the location of each tip seems inefficient or tedious, try using a ``f
 Automating Tip Pick Up
 ----------------------
 
-Adding a ``for`` loop to your protocol is a great way to take advantage of API tip tracking. When used with Python's :py:class:`range` class, a loop brings automation to the tip pickup and tracking process. It eliminates the need to call ``pick_up_tip()`` multiple times. For example, this snippet tells the robot to sequentially use all the tips in a 96-tip rack::
+When used with Python's :py:class:`range` class, a ``for`` loop brings automation to the tip pickup and tracking process. It also eliminates the need to call ``pick_up_tip()`` multiple times. For example, this snippet tells the robot to sequentially use all the tips in a 96-tip rack::
 
     for i in range(96):
         pipette.pick_up_tip()

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -35,7 +35,7 @@ If you omit the ``tip_rack`` argument from the ``pipette`` variable, the API wil
     pipette.drop_tip()
     pipette.pick_up_tip(tiprack_1['B1']) 
 
-If coding the location of each tip seems inefficient or tedious, try using a ``for`` loop to automate a sequential tip pick up process. When using a loop, the API tracks and manages the tip pickup locations automatically. But ``pick_up_tip`` is still a powerful feature. It lets you maintain control over tip use when that’s important in your protocol.
+If coding the location of each tip seems inefficient or tedious, try using a ``for`` loop to automate a sequential tip pick up process. When using a loop, the API keeps track of tips and manages tip pickup for you. But ``pick_up_tip`` is still a powerful feature. It gives you direct control over tip use when that’s important in your protocol.
 
 .. versionadded:: 2.0
 
@@ -49,7 +49,7 @@ When used with Python's :py:class:`range` class, a ``for`` loop brings automatio
         # liquid handling commands
         pipette.drop_tip()
 
-If your protocol requires a lot of tips, add a second tip rack to the protocol. Then associate it with your pipette and increase the number of repetitions in the loop. The robot will loop through both racks. 
+If your protocol requires a lot of tips, add a second tip rack to the protocol. Then, associate it with your pipette and increase the number of repetitions in the loop. The robot will work through both racks. 
 
 First, add another tip rack to the sample protocol::
 
@@ -72,7 +72,7 @@ Finally, sum the tip count in the range::
         pipette.pick_up_tip()
         pipette.drop_tip()
 
-For a more advanced "real-world" example, take a moment to review the :ref:`off-deck location protocol <off-deck-location>` on the :ref:`moving-labware` page. This example also uses a ``for`` loop to iterate through a tip rack, but it includes other commands that pause the protocol and let you replace an on-deck tip rack with another rack stored in an off-deck location.
+For a more advanced "real-world" example, review the :ref:`off-deck location protocol <off-deck-location>` on the :ref:`moving-labware` page. This example also uses a ``for`` loop to iterate through a tip rack, but it includes other commands that pause the protocol and let you replace an on-deck tip rack with another rack stored in an off-deck location.
 
 Dropping a Tip
 --------------

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -29,7 +29,7 @@ This simple statement works because the variable ``tiprack_1`` in the sample pro
     pipette.pick_up_tip()  # picks up tip from rack location B1
     pipette.drop_tip()     # drops tip in trash bin 
 
-If you omit the ``tip_rack`` argument from the ``pipette`` variable, the API will throw an error. You must pass in the tip rack's location to ``pick_up_tip`` like this::
+If you omit the ``tip_rack`` argument from the ``pipette`` variable, the API will raise an error. You must pass in the tip rack's location to ``pick_up_tip`` like this::
     
     pipette.pick_up_tip(tiprack_1['A1'])
     pipette.drop_tip()

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -29,7 +29,7 @@ This simple statement works because the variable ``tiprack_1`` in the sample pro
     pipette.pick_up_tip()  # picks up tip from rack location B1
     pipette.drop_tip()     # drops tip in trash bin 
 
-If you omit the ``tip_rack`` argument from the ``pipette`` variable, then you must pass in the tip rack's location to ``pick_up_tip`` like this::
+If you omit the ``tip_rack`` argument from the ``pipette`` variable, the API will throw an error. You must pass in the tip rack's location to ``pick_up_tip`` like this::
     
     pipette.pick_up_tip(tiprack_1['A1'])
     pipette.drop_tip()
@@ -102,7 +102,7 @@ To return a tip to its original location, call the :py:meth:`~.InstrumentContext
 Working With Used Tips
 ----------------------
 
-API versions 2.2 or higher consider tips as "used" after being picked up. For example, if the robot picked up a tip from rack location A1 and then returned it to the same location, it will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
+Currently, the API considers tips as "used" after being picked up. For example, if the robot picked up a tip from rack location A1 and then returned it to the same location, it will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
 
     pipette.pick_up_tip()                # picks up tip from rack location A1
     pipette.return_tip()                 # drops tip in rack location A1
@@ -110,7 +110,7 @@ API versions 2.2 or higher consider tips as "used" after being picked up. For ex
     pipette.drop_tip()                   # drops tip in trash bin
     pipette.pick_up_tip(tiprack_1['A1']) # picks up tip from rack location A1
 
-API versions 2.0 and 2.1 treated returned tips as unused items. They could be picked up again without an explicit argument. For example:: 
+Early API versions treated returned tips as unused items. They could be picked up again without an explicit argument. For example:: 
 
     pipette.pick_up_tip()  # picks up tip from rack location A1
     pipette.return_tip()   # drops tip in rack location A1

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -123,7 +123,7 @@ Depending on your robot model and/or API version, the foundation of a basic prot
 Manipulating Pipette Tips
 =========================
 
-Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each code snippet is designed to work with the sample protocols above.
+Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each code snippet is designed to work with the sample protocol code shown above.
 
 Picking Up a Tip
 ----------------
@@ -132,14 +132,14 @@ To pick up a tip, call the :py:meth:`~.InstrumentContext.pick_up_tip` method wit
     
     pipette.pick_up_tip()
 
-This simple statement works because the variable ``tiprack_1`` in the sample protocol includes the on-deck location of the tip rack (Flex ``location="D3"``, OT-2 ``location=3``) *and* the ``pipette`` variable includes the argument ``tip_racks=[tiprack_1]``. Given the information in the tip rack and pipette variables, the robot knows where to go and which tip to pick up. On subsequent calls to ``pick_up_tip()``, the robot will use the next available tip in the rack. For example::
+This simple statement works because the variable ``tiprack_1`` in the sample protocol includes the on-deck location of the tip rack (Flex ``location="D3"``, OT-2 ``location=3``) *and* the ``pipette`` variable includes the argument ``tip_racks=[tiprack_1]``. Given this information, the robot moves to the tip rack and picks up a tip from position A1 in the rack. On subsequent calls to ``pick_up_tip()``, the robot will use the next available tip. For example::
 
     pipette.pick_up_tip()  # picks up tip from rack location A1
     pipette.drop_tip()     # drops tip in trash bin
     pipette.pick_up_tip()  # picks up tip from rack location B1
     pipette.drop_tip()     # drops tip in trash bin 
 
-If you omit the ``tip_rack`` argument from the ``pipette`` variable, then you must pass in the tip rack location to ``pick_up_tip`` like this::
+If you omit the ``tip_rack`` argument from the ``pipette`` variable, then you must pass in the tip rack's location to ``pick_up_tip`` like this::
     
     pipette.pick_up_tip(tiprack_1['A1'])
     pipette.drop_tip()
@@ -159,7 +159,7 @@ A ``for`` loop and Python's :py:class:`range` class gives you a better way to au
         pipette.pick_up_tip()
         pipette.drop_tip()
 
-If your protocol requires a lot of tips, add a second tip rack to the protocol, and sum the tip count in the range. The robot will loop through both racks. For example, lets add another tip rack to the sample protocol::
+If your protocol requires a lot of tips, add a second tip rack to the protocol, and sum the tip count in the range. The robot will loop through both racks. For example, let's add another tip rack to the sample protocol::
 
     tiprack_2 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul",
@@ -215,7 +215,7 @@ To return a tip to its original location, call the :py:meth:`~.InstrumentContext
 Working With Used Tips
 ----------------------
 
-API versions 2.2 or higher consider tips as "used" after they've been picked up. For example, if you pick up a tip from rack location A1 and then return it to the same location, the robot will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
+API versions 2.2 or higher consider tips as "used" after being picked up. For example, if the robot picked up a tip from rack location A1 and then returned it to the same location, it will not attempt to pick up this tip again, unless explicitly specified. Instead, the robot will pick up a tip starting from rack location B1. For example::
 
     pipette.pick_up_tip()                # picks up tip from rack location A1
     pipette.return_tip()                 # drops tip in rack location A1

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -123,7 +123,9 @@ Depending on your robot model and/or API version, the foundation of a basic prot
 Manipulating Pipette Tips
 =========================
 
-Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack. Let's look at examples for each of these functions. Each code snippet works with the sample code shown above.
+Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack.
+
+The following sections demonstrate how to use each method and include sample code. The examples used here assume that you've loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`.
 
 Picking Up a Tip
 ----------------

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -8,6 +8,9 @@ Building Block Commands
 
 Building block commands execute some of the most basic actions that your robot can complete. But basic doesn’t mean these commands lack capabilities. They perform important tasks in your protocols. They're also foundational to the :ref:`complex commands <v2-complex-commands>` that help you write and run longer, more intricate procedures. In this section, we'll look at building block commands that let you work with pipette tips, liquids, and robot utility features.
 
+Manipulating Pipette Tips
+=========================
+
 Your robot needs to attach a disposable tip to the pipette before it can aspirate or dispense liquids. The API provides three basic functions that help the robot attach and manage pipette tips during a protocol run. These methods are :py:meth:`.InstrumentContext.pick_up_tip`, :py:meth:`.InstrumentContext.drop_tip`, and :py:meth:`.InstrumentContext.return_tip`. Respectively, these methods tell the robot to pick up a tip from a tip rack, drop a tip into the trash (or another location), and return a tip to its location in the tip rack.
 
 The following sections demonstrate how to use each method and include sample code. The examples used here assume that you've loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`.


### PR DESCRIPTION

# Overview

This PR is for managing changes made to the "Manipulating Pipette Tips" section of the doc, [Building Block Commands](https://docs.opentrons.com/v2/new_atomic_commands.html). Following the plan laid out in [this Figma file](https://www.figma.com/file/WsKj7gklIgDx68DkzegdaN/Commands-PAPI-docs-merge-strategies?type=whiteboard&node-id=0%3A1&t=souDTlzeZ3A0tmOj-1). This PR is for the first, small branch section in Merge Strategy 1.

The manipulating tips section has 4 parts:

- Picking Up a Tip
- Dropping a Tip
- Returning a Tip
- Iterating Through Tips

# Test Plan

-  Check code in the Black formatter and use that style.
- Make sure links work.
- The usual grammar, style, clarity stuff.

# Changelog

This refactoring introduces significant changes to the text used in the manipulating tips section. This includes things like:

- new code samples
- new and revised text
- some shortcuts/anchors
- fix section headers to use proper style

# Review requests

The usual suspects.

# Risk assessment

Low risk. Docs changes only.
