### PR TITLE
fix(robot-server,system-server): Make SQL transactions behave sanely

### DIFF
--- a/robot-server/robot_server/persistence/_database.py
+++ b/robot-server/robot_server/persistence/_database.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import sqlalchemy
 
+from server_utils import sql_utils
+
 from ._tables import add_tables_to_db
 from ._migrations import migrate
 
@@ -29,46 +31,16 @@ def create_sql_engine(path: Path) -> sqlalchemy.engine.Engine:
         Migrations can take several minutes. If calling this from an async function,
         offload this to a thread to avoid blocking the event loop.
     """
-    sql_engine = _open_db_no_cleanup(db_file_path=path)
+    sql_engine = sqlalchemy.create_engine(sql_utils.get_connection_url(path))
 
     try:
+        sql_utils.enable_foreign_key_constraints(sql_engine)
+        sql_utils.fix_transactions(sql_engine)
         add_tables_to_db(sql_engine)
         migrate(sql_engine)
+
     except Exception:
         sql_engine.dispose()
         raise
 
     return sql_engine
-
-
-def _open_db_no_cleanup(db_file_path: Path) -> sqlalchemy.engine.Engine:
-    """Create a database engine for performing transactions."""
-    engine = sqlalchemy.create_engine(
-        # sqlite://<hostname>/<path>
-        # where <hostname> is empty.
-        f"sqlite:///{db_file_path}",
-    )
-
-    # Enable foreign key support in sqlite
-    # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
-    @sqlalchemy.event.listens_for(engine, "connect")  # type: ignore[misc]
-    def _set_sqlite_pragma(
-        dbapi_connection: sqlalchemy.engine.CursorResult,
-        connection_record: sqlalchemy.engine.CursorResult,
-    ) -> None:
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON;")
-        cursor.close()
-
-    @sqlalchemy.event.listens_for(engine, "connect")  # type: ignore[misc]
-    def do_connect(dbapi_connection, connection_record):
-        # disable pysqlite's emitting of the BEGIN statement entirely.
-        # also stops it from emitting COMMIT before any DDL.
-        dbapi_connection.isolation_level = None
-
-    @sqlalchemy.event.listens_for(engine, "begin")  # type: ignore[misc]
-    def do_begin(conn):
-        # emit our own BEGIN
-        conn.exec_driver_sql("BEGIN")
-
-    return engine

--- a/server-utils/server_utils/sql_utils.py
+++ b/server-utils/server_utils/sql_utils.py
@@ -1,0 +1,76 @@
+"""Utilities for working with SQLite databases through SQLAlchemy."""
+
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy
+
+
+def get_connection_url(db_file_path: Path) -> str:
+    """Return a connection URL to pass to `sqlalchemy.create_engine()`.
+
+    Params:
+        db_file_path: The path to the SQLite database file to open.
+        (This file often has an extension like .db, .sqlite, or .sqlite3.)
+    """
+    # sqlite://<hostname>/<path>
+    # where <hostname> is empty.
+    return f"sqlite:///{db_file_path}"
+
+
+def enable_foreign_key_constraints(engine: sqlalchemy.engine.Engine) -> None:
+    """Enable SQLite's enforcement of foreign key constraints.
+
+    SQLite does not enforce foreign key constraints by default, for backwards compatibility.
+
+    This should be called once per SQLAlchemy engine, shortly after creating it,
+    before doing anything substantial with it.
+
+    Params:
+        engine: A SQLAlchemy engine connected to a SQLite database.
+    """
+    # Copied from:
+    # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
+
+    @sqlalchemy.event.listens_for(engine, "connect")  # type: ignore[misc]
+    def on_connect(
+        # TODO(mm, 2023-08-29): Improve these type annotations when we have SQLAlchemy 2.0.
+        dbapi_connection: Any,
+        connection_record: object,
+    ) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON;")
+        cursor.close()
+
+
+def fix_transactions(engine: sqlalchemy.engine.Engine) -> None:
+    """Make SQLite transactions behave sanely.
+
+    This works around various misbehaviors in Python's `sqlite3` driver (aka `pysqlite`),
+    which is a middle layer between SQLAlchemy and the underlying SQLite library.
+    These misbehaviors can make transactions not actually behave transactionally. See:
+    https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl
+
+    This should be called once per SQLAlchemy engine, shortly after creating it,
+    before doing anything substantial with it.
+
+    Params:
+        engine: A SQLAlchemy engine connected to a SQLite database.
+    """
+    # Copied from:
+    # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl.
+
+    @sqlalchemy.event.listens_for(engine, "connect")  # type: ignore[misc]
+    def on_connect(
+        # TODO(mm, 2023-08-29): Improve these type annotations when we have SQLAlchemy 2.0.
+        dbapi_connection: Any,
+        connection_record: object,
+    ) -> None:
+        # disable pysqlite's emitting of the BEGIN statement entirely.
+        # also stops it from emitting COMMIT before any DDL.
+        dbapi_connection.isolation_level = None
+
+    @sqlalchemy.event.listens_for(engine, "begin")  # type: ignore[misc]
+    def on_begin(conn: sqlalchemy.engine.Connection) -> None:
+        # emit our own BEGIN
+        conn.exec_driver_sql("BEGIN")

--- a/system-server/system_server/persistence/database.py
+++ b/system-server/system_server/persistence/database.py
@@ -2,6 +2,9 @@
 from pathlib import Path
 
 import sqlalchemy
+
+from server_utils import sql_utils
+
 from .tables import add_tables_to_db
 from .migrations import migrate
 
@@ -23,35 +26,16 @@ sqlite_rowid = sqlalchemy.column("_ROWID_")
 
 def create_sql_engine(path: Path) -> sqlalchemy.engine.Engine:
     """Create a SQL engine with tables and migrations."""
-    sql_engine = _open_db(db_file_path=path)
+    sql_engine = sqlalchemy.create_engine(sql_utils.get_connection_url(path))
 
     try:
+        sql_utils.enable_foreign_key_constraints(sql_engine)
+        sql_utils.fix_transactions(sql_engine)
         add_tables_to_db(sql_engine)
         migrate(sql_engine)
+
     except Exception:
         sql_engine.dispose()
         raise
 
     return sql_engine
-
-
-def _open_db(db_file_path: Path) -> sqlalchemy.engine.Engine:
-    """Create a database engine for performing transactions."""
-    engine = sqlalchemy.create_engine(
-        # sqlite://<hostname>/<path>
-        # where <hostname> is empty.
-        f"sqlite:///{db_file_path}",
-    )
-
-    # Enable foreign key support in sqlite
-    # https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
-    @sqlalchemy.event.listens_for(engine, "connect")  # type: ignore[misc]
-    def _set_sqlite_pragma(
-        dbapi_connection: sqlalchemy.engine.CursorResult,
-        connection_record: sqlalchemy.engine.CursorResult,
-    ) -> None:
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON;")
-        cursor.close()
-
-    return engine


### PR DESCRIPTION
# Overview

This fixes a bug (unticketed) where SQL transactions would not actually be transactional.👌

One effect of this was that if the process were killed in the middle of a long database migration, it would leave the database in a broken half-migrated state.

# Technical details

Between SQLAlchemy and the underlying SQLite database, there is a middle layer: Python's built-in `sqlite3` driver, aka `pysqlite`. According to [this note from the SQLAlchemy docs](https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl), there are known issues with it:

>  In its default mode of operation, SQLite features such as **SERIALIZABLE isolation,** **transactional DDL,** and SAVEPOINT support are non-functional, and in order to use these features, workarounds must be taken.

`SERIALIZABLE` isolation and transactional DDL are especially important for us. `SERIALIZABLE` isolation is just [the sane transaction behavior that everybody intuitively expects](https://www.cockroachlabs.com/blog/acid-rain/). Transactional DDL is the ability to do database migrations as one long transaction, rolling back the whole thing in case any part of it fails.

Fortunately, the good folks at SQLAlchemy have provided some magic code snippets to fix it the problems. So:

1. Use the magic code.
2. Share that code between `robot-server` and `system-server`. We do this through a new module in `server_utils`:  `server_utils.sql_utils`.

# Test Plan

The original bug is annoying to trigger artificially. I've reproduced it in another PR by:

1. Adding a new migration that adds a new column with an `ALTER TABLE` statement
2. Inserting a `time.sleep(120)` right after that `ALTER TABLE` statement
3. Running `make -C robot-server dev OT_ROBOT_SERVER_persistence_directory=tests/integration/persistence_snapshots/v6.2.0_large/`
4. Running `pkill make` in another terminal
5. Opening the .db file in the `sqlite3` CLI and noticing that the new column was there, even though the migration was left incomplete

I've confirmed that the bug doesn't happen with this fix applied.

This is our second SQLite fixup—the first is that we have to go out of our way to enable foreign key constraints. I think these have grown to the point where they need their own tests. I’m imagining we make some temporary databases with dummy schemas, apply these fixup functions to them, and test that when we access the tables, they behave the way we want. I've omitted those tests from this PR for expedience, but I'm happy to do them in a follow-up after some other high-priority stuff. RSS-331

# Review requests

Are these functions documented sufficiently so it's clear how to use them and why, even if it's not clear how they work at a low level?

# Risk assessment

There's low risk that this will *break* anything, but there is some risk that it won't work properly to fix the bug, given how non-obvious it is. See my note in the test plan about adding unit tests later.