### PR TITLE
feat(app): Add link support to toasts

### DIFF
--- a/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
@@ -43,9 +43,13 @@ describe('Toast', () => {
     getByText('Super-long-protocol-file-name-that-the-u...py')
   })
   it('calls onClose when close button is pressed', () => {
+    jest.useFakeTimers()
     const { getByRole } = render(props)
     const closeButton = getByRole('button')
     fireEvent.click(closeButton)
+    act(() => {
+      jest.advanceTimersByTime(TOAST_ANIMATION_DURATION)
+    })
     expect(props.onClose).toHaveBeenCalled()
   })
   it('does not render close button if buttonText and closeButton are undefined', () => {

--- a/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/ODDToast.test.tsx
@@ -152,4 +152,31 @@ describe('Toast', () => {
     })
     expect(props.onClose).toHaveBeenCalled()
   })
+  it('renders link text with an optional callback', async () => {
+    jest.useFakeTimers()
+    props = {
+      ...props,
+      linkText: 'test link',
+      onLinkClick: jest.fn(),
+    }
+    const { getByText } = render(props)
+    const clickableLink = getByText('test link')
+    fireEvent.click(clickableLink)
+    expect(props.onLinkClick).toHaveBeenCalled()
+  })
+  it('toast will not disappear on a general click if both close button and clickable link present', async () => {
+    jest.useFakeTimers()
+    props = {
+      ...props,
+      linkText: 'test link',
+      closeButton: true,
+    }
+    const { getByText } = render(props)
+    const clickableLink = getByText('test message')
+    fireEvent.click(clickableLink)
+    act(() => {
+      jest.advanceTimersByTime(TOAST_ANIMATION_DURATION)
+    })
+    expect(props.onClose).not.toHaveBeenCalled()
+  })
 })

