### PR TITLE
feat(api,robot-server): Don't scan for wifi networks on every request and expose option via query parameter

### DIFF
--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -318,17 +318,20 @@ def _add_security_type_to_scan(scan_out: Dict[str, Any]) -> Dict[str, Any]:
     return scan_out
 
 
-async def available_ssids() -> List[Dict[str, Any]]:
+async def available_ssids(rescan: Optional[bool] = False) -> List[Dict[str, Any]]:
     """List the visible (broadcasting SSID) wireless networks.
+
+    rescan: Forces a rescan instead of using the cached results.
 
     Returns a list of the SSIDs. They may contain spaces and should be escaped
     if later passed to a shell.
     """
-    # Force nmcli to actually scan rather than reuse cached results. We ignore
-    # errors here because NetworkManager yells at you if you do it twice in a
+    # Force nmcli to actually scan if rescan is true rather than reuse cached results.
+    # We ignore errors here because NetworkManager yells at you if you do it twice in a
     # row without another operation in between
-    cmd = ["device", "wifi", "rescan"]
-    _1, _2 = await _call(cmd, suppress_err=True)
+    if rescan:
+        cmd = ["device", "wifi", "rescan"]
+        _1, _2 = await _call(cmd, suppress_err=True)
 
     fields = ["ssid", "signal", "active", "security"]
     cmd = ["--terse", "--fields", ",".join(fields), "device", "wifi", "list"]

--- a/api/tests/opentrons/system/test_nmcli.py
+++ b/api/tests/opentrons/system/test_nmcli.py
@@ -133,7 +133,7 @@ mock_bad_security:50:no:foobar
         return mock_nmcli_output, ""
 
     monkeypatch.setattr(nmcli, "_call", mock_call)
-    result = await nmcli.available_ssids()
+    result = await nmcli.available_ssids(True)
     assert result == expected
 
 

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -4,10 +4,11 @@ import subprocess
 
 from starlette import status
 from starlette.responses import JSONResponse
