### PR TITLE
feat(api): hardware: add set_liquid_class

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -929,6 +929,9 @@ class API(
     async def update_deck_calibration(self, new_transform: RobotCalibration) -> None:
         pass
 
+    async def configure_for_volume(self, mount: top_types.Mount, volume: float) -> None:
+        pass
+
     # Pipette action API
     async def prepare_for_aspirate(
         self, mount: top_types.Mount, rate: float = 1.0

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -929,9 +929,6 @@ class API(
     async def update_deck_calibration(self, new_transform: RobotCalibration) -> None:
         pass
 
-    async def configure_for_volume(self, mount: top_types.Mount, volume: float) -> None:
-        pass
-
     # Pipette action API
     async def prepare_for_aspirate(
         self, mount: top_types.Mount, rate: float = 1.0

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -21,6 +21,11 @@ from opentrons_shared_data.pipette import (
     load_data as load_pipette_data,
     types as pip_types,
 )
+from opentrons_shared_data.errors.exceptions import (
+    InvalidLiquidClassName,
+    CommandPreconditionViolated,
+)
+
 
 from opentrons.types import Point, Mount
 from opentrons.config import robot_configs, feature_flags as ff
@@ -562,6 +567,17 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             }
         )
         return self._config_as_dict
+
+    def set_liquid_class_by_name(self, class_name: str) -> None:
+        """Change the currently active liquid class."""
+        if self.current_volume > 0:
+            raise CommandPreconditionViolated(
+                "Cannot switch liquid classes when liquid is in the tip"
+            )
+        if class_name != "default":
+            raise InvalidLiquidClassName(
+                message=f"Liquid class {class_name} is not valid for {self._config.display_name}"
+            )
 
 
 def _reload_and_check_skip(

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -975,6 +975,10 @@ class PipetteHandlerProvider(Generic[MountType]):
             )
         return pip
 
+    async def set_liquid_class(self, mount: MountType, liquid_class: str) -> None:
+        pip = self.get_pipette(mount)
+        pip.set_liquid_class_by_name(liquid_class)
+
 
 class OT3PipetteHandler(PipetteHandlerProvider[OT3Mount]):
     """Override for correct plunger_position."""

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -643,11 +643,13 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
 
         self._aspirate_flow_rate = (
             self._active_tip_settings.default_aspirate_flowrate.default
-            )
+        )
         self._dispense_flow_rate = (
             self._active_tip_settings.default_dispense_flowrate.default
         )
-        self._blow_out_flow_rate = self._active_tip_settings.default_blowout_flowrate.default
+        self._blow_out_flow_rate = (
+            self._active_tip_settings.default_blowout_flowrate.default
+        )
         self._flow_acceleration = self._active_tip_settings.default_flow_acceleration
 
         self._fallback_tip_length = self._active_tip_settings.default_tip_length

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -902,3 +902,11 @@ class OT3PipetteHandler:
                 f"No pipette attached to {mount.name} mount"
             )
         return pip
+
+    async def configure_for_volume(self, mount: OT3Mount, volume: float) -> None:
+        pip = self.get_pipette(mount)
+        if pip.current_volume > 0:
+            # Switching liquid classes can't happen when there's already liquid
+            return
+        new_class = pip.get_liquid_class_for_volume(volume + pip.current_volume)
+        pip.set_liquid_class_by_name(new_class)

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -903,10 +903,6 @@ class OT3PipetteHandler:
             )
         return pip
 
-    async def configure_for_volume(self, mount: OT3Mount, volume: float) -> None:
+    async def set_liquid_class(self, mount: OT3Mount, liquid_class: str) -> None:
         pip = self.get_pipette(mount)
-        if pip.current_volume > 0:
-            # Switching liquid classes can't happen when there's already liquid
-            return
-        new_class = pip.get_liquid_class_for_volume(volume + pip.current_volume)
-        pip.set_liquid_class_by_name(new_class)
+        pip.set_liquid_class_by_name(liquid_class)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1575,11 +1575,11 @@ class OT3API(
             acquire_lock=acquire_lock,
         )
 
