### PR TITLE
docs(api): Refactor liquid control section

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -495,15 +495,15 @@ The touch speed controls how fast the pipette moves in mm/s during a touch actio
 Mix
 ---
 
-The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in µL) of liquid, and the location of a well that contains the liquid you want to mix.   
+The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the mix repetitions, the amount of liquid (in µL) to mix, and the location of a well that contains the liquid you want to mix. Here are some examples::  
 
-.. code-block:: python
+    # mix from the pipette's current location 
+    pipette.mix(repetitions=3, volume=50)
 
-    # mix 3 times, 50 µL, current location
-    pipette.mix(3, 50)
-    # mix 4 times, 100 µL, from well A2
+    # mix 100 µL 4 times from well A2
     pipette.mix(4, 100, plate['A2'])
-    # mix 2 times, use the pipette's max volume, current location
+
+The volume amount is optional. If omitted, the pipette will use its maximum rated volume as the amount. For example, 
     pipette.mix(2)
 
 .. note::

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -338,7 +338,7 @@ The ``aspirate()`` method includes a ``location`` parameter that accepts either 
 
 **By Well**
 
-If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of a well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. See also, :ref:`new-default-op-positions` for information about controlling pipette height for based on well location.
+If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of the well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. See also, :ref:`new-default-op-positions` for information about controlling pipette height for based on well location.
 
 .. code-block:: python
 
@@ -353,8 +353,8 @@ You can also aspirate on a point along the center, z-axis within a well. For exa
 .. code-block:: python
 
     pipette.pick_up_tip()
-    depth = plate['A1'].bottom(z=2) # aspirate 2mm above well bottom
-    pipette.aspirate(200, depth)
+    depth = plate['A1'].bottom(z=2) # set pipette tp 2mm above well bottom
+    pipette.aspirate(200, depth)    # aspirate 2mm above well bottom
 
 Aspiration Flow Rates
 ^^^^^^^^^^^^^^^^^^^^^

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -517,15 +517,17 @@ The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and 
 Air Gap
 -------
 
-The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to aspirate some air after a liquid. Creating an air gap can help prevent a liquid from leaking out of the pipette after drawing it from a well. Calling the ``air_gap()`` method without any arguments uses the remaining volume in the pipette tip. For example, if you load a 1000 µL pipette on a Flex and tell the robot to aspirate 500 µL of liquid, it will use the remaining 500 µL for the air gap::
+The :py:meth:`~.InstrumentContext.air_gap` method tells the pipette to draw in air before and/or after aspiration. Creating an air gap helps keep liquid from seeping out of a pipette after drawing it from a well. Calling the this method without any arguments uses the remaining volume in the pipette tip for the air gap. For example, if you load a 1000 µL pipette on a Flex and tell the robot to aspirate 200 µL, it will use the remaining 800 µL for the air gap.
 
-    pipette.aspirate(500, plate['A1'])
-    pipette.air_gap() # draws 500 µL of air
+.. code-block:: python
 
-The ``air_gap()`` method also accepts the ``volume`` and ``height`` arguments. These let you control the amount of air (in µL) drawn in and the height (in mm) above the well for aspirating air. By default, the pipette will move 5 mm above a well before creating the air gap. For example, this code aspirates 200 µL of liquid from well A1. The aspiration action is followed by an air gap of 75 µL taken from 20 mm above the well::
+    pipette.aspirate(200, plate['A1']) # aspirate 200 µL from well A1
+    pipette.air_gap()                  # aspirate 800 µL of air
+
+The ``air_gap()`` method also accepts ``volume`` and ``height`` arguments. These let you control the amount of air (in µL) drawn in and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before creating the air gap. For example, this code tells the robot to draw 200 µL of liquid from well A1 and create an air gap of 75 µL at 20 mm above well A1::
     
     pipette.aspirate(200, plate['A1'])
-    pipette.air_gap(75, 20)
+    pipette.air_gap(volume=75, height=20)
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -311,7 +311,7 @@ To draw liquid up into a pipette tip, call the :py:meth:`.InstrumentContext.aspi
     pipette.pick_up_tip()
     pipette.aspirate(200, plate['A1'])
 
-If the pipette doesn't move, you can also specify an additional aspiration action without including a location. To demonstrate, lets pause the protocol, automatically resume it, and aspirate a second time from ``plate['A1'])``.
+If the pipette doesn't move, you can also specify an additional aspiration action without including a location. To demonstrate, lets pause the protocol, automatically resume it, and aspirate a second time from ``plate['A1']``).
 
 .. code-block:: python
 
@@ -342,13 +342,13 @@ You can also aspirate from a location along the center vertical axis within a we
 See also:
 
 - :ref:`new-default-op-positions` for information about controlling pipette height for a particular pipette.
-- :ref:`position-relative-labware` for formation about controlling pipette height from within a well.
+- :ref:`position-relative-labware` for information about controlling pipette height from within a well.
 - :ref:`move-to` for information about moving a pipette to any reachable deck location.
 
 Aspiration Flow Rates
 ^^^^^^^^^^^^^^^^^^^^^
 
-Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. As a best practice, don't set the flow rate higher than 3x the default. For example, this code causes the pipette to aspirate at twice its normal rate::
+Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Specifying the ``rate`` parameter multiplies the flow rate by that value. As a best practice, don't set the flow rate higher than 3x the default. For example, this code causes the pipette to aspirate at twice its normal rate::
 
     pipette.aspirate(200, plate['A1'], rate=2.0)
 
@@ -480,7 +480,8 @@ This example uses the current well and sets the speed to 80 mm/s::
 
 .. versionadded:: 2.0
 
-.. there was a recommendation to remove the note
+.. versionchanged:: 2.4
+    Lowered minimum speed to 1 mm/s.
 
 .. _mix:
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -437,11 +437,10 @@ Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-ra
 Blow Out
 --------
 
-To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.InstrumentContext.blow_out` method. A blow out is useful to clear the pipette of any remaining liquid. When using this method, you can use a specific well in a well plate or reservoir as a blow out location. If no location is specified, the pipette will blow out from its current well position. For example::
+To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.InstrumentContext.blow_out` method. You can use a specific well in a well plate or reservoir as the blow out location. If no location is specified, the pipette will blow out from its current well position. For example::
 
     pipette.blow_out()            # blow out from the current location
     pipette.blow_out(plate['B1']) # blow out into well B1
-
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -297,23 +297,14 @@ To check whether you should pick up a tip or not, you can utilize :py:meth:`.Ins
 Liquid Control
 ==============
 
-After attaching a tip, your robot is ready to aspirate, dispense, and perform other liquid handling tasks. The API provides the following methods that help you manipulate liquids in your protocols. These include:
-
-- :py:meth:`.InstrumentContext.aspirate`
-- :py:meth:`.InstrumentContext.dispense`
-- :py:meth:`.InstrumentContext.blow_out`
-- :py:meth:`.InstrumentContext.touch_tip`
-- :py:meth:`.InstrumentContext.mix`
-- :py:meth:`.InstrumentContext.air_gap`
-
-The following sections demonstrate how to use each method and include sample code. The examples used here assume that you've loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`. 
+After attaching a tip, your robot is ready to aspirate, dispense, and perform other liquid handling tasks. The API includes methods that help you perform these actions and the following sections show how to use them. The examples used here assume that you've loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`. 
 
 .. _new-aspirate:
 
 Aspirate
 --------
 
-To draw liquid up into a pipette tip, call the :py:meth:`~.InstrumentContext.aspirate` method. This method lets you specify the aspiration volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to remove 200 µL from well location A1.
+To draw liquid up into a pipette tip, call the :py:meth:`.InstrumentContext.aspirate` method. This method lets you specify the aspiration volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to aspirate 200 µL from well location A1.
 
 .. code-block:: python
 
@@ -334,11 +325,9 @@ Now our pipette holds 300 µL.
 Aspirate by Well or Location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``aspirate()`` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``. 
+The :py:meth:`~.InstrumentContext.aspirate` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``. 
 
-**By Well**
-
-If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below.
+If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well (see also, :ref:`new-default-op-positions`). To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. 
 
 .. code-block:: python
 
@@ -346,19 +335,13 @@ If you specify a well, like ``plate['A1']``, the pipette will aspirate from a de
     pipette.well_bottom_clearance.aspirate=2 # place tip 2 mm above well bottom
     pipette.aspirate(200, plate['A1'])
 
-See also, :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
-
-**By Location**
-
-You can also aspirate from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
+You can also aspirate from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods (see also, :ref:`position-relative-labware`). These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
 
 .. code-block:: python
 
     pipette.pick_up_tip()
     depth = plate['A1'].bottom(z=2) # place tip 2 mm above well bottom
     pipette.aspirate(200, depth)
