### PR TITLE
fix(api): base plunger speeds on working volume

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -125,15 +125,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             pip_types.PipetteTipType(self._liquid_class.max_volume)
         ]
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
-        self._aspirate_flow_rates_lookup = (
-            self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
-        )
-        self._dispense_flow_rates_lookup = (
-            self._active_tip_settings.default_dispense_flowrate.values_by_api_level
-        )
-        self._blowout_flow_rates_lookup = (
-            self._active_tip_settings.default_blowout_flowrate.values_by_api_level
-        )
+
         self._aspirate_flow_rate = (
             self._active_tip_settings.default_aspirate_flowrate.default
         )
@@ -426,15 +418,15 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
 
     @property
     def aspirate_flow_rates_lookup(self) -> Dict[str, float]:
-        return self._aspirate_flow_rates_lookup
+        return self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
 
     @property
     def dispense_flow_rates_lookup(self) -> Dict[str, float]:
-        return self._dispense_flow_rates_lookup
+        return self._active_tip_settings.default_dispense_flowrate.values_by_api_level
 
     @property
     def blow_out_flow_rates_lookup(self) -> Dict[str, float]:
-        return self._blowout_flow_rates_lookup
+        return self.active_tip_settings.default_blowout_flowrate.values_by_api_level
 
     @property
     def working_volume(self) -> float:
@@ -545,9 +537,9 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
                 "aspirate_flow_rate": self.aspirate_flow_rate,
                 "dispense_flow_rate": self.dispense_flow_rate,
                 "blow_out_flow_rate": self.blow_out_flow_rate,
-                "default_aspirate_flow_rates": self.active_tip_settings.default_aspirate_flowrate.values_by_api_level,
-                "default_blow_out_flow_rates": self.active_tip_settings.default_blowout_flowrate.values_by_api_level,
-                "default_dispense_flow_rates": self.active_tip_settings.default_dispense_flowrate.values_by_api_level,
+                "default_aspirate_flow_rates": self.aspirate_flow_rates_lookup,
+                "default_blow_out_flow_rates": self.blow_out_flow_rates_lookup,
+                "default_dispense_flow_rates": self.dispense_flow_rates_lookup,
                 "tip_length": self.current_tip_length,
                 "return_tip_height": self.active_tip_settings.default_return_tip_height,
                 "tip_overlap": self.tip_overlap,

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -451,13 +451,13 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plunger_speed(
         self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.working_volume, action)
+        mm_per_s = ul_per_s / instr.ul_per_mm(instr.liquid_class.max_volume, action)
         return round(mm_per_s, 6)
 
     def plunger_flowrate(
         self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.working_volume, action)
+        ul_per_s = mm_per_s * instr.ul_per_mm(instr.liquid_class.max_volume, action)
         return round(ul_per_s, 6)
 
     @overload
@@ -698,7 +698,6 @@ class PipetteHandlerProvider(Generic[MountType]):
         presses,
         increment,
     ):
-
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)
         if instrument.has_tip:

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -451,13 +451,13 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plunger_speed(
         self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.liquid_class.max_volume, action)
+        mm_per_s = ul_per_s / instr.ul_per_mm(instr.working_volume, action)
         return round(mm_per_s, 6)
 
     def plunger_flowrate(
         self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.liquid_class.max_volume, action)
+        ul_per_s = mm_per_s * instr.ul_per_mm(instr.working_volume, action)
         return round(ul_per_s, 6)
 
     @overload

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -111,16 +111,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         ]
         self._fallback_tip_length = self._active_tip_settings.default_tip_length
 
-        self._aspirate_flow_rates_lookup = (
-            self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
-        )
-        self._dispense_flow_rates_lookup = (
-            self._active_tip_settings.default_dispense_flowrate.values_by_api_level
-        )
-        self._blowout_flow_rates_lookup = (
-            self._active_tip_settings.default_blowout_flowrate.values_by_api_level
-        )
-
         self._aspirate_flow_rate = (
             self._active_tip_settings.default_aspirate_flowrate.default
         )
