### PR TITLE
fix(discovery-client): deep compare robot addresses to restart health poller

### DIFF
--- a/discovery-client/src/discovery-client.ts
+++ b/discovery-client/src/discovery-client.ts
@@ -1,3 +1,5 @@
+import isEqual from 'lodash/isEqual'
+
 import { DEFAULT_PORT } from './constants'
 import { createHealthPoller } from './health-poller'
 import { createMdnsBrowser } from './mdns-browser'
@@ -53,7 +55,7 @@ export function createDiscoveryClient(
         const addrs = getAddresses()
         const robots = getRobots()
 
-        if (addrs !== prevAddrs) healthPoller.start({ list: addrs })
+        if (!isEqual(addrs, prevAddrs)) healthPoller.start({ list: addrs })
         if (robots !== prevRobots) onListChange(robots)
 
         prevAddrs = addrs


### PR DESCRIPTION
# Overview

uses lodash isEqual to deep compare previous and current robot addresses to restart health poller. fixes overeager restart that was causing memory management issues in the electron main process.

# Test Plan

confirmed greatly reduced health poller restarts by monitoring logging in the electron main process.

# Changelog

 - deep compares previous and current robot addresses to restart health poller

# Review requests

confirm that the health polling restarts are reduced, and that health polling still restarts when needed. check usb connection and disconnection.

# Risk assessment

medium-ish, need to confirm that discovery still updates for robots that start/stop broadcasting.
