### PR TITLE
fix(usb-bridge): use correct USB gadget configuration strings

### DIFF
--- a/usb-bridge/ot3usb/__main__.py
+++ b/usb-bridge/ot3usb/__main__.py
@@ -4,7 +4,8 @@ import logging
 import time
 from typing import NoReturn
 
-from . import cli, usb_config, default_config, usb_monitor, tcp_conn, listener
+from . import cli, usb_config, usb_monitor, tcp_conn, listener
+from .default_config import get_gadget_config, PHY_NAME
 
 LOG = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ async def main() -> NoReturn:
     LOG.info("Starting USB-TCP bridge")
 
     config = usb_config.SerialGadget(
-        driver=usb_config.OSDriver(), config=default_config.default_gadget
+        driver=usb_config.OSDriver(), config=get_gadget_config()
     )
 
     try:
@@ -43,7 +44,7 @@ async def main() -> NoReturn:
     ser = None
 
     monitor = usb_monitor.USBConnectionMonitorFactory.create(
-        phy_udev_name=default_config.PHY_NAME, udc_folder=config.udc_folder()
+        phy_udev_name=PHY_NAME, udc_folder=config.udc_folder()
     )
 
     # Create a tcp connection that will be managed by `listen`

--- a/usb-bridge/ot3usb/default_config.py
+++ b/usb-bridge/ot3usb/default_config.py
@@ -5,23 +5,38 @@ DEFAULT_NAME = "ot3_usb"
 DEFAULT_VID = "0x1b67"
 DEFAULT_PID = "0x4037"
 DEFAULT_BCDEVICE = "0x0010"
-DEFAULT_SERIAL = "01121997"
+DEFAULT_SERIAL = "FLX00000000000000"
 DEFAULT_MANUFACTURER = "Opentrons"
-DEFAULT_PRODUCT = "OT3"
+DEFAULT_PRODUCT = "Flex"
 DEFAULT_CONFIGURATION = "ACM Device"
 DEFAULT_MAX_POWER = 150
 
-default_gadget = SerialGadgetConfig(
-    name=DEFAULT_NAME,
-    vid=DEFAULT_VID,
-    pid=DEFAULT_PID,
-    bcdDevice=DEFAULT_BCDEVICE,
-    serial_number=DEFAULT_SERIAL,
-    manufacturer=DEFAULT_MANUFACTURER,
-    product_desc=DEFAULT_PRODUCT,
-    configuration_desc=DEFAULT_CONFIGURATION,
-    max_power=DEFAULT_MAX_POWER,
-)
+SERIAL_NUMBER_FILE = "/var/serial"
+
+
+def _get_serial_number() -> str:
+    """Try to read the serial number from the filesystem."""
+    try:
+        with open(SERIAL_NUMBER_FILE, "r") as serial_file:
+            return serial_file.read()
+    except OSError:
+        return DEFAULT_SERIAL
+
+
+def get_gadget_config() -> SerialGadgetConfig:
+    """Get the default gadget configuration."""
+    return SerialGadgetConfig(
+        name=DEFAULT_NAME,
+        vid=DEFAULT_VID,
+        pid=DEFAULT_PID,
+        bcdDevice=DEFAULT_BCDEVICE,
+        serial_number=_get_serial_number(),
+        manufacturer=DEFAULT_MANUFACTURER,
+        product_desc=DEFAULT_PRODUCT,
+        configuration_desc=DEFAULT_CONFIGURATION,
+        max_power=DEFAULT_MAX_POWER,
+    )
+
 
 # The name of the PHY in sysfs for the OT3
 PHY_NAME = "usbphynop1"

--- a/usb-bridge/ot3usb/listener.py
+++ b/usb-bridge/ot3usb/listener.py
@@ -5,7 +5,9 @@ import select
 from typing import Optional, List, Any
 import serial  # type: ignore[import]
 
-from . import usb_config, default_config, usb_monitor, tcp_conn
+from . import usb_config, usb_monitor, tcp_conn
+
+from .default_config import DEFAULT_IP, DEFAULT_PORT
 
 LOG = logging.getLogger(__name__)
 
@@ -39,7 +41,7 @@ def update_ser_handle(
     elif connected and not ser:
         LOG.debug("New USB host connected")
         ser = config.get_handle()
-        tcp.connect(default_config.DEFAULT_IP, default_config.DEFAULT_PORT)
+        tcp.connect(DEFAULT_IP, DEFAULT_PORT)
     return ser
 
 

--- a/usb-bridge/tests/test_usb_config.py
+++ b/usb-bridge/tests/test_usb_config.py
@@ -22,7 +22,7 @@ def os_driver() -> mock.Mock:
 @pytest.fixture
 def subject(os_driver: mock.Mock) -> usb_config.SerialGadget:
     return usb_config.SerialGadget(
-        driver=os_driver, config=default_config.default_gadget
+        driver=os_driver, config=default_config.get_gadget_config()
     )
 
 
@@ -200,3 +200,21 @@ def test_get_udc_folder(subject: usb_config.SerialGadget) -> None:
     subject._udc_name = "fake_name"
     expected = usb_config.UDC_HANDLE_FOLDER + "fake_name"
     assert subject.udc_folder() == expected
+
+
+def test_get_gadget_serial_number(tmpdir: Path) -> None:
+    """Test that the gadget serial number is read."""
+    serial = Path(tmpdir) / "serial"
+    TEST_SERIAL = "fake_serial_number_123"
+    serial.write_text(TEST_SERIAL)
+    default_config.SERIAL_NUMBER_FILE = str(serial.absolute())
+
+    assert default_config.get_gadget_config().serial_number == TEST_SERIAL
+
+    # Make sure the default serial number is used if there's no serial file
+    default_config.SERIAL_NUMBER_FILE = "/fake/path/that/does/not/exist.txt"
+
+    assert (
+        default_config.get_gadget_config().serial_number
+        == default_config.DEFAULT_SERIAL
+    )


### PR DESCRIPTION


# Overview

- Use the serial number on the filesystem, and default to a serial number that follows our serial pattern
- Call the devices a Flex instead of OT3 in the public-facing device information


# Test Plan

Looked at the USB info with System Information.

* Uploaded to a robot that hadn't had the serial flashed, it shows up with the default serial
* Uploaded to a robot that _does_ have a serial number, it shows up as that serial number
* Both robots show up as a Flex instead of OT3

# Changelog


- Use the serial number on the filesystem, and default to a serial number that follows our serial pattern
- Call the devices a Flex instead of OT3 in the public-facing device information

# Review requests



# Risk assessment