-
-See also, :ref:`position-relative-labware` for information about on controlling pipette height from within a well.
 
 Aspiration Flow Rates
 ^^^^^^^^^^^^^^^^^^^^^

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -436,9 +436,9 @@ The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and d
 
 .. code-block:: python
 
-    # mix 3 times, 50uL, current location
+    # mix 3 times, 50 uL, current location
     pipette.mix(3, 50)
-    # mix 4 times, 100uL, from well A2
+    # mix 4 times, 100 uL, from well A2
     pipette.mix(4, 100, plate['A2'])
     # mix 2 times, use the pipette's max volume, current location
     pipette.mix(2)
@@ -454,13 +454,16 @@ The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and d
 Air Gap
 =======
 
-When dealing with certain liquids, you may need to aspirate air after aspirating the liquid to prevent it from sliding out of the pipette's tip. A call to :py:meth:`.InstrumentContext.air_gap` with a volume in µL will aspirate that much air into the tip. ``air_gap`` takes up to two arguments: ``air_gap(volume, height)``:
+The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to aspirate some air after a liquid. Creating an air gap can help prevent a liquid from leaking out of the pipette after drawing it from a well. Calling the ``air_gap()`` method without any arguments uses the remaining volume in the pipette tip. For example, if you load a 1000 uL pipette on a Flex and tell the robot to aspirate 500 uL of liquid, it will use the remaining 500 uL for the air gap::
 
-.. code-block:: python
+    pipette.aspirate(500, plate['A1'])
+    pipette.air_gap() # draws 500 uL of air
 
-    pipette.aspirate(100, plate['B4'])
-    pipette.air_gap(20)
-    pipette.drop_tip()
+The ``air_gap()`` method also accepts the ``volume`` and ``height`` arguments. These let you control the amount of air (in uL) drawn in and the height (in mm) above the well for aspirating air. By default, the pipette will move 5 mm above a well before creating the air gap. For example, this code aspirates 200 uL of liquid from well A1. The aspiration action is followed by an air gap of 75 uL taken from 20 mm above the well::
+
+    pipette.pick_up_tip()
+    pipette.aspirate(200, plate['A1'])
+    pipette.air_gap(75, 20)
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -318,7 +318,7 @@ If the pipette doesn't move, you can also specify an additional aspiration actio
     pipette.pick_up_tip()
     pipette.aspirate(200, plate['A1'])
     protocol.delay(seconds=5) # pause for 5 seconds
-    pipette.aspirate(100)     # aspirate 100 µL from current position
+    pipette.aspirate(100)     # aspirate 100 µL at current position
 
 Now our pipette holds 300 µL.
 
@@ -327,21 +327,23 @@ Aspirate by Well or Location
 
 The :py:meth:`~.InstrumentContext.aspirate` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``. 
 
-If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well (see also, :ref:`new-default-op-positions`). To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. 
-
-.. code-block:: python
+If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`:: 
 
     pipette.pick_up_tip
-    pipette.well_bottom_clearance.aspirate = 2 # place tip 2 mm above well bottom
+    pipette.well_bottom_clearance.aspirate = 2 # tip is 2 mm above well bottom
     pipette.aspirate(200, plate['A1'])
 
-You can also aspirate from a location along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods (see also, :ref:`position-relative-labware`). These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
-
-.. code-block:: python
+You can also aspirate from a location along the center vertical axis within a well using the :py:meth:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well::
 
     pipette.pick_up_tip()
-    depth = plate['A1'].bottom(z=2) # place tip 2 mm above well bottom
+    depth = plate['A1'].bottom(z=2) # tip is 2 mm above well bottom
     pipette.aspirate(200, depth)
+
+See also:
+
+- :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
+- :ref:`position-relative-labware` for formation about controlling pipette height from within a well.
+- :ref:`move-to` for information about moving a pipette to any reachable deck location.
 
 Aspiration Flow Rates
 ^^^^^^^^^^^^^^^^^^^^^
@@ -361,46 +363,40 @@ Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-ra
 Dispense
 --------
 
-To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.dispense` method. This method lets you specify the dispense volume in µL, the well location, and pipette flow rate. For example, this snippet tells the robot to dispense 200 µL into well location B1.
+To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dispense` method. This method lets you specify the dispense volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to dispense 200 µL into well location B1.
 
 .. code-block:: python
 
     pipette.dispense(200, plate['B1'])
 
-If the pipette doesn’t move, you can also specify an additional dispense action without including a location. To demonstrate, lets assume the pipette currently holds 200 µL. Next, we'll pause the protocol, automatically resume it, and dispense a second time into well location B1.
+If the pipette doesn’t move, you can also specify an additional dispense action without including a location. To demonstrate, lets pause the protocol, automatically resume it, and dispense a second time from location B1.
 
 .. code-block:: python
     
     pipette.dispense(100, plate['B1'])
     protocol.delay(seconds=5) # pause for 5 seconds
-    pipette.aspirate(100)     # aspirate 100 µL from current position
+    pipette.dispense(100)     # dispense 100 µL at current position
     
 Dispense by Well or Location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``dispense()`` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``.
+The :py:meth:`~.InstrumentContext.dispense` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``.
 
-**By Well**
+If you specify a well, like ``plate['B1']``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`::
 
-If you specify a well, like ``plate['B1']``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. 
-
-.. code-block:: python
-
-    pipette.well_bottom_clearance.dispense=2 # place tip 2 mm above well bottom
+    pipette.well_bottom_clearance.dispense=2 # tip is 2 mm above well bottom
     pipette.dispense(200, plate['B1'])
 
-See also, :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
+You can also dispense from a location along the center vertical axis within a well using the :py:meth:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well::
 
-**By Location**
-
-You can also dispense from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default dispense height as shown below.
-
-.. code-block:: python
-
-    depth = plate['B1'].bottom(z=2) # place tip 2 mm above well bottom
+    depth = plate['B1'].bottom(z=2) # tip is 2 mm above well bottom
     pipette.dispense(200, depth)
 
-See also, :ref:`position-relative-labware` for information about on controlling pipette height from within a well.
+See also:
+
+- :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
+- :ref:`position-relative-labware` for formation about controlling pipette height from within a well.
+- :ref:`move-to` for information about moving a pipette to any reachable deck location.
 
 Dispense Flow Rates
 ^^^^^^^^^^^^^^^^^^^
@@ -420,10 +416,17 @@ Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-ra
 Blow Out
 --------
 
-To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.InstrumentContext.blow_out` method. You can use a specific well in a well plate or reservoir as the blow out location. If no location is specified, the pipette will blow out from its current well position. For example::
+To blow an extra amount of air through the pipette's tip, call the :py:meth:`.InstrumentContext.blow_out` method. You can use a specific well in a well plate or reservoir as the blowout location. If no location is specified, the pipette will blowout from its current well position::
 
-    pipette.blow_out()            # blow out from the current location
-    pipette.blow_out(plate['B1']) # blow out into well B1
+    pipette.blow_out()
+
+You can also specify a particular well as the blowout location::
+
+    pipette.blow_out(plate['B1'])
+
+Many protocols use trash bin for blowing out the pipette. You can specify the trash bin as the blowout location by using the :py:meth:`.ProtocolContext.fixed_trash` method::
+
+    pipette.blow_out(protocol.fixed_trash['A1'])  
 
 .. versionadded:: 2.0
 
@@ -432,63 +435,69 @@ To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.I
 Touch Tip
 ---------
 
-The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps knock off any droplets that might cling to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well and the touch speed. Calling the ``touch_tip()`` method without arguments causes the pipette to touch the well walls from its current location::
+The :py:meth:`.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps knock off any droplets that might cling to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well and the touch speed. Calling :py:meth:`~.InstrumentContext.touch_tip` without arguments causes the pipette to touch the well walls from its current location::
 
     pipette.touch_tip() 
 
 Touch Location
 ^^^^^^^^^^^^^^
 
-These optional location arguments give you control over where the tip will touch the side of a well. Here are some examples::
+These optional location arguments give you control over where the tip will touch the side of a well.
 
-    # touch the tip in a specific well
+This example demonstrates touching the tip in a specific well::
+
     pipette.touch_tip(plate['B1'])
     
-    # touch the tip 2mm below the top of the current well
+This example uses an offset to set the touch tip location 2mm below the top of the current well::
+
     pipette.touch_tip(v_offset=-2) 
 
-    # move 75% of well's total radius and 2 mm below the top of well
+This example moves the pipette 75% of well's total radius and 2 mm below the top of well::
+
     pipette.touch_tip(plate['B1'], 
                       radius=0.75,
                       v_offset=-2)
 
