### PR TITLE
feat(app): ability to sort protocols via flex or ot-2

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -74,6 +74,7 @@
   "rerunning_protocol_modal_link": "Learn more about Labware Offset Data",
   "rerunning_protocol_modal_title": "See How Rerunning a Protocol Works",
   "robot_name_last_run": "{{robot_name}}’s last run",
+  "robot_type_first": "{{robotType}} protocols first",
   "run_again": "Run again",
   "run_protocol": "Run protocol",
   "run_timestamp_title": "Run timestamp",

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -49,7 +49,8 @@ const SORT_BY_BUTTON_STYLE = css`
     background-color: ${COLORS.medGreyEnabled};
   }
 `
-
+const FLEX = 'Flex'
+const OT2 = 'OT-2'
 interface ProtocolListProps {
   storedProtocols: StoredProtocolData[]
 }
@@ -106,6 +107,12 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
     },
     oldest: {
       label: t('oldest_updates'),
+    },
+    flex: {
+      label: t('robot_type_first', { robotType: FLEX }),
+    },
+    ot2: {
+      label: t('robot_type_first', { robotType: OT2 }),
     },
   }
 
@@ -196,14 +203,20 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
               <MenuItem onClick={() => handleProtocolsSortKey('alphabetical')}>
                 {t('shared:alphabetical')}
               </MenuItem>
+              <MenuItem onClick={() => handleProtocolsSortKey('flex')}>
+                {t('robot_type_first', { robotType: FLEX })}
+              </MenuItem>
               <MenuItem onClick={() => handleProtocolsSortKey('recent')}>
                 {t('most_recent_updates')}
               </MenuItem>
-              <MenuItem onClick={() => handleProtocolsSortKey('reverse')}>
-                {t('shared:reverse')}
-              </MenuItem>
               <MenuItem onClick={() => handleProtocolsSortKey('oldest')}>
                 {t('oldest_updates')}
+              </MenuItem>
+              <MenuItem onClick={() => handleProtocolsSortKey('ot2')}>
+                {t('robot_type_first', { robotType: OT2 })}
+              </MenuItem>
+              <MenuItem onClick={() => handleProtocolsSortKey('reverse')}>
+                {t('shared:reverse')}
               </MenuItem>
             </Flex>
           )}

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -203,8 +203,8 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
               <MenuItem onClick={() => handleProtocolsSortKey('alphabetical')}>
                 {t('shared:alphabetical')}
               </MenuItem>
-              <MenuItem onClick={() => handleProtocolsSortKey('flex')}>
-                {t('robot_type_first', { robotType: FLEX })}
+              <MenuItem onClick={() => handleProtocolsSortKey('reverse')}>
+                {t('shared:reverse')}
               </MenuItem>
               <MenuItem onClick={() => handleProtocolsSortKey('recent')}>
                 {t('most_recent_updates')}
@@ -212,11 +212,11 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
               <MenuItem onClick={() => handleProtocolsSortKey('oldest')}>
                 {t('oldest_updates')}
               </MenuItem>
+              <MenuItem onClick={() => handleProtocolsSortKey('flex')}>
+                {t('robot_type_first', { robotType: FLEX })}
+              </MenuItem>
               <MenuItem onClick={() => handleProtocolsSortKey('ot2')}>
                 {t('robot_type_first', { robotType: OT2 })}
-              </MenuItem>
-              <MenuItem onClick={() => handleProtocolsSortKey('reverse')}>
-                {t('shared:reverse')}
               </MenuItem>
             </Flex>
           )}

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolList.test.tsx
@@ -155,4 +155,22 @@ describe('ProtocolList', () => {
     const { getByText } = render(props)
     getByText('Oldest updates')
   })
+
+  it('renders Flex as the sort key when flex was selected last time', () => {
+    when(mockUseSortedProtocols)
+      .calledWith('flex', [storedProtocolData, storedProtocolDataTwo])
+      .mockReturnValue([storedProtocolData, storedProtocolDataTwo])
+    when(mockGetProtocolsDesktopSortKey).mockReturnValue('flex')
+    const { getByText } = render(props)
+    getByText('Flex protocols first')
+  })
+
+  it('renders ot2 as the sort key when ot2 was selected last time', () => {
+    when(mockUseSortedProtocols)
+      .calledWith('ot2', [storedProtocolData, storedProtocolDataTwo])
+      .mockReturnValue([storedProtocolData, storedProtocolDataTwo])
+    when(mockGetProtocolsDesktopSortKey).mockReturnValue('ot2')
+    const { getByText } = render(props)
+    getByText('OT-2 protocols first')
+  })
 })

--- a/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import { renderHook } from '@testing-library/react-hooks'
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { useSortedProtocols } from '../hooks'
 import { StoredProtocolData } from '../../../redux/protocol-storage'
 
 import type { Store } from 'redux'
