### PR TITLE
feat(app): include current labware offsets in touchscreen LPC, implement lpc protocol setup designs

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -99,6 +99,7 @@
   "stored_offsets_for_this_protocol": "Stored Labware Offset data that applies to this protocol",
   "table_view": "Table View",
   "tip_rack": "tip rack",
+  "view_current_offsets": "view current offsets",
   "view_data": "View data",
   "what_is_labware_offset_data": "What is labware offset data?"
 }

--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -125,7 +125,7 @@
   "must_have_labware_and_pip": "Protocol must load labware and a pipette",
   "n_a": "N/A",
   "no_data": "no data",
-  "no_labware_offset_data": "No Labware Offset Data yet",
+  "no_labware_offset_data": "no labware offset data yet",
   "no_modules_specified": "no modules are specified for this protocol.",
   "no_modules_used_in_this_protocol": "No modules used in this protocol",
   "no_tiprack_loaded": "Protocol must load a tip rack",

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -49,7 +49,6 @@ export function WizardRequiredEquipmentList(
           >
             {t('you_will_need')}
           </StyledText>
-
           <Flex
             backgroundColor="#16212D33"
             flexDirection={DIRECTION_COLUMN}
@@ -77,14 +76,19 @@ export function WizardRequiredEquipmentList(
         </>
       ) : (
         <>
-          <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+          <StyledText
+            as="h3"
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            marginBottom={SPACING.spacing8}
+          >
             {t('you_will_need')}
           </StyledText>
-          <Divider />
-          {equipmentList.map(requiredEquipmentProps => (
+          {equipmentList.length > 1 ? <Divider /> : null}
+          {equipmentList.map((requiredEquipmentProps, index) => (
             <RequiredEquipmentCard
               key={requiredEquipmentProps.loadName}
               {...requiredEquipmentProps}
+              bottomDivider={equipmentList.length - 1 !== index}
             />
           ))}
           {footer != null ? (
@@ -106,12 +110,13 @@ interface RequiredEquipmentCardProps {
   loadName: string
   displayName: string
   subtitle?: string
+  bottomDivider?: boolean
 }
 
 function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
-  const { loadName, displayName, subtitle } = props
+  const { loadName, displayName, subtitle, bottomDivider = true } = props
 
-  let imageSrc: string = labwareImages.generic_custom_tiprack
+  let imageSrc: string | null = null
   if (loadName in labwareImages) {
     imageSrc = labwareImages[loadName as keyof typeof labwareImages]
   } else if (loadName in equipmentImages) {
@@ -125,24 +130,26 @@ function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
         alignItems={ALIGN_CENTER}
         width="100%"
       >
-        <Flex
-          height={loadName in equipmentImages ? '3.5rem' : '6rem'}
-          flex="0 1 30%"
-          justifyContent={JUSTIFY_CENTER}
-          alignItems={ALIGN_CENTER}
-          marginRight={SPACING.spacing16}
-        >
-          <img
-            css={css`
-              max-width: 100%;
-              max-height: 100%;
-              flex: ${loadName in equipmentImages ? `0` : `0 1 5rem`};
-              display: block;
-            `}
-            src={imageSrc}
-            alt={displayName}
-          />
-        </Flex>
+        {imageSrc != null ? (
+          <Flex
+            height={loadName in equipmentImages ? '3.5rem' : '6rem'}
+            flex="0 1 30%"
+            justifyContent={JUSTIFY_CENTER}
+            alignItems={ALIGN_CENTER}
+            marginRight={SPACING.spacing16}
+          >
+            <img
+              css={css`
+                max-width: 100%;
+                max-height: 100%;
+                flex: ${loadName in equipmentImages ? `0` : `0 1 5rem`};
+                display: block;
+              `}
+              src={imageSrc}
+              alt={displayName}
+            />
+          </Flex>
+        ) : null}
         <Flex
           flex="0 1 70%"
           flexDirection={DIRECTION_COLUMN}
@@ -156,7 +163,7 @@ function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
           ) : null}
         </Flex>
       </Flex>
-      <Divider />
+      {bottomDivider ? <Divider /> : null}
     </>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupStep.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
@@ -11,7 +10,6 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   JUSTIFY_SPACE_BETWEEN,
-  SIZE_1,
   COLORS,
   SPACING,
   TYPOGRAPHY,
@@ -20,13 +18,20 @@ import {
 import { StyledText } from '../../../atoms/text'
 
 interface SetupStepProps {
+  /** whether or not to show the full contents of the step */
   expanded: boolean
+  /** always shown text name of the step */
   title: React.ReactNode
+  /** always shown text that provides a one sentence explanation of the contents */
   description: string
+  /** always shown text that sits above title of step (used for step number) */
   label: string
+  /** callback that should toggle the expanded state (managed by parent) */
   toggleExpanded: () => void
+  /** contents to be shown only when expanded */
   children: React.ReactNode
-  calibrationStatusComplete: boolean | null
+  /** element to be shown (right aligned) regardless of expanded state */
+  rightElement: React.ReactNode
 }
 
 const EXPANDED_STYLE = css`
@@ -57,10 +62,8 @@ export function SetupStep({
   label,
   toggleExpanded,
   children,
-  calibrationStatusComplete,
+  rightElement,
 }: SetupStepProps): JSX.Element {
-  const { t } = useTranslation('protocol_setup')
-
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <Btn textAlign={TYPOGRAPHY.textAlignLeft}>
@@ -100,34 +103,7 @@ export function SetupStep({
               </StyledText>
             </Flex>
             <Flex alignItems={ALIGN_CENTER} flexDirection={DIRECTION_ROW}>
-              {calibrationStatusComplete !== null ? (
-                <Flex flexDirection={DIRECTION_ROW}>
-                  <Icon
-                    size={SIZE_1}
-                    color={
-                      calibrationStatusComplete
-                        ? COLORS.successEnabled
-                        : COLORS.warningEnabled
-                    }
-                    marginRight={SPACING.spacing8}
-                    name={
-                      calibrationStatusComplete ? 'ot-check' : 'alert-circle'
-                    }
-                    id="RunSetupCard_calibrationIcon"
-                  />
-                  <StyledText
-                    color={COLORS.black}
-                    css={TYPOGRAPHY.pSemiBold}
-                    marginRight={SPACING.spacing16}
-                    textTransform={TYPOGRAPHY.textTransformCapitalize}
-                    id="RunSetupCard_calibrationText"
-                  >
-                    {calibrationStatusComplete
-                      ? t('calibration_ready')
-                      : t('calibration_needed')}
-                  </StyledText>
-                </Flex>
-              ) : null}
+              {rightElement}
               <Icon
                 color={COLORS.darkBlackEnabled}
                 size="1.5rem"

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupStep.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupStep.test.tsx
@@ -12,9 +12,9 @@ describe('SetupStep', () => {
     title = 'stub title',
     description = 'stub description',
     label = 'stub label',
-    calibrationStatusComplete = null,
     toggleExpanded = toggleExpandedMock,
     children = <button>stub children</button>,
+    rightElement = <div>right element</div>,
   }: Partial<React.ComponentProps<typeof SetupStep>> = {}) => {
     return renderWithProviders(
       <SetupStep
@@ -25,7 +25,7 @@ describe('SetupStep', () => {
           label,
           toggleExpanded,
           children,
-          calibrationStatusComplete,
+          rightElement,
         }}
       />,
       { i18nInstance: i18n }
@@ -55,5 +55,6 @@ describe('SetupStep', () => {
     getByText('stub label')
     getByText('stub title')
     queryAllByText('stub description')
+    queryAllByText('right element')
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+import {
+  CompletedProtocolAnalysis,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 import { StyledText } from '../../../atoms/text'
 import { RobotMotionLoader } from '../RobotMotionLoader'
 import { getPrepCommands } from './getPrepCommands'
@@ -8,9 +11,30 @@ import { useChainRunCommands } from '../../../resources/runs/hooks'
 import type { RegisterPositionAction } from '../types'
 import type { Jog } from '../../../molecules/JogControls'
 import { WizardRequiredEquipmentList } from '../../../molecules/WizardRequiredEquipmentList'
-import { GenericWizardTile } from '../../../molecules/GenericWizardTile'
 import { getIsOnDevice } from '../../../redux/config'
+import { NeedHelpLink } from '../../CalibrationPanels'
 import { useSelector } from 'react-redux'
+import { TwoUpTileLayout } from '../TwoUpTileLayout'
+import {
+  ALIGN_CENTER,
+  Box,
+  Btn,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_SPACE_BETWEEN,
+  PrimaryButton,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { LabwareOffset } from '@opentrons/api-client'
+import { css } from 'styled-components'
+import { Portal } from '../../../App/portal'
+import { LegacyModalShell } from '../../../molecules/LegacyModal'
+import { SmallButton } from '../../../atoms/buttons'
+import { TerseOffsetTable } from '../ResultsSummary'
+import { getLabwareDefinitionsFromCommands } from '../utils/labware'
 
 export const INTERVAL_MS = 3000
 const SUPPORT_PAGE_URL = 'https://support.opentrons.com/s/ot2-calibration'
@@ -23,6 +47,7 @@ export const IntroScreen = (props: {
   handleJog: Jog
   setFatalError: (errorMessage: string) => void
   isRobotMoving: boolean
+  existingOffsets: LabwareOffset[]
 }): JSX.Element | null => {
   const {
     proceed,
@@ -30,9 +55,10 @@ export const IntroScreen = (props: {
     chainRunCommands,
     isRobotMoving,
     setFatalError,
+    existingOffsets,
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
-  const { t } = useTranslation(['labware_position_check', 'shared'])
+  const { t, i18n } = useTranslation(['labware_position_check', 'shared'])
   const handleClickStartLPC = (): void => {
     const prepCommands = getPrepCommands(protocolData)
     chainRunCommands(prepCommands, false)
@@ -50,17 +76,16 @@ export const IntroScreen = (props: {
     )
   }
   return (
-    <GenericWizardTile
-      header={t('shared:before_you_begin')}
-      getHelp={isOnDevice ? undefined : SUPPORT_PAGE_URL}
-      bodyText={
+    <TwoUpTileLayout
+      title={t('shared:before_you_begin')}
+      body={
         <Trans
           t={t}
           i18nKey="labware_position_check_description"
           components={{ block: <StyledText as="p" /> }}
         />
       }
-      rightHandBody={
+      rightElement={
         <WizardRequiredEquipmentList
           equipmentList={[
             {
@@ -70,8 +95,102 @@ export const IntroScreen = (props: {
           ]}
         />
       }
-      proceedButtonText={t('shared:get_started')}
-      proceed={handleClickStartLPC}
+      footer={
+        <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+          {isOnDevice ? (
+            <ViewOffsets
+              existingOffsets={existingOffsets}
+              labwareDefinitions={getLabwareDefinitionsFromCommands(
+                protocolData.commands
+              )}
+            />
+          ) : (
+            <NeedHelpLink href={SUPPORT_PAGE_URL} />
+          )}
+          {isOnDevice ? (
+            <SmallButton
+              buttonText={t('shared:get_started')}
+              onClick={handleClickStartLPC}
+            />
+          ) : (
+            <PrimaryButton onClick={handleClickStartLPC}>
+              {i18n.format(t('shared:get_started'), 'capitalize')}
+            </PrimaryButton>
+          )}
+        </Flex>
+      }
     />
+  )
+}
+
+const VIEW_OFFSETS_BUTTON_STYLE = css`
+  ${TYPOGRAPHY.pSemiBold};
+  color: ${COLORS.darkBlackEnabled};
+  font-size: ${TYPOGRAPHY.fontSize22};
+  &:hover {
+    opacity: 100%;
+  }
+  &:active {
+    opacity: 70%;
+  }
+`
+interface ViewOffsetsProps {
+  existingOffsets: LabwareOffset[]
+  labwareDefinitions: LabwareDefinition2[]
+}
+function ViewOffsets(props: ViewOffsetsProps): JSX.Element {
+  const { existingOffsets, labwareDefinitions } = props
+  const { t, i18n } = useTranslation('labware_position_check')
+  const [showOffsetsTable, setShowOffsetsModal] = React.useState(false)
+  return existingOffsets.length > 0 ? (
+    <>
+      <Btn
+        display="flex"
+        gridGap={SPACING.spacing8}
+        alignItems={ALIGN_CENTER}
+        onClick={() => setShowOffsetsModal(true)}
+        css={VIEW_OFFSETS_BUTTON_STYLE}
+        aria-label="show labware offsets"
+      >
+        <Icon name="reticle" size="1.75rem" color={COLORS.darkBlackEnabled} />
+        <StyledText as="p">
+          {i18n.format(t('view_current_offsets'), 'capitalize')}
+        </StyledText>
+      </Btn>
+      {showOffsetsTable ? (
+        <Portal level="top">
+          <LegacyModalShell
+            width="60rem"
+            height="33.5rem"
+            padding={SPACING.spacing32}
+            display="flex"
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+            header={
+              <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightBold}>
+                {i18n.format(t('labware_offset_data'), 'capitalize')}
+              </StyledText>
+            }
+            footer={
+              <SmallButton
+                width="100%"
+                textTransform={TYPOGRAPHY.textTransformCapitalize}
+                buttonText={t('shared:close')}
+                onClick={() => setShowOffsetsModal(false)}
+              />
+            }
+          >
+            <Box overflowY="scroll" marginBottom={SPACING.spacing16}>
+              <TerseOffsetTable
+                offsets={existingOffsets}
+                labwareDefinitions={labwareDefinitions}
+              />
+            </Box>
+          </LegacyModalShell>
+        </Portal>
+      ) : null}
+    </>
+  ) : (
+    <Flex />
   )
 }

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -37,6 +37,8 @@ import { TerseOffsetTable } from '../ResultsSummary'
 import { getLabwareDefinitionsFromCommands } from '../utils/labware'
 
 export const INTERVAL_MS = 3000
+
+// TODO(BC, 09/01/23): replace updated support article link for LPC on OT-2/Flex 
 const SUPPORT_PAGE_URL = 'https://support.opentrons.com/s/ot2-calibration'
 
 export const IntroScreen = (props: {

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -38,7 +38,7 @@ import { getLabwareDefinitionsFromCommands } from '../utils/labware'
 
 export const INTERVAL_MS = 3000
 
-// TODO(BC, 09/01/23): replace updated support article link for LPC on OT-2/Flex 
+// TODO(BC, 09/01/23): replace updated support article link for LPC on OT-2/Flex
 const SUPPORT_PAGE_URL = 'https://support.opentrons.com/s/ot2-calibration'
 
 export const IntroScreen = (props: {

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -263,7 +263,9 @@ export const LabwarePositionCheckComponent = (
       />
     )
   } else if (currentStep.section === 'BEFORE_BEGINNING') {
-    modalContent = <IntroScreen {...movementStepProps} />
+    modalContent = (
+      <IntroScreen {...movementStepProps} {...{ existingOffsets }} />
+    )
   } else if (
     currentStep.section === 'CHECK_POSITIONS' ||
     currentStep.section === 'CHECK_TIP_RACKS' ||

--- a/app/src/organisms/LabwarePositionCheck/TwoUpTileLayout.tsx
+++ b/app/src/organisms/LabwarePositionCheck/TwoUpTileLayout.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+import {
+  DIRECTION_COLUMN,
+  Flex,
+  SPACING,
+  JUSTIFY_SPACE_BETWEEN,
+  DIRECTION_ROW,
+  TYPOGRAPHY,
+  JUSTIFY_CENTER,
+  RESPONSIVENESS,
+  DISPLAY_INLINE_BLOCK,
+} from '@opentrons/components'
+
+const Title = styled.h1`
+  ${TYPOGRAPHY.h1Default};
+  margin-bottom: ${SPACING.spacing8};
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    ${TYPOGRAPHY.level4HeaderSemiBold};
+    margin-bottom: 0;
+    height: ${SPACING.spacing40};
+    display: ${DISPLAY_INLINE_BLOCK};
+  }
+`
+
+const TILE_CONTAINER_STYLE = css`
+  flex-direction: ${DIRECTION_COLUMN};
+  justify-content: ${JUSTIFY_SPACE_BETWEEN};
+  padding: ${SPACING.spacing32};
+  height: 24.625rem;
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    height: 29.5rem;
+  }
+`
+export interface TwoUpTileLayoutProps {
+  /** main header text on left half */
+  title: string
+  /** paragraph text below title on left half */
+  body: React.ReactNode
+  /** entire contents of the right half */
+  rightElement: React.ReactNode
+  /** footer underneath both halves of content */
+  footer: React.ReactNode
+}
+
+export function TwoUpTileLayout(props: TwoUpTileLayoutProps): JSX.Element {
+  const { title, body, rightElement, footer } = props
+  return (
+    <Flex css={TILE_CONTAINER_STYLE}>
+      <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing24}>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          flex="1"
+          gridGap={SPACING.spacing16}
+        >
+          <Title>{title}</Title>
+          {body}
+        </Flex>
+        <Flex flex="1" justifyContent={JUSTIFY_CENTER}>
+          {rightElement}
+        </Flex>
+      </Flex>
+      {footer}
+    </Flex>
+  )
+}

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -567,7 +567,7 @@ function PrepareToRun({
                   : null
               }
               status="general"
-              disabled={lpcDisabledReason != null}
+              // disabled={lpcDisabledReason != null}
               disabledReason={lpcDisabledReason}
             />
             <ProtocolSetupStep

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -567,7 +567,7 @@ function PrepareToRun({
                   : null
               }
               status="general"
-              // disabled={lpcDisabledReason != null}
+              disabled={lpcDisabledReason != null}
               disabledReason={lpcDisabledReason}
             />
             <ProtocolSetupStep


### PR DESCRIPTION
# Overview

Include a link to "view current offsets" in the intro screen of LPC on the ODD. Also fully implement the designs for the LPC setup step in desktop

Closes RAUT-480

# Review requests

- run LPC from ODD: 
   "view current offsets" link should only appear on Intro screen (bottom left), if there are actually offsets on the run. The table contents should match the offset count in the `SetupStep`.
  
- run LPC from desktop:
  - "learn about labware offsets" link should appear in the setup step header (always showing, even if not expanded)
  - when expanded, there should either be an empty state or a table of current offsets, followed by the "launch LPC" and "proceed to labware setup" buttons
  - on the intro screen of LPC, there should be a "need help?" link in the bottom left (not a view offsets button)

# Risk assessment
medium