### PR TITLE
fix(app): remove hover from empty state in slideouts

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -290,7 +290,12 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
       width="100%"
       minHeight="11rem"
       padding={SPACING.spacing16}
-      css={BORDERS.cardOutlineBorder}
+      css={css`
+        ${BORDERS.cardOutlineBorder}
+        &:hover {
+          border-color: ${COLORS.medGreyEnabled};
+        }
+      `}
     >
       <Icon size="1.25rem" name="alert-circle" color={COLORS.medGreyEnabled} />
       <StyledText

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -200,7 +200,12 @@ export function ChooseRobotSlideout(
         </Flex>
         {!isScanning && healthyReachableRobots.length === 0 ? (
           <Flex
-            css={BORDERS.cardOutlineBorder}
+            css={css`
+              ${BORDERS.cardOutlineBorder}
+              &:hover {
+                border-color: ${COLORS.medGreyEnabled};
+              }
+            `}
             flexDirection={DIRECTION_COLUMN}
             justifyContent={JUSTIFY_CENTER}
             alignItems={ALIGN_CENTER}


### PR DESCRIPTION
# Overview
 
Remove gratuitous hover border color change from the empty state of the protocol and robot slideouts.

Closes RQA-1247

# Risk assessment
low
