### PR TITLE
fix(app): fix non deterministic run command query

### DIFF
--- a/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -106,11 +106,13 @@ describe('RunProgressMeter', () => {
   })
 
   it('should show only the total count of commands in run and not show the meter when protocol is non-deterministic', () => {
+    mockUseCommandQuery.mockReturnValue({ data: null } as any)
     const { getByText, queryByText } = render(props)
     expect(getByText('Current Step 42/?')).toBeTruthy()
     expect(queryByText('MOCK PROGRESS BAR')).toBeFalsy()
   })
   it('should give the correct info when run status is idle', () => {
+    mockUseCommandQuery.mockReturnValue({ data: null } as any)
     mockUseRunStatus.mockReturnValue(RUN_STATUS_IDLE)
     const { getByText } = render(props)
     getByText('Current Step:')

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -100,7 +100,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     analysisCommands.findIndex(c => c.key === lastRunCommand?.key) ?? 0
   const { data: runCommandDetails } = useCommandQuery(
     runId,
-    lastRunCommand?.key ?? null
+    lastRunCommand?.id ?? null
   )
   let countOfTotalText = ''
   if (


### PR DESCRIPTION
# Overview

Prior to this PR, non-deterministic protocols, or runs whose analysis is stale and no longer matches the command keys in the actual run, would mistakenly query the command by its key instead of command ID. This would result in the app querying for non-existent commands and get `CommandDoesNotExistError` in response. This PR fixes that by changing the query to use command IDs for such queries.

# Test Plan

Run a protocol that has a different set of commands during analysis vs. during actual run. On the current 7.0.0 branch, you should get `CommandDoesNotExistError` errors during the run (either by checking the app's network request & response view or by checking the robot's system logs).

Those errors should not show up with this PR.

# Review requests

- does this line change affect anything other than non-deterministic protocols?

# Risk assessment

Low. Doesn't change the underlying working of a run, just corrects command status querying.
