### PR TITLE
feat(hardware-testing): Adds --same-tip and --mix as experimental arguments to gravimetric test

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -322,6 +322,7 @@ def build_gravimetric_cfg(
     isolate_channels: List[int],
     extra: bool,
     jog: bool,
+    same_tip: bool,
     run_args: RunArgs,
 ) -> GravimetricConfig:
     """Build."""
@@ -348,6 +349,7 @@ def build_gravimetric_cfg(
         kind=ConfigType.gravimetric,
         extra=extra,
         jog=jog,
+        same_tip=same_tip,
     )
 
 
@@ -362,6 +364,7 @@ def build_photometric_cfg(
     refill: bool,
     extra: bool,
     jog: bool,
+    same_tip: bool,
     run_args: RunArgs,
 ) -> PhotometricConfig:
     """Run."""
@@ -388,6 +391,7 @@ def build_photometric_cfg(
         kind=ConfigType.photometric,
         extra=extra,
         jog=jog,
+        same_tip=same_tip,
     )
 
 
@@ -410,6 +414,7 @@ def _main(
             args.refill,
             args.extra,
             args.jog,
+            args.same_tip,
             run_args,
         )
         union_cfg = cfg_pm
@@ -428,6 +433,7 @@ def _main(
             args.isolate_channels if args.isolate_channels else [],
             args.extra,
             args.jog,
+            args.same_tip,
             run_args,
         )
 
@@ -485,6 +491,7 @@ if __name__ == "__main__":
     parser.add_argument("--isolate-channels", nargs="+", type=int, default=None)
     parser.add_argument("--extra", action="store_true")
     parser.add_argument("--jog", action="store_true")