+When ``radius=1``, the robot moves the centerline of the pipette’s plunger axis to the exact edge of the well. Sometimes this means a pipette tip hits the well edge or wall first and bends inwards. Setting the radius to < 1 helps avoid hitting the well wall prematurely. Test your protocol first, before using the ``radius`` argument in a touch tip step.
+
+.. warning::
+    *Do not* set the ``radius`` value greater than ``1.0``. When ``radius`` is > ``1.0``, the robot will forcibly move the pipette tip across a well wall or edge. This type of aggressive movement can damage the pipette tip and the pipette.
+
 Touch Speed
 ^^^^^^^^^^^
 
-The touch speed controls how fast the pipette moves in mm/s during a touch action. The default movement speed is 60 mm/s, the minimum is 20 mm/s, and the maximum is 80 mm/s. Here are some examples::
+Touch speed controls how fast the pipette moves in mm/s during a touch tip step. The default movement speed is 60 mm/s, the minimum is 20 mm/s, and the maximum is 80 mm/s. Calling ``touch_tip`` without any arguments moves a tip at the default speed in the current well::
 
-    pipette.touch_tip() # touch at the default speed
+    pipette.touch_tip()
 
-    # touch tip in well B1 at the maximum speed
-    pipette.touch_tip(plate['B1'], speed=80)
+This example specifies a well location and sets the speed to 20 mm/s::
+
+    pipette.touch_tip(plate['B1'], speed=20)
+
+This example uses the current well and sets the speed to 80 mm/s::
+
+    pipette.touch_tip(speed=80)
 
 .. versionadded:: 2.0
 
-.. note:
-
-    We recommend using API version to 2.4 (or higher) to take advantage of new ``touch_tip()``
-    features such as:
-
-        - A lower minimum speed (1 mm/s)
-        - Improved handling
-        - Removed diagonal X -> Y position changes while moving the tip directly to the specified height offset.
+.. there was a recommendation to remove the note
 
 .. _mix:
 
 Mix
 ---
 
-The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and dispense actions from a single well. It's designed to help mix well contents by using a single command rather than making multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the mix repetitions, the amount of liquid (in µL) to mix, and the location of a well that contains the liquid you want to mix. The volume amount is optional. If omitted, the pipette will use its maximum rated volume as the amount. Let's look at a few examples. 
+The :py:meth:`~.InstrumentContext.mix` method aspirates and dispenses repeatedly in a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix.
 
-This example aspirates 100 µL from the current well and mixes it three times::
+This example draws 100 µL from the current well and mixes it three times::
 
     pipette.mix(repetitions=3, volume=100)
 
-This example aspirates 100 µL from well B1 and mixes it three times:: 
+This example draws 100 µL from well B1 and mixes it three times:: 
 
     pipette.mix(3, 100, plate['B1'])
 
-This example aspirates an amount equal to the pipette's maximum rated volume and mixes it three times::
+This example draws an amount equal to the pipette's maximum rated volume and mixes it three times::
 
     pipette.mix(repetitions=3)
 
@@ -503,7 +512,7 @@ This example aspirates an amount equal to the pipette's maximum rated volume and
 Air Gap
 -------
 
-The :py:meth:`~.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that let you control the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling this method without any arguments uses the remaining volume in the pipette tip for the air gap. Let's look at a few examples.
+The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that let you control the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling :py:meth:`~.InstrumentContext.air_gap` without any arguments uses the entire remaining volume in the pipette.
 
 This example aspirates 200 µL of air 5 mm above the current well::
 
@@ -513,7 +522,7 @@ This example aspirates 200 µL of air 20 mm above the the current well::
 
     pipette.air_gap(volume=200, height=20)
 
-This example aspirates enough air to fill the remaining volume in a pipette after aspirating a liquid::
+This example aspirates enough air to fill the remaining volume in a pipette::
 
     pipette.air_gap()
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -458,7 +458,7 @@ This example moves the pipette 75% of well's total radius and 2 mm below the top
                       radius=0.75,
                       v_offset=-2)
 
-When ``radius=1``, the robot moves the centerline of the pipette’s plunger axis to the exact edge of the well. Sometimes this means a pipette tip hits the well edge or wall first and bends inwards. Setting the radius to < 1 helps avoid hitting the well wall prematurely. Test your protocol first, before using the ``radius`` argument in a touch tip step.
+When ``radius=1``, the robot moves the centerline of the pipette’s plunger axis to the exact edge of the well. Sometimes this means a pipette tip may hit the well wall or edge first and bends inwards. Setting the radius to < 1 helps avoid hitting the well wall prematurely. If you need to use it, test the radius argument first before starting a protocol production run.
 
 .. warning::
     *Do not* set the ``radius`` value greater than ``1.0``. When ``radius`` is > ``1.0``, the robot will forcibly move the pipette tip across a well wall or edge. This type of aggressive movement can damage the pipette tip and the pipette.
@@ -512,7 +512,7 @@ This example draws an amount equal to the pipette's maximum rated volume and mix
 Air Gap
 -------
 
-The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that let you control the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling :py:meth:`~.InstrumentContext.air_gap` without any arguments uses the entire remaining volume in the pipette.
+The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that let you control the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling :py:meth:`~.InstrumentContext.air_gap` with no arguments uses the entire remaining volume in the pipette.
 
 This example aspirates 200 µL of air 5 mm above the current well::
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -313,21 +313,26 @@ The following sections demonstrate how to use each method and include sample cod
 Aspirate
 --------
 
-To draw liquid up into a pipette tip, call the :py:meth:`~.InstrumentContext.aspirate` method. This method's arguments let you specify the aspirated volume in µL, the well to aspirate from, and how fast to draw liquid into the pipette. For example, this snippet tells the robot to remove 50 µL from well location A1 at a specific rate in µL/s::
+To draw liquid up into a pipette tip, call the :py:meth:`~.InstrumentContext.aspirate` method. This method's arguments let you specify the aspirated volume in µL, the well to aspirate from, and how fast to draw liquid into the pipette. For example, this snippet tells the robot to remove 200 µL from well location A1 at the pipette's default flow rate::
 
-    pipette.aspirate(50, plate['A1'], rate=2.0)
+    pipette.aspirate(200, plate['A1'])
 
-In this example: 
+The location parameter is either the well location (``plate['A']``) or a specified position within a well, relative to its bottom or top center. The code snippet above uses the well location. By default, the robot will aspirate 1 mm from the bottom of the well. To change the clearance, you would call :py:obj:`.well_bottom_clearance` like this::
 
-- The location parameter (e.g., ``plate['A1']``) tells the robot to aspirate from the default position in a well. You can also aspirate from a specific position within a well by adding an optional location argument (e.g., ``plate['A1'].bottom`` or ``plate['A1'].top``).
+    pipette.well_bottom_clearance.aspirate=2 # aspirate 2 mm above well bottom
+    pipette.aspirate(200, plate['A1'])
 
-- The ``rate`` parameter is a multiplication factor of the pipette's default aspiration flow rate. See  :ref:`new-plunger-flow-rates` for a list of Flex and OT-2 pipette flow rates.
+TBD NEED EXAMPLE HERE ``Well.top()`` and ``Well.bottom()``
+
+The ``rate`` parameter is a multiplication factor of the pipette's :ref:`default flow rate <new-plunger-flow-rates>`. You can add a value to the ``rate`` argument to increase the pipette's aspiration speed. For example, this code causes the pipette to aspirate at twice its normal rate::
+
+    pipette.aspirate(200, plate['A1'], rate=2.0)
 
 You can also just specify the volume to aspirate, and not mention a location. In this example, the pipette aspirates a second time from its current location, which we previously set as ``plate['A1'])``::
 
-    pipette.aspirate(50)  # aspirate 50uL from current position
+    pipette.aspirate(100)  # aspirate 100 uL from current position
 
-Now our pipette holds 100 µL.
+Now our pipette holds 300 µL.
 
 .. Version 1 mention in note. Is this too old to keep? Can we remove it?
 .. note::
@@ -347,7 +352,7 @@ Now our pipette holds 100 µL.
 .. _new-dispense:
 
 Dispense
-========
+--------
 
 To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.dispense` method. This method's arguments let you specify the dispensed volume µL, where to deposit a liquid (e.g. a well location on a plate or reservoir), and how quickly to dispense it in uL/s. For example, this snippet tells the robot to dispense 50 µL into well location B1 at a specific rate in µL/s::
 