--- a/app/src/atoms/Toast/__tests__/Toast.test.tsx
+++ b/app/src/atoms/Toast/__tests__/Toast.test.tsx
@@ -31,19 +31,20 @@ describe('Toast', () => {
   })
 
   it('calls onClose when close button is pressed', () => {
+    jest.useFakeTimers()
     const { getByRole } = render(props)
     const closeButton = getByRole('button')
     fireEvent.click(closeButton)
+    act(() => {
+      jest.advanceTimersByTime(TOAST_ANIMATION_DURATION)
+    })
     expect(props.onClose).toHaveBeenCalled()
   })
 
   it('does not render x button if prop is false', () => {
     props = {
-      id: '1',
-      message: 'test message',
-      type: 'success',
+      ...props,
       closeButton: false,
-      onClose: jest.fn(),
     }
     const { queryByRole } = render(props)
     expect(queryByRole('button')).toBeNull()
@@ -146,5 +147,32 @@ describe('Toast', () => {
       jest.advanceTimersByTime(TOAST_ANIMATION_DURATION)
     })
     expect(props.onClose).toHaveBeenCalled()
+  })
+  it('renders link text with an optional callback', async () => {
+    jest.useFakeTimers()
+    props = {
+      ...props,
+      linkText: 'test link',
+      onLinkClick: jest.fn(),
+    }
+    const { getByText } = render(props)
+    const clickableLink = getByText('test link')
+    fireEvent.click(clickableLink)
+    expect(props.onLinkClick).toHaveBeenCalled()
+  })
+  it('toast will not disappear on a general click if both close button and clickable link present', async () => {
+    jest.useFakeTimers()
+    props = {
+      ...props,
+      linkText: 'test link',
+      closeButton: true,
+    }
+    const { getByText } = render(props)
+    const clickableLink = getByText('test message')
+    fireEvent.click(clickableLink)
+    act(() => {
+      jest.advanceTimersByTime(TOAST_ANIMATION_DURATION)
+    })
+    expect(props.onClose).not.toHaveBeenCalled()
   })
 })

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'styled-components'
 
 import {
+  Btn,
   Flex,
   Icon,
   Link,
@@ -50,6 +51,8 @@ export interface ToastProps extends StyleProps {
   heading?: string
   displayType?: 'desktop' | 'odd'
   exitNow?: boolean
+  linkText?: string
+  onLinkClick?: () => void
 }
 
 // TODO: (jh: 08/10/23) refactor toast component and render logic.
@@ -69,6 +72,8 @@ export function Toast(props: ToastProps): JSX.Element {
     heading,
     displayType,
     exitNow = false,
+    linkText,
+    onLinkClick = () => null,
     ...styleProps
   } = props
   const { t } = useTranslation('shared')
@@ -84,12 +89,13 @@ export function Toast(props: ToastProps): JSX.Element {
     showODDStyle = true
   }
 
-  const closeText =
-    buttonText !== undefined && buttonText.length > 0
-      ? buttonText
-      : closeButton === true
-      ? t('close')
-      : ''
+  let closeText: string | null = null
+  if (buttonText != null) {
+    closeText = buttonText
+  } else if (closeButton) {
+    if (displayType === 'odd') closeText = t('close')
+    else closeText = ''
+  }
 
   const ANIMATION_OVERFLOW = `
   overflow: hidden;
@@ -185,6 +191,20 @@ export function Toast(props: ToastProps): JSX.Element {
   `
 
   const ODD_ANIMATION_NONE = css``
+
+  const TEXT_STYLE = css`
+    color: ${COLORS.darkBlackEnabled};
+    font-size: ${showODDStyle ? TYPOGRAPHY.fontSize22 : TYPOGRAPHY.fontSizeP};
+    font-weight: ${showODDStyle
+      ? TYPOGRAPHY.fontWeightSemiBold
+      : TYPOGRAPHY.fontWeightRegular};
+    line-height: ${showODDStyle
+      ? TYPOGRAPHY.lineHeight28
+      : TYPOGRAPHY.lineHeight20};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `
 
   let oddAnimation: FlattenSimpleInterpolation | ThemedCssFunction<DefaultTheme>
 
@@ -284,6 +304,13 @@ export function Toast(props: ToastProps): JSX.Element {
     }, calculatedDuration(message, headingText, duration))
   }
 