-    async def configure_for_volume(
-        self, mount: Union[top_types.Mount, OT3Mount], volume: float
+    async def set_liquid_class(
+        self, mount: Union[top_types.Mount, OT3Mount], liquid_class: str
     ) -> None:
         checked_mount = OT3Mount.from_mount(mount)
-        await self._pipette_handler.configure_for_volume(checked_mount, volume)
+        await self._pipette_handler.set_liquid_class(checked_mount, liquid_class)
 
     # Pipette action API
     async def prepare_for_aspirate(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1575,6 +1575,12 @@ class OT3API(
             acquire_lock=acquire_lock,
         )
 
+    async def configure_for_volume(
+        self, mount: Union[top_types.Mount, OT3Mount], volume: float
+    ) -> None:
+        checked_mount = OT3Mount.from_mount(mount)
+        await self._pipette_handler.configure_for_volume(checked_mount, volume)
+
     # Pipette action API
     async def prepare_for_aspirate(
         self, mount: Union[top_types.Mount, OT3Mount], rate: float = 1.0

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -16,6 +16,19 @@ class LiquidHandler(
     Calibratable[CalibrationType],
     Protocol[CalibrationType],
 ):
+    async def configure_for_volume(self, mount: Mount, volume: float) -> None:
+        """
+        Configure a pipette to handle the specified volume.
+
+        Some pipettes need to switch modes to handle different volumes of liquid. Calling
+        this ensures they do so. If the pipette does not need to switch modes, or the pipette
+        is already in the specified mode, nothing will happen.
+
+        If the pipette does need to switch modes, it will likely be unready for aspiration and
+        you will need to call :py:meth:`prepare_for_aspirate` afterwards.
+        """
+        ...
+
     async def prepare_for_aspirate(self, mount: Mount, rate: float = 1.0) -> None:
         """
         Prepare the pipette for aspiration.

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -434,12 +434,13 @@ async def test_configure_ot3(ot3_api_obj):
     await hw_api.prepare_for_aspirate(mount)
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(71.5)
+    assert hw_api._pipette_handler.get_pipette(OT3Mount.LEFT).push_out_volume == 2
 
     await hw_api.set_liquid_class(mount, "lowVolumeDefault")
-    await hw_api.configure_for_volume(mount, 1)
     await hw_api.prepare_for_aspirate(mount)
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(57.0)
+    assert hw_api._pipette_handler.get_pipette(OT3Mount.LEFT).push_out_volume == 7
 
     await hw_api.set_liquid_class(mount, "default")
     await hw_api.prepare_for_aspirate(mount)

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -374,7 +374,7 @@ async def test_aspirate_old(decoy: Decoy, mock_feature_flags: None, dummy_instru
     assert pos[Axis.B] == pytest.approx(new_plunger_pos)
 
 
-async def test_aspirate_ot3(dummy_instruments_ot3, ot3_api_obj):
+async def test_aspirate_ot3_50(dummy_instruments_ot3, ot3_api_obj):
     hw_api = await ot3_api_obj(
         attached_instruments=dummy_instruments_ot3[0], loop=asyncio.get_running_loop()
     )
@@ -389,6 +389,26 @@ async def test_aspirate_ot3(dummy_instruments_ot3, ot3_api_obj):
     await hw_api.prepare_for_aspirate(mount)
     await hw_api.aspirate(mount, aspirate_ul, aspirate_rate)
     new_plunger_pos = 71.1968
+    pos = await hw_api.current_position(mount)
+    assert pos[Axis.B] == pytest.approx(new_plunger_pos)
+
+
+async def test_aspirate_ot3_1000(dummy_instruments_ot3, ot3_api_obj):
+    hw_api = await ot3_api_obj(
+        attached_instruments=dummy_instruments_ot3[0], loop=asyncio.get_running_loop()
+    )
+    await hw_api.home()
+    await hw_api.cache_instruments()
+
+    mount = types.Mount.LEFT
+    await hw_api.pick_up_tip(mount, 20.0)
+
+    hw_api.set_working_volume(mount, 1000)
+    aspirate_ul = 3.0
+    aspirate_rate = 2
+    await hw_api.prepare_for_aspirate(mount)
+    await hw_api.aspirate(mount, aspirate_ul, aspirate_rate)
+    new_plunger_pos = 71.2122
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(new_plunger_pos)
 

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -430,24 +430,18 @@ async def test_configure_ot3(ot3_api_obj):
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
     hw_api.set_working_volume(mount, 50)
-    # hysteresis: don't switch until below 25
-    await hw_api.configure_for_volume(mount, 26)
+    await hw_api.set_liquid_class(mount, "default")
     await hw_api.prepare_for_aspirate(mount)
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(71.5)
 
+    await hw_api.set_liquid_class(mount, "lowVolumeDefault")
     await hw_api.configure_for_volume(mount, 1)
     await hw_api.prepare_for_aspirate(mount)
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(57.0)
 
-    # hysteresis: don't switch back until over 37.5
-    await hw_api.configure_for_volume(mount, 25)
-    await hw_api.prepare_for_aspirate(mount)
-    pos = await hw_api.current_position(mount)
-    assert pos[Axis.B] == pytest.approx(57)
-
-    await hw_api.configure_for_volume(mount, 37.8)
+    await hw_api.set_liquid_class(mount, "default")
     await hw_api.prepare_for_aspirate(mount)
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(71.5)

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -2,6 +2,7 @@ import pytest
 from mock import patch
 from typing import Union, Callable
 from pathlib import Path
+from opentrons_shared_data.errors.exceptions import InvalidLiquidClassName
 from opentrons.calibration_storage import types as cal_types
 from opentrons.types import Point, Mount
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import]
@@ -19,6 +20,7 @@ from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,
     mutable_configurations,
+    types as pip_types,
 )
 
 OT2_PIP_CAL = instrument_calibration.PipetteOffsetByPipetteMount(
@@ -162,7 +164,6 @@ def test_critical_points_pipette_offset(
         ot3_calibration.PipetteOffsetByPipetteMount,
     ],
 ) -> None:
-
     hw_pipette = pipette_builder(model, calibration)
     # pipette offset + nozzle offset to determine critical point
     offsets = calibration.offset + Point(*hw_pipette.nozzle_offset)
@@ -339,7 +340,6 @@ def test_reset_instrument_offset(
         ot3_calibration.PipetteOffsetByPipetteMount,
     ],
 ) -> None:
-
     hw_pipette = pipette_builder(model, calibration)
     assert hw_pipette.pipette_offset.offset == Point(1, 1, 1)
     hw_pipette.reset_pipette_offset(Mount.LEFT, to_default=True)
@@ -399,3 +399,32 @@ def test_reload_instrument_cal_ot3(
     assert skipped
     # it's the same pipette
     assert new_pip == old_pip
+
+
+def test_tip_type_changing(hardware_pipette_ot3: Callable) -> None:
+    pip = hardware_pipette_ot3(
+        pipette_load_name.convert_pipette_model("p1000_single_v3.3")
+    )
+    # at load, we have the max tip settings
+    assert pip.working_volume == 1000
+    # setting to the same thing works
+    pip.set_tip_type_by_volume(1000)
+    assert pip.working_volume == 1000
+    # setting to other tip types works
+    pip.set_tip_type_by_volume(200)
+    assert pip.working_volume == 200
+
+    # specifying a tip that doesn't exist raises an error
+    with pytest.raises(InvalidLiquidClassName):
+        pip.set_tip_type_by_volume(201)
+
+
+def test_liquid_class_changing(hardware_pipette_ot3: Callable) -> None:
+    pip = hardware_pipette_ot3(
+        pipette_load_name.convert_pipette_model("p50_multi_v3.3")
+    )
+    assert pip._liquid_class_name == pip_types.LiquidClasses.default
+    pip.set_liquid_class_by_name("lowVolumeDefault")
+    assert pip._liquid_class_name == pip_types.LiquidClasses.lowVolumeDefault
+    with pytest.raises(InvalidLiquidClassName):
+        pip.set_liquid_class_by_name("asdase")

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -166,6 +166,10 @@
       "detail": "Invalid Instrument Data",
       "category": "roboticsInteractionError"
     },
+    "3017": {
+      "detail": "Invalid Liquid Class Name",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -71,6 +71,7 @@ class ErrorCodes(Enum):
     INVALID_ACTUATOR = _code_from_dict_entry("3014")
     MODULE_NOT_PRESENT = _code_from_dict_entry("3015")
     INVALID_INSTRUMENT_DATA = _code_from_dict_entry("3016")
+    INVALID_LIQUID_CLASS_NAME = _code_from_dict_entry("3017")
     GENERAL_ERROR = _code_from_dict_entry("4000")
     ROBOT_IN_USE = _code_from_dict_entry("4001")
     API_REMOVED = _code_from_dict_entry("4002")

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -716,6 +716,21 @@ class InvalidInstrumentData(RoboticsInteractionError):
         super().__init__(ErrorCodes.INVALID_INSTRUMENT_DATA, message, detail, wrapping)
 
 
+class InvalidLiquidClassName(RoboticsInteractionError):
+    """An error indicating that a liquid class name does not exist on a pipette."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an InvalidLiquidClassName."""
+        super().__init__(
+            ErrorCodes.INVALID_LIQUID_CLASS_NAME, message, detail, wrapping
+        )
+
+
 class APIRemoved(GeneralError):
     """An error indicating that a specific API is no longer available."""
 


### PR DESCRIPTION
The other step after `push_out` for low volume handling is to change the `bottom` position of the pipette. Since this can cause motion, we won't do it automatically; instead, we'll have a new command and a new hardware control method to make the configuration change, and the position will change the next time someone calls `prepare_for_aspirate`.

This PR adds the hardware control side of that, including liquid class switching and some changes to tip settings. You call the new method `set_liquid_class` which sets the liquid class on a pipette, with appropriate errors if the class doesn't exist or isn't valid.

## Testing
- In a protocol, drill down to calling `hardware.set_liquid_class` with class `lowVolumeDefault` on a 50ul pipette on a flex and check that the bottom position changes appropriately.