### PR TITLE
feat(shared-data): add plunger homing configurations

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -13,6 +13,7 @@ from opentrons_shared_data.pipette.pipette_definition import (
     MotorConfigurations,
     SupportedTipsDefinition,
     TipHandlingConfigurations,
+    PlungerHomingConfigurations,
     PipetteNameType,
     PipetteModelVersionType,
     PipetteLiquidPropertiesDefinition,
@@ -66,6 +67,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._config_as_dict = config.dict()
         self._plunger_motor_current = config.plunger_motor_configurations
         self._pick_up_configurations = config.pick_up_tip_configurations
+        self._plunger_homing_configurations = config.plunger_homing_configurations
         self._drop_configurations = config.drop_tip_configurations
         self._pipette_offset = pipette_offset_cal
         self._pipette_type = self._config.pipette_type
@@ -184,6 +186,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self, pick_up_configs: TipHandlingConfigurations
     ) -> None:
         self._pick_up_configurations = pick_up_configs
+
+    @property
+    def plunger_homing_configurations(self) -> PlungerHomingConfigurations:
+        return self._plunger_homing_configurations
 
     @property
     def drop_configurations(self) -> TipHandlingConfigurations:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1528,6 +1528,14 @@ async def test_home_axis(
     stepper_ok: bool,
     encoder_ok: bool,
 ) -> None:
+    if axis in Axis.pipette_axes():
+        pipette_config = load_pipette_data.load_definition(
+            PipetteModelType("p1000"),
+            PipetteChannelType(1),
+            PipetteVersionType(3, 3),
+        )
+        instr_data = AttachedPipette(config=pipette_config, id="fakepip")
+        await ot3_hardware.cache_pipette(Axis.to_ot3_mount(axis), instr_data, None)
 
     backend = ot3_hardware.managed_obj._backend
     origin_pos = {ax: 100 for ax in Axis}

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -5.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_5.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake", "doubleDropTip"]
+  "quirks": ["dropTipShake", "doubleDropTip"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p10/1_6.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake", "doubleDropTip"]
+  "quirks": ["dropTipShake", "doubleDropTip"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/1_0.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -22,9 +28,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +47,9 @@
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_0.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -22,9 +28,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +47,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_3.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -22,9 +28,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +47,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_4.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -22,9 +28,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +47,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p1000/3_5.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -22,9 +28,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +47,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -31.6
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_multi"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p20/2_1.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -31.6
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_multi"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -2.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -3.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -3.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/1_5.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -3.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake", "doubleDropTip"]
+  "quirks": ["dropTipShake", "doubleDropTip"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -33.4
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_multi"],
   "backlashDistance": 0.0,
-  "quirks": ["needsUnstick"]
+  "quirks": ["needsUnstick"],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p300/2_1.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -33.4
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_multi"],
   "backlashDistance": 0.0,
-  "quirks": ["needsUnstick"]
+  "quirks": ["needsUnstick"],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -3.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -5.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/1_5.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": true,
     "availableConfigurations": [1, 2, 3, 4, 5, 6, 7, 8]
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["doubleDropTip", "dropTipShake"]
+  "quirks": ["doubleDropTip", "dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_0.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -28,9 +34,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -41,5 +53,9 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_3.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -28,9 +34,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -41,5 +53,9 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_4.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -28,9 +34,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -41,5 +53,9 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -28,9 +34,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -41,5 +53,9 @@
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/1_0.json
@@ -10,8 +10,15 @@
     "increment": 0.0,
     "distance": 19.0
   },
-  "dropTipConfigurations": { "current": 1.5, "speed": 5.5, "distance": 26.5 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 2.0 },
+  "dropTipConfigurations": {
+    "current": 1.5,
+    "speed": 5.5,
+    "distance": 26.5
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 2.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0,
@@ -22,9 +29,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +48,9 @@
   "shaftDiameter": 9.0,
   "shaftULperMM": 63.617,
   "backlashDistance": 0.3,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 2.0,
+    "speed": 5
+  }
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_0.json
@@ -10,8 +10,15 @@
     "increment": 0.0,
     "distance": 19.0
   },
-  "dropTipConfigurations": { "current": 1.5, "speed": 5.5, "distance": 26.5 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 2.0 },
+  "dropTipConfigurations": {
+    "current": 1.5,
+    "speed": 5.5,
+    "distance": 26.5
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 2.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0,
@@ -22,9 +29,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +48,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.3,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 2.0,
+    "speed": 5
+  }
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_3.json
@@ -10,8 +10,15 @@
     "increment": 0.0,
     "distance": 19.0
   },
