### PR TITLE
feat(protocol-designer, step-generation): fix labware & Heater-shaker...

### DIFF
--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -87,9 +87,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   string,
   string[]
 > = {
-  [DEEP_WELL_ADAPTER_LOADNAME]: [
-    'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',
-  ],
+  [DEEP_WELL_ADAPTER_LOADNAME]: ['opentrons/nest_96_wellplate_2ml_deep/2'],
   [FLAT_BOTTOM_ADAPTER_LOADNAME]: ['opentrons/nest_96_wellplate_200ul_flat/2'],
   [PCR_ADAPTER_LOADNAME]: [
     'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',

--- a/step-generation/src/utils/heaterShakerCollision.ts
+++ b/step-generation/src/utils/heaterShakerCollision.ts
@@ -81,10 +81,11 @@ export const pipetteIntoHeaterShakerLatchOpen = (
   labwareId: string
 ): boolean => {
   const labwareSlot: string = labware[labwareId]?.slot
+  const adapterSlot: string = labware[labwareSlot]?.slot
   const moduleUnderLabware: string | null | undefined =
     modules &&
-    labwareSlot &&
-    Object.keys(modules).find((moduleId: string) => moduleId === labwareSlot)
+    adapterSlot &&
+    Object.keys(modules).find((moduleId: string) => moduleId === adapterSlot)
   const moduleState =
     moduleUnderLabware && modules[moduleUnderLabware].moduleState
   const isHSLatchOpen: boolean = Boolean(


### PR DESCRIPTION
… errorCreator

closes RQA-1455

# Overview

Fix the 3 bugs listed in the ticket related to errors Rob saw during protocol analysis

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_error-creator-tweaks/

1. make a new protocol (either OT-2 or Flex) in PD, add a heater-shaker, add a `Opentrons 96 Deep Well Adapter` on top of the heater-shaker, when adding a labware on top of the adapter, make sure the only option is `NEST 96 Deep well plate 2ML`. Add that labware

2. try to add a transfer step into the labware on the Heater-shaker. There should be a timeline error saying that the labware latch needs to be closed before pipetting into the labware

3. delete the transfer step and add a move labware step to the labware on the heater-shaker. There should be a timeline error saying that the labware latch needs to be open before moving the labware (NOTE: this bug was actually addressed in a different PR but just mentioning it here since Rob documented it in the ticket)

# Changelog

- change the labware that is compatible with the 96 deep well adapter
- tweak `pipetteIntoHeaterShakerLatchOpen` to account for the labware being on top of an adapter

# Review requests

see test plan

# Risk assessment

low