### PR TITLE
fix(app): fix ODD UI bugs

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/index.css
+++ b/app/src/atoms/SoftwareKeyboard/index.css
@@ -13,11 +13,11 @@
   .hg-row:not(:last-child)
   .hg-button:not(:last-child) {
   margin-right: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 2px;
 }
 
 .simple-keyboard.simple-keyboard.oddTheme1 .hg-button {
-  height: 58px;
+  height: 48px;
 }
 
 .simple-keyboard .hg-button:active {

--- a/app/src/molecules/Modal/SmallModalChildren.tsx
+++ b/app/src/molecules/Modal/SmallModalChildren.tsx
@@ -28,6 +28,7 @@ export function SmallModalChildren(
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing8}
         width="100%"
+        whiteSpace="break-spaces"
       >
         <StyledText
           color={COLORS.darkBlackEnabled}

--- a/app/src/organisms/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/Navigation/NavigationMenu.tsx
@@ -22,10 +22,11 @@ import type { Dispatch } from '../../redux/types'
 interface NavigationMenuProps {
   onClick: React.MouseEventHandler
   robotName: string
+  setShowNavMenu: (showNavMenu: boolean) => void
 }
 
 export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
-  const { onClick, robotName } = props
+  const { onClick, robotName, setShowNavMenu } = props
   const { t, i18n } = useTranslation(['devices_landing', 'robot_controls'])
   const { lightsOn, toggleLights } = useLights()
   const dispatch = useDispatch<Dispatch>()
@@ -36,6 +37,11 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
 
   const handleRestart = (): void => {
     setShowRestartRobotConfirmationModal(true)
+  }
+
+  const handleHomeGantry = (): void => {
+    dispatch(home(robotName, ROBOT))
+    setShowNavMenu(false)
   }
 
   return (
@@ -49,10 +55,7 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
         />
       ) : null}
       <MenuList onClick={onClick} isOnDevice={true}>
-        <MenuItem
-          key="home-gantry"
-          onClick={() => dispatch(home(robotName, ROBOT))}
-        >
+        <MenuItem key="home-gantry" onClick={handleHomeGantry}>
           <Flex alignItems={ALIGN_CENTER}>
             <Icon
               name="home-gantry"

