### PR TITLE
refactor(app): update network setup header copy

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -50,7 +50,6 @@
   "confirm_device_reset_description": "This will permanently delete all protocol, calibration, and other data. You’ll have to redo initial setup before using the robot again.",
   "confirm_device_reset_heading": "Are you sure you want to reset your device?",
   "connect_the_estop_to_continue": "Connect the E-stop to continue",
-  "connect_to_a_network": "Connect to a network",
   "connect_to_wifi_network": "Connect to Wi-Fi network",
   "connect_to": "Connect to {{ssid}}",
   "connect_via_usb_description_1": "1. Connect the USB A-to-B cable to the robot’s USB-B port.",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -28,6 +28,7 @@
   "characters_max": "17 characters max",
   "check_for_updates": "Check for updates",
   "checking_for_updates": "Checking for updates",
+  "choose_network_type": "Choose network type",
   "choose_reset_settings": "Choose reset settings",
   "choose": "Choose...",
   "clear_all_data": "Clear all data",

--- a/app/src/pages/OnDeviceDisplay/NetworkSetupMenu.tsx
+++ b/app/src/pages/OnDeviceDisplay/NetworkSetupMenu.tsx
@@ -62,7 +62,7 @@ export function NetworkSetupMenu(): JSX.Element {
             fontWeight={TYPOGRAPHY.fontWeightBold}
             color={COLORS.black}
           >
-            {t('connect_to_a_network')}
+            {t('choose_network_type')}
           </StyledText>
         </Flex>
         <Flex

--- a/app/src/pages/OnDeviceDisplay/__tests__/NetworkSetupMenu.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/NetworkSetupMenu.test.tsx
@@ -31,7 +31,7 @@ describe('NetworkSetupMenu', () => {
   it('should render text and button, and step meter', () => {
     const [{ getByText }] = render()
 
-    getByText('Connect to a network')
+    getByText('Choose network type')
     getByText(
       'You’ll use this connection to run software updates and load protocols onto your Opentrons Flex.'
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Changes the copy on the network setup screen. In response to beta feedback that "users did not know these options are interactive. Instead of touching anything on the screen, they proceeded to use a USB connection method to a windows computer and ran into errors."

Hopefully including the word **Choose** in the header will make for a better experience.

Closes [RUXD-1082](https://opentrons.atlassian.net/jira/software/c/projects/RUXD/issues/RUXD-1082).

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- tested with `make -C app dev-odd`
<img width="1136" alt="Screenshot 2023-08-31 at 1 36 23 PM" src="https://github.com/Opentrons/opentrons/assets/1958332/d81d057b-eae8-4d95-b796-e18ebf2792f5">


# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- new localization string `choose_network_type`
- leaves `connect_to_a_network` in place on other screens
- updated test

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Check that this works in the flow and doesn't have any unintended effects on other screens.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Low. Small copy change.

[RUXD-1082]: https://opentrons.atlassian.net/browse/RUXD-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