### PR TITLE
perf(robot-server): Handle analysis requests serially to take more advantage of cache

### DIFF
--- a/robot-server/robot_server/protocols/analysis_memcache.py
+++ b/robot-server/robot_server/protocols/analysis_memcache.py
@@ -1,6 +1,5 @@
 """A simple size-limited memory cache used for large resources."""
-import asyncio
-from typing import Awaitable, Callable, Coroutine, Generic, TypeVar, Deque, Type, Dict
+from typing import Generic, TypeVar, Deque, Type, Dict
 from logging import getLogger
 
 from collections import deque
@@ -18,17 +17,12 @@ class MemoryCache(Generic[K, V]):
     _cache_order: Deque[K]
     _cache_size: int
 
-    _open_compute_tasks: Dict[K, "asyncio.Task[V]"]
-    _compute_concurrency_limiter: asyncio.Semaphore
-
     def __init__(self, size_limit: int, _keyhint: Type[K], _valhint: Type[V]) -> None:
         assert size_limit > 0, f"Cache size must be above 0 but was {size_limit}"
         _, _ = _keyhint, _valhint
         self._cache = {}
         self._cache_order = deque()
         self._cache_size = size_limit
-        self._open_compute_tasks = {}
-        self._compute_concurrency_limiter = asyncio.Semaphore(1)
 
     def contains(self, key: K) -> bool:
         """Returns True if the key is cached."""
@@ -37,29 +31,6 @@ class MemoryCache(Generic[K, V]):
     def get(self, key: K) -> V:
         """Get a cache element, raising KeyError if it is not cached."""
         return self._cache[key]
-
-    async def get_or_compute(self, key: K, compute: Callable[[], Awaitable[V]]) -> V:
-        if self.contains(key):
-            return self.get(key)
-
-        elif key in self._open_compute_tasks:
-            return await self._open_compute_tasks[key]
-
-        else:
-
-            async def limited_compute() -> V:
-                async with self._compute_concurrency_limiter:
-                    return await compute()
-
-            compute_task: "asyncio.Task[V]" = asyncio.create_task(limited_compute())  # type: ignore[arg-type]
-            self._open_compute_tasks[key] = compute_task
-
-            try:
-                result = await compute_task
-                self.insert(key=key, value=result)
-                return result
-            finally:  # Clean up compute_task even if it raises.
-                del self._open_compute_tasks[key]
 
     def _pop_eldest(self, key: K) -> None:
         if len(self._cache) < self._cache_size:

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -126,23 +126,23 @@ class CompletedAnalysisStore:
 
     async def get_by_id(self, analysis_id: str) -> Optional[CompletedAnalysisResource]:
         """Return the analysis with the given ID, if it exists."""
