### PR TITLE
fix(app): fix run setup pipette bugs

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupFlexPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupFlexPipetteCalibrationItem.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  ALIGN_CENTER,
+  DIRECTION_ROW,
+  SPACING,
+  JUSTIFY_FLEX_END,
+  WRAP,
+} from '@opentrons/components'
+import {
+  getPipetteNameSpecs,
+  NINETY_SIX_CHANNEL,
+  SINGLE_MOUNT_PIPETTES,
+} from '@opentrons/shared-data'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import { TertiaryButton } from '../../../atoms/buttons'
+import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { PipetteWizardFlows } from '../../PipetteWizardFlows'
+import { FLOWS } from '../../PipetteWizardFlows/constants'
+import { SetupCalibrationItem } from './SetupCalibrationItem'
+import type { PipetteData } from '@opentrons/api-client'
+import type { LoadPipetteRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/setup'
+import type { Mount } from '../../../redux/pipettes/types'
+
+interface SetupInstrumentCalibrationItemProps {
+  mount: Mount
+  runId: string
+  instrumentsRefetch?: () => void
+}
+
+export function SetupFlexPipetteCalibrationItem({
+  mount,
+  runId,
+  instrumentsRefetch,
+}: SetupInstrumentCalibrationItemProps): JSX.Element | null {
+  const { t } = useTranslation(['protocol_setup', 'devices_landing'])
+  const [showFlexPipetteFlow, setShowFlexPipetteFlow] = React.useState<boolean>(
+    false
+  )
+  const { data: attachedInstruments } = useInstrumentsQuery()
+  const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
+  const loadPipetteCommand = mostRecentAnalysis?.commands.find(
+    (command): command is LoadPipetteRunTimeCommand =>
+      command.commandType === 'loadPipette' && command.params.mount === mount
+  )
+  const requestedPipette = mostRecentAnalysis?.pipettes?.find(
+    pipette => pipette.id === loadPipetteCommand?.result?.pipetteId
+  )
+
+  if (requestedPipette == null) return null
+  const requestedPipetteSpecs = getPipetteNameSpecs(
+    requestedPipette.pipetteName
+  )
+  let button: JSX.Element | undefined
+  let subText
+
+  const attachedPipetteOnMount = attachedInstruments?.data?.find(
+    (instrument): instrument is PipetteData =>
+      instrument.ok && instrument.mount === mount
+  )
+  const requestedPipetteMatch =
+    requestedPipette.pipetteName === attachedPipetteOnMount?.instrumentName
+  const pipetteCalDate = requestedPipetteMatch
+    ? attachedPipetteOnMount?.data.calibratedOffset?.last_modified ?? null
+    : null
+  let flowType = ''
+  if (pipetteCalDate != null && requestedPipetteMatch) {
+    button = undefined
+  } else if (!requestedPipetteMatch) {
+    subText = t('attach_pipette_calibration')
+    flowType = FLOWS.ATTACH
+    button = (
+      <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
+        <TertiaryButton
+          id="PipetteCalibration_attachPipetteButton"
+          onClick={() => setShowFlexPipetteFlow(true)}
+        >
+          {t('attach_pipette_cta')}
+        </TertiaryButton>
+      </Flex>
+    )
+  } else {
+    flowType = FLOWS.CALIBRATE
+    button = (
+      <>
+        <Flex
+          alignItems={ALIGN_CENTER}
+          marginLeft={SPACING.spacing16}
+          flexWrap={WRAP}
+          justifyContent={JUSTIFY_FLEX_END}
+          gridGap={SPACING.spacing8}
+        >
+          <TertiaryButton
+            id="PipetteCalibration_calibratePipetteButton"
+            onClick={() => setShowFlexPipetteFlow(true)}
+          >
+            {t('calibrate_now')}
+          </TertiaryButton>
+        </Flex>
+      </>
+    )
+  }
+
+  return (
+    <>
+      {showFlexPipetteFlow && (
+        <PipetteWizardFlows
+          flowType={flowType}
+          mount={mount}
+          closeFlow={() => setShowFlexPipetteFlow(false)}
+          selectedPipette={
+            requestedPipetteSpecs?.channels === 96
+              ? NINETY_SIX_CHANNEL
+              : SINGLE_MOUNT_PIPETTES
+          }
+          pipetteInfo={mostRecentAnalysis?.pipettes}
+          onComplete={instrumentsRefetch}
+        />
+      )}
+      <SetupCalibrationItem
+        button={button}
+        calibratedDate={pipetteCalDate}
+        subText={subText}
+        label={t(`devices_landing:${mount}_mount`)}
+        title={requestedPipetteSpecs?.displayName}
+        id={`PipetteCalibration_${mount}MountTitle`}
+        runId={runId}
+      />
+    </>
+  )
+}

--- a/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
@@ -11,8 +11,13 @@ import {
 
 import { StyledText } from '../../../atoms/text'
 import * as PipetteConstants from '../../../redux/pipettes/constants'
-import { useRunPipetteInfoByMount, useStoredProtocolAnalysis } from '../hooks'
+import {
+  useRunPipetteInfoByMount,
+  useStoredProtocolAnalysis,
+  useIsOT3,
+} from '../hooks'
 import { SetupPipetteCalibrationItem } from './SetupPipetteCalibrationItem'
+import { SetupFlexPipetteCalibrationItem } from './SetupFlexPipetteCalibrationItem'
 import { SetupGripperCalibrationItem } from './SetupGripperCalibrationItem'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
@@ -33,8 +38,10 @@ export function SetupInstrumentCalibration({
 }: SetupInstrumentCalibrationProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
   const runPipetteInfoByMount = useRunPipetteInfoByMount(runId)
+  const isOT3 = useIsOT3(robotName)
 
   const { data: instrumentsQueryData, refetch } = useInstrumentsQuery({
+    enabled: isOT3,
     refetchInterval: EQUIPMENT_POLL_MS,
   })
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
@@ -58,16 +65,29 @@ export function SetupInstrumentCalibration({
       </StyledText>
       {PipetteConstants.PIPETTE_MOUNTS.map((mount, index) => {
         const pipetteInfo = runPipetteInfoByMount[mount]
-        return pipetteInfo != null ? (
-          <SetupPipetteCalibrationItem
-            key={index}
-            pipetteInfo={pipetteInfo}
-            mount={mount}
-            robotName={robotName}
-            runId={runId}
-            instrumentsRefetch={refetch}
-          />
-        ) : null
+        if (pipetteInfo != null && !isOT3) {
+          return (
+            <SetupPipetteCalibrationItem
+              key={index}
+              pipetteInfo={pipetteInfo}
+              mount={mount}
+              robotName={robotName}
+              runId={runId}
+              instrumentsRefetch={refetch}
+            />
+          )
+        } else if (isOT3) {
+          return (
+            <SetupFlexPipetteCalibrationItem
+              key={index}
+              mount={mount}
+              runId={runId}
+              instrumentsRefetch={refetch}
+            />
+          )
+        } else {
+          return null
+        }
       })}
       {usesGripper ? (
         <SetupGripperCalibrationItem

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupFlexPipetteCalibrationItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupFlexPipetteCalibrationItem.test.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react'
+import { resetAllWhenMocks } from 'jest-when'
+import { MemoryRouter } from 'react-router-dom'
+import { fireEvent } from '@testing-library/dom'
+
+import { renderWithProviders } from '@opentrons/components'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
+
+import { i18n } from '../../../../i18n'
+import { useMostRecentCompletedAnalysis } from '../../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { PipetteWizardFlows } from '../../../PipetteWizardFlows'
+import { SetupFlexPipetteCalibrationItem } from '../SetupFlexPipetteCalibrationItem'
+import _uncastedModifiedSimpleV6Protocol from '../../hooks/__fixtures__/modifiedSimpleV6.json'
+import { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+
+jest.mock('@opentrons/react-api-client')
+jest.mock('../../../PipetteWizardFlows')
+jest.mock('../../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
+jest.mock('../../hooks')
+
+const mockUseInstrumentsQuery = useInstrumentsQuery as jest.MockedFunction<
+  typeof useInstrumentsQuery
+>
+const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
+  typeof useMostRecentCompletedAnalysis
+>
+const mockPipetteWizardFlows = PipetteWizardFlows as jest.MockedFunction<
+  typeof PipetteWizardFlows
+>
+
+const RUN_ID = '1'
+const modifiedSimpleV6Protocol = ({
+  ..._uncastedModifiedSimpleV6Protocol,
+  pipettes: [
+    {
+      id: 'pipetteId',
+      pipetteName: 'p10_single',
+    },
+  ],
+} as any) as CompletedProtocolAnalysis
+
+describe('SetupFlexPipetteCalibrationItem', () => {
+  const render = ({
+    mount = 'left',
+    runId = RUN_ID,
+  }: Partial<
+    React.ComponentProps<typeof SetupFlexPipetteCalibrationItem>
+  > = {}) => {
+    return renderWithProviders(
+      <MemoryRouter>
+        <SetupFlexPipetteCalibrationItem
+          {...{
+            mount,
+            runId,
+          }}
+        />
+      </MemoryRouter>,
+      { i18nInstance: i18n }
+    )[0]
+  }
+
+  beforeEach(() => {
+    mockPipetteWizardFlows.mockReturnValue(<div>pipette wizard flows</div>)
+    mockUseMostRecentCompletedAnalysis.mockReturnValue(modifiedSimpleV6Protocol)
+    mockUseInstrumentsQuery.mockReturnValue({
+      data: {
+        data: [],
+      },
+    } as any)
+  })
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+
+  it('renders the mount and pipette name', () => {
+    const { getByText } = render()
+    getByText('Left Mount')
+    getByText('P10 Single-Channel GEN1')
+  })
+
+  it('renders an attach button if on a Flex and pipette is not attached', () => {
+    const { getByText, getByRole } = render()
+    getByText('Left Mount')
+    getByText('P10 Single-Channel GEN1')
+    const attach = getByRole('button', { name: 'Attach Pipette' })
+    fireEvent.click(attach)
+    getByText('pipette wizard flows')
+  })
+  it('renders a calibrate button if on a Flex and pipette is not calibrated', () => {
+    mockUseInstrumentsQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            instrumentType: 'pipette',
+            mount: 'left',
+            ok: true,
+            firmwareVersion: 12,
+            instrumentName: 'p10_single',
+            data: {},
+          } as any,
+        ],
+      },
+    } as any)
+    const { getByText, getByRole } = render()
+    getByText('Left Mount')
+    getByText('P10 Single-Channel GEN1')
+    const attach = getByRole('button', { name: 'Calibrate now' })
+    fireEvent.click(attach)
+    getByText('pipette wizard flows')
+  })
+  it('renders calibrated text if on a Flex and pipette is calibrated', () => {
+    mockUseInstrumentsQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            instrumentType: 'pipette',
+            mount: 'left',
+            ok: true,
+            firmwareVersion: 12,
+            instrumentName: 'p10_single',
+            data: {
+              calibratedOffset: {
+                last_modified: 'today',
+              },
+            },
+          } as any,
+        ],
+      },
+    } as any)
+    const { getByText } = render()
+    getByText('Left Mount')
+    getByText('P10 Single-Channel GEN1')
+    getByText('Last calibrated: today')
+  })
+})

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibrationItem.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibrationItem.test.tsx
@@ -6,28 +6,14 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
 import { mockPipetteInfo } from '../../../../redux/pipettes/__fixtures__'
