### PR TITLE
fix(app): fix improper capitalization of µL in labware overlays in protocol setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -32,6 +32,10 @@ interface LabwareInfoProps {
 }
 
 const labwareDisplayNameStyle = css`
+  font-size: ${TYPOGRAPHY.fontSizeH6};
+  font-weight: ${TYPOGRAPHY.fontWeightRegular};
+  line-height: ${TYPOGRAPHY.lineHeight12};
+  text-transform: none;
   overflow: hidden;
   white-space: initial;
   text-overflow: ellipsis;
@@ -61,7 +65,6 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
       >
         <StyledText
           as="h6"
-          lineHeight={TYPOGRAPHY.fontSizeCaption}
           css={labwareDisplayNameStyle}
           title={definitionDisplayName}
         >
@@ -75,7 +78,6 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
         <>
           <StyledText
             as="h6"
-            lineHeight={TYPOGRAPHY.fontSizeCaption}
             fontWeight={TYPOGRAPHY.fontWeightSemiBold}
             textTransform="uppercase"
           >

--- a/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -32,9 +32,6 @@ interface LabwareInfoProps {
 }
 
 const labwareDisplayNameStyle = css`
-  font-size: ${TYPOGRAPHY.fontSizeH6};
-  font-weight: ${TYPOGRAPHY.fontWeightRegular};
-  line-height: ${TYPOGRAPHY.lineHeight12};
   text-transform: none;
   overflow: hidden;
   white-space: initial;


### PR DESCRIPTION
# Overview

Remove cast to uppercase from labware overlays in labware and liquid setup steps. It reads more cleanly, and avoids bug where we capitalize "µ" to "M" confusing micro and milli

Closes RAUT-354

# Review requests

- confirm that the labware labels in the map view of labware and liquid setup steps appear correctly (properly capitalized)

# Risk assessment
low
