### PR TITLE
fix(hardware-testing): Reduce columns in Grav CSV to 3 by disabling CSVReport meta-data checking

### DIFF
--- a/hardware-testing/hardware_testing/data/csv_report.py
+++ b/hardware-testing/hardware_testing/data/csv_report.py
@@ -260,21 +260,37 @@ class CSVSection:
         return True
 
 
-def _generate_meta_data_section() -> CSVSection:
-    return CSVSection(
-        title=META_DATA_TITLE,
-        lines=[
-            CSVLine(tag=META_DATA_TEST_NAME, data=[str]),
-            CSVLine(tag=META_DATA_TEST_TAG, data=[str]),
-            CSVLine(tag=META_DATA_TEST_RUN_ID, data=[str]),
-            CSVLine(tag=META_DATA_TEST_DEVICE_ID, data=[str, str, CSVResult]),
-            CSVLine(tag=META_DATA_TEST_ROBOT_ID, data=[str]),
-            CSVLine(tag=META_DATA_TEST_TIME_UTC, data=[str]),
-            CSVLine(tag=META_DATA_TEST_OPERATOR, data=[str, CSVResult]),
-            CSVLine(tag=META_DATA_TEST_VERSION, data=[str]),
-            CSVLine(tag=META_DATA_TEST_FIRMWARE, data=[str]),
-        ],
-    )
+def _generate_meta_data_section(validate_meta_data: bool) -> CSVSection:
+    if validate_meta_data:
+        return CSVSection(
+            title=META_DATA_TITLE,
+            lines=[
+                CSVLine(tag=META_DATA_TEST_NAME, data=[str]),
+                CSVLine(tag=META_DATA_TEST_TAG, data=[str]),
+                CSVLine(tag=META_DATA_TEST_RUN_ID, data=[str]),
+                CSVLine(tag=META_DATA_TEST_DEVICE_ID, data=[str, str, CSVResult]),
+                CSVLine(tag=META_DATA_TEST_ROBOT_ID, data=[str]),
+                CSVLine(tag=META_DATA_TEST_TIME_UTC, data=[str]),
+                CSVLine(tag=META_DATA_TEST_OPERATOR, data=[str, CSVResult]),
+                CSVLine(tag=META_DATA_TEST_VERSION, data=[str]),
+                CSVLine(tag=META_DATA_TEST_FIRMWARE, data=[str]),
+            ],
+        )
+    else:
+        return CSVSection(
+            title=META_DATA_TITLE,
+            lines=[
+                CSVLine(tag=META_DATA_TEST_NAME, data=[str]),
+                CSVLine(tag=META_DATA_TEST_TAG, data=[str]),
+                CSVLine(tag=META_DATA_TEST_RUN_ID, data=[str]),
+                CSVLine(tag=META_DATA_TEST_DEVICE_ID, data=[str]),
+                CSVLine(tag=META_DATA_TEST_ROBOT_ID, data=[str]),
+                CSVLine(tag=META_DATA_TEST_TIME_UTC, data=[str]),
+                CSVLine(tag=META_DATA_TEST_OPERATOR, data=[str]),
+                CSVLine(tag=META_DATA_TEST_VERSION, data=[str]),
+                CSVLine(tag=META_DATA_TEST_FIRMWARE, data=[str]),
+            ],
+        )
 
 
 def _generate_results_overview_section(tags: List[str]) -> CSVSection:
@@ -293,13 +309,15 @@ class CSVReport:
         sections: List[CSVSection],
         run_id: Optional[str] = None,
         start_time: Optional[float] = None,
+        validate_meta_data: bool = True
     ) -> None:
         """CSV Report init."""
         self._test_name = test_name
         self._run_id = run_id if run_id else data_io.create_run_id()
+        self._validate_meta_data = validate_meta_data
         self._tag: Optional[str] = None
         self._file_name: Optional[str] = None
-        _section_meta = _generate_meta_data_section()
+        _section_meta = _generate_meta_data_section(validate_meta_data)
         _section_titles = [META_DATA_TITLE] + [s.title for s in sections]
         _section_results = _generate_results_overview_section(_section_titles)
         self._sections = [_section_meta, _section_results] + sections
@@ -411,10 +429,13 @@ class CSVReport:
         )
         self.save_to_disk()
 
-    def set_device_id(self, device_id: str, barcode_id: str) -> None:
+    def set_device_id(self, device_id: str, barcode_id: Optional[str] = None) -> None:
         """Store DUT serial number."""
-        result = CSVResult.from_bool(device_id == barcode_id)
-        self(META_DATA_TITLE, META_DATA_TEST_DEVICE_ID, [device_id, barcode_id, result])
+        if self._validate_meta_data:
+            result = CSVResult.from_bool(device_id == barcode_id)
+            self(META_DATA_TITLE, META_DATA_TEST_DEVICE_ID, [device_id, barcode_id, result])
+        else:
+            self(META_DATA_TITLE, META_DATA_TEST_DEVICE_ID, [device_id])
 
     def set_robot_id(self, robot_id: str) -> None:
         """Store robot serial number."""
@@ -422,8 +443,11 @@ class CSVReport:
 
     def set_operator(self, operator: str) -> None:
         """Set operator."""
-        result = CSVResult.from_bool(bool(operator))
-        self(META_DATA_TITLE, META_DATA_TEST_OPERATOR, [operator, result])
+        if self._validate_meta_data:
+            result = CSVResult.from_bool(bool(operator))
+            self(META_DATA_TITLE, META_DATA_TEST_OPERATOR, [operator, result])
+        else:
+            self(META_DATA_TITLE, META_DATA_TEST_OPERATOR, [operator])
 
     def set_version(self, version: str) -> None:
         """Set version."""

--- a/hardware-testing/hardware_testing/data/csv_report.py
+++ b/hardware-testing/hardware_testing/data/csv_report.py
@@ -309,7 +309,7 @@ class CSVReport:
         sections: List[CSVSection],
         run_id: Optional[str] = None,
         start_time: Optional[float] = None,
-        validate_meta_data: bool = True
+        validate_meta_data: bool = True,
     ) -> None:
         """CSV Report init."""
         self._test_name = test_name
@@ -433,7 +433,11 @@ class CSVReport:
         """Store DUT serial number."""
         if self._validate_meta_data:
             result = CSVResult.from_bool(device_id == barcode_id)
-            self(META_DATA_TITLE, META_DATA_TEST_DEVICE_ID, [device_id, barcode_id, result])
+            self(
+                META_DATA_TITLE,
+                META_DATA_TEST_DEVICE_ID,
+                [device_id, barcode_id, result],
+            )
         else:
             self(META_DATA_TITLE, META_DATA_TEST_DEVICE_ID, [device_id])
 

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -196,6 +196,7 @@ def create_csv_test_report(
     report = CSVReport(
         test_name=name,
         run_id=run_id,
+        validate_meta_data=False,  # to avoid >3 columns in CSV (:shrug:)
         sections=[
             CSVSection(
                 title="SERIAL-NUMBERS",


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds an optional argument to `CSVReport` to disable meta-data validation, and then sets that arg in gravimetric tests so that the number of columns in the CSV doesn't increase from 3 to 5.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