-from fastapi import APIRouter, HTTPException, File, Path, UploadFile
+from typing import Optional
+from fastapi import APIRouter, HTTPException, File, Path, UploadFile, Query
+
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons.system import nmcli, wifi
-
 from robot_server.errors import LegacyErrorResponse
 from robot_server.service.legacy.models import V1BasicResponse
 from robot_server.service.legacy.models.networking import (
@@ -36,7 +37,7 @@ router = APIRouter()
 @router.get(
     "/networking/status",
     summary="Query the current network connectivity state",
-    description="Gets information about the OT-2's network interfaces "
+    description="Gets information about the robot's network interfaces "
     "including their connectivity, their "
     "addresses, and their networking info",
     response_model=NetworkingStatus,
@@ -60,19 +61,28 @@ async def get_networking_status() -> NetworkingStatus:
 @router.get(
     "/wifi/list",
     summary="Scan for visible Wi-Fi networks",
-    description="Scans for beaconing WiFi networks and returns the "
-    "list of visible ones along with some data about "
-    "their security and strength",
+    description="Returns the list of the visible wifi networks "
+    "along with some data about their security and strength. ",
     response_model=WifiNetworks,
 )
-async def get_wifi_networks() -> WifiNetworks:
-    networks = await nmcli.available_ssids()
+async def get_wifi_networks(
+    rescan: Optional[bool] = Query(
+        default=False,
+        description=(
+            "If `true` it forces a rescan for beaconing WiFi networks, "
+            "this is an expensive operation which can take ~10 seconds."
+            "If `false` it returns the cached wifi networks, "
+            "letting the system decide when to do a rescan."
+        ),
+    )
+) -> WifiNetworks:
+    networks = await nmcli.available_ssids(rescan)
     return WifiNetworks(list=[WifiNetworkFull(**n) for n in networks])
 
 
 @router.post(
     path="/wifi/configure",
-    summary="Configure the OT-2's Wi-Fi",
+    summary="Configure the robot's Wi-Fi",
     description=(
         "Configures the wireless network interface to " "connect to a network"
     ),
@@ -134,7 +144,7 @@ async def get_wifi_keys():
 
 @router.post(
     "/wifi/keys",
-    description="Send a new key file to the OT-2",
+    description="Send a new key file to the robot",
     responses={status.HTTP_200_OK: {"model": AddWifiKeyFileResponse}},
     response_model=AddWifiKeyFileResponse,
     status_code=status.HTTP_201_CREATED,
@@ -158,7 +168,7 @@ async def post_wifi_key(key: UploadFile = File(...)):
 
 @router.delete(
     path="/wifi/keys/{key_uuid}",
-    description="Delete a key file from the OT-2",
+    description="Delete a key file from the robot",
     response_model=V1BasicResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {"model": LegacyErrorResponse},
@@ -211,7 +221,7 @@ async def get_eap_options() -> EapOptions:
 
 @router.post(
     "/wifi/disconnect",
-    summary="Disconnect the OT-2 from Wi-Fi",
+    summary="Disconnect the robot from Wi-Fi",
     description="Deactivates the Wi-Fi connection and removes it "
     "from known connections",
     response_model=V1BasicResponse,

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -62,7 +62,9 @@ async def get_networking_status() -> NetworkingStatus:
     "/wifi/list",
     summary="Scan for visible Wi-Fi networks",
     description="Returns the list of the visible wifi networks "
-    "along with some data about their security and strength. ",
+    "along with some data about their security and strength. "
+    "Only use rescan=True based on the user needs like clicking on"
+    "the scan network button and not to just poll.",
     response_model=WifiNetworks,
 )
 async def get_wifi_networks(

--- a/robot-server/tests/service/legacy/routers/test_networking.py
+++ b/robot-server/tests/service/legacy/routers/test_networking.py
@@ -5,6 +5,7 @@ from mock import patch
 
 import pytest
 from opentrons.system import nmcli, wifi
+from typing import Optional
 
 
 def test_networking_status(api_client, monkeypatch):
@@ -84,7 +85,7 @@ def test_wifi_list(api_client, monkeypatch):
         },
     ]
 
-    async def mock_available():
+    async def mock_available(rescan: Optional[bool] = False):
         return expected_res
 
     monkeypatch.setattr(nmcli, "available_ssids", mock_available)


### PR DESCRIPTION
# Overview

Scanning for wifi networks is an expensive operation. Since we have multiple clients including the ODD, that can often request the wifi list numerous times a second, this can lead to the wifi driver on the Flex crashing. Since we call out to `nmcli` (NetworkManager Command Line Interface) command via a python subprocess which when scanning can take about 10-20 seconds to return, this can lead to the creation of many file descriptors which can lead to a resource accumulation problem. 

So let's make the triggering of network scans optional so it does not happen on every `/wifi/list` request but instead exposed via a query parameter `rescan` which is `False` by default, allowing the client to control when they want a new scan. This means that we won't perform a network scan every time we request the wifi list, instead, [nmcli](https://developer-old.gnome.org/NetworkManager/stable/nmcli.html) will return its cached list of wifi networks which is internally refreshed at least every 30 seconds.

Closes: [RQA-1238](https://opentrons.atlassian.net/browse/RQA-1238)

# Test Plan

- [x] GET `/wifi/list` without a query parameter returns cached nmcli wifi networks.
- [x] GET `/wifi/list?rescan=false` returns cached nmcli wifi networks.
- [x] GET `/wifi/list?rescan=true` triggers a network rescan, returning the latest wifi networks.
- [x] Test on the OT-2
- [x] Test on the Flex

# Changelog
- Make nmcli wifi rescan optional and expose it via a query parameter
- Update command descriptions to say `robot` instead of just `OT2` since we also have the Flex.

# Review requests
- is there anything I'm missing?

# Risk assessment
- Medium, affects OT-2 and Flex 
- wifi networks from `/wifi/list` will be slightly stale but will increase performance.



[RQA-1238]: https://opentrons.atlassian.net/browse/RQA-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