+    parser.add_argument("--same-tip", action="store_true")
     args = parser.parse_args()
     run_args = RunArgs.build_run_args(args)
     try:

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -315,7 +315,6 @@ def build_gravimetric_cfg(
     return_tip: bool,
     blank: bool,
     mix: bool,
-    inspect: bool,
     user_volumes: bool,
     gantry_speed: int,
     scale_delay: int,
@@ -341,7 +340,6 @@ def build_gravimetric_cfg(
         return_tip=return_tip,
         blank=blank,
         mix=mix,
-        inspect=inspect,
         user_volumes=user_volumes,
         gantry_speed=gantry_speed,
         scale_delay=scale_delay,
@@ -358,7 +356,6 @@ def build_photometric_cfg(
     tip_volume: int,
     return_tip: bool,
     mix: bool,
-    inspect: bool,
     user_volumes: bool,
     touch_tip: bool,
     refill: bool,
@@ -384,7 +381,6 @@ def build_photometric_cfg(
         slots_tiprack=run_args.protocol_cfg.SLOTS_TIPRACK[tip_volume],  # type: ignore[attr-defined]
         return_tip=return_tip,
         mix=mix,
-        inspect=inspect,
         user_volumes=user_volumes,
         touch_tip=touch_tip,
         refill=refill,
@@ -408,7 +404,6 @@ def _main(
             tip,
             args.return_tip,
             args.mix,
-            args.inspect,
             args.user_volumes,
             args.touch_tip,
             args.refill,
@@ -426,7 +421,6 @@ def _main(
             args.return_tip,
             False if args.no_blank else True,
             args.mix,
-            args.inspect,
             args.user_volumes,
             args.gantry_speed,
             args.scale_delay,
@@ -481,7 +475,6 @@ if __name__ == "__main__":
     parser.add_argument("--skip-labware-offsets", action="store_true")
     parser.add_argument("--no-blank", action="store_true")
     parser.add_argument("--mix", action="store_true")
-    parser.add_argument("--inspect", action="store_true")
     parser.add_argument("--user-volumes", action="store_true")
     parser.add_argument("--gantry-speed", type=int, default=GANTRY_MAX_SPEED)
     parser.add_argument("--scale-delay", type=int, default=DELAY_FOR_MEASUREMENT)

--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -29,7 +29,6 @@ class VolumetricConfig:
     increment: bool
     return_tip: bool
     mix: bool
-    inspect: bool
     user_volumes: bool
     kind: ConfigType
     extra: bool

--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -34,6 +34,7 @@ class VolumetricConfig:
     kind: ConfigType
     extra: bool
     jog: bool
+    same_tip: bool
 
 
 @dataclass

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -246,9 +246,7 @@ def _run_trial(
         )
     else:
         # center channel over well
-        trial.pipette.move_to(
-            trial.well.top(50).move(trial.channel_offset)
-        )
+        trial.pipette.move_to(trial.well.top(50).move(trial.channel_offset))
     mnt = OT3Mount.RIGHT if trial.pipette.mount == "right" else OT3Mount.LEFT
     trial.ctx._core.get_hardware().retract(mnt)  # retract to top of gantry
     m_data_init = _record_measurement_and_store(MeasurementType.INIT)
@@ -466,7 +464,7 @@ def _get_liquid_height(
     return _liquid_height
 
 
-def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:
+def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:  # noqa: C901
     """Run."""
     global _PREV_TRIAL_GRAMS
     global _MEASUREMENTS
@@ -546,7 +544,9 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:
         ui.print_info("dropping tip")
         if not cfg.same_tip:
             _drop_tip(
-                resources.pipette, return_tip=False, minimum_z_height=_minimum_z_height(cfg)
+                resources.pipette,
+                return_tip=False,
+                minimum_z_height=_minimum_z_height(cfg),
             )  # always trash calibration tips
         calibration_tip_in_use = False
         trial_count = 0
@@ -640,7 +640,9 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:
                     )
                     ui.print_info("dropping tip")
                     if not cfg.same_tip:
-                        _drop_tip(resources.pipette, cfg.return_tip, _minimum_z_height(cfg))
+                        _drop_tip(
+                            resources.pipette, cfg.return_tip, _minimum_z_height(cfg)
+                        )
 
                 ui.print_header(f"{volume} uL channel {channel + 1} CALCULATIONS")
                 aspirate_average, aspirate_cv, aspirate_d = _calculate_stats(

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -215,7 +215,7 @@ def _run_trial(
             trial.pipette.mount,
             trial.stable,
             trial.env_sensor,
-            shorten=trial.inspect,
+            shorten=False,  # TODO: remove this
             delay_seconds=trial.scale_delay,
         )
         report.store_measurement(trial.test_report, m_tag, m_data)
@@ -527,7 +527,7 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:
         ui.print_info(
             f"software thinks there is {vial_volume} uL of liquid in the vial"
         )
-        if not cfg.blank or cfg.inspect:
+        if not cfg.blank:
             average_aspirate_evaporation_ul = 0.0
             average_dispense_evaporation_ul = 0.0
         else:

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -157,8 +157,6 @@ def _run_trial(trial: PhotometricTrial) -> None:
         trial.liquid_tracker,
         callbacks=pipetting_callbacks,
         blank=False,
-        inspect=trial.inspect,
-        mix=trial.mix,
         touch_tip=False,
     )
 
@@ -181,8 +179,6 @@ def _run_trial(trial: PhotometricTrial) -> None:
             trial.liquid_tracker,
             callbacks=pipetting_callbacks,
             blank=False,
-            inspect=trial.inspect,
-            mix=trial.mix,
             added_blow_out=(i + 1) == num_dispenses,
             touch_tip=trial.cfg.touch_tip,
         )

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -187,13 +187,11 @@ def _run_trial(trial: PhotometricTrial) -> None:
             touch_tip=trial.cfg.touch_tip,
         )
         _record_measurement_and_store(MeasurementType.DISPENSE)
-        trial.pipette.move_to(location=trial.dest["A1"].top().move(Point(0, 0, 133)))
+        trial.ctx._core.get_hardware().retract(OT3Mount.LEFT)
         if (i + 1) == num_dispenses:
-            _drop_tip(trial.pipette, trial.cfg.return_tip)
-        else:
-            trial.pipette.move_to(
-                location=trial.dest["A1"].top().move(Point(0, 107, 133))
-            )
+            if not trial.cfg.same_tip:
+                _drop_tip(trial.pipette, trial.cfg.return_tip)
+                trial.ctx._core.get_hardware().retract(OT3Mount.LEFT)
         if not trial.ctx.is_simulating():
             ui.get_user_ready("add SEAL to plate and remove from DECK")
     return
@@ -307,9 +305,10 @@ def execute_trials(
                 ui.get_user_ready(f"put PLATE #{trial.trial + 1} and remove SEAL")
             next_tip: Well = _next_tip()
             next_tip_location = next_tip.top()
-            _pick_up_tip(
-                resources.ctx, resources.pipette, cfg, location=next_tip_location
-            )
+            if not cfg.same_tip:
+                _pick_up_tip(
+                    resources.ctx, resources.pipette, cfg, location=next_tip_location
+                )
             _run_trial(trial)
 
 
@@ -325,7 +324,7 @@ def _find_liquid_height(
     _pick_up_tip(resources.ctx, resources.pipette, cfg, location=setup_tip.top())
     mnt = OT3Mount.LEFT if cfg.pipette_mount == "left" else OT3Mount.RIGHT
     resources.ctx._core.get_hardware().retract(mnt)
-    if not resources.ctx.is_simulating():
+    if not resources.ctx.is_simulating() and not cfg.same_tip:
         ui.get_user_ready("REPLACE first tip with NEW TIP")
     required_ul = max(
         (volume_for_setup * channel_count * cfg.trials) + _MIN_END_VOLUME_UL,
@@ -372,9 +371,12 @@ def _find_liquid_height(
         raise RuntimeError(
             f"bad volume in reservoir: {round(reservoir_ul / 1000, 1)} ml"
         )
-    resources.pipette.drop_tip(home_after=False)  # always trash setup tips
-    # NOTE: the first tip-rack should have already been replaced
-    #       with new tips by the operator
+    resources.ctx._core.get_hardware().retract(OT3Mount.LEFT)
+    if not cfg.same_tip:
+        resources.pipette.drop_tip(home_after=False)  # always trash setup tips
+        resources.ctx._core.get_hardware().retract(OT3Mount.LEFT)
+        # NOTE: the first tip-rack should have already been replaced
+        #       with new tips by the operator
 
 
 def run(cfg: config.PhotometricConfig, resources: TestResources) -> None:

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -9,7 +9,7 @@ from .definition import (
 )
 
 _default_submerge_mm = 1.5
-_default_retract_mm = 3.0
+_default_retract_mm = 5.0
 _default_retract_discontinuity = 20
 
 _default_aspirate_delay_seconds = 1.0

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -176,6 +176,7 @@ def _pipette_with_liquid_settings(  # noqa: C901
     # FIXME: stop using hwapi, and get those functions into core software
     hw_api = ctx._core.get_hardware()
     hw_mount = OT3Mount.LEFT if pipette.mount == "left" else OT3Mount.RIGHT
+    hw_pipette = hw_api.hardware_pipettes[hw_mount.to_mount()]
     _check_aspirate_dispense_args(mix, aspirate, dispense)
 
     def _dispense_with_added_blow_out() -> None:
@@ -189,8 +190,11 @@ def _pipette_with_liquid_settings(  # noqa: C901
         # FIXME: using the HW-API to specify that we want to blow-out the full
         #        available blow-out volume
         # NOTE: calculated using blow-out distance (mm) and the nominal ul-per-mm
-        max_blow_out_volume = 79.5 if pipette.max_volume >= 1000 else 3.9
-        hw_api.blow_out(hw_mount, max_blow_out_volume)
+        blow_out_ul_per_mm = hw_pipette.config.shaft_ul_per_mm
+        bottom = hw_pipette.plunger_positions.bottom
+        blow_out = hw_pipette.plunger_positions.blow_out
+        max_blow_out_ul = (blow_out - bottom) * blow_out_ul_per_mm
+        hw_api.blow_out(hw_mount, max_blow_out_ul)
 
     # ASPIRATE/DISPENSE SEQUENCE HAS THREE PHASES:
     #  1. APPROACH

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -235,7 +235,7 @@ def _pipette_with_liquid_settings(
                 pipette.dispense(mix)
             else:
                 _dispense_with_added_blow_out()
-            ctx.delay(liquid_class.aspirate.delay)
+            ctx.delay(liquid_class.dispense.delay)
         # don't go all the way up to retract position, but instead just above liquid
         _retract(ctx, pipette, well, channel_offset, approach_mm, retract_speed, _z_disc)
         _blow_out_remaining_air()

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -156,7 +156,7 @@ def _retract(
     hw_api.set_gantry_load(hw_api.gantry_load)
 
 
-def _pipette_with_liquid_settings(
+def _pipette_with_liquid_settings(  # noqa: C901
     ctx: ProtocolContext,
     pipette: InstrumentContext,
     liquid_class: LiquidClassSettings,
@@ -237,7 +237,9 @@ def _pipette_with_liquid_settings(
                 _dispense_with_added_blow_out()
             ctx.delay(liquid_class.dispense.delay)
         # don't go all the way up to retract position, but instead just above liquid
-        _retract(ctx, pipette, well, channel_offset, approach_mm, retract_speed, _z_disc)
+        _retract(
+            ctx, pipette, well, channel_offset, approach_mm, retract_speed, _z_disc
+        )
         _blow_out_remaining_air()
         hw_api.prepare_for_aspirate(hw_mount)
         assert pipette.current_volume == 0

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -189,7 +189,7 @@ def _pipette_with_liquid_settings(  # noqa: C901
         # FIXME: using the HW-API to specify that we want to blow-out the full
         #        available blow-out volume
         # NOTE: calculated using blow-out distance (mm) and the nominal ul-per-mm
-        max_blow_out_volume = 79.5 if pipette.max_volume >= 1000 else 14.9
+        max_blow_out_volume = 79.5 if pipette.max_volume >= 1000 else 3.9
         hw_api.blow_out(hw_mount, max_blow_out_volume)
 
     # ASPIRATE/DISPENSE SEQUENCE HAS THREE PHASES:

--- a/hardware-testing/hardware_testing/gravimetric/trial.py
+++ b/hardware-testing/hardware_testing/gravimetric/trial.py
@@ -22,7 +22,6 @@ class VolumetricTrial:
     pipette: InstrumentContext
     test_report: CSVReport
     liquid_tracker: LiquidTracker
-    inspect: bool
     trial: int
     tip_volume: int
     volume: float
@@ -114,7 +113,6 @@ def build_gravimetric_trials(
                     test_report=test_report,
                     liquid_tracker=liquid_tracker,
                     blank=blank,
-                    inspect=cfg.inspect,
                     mix=cfg.mix,
                     stable=True,
                     scale_delay=cfg.scale_delay,
@@ -157,7 +155,6 @@ def build_gravimetric_trials(
                             test_report=test_report,
                             liquid_tracker=liquid_tracker,
                             blank=blank,
-                            inspect=cfg.inspect,
                             mix=cfg.mix,
                             stable=True,
                             scale_delay=cfg.scale_delay,
@@ -205,7 +202,6 @@ def build_photometric_trials(
                     volume=volume,
                     trial=trial,
                     liquid_tracker=liquid_tracker,
-                    inspect=cfg.inspect,
                     cfg=cfg,
                     mix=cfg.mix,
                     acceptable_cv=cv,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Some new experimental options were added last week to gravimetric testing, and they are useful enough that we should probably keep them around forever:

- Argument `--same-tip` where the pipette will never replace the current tip(s) during the entire test
- Argument `--mix` actually does something now, where the pipette will mix 5x times before every aspiration

A couple of small bug fixes too:

- Remove unused `--inspect` argument
- Fix retract bug where specified millimeter height was being added to top of vial, instead of being added to liquid surface
  - because of above bug, increases retract distance from 3mm to 5mm so it is guaranteed to leave liquid

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
