### PR TITLE
fix(app): do not check estop status if robot is not a Flex

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -143,7 +143,7 @@ export function ProtocolRunHeader({
     runRecord?.data.errors?.[0] != null
       ? getHighestPriorityError(runRecord?.data?.errors)
       : undefined
-  const { data: estopStatus, error: estopError } = useEstopQuery({
+  const { data: estopStatus } = useEstopQuery({
     refetchInterval: ESTOP_POLL_MS,
   })
   const [
@@ -153,7 +153,7 @@ export function ProtocolRunHeader({
   const isOT3 = useIsOT3(robotName)
 
   React.useEffect(() => {
-    if (estopStatus?.data.status !== DISENGAGED && estopError == null) {
+    if (estopStatus?.data.status !== DISENGAGED) {
       setShowEmergencyStopRunBanner(true)
     }
   }, [estopStatus?.data.status])
@@ -291,7 +291,6 @@ export function ProtocolRunHeader({
           />
         ) : null}
         {estopStatus?.data.status !== DISENGAGED &&
-        estopError == null &&
         isOT3 &&
         showEmergencyStopRunBanner ? (
           <EmergencyStopRunBanner

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -16,11 +16,7 @@ import {
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   RunStatus,
 } from '@opentrons/api-client'
-import {
-  useRunQuery,
-  useModulesQuery,
-  useEstopQuery,
-} from '@opentrons/react-api-client'
+import { useRunQuery, useModulesQuery } from '@opentrons/react-api-client'
 import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
 import {
   Box,
@@ -83,14 +79,12 @@ import {
   useIsRobotViewable,
   useTrackProtocolRunEvent,
   useRobotAnalyticsData,
-  useIsOT3,
 } from '../hooks'
 import { formatTimestamp } from '../utils'
 import { RunTimer } from './RunTimer'
 import { EMPTY_TIMESTAMP } from '../constants'
 import { getHighestPriorityError } from '../../OnDeviceDisplay/RunningProtocol'
 import { RunFailedModal } from './RunFailedModal'
-import { DISENGAGED } from '../../EmergencyStop'
 
 import type { Run, RunError } from '@opentrons/api-client'
 import type { State } from '../../../redux/types'
@@ -98,7 +92,6 @@ import type { HeaterShakerModule } from '../../../redux/modules/types'
 import { RunProgressMeter } from '../../RunProgressMeter'
 
 const EQUIPMENT_POLL_MS = 5000
-const ESTOP_POLL_MS = 5000
 const CANCELLABLE_STATUSES = [
   RUN_STATUS_RUNNING,
   RUN_STATUS_PAUSED,
@@ -142,21 +135,7 @@ export function ProtocolRunHeader({
   const highestPriorityError =
     runRecord?.data.errors?.[0] != null
       ? getHighestPriorityError(runRecord?.data?.errors)
-      : undefined
-  const { data: estopStatus } = useEstopQuery({
-    refetchInterval: ESTOP_POLL_MS,
-  })
-  const [
-    showEmergencyStopRunBanner,
-    setShowEmergencyStopRunBanner,
-  ] = React.useState<boolean>(false)
-  const isOT3 = useIsOT3(robotName)
-
-  React.useEffect(() => {
-    if (estopStatus?.data.status !== DISENGAGED) {
-      setShowEmergencyStopRunBanner(true)
-    }
-  }, [estopStatus?.data.status])
+      : null
 
   React.useEffect(() => {
     if (protocolData != null && !isRobotViewable) {
@@ -288,13 +267,6 @@ export function ProtocolRunHeader({
               setShowRunFailedModal,
               highestPriorityError,
             }}
-          />
-        ) : null}
-        {estopStatus?.data.status !== DISENGAGED &&
-        isOT3 &&
-        showEmergencyStopRunBanner ? (
-          <EmergencyStopRunBanner
-            setShowEmergencyStopRunBanner={setShowEmergencyStopRunBanner}
           />
         ) : null}
         <Box display="grid" gridTemplateColumns="4fr 3fr 3fr 4fr">
@@ -644,7 +616,7 @@ interface TerminalRunProps {
   handleClearClick: () => void
   isClosingCurrentRun: boolean
   setShowRunFailedModal: (showRunFailedModal: boolean) => void
-  highestPriorityError?: RunError
+  highestPriorityError?: RunError | null
 }
 function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
   const {
@@ -697,24 +669,4 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
     )
   }
   return null
-}
-
-interface EmergencyStopRunPropsBanner {
-  setShowEmergencyStopRunBanner: (showEmergencyStopRunBanner: boolean) => void
-}
-
-function EmergencyStopRunBanner({
-  setShowEmergencyStopRunBanner,
-}: EmergencyStopRunPropsBanner): JSX.Element {
-  const { t } = useTranslation('run_details')
-  return (
-    <Banner
-      type="error"
-      onCloseClick={() => setShowEmergencyStopRunBanner(false)}
-    >
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
-        {t('run_failed')}
-      </Flex>
-    </Banner>
-  )
 }

--- a/app/src/organisms/Devices/ProtocolRun/RunFailedModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunFailedModal.tsx
@@ -40,7 +40,7 @@ interface RunFailedModalProps {
   robotName: string
   runId: string
   setShowRunFailedModal: (showRunFailedModal: boolean) => void
-  highestPriorityError?: RunError
+  highestPriorityError?: RunError | null
 }
 
 export function RunFailedModal({

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -75,13 +75,7 @@ import { formatTimestamp } from '../../utils'
 import { ProtocolRunHeader } from '../ProtocolRunHeader'
 import { HeaterShakerIsRunningModal } from '../../HeaterShakerIsRunningModal'
 import { RunFailedModal } from '../RunFailedModal'
-import {
-  DISENGAGED,
-  ENGAGED,
-  LOGICALLY_ENGAGED,
-  NOT_PRESENT,
-  PHYSICALLY_ENGAGED,
-} from '../../../EmergencyStop'
+import { DISENGAGED, NOT_PRESENT } from '../../../EmergencyStop'
 
 import type { UseQueryResult } from 'react-query'
 import type { Run } from '@opentrons/api-client'

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -843,31 +843,4 @@ describe('ProtocolRunHeader', () => {
     getByText('Run completed.')
     getByLabelText('ot-spinner')
   })
-
-  it('renders banner when estop pressed - physicallyEngaged', () => {
-    mockEstopStatus.data.status = PHYSICALLY_ENGAGED
-    mockEstopStatus.data.leftEstopPhysicalStatus = ENGAGED
-
-    mockUseEstopQuery({ data: mockEstopStatus } as any)
-    const [{ getByText }] = render()
-    getByText('Run failed.')
-  })
-
-  it('renders banner when estop pressed - logicallyEngaged', () => {
-    mockEstopStatus.data.status = LOGICALLY_ENGAGED
-    mockEstopStatus.data.leftEstopPhysicalStatus = ENGAGED
-
-    mockUseEstopQuery({ data: mockEstopStatus } as any)
-    const [{ getByText }] = render()
-    getByText('Run failed.')
-  })
-
-  it('renders banner when estop pressed - notPresent', () => {
-    mockEstopStatus.data.status = NOT_PRESENT
-    mockEstopStatus.data.leftEstopPhysicalStatus = NOT_PRESENT
-
-    mockUseEstopQuery({ data: mockEstopStatus } as any)
-    const [{ getByText }] = render()
-    getByText('Run failed.')
-  })
 })

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/ViewUpdateModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/ViewUpdateModal.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { mountWithStore } from '@opentrons/components'
+import { useIsRobotBusy } from '../../../hooks'
 import * as RobotUpdate from '../../../../../redux/robot-update'
 
 import { DownloadUpdateModal } from '../DownloadUpdateModal'
@@ -11,6 +12,7 @@ import { ViewUpdateModal } from '../ViewUpdateModal'
 import type { State } from '../../../../../redux/types'
 
 jest.mock('../../../../../redux/robot-update')
+jest.mock('../../../hooks')
 
 const getRobotUpdateInfo = RobotUpdate.getRobotUpdateInfo as jest.MockedFunction<
   typeof RobotUpdate.getRobotUpdateInfo
@@ -20,6 +22,10 @@ const getRobotUpdateDownloadProgress = RobotUpdate.getRobotUpdateDownloadProgres
 >
 const getRobotUpdateDownloadError = RobotUpdate.getRobotUpdateDownloadError as jest.MockedFunction<
   typeof RobotUpdate.getRobotUpdateDownloadError
+>
+
+const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
+  typeof useIsRobotBusy
 >
 
 const MOCK_STATE: State = { mockState: true } as any
@@ -55,6 +61,7 @@ describe('ViewUpdateModal', () => {
     getRobotUpdateInfo.mockReturnValue(null)
     getRobotUpdateDownloadProgress.mockReturnValue(50)
     getRobotUpdateDownloadError.mockReturnValue(null)
+    mockUseIsRobotBusy.mockReturnValue(false)
   })
 
   afterEach(() => {

--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -8,7 +8,6 @@ import {
   DISENGAGED,
   NOT_PRESENT,
   PHYSICALLY_ENGAGED,
-  ENGAGED,
 } from '../../../EmergencyStop'
 
 import { useIsRobotBusy } from '../useIsRobotBusy'

--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -12,11 +12,13 @@ import {
 } from '../../../EmergencyStop'
 
 import { useIsRobotBusy } from '../useIsRobotBusy'
+import { useIsOT3 } from '../useIsOT3'
 
 import type { Sessions, Runs } from '@opentrons/api-client'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../ProtocolUpload/hooks')
+jest.mock('../useIsOT3')
 
 const mockEstopStatus = {
   data: {
@@ -35,6 +37,7 @@ const mockUseAllRunsQuery = useAllRunsQuery as jest.MockedFunction<
 const mockUseEstopQuery = useEstopQuery as jest.MockedFunction<
   typeof useEstopQuery
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 describe('useIsRobotBusy', () => {
   beforeEach(() => {
@@ -49,6 +52,7 @@ describe('useIsRobotBusy', () => {
       },
     } as UseQueryResult<Runs, Error>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
+    mockUseIsOT3.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -113,7 +117,8 @@ describe('useIsRobotBusy', () => {
     expect(result).toBe(false)
   })
 
-  it('returns true when Estop status is not disengaged', () => {
+  it('returns true when robot is a Flex and Estop status is engaged', () => {
+    mockUseIsOT3.mockReturnValue(true)
     mockUseAllRunsQuery.mockReturnValue({
       data: {
         links: {
@@ -134,9 +139,41 @@ describe('useIsRobotBusy', () => {
       links: {},
     } as unknown) as UseQueryResult<Sessions, Error>)
     const mockEngagedStatus = {
-      ...mockEstopStatus,
-      status: PHYSICALLY_ENGAGED,
-      leftEstopPhysicalStatus: ENGAGED,
+      data: {
+        ...mockEstopStatus.data,
+        status: PHYSICALLY_ENGAGED,
+      },
+    }
+    mockUseEstopQuery.mockReturnValue({ data: mockEngagedStatus } as any)
+    const result = useIsRobotBusy()
+    expect(result).toBe(true)
+  })
+  it('returns false when robot is NOT a Flex and Estop status is engaged', () => {
+    mockUseIsOT3.mockReturnValue(false)
+    mockUseAllRunsQuery.mockReturnValue({
+      data: {
+        links: {
+          current: null,
+        },
+      },
+    } as any)
+    mockUseAllSessionsQuery.mockReturnValue(({
+      data: [
+        {
+          id: 'test',
+          createdAt: '2019-08-24T14:15:22Z',
+          details: {},
+          sessionType: 'calibrationCheck',
+          createParams: {},
+        },
+      ],
+      links: {},
+    } as unknown) as UseQueryResult<Sessions, Error>)
+    const mockEngagedStatus = {
+      data: {
+        ...mockEstopStatus.data,
+        status: PHYSICALLY_ENGAGED,
+      },
     }
     mockUseEstopQuery.mockReturnValue({ data: mockEngagedStatus } as any)
     const result = useIsRobotBusy()

--- a/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
+++ b/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
@@ -2,8 +2,10 @@ import {
   useAllSessionsQuery,
   useAllRunsQuery,
   useEstopQuery,
+  useHost,
 } from '@opentrons/react-api-client'
 import { DISENGAGED } from '../../EmergencyStop'
+import { useIsOT3 } from './useIsOT3'
 
 const ROBOT_STATUS_POLL_MS = 30000
 
@@ -18,12 +20,18 @@ export function useIsRobotBusy(
   const robotHasCurrentRun =
     useAllRunsQuery({}, queryOptions)?.data?.links?.current != null
   const allSessionsQueryResponse = useAllSessionsQuery(queryOptions)
-  const { data: estopStatus, error: estopError } = useEstopQuery(queryOptions)
+  const host = useHost()
+  const robotName = host?.robotName
+  const isOT3 = useIsOT3(robotName ?? '')
+  const { data: estopStatus, error: estopError } = useEstopQuery({
+    ...queryOptions,
+    enabled: isOT3,
+  })
 
   return (
     robotHasCurrentRun ||
     (allSessionsQueryResponse?.data?.data != null &&
       allSessionsQueryResponse?.data?.data?.length !== 0) ||
-    (estopStatus?.data.status !== DISENGAGED && estopError == null)
+    (isOT3 && estopStatus?.data.status !== DISENGAGED && estopError == null)
   )
 }

--- a/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -23,9 +23,11 @@ interface DeviceDetailsComponentProps {
 export function DeviceDetailsComponent({
   robotName,
 }: DeviceDetailsComponentProps): JSX.Element {
-  const { data: estopStatus, error: estopError } = useEstopQuery()
-  const { isEmergencyStopModalDismissed } = useEstopContext()
   const isOT3 = useIsOT3(robotName)
+  const { data: estopStatus, error: estopError } = useEstopQuery({
+    enabled: isOT3,
+  })
+  const { isEmergencyStopModalDismissed } = useEstopContext()
 
   return (
     <Box
@@ -35,9 +37,9 @@ export function DeviceDetailsComponent({
       paddingTop={SPACING.spacing16}
       paddingBottom={SPACING.spacing48}
     >
-      {estopStatus?.data.status !== DISENGAGED &&
+      {isOT3 &&
+      estopStatus?.data.status !== DISENGAGED &&
       estopError == null &&
-      isOT3 &&
       isEmergencyStopModalDismissed ? (
         <Flex marginBottom={SPACING.spacing16}>
           <EstopBanner status={estopStatus?.data.status} />


### PR DESCRIPTION
# Overview
This PR updates the `useIsRobotBusy` hook to NOT account for the status of the e-stop endpoint if the robot is NOT a Flex. This fixes several bugs where app controls were disabled.

closes RQA-1406

# Changelog

- Do not check estop status if robot is not a Flex


# Risk assessment

Low
