### PR TITLE
chore(api): remove spammy log

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -607,10 +607,8 @@ class OT3API(
         and set up hardware controller internal state if necessary.
         """
         skip_configure = await self._cache_instruments(require)
-        self._log.info(
-            f"Instrument model cache updated, skip configure: {skip_configure}"
-        )
         if not skip_configure:
+            self._log.info("Instrument model cache updated, reconfiguring")
             await self._configure_instruments()
 
     async def _cache_instruments(  # noqa: C901


### PR DESCRIPTION
This happens a _lot_ now and it is meaningless most of the time so only log when it's meaningful.
