### PR TITLE
fix(app): remove deck state modification support link until article written

### DIFF
--- a/app/src/organisms/InterventionModal/index.tsx
+++ b/app/src/organisms/InterventionModal/index.tsx
@@ -18,11 +18,9 @@ import {
   DISPLAY_FLEX,
   DIRECTION_COLUMN,
   ALIGN_FLEX_START,
-  TYPOGRAPHY,
-  JUSTIFY_SPACE_BETWEEN,
-  Link,
   Icon,
   PrimaryButton,
+  JUSTIFY_FLEX_END,
 } from '@opentrons/components'
 
 import { SmallButton } from '../../atoms/buttons'
@@ -84,7 +82,7 @@ const FOOTER_STYLE = {
   display: DISPLAY_FLEX,
   width: '100%',
   alignItems: ALIGN_CENTER,
-  justifyContent: JUSTIFY_SPACE_BETWEEN,
+  justifyContent: JUSTIFY_FLEX_END,
 } as const
 
 export interface InterventionModalProps {
@@ -204,6 +202,8 @@ export function InterventionModal({
           <Box {...CONTENT_STYLE}>
             {childContent}
             <Box {...FOOTER_STYLE}>
+              {/* 
+              TODO(BC, 08/31/23): reintroduce this link and justify space between when support article is written 
               <Link css={TYPOGRAPHY.darkLinkH4SemiBold} href="" external>
                 {t('protocol_info:manual_steps_learn_more')}
                 <Icon
@@ -212,6 +212,7 @@ export function InterventionModal({
                   size="0.5rem"
                 />
               </Link>
+              */}
               <PrimaryButton onClick={onResume}>
                 {t('confirm_and_resume')}
               </PrimaryButton>


### PR DESCRIPTION
# Overview

Remove link to deck state modification support documentation until there is actual documentation to point to.

Closes RAUT-610

Before: 

<img width="757" alt="Screen Shot 2023-08-31 at 12 47 11 PM" src="https://github.com/Opentrons/opentrons/assets/4731953/34061181-9fc6-4350-81c0-f5fba4b6df76">

After:

<img width="754" alt="Screen Shot 2023-08-31 at 12 47 16 PM" src="https://github.com/Opentrons/opentrons/assets/4731953/39e160ac-4993-49fe-ab45-2d42bdc4cd16">

# Risk assessment
low