@@ -426,15 +416,15 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
 
     @property
     def aspirate_flow_rates_lookup(self) -> Dict[str, float]:
-        return self._aspirate_flow_rates_lookup
+        return self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
 
     @property
     def dispense_flow_rates_lookup(self) -> Dict[str, float]:
-        return self._dispense_flow_rates_lookup
+        return self._active_tip_settings.default_dispense_flowrate.values_by_api_level
 
     @property
     def blow_out_flow_rates_lookup(self) -> Dict[str, float]:
-        return self._blowout_flow_rates_lookup
+        return self._active_tip_settings.default_blowout_flowrate.values_by_api_level
 
     @property
     def working_volume(self) -> float:
@@ -550,9 +540,9 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
                 "dispense_flow_rate": self.dispense_flow_rate,
                 "blow_out_flow_rate": self.blow_out_flow_rate,
                 "flow_acceleration": self.flow_acceleration,
-                "default_aspirate_flow_rates": self.active_tip_settings.default_aspirate_flowrate.values_by_api_level,
-                "default_blow_out_flow_rates": self.active_tip_settings.default_blowout_flowrate.values_by_api_level,
-                "default_dispense_flow_rates": self.active_tip_settings.default_dispense_flowrate.values_by_api_level,
+                "default_aspirate_flow_rates": self.aspirate_flow_rates_lookup,
+                "default_blow_out_flow_rates": self.blow_out_flow_rates_lookup,
+                "default_dispense_flow_rates": self.dispense_flow_rates_lookup,
                 "default_flow_acceleration": self.active_tip_settings.default_flow_acceleration,
                 "tip_length": self.current_tip_length,
                 "return_tip_height": self.active_tip_settings.default_return_tip_height,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -466,13 +466,13 @@ class PipetteHandlerProvider:
     def plunger_speed(
         self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        mm_per_s = ul_per_s / instr.ul_per_mm(instr.liquid_class.max_volume, action)
+        mm_per_s = ul_per_s / instr.ul_per_mm(instr.working_volume, action)
         return round(mm_per_s, 6)
 
     def plunger_flowrate(
         self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
     ) -> float:
-        ul_per_s = mm_per_s * instr.ul_per_mm(instr.liquid_class.max_volume, action)
+        ul_per_s = mm_per_s * instr.ul_per_mm(instr.working_volume, action)
         return round(ul_per_s, 6)
 
     def plunger_acceleration(self, instr: Pipette, ul_per_s_per_s: float) -> float:

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -32,7 +32,7 @@ def dummy_instruments_attached():
             "id": None,
             "name": None,
         },
-    }
+    }, 10
 
 
 @pytest.fixture
@@ -49,7 +49,7 @@ def dummy_instruments_attached_ot3():
         },
         types.Mount.RIGHT: {"model": None, "id": None, "name": None},
         OT3Mount.GRIPPER: None,
-    }
+    }, 200
 
 
 @pytest.fixture
@@ -123,7 +123,7 @@ def get_plunger_speed(api):
 
 
 async def test_cache_instruments(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, _) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -137,7 +137,7 @@ async def test_cache_instruments(sim_and_instr):
 
 
 async def test_mismatch_fails(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, _) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -149,10 +149,8 @@ async def test_mismatch_fails(sim_and_instr):
         await hw_api.cache_instruments(requested_instr)
 
 
