### PR TITLE
docs(api): adjust OT-2 `apiLevel` and other small fixes

### DIFF
--- a/api/docs/v2/adapting_ot2_flex.rst
+++ b/api/docs/v2/adapting_ot2_flex.rst
@@ -34,7 +34,7 @@ You also need to specify ``'robotType': 'Flex'``. If you omit ``robotType`` in t
             metadata = {
                 "protocolName": "My Protocol",
                 "description": "This protocol uses the OT-2",
-                "apiLevel": "|apiLevel|" 
+                "apiLevel": "2.14" 
             }
 
     .. tab:: Updated Flex code

--- a/api/docs/v2/deck_slots.rst
+++ b/api/docs/v2/deck_slots.rst
@@ -40,13 +40,13 @@ For example, these two ``load_labware()`` commands are equivalent:
 
     protocol.load_labware("nest_96_wellplate_200ul_flat", "A1")
     
-.. versionadded:: 2.0
+.. versionadded:: 2.15
 
 .. code-block:: python
 
     protocol.load_labware("nest_96_wellplate_200ul_flat", 10)
     
-.. versionadded:: 2.15
+.. versionadded:: 2.0
 
 Both of these commands would require you to load the well plate in the back left slot of the robot.
 

--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -123,7 +123,7 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
             }
 
             # requirements
-            requirements = {"robotType": "OT-2", "apiLevel": "|apiLevel|"}
+            requirements = {"robotType": "OT-2", "apiLevel": "2.14"}
 
             # protocol run function
             def run(protocol: protocol_api.ProtocolContext):
@@ -149,7 +149,7 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
         This example proceeds completely linearly. Following it line-by-line, you can see that it has the following effects:
 
         1. Gives the name, contact information, and a brief description for the protocol.
-        2. Indicates the protocol should run on an OT-2 robot, using API version |apiLevel|.
+        2. Indicates the protocol should run on an OT-2 robot, using API version 2.14.
         3. Tells the robot that there is:
             a. A 96-well flat plate in slot 1.
             b. A rack of 300 µL tips in slot 2.

--- a/api/docs/v2/modules/setup.rst
+++ b/api/docs/v2/modules/setup.rst
@@ -40,7 +40,7 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.
 
             from opentrons import protocol_api
             
-            metadata = {'apiLevel': '2.13'}
+            metadata = {'apiLevel': '2.14'}
             
             def run(protocol: protocol_api.ProtocolContext): 
                 # Load a Magnetic Module GEN2 in deck slot 1.

--- a/api/docs/v2/modules/setup.rst
+++ b/api/docs/v2/modules/setup.rst
@@ -31,7 +31,7 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.
                 temperature_module = protocol.load_module(
                   module_name='temperature module gen2', location='D3')
 
-        After the ``load_module()`` method loads labware into your protocol, it returns the :py:class:`~opentrons.protocol_api.HeaterShakerContext` and :py:class:`~opentrons.protocol_api.TemperatureModuleContext` objects.
+        After the ``load_module()`` method loads the modules into your protocol, it returns the :py:class:`~opentrons.protocol_api.HeaterShakerContext` and :py:class:`~opentrons.protocol_api.TemperatureModuleContext` objects.
         
     .. tab:: OT-2
         
@@ -51,7 +51,7 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.
                 temperature_module = protocol.load_module(
                   module_name='temperature module', location=3)
 
-        After the ``load_module()`` method loads labware into your protocol, it returns the :py:class:`~opentrons.protocol_api.MagneticModuleContext` and :py:class:`~opentrons.protocol_api.TemperatureModuleContext` objects.
+        After the ``load_module()`` method loads the modules into your protocol, it returns the :py:class:`~opentrons.protocol_api.MagneticModuleContext` and :py:class:`~opentrons.protocol_api.TemperatureModuleContext` objects.
 
 
 .. versionadded:: 2.0

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -16,7 +16,7 @@ The examples in this section would be added to the following:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack = protocol.load_labware('corning_96_wellplate_360ul_flat', 2)
@@ -123,7 +123,7 @@ For this section, instead of using the protocol defined above, consider this set
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware(
@@ -212,7 +212,7 @@ The examples in this section should be inserted in the following:
 .. code-block:: python
     :substitutions:
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 2)
@@ -420,7 +420,7 @@ will be displayed in the Opentrons App when protocol execution pauses.
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # The start of your protocol goes here...
@@ -452,7 +452,7 @@ None of these functions take any arguments:
 
     from opentrons import protocol_api, types
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         pipette = protocol.load_instrument('p300_single', 'right')
@@ -474,7 +474,7 @@ The method :py:meth:`.ProtocolContext.comment` lets you display messages in the 
 
     from opentrons import protocol_api, types
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         protocol.comment('Hello, world!')
@@ -493,7 +493,7 @@ You can turn the robot rail lights on or off in the protocol using :py:meth:`.Pr
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # turn on robot rail lights

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -20,7 +20,7 @@ The examples in this section will use the following set up:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -99,7 +99,7 @@ This protocol uses some :ref:`basic commands <v2-atomic-commands>` to tell the r
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.15'}
+            metadata = {'apiLevel': '2.14'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -155,7 +155,7 @@ This protocol accomplishes the same thing as the previous example, but does it a
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.15'}
+            metadata = {'apiLevel': '2.14'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -259,7 +259,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel':'2.15'}
+            requirements = {'robotType': 'Flex', 'apiLevel':'|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -338,7 +338,7 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
 
             from opentrons import protocol_api
 
-            requirements = {'robotType':'Flex', 'apiLevel': '2.15'}
+            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -381,7 +381,7 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.15'}
+            metadata = {'apiLevel': '2.14'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -219,7 +219,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {'apiLevel': '2.14'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -294,7 +294,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {'apiLevel': '2.14'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -478,7 +478,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
             :substitutions:
 
             from opentrons import protocol_api
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {'apiLevel': '2.14'}
                 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -68,7 +68,7 @@ This code sample loads a P1000 Single-Channel GEN2 pipette in the left mount and
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {'apiLevel': '2.14'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack1 = protocol.load_labware(

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -71,7 +71,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software support the following version ranges: 
+Opentrons robots running the latest software (7.0.0) support the following version ranges: 
 
     * **Flex:** version 2.15.
     * **OT-2:** versions 2.0–|apiLevel|.


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This is a PAPI docs hotfix to implement some user feedback and fix a small error.

Addresses RTC-328.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Check that all and only OT-2 code snippets were changed from the dynamic `|apiLevel|`, which was being replaced with 2.15, to `2.14`.

[Sandbox link](http://sandbox.docs.opentrons.com/docs-hotfix-2.15_1/v2/)

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- fix backwards `.. versionadded::` notices on Deck Slots
- separate commits:
  - change `|apiLevel|` to `2.14` in OT-2 snippets on all but Building Block Commands and Complex Commands
  - change `|apiLevel|` to `2.14` in OT-2 snippets on Building Block Commands and Complex Commands

# Review requests

<!--
Describe any requests for your reviewers here.
-->

@jwwojak The changes to Building Block Commands may introduce merge conflicts for #13376. It's probably best to make the change now and deal with the conflicts later, but I deliberately put them in a separate commit if you'd prefer I take them out of this PR.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

v low, docs.