@@ -384,7 +389,7 @@ You can also just specify the volume to aspirate, and not mention a location. Fo
 .. _blow-out:
 
 Blow Out
-========
+--------
 
 To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.InstrumentContext.blow_out` method. A blow out is useful to clear the pipette of any remaining liquid. When using this method, you can use a specific well in a well plate or reservoir as a blow out location. If no location is specified, the pipette will blow out from its current well position. For example::
 
@@ -397,7 +402,7 @@ To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.I
 .. _touch-tip:
 
 Touch Tip
-=========
+---------
 
 The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate and the touch speed. Calling the ``touch_tip()`` method without arguments causes the pipette to touch the well walls from its current location::
 
@@ -429,7 +434,7 @@ The ``touch_tip()`` method also includes optional arguments that control the loc
 .. _mix:
 
 Mix
-===
+---
 
 The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in uL) of liquid, and the location of a well that contains the liquid you want to mix.   
 
@@ -451,7 +456,7 @@ The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and d
 .. _air-gap:
 
 Air Gap
-=======
+-------
 
 The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to aspirate some air after a liquid. Creating an air gap can help prevent a liquid from leaking out of the pipette after drawing it from a well. Calling the ``air_gap()`` method without any arguments uses the remaining volume in the pipette tip. For example, if you load a 1000 uL pipette on a Flex and tell the robot to aspirate 500 uL of liquid, it will use the remaining 500 uL for the air gap::
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -293,12 +293,11 @@ To check whether you should pick up a tip or not, you can utilize :py:meth:`.Ins
 
 **********************
 
-.. start here, branch docs-liquid-control
 
 Liquid Control
 ==============
 
-After attaching a tip, your robot is ready to manipulate liquids. The API provides several liquid-handling methods that give you a lot of control over how to use liquids in your protocols. These methods include:
+After attaching a tip, your robot is ready to aspirate, dispense, and perform other liquid handling tasks. The API provides the following methods that help you manipulate liquids in your protocols. These include:
 
 - :py:meth:`.InstrumentContext.aspirate`
 - :py:meth:`.InstrumentContext.dispense`
@@ -314,7 +313,7 @@ The following sections demonstrate how to use each method and include sample cod
 Aspirate
 --------
 
-To draw liquid up into a pipette tip, call the :py:meth:`~.InstrumentContext.aspirate` method. This method's arguments let you specify the aspirated volume µL, where to aspirate from (e.g. a well plate or reservoir), and how fast to aspirate liquid. For example, this snippet tells the robot to draw 50 µL from well location A1 at a specific rate in µL/s::
+To draw liquid up into a pipette tip, call the :py:meth:`~.InstrumentContext.aspirate` method. This method's arguments let you specify the aspirated volume in µL, the well to aspirate from, and how fast to draw liquid into the pipette. For example, this snippet tells the robot to remove 50 µL from well location A1 at a specific rate in µL/s::
 
     pipette.aspirate(50, plate['A1'], rate=2.0)
 
@@ -337,7 +336,7 @@ Now our pipette holds 100 µL.
 
 .. note::
 
-    By default, the pipette will move to 1 mm above the bottom of the target well before aspirating.
+    By default, the pipette will moves to 1 mm above the bottom of the target well before aspirating.
     You can change this by using a well position function like :py:meth:`.Well.bottom` (see
     :ref:`v2-location-within-wells`) every time you call ``aspirate``, or - if you want to change
     the default throughout your protocol - you can change the default offset with
@@ -350,17 +349,17 @@ Now our pipette holds 100 µL.
 Dispense
 ========
 
-To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.dispense` method. This method's arguments let you specify the dispensed volume µL, where to deposit a liquid (e.g. a well plate or reservoir), and how quickly to dispense it in uL/s. For example, this snippet tells the robot to dispense 50 µL into well location B1 at a specific rate in µL/s::
+To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.dispense` method. This method's arguments let you specify the dispensed volume µL, where to deposit a liquid (e.g. a well location on a plate or reservoir), and how quickly to dispense it in uL/s. For example, this snippet tells the robot to dispense 50 µL into well location B1 at a specific rate in µL/s::
 
     pipette.dispense(50, plate['B1'], rate=2.0)
     
 In this example:
 
-- The location parameter (e.g., ``plate['A1']``) tells the robot to aspirate from the default position in a well. You can also aspirate from a specific position within a well by adding an optional location argument (e.g., ``plate['A1'].bottom`` or ``plate['A1'].top``).
+- The location parameter (e.g., ``plate['A1']``) tells the robot to aspirate from the default position in a well. You can also aspirate from a the top or bottom of a well by adding an optional location argument (e.g., ``plate['A1'].top`` or ``plate['A1'].bottom``).
 
 - The ``rate`` parameter is a multiplication factor of the pipette's default aspiration flow rate. See  :ref:`new-plunger-flow-rates` for a list of Flex and OT-2 pipette flow rates.
 
-You can also just specify the volume to aspirate, and not mention a location. For example, if our pipette holds 100 uL and you want to dispense a second time from its current location (``plate['A1'])``), you could call the ``dispense()`` method again without location argument:: 
+You can also just specify the volume to aspirate, and not mention a location. For example, if our pipette holds 100 uL and you want to dispense a second time from its current location (``plate['A1'])``), you could call the ``dispense()`` method again without a location argument:: 
     
     pipette.dispense(50)
 
@@ -371,7 +370,7 @@ You can also just specify the volume to aspirate, and not mention a location. Fo
 
 .. note::
 
-    By default, the pipette will move to 1 mm above the bottom of the target well before dispensing.
+    By default, the pipette moves to 1 mm above the bottom of the target well before dispensing.
     You can change this by using a well position function like :py:meth:`.Well.bottom` (see
     :ref:`v2-location-within-wells`) every time you call ``dispense``, or - if you want to change
     the default throughout your protocol - you can change the default offset with
@@ -387,10 +386,10 @@ You can also just specify the volume to aspirate, and not mention a location. Fo
 Blow Out
 ========
 
-To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.InstrumentContext.blow_out` method. A blow out is useful to clear the pipette tip of any remaining liquid. When using this method, you can specify a blow out location. If no location is specified, the pipette will blow out from its current position. For example::
+To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.InstrumentContext.blow_out` method. A blow out is useful to clear the pipette of any remaining liquid. When using this method, you can use a specific well in a well plate or reservoir as a blow out location. If no location is specified, the pipette will blow out from its current well position. For example::
 
     pipette.blow_out()            # blow out from the current location
-    pipette.blow_out(plate['B3']) # blow out in well plate location B3
+    pipette.blow_out(plate['B1']) # blow out into well B1
 
 
 .. versionadded:: 2.0
@@ -400,7 +399,7 @@ To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.I
 Touch Tip
 =========
 
-The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate. By default, the ``touch_tip()`` method performs its action within the current well location::
+The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate and the touch speed. Calling the ``touch_tip()`` method without arguments causes the pipette to touch the well walls from its current location::
 
     pipette.touch_tip() 
 
@@ -421,7 +420,7 @@ The ``touch_tip()`` method also includes optional arguments that control the loc
 
 .. note:
 
-    We recommend changing your API version to 2.4 to take advantage of new ``touch_tip()``
+    We recommend changing your API version to 2.4 (or higher) to take advantage of new ``touch_tip()``
     features such as:
         - A lower minimum speed (1 mm/s)
         - Improved handling
@@ -432,7 +431,7 @@ The ``touch_tip()`` method also includes optional arguments that control the loc
 Mix
 ===
 
-The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help blend the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in uL) of liquid, and the location of a well that contains the liquid you want to mix.   
+The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in uL) of liquid, and the location of a well that contains the liquid you want to mix.   
 
 .. code-block:: python
 
@@ -445,7 +444,7 @@ The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and d
 
 .. note::
 
-    In API Versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette does not move between aspiratea and dispense mixing actions. 
+    In API Versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette does not move between aspirate and dispense mixing actions. 
 
 .. versionadded:: 2.0
 
@@ -460,8 +459,7 @@ The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to aspirate s
     pipette.air_gap() # draws 500 uL of air
 
 The ``air_gap()`` method also accepts the ``volume`` and ``height`` arguments. These let you control the amount of air (in uL) drawn in and the height (in mm) above the well for aspirating air. By default, the pipette will move 5 mm above a well before creating the air gap. For example, this code aspirates 200 uL of liquid from well A1. The aspiration action is followed by an air gap of 75 uL taken from 20 mm above the well::
