### PR TITLE
fix(api): 96 channel load name bug

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
 from opentrons.types import Mount, Location, DeckLocation, DeckSlotName
 from opentrons.broker import Broker
@@ -41,7 +42,6 @@ from .core.module import (
     AbstractMagneticBlockCore,
 )
 from .core.engine import ENGINE_CORE_API_VERSION
-from .core.engine.protocol import ProtocolCore as ProtocolEngineCore
 from .core.legacy.legacy_protocol_core import LegacyProtocolCore
 
 from . import validation
@@ -757,13 +757,10 @@ class ProtocolContext(CommandPublisher):
                              replaced by `instrument_name`.
         """
         instrument_name = validation.ensure_lowercase_name(instrument_name)
-        is_96_channel = instrument_name in ("p1000_96", "flex_96channel_1000")
-        if is_96_channel and isinstance(self._core, ProtocolEngineCore):
-            checked_instrument_name = instrument_name
-            checked_mount = Mount.LEFT
-        else:
-            checked_instrument_name = validation.ensure_pipette_name(instrument_name)
-            checked_mount = validation.ensure_mount(mount)
+        checked_instrument_name = validation.ensure_pipette_name(instrument_name)
+        is_96_channel = checked_instrument_name == PipetteNameType.P1000_96
+
+        checked_mount = Mount.LEFT if is_96_channel else validation.ensure_mount(mount)
 
         tip_racks = tip_racks or []
 
@@ -782,7 +779,7 @@ class ProtocolContext(CommandPublisher):
         # TODO (tz, 11-22-22): was added to support 96 channel pipette.
         #  Should remove when working on https://opentrons.atlassian.net/browse/RLIQ-255
         instrument_core = self._core.load_instrument(
-            instrument_name=checked_instrument_name,  # type: ignore[arg-type]
+            instrument_name=checked_instrument_name,
             mount=checked_mount,
         )
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -756,6 +756,7 @@ class ProtocolContext(CommandPublisher):
                              `mount` (if such an instrument exists) should be
                              replaced by `instrument_name`.
         """
+        # TODO (spp: 2023-08-30): disallow loading Flex pipettes on OT-2 by checking robotType
         instrument_name = validation.ensure_lowercase_name(instrument_name)
         checked_instrument_name = validation.ensure_pipette_name(instrument_name)
         is_96_channel = checked_instrument_name == PipetteNameType.P1000_96

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -131,7 +131,7 @@ def test_load_instrument(
     mock_core: ProtocolCore,
     subject: ProtocolContext,
 ) -> None:
-    """It should create a instrument using its execution core."""
+    """It should create an instrument using its execution core."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
     mock_tip_racks = [decoy.mock(cls=Labware), decoy.mock(cls=Labware)]
 
@@ -204,6 +204,33 @@ def test_load_instrument_replace(
 
     with pytest.raises(RuntimeError, match="Instrument already present"):
         subject.load_instrument(instrument_name="ada", mount=Mount.RIGHT)
+
+
+def test_96_channel_pipette_always_loads_on_the_left_mount(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should always load a 96-channel pipette on left mount, regardless of the mount arg specified."""
+    mock_instrument_core = decoy.mock(cls=InstrumentCore)
+
+    decoy.when(mock_validation.ensure_lowercase_name("A 96 Channel Name")).then_return(
+        "a 96 channel name"
+    )
+    decoy.when(mock_validation.ensure_pipette_name("a 96 channel name")).then_return(
+        PipetteNameType.P1000_96
+    )
+    decoy.when(
+        mock_core.load_instrument(
+            instrument_name=PipetteNameType.P1000_96,
+            mount=Mount.LEFT,
+        )
+    ).then_return(mock_instrument_core)
+
+    result = subject.load_instrument(
+        instrument_name="A 96 Channel Name", mount="shadowfax"
+    )
+    assert result == subject.loaded_instruments["left"]
 
 
 def test_load_labware(


### PR DESCRIPTION
# Overview

Fixes a bug in `load_instruments` which was not recognizing the official load name of the 96 channel pipette- 'flex_96channel_1000'

# Test Plan

Test that a protocol that loads the 96 channel with either-
`protocol_context.load_instrument("flex_1channel_50", "left")`
or 
`protocol_context.load_instrument("p1000_96", "left")`  

loads the 96 channel correctly. 
(Note: `p1000_96` is only supported for backwards compatibility of internal test protocols)

# Changelog

- included 96 channel in pipette name validation and conversion too

# Review requests

- check that changes look good and that this works correctly

# Risk assessment

Low.
