### PR TITLE
refactor(protocol-designer, step-generation): adapter support in moveLabware and text cleanup

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/AdapterControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/AdapterControls.tsx
@@ -79,7 +79,6 @@ export const AdapterControlsComponents = (
     (itemType !== DND_TYPES.LABWARE && itemType !== null)
   )
     return null
-
   const draggedDef = draggedItem?.labwareOnDeck?.def
   const isCustomLabware = draggedItem
     ? getLabwareIsCustom(customLabwareDefs, draggedItem.labwareOnDeck)
@@ -146,18 +145,23 @@ const mapStateToProps = (state: BaseState): SP => {
   }
 }
 
-const mapDispatchToProps = (
-  dispatch: ThunkDispatch<any>,
-  ownProps: OP
-): DP => ({
-  addLabware: () => dispatch(openAddLabwareModal({ slot: ownProps.labwareId })),
-  moveDeckItem: (sourceSlot, destSlot) =>
-    dispatch(moveDeckItem(sourceSlot, destSlot)),
-  deleteLabware: () => {
-    window.confirm(i18n.t('deck.warning.cancelForSure')) &&
-      dispatch(deleteContainer({ labwareId: ownProps.labwareId }))
-  },
-})
+const mapDispatchToProps = (dispatch: ThunkDispatch<any>, ownProps: OP): DP => {
+  const adapterName =
+    ownProps.allLabware.find(labware => labware.id === ownProps.labwareId)?.def
+      .metadata.displayName ?? ''
+
+  return {
+    addLabware: () =>
+      dispatch(openAddLabwareModal({ slot: ownProps.labwareId })),
+    moveDeckItem: (sourceSlot, destSlot) =>
+      dispatch(moveDeckItem(sourceSlot, destSlot)),
+    deleteLabware: () => {
+      window.confirm(
+        i18n.t('deck.warning.cancelForSure', { adapterName: adapterName })
+      ) && dispatch(deleteContainer({ labwareId: ownProps.labwareId }))
+    },
+  }
+}
 
 const slotTarget = {
   drop: (props: SlotControlsProps, monitor: DropTargetMonitor) => {

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/AdapterControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/AdapterControls.tsx
@@ -127,7 +127,7 @@ export const AdapterControlsComponents = (
           <a className={styles.overlay_button} onClick={addLabware}>
             {!isOver && <Icon className={styles.overlay_icon} name="plus" />}
             {i18n.t(
-              `deck.overlay.slot.${isOver ? 'place_here' : 'add_adapter'}`
+              `deck.overlay.slot.${isOver ? 'place_here' : 'add_labware'}`
             )}
           </a>
           <a className={styles.overlay_button} onClick={deleteLabware}>

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
@@ -91,6 +91,18 @@ export const SlotControlsComponent = (
     slotBlocked = 'Labware incompatible with this module'
   }
 
+  const isOnHeaterShaker = moduleType === 'heaterShakerModuleType'
+  const isNoAdapterOption =
+    moduleType === 'magneticBlockType' ||
+    moduleType === 'magneticModuleType' ||
+    moduleType === 'thermocyclerModuleType'
+  let overlayText: string = 'add_adapter_or_labware'
+  if (isOnHeaterShaker) {
+    overlayText = 'add_adapter'
+  } else if (isNoAdapterOption) {
+    overlayText = 'add_labware'
+  }
+
   return connectDropTarget(
     <g>
       {slotBlocked ? (
@@ -116,9 +128,7 @@ export const SlotControlsComponent = (
         >
           <a className={styles.overlay_button} onClick={addLabware}>
             {!isOver && <Icon className={styles.overlay_icon} name="plus" />}
-            {i18n.t(
-              `deck.overlay.slot.${isOver ? 'place_here' : 'add_labware'}`
-            )}
+            {i18n.t(`deck.overlay.slot.${isOver ? 'place_here' : overlayText}`)}
           </a>
         </RobotCoordsForeignDiv>
       )}

--- a/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
@@ -1,7 +1,15 @@
+import { getModuleDisplayName } from '@opentrons/shared-data'
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { i18n } from '../../../../localization'
-import { getUnocuppiedLabwareLocationOptions } from '../../../../top-selectors/labware-locations'
+import {
+  getLabwareEntities,
+  getModuleEntities,
+} from '../../../../step-forms/selectors'
+import {
+  getRobotStateAtActiveItem,
+  getUnocuppiedLabwareLocationOptions,
+} from '../../../../top-selectors/labware-locations'
 import { StepFormDropdown } from '../StepFormDropdownField'
 
 export function LabwareLocationField(
@@ -9,6 +17,10 @@ export function LabwareLocationField(
     useGripper: boolean
   } & { canSave: boolean } & { labware: string }
 ): JSX.Element {
+  const labwareEntities = useSelector(getLabwareEntities)
+  const robotState = useSelector(getRobotStateAtActiveItem)
+  const moduleEntities = useSelector(getModuleEntities)
+
   let unoccupiedLabwareLocationsOptions =
     useSelector(getUnocuppiedLabwareLocationOptions) ?? []
 
@@ -17,15 +29,38 @@ export function LabwareLocationField(
       option => option.value !== 'offDeck'
     )
   }
-  const bothFieldsSelected = props.labware != null && props.value != null
+  const location: string = props.value as string
 
+  const bothFieldsSelected = props.labware != null && props.value != null
+  const labwareDisplayName =
+    props.labware != null
+      ? labwareEntities[props.labware]?.def.metadata.displayName
+      : ''
+  let locationString = `slot ${location}`
+  if (location != null) {
+    if (robotState?.modules[location] != null) {
+      const moduleSlot = robotState?.modules[location].slot ?? ''
+      locationString = `${getModuleDisplayName(
+        moduleEntities[location].model
+      )} in slot ${moduleSlot}`
+    } else if (robotState?.labware[location] != null) {
+      const adapterSlot = robotState?.labware[location].slot
+      locationString =
+        robotState?.modules[adapterSlot] != null
+          ? `${getModuleDisplayName(
+              moduleEntities[adapterSlot].model
+            )} in slot ${robotState?.modules[adapterSlot].slot}`
+          : `slot ${robotState?.labware[location].slot}` ?? ''
+    }
+  }
   return (
     <StepFormDropdown
       {...props}
       errorToShow={
         !props.canSave && bothFieldsSelected
           ? i18n.t(
-              'form.step_edit_form.labwareLabel.errors.labwareSlotIncompatible'
+              'form.step_edit_form.labwareLabel.errors.labwareSlotIncompatible',
+              { labwareName: labwareDisplayName, slot: locationString }
             )
           : undefined
       }

--- a/protocol-designer/src/localization/en/deck.json
+++ b/protocol-designer/src/localization/en/deck.json
@@ -1,7 +1,7 @@
 {
   "warning": {
     "gen1multichannel": "No GEN1 8-Channel access",
-    "cancelForSure": "Are you sure you want to permanently delete this adapter?"
+    "cancelForSure": "Are you sure you want to remove this adapter?"
   },
   "blocked_slot": {
     "MODULE_INCOMPATIBLE_SINGLE_LABWARE": "Labware incompatible with this module",
@@ -29,7 +29,8 @@
       "add_labware": "Add Labware",
       "drag_to_new_slot": "Drag To New Slot",
       "place_here": "Place Here",
-      "add_adapter": "Add Adapter"
+      "add_adapter_or_labware": "Add Labware or Adapter",
+      "add_adapter": "Add adapter"
     }
   },
   "inactive_deck": "hover on a step to see deck state"

--- a/protocol-designer/src/localization/en/deck.json
+++ b/protocol-designer/src/localization/en/deck.json
@@ -1,7 +1,7 @@
 {
   "warning": {
     "gen1multichannel": "No GEN1 8-Channel access",
-    "cancelForSure": "Are you sure you want to remove this adapter?"
+    "cancelForSure": "Are you sure you want to remove this {{adapterName}}?"
   },
   "blocked_slot": {
     "MODULE_INCOMPATIBLE_SINGLE_LABWARE": "Labware incompatible with this module",

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -37,7 +37,7 @@
       "mixLabware": "labware",
       "movedLabware": "labware",
       "errors": {
-        "labwareSlotIncompatible": "The selected labware and new location are incompatible"
+        "labwareSlotIncompatible": "The {{labwareName}} in {{slot}} is incompatible"
       }
     },
     "mixVolumeLabel": "mix volume",

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -122,6 +122,8 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
         const modIdWithAdapter = Object.keys(modules).find(
           modId => modId === labwareOnDeck.slot
         )
+        const adapterDisplayName =
+          labwareEntities[labwareId].def.metadata.displayName
         const modSlot =
           modIdWithAdapter != null ? modules[modIdWithAdapter].slot : null
         const isAdapter = getIsAdapter(labwareId, labwareEntities)
@@ -130,7 +132,7 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
           ? [
               ...acc,
               {
-                name: `Adapter on top of ${
+                name: `${adapterDisplayName} on top of ${
                   modIdWithAdapter != null
                     ? getModuleDisplayName(
                         moduleEntities[modIdWithAdapter].model

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -16,6 +16,8 @@ export function forMoveLabware(
     newLocationString = newLocation.moduleId
   } else if ('slotName' in newLocation) {
     newLocationString = newLocation.slotName
+  } else if ('labwareId' in newLocation) {
+    newLocationString = newLocation.labwareId
   }
 
   robotState.labware[labwareId].slot = newLocationString


### PR DESCRIPTION
closes RAUT-621, RAUT-642, RAUT-643, RAUT-645, RQA-1441, RQA-1440

# Overview

A bit of PD adapter followup, this PR does 4 things:
1. fixes the `add adapter` text and has `add adapter`, `add labware` or `add adapter and labware`: RAUT-643 & RQA-1441 & RQA-1440
2. fixes copy for deleting adapter: RAUT-645
3. fixes moving a labware on top of the adapter: RAUT-642
4. add labware and location names to error string and dropdown option in Move Labware form: RAUT-621

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_adapter-split-touchups/

Verify that each of the items mentioned in the ticket works:
 1. make a protocol and add labware on top of module, on the deck and on top of adapter. It should have correct copy of either `add adapter`, `add labware` or `add adapter and labware`
 2. delete an adapter from the deck, check the copy of the confirm deletion modal
 3. add a move labware command of moving a labware on/off an adapter. it should work as expected and render on the deck correctly
 4. if you move a labware to a new position that is not compatible, make sure the error string mentions the labware and the new location


# Changelog

- added logic for string for adding labware/adapter 
- in `LabwareLocationField`, added logic for the error string
- wired up the labwareId in newLocation in `forMoveLabware`

# Review requests

see test plan

# Risk assessment

low