-
-    pipette.pick_up_tip()
+    
     pipette.aspirate(200, plate['A1'])
     pipette.air_gap(75, 20)
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -175,8 +175,8 @@ To return the tip to the original location, you can call :py:meth:`.InstrumentCo
 
 .. note:
 
-    In API Version 2.0 and 2.1, the returned tips are added back into the tip-tracker and thus treated as `unused`. If you make a subsequent call to `pick_up_tip` then the software will treat returned tips as valid locations.
-    In API Version 2.2, returned tips are no longer added back into the tip tracker. This means that returned tips are no longer valid locations and the pipette will not attempt to pick up tips from these locations.
+    In API versions 2.0 and 2.1, the returned tips are added back into the tip-tracker and thus treated as `unused`. If you make a subsequent call to `pick_up_tip` then the software will treat returned tips as valid locations.
+    In API version 2.2, returned tips are no longer added back into the tip tracker. This means that returned tips are no longer valid locations and the pipette will not attempt to pick up tips from these locations.
     Also in API Version 2.2, the return tip height was corrected to utilize values determined by hardware testing. This is more in-line with return tip behavior from Python Protocol API Version 1.
 
 In API version 2.2 or above:
@@ -491,7 +491,7 @@ The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and 
 
 .. note::
 
-    In API Versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette does not move while mixing. 
+    In API versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API versions 2.3 and later, the pipette does not move while mixing. 
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -311,7 +311,7 @@ To draw liquid up into a pipette tip, call the :py:meth:`.InstrumentContext.aspi
     pipette.pick_up_tip()
     pipette.aspirate(200, plate['A1'])
 
-If the pipette doesn't move, you can also specify an additional aspiration action without including a location. To demonstrate, lets pause the protocol, automatically resume it, and aspirate a second time from ``plate['A1']``).
+If the pipette doesn't move, you can also specify an additional aspiration action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and aspirates a second time from ``plate['A1']``).
 
 .. code-block:: python
 
@@ -369,7 +369,7 @@ To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dis
 
     pipette.dispense(200, plate['B1'])
 
-If the pipette doesn’t move, you can also specify an additional dispense action without including a location. To demonstrate, lets pause the protocol, automatically resume it, and dispense a second time from location B1.
+If the pipette doesn’t move, you can also specify an additional dispense action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and dispense a second time from location B1.
 
 .. code-block:: python
     

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -295,9 +295,9 @@ To check whether you should pick up a tip or not, you can utilize :py:meth:`.Ins
 
 .. start here, branch docs-liquid-control
 
-****************
 Liquid Control
-****************
+==============
+
 
 This section describes the :py:class:`.InstrumentContext` 's liquid-handling commands.
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -293,6 +293,8 @@ To check whether you should pick up a tip or not, you can utilize :py:meth:`.Ins
 
 **********************
 
+.. start here, branch docs-liquid-control
+
 ****************
 Liquid Control
 ****************

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -449,22 +449,28 @@ To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.I
 Touch Tip
 ---------
 
-The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate and the touch speed. Calling the ``touch_tip()`` method without arguments causes the pipette to touch the well walls from its current location::
+The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps knock off any droplets that might cling to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well and the touch speed. Calling the ``touch_tip()`` method without arguments causes the pipette to touch the well walls from its current location::
 
     pipette.touch_tip() 
 
-The ``touch_tip()`` method also includes optional arguments that control the location and speed of a touch procedure. For example::
+Touch Location
+^^^^^^^^^^^^^^
 
     # touch tip in well B1
     pipette.touch_tip(plate['B1'])
     # touch tip 2mm below the top of the current location
     pipette.touch_tip(v_offset=-2) 
-    # touch tip in well B1 at 100 mm/s
-    pipette.touch_tip(plate['B1'], speed=100)
+
     # touch tip in well B1, at 75% of total radius and -2mm from top of well
     pipette.touch_tip(plate['B1'], 
                       radius=0.75,
                       v_offset=-2)
+
+Touch Speed
+^^^^^^^^^^^
+
+# touch tip in well B1 at 100 mm/s
+    pipette.touch_tip(plate['B1'], speed=100)
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -458,7 +458,7 @@ This example moves the pipette 75% of well's total radius and 2 mm below the top
                       radius=0.75,
                       v_offset=-2)
 
-When ``radius=1``, the robot moves the centerline of the pipette’s plunger axis to the exact edge of the well. Sometimes this means a pipette tip may hit the well wall or edge first and bends inwards. Setting the radius to < 1 helps avoid hitting the well wall prematurely. If you need to use it, test the radius argument first before starting a protocol production run.
+The ``touch_tip`` feature allows the pipette to touch the edges of a well gently instead of crashing into them. When ``radius=1`` the robot moves the centerline of the pipette’s plunger axis to the edge of the well. This means a pipette tip may sometimes hit the well wall too early, causing the tip to bend inwards. A smaller radius helps avoid a premature wall collision and a lower speed produces gentler motion. Different liquid droplets behave differently, so test out these parameters in a single well before performing a full protocol run.
 
 .. warning::
     *Do not* set the ``radius`` value greater than ``1.0``. When ``radius`` is > ``1.0``, the robot will forcibly move the pipette tip across a well wall or edge. This type of aggressive movement can damage the pipette tip and the pipette.

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -327,7 +327,7 @@ Aspirate by Well or Location
 
 The :py:meth:`~.InstrumentContext.aspirate` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``. 
 
-If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`:: 
+If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, first set the ``aspirate`` attribute of :py:obj:`.well_bottom_clearance`:: 
 
     pipette.pick_up_tip
     pipette.well_bottom_clearance.aspirate = 2 # tip is 2 mm above well bottom

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -373,7 +373,6 @@ Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-ra
 
 Dispense
 --------
-To draw liquid up into a pipette tip, call the :py:meth:`~.InstrumentContext.aspirate` method. This method lets you specify the aspiration volume in µL, the well location, and aspiration speed. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to remove 200 µL from well location A1.
 
 To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.dispense` method. This method lets you specify the dispense volume in µL, the well location, and pipette flow rate. For example, this snippet tells the robot to dispense 200 µL into well location B1.
 
@@ -383,8 +382,10 @@ To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.di
     
 Dispense by Well or Location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The ``aspirate()`` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``.
 
+.. copy from aspirate section
 **By Well**
 
 You can also just specify the volume to aspirate, and not mention a location. For example, if our pipette holds 100 uL and you want to dispense a second time from its current location (``plate['A1'])``), you could call the ``dispense()`` method again without a location argument:: 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -304,14 +304,14 @@ After attaching a tip, your robot is ready to aspirate, dispense, and perform ot
 Aspirate
 --------
 
-To draw liquid up into a pipette tip, call the :py:meth:`.InstrumentContext.aspirate` method. This method lets you specify the aspiration volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to aspirate 200 µL from well location A1.
+To draw liquid up into a pipette tip, call the :py:meth:`.InstrumentContext.aspirate` method. Using this method, you can specify the aspiration volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to aspirate 200 µL from well location A1.
 
 .. code-block:: python
 
     pipette.pick_up_tip()
     pipette.aspirate(200, plate['A1'])
 
-If the pipette doesn't move, you can also specify an additional aspiration action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and aspirates a second time from ``plate['A1']``).
+If the pipette doesn't move, you can specify an additional aspiration action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and aspirates a second time from ``plate['A1']``).
 
 .. code-block:: python
 
@@ -363,13 +363,13 @@ Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-ra
 Dispense
 --------
 
-To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dispense` method. This method lets you specify the dispense volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to dispense 200 µL into well location B1.
+To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dispense` method. Using this method, you can specify the dispense volume in µL, the well location, and pipette flow rate. Other parameters let you position the pipette within a well. For example, this snippet tells the robot to dispense 200 µL into well location B1.
 
 .. code-block:: python
 
     pipette.dispense(200, plate['B1'])
 
-If the pipette doesn’t move, you can also specify an additional dispense action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and dispense a second time from location B1.
+If the pipette doesn’t move, you can specify an additional dispense action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and dispense a second time from location B1.
 
 .. code-block:: python
     
@@ -435,7 +435,7 @@ Many protocols use trash bin for blowing out the pipette. You can specify the tr
 Touch Tip
 ---------
 
-The :py:meth:`.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps knock off any droplets that might cling to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well and the touch speed. Calling :py:meth:`~.InstrumentContext.touch_tip` without arguments causes the pipette to touch the well walls from its current location::
+The :py:meth:`.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps knock off any droplets that might cling to the pipette's tip. This method includes optional arguments that allow you to control where the tip will touch the inner walls of a well and the touch speed. Calling :py:meth:`~.InstrumentContext.touch_tip` without arguments causes the pipette to touch the well walls from its current location::
 
     pipette.touch_tip() 
 