-  "dropTipConfigurations": { "current": 1.5, "speed": 5.5, "distance": 26.5 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 2.0 },
+  "dropTipConfigurations": {
+    "current": 1.5,
+    "speed": 5.5,
+    "distance": 26.5
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 2.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0,
@@ -22,9 +29,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -35,5 +48,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.3,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 2.0,
+    "speed": 5
+  }
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
@@ -29,9 +29,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -42,5 +48,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.3,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 0.8,
+    "speed": 5
+  }
 }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
@@ -29,9 +29,15 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 2 },
-    "capacitive": { "count": 2 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 2
+    },
+    "capacitive": {
+      "count": 2
+    },
+    "environment": {
+      "count": 1
+    }
   },
   "partialTipConfigurations": {
     "partialTipSupported": true,
@@ -42,5 +48,9 @@
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.3,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 0.8,
+    "speed": 5
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -6.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -5.2
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p10/1_5.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -5.2
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -2.2
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 63.617,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake", "dropTipShake"]
+  "quirks": ["pickupTipShake", "dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 63.617,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake", "dropTipShake"]
+  "quirks": ["pickupTipShake", "dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 63.617,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake", "dropTipShake"]
+  "quirks": ["pickupTipShake", "dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/1_5.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.5 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.5
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 63.617,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake", "dropTipShake"]
+  "quirks": ["pickupTipShake", "dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.5,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -37.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 28.274,
   "backCompatNames": ["p1000_single"],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake"]
+  "quirks": ["pickupTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_1.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -37.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 28.274,
   "backCompatNames": ["p1000_single"],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake"]
+  "quirks": ["pickupTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/2_2.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -37.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 28.274,
   "backCompatNames": ["p1000_single"],
   "backlashDistance": 0.0,
-  "quirks": ["pickupTipShake"]
+  "quirks": ["pickupTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_0.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -22,15 +28,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_3.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -22,15 +28,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_4.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 15 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 15
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -22,15 +28,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p1000/3_5.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 15 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 15
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -22,15 +28,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 4.5,
   "shaftULperMM": 15.904,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -27.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_single"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_1.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -27.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_single"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p20/2_2.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -27.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 0.785,
   "backCompatNames": ["p10_single"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -5.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/1_5.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 19.635,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -37.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_single"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p300/2_1.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -37.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 9.621,
   "backCompatNames": ["p300_single"],
   "backlashDistance": 0.0,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_0.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -4.5
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_3.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -6.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_4.json
@@ -17,7 +17,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -26,7 +29,9 @@
       "drop": -5.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -36,5 +41,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/1_5.json
@@ -19,7 +19,10 @@
     "increment": 0.0,
     "distance": 0.0
   },
-  "plungerMotorConfigurations": { "idle": 0.05, "run": 0.3 },
+  "plungerMotorConfigurations": {
+    "idle": 0.05,
+    "run": 0.3
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 19.5,
@@ -28,7 +31,9 @@
       "drop": -5.0
     }
   },
-  "availableSensors": { "sensors": [] },
+  "availableSensors": {
+    "sensors": []
+  },
   "partialTipConfigurations": {
     "partialTipSupported": false,
     "availableConfigurations": null
@@ -38,5 +43,9 @@
   "shaftULperMM": 3.142,
   "backCompatNames": [],
   "backlashDistance": 0.0,
-  "quirks": ["dropTipShake"]
+  "quirks": ["dropTipShake"],
+  "plungerHomingConfigurations": {
+    "current": 0.3,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_0.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -28,15 +34,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_3.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 10 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 10
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.5,
@@ -28,15 +34,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_4.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 15 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 15
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -28,15 +34,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/pipette/definitions/2/general/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/single_channel/p50/3_5.json
@@ -10,8 +10,14 @@
     "increment": 0.0,
     "distance": 13.0
   },
-  "dropTipConfigurations": { "current": 1.0, "speed": 15 },
-  "plungerMotorConfigurations": { "idle": 0.3, "run": 1.0 },
+  "dropTipConfigurations": {
+    "current": 1.0,
+    "speed": 15
+  },
+  "plungerMotorConfigurations": {
+    "idle": 0.3,
+    "run": 1.0
+  },
   "plungerPositionsConfigurations": {
     "default": {
       "top": 0.0,
@@ -28,15 +34,27 @@
   },
   "availableSensors": {
     "sensors": ["pressure", "capacitive", "environment"],
-    "pressure": { "count": 1 },
-    "capacitive": { "count": 1 },
-    "environment": { "count": 1 }
+    "pressure": {
+      "count": 1
+    },
+    "capacitive": {
+      "count": 1
+    },
+    "environment": {
+      "count": 1
+    }
   },
-  "partialTipConfigurations": { "partialTipSupported": false },
+  "partialTipConfigurations": {
+    "partialTipSupported": false
+  },
   "backCompatNames": [],
   "channels": 1,
   "shaftDiameter": 1.0,
   "shaftULperMM": 0.785,
   "backlashDistance": 0.1,
-  "quirks": []
+  "quirks": [],
+  "plungerHomingConfigurations": {
+    "current": 1.0,
+    "speed": 30
+  }
 }

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -139,7 +139,7 @@ class PlungerPositions(BaseModel):
     )
 
 
-class TipHandlingConfigurations(BaseModel):
+class PlungerHomingConfigurations(BaseModel):
     current: float = Field(
         ...,
         description="Either the z motor current needed for picking up tip or the plunger motor current for dropping tip off the nozzle.",
@@ -148,6 +148,9 @@ class TipHandlingConfigurations(BaseModel):
         ...,
         description="The speed to move the z or plunger axis for tip pickup or drop off.",
     )
+
+
+class TipHandlingConfigurations(PlungerHomingConfigurations):
     presses: int = Field(
         default=0.0, description="The number of tries required to force pick up a tip."
     )
@@ -210,6 +213,9 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
     )
     drop_tip_configurations: TipHandlingConfigurations = Field(
         ..., alias="dropTipConfigurations"
+    )
+    plunger_homing_configurations: PlungerHomingConfigurations = Field(
+        ..., alias="plungerHomingConfigurations"
     )
     plunger_motor_configurations: MotorConfigurations = Field(
         ..., alias="plungerMotorConfigurations"

--- a/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
+++ b/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
@@ -158,6 +158,7 @@ def build_nozzle_map(
 ) -> Dict[str, List[float]]:
     Y_OFFSET = 9
     X_OFFSET = -9
+    breakpoint()
     if channels == PipetteChannelType.SINGLE_CHANNEL:
         return {"A1": nozzle_offset}
     elif channels == PipetteChannelType.EIGHT_CHANNEL:

--- a/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
+++ b/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
@@ -158,7 +158,6 @@ def build_nozzle_map(
 ) -> Dict[str, List[float]]:
     Y_OFFSET = 9
     X_OFFSET = -9
-    breakpoint()
     if channels == PipetteChannelType.SINGLE_CHANNEL:
         return {"A1": nozzle_offset}
     elif channels == PipetteChannelType.EIGHT_CHANNEL:


### PR DESCRIPTION
## Overview
We want to be able to specify a higher speed or current for pipette homing in order to overcome any potential static friction.

## Changelog

- add new `plungerHomingConfig` to shared-data
- apply the speed and current from that config to plunger homing in the hardware controller
  - break pipette plunger homing out of `OT3API._home_axis()` a little bit to apply the current and speed

## Testing
make sure homing works the same as it has on all axes