-import {
-  useDeckCalibrationData,
-  useAttachedPipettesFromInstrumentsQuery,
-  useIsOT3,
-} from '../../hooks'
-import { PipetteWizardFlows } from '../../../PipetteWizardFlows'
+import { useDeckCalibrationData } from '../../hooks'
 import { SetupPipetteCalibrationItem } from '../SetupPipetteCalibrationItem'
 import { MemoryRouter } from 'react-router-dom'
-import { fireEvent } from '@testing-library/dom'
 
 jest.mock('../../hooks')
-jest.mock('../../../PipetteWizardFlows')
 
 const mockUseDeckCalibrationData = useDeckCalibrationData as jest.MockedFunction<
   typeof useDeckCalibrationData
->
-const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
-const mockUseAttachedPipettesFromInstrumentsQuery = useAttachedPipettesFromInstrumentsQuery as jest.MockedFunction<
-  typeof useAttachedPipettesFromInstrumentsQuery
->
-const mockPipetteWizardFlows = PipetteWizardFlows as jest.MockedFunction<
-  typeof PipetteWizardFlows
 >
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
@@ -57,7 +43,6 @@ describe('SetupPipetteCalibrationItem', () => {
   }
 
   beforeEach(() => {
-    mockPipetteWizardFlows.mockReturnValue(<div>pipette wizard flows</div>)
     when(mockUseDeckCalibrationData).calledWith(ROBOT_NAME).mockReturnValue({
       deckCalibrationData: mockDeckCalData,
       isDeckCalibrated: true,
@@ -101,75 +86,5 @@ describe('SetupPipetteCalibrationItem', () => {
     })
     getByRole('link', { name: 'Learn more' })
     getByText('Pipette generation mismatch.')
-  })
-  it('renders an attach button if on a Flex and pipette is not attached', () => {
-    mockUseIsOT3.mockReturnValue(true)
-    mockUseAttachedPipettesFromInstrumentsQuery.mockReturnValue({
-      left: null,
-      right: null,
-    })
-    const { getByText, getByRole } = render({
-      pipetteInfo: {
-        ...mockPipetteInfo,
-        tipRacksForPipette: [],
-        requestedPipetteMatch: 'incompatible',
-        pipetteCalDate: null,
-      },
-    })
-    getByText('Left Mount')
-    getByText(mockPipetteInfo.pipetteSpecs.displayName)
-    const attach = getByRole('button', { name: 'Attach Pipette' })
-    fireEvent.click(attach)
-    getByText('pipette wizard flows')
-  })
-  it('renders a calibrate button if on a Flex and pipette is not calibrated', () => {
-    mockUseIsOT3.mockReturnValue(true)
-    mockUseAttachedPipettesFromInstrumentsQuery.mockReturnValue({
-      left: {
-        data: {
-          calibratedOffset: {
-            last_modified: undefined,
-          },
-        },
-      } as any,
-      right: null,
-    })
-    const { getByText, getByRole } = render({
-      pipetteInfo: {
-        ...mockPipetteInfo,
-        tipRacksForPipette: [],
-        requestedPipetteMatch: 'match',
-        pipetteCalDate: null,
-      },
-    })
-    getByText('Left Mount')
-    getByText(mockPipetteInfo.pipetteSpecs.displayName)
-    const attach = getByRole('button', { name: 'Calibrate now' })
-    fireEvent.click(attach)
-    getByText('pipette wizard flows')
-  })
-  it('renders calibrated text if on a Flex and pipette is calibrated', () => {
-    mockUseIsOT3.mockReturnValue(true)
-    mockUseAttachedPipettesFromInstrumentsQuery.mockReturnValue({
-      left: {
-        data: {
-          calibratedOffset: {
-            last_modified: 'today',
-          },
-        },
-      } as any,
-      right: null,
-    })
-    const { getByText } = render({
-      pipetteInfo: {
-        ...mockPipetteInfo,
-        tipRacksForPipette: [],
-        requestedPipetteMatch: 'match',
-        pipetteCalDate: null,
-      },
-    })
-    getByText('Left Mount')
-    getByText(mockPipetteInfo.pipetteSpecs.displayName)
-    getByText('Last calibrated: today')
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -166,28 +166,6 @@ export const Results = (props: ResultsProps): JSX.Element => {
         .catch(error => {
           setShowErrorMessage(error.message)
         })
-    } else if (
-      isSuccess &&
-      flowType === FLOWS.DETACH &&
-      currentStepIndex !== totalStepCount
-    ) {
-      chainRunCommands?.(
-        [
-          {
-            commandType: 'calibration/moveToMaintenancePosition' as const,
-            params: {
-              mount: mount,
-            },
-          },
-        ],
-        false
-      )
-        .then(() => {
-          proceed()
-        })
-        .catch(error => {
-          setShowErrorMessage(error.message)
-        })
     } else {
       proceed()
     }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -232,17 +232,7 @@ describe('Results', () => {
     getByText('attach pipette')
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.chainRunCommands).toHaveBeenCalledWith(
-      [
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: 'left',
-          },
-        },
-      ],
-      false
-    )
+    expect(props.proceed).toHaveBeenCalled()
   })
   it('renders the correct information when pipette wizard succeeds to calibrate in attach flow 96-channel', () => {
     props = {


### PR DESCRIPTION
fix RQA-1428, RQA-1433

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
We were grabbing pipette compatibility for run setup from the `/pipettes` endpoint which doesn't poll as often as `/instruments`. This was causing a delay in registering that the pipette is now attached or calibrated in the run setup Robot Calibration tab.

# Test Plan
Swap out a pipette during run setup, get through the flow successfully and see results reflected once flow is closed. See video:
https://github.com/Opentrons/opentrons/assets/14302493/9f3cd608-9805-4b00-8e94-b3e90af852c9


<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Separate out `SetupPipetteCalibrationItem` for OT2 and Flex because of the high divergence in logic and data. Create `SetupFlexPipetteCalibrationItem` that grabs all data from `/instruments` instead of `pipettes`
2. Remove `moveToMaintenancePosition` command between detach and attach in the pipette replace flow. The mount will already be in this position so we don't need an extra call, and this was failing because the motor needed to be homed before making the request, which we already do after attaching a pipette.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
See if I missed anything in the file separation
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
