### PR TITLE
fix(robot-server): Resolve LabwareRole pickle warnings

### DIFF
--- a/robot-server/robot_server/persistence/legacy_pickle.py
+++ b/robot-server/robot_server/persistence/legacy_pickle.py
@@ -158,6 +158,11 @@ def _get_legacy_ot_types() -> List[_LegacyTypeInfo]:
         _LegacyTypeInfo(original_name="LabwareMovementStrategy", current_type=LabwareMovementStrategy)
     )
 
+    from opentrons_shared_data.labware.labware_definition import LabwareRole
+    _legacy_ot_types.append(
+        _LegacyTypeInfo(original_name="LabwareRole", current_type=LabwareRole)
+    )
+
     from opentrons.protocol_engine import ModuleModel
     _legacy_ot_types.append(
         _LegacyTypeInfo(original_name="ModuleModel", current_type=ModuleModel)


### PR DESCRIPTION
# Overview

PR #12811 added a new type, `LabwareRole`, that gets pickled in robot-server's database.

robot-server is warning us that we haven't specifically acknowledged that, so if we're not careful, we might rename or move `LabwareRole` and break database compatibility.

> Unpickling unknown type "LabwareRole"...this may cause problems with reading records created by older versions of this robot software. This should be reported to Opentrons and investigated. 

This PR adds `LabwareRole` to the list in `legacy_pickle.py` to resolve the warning.

This is a result of not having resolved RSS-98. See that ticket for background.

# Test Plan

None needed.

# Review requests

None in particular.

# Risk assessment

Low.