-import type { State } from '../../../redux/types'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
+import type { State } from '../../../redux/types'
 
 const mockStoredProtocolData = [
   {
@@ -17,6 +18,7 @@ const mockStoredProtocolData = [
     srcFileNames: ['secondProtocol.json'],
     srcFiles: [],
     mostRecentAnalysis: {
+      robotType: FLEX_ROBOT_TYPE,
       createdAt: '2022-05-03T21:36:12.494778+00:00',
       files: [
         {
@@ -102,6 +104,7 @@ const mockStoredProtocolData = [
     srcFileNames: ['testProtocol.json'],
     srcFiles: [],
     mostRecentAnalysis: {
+      robotType: OT2_ROBOT_TYPE,
       createdAt: '2022-05-10T17:04:43.132768+00:00',
       files: [
         {
@@ -375,6 +378,53 @@ describe('useSortedProtocols', () => {
     )
     expect(thirdProtocol.protocolKey).toBe(
       '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+  })
+
+  it('should return an object with protocols sorted by flex then ot-2', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    const { result } = renderHook(
+      () => useSortedProtocols('flex', mockStoredProtocolData),
+      { wrapper }
+    )
+    const firstProtocol = result.current[0]
+    const secondProtocol = result.current[1]
+    const thirdProtocol = result.current[2]
+
+    expect(firstProtocol.protocolKey).toBe(
+      '26ed5a82-502f-4074-8981-57cdda1d066d'
+    )
+    expect(secondProtocol.protocolKey).toBe(
+      '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+    expect(thirdProtocol.protocolKey).toBe(
+      'f130337e-68ad-4b5d-a6d2-cbc20515b1f7'
+    )
+  })
+  it('should return an object with protocols sorted by ot-2 then flex', () => {
+    const wrapper: React.FunctionComponent<{}> = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    const { result } = renderHook(
+      () => useSortedProtocols('ot2', mockStoredProtocolData),
+      { wrapper }
+    )
+    const firstProtocol = result.current[0]
+    const secondProtocol = result.current[1]
+    const thirdProtocol = result.current[2]
+
+    expect(firstProtocol.protocolKey).toBe(
+      '3dc99ffa-f85e-4c01-ab0a-edecff432dac'
+    )
+    expect(secondProtocol.protocolKey).toBe(
+      'f130337e-68ad-4b5d-a6d2-cbc20515b1f7'
+    )
+    expect(thirdProtocol.protocolKey).toBe(
+      '26ed5a82-502f-4074-8981-57cdda1d066d'
     )
   })
 })

--- a/app/src/organisms/ProtocolsLanding/hooks.tsx
+++ b/app/src/organisms/ProtocolsLanding/hooks.tsx
@@ -1,7 +1,14 @@
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { StoredProtocolData } from '../../redux/protocol-storage'
 import { getProtocolDisplayName } from './utils'
 
-export type ProtocolSort = 'alphabetical' | 'reverse' | 'recent' | 'oldest'
+export type ProtocolSort =
+  | 'alphabetical'
+  | 'reverse'
+  | 'recent'
+  | 'oldest'
+  | 'flex'
+  | 'ot2'
 
 export function useSortedProtocols(
   sortBy: ProtocolSort,
@@ -18,6 +25,8 @@ export function useSortedProtocols(
       b.srcFileNames,
       b?.mostRecentAnalysis
     )
+    const protocolRobotTypeA = a?.mostRecentAnalysis?.robotType
+    const protocolRobotTypeB = b?.mostRecentAnalysis?.robotType
 
     if (sortBy === 'alphabetical') {
       if (protocolNameA.toLowerCase() === protocolNameB.toLowerCase()) {
@@ -30,6 +39,34 @@ export function useSortedProtocols(
       return b.modified - a.modified
     } else if (sortBy === 'oldest') {
       return a.modified - b.modified
+    } else if (sortBy === 'flex') {
+      if (
+        protocolRobotTypeA === FLEX_ROBOT_TYPE &&
+        protocolRobotTypeB !== FLEX_ROBOT_TYPE
+      ) {
+        return -1
+      }
+      if (
+        protocolRobotTypeA !== FLEX_ROBOT_TYPE &&
+        protocolRobotTypeB === FLEX_ROBOT_TYPE
+      ) {
+        return 1
+      }
+      return b.modified - a.modified
+    } else if (sortBy === 'ot2') {
+      if (
+        protocolRobotTypeA !== FLEX_ROBOT_TYPE &&
+        protocolRobotTypeB === FLEX_ROBOT_TYPE
+      ) {
+        return -1
+      }
+      if (
+        protocolRobotTypeA === FLEX_ROBOT_TYPE &&
+        protocolRobotTypeB !== FLEX_ROBOT_TYPE
+      ) {
+        return 1
+      }
+      return b.modified - a.modified
     }
     return 0
   })


### PR DESCRIPTION
closes RQA-1037

# Overview

Adds ability to sort protocols with Flex protocols first or OT-2 protocols first. And also they sort through most recently added (Flex most recently added -> Ot-2 most recently added)

# Test Plan

Check on the desktop app, look at the sortBy dropdown and see the `Flex protocols first` and `OT-2 protocols first`. Make sure they work as expected. Dropdown options should be alphabetical

# Changelog

- add options and logic to `useSortedProtocols` and `ProtocolList`, add test coverage

# Review requests

see test plan

# Risk assessment

low