--- a/app/src/organisms/Navigation/__tests__/NavigationMenu.test.tsx
+++ b/app/src/organisms/Navigation/__tests__/NavigationMenu.test.tsx
@@ -33,6 +33,7 @@ describe('NavigationMenu', () => {
     props = {
       onClick: jest.fn(),
       robotName: 'otie',
+      setShowNavMenu: jest.fn(),
     }
     mockUseLights.mockReturnValue({
       lightsOn: false,
@@ -42,14 +43,14 @@ describe('NavigationMenu', () => {
       <div>mock RestartRobotConfirmationModal</div>
     )
   })
-  it('should render the home menu item and clicking home robot arm, dispatches home', () => {
+  it('should render the home menu item and clicking home gantry, dispatches home and call a mock function', () => {
     const { getByText, getByLabelText } = render(props)
     getByLabelText('BackgroundOverlay_ModalShell').click()
     expect(props.onClick).toHaveBeenCalled()
-    const home = getByText('Home gantry')
     getByLabelText('home-gantry_icon')
-    home.click()
+    getByText('Home gantry').click()
     expect(mockHome).toHaveBeenCalled()
+    expect(props.setShowNavMenu).toHaveBeenCalled()
   })
 
   it('should render the restart robot menu item and clicking it, dispatches restart robot', () => {

--- a/app/src/organisms/Navigation/index.tsx
+++ b/app/src/organisms/Navigation/index.tsx
@@ -131,6 +131,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
         <NavigationMenu
           onClick={() => handleMenu(false)}
           robotName={robotName}
+          setShowNavMenu={setShowNavMenu}
         />
       )}
     </>

--- a/app/src/organisms/NetworkSettings/SelectAuthenticationType.tsx
+++ b/app/src/organisms/NetworkSettings/SelectAuthenticationType.tsx
@@ -18,6 +18,7 @@ import { StyledText } from '../../atoms/text'
 import { RadioButton } from '../../atoms/buttons'
 import { getLocalRobot } from '../../redux/discovery'
 import { getNetworkInterfaces, fetchStatus } from '../../redux/networking'
+import { useIsUnboxingFlowOngoing } from '../RobotSettingsDashboard/NetworkSettings/hooks'
 import { AlternativeSecurityTypeModal } from './AlternativeSecurityTypeModal'
 
 import type { WifiSecurityType } from '@opentrons/api-client'
@@ -36,6 +37,7 @@ export function SelectAuthenticationType({
   const dispatch = useDispatch<Dispatch>()
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
+  const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
   const { wifi } = useSelector((state: State) =>
     getNetworkInterfaces(state, robotName)
   )
@@ -81,7 +83,7 @@ export function SelectAuthenticationType({
         <Flex
           alignItems={ALIGN_CENTER}
           flexDirection={DIRECTION_COLUMN}
-          marginTop="7.75rem"
+          marginTop={isUnboxingFlowOngoing ? undefined : '7.75rem'}
         >
           <Flex
             flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/NetworkSettings/SelectAuthenticationType.tsx
+++ b/app/src/organisms/NetworkSettings/SelectAuthenticationType.tsx
@@ -78,7 +78,11 @@ export function SelectAuthenticationType({
         flexDirection={DIRECTION_COLUMN}
         padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`}
       >
-        <Flex alignItems={ALIGN_CENTER} flexDirection={DIRECTION_COLUMN}>
+        <Flex
+          alignItems={ALIGN_CENTER}
+          flexDirection={DIRECTION_COLUMN}
+          marginTop="7.75rem"
+        >
           <Flex
             flexDirection={DIRECTION_COLUMN}
             gridGap={SPACING.spacing8}

--- a/app/src/organisms/NetworkSettings/SetWifiCred.tsx
+++ b/app/src/organisms/NetworkSettings/SetWifiCred.tsx
@@ -12,6 +12,7 @@ import {
   DIRECTION_ROW,
   Flex,
   Icon,
+  JUSTIFY_SPACE_BETWEEN,
   POSITION_FIXED,
   SPACING,
   TYPOGRAPHY,
@@ -31,6 +32,7 @@ const SSID_INPUT_FIELD_STYLE = css`
   color: ${COLORS.darkBlack100};
   padding-left: ${SPACING.spacing24};
   box-sizing: border-box;
+  width: 42.625rem;
 
   &:focus {
     border: 3px solid ${COLORS.blueEnabled};
@@ -54,12 +56,20 @@ export function SetWifiCred({
 
   return (
     <>
-      <Flex width="100%" flexDirection={DIRECTION_COLUMN} paddingLeft="6.25rem">
+      <Flex
+        width="100%"
+        flexDirection={DIRECTION_COLUMN}
+        padding={`0 6.25rem ${SPACING.spacing40}`}
+        marginTop="7.75rem"
+      >
         <StyledText as="p" marginBottom={SPACING.spacing12}>
           {t('enter_password')}
         </StyledText>
-        <Flex flexDirection={DIRECTION_ROW}>
-          <Box width="36.375rem">
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+        >
+          <Box width="100%">
             <InputField
               aria-label="wifi_password"
               value={password}

--- a/app/src/organisms/NetworkSettings/SetWifiCred.tsx
+++ b/app/src/organisms/NetworkSettings/SetWifiCred.tsx
@@ -21,6 +21,7 @@ import {
 import { StyledText } from '../../atoms/text'
 import { InputField } from '../../atoms/InputField'
 import { NormalKeyboard } from '../../atoms/SoftwareKeyboard'
+import { useIsUnboxingFlowOngoing } from '../RobotSettingsDashboard/NetworkSettings/hooks'
 
 const SSID_INPUT_FIELD_STYLE = css`
   padding-top: 2.125rem;
@@ -53,6 +54,7 @@ export function SetWifiCred({
   const { t } = useTranslation(['device_settings', 'shared'])
   const keyboardRef = React.useRef(null)
   const [showPassword, setShowPassword] = React.useState<boolean>(false)
+  const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
   return (
     <>
@@ -60,7 +62,7 @@ export function SetWifiCred({
         width="100%"
         flexDirection={DIRECTION_COLUMN}
         padding={`0 6.25rem ${SPACING.spacing40}`}
-        marginTop="7.75rem"
+        marginTop={isUnboxingFlowOngoing ? undefined : '7.75rem'}
       >
         <StyledText as="p" marginBottom={SPACING.spacing12}>
           {t('enter_password')}

--- a/app/src/organisms/NetworkSettings/SetWifiSsid.tsx
+++ b/app/src/organisms/NetworkSettings/SetWifiSsid.tsx
@@ -54,6 +54,7 @@ export function SetWifiSsid({
         flexDirection={DIRECTION_COLUMN}
         paddingX="6.34375rem"
         gridGap={SPACING.spacing8}
+        marginTop="7.75rem"
       >
         <StyledText
           as="p"

--- a/app/src/organisms/NetworkSettings/SetWifiSsid.tsx
+++ b/app/src/organisms/NetworkSettings/SetWifiSsid.tsx
@@ -15,6 +15,7 @@ import {
 import { StyledText } from '../../atoms/text'
 import { InputField } from '../../atoms/InputField'
 import { NormalKeyboard } from '../../atoms/SoftwareKeyboard'
+import { useIsUnboxingFlowOngoing } from '../RobotSettingsDashboard/NetworkSettings/hooks'
 
 const SSID_INPUT_FIELD_STYLE = css`
   padding-top: 2.125rem;
@@ -47,6 +48,7 @@ export function SetWifiSsid({
 }: SetWifiSsidProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'shared'])
   const keyboardRef = React.useRef(null)
+  const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
   return (
     <>
@@ -54,7 +56,7 @@ export function SetWifiSsid({
         flexDirection={DIRECTION_COLUMN}
         paddingX="6.34375rem"
         gridGap={SPACING.spacing8}
-        marginTop="7.75rem"
+        marginTop={isUnboxingFlowOngoing ? undefined : '7.75rem'}
       >
         <StyledText
           as="p"

--- a/app/src/pages/OnDeviceDisplay/NameRobot.tsx
+++ b/app/src/pages/OnDeviceDisplay/NameRobot.tsx
@@ -21,8 +21,6 @@ import {
   Icon,
   Btn,
 } from '@opentrons/components'
-import { getOnDeviceDisplaySettings } from '../../redux/config'
-
 import { useUpdateRobotNameMutation } from '@opentrons/react-api-client'
 
 import {
@@ -38,17 +36,15 @@ import { InputField } from '../../atoms/InputField'
 import { CustomKeyboard } from '../../atoms/SoftwareKeyboard'
 import { SmallButton } from '../../atoms/buttons'
 import { StepMeter } from '../../atoms/StepMeter'
+import { useIsUnboxingFlowOngoing } from '../../organisms/RobotSettingsDashboard/NetworkSettings/hooks'
 import { ConfirmRobotName } from '../../organisms/OnDeviceDisplay/NameRobot/ConfirmRobotName'
 
 import type { UpdatedRobotName } from '@opentrons/api-client'
 import type { State, Dispatch } from '../../redux/types'
 
-// Note: kj 12/15/2022 the current input field is optimized for the desktop
-// Need to update the InputField for the ODD app
-// That will be done in another PR
 const INPUT_FIELD_ODD_STYLE = css`
-  padding-top: ${SPACING.spacing40};
-  padding-bottom: ${SPACING.spacing40};
+  padding-top: ${SPACING.spacing32};
+  padding-bottom: ${SPACING.spacing32};
   font-size: 2.5rem;
   line-height: 3.25rem;
   text-align: center;
@@ -72,12 +68,8 @@ export function NameRobot(): JSX.Element {
   ] = React.useState<boolean>(false)
   const keyboardRef = React.useRef(null)
   const dispatch = useDispatch<Dispatch>()
-  const { unfinishedUnboxingFlowRoute } = useSelector(
-    getOnDeviceDisplaySettings
-  )
-  const isInitialSetup = unfinishedUnboxingFlowRoute !== null
+  const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
-  // check for robot name
   const connectableRobots = useSelector((state: State) =>
     getConnectableRobots(state)
   )
@@ -126,7 +118,7 @@ export function NameRobot(): JSX.Element {
     onSuccess: (data: UpdatedRobotName) => {
       if (data.name != null) {
         setNewName(data.name)
-        if (!isInitialSetup) {
+        if (!isUnboxingFlowOngoing) {
           history.push('/robot-settings')
         } else {
           setIsShowConfirmRobotName(true)
@@ -143,7 +135,6 @@ export function NameRobot(): JSX.Element {
 
   const handleConfirm = (): void => {
     // check robot name in the same network
-    // ToDo (kj:04/09/2023) need to specify for odd
     trackEvent({
       name: ANALYTICS_RENAME_ROBOT,
       properties: {
@@ -156,30 +147,31 @@ export function NameRobot(): JSX.Element {
 
   return (
     <>
-      {isShowConfirmRobotName && isInitialSetup ? (
+      {isShowConfirmRobotName && isUnboxingFlowOngoing ? (
         <ConfirmRobotName robotName={newName} />
       ) : (
         <>
-          {isInitialSetup ? <StepMeter totalSteps={6} currentStep={5} /> : null}
+          {isUnboxingFlowOngoing ? (
+            <StepMeter totalSteps={6} currentStep={5} />
+          ) : null}
           <Flex
             flexDirection={DIRECTION_COLUMN}
-            marginTop={SPACING.spacing32}
-            marginX={SPACING.spacing40}
+            paddingY={SPACING.spacing32}
+            paddingX={SPACING.spacing40}
           >
             <Flex
               flexDirection={DIRECTION_ROW}
               alignItems={ALIGN_CENTER}
               justifyContent={
-                isInitialSetup ? JUSTIFY_CENTER : JUSTIFY_SPACE_BETWEEN
+                isUnboxingFlowOngoing ? JUSTIFY_CENTER : JUSTIFY_SPACE_BETWEEN
               }
               position={POSITION_RELATIVE}
-              marginBottom="3.041875rem"
             >
               <Flex position={POSITION_ABSOLUTE} left="0">
                 <Btn
                   data-testid="name_back_button"
                   onClick={() => {
-                    if (isInitialSetup) {
+                    if (isUnboxingFlowOngoing) {
                       history.push('/emergency-stop')
                     } else {
                       history.push('/robot-settings')
@@ -189,9 +181,11 @@ export function NameRobot(): JSX.Element {
                   <Icon name="back" size="3rem" color={COLORS.darkBlack100} />
                 </Btn>
               </Flex>
-              <Flex marginLeft={isInitialSetup ? '0' : '4rem'}>
+              <Flex marginLeft={isUnboxingFlowOngoing ? '0' : '4rem'}>
                 <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightBold}>
-                  {isInitialSetup ? t('name_your_robot') : t('rename_robot')}
+                  {isUnboxingFlowOngoing
+                    ? t('name_your_robot')
+                    : t('rename_robot')}
                 </StyledText>
               </Flex>
               <Flex position={POSITION_ABSOLUTE} right="0">
@@ -211,63 +205,65 @@ export function NameRobot(): JSX.Element {
                 )}
               </Flex>
             </Flex>
-            <Flex
-              width="100%"
-              flexDirection={DIRECTION_COLUMN}
-              alignItems={ALIGN_CENTER}
-            >
-              {isInitialSetup ? (
-                <StyledText
-                  as="h4"
-                  fontWeight={TYPOGRAPHY.fontWeightRegular}
-                  color={COLORS.darkBlack70}
-                  marginBottom={SPACING.spacing40}
-                >
-                  {t('name_your_robot_description')}
-                </StyledText>
-              ) : null}
-              <Flex
-                flexDirection={DIRECTION_ROW}
-                alignItems={ALIGN_CENTER}
-                marginBottom={SPACING.spacing8}
-                justifyContent={JUSTIFY_CENTER}
-                width="100%"
-              >
-                <InputField
-                  data-testid="name-robot_input"
-                  id="newRobotName"
-                  name="newRobotName"
-                  type="text"
-                  onChange={formik.handleChange}
-                  value={name}
-                  error={formik.errors.newRobotName && ''}
-                  css={INPUT_FIELD_ODD_STYLE}
-                />
-              </Flex>
+          </Flex>
+          <Flex
+            width="100%"
+            flexDirection={DIRECTION_COLUMN}
+            alignItems={ALIGN_CENTER}
+            paddingX={SPACING.spacing40}
+            height="15.125rem "
+          >
+            {isUnboxingFlowOngoing ? (
               <StyledText
-                as="p"
-                color={COLORS.darkBlack70}
+                as="h4"
                 fontWeight={TYPOGRAPHY.fontWeightRegular}
+                color={COLORS.darkBlack70}
+                marginBottom={SPACING.spacing24}
               >
-                {t('name_rule_description')}
+                {t('name_your_robot_description')}
               </StyledText>
-              {formik.errors.newRobotName && (
-                <StyledText
-                  as="p"
-                  fontWeight={TYPOGRAPHY.fontWeightRegular}
-                  color={COLORS.red2}
-                >
-                  {formik.errors.newRobotName}
-                </StyledText>
-              )}
-            </Flex>
-
-            <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">
-              <CustomKeyboard
-                onChange={e => e != null && setName(e)}
-                keyboardRef={keyboardRef}
+            ) : null}
+            <Flex
+              alignItems={ALIGN_CENTER}
+              marginBottom={SPACING.spacing8}
+              justifyContent={JUSTIFY_CENTER}
+              width="100%"
+              paddingX={SPACING.spacing60}
+            >
+              <InputField
+                data-testid="name-robot_input"
+                id="newRobotName"
+                name="newRobotName"
+                type="text"
+                onChange={formik.handleChange}
+                value={name}
+                error={formik.errors.newRobotName && ''}
+                css={INPUT_FIELD_ODD_STYLE}
               />
             </Flex>
+            <StyledText
+              as="p"
+              color={COLORS.darkBlack70}
+              fontWeight={TYPOGRAPHY.fontWeightRegular}
+            >
+              {t('name_rule_description')}
+            </StyledText>
+            {formik.errors.newRobotName && (
+              <StyledText
+                as="p"
+                fontWeight={TYPOGRAPHY.fontWeightRegular}
+                color={COLORS.red2}
+              >
+                {formik.errors.newRobotName}
+              </StyledText>
+            )}
+          </Flex>
+
+          <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">
+            <CustomKeyboard
+              onChange={e => e != null && setName(e)}
+              keyboardRef={keyboardRef}
+            />
           </Flex>
         </>
       )}

--- a/app/src/pages/OnDeviceDisplay/NetworkSetupMenu.tsx
+++ b/app/src/pages/OnDeviceDisplay/NetworkSetupMenu.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
 
 import {
   Flex,
@@ -10,11 +9,9 @@ import {
   JUSTIFY_CENTER,
   ALIGN_CENTER,
   DIRECTION_ROW,
-  ALIGN_FLEX_END,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-import { TertiaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { StepMeter } from '../../atoms/StepMeter'
 import { CardButton } from '../../molecules/CardButton'
@@ -92,15 +89,6 @@ export function NetworkSetupMenu(): JSX.Element {
               description={t(networkOption.description)}
             />
           ))}
-        </Flex>
-        <Flex
-          alignSelf={ALIGN_FLEX_END}
-          marginTop={SPACING.spacing24}
-          width="fit-content"
-        >
-          <Link to="menu">
-            <TertiaryButton>To ODD Menu</TertiaryButton>
-          </Link>
         </Flex>
       </Flex>
     </>

--- a/app/src/pages/OnDeviceDisplay/__tests__/NameRobot.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/NameRobot.test.tsx
@@ -9,7 +9,7 @@ import {
   getConnectableRobots,
   getReachableRobots,
 } from '../../../redux/discovery'
-import { getOnDeviceDisplaySettings } from '../../../redux/config'
+import { useIsUnboxingFlowOngoing } from '../../../organisms/RobotSettingsDashboard/NetworkSettings/hooks'
 import {
   mockConnectableRobot,
   mockReachableRobot,
@@ -17,11 +17,10 @@ import {
 
 import { NameRobot } from '../NameRobot'
 
-import type { OnDeviceDisplaySettings } from '../../../redux/config/types'
-
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/config')
 jest.mock('../../../redux/analytics')
+jest.mock('../../../organisms/RobotSettingsDashboard/NetworkSettings/hooks')
 
 const mockPush = jest.fn()
 
@@ -33,13 +32,6 @@ jest.mock('react-router-dom', () => {
   }
 })
 
-const mockSettings = {
-  sleepMs: 0,
-  brightness: 1,
-  textSize: 1,
-  unfinishedUnboxingFlowRoute: '/robot-settings/rename-robot',
-} as OnDeviceDisplaySettings
-
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots
 >
@@ -49,8 +41,8 @@ const mockGetReachableRobots = getReachableRobots as jest.MockedFunction<
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
-const mockGetOnDeviceDisplaySettings = getOnDeviceDisplaySettings as jest.MockedFunction<
-  typeof getOnDeviceDisplaySettings
+const mockuseIsUnboxingFlowOngoing = useIsUnboxingFlowOngoing as jest.MockedFunction<
+  typeof useIsUnboxingFlowOngoing
 >
 let mockTrackEvent: jest.Mock
 
@@ -71,7 +63,7 @@ describe('NameRobot', () => {
     mockReachableRobot.name = 'reachableOtie'
     mockGetConnectableRobots.mockReturnValue([mockConnectableRobot])
     mockGetReachableRobots.mockReturnValue([mockReachableRobot])
-    mockGetOnDeviceDisplaySettings.mockReturnValue(mockSettings)
+    mockuseIsUnboxingFlowOngoing.mockReturnValue(true)
   })
 
   it('should render text, button and keyboard', () => {
@@ -145,8 +137,7 @@ describe('NameRobot', () => {
   })
 
   it('should render text and button when coming from robot settings', () => {
-    mockSettings.unfinishedUnboxingFlowRoute = null
-    mockGetOnDeviceDisplaySettings.mockReturnValue(mockSettings)
+    mockuseIsUnboxingFlowOngoing.mockReturnValue(false)
     const [{ getByText, queryByText }] = render()
     getByText('Rename robot')
     expect(
@@ -157,7 +148,7 @@ describe('NameRobot', () => {
   })
 
   it('should call a mock function when tapping back button', () => {
-    mockSettings.unfinishedUnboxingFlowRoute = null
+    mockuseIsUnboxingFlowOngoing.mockReturnValue(false)
     const [{ getByTestId }] = render()
     getByTestId('name_back_button').click()
     expect(mockPush).toHaveBeenCalledWith('/robot-settings')

--- a/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
@@ -209,6 +209,7 @@ export function ProtocolCard(props: {
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={SPACING.spacing8}
                 maxWidth="100%"
+                whiteSpace="break-spaces"
               >
                 <Trans
                   t={t}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR will fix some UI bugs in ODD app.
Close RAUT-654 and RQA-924

In terms of components that related to Network settings, the current implementation isn't good since there were design updates and components' structure change etc.
I will do refactoring to make all related components more readable and maintainable.


- Network Settings layout issue in RobotSettings.
#### before
![Screenshot 2023-08-31 at 5 18 19 PM](https://github.com/Opentrons/opentrons/assets/474225/ab647703-1fcb-461c-ace7-0c9fb45917af)
![Screenshot 2023-08-31 at 5 27 48 PM](https://github.com/Opentrons/opentrons/assets/474225/4ed20b56-9c4c-4f8b-b4ad-305c316d5908)
![Screenshot 2023-08-31 at 6 07 01 PM](https://github.com/Opentrons/opentrons/assets/474225/f71cc2b4-8703-4dc8-8966-82629f6c972d)

#### after
Also update input form padding to align with the latest design
![Screenshot 2023-08-31 at 6 11 02 PM](https://github.com/Opentrons/opentrons/assets/474225/09afb41b-025a-463b-9dc9-2960591a3789)
![Screenshot 2023-08-31 at 6 11 09 PM](https://github.com/Opentrons/opentrons/assets/474225/6b5f8ab0-9862-4799-af1a-6ff1b5fbbc54)
![Screenshot 2023-08-31 at 6 11 21 PM](https://github.com/Opentrons/opentrons/assets/474225/de9298fc-cf07-44cb-bc65-0af7c64fa297)


- Text wrapping issue in Modals
#### before
![Screenshot 2023-09-01 at 1 23 39 PM](https://github.com/Opentrons/opentrons/assets/474225/cca88979-8f23-41d0-88f5-9a3074605d37)
![Screenshot 2023-09-01 at 1 29 00 PM](https://github.com/Opentrons/opentrons/assets/474225/c79a6f4f-eae1-4ea7-a6d9-9b5e46cb7402)


#### after
![Screenshot 2023-09-01 at 2 55 21 PM](https://github.com/Opentrons/opentrons/assets/474225/be7fda75-e689-48e7-9e74-d9820d5073db)
![Screenshot 2023-09-01 at 2 58 00 PM](https://github.com/Opentrons/opentrons/assets/474225/0df63592-9c5a-48cc-8698-513681e6b183)

- Remove Temp ODD menu from Choose network type screen

- Fix overflow menu's behavior in navigation when tapping home gantry

- Update software keyboard (key-height and margin-bottom) 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