@@ -458,7 +458,7 @@ This example moves the pipette 75% of well's total radius and 2 mm below the top
                       radius=0.75,
                       v_offset=-2)
 
-The ``touch_tip`` feature allows the pipette to touch the edges of a well gently instead of crashing into them. When ``radius=1`` the robot moves the centerline of the pipette’s plunger axis to the edge of the well. This means a pipette tip may sometimes hit the well wall too early, causing the tip to bend inwards. A smaller radius helps avoid a premature wall collision and a lower speed produces gentler motion. Different liquid droplets behave differently, so test out these parameters in a single well before performing a full protocol run.
+The ``touch_tip`` feature allows the pipette to touch the edges of a well gently instead of crashing into them. It includes the ``radius`` argument. When ``radius=1`` the robot moves the centerline of the pipette’s plunger axis to the edge of a well. This means a pipette tip may sometimes touch the well wall too early, causing it to bend inwards. A smaller radius helps avoid premature wall collisions and a lower speed produces gentler motion. Different liquid droplets behave differently, so test out these parameters in a single well before performing a full protocol run.
 
 .. warning::
     *Do not* set the ``radius`` value greater than ``1.0``. When ``radius`` is > ``1.0``, the robot will forcibly move the pipette tip across a well wall or edge. This type of aggressive movement can damage the pipette tip and the pipette.
@@ -488,7 +488,7 @@ This example uses the current well and sets the speed to 80 mm/s::
 Mix
 ---
 
-The :py:meth:`~.InstrumentContext.mix` method aspirates and dispenses repeatedly in a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix.
+The :py:meth:`~.InstrumentContext.mix` method aspirates and dispenses repeatedly in a single location. It's designed to mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix.
 
 This example draws 100 µL from the current well and mixes it three times::
 
@@ -513,7 +513,7 @@ This example draws an amount equal to the pipette's maximum rated volume and mix
 Air Gap
 -------
 
-The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that let you control the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling :py:meth:`~.InstrumentContext.air_gap` with no arguments uses the entire remaining volume in the pipette.
+The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that give you control over the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling :py:meth:`~.InstrumentContext.air_gap` with no arguments uses the entire remaining volume in the pipette.
 
 This example aspirates 200 µL of air 5 mm above the current well::
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -307,7 +307,7 @@ After attaching a tip, your robot is ready to manipulate liquids. The API provid
 - :py:meth:`.InstrumentContext.mix`
 - :py:meth:`.InstrumentContext.air_gap`
 
-The following sections demonstrate how to use each method and include sample code. Each code snippet works with the sample code shown above. 
+The following sections demonstrate how to use each method and include sample code. The examples used here assume that you've loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`. 
 
 .. _new-aspirate:
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -400,31 +400,32 @@ To blow an extra amount of air through the pipette's tip, call the :py:meth:`~.I
 Touch Tip
 =========
 
-The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate.
+The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate. By default, the ``touch_tip()`` method performs its action within the current well location::
 
-:py:meth:`.InstrumentContext.touch_tip` can take up to 4 arguments: ``touch_tip(location, radius, v_offset, speed)``.
+    pipette.touch_tip() # touch tip in current well location
 
-.. code-block:: python
+The ``touch_tip()`` method also includes optional arguments that control the location and speed of a touch procedure. For example::
 
-    pipette.touch_tip()            # touch tip within current location
-    pipette.touch_tip(v_offset=-2) # touch tip 2mm below the top of the current location
-    pipette.touch_tip(plate['B1']) # touch tip within plate:B1
-    pipette.touch_tip(plate['B1'], speed=100) # touch tip within plate:B1 at 100 mm/s
-    pipette.touch_tip(plate['B1'], # touch tip in plate:B1, at 75% of total radius and -2mm from top of well
+    # touch tip in well B1
+    pipette.touch_tip(plate['B1'])
+    # touch tip 2mm below the top of the current location
+    pipette.touch_tip(v_offset=-2) 
+    # touch tip in well B1 at 100 mm/s
+    pipette.touch_tip(plate['B1'], speed=100)
+    # touch tip in well B1, at 75% of total radius and -2mm from top of well
+    pipette.touch_tip(plate['B1'], 
                       radius=0.75,
                       v_offset=-2)
-
 
 .. versionadded:: 2.0
 
 .. note:
 
-    It is recommended that you change your API version to 2.4 to take advantage of new
-    features added into `touch_tip` such as:
+    We recommend changing your API version to 2.4 to take advantage of new ``touch_tip()``
+    features such as:
         - A lower minimum speed (1 mm/s)
-        - Better handling around near by geometry considerations
-        - Removed certain extraneous behaviors such as a diagonal move from X -> Y and
-        moving directly to the height offset specified.
+        - Improved handling
+        - Removed diagonal X -> Y position changes while moving the tip directly to the specified height offset.
 
 .. _mix:
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -465,7 +465,6 @@ The ``air_gap()`` method also accepts the ``volume`` and ``height`` arguments. T
 
 .. versionadded:: 2.0
 
-**********************
 
 .. _new-utility-commands:
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -338,23 +338,27 @@ The ``aspirate()`` method includes a ``location`` parameter that accepts either 
 
 **By Well**
 
-If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of the well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. See also, :ref:`new-default-op-positions` for information about controlling pipette height for based on well location.
+If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below.
 
 .. code-block:: python
 
     pipette.pick_up_tip
-    pipette.well_bottom_clearance.aspirate=2 # aspirate 2 mm above well bottom
+    pipette.well_bottom_clearance.aspirate=2 # place tip 2 mm above well bottom
     pipette.aspirate(200, plate['A1'])
+
+See also, :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
 
 **By Location**
 
-You can also aspirate on a point along the center, z-axis within a well. For example, the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods let you aspirate a set distances from the top or bottom center of a well as shown below. See also, :ref:`position-relative-labware` for information about on controlling pipette height from within a well.
+You can also aspirate from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
 
 .. code-block:: python
 
     pipette.pick_up_tip()
-    depth = plate['A1'].bottom(z=2) # set pipette tp 2mm above well bottom
-    pipette.aspirate(200, depth)    # aspirate 2mm above well bottom
+    depth = plate['A1'].bottom(z=2) # place tip 2 mm above well bottom
+    pipette.aspirate(200, depth)
+
+See also, :ref:`position-relative-labware` for information about on controlling pipette height from within a well.
 
 Aspiration Flow Rates
 ^^^^^^^^^^^^^^^^^^^^^
@@ -379,39 +383,50 @@ To dispense liquid from a pipette tip, call the :py:meth:`~.InstrumentContext.di
 .. code-block:: python
 
     pipette.dispense(200, plate['B1'])
+
+If the pipette doesn’t move, you can also specify an additional dispense action without including a location. To demonstrate, lets assume the pipette currently holds 200 µL. Next, we'll pause the protocol, automatically resume it, and dispense a second time into well location B1.
+
+.. code-block:: python
+    
+    pipette.dispense(100, plate['B1'])
+    protocol.delay(seconds=5) # pause for 5 seconds
+    pipette.aspirate(100)     # aspirate 100 uL from current position
     
 Dispense by Well or Location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``aspirate()`` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``.
+The ``dispense()`` method includes a ``location`` parameter that accepts either a ``Well`` or a ``Location``.
 
-.. copy from aspirate section
 **By Well**
 
-You can also just specify the volume to aspirate, and not mention a location. For example, if our pipette holds 100 uL and you want to dispense a second time from its current location (``plate['A1'])``), you could call the ``dispense()`` method again without a location argument:: 
-    
-    pipette.dispense(50)
+If you specify a well, like ``plate['B1']``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance` as shown below. 
+
+.. code-block:: python
+
+    pipette.well_bottom_clearance.dispense=2 # place tip 2 mm above well bottom
+    pipette.aspirate(200, plate['B1'])
+
+See also, :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
 
 **By Location**
 
+You can also dispense from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default dispense height as shown below.
+
+.. code-block:: python
+
+    depth = plate['B1'].bottom(z=2) # place tip 2 mm above well bottom
+    pipette.dispense(200, depth)
+
+See also, :ref:`position-relative-labware` for information about on controlling pipette height from within a well.
+
 Dispense Flow Rates
--------------------
+^^^^^^^^^^^^^^^^^^^
 
-- The ``rate`` parameter is a multiplication factor of the pipette's default aspiration flow rate. See  :ref:`new-plunger-flow-rates` for a list of Flex and OT-2 pipette flow rates.
+Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. For example, this code causes the pipette to dispense at twice its normal rate::
 
-.. same question as with aspirate. Note below is kinda old (api v1 reference). Can we remove?
-.. note::
+    pipette.dispense(200, plate['B1'], rate=2.0)
 
-    In version 1 of this API, ``dispense`` (and ``aspirate``) would inspect the types of the ``volume`` and ``location`` arguments and do the right thing if you specified only a location or specified location and volume out of order. In this and future versions of the Python Protocol API, this is no longer true. Like any other Python function, if you are specifying arguments by position without using their names, you must always specify them in order.
-
-.. note::
-
-    By default, the pipette moves to 1 mm above the bottom of the target well before dispensing.
-    You can change this by using a well position function like :py:meth:`.Well.bottom` (see
-    :ref:`v2-location-within-wells`) every time you call ``dispense``, or - if you want to change
-    the default throughout your protocol - you can change the default offset with
-    :py:obj:`.InstrumentContext.well_bottom_clearance` (see :ref:`new-default-op-positions`).
-
+.. Removing the 2 notes here from the original. Covered by new revisions.
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -341,7 +341,7 @@ You can also aspirate from a location along the center vertical axis within a we
 
 See also:
 
-- :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
+- :ref:`new-default-op-positions` for information about controlling pipette height for a particular pipette.
 - :ref:`position-relative-labware` for formation about controlling pipette height from within a well.
 - :ref:`move-to` for information about moving a pipette to any reachable deck location.
 
@@ -394,7 +394,7 @@ You can also dispense from a location along the center vertical axis within a we
 
 See also:
 
-- :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
+- :ref:`new-default-op-positions` for information about controlling pipette height for a particular pipette.
 - :ref:`position-relative-labware` for formation about controlling pipette height from within a well.
 - :ref:`move-to` for information about moving a pipette to any reachable deck location.
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -402,7 +402,7 @@ Touch Tip
 
 The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip touches each wall of a well. A touch tip procedure helps to knock off any droplets that might be hanging on to the pipette's tip. This method includes optional arguments that let you specify where the tip will touch the inner walls of a well plate. By default, the ``touch_tip()`` method performs its action within the current well location::
 
-    pipette.touch_tip() # touch tip in current well location
+    pipette.touch_tip() 
 
 The ``touch_tip()`` method also includes optional arguments that control the location and speed of a touch procedure. For example::
 
@@ -432,22 +432,20 @@ The ``touch_tip()`` method also includes optional arguments that control the loc
 Mix
 ===
 
-To mix is to perform a series of ``aspirate`` and ``dispense`` commands in a row on a single location. Instead of having to write those commands out every time, you can call :py:meth:`.InstrumentContext.mix`.
-
-The ``mix`` command takes up to three arguments: ``mix(repetitions, volume, location)``:
+The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help blend the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in uL) of liquid, and the location of a well that contains the liquid you want to mix.   
 
 .. code-block:: python
 
