### PR TITLE
feat(engine): disallow gripper movement for combination adapter labware

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -125,7 +125,7 @@ class MoveLabwareImplementation(
                     message="Labware movement using a gripper is not supported on the OT-2",
                     details={"strategy": params.strategy},
                 )
-            if labware_validation.validate_gripper_compatible(
+            if not labware_validation.validate_gripper_compatible(
                 current_labware_definition
             ):
                 raise LabwareMovementNotAllowedError(
@@ -137,7 +137,7 @@ class MoveLabwareImplementation(
                 current_labware_definition
             ):
                 raise LabwareMovementNotAllowedError(
-                    f"Cannot move adapter {params.labwareId} with gripper."
+                    f"Cannot move adapter '{current_labware_definition.parameters.loadName}' with gripper."
                 )
 
             validated_current_loc = (

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -125,6 +125,14 @@ class MoveLabwareImplementation(
                     message="Labware movement using a gripper is not supported on the OT-2",
                     details={"strategy": params.strategy},
                 )
+            if labware_validation.validate_gripper_compatible(
+                current_labware_definition
+            ):
+                raise LabwareMovementNotAllowedError(
+                    f"Cannot move labware '{current_labware_definition.parameters.loadName}' with gripper."
+                    f" If trying to move a labware on an adapter, load the adapter separately to allow"
+                    f" gripper movement."
+                )
             if labware_validation.validate_definition_is_adapter(
                 current_labware_definition
             ):

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -22,3 +22,11 @@ def validate_labware_can_be_stacked(
 ) -> bool:
     """Validate that the labware being loaded onto is in the above labware's stackingOffsetWithLabware definition."""
     return below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
+
+
+def validate_gripper_compatible(definition: LabwareDefinition) -> bool:
+    """Validate that the labware definition does not have a quirk disallowing movement with gripper."""
+    return (
+        definition.parameters.quirks is None
+        or "gripperIncompatible" not in definition.parameters.quirks
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -3,6 +3,8 @@ import inspect
 import pytest
 from decoy import Decoy
 
+from opentrons_shared_data.labware.labware_definition import Parameters
+
 from opentrons.types import DeckSlotName
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import errors, Config
@@ -188,6 +190,11 @@ async def test_gripper_move_labware_implementation(
         dropOffset=None,
     )
 
+    decoy.when(
+        state_view.labware.get_definition(labware_id="my-cool-labware-id")
+    ).then_return(
+        LabwareDefinition.construct(namespace="my-cool-namespace")  # type: ignore[call-arg]
+    )
     decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
         LoadedLabware(
             id="my-cool-labware-id",
@@ -217,6 +224,11 @@ async def test_gripper_move_labware_implementation(
     decoy.when(
         state_view.geometry.ensure_valid_gripper_location(new_location)
     ).then_return(validated_new_location)
+    decoy.when(
+        labware_validation.validate_gripper_compatible(
+            LabwareDefinition.construct(namespace="my-cool-namespace")  # type: ignore[call-arg]
+        )
+    ).then_return(True)
 
     result = await subject.execute(data)
     decoy.verify(
@@ -403,6 +415,10 @@ async def test_move_labware_raises_when_moving_adapter_with_gripper(
         strategy=LabwareMovementStrategy.USING_GRIPPER,
     )
 
+    definition = LabwareDefinition.construct(  # type: ignore[call-arg]
+        parameters=Parameters.construct(loadName="My cool adapter"),  # type: ignore[call-arg]
+    )
+
     decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
         LoadedLabware(
             id="my-cool-labware-id",
@@ -414,16 +430,65 @@ async def test_move_labware_raises_when_moving_adapter_with_gripper(
     )
     decoy.when(
         state_view.labware.get_definition(labware_id="my-cool-labware-id")
-    ).then_return(
-        LabwareDefinition.construct(namespace="spacename")  # type: ignore[call-arg]
+    ).then_return(definition)
+    decoy.when(labware_validation.validate_gripper_compatible(definition)).then_return(
+        True
     )
     decoy.when(
-        labware_validation.validate_definition_is_adapter(
-            LabwareDefinition.construct(namespace="spacename")  # type: ignore[call-arg]
-        )
+        labware_validation.validate_definition_is_adapter(definition)
     ).then_return(True)
 
-    with pytest.raises(errors.LabwareMovementNotAllowedError, match="gripper"):
+    with pytest.raises(
+        errors.LabwareMovementNotAllowedError, match="move adapter 'My cool adapter'"
+    ):
+        await subject.execute(data)
+
+
+async def test_move_labware_raises_when_moving_labware_with_gripper_incompatible_quirk(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    labware_movement: LabwareMovementHandler,
+    state_view: StateView,
+    run_control: RunControlHandler,
+) -> None:
+    """It should raise an error when trying to move an adapter with a gripper."""
+    subject = MoveLabwareImplementation(
+        state_view=state_view,
+        equipment=equipment,
+        labware_movement=labware_movement,
+        run_control=run_control,
+    )
+
+    data = MoveLabwareParams(
+        labwareId="my-cool-labware-id",
+        newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+        strategy=LabwareMovementStrategy.USING_GRIPPER,
+    )
+
+    definition = LabwareDefinition.construct(  # type: ignore[call-arg]
+        parameters=Parameters.construct(loadName="My cool labware"),  # type: ignore[call-arg]
+    )
+
+    decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
+        LoadedLabware(
+            id="my-cool-labware-id",
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+            offsetId=None,
+        )
+    )
+    decoy.when(
+        state_view.labware.get_definition(labware_id="my-cool-labware-id")
+    ).then_return(definition)
+    decoy.when(labware_validation.validate_gripper_compatible(definition)).then_return(
+        False
+    )
+
+    with pytest.raises(
+        errors.LabwareMovementNotAllowedError,
+        match="Cannot move labware 'My cool labware' with gripper",
+    ):
         await subject.execute(data)
 
 

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
@@ -1,7 +1,11 @@
 """Test labware validation."""
 import pytest
 
-from opentrons_shared_data.labware.labware_definition import LabwareRole, OverlapOffset
+from opentrons_shared_data.labware.labware_definition import (
+    LabwareRole,
+    OverlapOffset,
+    Parameters,
+)
 from opentrons.protocols.models import LabwareDefinition
 
 from opentrons.protocol_engine.resources import labware_validation as subject
@@ -53,3 +57,18 @@ def test_validate_labware_can_be_stacked(
         subject.validate_labware_can_be_stacked(definition, "labware123")
         == expected_result
     )
+
+
+@pytest.mark.parametrize(
+    ("definition", "expected_result"),
+    [
+        (LabwareDefinition.construct(parameters=Parameters.construct(quirks=None)), True),  # type: ignore[call-arg]
+        (LabwareDefinition.construct(parameters=Parameters.construct(quirks=["foo"])), True),  # type: ignore[call-arg]
+        (LabwareDefinition.construct(parameters=Parameters.construct(quirks=["gripperIncompatible"])), False),  # type: ignore[call-arg]
+    ],
+)
+def test_validate_gripper_compatible(
+    definition: LabwareDefinition, expected_result: bool
+) -> None:
+    """It should validate if definition is defined as an adapter."""
+    assert subject.validate_gripper_compatible(definition) == expected_result

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -2704,6 +2704,7 @@
       ],
       "parameters": {
         "format": "irregular",
+        "quirks": ["gripperIncompatible"],
         "isTiprack": false,
         "isMagneticModuleCompatible": false,
         "loadName": "opentrons_24_aluminumblock_nest_1.5ml_snapcap"

--- a/shared-data/js/__tests__/labwareDefQuirks.test.ts
+++ b/shared-data/js/__tests__/labwareDefQuirks.test.ts
@@ -10,6 +10,7 @@ const EXPECTED_VALID_QUIRKS = [
   'centerMultichannelOnWells',
   'touchTipDisabled',
   'fixedTrash',
+  'gripperIncompatible',
 ]
 
 describe('check quirks for all labware defs', () => {

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_generic_2ml_screwcap/2.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_generic_2ml_screwcap/2.json
@@ -23,6 +23,7 @@
   },
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap"

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_0.5ml_screwcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_0.5ml_screwcap/1.json
@@ -283,6 +283,7 @@
   ],
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_24_aluminumblock_nest_0.5ml_screwcap"

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_screwcap/1.json
@@ -283,6 +283,7 @@
   ],
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_24_aluminumblock_nest_1.5ml_screwcap"

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1.json
@@ -285,6 +285,7 @@
   ],
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_24_aluminumblock_nest_1.5ml_snapcap"

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_screwcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_screwcap/1.json
@@ -283,6 +283,7 @@
   ],
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_24_aluminumblock_nest_2ml_screwcap"

--- a/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_snapcap/1.json
+++ b/shared-data/labware/definitions/2/opentrons_24_aluminumblock_nest_2ml_snapcap/1.json
@@ -285,6 +285,7 @@
   ],
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_24_aluminumblock_nest_2ml_snapcap"

--- a/shared-data/labware/definitions/2/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/1.json
+++ b/shared-data/labware/definitions/2/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/1.json
@@ -381,6 +381,7 @@
   "version": 1,
   "parameters": {
     "format": "irregular",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip"

--- a/shared-data/labware/definitions/2/opentrons_96_aluminumblock_biorad_wellplate_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_aluminumblock_biorad_wellplate_200ul/1.json
@@ -29,6 +29,7 @@
   },
   "parameters": {
     "format": "96Standard",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_aluminumblock_biorad_wellplate_200ul"

--- a/shared-data/labware/definitions/2/opentrons_96_aluminumblock_generic_pcr_strip_200ul/2.json
+++ b/shared-data/labware/definitions/2/opentrons_96_aluminumblock_generic_pcr_strip_200ul/2.json
@@ -29,6 +29,7 @@
   },
   "parameters": {
     "format": "96Standard",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_aluminumblock_generic_pcr_strip_200ul"

--- a/shared-data/labware/definitions/2/opentrons_96_aluminumblock_nest_wellplate_100ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_aluminumblock_nest_wellplate_100ul/1.json
@@ -1011,6 +1011,7 @@
   ],
   "parameters": {
     "format": "96Standard",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_aluminumblock_nest_wellplate_100ul"

--- a/shared-data/labware/definitions/2/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/1.json
@@ -1105,7 +1105,7 @@
   ],
   "parameters": {
     "format": "96Standard",
-    "quirks": [],
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep"

--- a/shared-data/labware/definitions/2/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json
@@ -1011,7 +1011,7 @@
   ],
   "parameters": {
     "format": "96Standard",
-    "quirks": [],
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat"

--- a/shared-data/labware/definitions/2/opentrons_96_pcr_adapter_armadillo_wellplate_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_pcr_adapter_armadillo_wellplate_200ul/1.json
@@ -4,6 +4,7 @@
   "schemaVersion": 2,
   "parameters": {
     "loadName": "opentrons_96_pcr_adapter_armadillo_wellplate_200ul",
+    "quirks": ["gripperIncompatible"],
     "format": "96Standard",
     "isTiprack": false,
     "isMagneticModuleCompatible": false

--- a/shared-data/labware/definitions/2/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json
@@ -1009,7 +1009,7 @@
   ],
   "parameters": {
     "format": "96Standard",
-    "quirks": [],
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt"

--- a/shared-data/labware/definitions/2/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json
+++ b/shared-data/labware/definitions/2/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json
@@ -4694,6 +4694,7 @@
   ],
   "parameters": {
     "format": "384Standard",
+    "quirks": ["gripperIncompatible"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat"


### PR DESCRIPTION
# Overview

Closes RLAB-363.

This PR makes it so that combination labware/adapter labware cannot be moved with the gripper. This should not be done in the first place since the gripper does not have logic to correctly pick up and place down these labware, and using the split adapter and labware definitions should be encouraged. Manual moves are still allowed.

In order to accomplish this, a new labware quirk `gripperIncompatible` was added to all combination adapter/labware definitions and a check in the PE `moveLabware` execution was added. Since gripper movement will be new to api level 2.15 and the addition of the new quirk will not change previous behavior, the labware definitions were not bumped up to a new version.

# Test Plan

Tested analysis with the following protocol

```
metadata = {
    'protocolName': 'PAPI Gripper incompatible',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.15"
}


def run(context):
    heater_shaker_1 = context.load_module("heaterShakerModuleV1", location="D1")
    heater_shaker_1.open_labware_latch()

    heater_shaker_2 = context.load_module("heaterShakerModuleV1", location="D3")
    heater_shaker_2.open_labware_latch()

    pcr_adapter = heater_shaker_1.load_adapter("opentrons_96_pcr_adapter")
    armadillo_plate = pcr_adapter.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt")

    plate_with_adapter = heater_shaker_2.load_labware("opentrons_96_pcr_adapter_armadillo_wellplate_200ul")

    # This move should work
    context.move_labware(armadillo_plate, new_location="C1", use_gripper=True)

    # If commented back in this should fail
    #context.move_labware(plate_with_adapter, new_location="C3", use_gripper=True)

    # This move should work since it is manual
    context.move_labware(plate_with_adapter, new_location="C3", use_gripper=False)
```

# Changelog

- Added `gripperIncompatible` to combination adapter/labware definitions
- Added check for the quirk in `moveLabware` execution if using the gripper, which if found will raise an error.

# Review requests

Mostly the error text for this new check, want to make it clear to users that they should be using the separate adapter and labware loads if they want to use the gripper, otherwise use manual movement.

# Risk assessment

Codewise low, it's a small change and contained only the relevant definitions and `moveLabware` with a gripper, but this change should be made clear since it will cause protocols that were previously passing to fail (although they were incorrect in the sense that the gripper would not function as intended during execution).