### PR TITLE
fix(api): readjust hardware controller end state in engine cleanup

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -41,6 +41,7 @@ from opentrons.hardware_control import (
     ThreadManagedHardware,
     ThreadManager,
 )
+from opentrons.protocol_engine.types import PostRunHardwareState
 
 from opentrons.protocols import parse
 from opentrons.protocols.api_support.deck_type import (
@@ -572,7 +573,8 @@ def _create_live_context_pe(
         create_protocol_engine_in_thread(
             hardware_api=hardware_api.wrapped(),
             config=_get_protocol_engine_config(),
-            drop_tips_and_home_after=False,
+            drop_tips_after_run=False,
+            post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
         )
     )
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -743,19 +743,18 @@ class OT3API(
         """Cancel execution manager and all running (hardware module) tasks."""
         await self._execution_manager.cancel()
 
-    async def halt(self) -> None:
+    async def halt(self, disengage_before_stopping: bool = False) -> None:
         """Immediately disengage all present motors and clear motor and module tasks."""
-        # TODO (spp, 2023-08-22): check if disengaging motors is really required
-        await self.disengage_axes(
-            [ax for ax in Axis if self._backend.axis_is_present(ax)]
-        )
+        if disengage_before_stopping:
+            await self.disengage_axes(
+                [ax for ax in Axis if self._backend.axis_is_present(ax)]
+            )
         await self._stop_motors()
-        await self._cancel_execution_and_running_tasks()
 
     async def stop(self, home_after: bool = True) -> None:
         """Stop motion as soon as possible, reset, and optionally home."""
         await self._stop_motors()
-
+        await self._cancel_execution_and_running_tasks()
         self._log.info("Resetting OT3API")
         await self.reset()
         if home_after:

--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -8,7 +8,7 @@ from ..types import Axis, CriticalPoint, MotionChecks
 class MotionController(Protocol):
     """Protocol specifying fundamental motion controls."""
 
-    async def halt(self) -> None:
+    async def halt(self, disengage_before_stopping: bool = False) -> None:
         """Immediately stop motion.
 
         Calls to stop through the synch adapter while other calls
@@ -17,8 +17,9 @@ class MotionController(Protocol):
         smoothie. To provide actual immediate halting, call this method which
         does not require use of the loop.
 
-        After this call, the hardware will be in a bad state until a call to
-        stop
+        If disengage_before_stopping is True, the motors will disengage first and then
+        stop in place. Disengaging creates a smoother halt but requires homing after
+        in order to resume movement.
         """
         ...
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -7,7 +7,6 @@ from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import AbstractModule as HardwareModuleAPI
 from opentrons.hardware_control.types import PauseType as HardwarePauseType
-
 from opentrons_shared_data.errors import (
     ErrorCodes,
     EnumeratedError,
@@ -24,6 +23,7 @@ from .types import (
     ModuleModel,
     Liquid,
     HexColor,
+    PostRunHardwareState,
 )
 from .execution import (
     QueueWorker,
@@ -306,8 +306,9 @@ class ProtocolEngine:
     async def finish(
         self,
         error: Optional[Exception] = None,
-        drop_tips_and_home: bool = True,
+        drop_tips_after_run: bool = True,
         set_run_status: bool = True,
+        post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
     ) -> None:
         """Gracefully finish using the ProtocolEngine, waiting for it to become idle.
 
@@ -321,19 +322,23 @@ class ProtocolEngine:
 
         Arguments:
             error: An error that caused the stop, if applicable.
-            drop_tips_and_home: Whether to home and drop tips as part of cleanup.
+            drop_tips_after_run: Whether to drop tips as part of cleanup.
             set_run_status: Whether to calculate a `success` or `failure` run status.
                 If `False`, will set status to `stopped`.
+            post_run_hardware_state: The state in which to leave the gantry and motors in
+                after the run is over.
         """
         if self._state_store.commands.state.stopped_by_estop:
-            drop_tips_and_home = False
+            drop_tips_after_run = False
+            post_run_hardware_state = PostRunHardwareState.DISENGAGE_IN_PLACE
             if error is None:
                 error = EStopActivatedError(message="Estop was activated during a run")
         if error:
             if isinstance(error, EnumeratedError) and self._code_in_exception_stack(
                 error=error, code=ErrorCodes.E_STOP_ACTIVATED
             ):
-                drop_tips_and_home = False
+                drop_tips_after_run = False
+                post_run_hardware_state = PostRunHardwareState.DISENGAGE_IN_PLACE
 
             error_details: Optional[FinishErrorDetails] = FinishErrorDetails(
                 error_id=self._model_utils.generate_id(),
@@ -357,13 +362,21 @@ class ProtocolEngine:
         exit_stack.push_async_callback(
             # Cleanup after hardware halt and reset the hardware controller
             self._hardware_stopper.do_stop_and_recover,
-            drop_tips_and_home=drop_tips_and_home,
+            post_run_hardware_state=post_run_hardware_state,
+            drop_tips_after_run=drop_tips_after_run,
         )
         exit_stack.callback(self._door_watcher.stop)
 
-        # Halt any movements immediately. Requires a hardware stop & reset after, in order to
-        # recover from halt and resume hardware operations.
-        exit_stack.push_async_callback(self._hardware_stopper.do_halt)
+        disengage_before_stopping = (
+            False
+            if post_run_hardware_state == PostRunHardwareState.STAY_ENGAGED_IN_PLACE
+            else True
+        )
+        # Halt any movements immediately
+        exit_stack.push_async_callback(
+            self._hardware_stopper.do_halt,
+            disengage_before_stopping=disengage_before_stopping,
+        )
         exit_stack.push_async_callback(self._queue_worker.join)  # First step.
 
         try:

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -629,3 +629,30 @@ class LabwareMovementStrategy(str, Enum):
     USING_GRIPPER = "usingGripper"
     MANUAL_MOVE_WITH_PAUSE = "manualMoveWithPause"
     MANUAL_MOVE_WITHOUT_PAUSE = "manualMoveWithoutPause"
+
+
+class PostRunHardwareState(Enum):
+    """State of robot gantry & motors after a stop is performed and the hardware API is reset.
+
+    HOME_AND_STAY_ENGAGED: home the gantry and keep all motors engaged. This allows the
+        robot to continue performing movement actions without re-homing
+    HOME_THEN_DISENGAGE: home the gantry and then disengage motors.
+        Reduces current consumption of the motors and prevents coil heating.
+        Re-homing is required to re-engage the motors and resume robot movement.
+    STAY_ENGAGED_IN_PLACE: do not home after the stop and keep the motors engaged.
+        Keeps gantry in the same position as prior to `stop()` execution
+        and allows the robot to execute movement commands without requiring to re-home first.
+    DISENGAGE_IN_PLACE: disengage motors and do not home the robot
+    Probable states for pipette:
+        - for 1- or 8-channel:
+            - HOME_AND_STAY_ENGAGED after protocol runs
+            - STAY_ENGAGED_IN_PLACE after maintenance runs
+        - for 96-channel:
+            - HOME_THEN_DISENGAGE after protocol runs
+            - DISENGAGE_IN_PLACE after maintenance runs
+    """
+
+    HOME_AND_STAY_ENGAGED = "homeAndStayEngaged"
+    HOME_THEN_DISENGAGE = "homeThenDisengage"
+    STAY_ENGAGED_IN_PLACE = "stayEngagedInPlace"
+    DISENGAGE_IN_PLACE = "disengageInPlace"

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -35,6 +35,7 @@ from .legacy_wrappers import (
     LegacyExecutor,
     LegacyLoadInfo,
 )
+from ..protocol_engine.types import PostRunHardwareState
 
 
 class RunResult(NamedTuple):
@@ -80,8 +81,9 @@ class AbstractRunner(ABC):
             await self._protocol_engine.stop()
         else:
             await self._protocol_engine.finish(
-                drop_tips_and_home=False,
+                drop_tips_after_run=False,
                 set_run_status=False,
+                post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             )
 
     @abstractmethod

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -25,6 +25,8 @@ from typing_extensions import TypedDict
 import pytest
 from decoy import Decoy
 
+from opentrons.protocol_engine.types import PostRunHardwareState
+
 try:
     import aionotify  # type: ignore[import]
 except (OSError, ModuleNotFoundError):
@@ -296,7 +298,8 @@ def _make_ot3_pe_ctx(
             use_virtual_gripper=True,
             block_on_door_open=False,
         ),
-        drop_tips_and_home_after=False,
+        drop_tips_after_run=False,
+        post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
     ) as (
         engine,
         loop,

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -27,6 +27,7 @@ from opentrons.protocol_engine.types import (
     ModuleDefinition,
     ModuleModel,
     Liquid,
+    PostRunHardwareState,
 )
 from opentrons.protocol_engine.execution import (
     QueueWorker,
@@ -408,8 +409,17 @@ def test_pause(
     )
 
 
-@pytest.mark.parametrize("drop_tips_and_home", [True, False])
+@pytest.mark.parametrize("drop_tips_after_run", [True, False])
 @pytest.mark.parametrize("set_run_status", [True, False])
+@pytest.mark.parametrize(
+    argnames=["post_run_hardware_state", "expected_halt_disengage"],
+    argvalues=[
+        (PostRunHardwareState.HOME_AND_STAY_ENGAGED, True),
+        (PostRunHardwareState.HOME_THEN_DISENGAGE, True),
+        (PostRunHardwareState.STAY_ENGAGED_IN_PLACE, False),
+        (PostRunHardwareState.DISENGAGE_IN_PLACE, True),
+    ],
+)
 async def test_finish(
     decoy: Decoy,
     action_dispatcher: ActionDispatcher,
@@ -417,8 +427,10 @@ async def test_finish(
     queue_worker: QueueWorker,
     subject: ProtocolEngine,
     hardware_stopper: HardwareStopper,
-    drop_tips_and_home: bool,
+    drop_tips_after_run: bool,
     set_run_status: bool,
+    post_run_hardware_state: PostRunHardwareState,
+    expected_halt_disengage: bool,
     model_utils: ModelUtils,
     state_store: StateStore,
     door_watcher: DoorWatcher,
@@ -430,16 +442,21 @@ async def test_finish(
     decoy.when(state_store.commands.state.stopped_by_estop).then_return(False)
 
     await subject.finish(
-        drop_tips_and_home=drop_tips_and_home,
+        drop_tips_after_run=drop_tips_after_run,
         set_run_status=set_run_status,
+        post_run_hardware_state=post_run_hardware_state,
     )
 
     decoy.verify(
         action_dispatcher.dispatch(FinishAction(set_run_status=set_run_status)),
         await queue_worker.join(),
+        await hardware_stopper.do_halt(
+            disengage_before_stopping=expected_halt_disengage
+        ),
         door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(
-            drop_tips_and_home=drop_tips_and_home
+            drop_tips_after_run=drop_tips_after_run,
+            post_run_hardware_state=post_run_hardware_state,
         ),
         await plugin_starter.stop(),
         action_dispatcher.dispatch(
@@ -461,11 +478,21 @@ async def test_finish_with_defaults(
 
     decoy.verify(
         action_dispatcher.dispatch(FinishAction(set_run_status=True)),
-        await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
+        await hardware_stopper.do_halt(disengage_before_stopping=True),
+        await hardware_stopper.do_stop_and_recover(
+            drop_tips_after_run=True,
+            post_run_hardware_state=PostRunHardwareState.HOME_AND_STAY_ENGAGED,
+        ),
     )
 
 
-@pytest.mark.parametrize("stopped_by_estop", [True, False])
+@pytest.mark.parametrize(
+    argnames=["stopped_by_estop", "expected_drop_tips", "expected_end_state"],
+    argvalues=[
+        (True, False, PostRunHardwareState.DISENGAGE_IN_PLACE),
+        (False, True, PostRunHardwareState.HOME_AND_STAY_ENGAGED),
+    ],
+)
 async def test_finish_with_error(
     decoy: Decoy,
     action_dispatcher: ActionDispatcher,
@@ -477,6 +504,8 @@ async def test_finish_with_error(
     door_watcher: DoorWatcher,
     state_store: StateStore,
     stopped_by_estop: bool,
+    expected_drop_tips: bool,
+    expected_end_state: PostRunHardwareState,
 ) -> None:
     """It should be able to tell the engine it's finished because of an error."""
     error = RuntimeError("oh no")
@@ -501,9 +530,11 @@ async def test_finish_with_error(
             FinishAction(error_details=expected_error_details, set_run_status=True)
         ),
         await queue_worker.join(),
+        await hardware_stopper.do_halt(disengage_before_stopping=True),
         door_watcher.stop(),
         await hardware_stopper.do_stop_and_recover(
-            drop_tips_and_home=not stopped_by_estop
+            drop_tips_after_run=expected_drop_tips,
+            post_run_hardware_state=expected_end_state,
         ),
         await plugin_starter.stop(),
         action_dispatcher.dispatch(
@@ -551,8 +582,12 @@ async def test_finish_with_estop_error_will_not_drop_tip_and_home(
             FinishAction(error_details=expected_error_details, set_run_status=True)
         ),
         await queue_worker.join(),
+        await hardware_stopper.do_halt(disengage_before_stopping=True),
         door_watcher.stop(),
-        await hardware_stopper.do_stop_and_recover(drop_tips_and_home=False),
+        await hardware_stopper.do_stop_and_recover(
+            drop_tips_after_run=False,
+            post_run_hardware_state=PostRunHardwareState.DISENGAGE_IN_PLACE,
+        ),
         await plugin_starter.stop(),
         action_dispatcher.dispatch(
             HardwareStoppedAction(
@@ -594,9 +629,12 @@ async def test_finish_stops_hardware_if_queue_worker_join_fails(
         action_dispatcher.dispatch(FinishAction()),
         # await queue_worker.join() should be called, and should raise, here.
         # We can't verify that step in the sequence here because of a Decoy limitation.
-        await hardware_stopper.do_halt(),
+        await hardware_stopper.do_halt(disengage_before_stopping=True),
         door_watcher.stop(),
-        await hardware_stopper.do_stop_and_recover(drop_tips_and_home=True),
+        await hardware_stopper.do_stop_and_recover(
+            drop_tips_after_run=True,
+            post_run_hardware_state=PostRunHardwareState.HOME_AND_STAY_ENGAGED,
+        ),
         await plugin_starter.stop(),
         action_dispatcher.dispatch(
             HardwareStoppedAction(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -11,6 +11,7 @@ from opentrons_shared_data.protocol.dev_types import (
 from opentrons.broker import Broker
 from opentrons.equipment_broker import EquipmentBroker
 from opentrons.hardware_control import API as HardwareAPI
+from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.parse import PythonParseMode
 from opentrons_shared_data.protocol.models import ProtocolSchemaV6, ProtocolSchemaV7
@@ -275,7 +276,11 @@ async def test_stop_when_run_never_started(
     await subject.stop()
 
     decoy.verify(
-        await protocol_engine.finish(drop_tips_and_home=False, set_run_status=False),
+        await protocol_engine.finish(
+            drop_tips_after_run=False,
+            set_run_status=False,
+            post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
+        ),
         times=1,
     )
 

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from typing import List, NamedTuple, Optional
 
+from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.config import feature_flags
@@ -171,7 +172,11 @@ class MaintenanceEngineStore:
         state_view = engine.state_view
 
         if state_view.commands.get_is_okay_to_clear():
-            await engine.finish(drop_tips_and_home=False, set_run_status=False)
+            await engine.finish(
+                drop_tips_after_run=False,
+                set_run_status=False,
+                post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
+            )
         else:
             raise EngineConflictError("Current run is not idle or stopped.")
 

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -1,6 +1,7 @@
 """In-memory storage of ProtocolEngine instances."""
 from typing import List, NamedTuple, Optional
 
+from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons_shared_data.robot.dev_types import RobotType
 
 from opentrons.config import feature_flags
@@ -219,7 +220,11 @@ class EngineStore:
         state_view = engine.state_view
 
         if state_view.commands.get_is_okay_to_clear():
-            await engine.finish(drop_tips_and_home=False, set_run_status=False)
+            await engine.finish(
+                drop_tips_after_run=False,
+                set_run_status=False,
+                post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
+            )
         else:
             raise EngineConflictError("Current run is not idle or stopped.")
 


### PR DESCRIPTION
# Overview

While handling a bug in engine cleanup in #13339, we rearranged the sequence of motor disengage, re-engage and home, which undid the work done in   to **not** end a run with motors disengaged. This PR re-rearranges the sequence again, with additional refactors for clarity and upcoming support for disengaging the 96-channel at the end of runs. 

See [this document](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3794468865/Run+cleanup+post-run+hardware+state+design) for detailed notes on requirements for motor disengaging. 

Also separates out the concerns of post-run-tip-drop & post-run-homing-and-disengaging.

# Test Plan

- On a Flex as well as OT2:
    1. Start a protocol run and while a motor is moving, cancel the run abruptly. Check that:
        - [ ] the motion is halted immediately. 
        - [ ] The motor halt is smooth (i.e., not jerky & loud) and is followed by a tip drop and home
    2. Start a maintenance run via HTTP requests (not through the app), load a pipette and verify that a `moveTo` command succeeds without any `MustHomeError`s or other errors indicating that motors are disengaged. (This checks for starting state of maintenance run after a protocol run)
    3. Delete the maintenance run and verify that the gantry does not home.
    4.  Restart another maintenance run. Verify that `moveTo` command still works correctly as in (2), without requiring a `Home`. (This checks for starting state of maintenance run after a previous maintenance run)
    5. During the maintenance run, send a move command and immediately send a `DEL` request to delete the maintenance run. Verify that the deletion request fails with `EngineConflictError`. Then reattempt deletion after the movement is over and it should delete the run successfully and keep the gantry in place.

# Changelog

- Added a `PostRunHardwareState` enum that clearly defines the allowed end states for hardware after a run is finished.
- Updated engine.finish() by splitting the `drop_tips_and_home` argument into:
    - `drop_tips_after_run`: whether to drop tips during the current run's cleanup
    - `post_run_hardware_state`: whether to home and/or disengage motors after the run cleanup
- Hardware control changes: 
    - updated `api.halt()` to optionally disengage motors before performing an abrupt halt/stop
    - made task cancellation and execution manager state update a part of `api.stop()` so that halt only cares about halting hardware motion while stop does all the cleanup.
-  Updated tests to cover all scenarios of tip drops and post-run-hardware-state.

# Review requests

- Does the code add more clarity after the refactor?
- Is it fine to have hardware end states in the enum that aren't used yet? I've added them in preparation for 96-channel support.
- any comments about hardware controller changes?

# Risk assessment

Medium. Re-implements the intentions of #13185 so that's a state change sequence we had been using and testing with before the run cancellation bug fix. Thorough testing will make sure we aren't introducing any regressions.