-    # mix 4 times, 100uL, in plate:A2
-    pipette.mix(4, 100, plate['A2'])
-    # mix 3 times, 50uL, in current location
+    # mix 3 times, 50uL, current location
     pipette.mix(3, 50)
-    # mix 2 times, pipette's max volume, in current location
+    # mix 4 times, 100uL, from well A2
+    pipette.mix(4, 100, plate['A2'])
+    # mix 2 times, use the pipette's max volume, current location
     pipette.mix(2)
 
 .. note::
 
-    In API Versions 2.2 and earlier, mixes consist of aspirates and then immediate dispenses. In between these actions, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette will not move between actions. 
+    In API Versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette does not move between aspiratea and dispense mixing actions. 
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -332,7 +332,7 @@ If you specify a well, like ``plate['A1']``, the pipette will aspirate from a de
 .. code-block:: python
 
     pipette.pick_up_tip
-    pipette.well_bottom_clearance.aspirate=2 # place tip 2 mm above well bottom
+    pipette.well_bottom_clearance.aspirate = 2 # place tip 2 mm above well bottom
     pipette.aspirate(200, plate['A1'])
 
 You can also aspirate from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods (see also, :ref:`position-relative-labware`). These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
@@ -387,7 +387,7 @@ If you specify a well, like ``plate['B1']``, the pipette will dispense from a de
 .. code-block:: python
 
     pipette.well_bottom_clearance.dispense=2 # place tip 2 mm above well bottom
-    pipette.aspirate(200, plate['B1'])
+    pipette.dispense(200, plate['B1'])
 
 See also, :ref:`new-default-op-positions` for information about controlling pipette height for a particular well.
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -335,7 +335,7 @@ If you specify a well, like ``plate['A1']``, the pipette will aspirate from a de
     pipette.well_bottom_clearance.aspirate = 2 # place tip 2 mm above well bottom
     pipette.aspirate(200, plate['A1'])
 
-You can also aspirate from a point along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods (see also, :ref:`position-relative-labware`). These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
+You can also aspirate from a location along the center vertical axis within a well using the :py:obj:`.Well.top` and :py:meth:`.Well.bottom` methods (see also, :ref:`position-relative-labware`). These methods move the pipette to a specified distance relative to the top or bottom center of a well. For example, you could change the default aspirate height as shown below.
 
 .. code-block:: python
 
@@ -478,15 +478,18 @@ The touch speed controls how fast the pipette moves in mm/s during a touch actio
 Mix
 ---
 
-The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and dispense actions from a single well. It's designed to help mix well contents by using a single command rather than multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the mix repetitions, the amount of liquid (in µL) to mix, and the location of a well that contains the liquid you want to mix. The volume amount is optional. If omitted, the pipette will use its maximum rated volume as the amount. Here are some examples::  
+The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and dispense actions from a single well. It's designed to help mix well contents by using a single command rather than making multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the mix repetitions, the amount of liquid (in µL) to mix, and the location of a well that contains the liquid you want to mix. The volume amount is optional. If omitted, the pipette will use its maximum rated volume as the amount. Let's look at a few examples. 
 
-    # mix 100 µL 3 times from the current location 
+This example aspirates 100 µL from the current well and mixes it three times::
+
     pipette.mix(repetitions=3, volume=100)
 
-    # mix 100 µL 3 times from well A1
-    pipette.mix(3, 100, plate['A1'])
+This example aspirates 100 µL from well B1 and mixes it three times:: 
 
-    # use the pipette's maximum volume 
+    pipette.mix(3, 100, plate['B1'])
+
+This example aspirates an amount equal to the pipette's maximum rated volume and mixes it three times::
+
     pipette.mix(repetitions=3)
 
 .. note::
@@ -500,17 +503,19 @@ The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and 
 Air Gap
 -------
 
-The :py:meth:`~.InstrumentContext.air_gap` method tells the pipette to draw in air before and/or after aspiration. Creating an air gap helps keep liquid from seeping out of a pipette after drawing it from a well. Calling the this method without any arguments uses the remaining volume in the pipette tip for the air gap. For example, if you load a 1000 µL pipette on a Flex and tell the robot to aspirate 200 µL, it will use the remaining 800 µL for the air gap.
+The :py:meth:`~.InstrumentContext.air_gap` method tells the pipette to draw in air before or after a liquid. Creating an air gap helps keep liquids from seeping out of a pipette after drawing it from a well. This method includes arguments that let you control the amount of air to aspirate and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before aspirating air. Calling this method without any arguments uses the remaining volume in the pipette tip for the air gap. Let's look at a few examples.
 
-.. code-block:: python
+This example aspirates 200 µL of air 5 mm above the current well::
 
-    pipette.aspirate(200, plate['A1']) # aspirate 200 µL from well A1
-    pipette.air_gap()                  # aspirate 800 µL of air
+    pipette.air_gap(volume=200)
 
-The ``air_gap()`` method also accepts ``volume`` and ``height`` arguments. These let you control the amount of air (in µL) drawn in and the pipette's height (in mm) above the well. By default, the pipette moves 5 mm above a well before creating the air gap. For example, this code tells the robot to draw 200 µL of liquid from well A1 and create an air gap of 75 µL at 20 mm above well A1::
-    
-    pipette.aspirate(200, plate['A1'])
-    pipette.air_gap(volume=75, height=20)
+This example aspirates 200 µL of air 20 mm above the the current well::
+
+    pipette.air_gap(volume=200, height=20)
+
+This example aspirates enough air to fill the remaining volume in a pipette after aspirating a liquid::
+
+    pipette.air_gap()
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -327,7 +327,7 @@ If the pipette doesn't move, you can also specify an additional aspiration actio
     pipette.pick_up_tip()
     pipette.aspirate(200, plate['A1'])
     protocol.delay(seconds=5) # pause for 5 seconds
