### PR TITLE
fix(app): Module cal banner flex only

### DIFF
--- a/app/src/molecules/UpdateBanner/__tests__/UpdateBanner.test.tsx
+++ b/app/src/molecules/UpdateBanner/__tests__/UpdateBanner.test.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react'
+import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import { UpdateBanner } from '..'
+import { useIsOT3 } from '../../../organisms/Devices/hooks'
+
+jest.mock('../../../organisms/Devices/hooks')
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const render = (props: React.ComponentProps<typeof UpdateBanner>) => {
   return renderWithProviders(<UpdateBanner {...props} />, {
     i18nInstance: i18n,
+    initialState: { robotsByName: 'test' },
   })[0]
 }
 
@@ -15,11 +21,13 @@ describe('Module Update Banner', () => {
 
   beforeEach(() => {
     props = {
+      robotName: 'testRobot',
       updateType: 'calibration',
       setShowBanner: jest.fn(),
       handleUpdateClick: jest.fn(),
       serialNumber: 'test_number',
     }
+    when(mockUseIsOT3).calledWith(props.robotName).mockReturnValue(true)
   })
   it('enables the updateType and serialNumber to be used as the test ID', () => {
     const { getByTestId } = render(props)
@@ -93,5 +101,10 @@ describe('Module Update Banner', () => {
     }
     const { queryByText } = render(props)
     expect(queryByText('Update now')).toBeInTheDocument()
+  })
+  it('should not render a calibrate update link if the robot is an OT-2', () => {
+    when(mockUseIsOT3).calledWith(props.robotName).mockReturnValue(false)
+    const { queryByText } = render(props)
+    expect(queryByText('Calibrate now')).not.toBeInTheDocument()
   })
 })

--- a/app/src/molecules/UpdateBanner/index.tsx
+++ b/app/src/molecules/UpdateBanner/index.tsx
@@ -11,8 +11,10 @@ import {
 } from '@opentrons/components'
 
 import { Banner } from '../../atoms/Banner'
+import { useIsOT3 } from '../../organisms/Devices/hooks'
 
 interface UpdateBannerProps {
+  robotName: string
   updateType: 'calibration' | 'firmware' | 'firmware_important'
   setShowBanner: (arg0: boolean) => void
   handleUpdateClick: () => void
@@ -22,13 +24,14 @@ interface UpdateBannerProps {
 }
 
 export const UpdateBanner = ({
+  robotName,
   updateType,
   serialNumber,
   setShowBanner,
   handleUpdateClick,
   attachPipetteRequired,
   updatePipetteFWRequired,
-}: UpdateBannerProps): JSX.Element => {
+}: UpdateBannerProps): JSX.Element | null => {
   const { t } = useTranslation('device_details')
 
   let bannerType: 'error' | 'warning'
@@ -54,6 +57,9 @@ export const UpdateBanner = ({
     bannerMessage = t('firmware_update_available')
     hyperlinkText = t('update_now')
   }
+
+  const isOT3 = useIsOT3(robotName)
+  if (!isOT3 && updateType === 'calibration') return null
 
   return (
     <Flex

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -217,6 +217,7 @@ export function InstrumentsAndModules({
                   description={t('instrument_attached')}
                   banner={
                     <UpdateBanner
+                      robotName={robotName}
                       serialNumber={
                         attachedLeftPipette != null
                           ? attachedLeftPipette.serialNumber
@@ -243,6 +244,7 @@ export function InstrumentsAndModules({
                   description={t('instrument_attached')}
                   banner={
                     <UpdateBanner
+                      robotName={robotName}
                       serialNumber={
                         attachedGripper != null
                           ? attachedGripper.serialNumber
@@ -298,6 +300,7 @@ export function InstrumentsAndModules({
                   description={t('instrument_attached')}
                   banner={
                     <UpdateBanner
+                      robotName={robotName}
                       serialNumber={
                         attachedRightPipette != null
                           ? attachedRightPipette.serialNumber

--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import * as RobotApi from '../../../redux/robot-api'
 import { useToaster } from '../../ToasterOven'
+import { useIsOT3 } from '../../Devices/hooks'
 import { MagneticModuleData } from '../MagneticModuleData'
 import { TemperatureModuleData } from '../TemperatureModuleData'
 import { ThermocyclerModuleData } from '../ThermocyclerModuleData'
@@ -52,6 +53,7 @@ jest.mock('react-router-dom', () => {
     useHistory: () => ({ push: jest.fn() } as any),
   }
 })
+jest.mock('../../../organisms/Devices/hooks')
 
 const mockMagneticModuleData = MagneticModuleData as jest.MockedFunction<
   typeof MagneticModuleData
@@ -203,6 +205,7 @@ const mockHotThermo = {
     portGroup: 'unknown',
   },
 } as ThermocyclerModule
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const mockMakeSnackbar = jest.fn()
 const mockMakeToast = jest.fn()
@@ -250,6 +253,7 @@ describe('ModuleCard', () => {
     when(mockUseCurrentRunStatus)
       .calledWith(expect.any(Object))
       .mockReturnValue(RUN_STATUS_IDLE)
+    when(mockUseIsOT3).calledWith(props.robotName).mockReturnValue(true)
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -296,6 +296,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
             requireModuleCalibration &&
             !isPending ? (
               <UpdateBanner
+                robotName={robotName}
                 updateType="calibration"
                 serialNumber={module.serialNumber}
                 setShowBanner={() => null}
@@ -310,6 +311,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
             showFWBanner &&
             !isPending ? (
               <UpdateBanner
+                robotName={robotName}
                 updateType="firmware"
                 serialNumber={module.serialNumber}
                 setShowBanner={setshowFWBanner}


### PR DESCRIPTION
Closes RAUT-657

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an issue where OT-2 robots would render the "require module calibration" banners on the DeviceDetails page on the desktop app. 

### OT-2
![ot2](https://github.com/Opentrons/opentrons/assets/64858653/6bd49a0d-47d5-4b3f-b5fe-2096ffba92bd)

### Flex
![ot3](https://github.com/Opentrons/opentrons/assets/64858653/902dee28-2054-4270-a895-b74c3fa1f707)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Verified OT-2 robots do not render module calibration banners.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added conditional logic within the UpdateBanner component to check if the device is an OT-2/Flex. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
