### PR TITLE
fix(otupdate): use expanduser to get a relative path for authorized_keys.

### DIFF
--- a/update-server/otupdate/common/ssh_key_management.py
+++ b/update-server/otupdate/common/ssh_key_management.py
@@ -68,7 +68,7 @@ def authorized_keys(mode: str = "r") -> Generator[IO[Any], None, None]:
 
     :param mode: As :py:meth:`open`
     """
-    path = "/var/home/.ssh/authorized_keys"
+    path = os.path.expanduser("~/.ssh/authorized_keys")
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path))
         open(path, "w").close()


### PR DESCRIPTION
# Overview

The authorized_keys path where we store valid ssh public keys is different for the OT-2 and the Flex, the OT-2 bind mounts the home dir to `/var/home` whereas we just use `/home` for the Flex which is bind mounted to `/userfs/home`. For this reason, it's better to not have a static path for the authorized_keys, instead, we should have a relative path depending on the user.

# Test Plan

- [x] Test on the OT-2/Flex and make sure we ssh pub keys are stored in the correct location when the `/server/ssh_keys` endpoint is hit

# Changelog

- Use `os.path.expanduser` instead of hardcoded path to `authoreized_keys` file

# Review requests


# Risk assessment
Low
