### PR TITLE
refactor(protocol-designer): 7.0 release candidate b various bug fixes

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -23,6 +23,7 @@ import {
   TEMPERATURE_MODULE_V1,
   RobotType,
   FLEX_ROBOT_TYPE,
+  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import {
@@ -155,7 +156,13 @@ export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
           { selectedSlot }
         )
       }
-    } else if (hasSlotIssue(selectedSlot)) {
+    } else if (
+      //  TODO(jr, 8/31/23): this is a bit hacky since the TCGEN2 slot is only B1 instead of B1 and A1
+      //  so we have to manually check if slot A1 has issues as well as looking at selectedSlot
+      //  this probably deserves a more elegant refactor
+      (selectedModel === THERMOCYCLER_MODULE_V2 && hasSlotIssue('A1')) ||
+      hasSlotIssue(selectedSlot)
+    ) {
       errors.selectedSlot = i18n.t(
         'alert.module_placement.SLOT_OCCUPIED.body',
         { selectedSlot }
@@ -233,7 +240,6 @@ const EditModulesModalComponent = (
   const disabledModuleRestriction = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
-  const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const robotType = useSelector(getRobotType)
 
   const noCollisionIssue =
@@ -253,12 +259,6 @@ const EditModulesModalComponent = (
   const slotIssue =
     errors?.selectedSlot && errors.selectedSlot.includes('occupied')
 
-  const tcGen2SlotIssue =
-    moduleType === 'thermocyclerModuleType' &&
-    getSlotIsEmpty(initialDeckSetup, 'B1')
-
-  console.log(moduleType === 'thermocyclerModuleType')
-  console.log(getSlotIsEmpty(initialDeckSetup, 'B1'))
   useResetSlotOnModelChange(supportedModuleSlot)
 
   const [targetProps, tooltipProps] = useHoverTooltip({
@@ -289,7 +289,7 @@ const EditModulesModalComponent = (
       contentsClassName={styles.modal_contents}
     >
       <>
-        {(slotIssue || tcGen2SlotIssue) && (
+        {slotIssue && (
           <PDAlert
             alertType="warning"
             title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -233,6 +233,7 @@ const EditModulesModalComponent = (
   const disabledModuleRestriction = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
+  const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const robotType = useSelector(getRobotType)
 
   const noCollisionIssue =
@@ -252,6 +253,12 @@ const EditModulesModalComponent = (
   const slotIssue =
     errors?.selectedSlot && errors.selectedSlot.includes('occupied')
 
+  const tcGen2SlotIssue =
+    moduleType === 'thermocyclerModuleType' &&
+    getSlotIsEmpty(initialDeckSetup, 'B1')
+
+  console.log(moduleType === 'thermocyclerModuleType')
+  console.log(getSlotIsEmpty(initialDeckSetup, 'B1'))
   useResetSlotOnModelChange(supportedModuleSlot)
 
   const [targetProps, tooltipProps] = useHoverTooltip({
@@ -282,7 +289,7 @@ const EditModulesModalComponent = (
       contentsClassName={styles.modal_contents}
     >
       <>
-        {slotIssue && (
+        {(slotIssue || tcGen2SlotIssue) && (
           <PDAlert
             alertType="warning"
             title={i18n.t('alert.module_placement.SLOT_OCCUPIED.title')}

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
@@ -46,8 +46,7 @@ function PipetteGroup(props: Props): JSX.Element {
           imageStyle={
             robotType === FLEX_ROBOT_TYPE
               ? css`
-                  left: 38.5rem;
-                  position: fixed;
+                  margin-right: 1rem;
                 `
               : undefined
           }
@@ -64,7 +63,7 @@ function PipetteGroup(props: Props): JSX.Element {
             robotType === FLEX_ROBOT_TYPE
               ? css`
                   right: -1.5rem;
-                  position: fixed;
+                  position: absolute;
                 `
               : undefined
           }

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
@@ -46,7 +46,7 @@ function PipetteGroup(props: Props): JSX.Element {
           imageStyle={
             robotType === FLEX_ROBOT_TYPE
               ? css`
-                  left: 36rem;
+                  left: 38.5rem;
                   position: fixed;
                 `
               : undefined
@@ -63,7 +63,7 @@ function PipetteGroup(props: Props): JSX.Element {
           imageStyle={
             robotType === FLEX_ROBOT_TYPE
               ? css`
-                  right: -2rem;
+                  right: -1.5rem;
                   position: fixed;
                 `
               : undefined

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -96,7 +96,7 @@ export function PipetteFields(props: Props): JSX.Element {
     const { tabIndex, mount } = props
     const pipetteName = values[mount].pipetteName
     return (
-      <Flex width="15rem">
+      <Flex width="13.8rem">
         <PipetteSelect
           nameBlocklist={
             //  filtering out 96-channel for Flex for now
@@ -157,8 +157,8 @@ export function PipetteFields(props: Props): JSX.Element {
 
   return (
     <>
-      <div className={styles.mount_fields_row}>
-        <div className={styles.mount_column}>
+      <div className={styles.mount_fields_row} style={{ overflowX: 'hidden' }}>
+        <div>
           <FormGroup
             key="leftPipetteModel"
             label={i18n.t('modal.pipette_fields.left_pipette')}
@@ -185,7 +185,7 @@ export function PipetteFields(props: Props): JSX.Element {
           leftPipette={values.left.pipetteName}
           rightPipette={values.right.pipetteName}
         />
-        <div className={styles.mount_column}>
+        <div style={{ width: '13.8rem' }}>
           <FormGroup
             key="rightPipetteModel"
             label={i18n.t('modal.pipette_fields.right_pipette')}

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -37,7 +37,7 @@
     },
     "deck_setup_explanation": {
       "title": "Setting up your protocol",
-      "body1": "If you look to your left you will see the Protocol Timeline, and that the \"Starting Deck State\" step is blue. The blue means that this is the step you are currently working on.",
+      "body1": "If you look to your left you will see the Protocol Timeline, and that the \"Starting Deck State\" step is listed first.",
       "body2": "Before you can build a protocol that tells the robot how to move liquid around, you'll need to tell the Protocol Designer where all of your labware is on the deck, and which liquids start in which wells. As you add steps to your protocol the Protocol Designer will move liquid from the starting positions you defined in the Starting Deck State to new positions.",
       "body3": "Hover on empty slots in the deck to add labware. Hover on labware to add liquid to the wells."
     },

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -113,6 +113,10 @@ export const getSlotIsEmpty = (
   } else if (getSlotIdsBlockedBySpanning(initialDeckSetup).includes(slot)) {
     // if a slot is being blocked by a spanning labware/module (eg thermocycler), it's not empty
     return false
+    //  don't allow duplicating into the trash slot.
+    //  TODO(jr, 8/31/23): delete this when we support moveable trash
+  } else if (slot === '12' || slot === 'A3') {
+    return false
   }
 
   // NOTE: should work for both deck slots and module slots


### PR DESCRIPTION
 closes RQA-1183, RQA-1126, RQA-1123, RQA-1080

# Overview

Fixes a handful of bugs QA found

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_rc-b-bug-fixes/

1. create a protocol with either OT-2 or flex, when you go to the Design tab, there is a modal that should pop up (if it doesn't then you turned off the hints and need to turn them back on in the settings). The modal should have NO reference to a blue highlighted step anymore (RQA-1183)
2. after you dismiss the modal, click on the duplicate button when you hover over the tiprack or any labware on the deck. Duplicate until the whole deck is filled. Make sure that it doesn't duplicate onto the trash slot. (RQA-1126)
3. create a new protocol with the Flex (not OT-2). Go to the design tab and add a labware to the `A1` location. Go to the File tab and add a thermocycler. When you select the GEN2 model, there should be warning that shows up saying that the slot is occupied so you can't place the module there (RQA-1123)
4. exit out of adding a thermocycler modal, click on editing the pipettes model up above. The pipette images should be aligned and not overlapping with the dropdown menus. (RQA-1080)

# Changelog

- fix copy in deck setup explanation modal
- add logic to indicate that if slot A1 is occupied then the TC GEn2 can't go on the deck
- tweak the pipette diagram locations
- filter out the trash slots for duplicating labware

# Review requests

see test plan

# Risk assessment

low