### PR TITLE
chore: Update v7.0.0 release notes for PR #13425

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -32,7 +32,6 @@ This update may take longer than usual. Allow **approximately 15 minutes** for y
 
 - The API relaxes placement restrictions for the Heater-Shaker Module on Flex.
 - Pipettes drop tips in multiple locations above the trash bin to prevent tips from stacking up.
-- Load times for various parts of the Opentrons App have been reduced.
 
 ### Known Issues
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,11 +10,7 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.0.0 release of the Opentrons robot software! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.
 
-### Upgrade Note: Allow Extra Time for Restart
-
-When you first upgrade a robot to this version, it will take longer to restart, because it needs to convert some internal storage to a more efficient format.
-
-How much longer depends on how many different protocols you've recently run and how big they are. A lightly-loaded robot should only take an additional minute, but a heavily-loaded robot can take 10 minutes.
+This update may take longer than usual. Allow **approximately 15 minutes** for your robot to restart. This delay will only happen once.
 
 ### New Features
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,6 +10,12 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.0.0 release of the Opentrons robot software! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.
 
+### Upgrade Note: Allow Extra Time for Restart
+
+When you first upgrade a robot to this version, it will take longer to restart, because it needs to convert some internal storage to a more efficient format.
+
+How much longer depends on how many different protocols you've recently run and how big they are. A lightly-loaded robot should only take an additional minute, but a heavily-loaded robot can take 10 minutes.
+
 ### New Features
 
 - Flex touchscreen
@@ -30,6 +36,7 @@ Welcome to the v7.0.0 release of the Opentrons robot software! This release adds
 
 - The API relaxes placement restrictions for the Heater-Shaker Module on Flex.
 - Pipettes drop tips in multiple locations above the trash bin to prevent tips from stacking up.
+- Load times for various parts of the Opentrons App have been reduced.
 
 ### Known Issues
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,11 +10,7 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.0.0 release of the Opentrons App! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.
 
-### Upgrade Note: Allow Extra Time for Restart
-
-When you first upgrade a robot to this version, it will take longer to restart, because it needs to convert some internal storage to a more efficient format.
-
-How much longer depends on how many different protocols you've recently run and how big they are. A lightly-loaded robot should only take an additional minute, but a heavily-loaded robot can take 10 minutes.
+This update may take longer than usual. Allow **approximately 15 minutes** for your robot to restart. This delay will only happen once.
 
 ### New Features
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -23,7 +23,7 @@ Welcome to the v7.0.0 release of the Opentrons App! This release adds support fo
 
 ### Improved Features
 
-- Load times for various pages have been reduced.
+- The app loads various pages faster.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,6 +10,12 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.0.0 release of the Opentrons App! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.
 
+### Upgrade Note: Allow Extra Time for Restart
+
+When you first upgrade a robot to this version, it will take longer to restart, because it needs to convert some internal storage to a more efficient format.
+
+How much longer depends on how many different protocols you've recently run and how big they are. A lightly-loaded robot should only take an additional minute, but a heavily-loaded robot can take 10 minutes.
+
 ### New Features
 
 - Opentrons Flex features
@@ -20,6 +26,10 @@ Welcome to the v7.0.0 release of the Opentrons App! This release adds support fo
 - General app features
   - Manually move labware around the deck during protocols. The app shows animated instructions for which labware to move, and lets you resume the protocol when movement is complete.
   - See when your protocol will pause. During a run, marks on the protocol timeline show all pauses that require user attention, including labware movement.
+
+### Improved Features
+
+- Load times for various pages have been reduced.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,8 +10,6 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.0.0 release of the Opentrons App! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.
 
-This update may take longer than usual. Allow **approximately 15 minutes** for your robot to restart. This delay will only happen once.
-
 ### New Features
 
 - Opentrons Flex features


### PR DESCRIPTION
# Overview

PR #13425 introduces a database migration. When robots in the field upgrade to it, it will take longer for them to restart. Call this out in the release notes.

I guess in practice, this will only affect OT-2 users, and it will only affect them after we reunify the Flex and OT-2 releases. So arguably, this should be in the v7.1.0 release notes, not v7.0.0? I don't know. It at least seems prudent to add this note here now so we don't forget later on.

Also, PR #13425 should make various things load faster. Call this out as an "improved feature."

# Review requests

* Does this make sense to add to the release notes now?
* words good?