+  type ToastCloseType = typeof onCloseHandler | null
+  // Require intentional clicking if links and close button present on toast.
+  const toastClose = (): ToastCloseType => {
+    if (closeButton != null && linkText != null) return null
+    return onCloseHandler
+  }
+
   return (
     <Flex
       css={showODDStyle ? oddAnimation : desktopAnimation}
@@ -297,7 +324,7 @@ export function Toast(props: ToastProps): JSX.Element {
       border={BORDERS.styleSolid}
       boxShadow={BORDERS.shadowBig}
       backgroundColor={toastStyleByType[type].backgroundColor}
-      onClick={isAutomaticAnimationExit ? onClose : onCloseHandler}
+      onClick={toastClose()}
       // adjust padding when heading is present and creates extra column
       padding={
         showODDStyle
@@ -358,29 +385,32 @@ export function Toast(props: ToastProps): JSX.Element {
               {headingText}
             </StyledText>
           ) : null}
-          <StyledText
-            color={COLORS.darkBlackEnabled}
-            fontSize={
-              showODDStyle ? TYPOGRAPHY.fontSize22 : TYPOGRAPHY.fontSizeP
-            }
-            fontWeight={
-              showODDStyle
-                ? TYPOGRAPHY.fontWeightSemiBold
-                : TYPOGRAPHY.fontWeightRegular
-            }
-            lineHeight={
-              showODDStyle ? TYPOGRAPHY.lineHeight28 : TYPOGRAPHY.lineHeight20
-            }
-            overflow="hidden"
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-          >
-            {message}
-          </StyledText>
+          <Flex alignItems={ALIGN_CENTER}>
+            <StyledText css={TEXT_STYLE}>{message}</StyledText>
+            {linkText ? (
+              <Link
+                role="button"
+                onClick={() => {
+                  onLinkClick()
+                  onCloseHandler()
+                }}
+                css={TEXT_STYLE}
+                marginLeft={SPACING.spacing4}
+                marginRight={SPACING.spacing8}
+                textDecoration={TYPOGRAPHY.textDecorationUnderline}
+              >
+                {linkText}
+              </Link>
+            ) : null}
+          </Flex>
         </Flex>
       </Flex>
-      {closeText.length > 0 && (
-        <Link role="button">
+      {closeText ? (
+        <Link
+          role="button"
+          data-testid="Toast_close-text"
+          onClick={() => onCloseHandler()}
+        >
           <StyledText
             color={COLORS.darkBlackEnabled}
             fontSize={
@@ -403,7 +433,18 @@ export function Toast(props: ToastProps): JSX.Element {
             {closeText}
           </StyledText>
         </Link>
-      )}
+      ) : null}
+      {!closeText && closeButton ? (
+        <Btn data-testid="Toast_close-button" onClick={() => onCloseHandler()}>
+          <Icon
+            width={SPACING.spacing24}
+            height={SPACING.spacing24}
+            marginTop={SPACING.spacing6}
+            name="close"
+            aria-label="close_icon"
+          />
+        </Btn>
+      ) : null}
     </Flex>
   )
 }

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -404,11 +404,7 @@ export function Toast(props: ToastProps): JSX.Element {
         </Flex>
       </Flex>
       {closeText ? (
-        <Link
-          role="button"
-          data-testid="Toast_close-text"
-          onClick={() => onCloseHandler()}
-        >
+        <Link role="button" onClick={() => onCloseHandler()}>
           <StyledText
             color={COLORS.darkBlackEnabled}
             fontSize={
@@ -433,7 +429,7 @@ export function Toast(props: ToastProps): JSX.Element {
         </Link>
       ) : null}
       {!closeText && closeButton ? (
-        <Btn data-testid="Toast_close-button" onClick={() => onCloseHandler()}>
+        <Btn onClick={() => onCloseHandler()}>
           <Icon
             width={SPACING.spacing24}
             height={SPACING.spacing24}

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -304,11 +304,9 @@ export function Toast(props: ToastProps): JSX.Element {
     }, calculatedDuration(message, headingText, duration))
   }
 
-  type ToastCloseType = typeof onCloseHandler | null
   // Require intentional clicking if links and close button present on toast.
-  const toastClose = (): ToastCloseType => {
-    if (closeButton != null && linkText != null) return null
-    return onCloseHandler
+  const toastClose = (): void => {
+    if (closeButton == null || linkText == null) onCloseHandler()
   }
 
   return (
@@ -324,7 +322,7 @@ export function Toast(props: ToastProps): JSX.Element {
       border={BORDERS.styleSolid}
       boxShadow={BORDERS.shadowBig}
       backgroundColor={toastStyleByType[type].backgroundColor}
-      onClick={toastClose()}
+      onClick={toastClose}
       // adjust padding when heading is present and creates extra column
       padding={
         showODDStyle


### PR DESCRIPTION
Partially closes RAUT-501

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

_This PR is one in a series of many addressing the new desktop app update flows._

Toasts now support linkable text that take an optional callback. Update default close button for desktop to be the close icon instead of "Close" text. Refactor onClick close logic to support link support.

![Screenshot 2023-08-25 at 1 29 07 PM](https://github.com/Opentrons/opentrons/assets/64858653/e4db56d7-74ce-43a5-9d65-5c8e14840542)


# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Verified existing Toasts work as expected on desktop and emulated ODD.
- Verified linkable toasts do not dismiss unless the close button is intentionally clicked (if both are present).

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Added link support for toasts.
- Refactored exit logic to prevent misclicks when exit button and linkable text are present in a toast.
- Added testing.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low