-@pytest.mark.ot2_only
-async def test_backwards_compatibility(dummy_backwards_compatibility, sim_and_instr):
-    sim_builder, _ = sim_and_instr
-    hw_api = await sim_builder(
+async def test_backwards_compatibility(dummy_backwards_compatibility):
+    hw_api = await API.build_hardware_simulator(
         attached_instruments=dummy_backwards_compatibility,
         loop=asyncio.get_running_loop(),
     )
@@ -217,7 +215,7 @@ async def test_cache_instruments_hc(
 
 @pytest.mark.ot2_only
 async def test_cache_instruments_sim(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, _) = sim_and_instr
 
     def fake_func1(value):
         return value
@@ -305,7 +303,7 @@ async def test_cache_instruments_sim(sim_and_instr):
 
 
 async def test_prep_aspirate(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, dummy_tip_vol) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -314,6 +312,7 @@ async def test_prep_aspirate(sim_and_instr):
 
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
+    hw_api.set_working_volume(mount, dummy_tip_vol)
     # If we just picked up a new tip, we should be fine
     await hw_api.aspirate(mount, 1)
 
@@ -330,19 +329,20 @@ async def test_prep_aspirate(sim_and_instr):
     # If we don't prep_after, we should still be fine
     await hw_api.drop_tip(mount)
     await hw_api.pick_up_tip(mount, 20.0, prep_after=False)
+    hw_api.set_working_volume(mount, dummy_tip_vol)
     await hw_api.aspirate(mount, 1, 1.0)
 
 
 async def test_aspirate_new(dummy_instruments):
     hw_api = await API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
+        attached_instruments=dummy_instruments[0], loop=asyncio.get_running_loop()
     )
     await hw_api.home()
     await hw_api.cache_instruments()
 
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
-
+    hw_api.set_working_volume(mount, 10)
     aspirate_ul = 3.0
     aspirate_rate = 2
     await hw_api.prepare_for_aspirate(mount)
@@ -356,14 +356,14 @@ async def test_aspirate_old(decoy: Decoy, mock_feature_flags: None, dummy_instru
     decoy.when(config.feature_flags.use_old_aspiration_functions()).then_return(True)
 
     hw_api = await API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
+        attached_instruments=dummy_instruments[0], loop=asyncio.get_running_loop()
     )
     await hw_api.home()
     await hw_api.cache_instruments()
 
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
-
+    hw_api.set_working_volume(mount, 10)
     aspirate_ul = 3.0
     aspirate_rate = 2
     await hw_api.prepare_for_aspirate(mount)
@@ -375,26 +375,26 @@ async def test_aspirate_old(decoy: Decoy, mock_feature_flags: None, dummy_instru
 
 async def test_aspirate_ot3(dummy_instruments_ot3, ot3_api_obj):
     hw_api = await ot3_api_obj(
-        attached_instruments=dummy_instruments_ot3, loop=asyncio.get_running_loop()
+        attached_instruments=dummy_instruments_ot3[0], loop=asyncio.get_running_loop()
     )
     await hw_api.home()
     await hw_api.cache_instruments()
 
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
-
+    hw_api.set_working_volume(mount, 50)
     aspirate_ul = 3.0
     aspirate_rate = 2
     await hw_api.prepare_for_aspirate(mount)
     await hw_api.aspirate(mount, aspirate_ul, aspirate_rate)
-    new_plunger_pos = 71.212208
+    new_plunger_pos = 71.1968
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(new_plunger_pos)
 
 
 async def test_dispense_ot2(dummy_instruments):
     hw_api = await API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
+        attached_instruments=dummy_instruments[0], loop=asyncio.get_running_loop()
     )
     await hw_api.home()
 
@@ -402,6 +402,7 @@ async def test_dispense_ot2(dummy_instruments):
 
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
+    hw_api.set_working_volume(mount, 10)
 
     aspirate_ul = 10.0
     aspirate_rate = 2
@@ -420,7 +421,7 @@ async def test_dispense_ot2(dummy_instruments):
 
 async def test_dispense_ot3(dummy_instruments_ot3, ot3_api_obj):
     hw_api = await ot3_api_obj(
-        attached_instruments=dummy_instruments_ot3, loop=asyncio.get_running_loop()
+        attached_instruments=dummy_instruments_ot3[0], loop=asyncio.get_running_loop()
     )
     await hw_api.home()
 
@@ -428,7 +429,7 @@ async def test_dispense_ot3(dummy_instruments_ot3, ot3_api_obj):
 
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
-
+    hw_api.set_working_volume(mount, 50)
     aspirate_ul = 10.0
     aspirate_rate = 2
     await hw_api.prepare_for_aspirate(mount)
@@ -436,7 +437,7 @@ async def test_dispense_ot3(dummy_instruments_ot3, ot3_api_obj):
 
     dispense_1 = 3.0
     await hw_api.dispense(mount, dispense_1)
-    plunger_pos_1 = 70.92099
+    plunger_pos_1 = 70.938414
     assert (await hw_api.current_position(mount))[Axis.B] == pytest.approx(
         plunger_pos_1
     )
@@ -449,7 +450,7 @@ async def test_dispense_ot3(dummy_instruments_ot3, ot3_api_obj):
 
 
 async def test_no_pipette(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, _) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -462,7 +463,7 @@ async def test_no_pipette(sim_and_instr):
 
 
 async def test_pick_up_tip(is_robot, sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, _) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -483,7 +484,7 @@ async def test_pick_up_tip(is_robot, sim_and_instr):
 
 async def test_pick_up_tip_pos_ot2(is_robot, dummy_instruments):
     hw_api = await API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
+        attached_instruments=dummy_instruments[0], loop=asyncio.get_running_loop()
     )
     mount = types.Mount.LEFT
     await hw_api.home()