-    pipette.aspirate(100)     # aspirate 100 uL from current position
+    pipette.aspirate(100)     # aspirate 100 µL from current position
 
 Now our pipette holds 300 µL.
 
@@ -363,7 +363,7 @@ See also, :ref:`position-relative-labware` for information about on controlling 
 Aspiration Flow Rates
 ^^^^^^^^^^^^^^^^^^^^^
 
-Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. For example, this code causes the pipette to aspirate at twice its normal rate::
+Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. As a best practice, don't set the flow rate higher than 3x the default. For example, this code causes the pipette to aspirate at twice its normal rate::
 
     pipette.aspirate(200, plate['A1'], rate=2.0)
 
@@ -390,7 +390,7 @@ If the pipette doesn’t move, you can also specify an additional dispense actio
     
     pipette.dispense(100, plate['B1'])
     protocol.delay(seconds=5) # pause for 5 seconds
-    pipette.aspirate(100)     # aspirate 100 uL from current position
+    pipette.aspirate(100)     # aspirate 100 µL from current position
     
 Dispense by Well or Location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +422,7 @@ See also, :ref:`position-relative-labware` for information about on controlling 
 Dispense Flow Rates
 ^^^^^^^^^^^^^^^^^^^
 
-Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. For example, this code causes the pipette to dispense at twice its normal rate::
+Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. As a best practice, don't set the flow rate higher than 3x the default. For example, this code causes the pipette to dispense at twice its normal rate::
 
     pipette.dispense(200, plate['B1'], rate=2.0)
 
@@ -456,12 +456,15 @@ The :py:meth:`~.InstrumentContext.touch_tip` method moves the pipette so the tip
 Touch Location
 ^^^^^^^^^^^^^^
 
-    # touch tip in well B1
+These optional location arguments give you control over where the tip will touch the side of a well. Here are some examples::
+
+    # touch the tip in a specific well
     pipette.touch_tip(plate['B1'])
-    # touch tip 2mm below the top of the current location
+    
+    # touch the tip 2mm below the top of the current well
     pipette.touch_tip(v_offset=-2) 
 
-    # touch tip in well B1, at 75% of total radius and -2mm from top of well
+    # move 75% of well's total radius and 2 mm below the top of well
     pipette.touch_tip(plate['B1'], 
                       radius=0.75,
                       v_offset=-2)
@@ -469,15 +472,20 @@ Touch Location
 Touch Speed
 ^^^^^^^^^^^
 
-# touch tip in well B1 at 100 mm/s
-    pipette.touch_tip(plate['B1'], speed=100)
+The touch speed controls how fast the pipette moves in mm/s during a touch action. The default movement speed is 60 mm/s, the minimum is 20 mm/s, and the maximum is 80 mm/s. Here are some examples::
+
+    pipette.touch_tip() # touch at the default speed
+
+    # touch tip in well B1 at the maximum speed
+    pipette.touch_tip(plate['B1'], speed=80)
 
 .. versionadded:: 2.0
 
 .. note:
 
-    We recommend changing your API version to 2.4 (or higher) to take advantage of new ``touch_tip()``
+    We recommend using API version to 2.4 (or higher) to take advantage of new ``touch_tip()``
     features such as:
+
         - A lower minimum speed (1 mm/s)
         - Improved handling
         - Removed diagonal X -> Y position changes while moving the tip directly to the specified height offset.
@@ -487,13 +495,13 @@ Touch Speed
 Mix
 ---
 
-The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in uL) of liquid, and the location of a well that contains the liquid you want to mix.   
+The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in µL) of liquid, and the location of a well that contains the liquid you want to mix.   
 
 .. code-block:: python
 
-    # mix 3 times, 50 uL, current location
+    # mix 3 times, 50 µL, current location
     pipette.mix(3, 50)
-    # mix 4 times, 100 uL, from well A2
+    # mix 4 times, 100 µL, from well A2
     pipette.mix(4, 100, plate['A2'])
     # mix 2 times, use the pipette's max volume, current location
     pipette.mix(2)
@@ -509,12 +517,12 @@ The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and d
 Air Gap
 -------
 
-The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to aspirate some air after a liquid. Creating an air gap can help prevent a liquid from leaking out of the pipette after drawing it from a well. Calling the ``air_gap()`` method without any arguments uses the remaining volume in the pipette tip. For example, if you load a 1000 uL pipette on a Flex and tell the robot to aspirate 500 uL of liquid, it will use the remaining 500 uL for the air gap::
+The :py:meth:`.InstrumentContext.air_gap` method tells the pipette to aspirate some air after a liquid. Creating an air gap can help prevent a liquid from leaking out of the pipette after drawing it from a well. Calling the ``air_gap()`` method without any arguments uses the remaining volume in the pipette tip. For example, if you load a 1000 µL pipette on a Flex and tell the robot to aspirate 500 µL of liquid, it will use the remaining 500 µL for the air gap::
 
     pipette.aspirate(500, plate['A1'])
-    pipette.air_gap() # draws 500 uL of air
+    pipette.air_gap() # draws 500 µL of air
 
-The ``air_gap()`` method also accepts the ``volume`` and ``height`` arguments. These let you control the amount of air (in uL) drawn in and the height (in mm) above the well for aspirating air. By default, the pipette will move 5 mm above a well before creating the air gap. For example, this code aspirates 200 uL of liquid from well A1. The aspiration action is followed by an air gap of 75 uL taken from 20 mm above the well::
+The ``air_gap()`` method also accepts the ``volume`` and ``height`` arguments. These let you control the amount of air (in µL) drawn in and the height (in mm) above the well for aspirating air. By default, the pipette will move 5 mm above a well before creating the air gap. For example, this code aspirates 200 µL of liquid from well A1. The aspiration action is followed by an air gap of 75 µL taken from 20 mm above the well::
     
     pipette.aspirate(200, plate['A1'])
     pipette.air_gap(75, 20)

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -495,20 +495,20 @@ The touch speed controls how fast the pipette moves in mm/s during a touch actio
 Mix
 ---
 
-The :py:meth:`.InstrumentContext.mix` method performs a series of aspirate and dispense on a single location. It's designed to help mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the mix repetitions, the amount of liquid (in µL) to mix, and the location of a well that contains the liquid you want to mix. Here are some examples::  
+The :py:meth:`~.InstrumentContext.mix` method performs a series of aspirate and dispense actions from a single well. It's designed to help mix well contents by using a single command rather than multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the mix repetitions, the amount of liquid (in µL) to mix, and the location of a well that contains the liquid you want to mix. The volume amount is optional. If omitted, the pipette will use its maximum rated volume as the amount. Here are some examples::  
 
-    # mix from the pipette's current location 
-    pipette.mix(repetitions=3, volume=50)
+    # mix 100 µL 3 times from the current location 
+    pipette.mix(repetitions=3, volume=100)
 
-    # mix 100 µL 4 times from well A2
-    pipette.mix(4, 100, plate['A2'])
+    # mix 100 µL 3 times from well A1
+    pipette.mix(3, 100, plate['A1'])
 
-The volume amount is optional. If omitted, the pipette will use its maximum rated volume as the amount. For example, 
-    pipette.mix(2)
+    # use the pipette's maximum volume 
+    pipette.mix(repetitions=3)
 
 .. note::
 
-    In API Versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette does not move between aspirate and dispense mixing actions. 
+    In API Versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API Version 2.3 and later, the pipette does not move while mixing. 
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -129,6 +129,7 @@ Independent Movement
 
 For convenience, many methods have location arguments and incorporate movement automatically. This section will focus on moving the pipette independently, without performing other actions like ``aspirate()`` or ``dispense()``.
 
+.. _move-to:
 
 Move To
 -------


### PR DESCRIPTION
# Overview

This PR is for managing changes made to the "Liquid Control" section of the doc, [Building Block Commands](https://docs.opentrons.com/v2/new_atomic_commands.html). 

Following the plan laid out in [this Figma file](https://www.figma.com/file/WsKj7gklIgDx68DkzegdaN/Commands-PAPI-docs-merge-strategies?type=whiteboard&node-id=0%3A1&t=souDTlzeZ3A0tmOj-1). This PR is for the second small branch section in Merge Strategy 1 of the Figma file.

The original manipulating tips section has 6 parts:

- Aspirate
- Dispense
- Blow out
- Touch tip
- Mix
- Air gap

 # Test Plan

- Check code in the Black formatter and use that style.
- Make sure links work.
- The usual grammar, style, clarity stuff.

# Changelog

- Adding text about the protocol template the code samples work with.
- Change headers to match current style.
- Revise text and code examples in each section.

# Review requests

The usual suspects.

# Risk assessment

Low, docs changes only.