### PR TITLE
feat(api) Add ability to configure liquid class in Protocol Engine

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -23,6 +23,7 @@ from typing import (
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
 )
+from opentrons_shared_data.pipette.types import LiquidClasses
 from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons import types as top_types
@@ -929,14 +930,17 @@ class API(
 
     # Pipette action API
     async def prepare_for_aspirate(
-        self, mount: top_types.Mount, rate: float = 1.0
+        self,
+        mount: top_types.Mount,
+        rate: float = 1.0,
+        liquid_class: Optional[LiquidClasses] = None,
     ) -> None:
         """
         Prepare the pipette for aspiration.
         """
         instrument = self.get_pipette(mount)
         self.ready_for_tip_action(instrument, HardwareAction.PREPARE_ASPIRATE)
-
+        instrument.configure_liquid_class(liquid_class)
         if instrument.current_volume == 0:
             speed = self.plunger_speed(
                 instrument, instrument.blow_out_flow_rate, "aspirate"

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -92,6 +92,7 @@ class PipetteDict(InstrumentDict):
     liquid_properties: Dict[
         pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
     ]
+    model_version: pipette_definition.PipetteModelVersionType
 
 
 class PipetteStateDict(TypedDict):

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -15,11 +15,7 @@ from opentrons_shared_data.pipette.dev_types import (
     PipetteName,
     ChannelCount,
 )
-from opentrons_shared_data.pipette.types import PipetteTipType
-from opentrons_shared_data.pipette.pipette_definition import (
-    PipetteConfigurations,
-    SupportedTipsDefinition,
-)
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons_shared_data.gripper import (
     GripperModel,
     GripperDefinition,
@@ -43,7 +39,7 @@ class GripperSpec(InstrumentSpec):
 
 
 class AttachedPipette(TypedDict):
-    config: Optional[PipetteConfigurations]
+    config: Optional[pipette_definition.PipetteConfigurations]
     id: Optional[str]
 
 
@@ -93,7 +89,9 @@ class PipetteDict(InstrumentDict):
     ready_to_aspirate: bool
     has_tip: bool
     default_blow_out_volume: float
-    supported_tips: Dict[PipetteTipType, SupportedTipsDefinition]
+    liquid_properties: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ]
 
 
 class PipetteStateDict(TypedDict):

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -191,9 +191,13 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def liquid_class(self) -> PipetteLiquidPropertiesDefinition:
         return self._liquid_class
 
-    def configure_liquid_class(self, liquid_class: pip_types.LiquidClasses) -> None:
-        self._liquid_class = self._config.liquid_properties[liquid_class]
-        self._update_active_settings_from_liquid_class()
+    def configure_liquid_class(
+        self, liquid_class: Optional[pip_types.LiquidClasses]
+    ) -> None:
+        if liquid_class:
+            self._liquid_class_name = liquid_class
+            self._liquid_class = self._config.liquid_properties[liquid_class]
+            self._update_active_settings_from_liquid_class()
 
     @property
     def nozzle_offset(self) -> List[float]:

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -191,6 +191,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def liquid_class(self) -> PipetteLiquidPropertiesDefinition:
         return self._liquid_class
 
+    def configure_liquid_class(self, liquid_class: pip_types.LiquidClasses) -> None:
+        self._liquid_class = self._config.liquid_properties[liquid_class]
+        self._update_active_settings_from_liquid_class()
+
     @property
     def nozzle_offset(self) -> List[float]:
         return self._nozzle_offset
@@ -232,6 +236,35 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     @property
     def active_tip_settings(self) -> SupportedTipsDefinition:
         return self._active_tip_settings
+
+    def _update_active_settings_from_liquid_class(self) -> None:
+        self._active_tip_settings = self._liquid_class.supported_tips[
+            pip_types.PipetteTipType(self._liquid_class.max_volume)
+        ]
+        self._fallback_tip_length = self._active_tip_settings.default_tip_length
+
+        self._aspirate_flow_rates_lookup = (
+            self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
+        )
+        self._dispense_flow_rates_lookup = (
+            self._active_tip_settings.default_dispense_flowrate.values_by_api_level
+        )
+        self._blowout_flow_rates_lookup = (
+            self._active_tip_settings.default_blowout_flowrate.values_by_api_level
+        )
+
+        self._aspirate_flow_rate = (
+            self._active_tip_settings.default_aspirate_flowrate.default
+        )
+        self._dispense_flow_rate = (
+            self._active_tip_settings.default_dispense_flowrate.default
+        )
+        self._blow_out_flow_rate = (
+            self._active_tip_settings.default_blowout_flowrate.default
+        )
+        self._flow_acceleration = self._active_tip_settings.default_flow_acceleration
+
+        self._tip_overlap_lookup = self._liquid_class.tip_overlap_dictionary
 
     def update_config_item(
         self,

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -341,6 +341,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         return self._pipette_type
 
     @property
+    def pipette_model(self) -> PipetteModelVersionType:
+        return self._pipette_model
+
+    @property
     def pipette_id(self) -> Optional[str]:
         return self._pipette_id
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -216,7 +216,7 @@ class PipetteHandlerProvider(Generic[MountType]):
                 "default_blow_out_flow_rates",
                 "default_dispense_flow_rates",
                 "back_compat_names",
-                "supported_tips",
+                "liquid_properties",
             ]
 
             instr_dict = instr.as_dict()

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -254,6 +254,7 @@ class PipetteHandlerProvider(Generic[MountType]):
                 alvl: self.plunger_speed(instr, fr, "aspirate")
                 for alvl, fr in instr.aspirate_flow_rates_lookup.items()
             }
+            result["model_version"] = instr.pipette_model
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -147,9 +147,13 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def liquid_class(self) -> PipetteLiquidPropertiesDefinition:
         return self._liquid_class
 
-    def configure_liquid_class(self, liquid_class: pip_types.LiquidClasses) -> None:
-        self._liquid_class = self._config.liquid_properties[liquid_class]
-        self._update_active_settings_from_liquid_class()
+    def configure_liquid_class(
+        self, liquid_class: Optional[pip_types.LiquidClasses]
+    ) -> None:
+        if liquid_class:
+            self._liquid_class_name = liquid_class
+            self._liquid_class = self._config.liquid_properties[liquid_class]
+            self._update_active_settings_from_liquid_class()
 
     @property
     def channels(self) -> pip_types.PipetteChannelType:

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -308,6 +308,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         return self._pipette_type
 
     @property
+    def pipette_model(self) -> PipetteModelVersionType:
+        return self._pipette_model
+
+    @property
     def pipette_id(self) -> Optional[str]:
         return self._pipette_id
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -147,6 +147,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     def liquid_class(self) -> PipetteLiquidPropertiesDefinition:
         return self._liquid_class
 
+    def configure_liquid_class(self, liquid_class: pip_types.LiquidClasses) -> None:
+        self._liquid_class = self._config.liquid_properties[liquid_class]
+        self._update_active_settings_from_liquid_class()
+
     @property
     def channels(self) -> pip_types.PipetteChannelType:
         return self._max_channels
@@ -192,6 +196,35 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     @property
     def active_tip_settings(self) -> SupportedTipsDefinition:
         return self._active_tip_settings
+
+    def _update_active_settings_from_liquid_class(self) -> None:
+        self._active_tip_settings = self._liquid_class.supported_tips[
+            pip_types.PipetteTipType(self._liquid_class.max_volume)
+        ]
+        self._fallback_tip_length = self._active_tip_settings.default_tip_length
+
+        self._aspirate_flow_rates_lookup = (
+            self._active_tip_settings.default_aspirate_flowrate.values_by_api_level
+        )
+        self._dispense_flow_rates_lookup = (
+            self._active_tip_settings.default_dispense_flowrate.values_by_api_level
+        )
+        self._blowout_flow_rates_lookup = (
+            self._active_tip_settings.default_blowout_flowrate.values_by_api_level
+        )
+
+        self._aspirate_flow_rate = (
+            self._active_tip_settings.default_aspirate_flowrate.default
+        )
+        self._dispense_flow_rate = (
+            self._active_tip_settings.default_dispense_flowrate.default
+        )
+        self._blow_out_flow_rate = (
+            self._active_tip_settings.default_blowout_flowrate.default
+        )
+        self._flow_acceleration = self._active_tip_settings.default_flow_acceleration
+
+        self._tip_overlap_lookup = self._liquid_class.tip_overlap_dictionary
 
     def act_as(self, name: PipetteName) -> None:
         """Reconfigure to act as ``name``. ``name`` must be either the

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -228,7 +228,7 @@ class PipetteHandlerProvider:
                 "default_blow_out_flow_rates",
                 "default_dispense_flow_rates",
                 "back_compat_names",
-                "supported_tips",
+                "liquid_properties",
             ]
 
             instr_dict = instr.as_dict()

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -269,6 +269,7 @@ class PipetteHandlerProvider:
             result[
                 "default_blow_out_volume"
             ] = instr.active_tip_settings.default_blowout_volume
+            result["model_version"] = instr.pipette_model
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -51,7 +51,7 @@ from opentrons_hardware.hardware_control.motion_planning import (
     MoveTarget,
     ZeroLengthMoveError,
 )
-
+from opentrons_shared_data.pipette.types import LiquidClasses
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 
 from .util import use_or_initialize_loop, check_motion_bounds
@@ -1572,7 +1572,10 @@ class OT3API(
 
     # Pipette action API
     async def prepare_for_aspirate(
-        self, mount: Union[top_types.Mount, OT3Mount], rate: float = 1.0
+        self,
+        mount: Union[top_types.Mount, OT3Mount],
+        rate: float = 1.0,
+        liquid_class: Optional[LiquidClasses] = None,
     ) -> None:
         """Prepare the pipette for aspiration."""
         checked_mount = OT3Mount.from_mount(mount)
@@ -1580,6 +1583,7 @@ class OT3API(
         self._pipette_handler.ready_for_tip_action(
             instrument, HardwareAction.PREPARE_ASPIRATE
         )
+        instrument.configure_liquid_class(liquid_class)
         if instrument.current_volume == 0:
             await self._move_to_plunger_bottom(checked_mount, rate)
             instrument.ready_to_aspirate = True

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -25,6 +25,7 @@ from .actions import (
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     AddPipetteConfigAction,
+    UpdateLiquidClassAction,
 )
 
 __all__ = [
@@ -50,6 +51,7 @@ __all__ = [
     "ResetTipsAction",
     "SetPipetteMovementSpeedAction",
     "AddPipetteConfigAction",
+    "UpdateLiquidClassAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -13,6 +13,7 @@ from opentrons.hardware_control.types import DoorState
 from opentrons.hardware_control.modules import LiveData
 
 from opentrons_shared_data.errors import EnumeratedError
+from opentrons_shared_data.pipette.types import LiquidClasses
 
 from ..resources import pipette_data_provider
 from ..commands import Command, CommandCreate
@@ -189,6 +190,14 @@ class AddPipetteConfigAction:
     config: pipette_data_provider.LoadedStaticPipetteData
 
 
+@dataclass(frozen=True)
+class UpdateLiquidClassAction:
+    """Update a pipette's current liquid class in the state store."""
+
+    pipette_id: str
+    liquid_class: str
+
+
 Action = Union[
     PlayAction,
     PauseAction,
@@ -206,4 +215,5 @@ Action = Union[
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     AddPipetteConfigAction,
+    UpdateLiquidClassAction,
 ]

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -13,7 +13,6 @@ from opentrons.hardware_control.types import DoorState
 from opentrons.hardware_control.modules import LiveData
 
 from opentrons_shared_data.errors import EnumeratedError
-from opentrons_shared_data.pipette.types import LiquidClasses
 
 from ..resources import pipette_data_provider
 from ..commands import Command, CommandCreate

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -213,7 +213,7 @@ class EquipmentHandler:
 
             serial_number = pipette_dict["pipette_id"]
             static_pipette_config = pipette_data_provider.get_pipette_static_config(
-                pipette_dict
+                pipette_dict["model_version"]
             )
 
         else:

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -10,10 +10,6 @@ from opentrons_shared_data.pipette import (
     pipette_definition,
 )
 
-from opentrons.hardware_control.dev_types import PipetteDict
-
-from ..types import FlowRates
-
 
 @dataclass(frozen=True)
 class LoadedStaticPipetteData:
@@ -50,15 +46,21 @@ def get_virtual_pipette_static_config(
     )
 
 
-def get_pipette_static_config(pipette_dict: PipetteDict) -> LoadedStaticPipetteData:
-    """Get the config for a pipette, given the state/config object from the HW API."""
+def get_pipette_static_config(
+    pipette_model: pipette_definition.PipetteModelVersionType,
+) -> LoadedStaticPipetteData:
+    """Get the config for a pipette, given the pipette model from the HW API."""
+    config = load_pipette_data.load_definition(
+        pipette_model.pipette_type,
+        pipette_model.pipette_channels,
+        pipette_model.pipette_version,
+    )
+
     return LoadedStaticPipetteData(
-        model=pipette_dict["model"],
-        display_name=pipette_dict["display_name"],
-        channels=pipette_dict["channels"],
-        # TODO(mc, 2023-02-28): these two values are not present in PipetteDict
-        # https://opentrons.atlassian.net/browse/RCORE-655
-        home_position=0,
-        nozzle_offset_z=0,
-        liquid_properties=pipette_dict["liquid_properties"],
+        model=str(pipette_model),
+        display_name=config.display_name,
+        channels=config.channels,
+        home_position=config.mount_configurations.homePosition,
+        nozzle_offset_z=config.nozzle_offset[2],
+        liquid_properties=config.liquid_properties,
     )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -591,7 +591,7 @@ class LegacyCommandMapper:
             pipette_id=pipette_id,
             serial_number=instrument_load_info.pipette_dict["pipette_id"],
             config=pipette_data_provider.get_pipette_static_config(
-                instrument_load_info.pipette_dict
+                instrument_load_info.pipette_dict["model_version"]
             ),
         )
 

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -233,9 +233,10 @@ def pipette_liquid_properties_fixture(
 ) -> Dict[
     pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
 ]:
+    """Get a mock liquid properties definition."""
     return {
         pip_types.LiquidClasses.default: pipette_definition.PipetteLiquidPropertiesDefinition(
-            supportedTips={pip_types.PipetteTipType.t1000: supported_tip_fixture},
+            supportedTips={"t1000": supported_tip_fixture},  # type: ignore
             defaultTipOverlapDictionary={},
             maxVolume=1000,
             minVolume=5,

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import pytest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.deck import load as load_deck
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.labware import load_definition
-from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocols.api_support.deck_type import (
     STANDARD_OT2_DECK,
@@ -225,3 +225,20 @@ def supported_tip_fixture() -> pipette_definition.SupportedTipsDefinition:
         dispense=pipette_definition.ulPerMMDefinition(default={"1": [(0, 0, 0)]}),
         defaultBlowoutVolume=5,
     )
+
+
+@pytest.fixture(scope="session")
+def pipette_liquid_properties_fixture(
+    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+) -> Dict[
+    pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+]:
+    return {
+        pip_types.LiquidClasses.default: pipette_definition.PipetteLiquidPropertiesDefinition(
+            supportedTips={pip_types.PipetteTipType.t1000: supported_tip_fixture},
+            defaultTipOverlapDictionary={},
+            maxVolume=1000,
+            minVolume=5,
+            defaultTipracks=[],
+        )
+    }

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -5,8 +5,12 @@ from datetime import datetime
 from decoy import Decoy, matchers
 from typing import Any, Optional, cast, Dict
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.pipette import pipette_definition, types as pip_types
+from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
+from opentrons_shared_data.pipette import (
+    pipette_definition,
+    pipette_load_name_conversions,
+    types as pip_types,
+)
 from opentrons_shared_data.labware.dev_types import LabwareUri
 
 from opentrons.calibration_storage.helpers import uri_from_details
@@ -597,7 +601,13 @@ async def test_load_pipette(
     subject: EquipmentHandler,
 ) -> None:
     """It should load pipette data, check attachment, and generate an ID."""
-    pipette_dict = cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+    model_version = pipette_load_name_conversions.convert_pipette_model(
+        PipetteModel("p300_single_v2.2")
+    )
+    pipette_dict = cast(
+        PipetteDict,
+        {"model": "hello", "pipette_id": "world", "model_version": model_version},
+    )
 
     decoy.when(state_store.config.use_virtual_pipettes).then_return(False)
     decoy.when(model_utils.generate_id()).then_return("unique-id")
@@ -609,7 +619,7 @@ async def test_load_pipette(
     )
 
     decoy.when(
-        pipette_data_provider.get_pipette_static_config(pipette_dict)
+        pipette_data_provider.get_pipette_static_config(pipette_dict["model_version"])
     ).then_return(loaded_static_pipette_data)
 
     decoy.when(hardware_api.get_instrument_max_height(mount=HwMount.LEFT)).then_return(
@@ -651,7 +661,13 @@ async def test_load_pipette_96_channels(
     subject: EquipmentHandler,
 ) -> None:
     """It should load pipette data, check attachment, and generate an ID."""
-    pipette_dict = cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+    model_version = pipette_load_name_conversions.convert_pipette_model(
+        PipetteModel("p1000_96_v3.3")
+    )
+    pipette_dict = cast(
+        PipetteDict,
+        {"model": "hello", "pipette_id": "world", "model_version": model_version},
+    )
 
     decoy.when(state_store.config.use_virtual_pipettes).then_return(False)
     decoy.when(model_utils.generate_id()).then_return("unique-id")
@@ -659,7 +675,7 @@ async def test_load_pipette_96_channels(
         pipette_dict
     )
     decoy.when(
-        pipette_data_provider.get_pipette_static_config(pipette_dict)
+        pipette_data_provider.get_pipette_static_config(pipette_dict["model_version"])
     ).then_return(loaded_static_pipette_data)
 
     decoy.when(hardware_api.get_instrument_max_height(mount=HwMount.LEFT)).then_return(
@@ -695,14 +711,20 @@ async def test_load_pipette_uses_provided_id(
     subject: EquipmentHandler,
 ) -> None:
     """It should use the provided ID rather than generating an ID for the pipette."""
-    pipette_dict = cast(PipetteDict, {"model": "hello", "pipette_id": "world"})
+    model_version = pipette_load_name_conversions.convert_pipette_model(
+        PipetteModel("p300_single_v2.2")
+    )
+    pipette_dict = cast(
+        PipetteDict,
+        {"model": "hello", "pipette_id": "world", "model_version": model_version},
+    )
 
     decoy.when(state_store.config.use_virtual_pipettes).then_return(False)
     decoy.when(hardware_api.get_attached_instrument(mount=HwMount.LEFT)).then_return(
         pipette_dict
     )
     decoy.when(
-        pipette_data_provider.get_pipette_static_config(pipette_dict)
+        pipette_data_provider.get_pipette_static_config(pipette_dict["model_version"])
     ).then_return(loaded_static_pipette_data)
 
     result = await subject.load_pipette(

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -3,10 +3,10 @@ import pytest
 import inspect
 from datetime import datetime
 from decoy import Decoy, matchers
-from typing import Any, Optional, cast
+from typing import Any, Optional, cast, Dict
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons_shared_data.labware.dev_types import LabwareUri
 
 from opentrons.calibration_storage.helpers import uri_from_details
@@ -36,7 +36,6 @@ from opentrons.protocol_engine.types import (
     ModuleModel,
     ModuleDefinition,
     OFF_DECK_LOCATION,
-    FlowRates,
 )
 
 from opentrons.protocol_engine.state import Config, StateStore
@@ -128,22 +127,16 @@ async def temp_module_v2(decoy: Decoy) -> TempDeck:
 
 @pytest.fixture
 def loaded_static_pipette_data(
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> LoadedStaticPipetteData:
     """Get a pipette config data value object."""
     return LoadedStaticPipetteData(
         model="pipette_model",
         display_name="pipette name",
-        min_volume=1.23,
-        max_volume=4.56,
         channels=7,
-        flow_rates=FlowRates(
-            default_blow_out={"a": 1.23},
-            default_aspirate={"b": 4.56},
-            default_dispense={"c": 7.89},
-        ),
-        tip_configuration_lookup_table={4.56: supported_tip_fixture},
-        nominal_tip_overlap={"default": 9.87},
+        liquid_properties=pipette_liquid_properties_fixture,
         home_position=10.11,
         nozzle_offset_z=12.13,
     )

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -1,10 +1,12 @@
 """Test pipette data provider."""
 from typing import Dict
 from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
-from opentrons_shared_data.pipette import pipette_definition, types as pip_types
+from opentrons_shared_data.pipette import (
+    pipette_definition,
+    types as pip_types,
+    pipette_load_name_conversions,
+)
 
-from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocol_engine.types import FlowRates
 from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
 )
@@ -12,11 +14,7 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
 from opentrons.protocol_engine.resources import pipette_data_provider as subject
 
 
-def test_get_virtual_pipette_static_config(
-    pipette_liquid_properties_fixture: Dict[
-        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
-    ]
-) -> None:
+def test_get_virtual_pipette_static_config() -> None:
     """It should return config data given a pipette name."""
     result = subject.get_virtual_pipette_static_config(
         PipetteNameType.P20_SINGLE_GEN2.value
@@ -28,51 +26,22 @@ def test_get_virtual_pipette_static_config(
         channels=1,
         nozzle_offset_z=10.45,
         home_position=172.15,
-        liquid_properties=pipette_liquid_properties_fixture,
+        liquid_properties=result.liquid_properties,
     )
 
 
-def test_get_pipette_static_config(
-    pipette_liquid_properties_fixture: Dict[
-        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
-    ],
-) -> None:
+def test_get_pipette_static_config() -> None:
     """It should return config data given a PipetteDict."""
-    pipette_dict: PipetteDict = {
-        "name": "p300_single_gen2",
-        "channels": 1,
-        "aspirate_flow_rate": 46.43,
-        "dispense_flow_rate": 46.43,
-        "pipette_id": "P3HSV202020060308",
-        "current_volume": 0.0,
-        "display_name": "P300 Single-Channel GEN2",
-        "tip_length": 0.0,
-        "model": PipetteModel("p300_single_v2.0"),
-        "blow_out_flow_rate": 46.43,
-        "working_volume": 300,
-        "available_volume": 300.0,
-        "return_tip_height": 0.5,
-        "default_aspirate_flow_rates": {"2.0": 46.43, "2.1": 92.86},
-        "default_blow_out_flow_rates": {"2.0": 46.43, "2.2": 92.86},
-        "default_dispense_flow_rates": {"2.0": 46.43, "2.3": 92.86},
-        "back_compat_names": ["p300_single"],
-        "has_tip": False,
-        "aspirate_speed": 5.021202,
-        "dispense_speed": 5.021202,
-        "blow_out_speed": 5.021202,
-        "ready_to_aspirate": False,
-        "liquid_properties": pipette_liquid_properties_fixture,
-    }
-
-    result = subject.get_pipette_static_config(pipette_dict)
+    model_version = pipette_load_name_conversions.convert_pipette_model(
+        PipetteModel("p300_single_v2.0")
+    )
+    result = subject.get_pipette_static_config(model_version)
 
     assert result == LoadedStaticPipetteData(
         model="p300_single_v2.0",
         display_name="P300 Single-Channel GEN2",
         channels=1,
-        liquid_properties=pipette_liquid_properties_fixture,
-        # TODO(mc, 2023-02-28): these two values are not present in PipetteDict
-        # https://opentrons.atlassian.net/browse/RCORE-655
-        nozzle_offset_z=0,
-        home_position=0,
+        liquid_properties=result.liquid_properties,
+        nozzle_offset_z=29.45,
+        home_position=172.15,
     )

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -1,4 +1,5 @@
 """Test pipette data provider."""
+from typing import Dict
 from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
 from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 
@@ -11,7 +12,11 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
 from opentrons.protocol_engine.resources import pipette_data_provider as subject
 
 
-def test_get_virtual_pipette_static_config() -> None:
+def test_get_virtual_pipette_static_config(
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ]
+) -> None:
     """It should return config data given a pipette name."""
     result = subject.get_virtual_pipette_static_config(
         PipetteNameType.P20_SINGLE_GEN2.value
@@ -20,37 +25,21 @@ def test_get_virtual_pipette_static_config() -> None:
     assert result == LoadedStaticPipetteData(
         model="p20_single_v2.0",
         display_name="P20 Single-Channel GEN2",
-        min_volume=1,
-        max_volume=20.0,
         channels=1,
         nozzle_offset_z=10.45,
         home_position=172.15,
-        flow_rates=FlowRates(
-            default_aspirate={"2.0": 3.78, "2.6": 7.56},
-            default_dispense={"2.0": 3.78, "2.6": 7.56},
-            default_blow_out={"2.0": 3.78, "2.6": 7.56},
-        ),
-        tip_configuration_lookup_table=result.tip_configuration_lookup_table,
-        nominal_tip_overlap={
-            "default": 8.25,
-            "opentrons/eppendorf_96_tiprack_10ul_eptips/1": 8.4,
-            "opentrons/geb_96_tiprack_10ul/1": 8.3,
-            "opentrons/opentrons_96_filtertiprack_10ul/1": 8.25,
-            "opentrons/opentrons_96_filtertiprack_20ul/1": 8.25,
-            "opentrons/opentrons_96_tiprack_10ul/1": 8.25,
-            "opentrons/opentrons_96_tiprack_20ul/1": 8.25,
-        },
+        liquid_properties=pipette_liquid_properties_fixture,
     )
 
 
 def test_get_pipette_static_config(
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should return config data given a PipetteDict."""
     pipette_dict: PipetteDict = {
         "name": "p300_single_gen2",
-        "min_volume": 20,
-        "max_volume": 300,
         "channels": 1,
         "aspirate_flow_rate": 46.43,
         "dispense_flow_rate": 46.43,
@@ -61,11 +50,6 @@ def test_get_pipette_static_config(
         "model": PipetteModel("p300_single_v2.0"),
         "blow_out_flow_rate": 46.43,
         "working_volume": 300,
-        "tip_overlap": {
-            "default": 8.2,
-            "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
-            "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2,
-        },
         "available_volume": 300.0,
         "return_tip_height": 0.5,
         "default_aspirate_flow_rates": {"2.0": 46.43, "2.1": 92.86},
@@ -77,11 +61,7 @@ def test_get_pipette_static_config(
         "dispense_speed": 5.021202,
         "blow_out_speed": 5.021202,
         "ready_to_aspirate": False,
-        "default_blow_out_speeds": {"2.0": 5.021202, "2.6": 10.042404},
-        "default_dispense_speeds": {"2.0": 5.021202, "2.6": 10.042404},
-        "default_aspirate_speeds": {"2.0": 5.021202, "2.6": 10.042404},
-        "default_blow_out_volume": 10,
-        "supported_tips": {pip_types.PipetteTipType.t300: supported_tip_fixture},
+        "liquid_properties": pipette_liquid_properties_fixture,
     }
 
     result = subject.get_pipette_static_config(pipette_dict)
@@ -89,20 +69,8 @@ def test_get_pipette_static_config(
     assert result == LoadedStaticPipetteData(
         model="p300_single_v2.0",
         display_name="P300 Single-Channel GEN2",
-        min_volume=20,
-        max_volume=300,
         channels=1,
-        flow_rates=FlowRates(
-            default_aspirate={"2.0": 46.43, "2.1": 92.86},
-            default_dispense={"2.0": 46.43, "2.3": 92.86},
-            default_blow_out={"2.0": 46.43, "2.2": 92.86},
-        ),
-        tip_configuration_lookup_table={300: supported_tip_fixture},
-        nominal_tip_overlap={
-            "default": 8.2,
-            "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
-            "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2,
-        },
+        liquid_properties=pipette_liquid_properties_fixture,
         # TODO(mc, 2023-02-28): these two values are not present in PipetteDict
         # https://opentrons.atlassian.net/browse/RCORE-655
         nozzle_offset_z=0,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -3,11 +3,11 @@ import inspect
 
 import pytest
 from decoy import Decoy
-from typing import cast, List, Tuple, Union, Optional, NamedTuple
+from typing import cast, List, Tuple, Union, Optional, NamedTuple, Dict
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
 from opentrons_shared_data.labware.dev_types import LabwareUri
-from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import Point, DeckSlotName, MountType
@@ -1356,7 +1356,9 @@ def test_get_next_drop_tip_location(
     pipette_channels: int,
     pipette_mount: MountType,
     expected_locations: List[DropTipWellLocation],
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should provide the next location to drop tips into within a labware."""
     decoy.when(labware_view.is_fixed_trash(labware_id="abc")).then_return(True)
@@ -1365,14 +1367,11 @@ def test_get_next_drop_tip_location(
     ).then_return((well_size, 0, 0))
     decoy.when(mock_pipette_view.get_config("pip-123")).then_return(
         StaticPipetteConfig(
-            min_volume=1,
-            max_volume=9001,
             channels=pipette_channels,
             model="blah",
             display_name="bleh",
             serial_number="",
-            tip_configuration_lookup_table={9001: supported_tip_fixture},
-            nominal_tip_overlap={},
+            liquid_properties=pipette_liquid_properties_fixture,
             home_position=0,
             nozzle_offset_z=0,
         )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -69,6 +69,9 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         movement_speed_by_id={},
         static_config_by_id={},
         flow_rates_by_id={},
+        liquid_class_by_id={},
+        liquid_class_definition_by_id={},
+        tip_configuration_by_id={},
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -1,10 +1,10 @@
 """Tests for pipette state changes in the protocol_engine state store."""
 import pytest
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 
 from opentrons.types import DeckSlotName, MountType
 from opentrons.protocol_engine import commands as cmd
@@ -592,7 +592,9 @@ def test_set_movement_speed(subject: PipetteStore) -> None:
 
 def test_add_pipette_config(
     subject: PipetteStore,
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should issue an action to add a pipette config."""
     subject.handle_action(
@@ -602,16 +604,8 @@ def test_add_pipette_config(
             config=LoadedStaticPipetteData(
                 model="pipette-model",
                 display_name="pipette name",
-                min_volume=1.23,
-                max_volume=4.56,
                 channels=7,
-                flow_rates=FlowRates(
-                    default_aspirate={"a": 1},
-                    default_dispense={"b": 2},
-                    default_blow_out={"c": 3},
-                ),
-                tip_configuration_lookup_table={4: supported_tip_fixture},
-                nominal_tip_overlap={"default": 5},
+                liquid_properties=pipette_liquid_properties_fixture,
                 home_position=8.9,
                 nozzle_offset_z=10.11,
             ),
@@ -622,11 +616,8 @@ def test_add_pipette_config(
         model="pipette-model",
         serial_number="pipette-serial",
         display_name="pipette name",
-        min_volume=1.23,
-        max_volume=4.56,
         channels=7,
-        tip_configuration_lookup_table={4: supported_tip_fixture},
-        nominal_tip_overlap={"default": 5},
+        liquid_properties=pipette_liquid_properties_fixture,
         home_position=8.9,
         nozzle_offset_z=10.11,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -3,7 +3,7 @@ import pytest
 from typing import cast, Dict, List, Optional
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 
 from opentrons.config.defaults_ot2 import Z_RETRACT_DISTANCE
 from opentrons.types import MountType, Mount as HwMount
@@ -230,6 +230,9 @@ def test_get_aspirated_volume() -> None:
 
 def test_get_pipette_working_volume(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should get the minimum value of tip volume and max volume."""
     subject = get_pipette_view(
@@ -238,14 +241,15 @@ def test_get_pipette_working_volume(
         },
         static_config_by_id={
             "pipette-id": StaticPipetteConfig(
-                min_volume=1,
-                max_volume=9001,
                 channels=5,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
                 tip_configuration_lookup_table={9001: supported_tip_fixture},
-                nominal_tip_overlap={},
+                current_liquid_class=pipette_liquid_properties_fixture[
+                    pip_types.LiquidClasses.default
+                ],
+                liquid_properties=pipette_liquid_properties_fixture,
                 home_position=0,
                 nozzle_offset_z=0,
             )
@@ -257,6 +261,9 @@ def test_get_pipette_working_volume(
 
 def test_get_pipette_working_volume_raises_if_tip_volume_is_none(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """Should raise an exception that no tip is attached."""
     subject = get_pipette_view(
@@ -265,14 +272,15 @@ def test_get_pipette_working_volume_raises_if_tip_volume_is_none(
         },
         static_config_by_id={
             "pipette-id": StaticPipetteConfig(
-                min_volume=1,
-                max_volume=9001,
                 channels=5,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
                 tip_configuration_lookup_table={9001: supported_tip_fixture},
-                nominal_tip_overlap={},
+                current_liquid_class=pipette_liquid_properties_fixture[
+                    pip_types.LiquidClasses.default
+                ],
+                liquid_properties=pipette_liquid_properties_fixture,
                 home_position=0,
                 nozzle_offset_z=0,
             )
@@ -288,6 +296,9 @@ def test_get_pipette_working_volume_raises_if_tip_volume_is_none(
 
 def test_get_pipette_available_volume(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should get the available volume for a pipette."""
     subject = get_pipette_view(
@@ -301,26 +312,28 @@ def test_get_pipette_available_volume(
         aspirated_volume_by_id={"pipette-id": 58},
         static_config_by_id={
             "pipette-id": StaticPipetteConfig(
-                min_volume=1,
-                max_volume=123,
                 channels=3,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
                 tip_configuration_lookup_table={123: supported_tip_fixture},
-                nominal_tip_overlap={},
+                current_liquid_class=pipette_liquid_properties_fixture[
+                    pip_types.LiquidClasses.default
+                ],
+                liquid_properties=pipette_liquid_properties_fixture,
                 home_position=0,
                 nozzle_offset_z=0,
             ),
             "pipette-id-none": StaticPipetteConfig(
-                min_volume=1,
-                max_volume=123,
                 channels=5,
                 model="blah",
                 display_name="bleh",
                 serial_number="",
                 tip_configuration_lookup_table={123: supported_tip_fixture},
-                nominal_tip_overlap={},
+                current_liquid_class=pipette_liquid_properties_fixture[
+                    pip_types.LiquidClasses.default
+                ],
+                liquid_properties=pipette_liquid_properties_fixture,
                 home_position=0,
                 nozzle_offset_z=0,
             ),
@@ -418,17 +431,21 @@ def test_get_deck_point(
 
 def test_get_static_config(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should return the static pipette configuration that was set for the given pipette."""
     config = StaticPipetteConfig(
         model="pipette-model",
         display_name="display name",
         serial_number="serial-number",
-        min_volume=1.23,
-        max_volume=4.56,
         channels=9,
         tip_configuration_lookup_table={4.56: supported_tip_fixture},
-        nominal_tip_overlap={},
+        current_liquid_class=pipette_liquid_properties_fixture[
+            pip_types.LiquidClasses.default
+        ],
+        liquid_properties=pipette_liquid_properties_fixture,
         home_position=10.12,
         nozzle_offset_z=12.13,
     )
@@ -462,20 +479,25 @@ def test_get_static_config(
 
 def test_get_nominal_tip_overlap(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should return the static pipette configuration that was set for the given pipette."""
     config = StaticPipetteConfig(
         model="",
         display_name="",
         serial_number="",
-        min_volume=0,
-        max_volume=0,
         channels=10,
         tip_configuration_lookup_table={0: supported_tip_fixture},
         nominal_tip_overlap={
             "some-uri": 100,
             "default": 10,
         },
+        current_liquid_class=pipette_liquid_properties_fixture[
+            pip_types.LiquidClasses.default
+        ],
+        liquid_properties=pipette_liquid_properties_fixture,
         home_position=0,
         nozzle_offset_z=0,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 
 from opentrons.protocol_engine import actions, commands
 from opentrons.protocol_engine.state.tips import TipStore, TipView
-from opentrons.protocol_engine.types import FlowRates, DeckPoint
+from opentrons.protocol_engine.types import DeckPoint
 from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
 )

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -1,13 +1,13 @@
 """Tests for tip state store and selectors."""
 import pytest
 
-from typing import Optional
+from typing import Optional, Dict
 
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     Parameters as LabwareParameters,
 )
-from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 
 from opentrons.protocol_engine import actions, commands
 from opentrons.protocol_engine.state.tips import TipStore, TipView
@@ -175,7 +175,9 @@ def test_get_next_tip_skips_picked_up_tip(
     get_next_tip_tips: int,
     input_starting_tip: Optional[str],
     result_well_name: Optional[str],
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should get the next tip in the column if one has been picked up."""
     subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
@@ -185,17 +187,9 @@ def test_get_next_tip_skips_picked_up_tip(
             serial_number="pipette-serial",
             config=LoadedStaticPipetteData(
                 channels=input_tip_amount,
-                max_volume=15,
-                min_volume=3,
                 model="gen a",
                 display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
+                liquid_properties=pipette_liquid_properties_fixture,
                 nozzle_offset_z=1.23,
                 home_position=4.56,
             ),
@@ -232,7 +226,9 @@ def test_reset_tips(
     subject: TipStore,
     load_labware_command: commands.LoadLabware,
     pick_up_tip_command: commands.PickUpTip,
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should be able to reset tip tracking state."""
     subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
@@ -242,17 +238,9 @@ def test_reset_tips(
             serial_number="pipette-serial",
             config=LoadedStaticPipetteData(
                 channels=8,
-                max_volume=15,
-                min_volume=3,
                 model="gen a",
                 display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
+                liquid_properties=pipette_liquid_properties_fixture,
                 nozzle_offset_z=1.23,
                 home_position=4.56,
             ),
@@ -271,7 +259,10 @@ def test_reset_tips(
 
 
 def test_handle_pipette_config_action(
-    subject: TipStore, supported_tip_fixture: pipette_definition.SupportedTipsDefinition
+    subject: TipStore,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """Should add pipette channel to state."""
     subject.handle_action(
@@ -280,17 +271,9 @@ def test_handle_pipette_config_action(
             serial_number="pipette-serial",
             config=LoadedStaticPipetteData(
                 channels=8,
-                max_volume=15,
-                min_volume=3,
                 model="gen a",
                 display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
+                liquid_properties=pipette_liquid_properties_fixture,
                 nozzle_offset_z=1.23,
                 home_position=4.56,
             ),
@@ -337,7 +320,9 @@ def test_drop_tip(
     pick_up_tip_command: commands.PickUpTip,
     drop_tip_command: commands.DropTip,
     drop_tip_in_place_command: commands.DropTipInPlace,
-    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+    pipette_liquid_properties_fixture: Dict[
+        pip_types.LiquidClasses, pipette_definition.PipetteLiquidPropertiesDefinition
+    ],
 ) -> None:
     """It should be clear tip length when a tip is dropped."""
     subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
@@ -347,17 +332,9 @@ def test_drop_tip(
             serial_number="pipette-serial",
             config=LoadedStaticPipetteData(
                 channels=8,
-                max_volume=15,
-                min_volume=3,
                 model="gen a",
                 display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
+                liquid_properties=pipette_liquid_properties_fixture,
                 nozzle_offset_z=1.23,
                 home_position=4.56,
             ),

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -36,7 +36,8 @@ from opentrons.protocol_runner.legacy_wrappers import (
 )
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
+from opentrons_shared_data.pipette import pipette_load_name_conversions
 from opentrons.types import DeckSlotName, Mount, MountType
 
 
@@ -292,7 +293,13 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
 
 def test_map_instrument_load(decoy: Decoy) -> None:
     """It should correctly map an instrument load."""
-    pipette_dict = cast(PipetteDict, {"pipette_id": "fizzbuzz"})
+    model_version = pipette_load_name_conversions.convert_pipette_model(
+        PipetteModel("p1000_single_v2.0")
+    )
+
+    pipette_dict = cast(
+        PipetteDict, {"pipette_id": "fizzbuzz", "model_version": model_version}
+    )
     input = LegacyInstrumentLoadInfo(
         instrument_load_name="p1000_single_gen2",
         mount=Mount.LEFT,
@@ -301,7 +308,7 @@ def test_map_instrument_load(decoy: Decoy) -> None:
     pipette_config = cast(LoadedStaticPipetteData, {"config": True})
 
     decoy.when(
-        pipette_data_provider.get_pipette_static_config(pipette_dict)
+        pipette_data_provider.get_pipette_static_config(pipette_dict["model_version"])
     ).then_return(pipette_config)
 
     result = LegacyCommandMapper().map_equipment_load(input)

--- a/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
+++ b/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
@@ -158,7 +158,6 @@ def build_nozzle_map(
 ) -> Dict[str, List[float]]:
     Y_OFFSET = 9
     X_OFFSET = -9
-    breakpoint()
     if channels == PipetteChannelType.SINGLE_CHANNEL:
         return {"A1": nozzle_offset}
     elif channels == PipetteChannelType.EIGHT_CHANNEL:


### PR DESCRIPTION
# Overview

This should encapsulate some of the work required to add an additional command to update the liquid class in the protocol engine. I did not edit the user facing API yet because I thought that would be better suited in a follow-up PR, though I expect it to be a much faster follow-up than this PR.

# To Do

- [ ] Fix failing tests (which might be due to bug in code I wrote)
- [ ] Rebase on latest 7.0.0
- [ ] Ensure that the command for updating liquid class is in all the correct places without being utilized by `core` yet

# Test Plan
Make sure you can still successfully simulate and run a protocol

# Changelog

- Add the ability to change the liquid class type in `prepare_for_aspirate`
- Add a `model_version` in the pipette dict so that the protocol engine can use that value to look up static configs
- Modified the static configs to pass in the liquid class and look up the rest of the data in the `state/pipettes.py` file

# Review requests

Check that the code makes sense and such.

# Risk assessment

Medium-ish. Theoretically there should be no information change (aside from updating the run-time static config).