@@ -520,7 +521,7 @@ def assert_move_called(mock_move, speed, lock=None):
 
 
 async def test_aspirate_flow_rate(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, tip_vol) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -529,6 +530,7 @@ async def test_aspirate_flow_rate(sim_and_instr):
     await hw_api.cache_instruments()
 
     await hw_api.pick_up_tip(mount, 20.0)
+    hw_api.set_working_volume(mount, tip_vol)
 
     pip = hw_api.hardware_instruments[mount]
     with mock.patch.object(hw_api, "_move") as mock_move:
@@ -577,7 +579,7 @@ async def test_aspirate_flow_rate(sim_and_instr):
 
 
 async def test_dispense_flow_rate(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, tip_vol) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -586,6 +588,7 @@ async def test_dispense_flow_rate(sim_and_instr):
     await hw_api.cache_instruments()
 
     await hw_api.pick_up_tip(mount, 20.0)
+    hw_api.set_working_volume(mount, tip_vol)
 
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(mount, 10)
@@ -632,7 +635,7 @@ async def test_dispense_flow_rate(sim_and_instr):
 
 
 async def test_blowout_flow_rate(sim_and_instr):
-    sim_builder, dummy_instruments = sim_and_instr
+    sim_builder, (dummy_instruments, tip_vol) = sim_and_instr
     hw_api = await sim_builder(
         attached_instruments=dummy_instruments, loop=asyncio.get_running_loop()
     )
@@ -641,6 +644,7 @@ async def test_blowout_flow_rate(sim_and_instr):
     await hw_api.cache_instruments()
 
     await hw_api.pick_up_tip(mount, 20.0)
+    hw_api.set_working_volume(mount, tip_vol)
 
     pip = hw_api.hardware_instruments[mount]
 


### PR DESCRIPTION
When 62962c599b8b71bccc4c6b18a59a798f8b8989a3 added "liquid classes", we had to change the way we look up various volumes, and we used the liquid class max volume as the volume to look up ul/mm transforms for determining speeds. The thing is, the liquid class max volume didn't depend on the tip type, but the ul/mm transform did - so if you were using a 50ul tip on a p1000, you'd try and get the ul/mm for 1000ul on a 50ul tip and get an error.

We can use the working volume instead, which is the maximum volume of the tip, and fix this up but I think we need a better fix for this that moves volume constraints into tip definitions.

This change is only for the flex, for two reasons. First, the per-tip configurations on the OT-2 have ul/mm tables that go up to the pipette max volume on all tips, so it's not needed; and second, this change would actually (extremely slightly) change the flowrates on the non-default tips on old api versions, so we can't do it.

## Review requests
- does this look right? It feels a bit awkward, `working_volume` is this sort of weird add-on from the gen2 pipette days and I think we need to promote max and min volumes to properties of tips

## Testing and risk

This is in pretty core code, but it's also fixing a straightforward bug. We should run a protocol that uses various kinds of tips - i.e. 200ul tips on a 1000, other stuff like that - and check that (a) we don't get exceptions and (b) the flow rates match the configs.

Did the test and it all looks good.