### PR TITLE
refactor(protocol-designer): OT-2 module default selection set module…

### DIFF
--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -58,7 +58,6 @@ export interface ModuleFieldsProps {
       }
   values: FormModulesByType
   onFieldChange: (event: React.ChangeEvent) => unknown
-  onSetFieldValue: (field: string, value: string | null) => void
   onSetFieldTouched: (field: string, touched: boolean) => void
   onBlur: (event: React.FocusEvent<HTMLSelectElement>) => unknown
 }
@@ -66,7 +65,6 @@ export interface ModuleFieldsProps {
 export function ModuleFields(props: ModuleFieldsProps): JSX.Element {
   const {
     onFieldChange,
-    onSetFieldValue,
     onSetFieldTouched,
     onBlur,
     values,
@@ -81,15 +79,7 @@ export function ModuleFields(props: ModuleFieldsProps): JSX.Element {
   )
   const handleOnDeckChange = (type: ModuleType) => (e: React.ChangeEvent) => {
     const targetToClear = `modulesByType.${type}.model`
-
     onFieldChange(e)
-
-    if (
-      targetToClear !== 'modulesByType.thermocyclerModuleType.model' &&
-      targetToClear !== 'modulesByType.heaterShakerModuleType.model'
-    ) {
-      onSetFieldValue(targetToClear, null)
-    }
     onSetFieldTouched(targetToClear, false)
   }
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/ModuleFields.test.tsx
@@ -65,7 +65,6 @@ describe('ModuleFields', () => {
         [MAGNETIC_BLOCK_TYPE]: magneticBlockNotOnDeck,
       },
       onFieldChange: jest.fn(),
-      onSetFieldValue: jest.fn(),
       onSetFieldTouched: jest.fn(),
       onBlur: jest.fn(),
       touched: null,
@@ -105,7 +104,6 @@ describe('ModuleFields', () => {
     temperatureSelectChange(expectedEvent)
 
     expect(props.onFieldChange).toHaveBeenCalledWith(expectedEvent)
-    expect(props.onSetFieldValue).toHaveBeenCalledWith(targetToClear, null)
     expect(props.onSetFieldTouched).toHaveBeenCalledWith(targetToClear, false)
   })
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -434,7 +434,6 @@ export class FilePipettesModal extends React.Component<Props, State> {
                             errors={errors.modulesByType ?? null}
                             values={values.modulesByType}
                             onFieldChange={handleChange}
-                            onSetFieldValue={setFieldValue}
                             onBlur={handleBlur}
                             // @ts-expect-error(sa, 2021-7-2): we need to explicitly check that the module model inside of modulesByType exists, because it could be undefined
                             touched={touched.modulesByType ?? null}


### PR DESCRIPTION
… model

closes RAUT-649

# Overview

As outlined in the ticket, you get a white screen on the design tab when you add a temperature or magnetic module to an OT-2 protocol with the default model. This is because on click, we were deleting the model for some reason (this is a legacy component so idk why we needed to have that functionality to begin with). Anyway, this PR fixes that.

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_ot2-module-selection-bug-fix/

Go through the create wizard for an OT-2 protocol, when you get to the Modules page, add a temperature module or magnetic module and keep the default model that is selected. Click the continue button to create the protocol. Then click on the design tab to the left. You should not see a white screen and should work as expected

# Changelog

- delete the `onSetFieldValue(targetToClear, null)` in `handleOnDeckChange` and delete unneeded code in the tests and parent components

# Review requests

see test plan

# Risk assessment

low