-
-        async def get_from_db_and_parse() -> Optional[CompletedAnalysisResource]:
-            statement = sqlalchemy.select(analysis_table).where(
-                analysis_table.c.id == analysis_id
-            )
-            with self._sql_engine.begin() as transaction:
-                try:
-                    raw_value_from_db = transaction.execute(statement).one()
-                except sqlalchemy.exc.NoResultFound:
-                    return None
-            return await CompletedAnalysisResource.from_sql_row(
-                raw_value_from_db, self._current_analyzer_version
-            )
-
-        return await self._memcache.get_or_compute(
-            key=analysis_id, compute=get_from_db_and_parse
+        try:
+            return self._memcache.get(analysis_id)
+        except KeyError:
+            pass
+        statement = sqlalchemy.select(analysis_table).where(
+            analysis_table.c.id == analysis_id
         )
+        with self._sql_engine.begin() as transaction:
+            try:
+                result = transaction.execute(statement).one()
+            except sqlalchemy.exc.NoResultFound:
+                return None
+        resource = await CompletedAnalysisResource.from_sql_row(
+            result, self._current_analyzer_version
+        )
+        self._memcache.insert(resource.id, resource)
+        return resource
 
     async def get_by_protocol(
         self, protocol_id: str
@@ -152,62 +152,55 @@ class CompletedAnalysisStore:
         If protocol_id doesn't point to a valid protocol, returns an empty list;
         doesn't raise an error.
         """
-        # In one atomic step (one SQL transaction, and no `await`s):
-        #
-        # 1) Figure out which of the protocol's analyses are already in self._memcache.
-        # 2) For those that are, get just their IDs.
-        # 3) For those that aren't, get their IDs and their blobs so we can parse them.
+        id_statement = (
+            sqlalchemy.select(analysis_table.c.id)
+            .where(analysis_table.c.protocol_id == protocol_id)
+            .order_by(sqlite_rowid)
+        )
         with self._sql_engine.begin() as transaction:
-            get_ids_statement = (
-                sqlalchemy.select(analysis_table.c.id)
-                .where(analysis_table.c.protocol_id == protocol_id)
-                .order_by(sqlite_rowid)
-            )
-            ordered_analysis_ids = list(
-                transaction.execute(get_ids_statement).scalars()
-            )
+            ordered_analyses_for_protocol = [
+                row.id for row in transaction.execute(id_statement).all()
+            ]
 
-            analysis_ids = set(ordered_analysis_ids)
-            cached_analysis_ids = {
-                analysis_id
-                for analysis_id in ordered_analysis_ids
-                if self._memcache.contains(analysis_id)
-            }
-            uncached_analysis_ids = analysis_ids - cached_analysis_ids
+        analysis_set = set(ordered_analyses_for_protocol)
+        cached_analyses = {
+            analysis_id
+            for analysis_id in ordered_analyses_for_protocol
+            if self._memcache.contains(analysis_id)
+        }
+        uncached_analyses = analysis_set - cached_analyses
 
-            get_uncached_rows_statement = sqlalchemy.select(analysis_table).where(
-                analysis_table.c.id.in_(uncached_analysis_ids)
-            )
-            uncached_rows = transaction.execute(get_uncached_rows_statement).all()
-
-        # Because we'll be loading whatever resources are not currently cached
+        # Because we'll be loading whatever resources are not currently cached from sql
         # using an async method, if this method is called reentrantly then inserting those
         # newly-fetched resources into the memcache could race and eject resources we just
         # added and were about to return. To prevent this, we'll make a second memcache just
         # for this coroutine - since we don't care about size limitations we can just use a
         # dict.
-        parsed_analyses: Dict[str, CompletedAnalysisResource] = {}
+        local_memcache: Dict[str, CompletedAnalysisResource] = {}
 
-        # We're assuming self._memcache.get() won't raise. For this to be correct, there must be no
-        # `await`s between where we populated cached_analysis_ids and here.
-        for cached_analysis_id in cached_analysis_ids:
-            parsed_analyses[cached_analysis_id] = self._memcache.get(cached_analysis_id)
+        for key in cached_analyses:
+            local_memcache[key] = self._memcache.get(key)
 
-        for row_to_parse in uncached_rows:
-            uncached_analysis_id = row_to_parse.id
-
-            async def compute() -> Optional[CompletedAnalysisResource]:
-                return await CompletedAnalysisResource.from_sql_row(
-                    row_to_parse, self._current_analyzer_version
-                )
-
-            parsed_analyses[uncached_analysis_id] = await self._memcache.get_or_compute(
-                key=uncached_analysis_id, compute=compute  # TODO: None/NULL handling.
+        if uncached_analyses:
+            statement = (
+                sqlalchemy.select(analysis_table)
+                .where(analysis_table.c.id.in_(uncached_analyses))
+                .order_by(sqlite_rowid)
             )
+            with self._sql_engine.begin() as transaction:
+                results = transaction.execute(statement).all()
+            for r in results:
+                resource = await CompletedAnalysisResource.from_sql_row(
+                    r, self._current_analyzer_version
+                )
+                local_memcache[resource.id] = resource
+                self._memcache.insert(resource.id, resource)
 
-        # note: we want to iterate through ordered_analyses_for_protocol rather than
+        # note: we want to iterate through ordered_analyseS_for_protocol rather than
         # just the local_memcache dict to preserve total ordering
-        return [parsed_analyses[analysis_id] for analysis_id in ordered_analysis_ids]
+        return [
+            local_memcache[analysis_id] for analysis_id in ordered_analyses_for_protocol
+        ]
 
     def get_ids_by_protocol(self, protocol_id: str) -> List[str]:
         """Like `get_by_protocol()`, but return only the ID of each analysis."""

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -112,10 +112,25 @@ class CompletedAnalysisStore:
     cache because the access methods are async, and lru_cache doesn't work with those.
     """
 
-    _memcache: MemoryCache[str, CompletedAnalysisResource]
     _sql_engine: sqlalchemy.engine.Engine
     _current_analyzer_version: str
-    _compute_limiter: asyncio.Lock
+
+    # Parsing and validating blobs from the database into CompletedAnalysisResources
+    # is a major compute bottleneck. It can take minutes for long protocols.
+    # Caching it can speed up the overall HTTP response time by ~10x (after the first request).
+    _memcache: MemoryCache[str, CompletedAnalysisResource]
+
+    # This is a lock for performance, not correctness.
+    #
+    # If multiple clients request the same resources all at once, we want to handle the requests
+    # serially to take the most advantage of _memcache. Otherwise, two concurrent requests for the
+    # same uncached CompletedAnalysisResource would each do their own work to parse it, which would
+    # be redundant and waste compute time.
+    #
+    # Handling requests serially does not harm overall throughput because even if we handled them
+    # concurrently, we'd be bottlenecked by Python's GIL. It will, however, increase latency for
+    # a small request if it gets blocked behind a big request.
+    _memcache_lock: asyncio.Lock
 
     def __init__(
         self,
@@ -124,17 +139,18 @@ class CompletedAnalysisStore:
         current_analyzer_version: str,
     ) -> None:
         self._sql_engine = sql_engine
-        self._memcache = memory_cache
         self._current_analyzer_version = current_analyzer_version
-        self._compute_limiter = asyncio.Lock()
+        self._memcache = memory_cache
+        self._memcache_lock = asyncio.Lock()
 
     async def get_by_id(self, analysis_id: str) -> Optional[CompletedAnalysisResource]:
         """Return the analysis with the given ID, if it exists."""
-        async with self._compute_limiter:
+        async with self._memcache_lock:
             try:
                 return self._memcache.get(analysis_id)
             except KeyError:
                 pass
+
             statement = sqlalchemy.select(analysis_table).where(
                 analysis_table.c.id == analysis_id
             )
@@ -143,10 +159,12 @@ class CompletedAnalysisStore:
                     result = transaction.execute(statement).one()
                 except sqlalchemy.exc.NoResultFound:
                     return None
+
             resource = await CompletedAnalysisResource.from_sql_row(
                 result, self._current_analyzer_version
             )
             self._memcache.insert(resource.id, resource)
+
             return resource
 
     async def get_by_protocol(
@@ -157,7 +175,7 @@ class CompletedAnalysisStore:
         If protocol_id doesn't point to a valid protocol, returns an empty list;
         doesn't raise an error.
         """
-        async with self._compute_limiter:
+        async with self._memcache_lock:
             id_statement = (
                 sqlalchemy.select(analysis_table.c.id)
                 .where(analysis_table.c.protocol_id == protocol_id)

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -1,9 +1,11 @@
 """Completed analysis storage and access."""
 from __future__ import annotations
 
+import asyncio
 from typing import Dict, List, Optional
 from logging import getLogger
 from dataclasses import dataclass
+
 import sqlalchemy
 import anyio
 
@@ -113,6 +115,7 @@ class CompletedAnalysisStore:
     _memcache: MemoryCache[str, CompletedAnalysisResource]
     _sql_engine: sqlalchemy.engine.Engine
     _current_analyzer_version: str
+    _compute_limiter: asyncio.Lock
 
     def __init__(
         self,
@@ -123,26 +126,28 @@ class CompletedAnalysisStore:
         self._sql_engine = sql_engine
         self._memcache = memory_cache
         self._current_analyzer_version = current_analyzer_version
+        self._compute_limiter = asyncio.Lock()
 
     async def get_by_id(self, analysis_id: str) -> Optional[CompletedAnalysisResource]:
         """Return the analysis with the given ID, if it exists."""
-        try:
-            return self._memcache.get(analysis_id)
-        except KeyError:
-            pass
-        statement = sqlalchemy.select(analysis_table).where(
-            analysis_table.c.id == analysis_id
-        )
-        with self._sql_engine.begin() as transaction:
+        async with self._compute_limiter:
             try:
-                result = transaction.execute(statement).one()
-            except sqlalchemy.exc.NoResultFound:
-                return None
-        resource = await CompletedAnalysisResource.from_sql_row(
-            result, self._current_analyzer_version
-        )
-        self._memcache.insert(resource.id, resource)
-        return resource
+                return self._memcache.get(analysis_id)
+            except KeyError:
+                pass
+            statement = sqlalchemy.select(analysis_table).where(
+                analysis_table.c.id == analysis_id
+            )
+            with self._sql_engine.begin() as transaction:
+                try:
+                    result = transaction.execute(statement).one()
+                except sqlalchemy.exc.NoResultFound:
+                    return None
+            resource = await CompletedAnalysisResource.from_sql_row(
+                result, self._current_analyzer_version
+            )
+            self._memcache.insert(resource.id, resource)
+            return resource
 
     async def get_by_protocol(
         self, protocol_id: str
@@ -152,55 +157,57 @@ class CompletedAnalysisStore:
         If protocol_id doesn't point to a valid protocol, returns an empty list;
         doesn't raise an error.
         """
-        id_statement = (
-            sqlalchemy.select(analysis_table.c.id)
-            .where(analysis_table.c.protocol_id == protocol_id)
-            .order_by(sqlite_rowid)
-        )
-        with self._sql_engine.begin() as transaction:
-            ordered_analyses_for_protocol = [
-                row.id for row in transaction.execute(id_statement).all()
-            ]
-
-        analysis_set = set(ordered_analyses_for_protocol)
-        cached_analyses = {
-            analysis_id
-            for analysis_id in ordered_analyses_for_protocol
-            if self._memcache.contains(analysis_id)
-        }
-        uncached_analyses = analysis_set - cached_analyses
-
-        # Because we'll be loading whatever resources are not currently cached from sql
-        # using an async method, if this method is called reentrantly then inserting those
-        # newly-fetched resources into the memcache could race and eject resources we just
-        # added and were about to return. To prevent this, we'll make a second memcache just
-        # for this coroutine - since we don't care about size limitations we can just use a
-        # dict.
-        local_memcache: Dict[str, CompletedAnalysisResource] = {}
-
-        for key in cached_analyses:
-            local_memcache[key] = self._memcache.get(key)
-
-        if uncached_analyses:
-            statement = (
-                sqlalchemy.select(analysis_table)
-                .where(analysis_table.c.id.in_(uncached_analyses))
+        async with self._compute_limiter:
+            id_statement = (
+                sqlalchemy.select(analysis_table.c.id)
+                .where(analysis_table.c.protocol_id == protocol_id)
                 .order_by(sqlite_rowid)
             )
             with self._sql_engine.begin() as transaction:
-                results = transaction.execute(statement).all()
-            for r in results:
-                resource = await CompletedAnalysisResource.from_sql_row(
-                    r, self._current_analyzer_version
-                )
-                local_memcache[resource.id] = resource
-                self._memcache.insert(resource.id, resource)
+                ordered_analyses_for_protocol = [
+                    row.id for row in transaction.execute(id_statement).all()
+                ]
 
-        # note: we want to iterate through ordered_analyseS_for_protocol rather than
-        # just the local_memcache dict to preserve total ordering
-        return [
-            local_memcache[analysis_id] for analysis_id in ordered_analyses_for_protocol
-        ]
+            analysis_set = set(ordered_analyses_for_protocol)
+            cached_analyses = {
+                analysis_id
+                for analysis_id in ordered_analyses_for_protocol
+                if self._memcache.contains(analysis_id)
+            }
+            uncached_analyses = analysis_set - cached_analyses
+
+            # Because we'll be loading whatever resources are not currently cached from sql
+            # using an async method, if this method is called reentrantly then inserting those
+            # newly-fetched resources into the memcache could race and eject resources we just
+            # added and were about to return. To prevent this, we'll make a second memcache just
+            # for this coroutine - since we don't care about size limitations we can just use a
+            # dict.
+            local_memcache: Dict[str, CompletedAnalysisResource] = {}
+
+            for key in cached_analyses:
+                local_memcache[key] = self._memcache.get(key)
+
+            if uncached_analyses:
+                statement = (
+                    sqlalchemy.select(analysis_table)
+                    .where(analysis_table.c.id.in_(uncached_analyses))
+                    .order_by(sqlite_rowid)
+                )
+                with self._sql_engine.begin() as transaction:
+                    results = transaction.execute(statement).all()
+                for r in results:
+                    resource = await CompletedAnalysisResource.from_sql_row(
+                        r, self._current_analyzer_version
+                    )
+                    local_memcache[resource.id] = resource
+                    self._memcache.insert(resource.id, resource)
+
+            # note: we want to iterate through ordered_analyseS_for_protocol rather than
+            # just the local_memcache dict to preserve total ordering
+            return [
+                local_memcache[analysis_id]
+                for analysis_id in ordered_analyses_for_protocol
+            ]
 
     def get_ids_by_protocol(self, protocol_id: str) -> List[str]:
         """Like `get_by_protocol()`, but return only the ID of each analysis."""


### PR DESCRIPTION
# Overview

When an HTTP client requests a protocol analysis, the server:

1. Retrieves a binary blob of the analysis from the database.
2. Parses and validates the blob into a Python `CompletedAnalysisResource` objects.
3. Serializes the `CompletedAnalysisResource` down to JSON and returns it to the client.

Step 2 is a known major compute bottleneck. PR #12648 put it behind a cache, which helps a lot. But that implementation has a hole: if there are two simultaneous requests for the same uncached analysis, they'll *both* parse the analysis from scratch. Ideally, one of the requests would wait for the other one to complete, and just reuse its result. This PR makes it do that.

This was an attempt to treat RSS-328. For unknown reasons, it doesn't improve the overall *user-facing* time, even though our *benchmarks* do show an improvement.

# Test plan

Behaviorally, I think we're adequately covered by existing integration and unit tests.

Performance-wise, I've tested this by running [this benchmarking script](https://gist.github.com/SyntaxColoring/8555a2dc0c36a7bc1a654b85c82f982b) from the discussion in RSS-328. I've confirmed that when running it in parallel 3 times, the "getting each protocol analysis" phase is ~3x faster: ~160s, down from ~500s.

# Changelog

* If an analysis request might be cached or add to the cache, handle it serially with respect to other such requests.
    * Add an `asyncio.Lock` to `CompletedAnalysisStore`.
    * Acquire that lock every time something calls `.get_by_id()` or `.get_by_protocol()`.

# Review requests

* Does this fix make sense?
* Can the comments be made more clear or concise?
* This implementation has a limitation where small requests will get blocked behind big ones. This doesn't affect overall throughput, but it does affect latency. There are ways around this, but they're significantly more complicated, so I left them out. Does this sound acceptable?

# Risk assessment

Low, but see the note above about small requests getting blocked behind big ones.