### PR TITLE
fix(app): fix release notes url in ODD settings

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -288,7 +288,7 @@
   "use_older_protocol_analysis_method": "Use older protocol analysis method",
   "validating_software": "Validating software...",
   "view_details": "View details",
-  "view_latest_release_notes_at": "View latest release notes at ",
+  "view_latest_release_notes_at": "View latest release notes at {{url}}",
   "view_network_details": "View network details",
   "view_opentrons_issue_tracker": "View Opentrons issue tracker",
   "view_opentrons_release_notes": "View full Opentrons release notes",

--- a/app/src/organisms/RobotSettingsDashboard/RobotSystemVersion.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/RobotSystemVersion.tsx
@@ -77,7 +77,9 @@ export function RobotSystemVersion({
           marginTop="7.75rem"
         >
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
-            <StyledText as="p">{t('view_latest_release_notes_at', {url: GITHUB_URL})}</StyledText>
+            <StyledText as="p">
+              {t('view_latest_release_notes_at', { url: GITHUB_URL })}
+            </StyledText>
             <Flex
               backgroundColor={COLORS.light1}
               flexDirection={DIRECTION_ROW}

--- a/app/src/organisms/RobotSettingsDashboard/RobotSystemVersion.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/RobotSystemVersion.tsx
@@ -21,7 +21,7 @@ import { getShellUpdateState } from '../../redux/shell'
 
 import type { SetSettingOption } from '../../pages/OnDeviceDisplay/RobotSettingsDashboard'
 
-const GITHUB_URL = 'https://github.com/Opentrons/opentrons'
+const GITHUB_URL = 'https://github.com/Opentrons/opentrons/releases'
 
 interface RobotSystemVersionProps {
   currentVersion: string
@@ -77,9 +77,7 @@ export function RobotSystemVersion({
           marginTop="7.75rem"
         >
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
-            <StyledText as="p">{`${t(
-              'view_latest_release_notes_at'
-            )} ${GITHUB_URL}`}</StyledText>
+            <StyledText as="p">{t('view_latest_release_notes_at', {url: GITHUB_URL})}</StyledText>
             <Flex
               backgroundColor={COLORS.light1}
               flexDirection={DIRECTION_ROW}

--- a/app/src/organisms/RobotSettingsDashboard/__tests__/RobotSystemVersion.test.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/__tests__/RobotSystemVersion.test.tsx
@@ -48,7 +48,7 @@ describe('RobotSystemVersion', () => {
     const [{ getByText }] = render(props)
     getByText('Robot System Version')
     getByText(
-      'View latest release notes at https://github.com/Opentrons/opentrons'
+      'View latest release notes at https://github.com/Opentrons/opentrons/releases'
     )
     getByText('Current Version:')
     getByText('mock7.0.0')


### PR DESCRIPTION
# Overview

Provide full path to opentrons github releases in URL of ODD robot version settings page.

<img width="1022" alt="Screen Shot 2023-09-01 at 4 30 47 PM" src="https://github.com/Opentrons/opentrons/assets/4731953/f952bd32-19b4-42ac-b85b-b39b3432ea87">

Closes RAUT-658 and RQA-1434
