### PR TITLE
fix(robot-server): Pin pickle protocol version to v4

### DIFF
--- a/robot-server/robot_server/persistence/_tables.py
+++ b/robot-server/robot_server/persistence/_tables.py
@@ -2,6 +2,7 @@
 import sqlalchemy
 
 from . import legacy_pickle
+from .pickle_protocol_version import PICKLE_PROTOCOL_VERSION
 from ._utc_datetime import UTCDateTime
 
 _metadata = sqlalchemy.MetaData()
@@ -94,13 +95,13 @@ run_table = sqlalchemy.Table(
     # column added in schema v1
     sqlalchemy.Column(
         "state_summary",
-        sqlalchemy.PickleType(pickler=legacy_pickle),
+        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
         nullable=True,
     ),
     # column added in schema v1
     sqlalchemy.Column(
         "commands",
-        sqlalchemy.PickleType(pickler=legacy_pickle),
+        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
         nullable=True,
     ),
     # column added in schema v1

--- a/robot-server/robot_server/persistence/pickle_protocol_version.py
+++ b/robot-server/robot_server/persistence/pickle_protocol_version.py
@@ -1,0 +1,23 @@
+# noqa: D100
+
+
+from typing_extensions import Final
+
+
+PICKLE_PROTOCOL_VERSION: Final = 4
+"""The version of Python's pickle protocol that we should use for serializing new objects.
+
+We set this to v4 because it's the least common denominator between all of our environments.
+At the time of writing (2023-09-05):
+
+* Flex: Python 3.8, pickle protocol v5 by default
+* OT-2: Python 3.7, pickle protocol v4 by default
+* Typical local dev environments: Python 3.7, pickle protocol v4 by default
+
+For troubleshooting, we want our dev environments be able to read pickles created by any robot.
+"""
+
+
+# TODO(mm, 2023-09-05): Delete this when robot-server stops pickling new objects
+# (https://opentrons.atlassian.net/browse/RSS-98), or when we upgrade the Python version
+# in our dev environments.

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -11,6 +11,7 @@ import anyio
 
 from robot_server.persistence import analysis_table, sqlite_rowid
 from robot_server.persistence import legacy_pickle
+from robot_server.persistence.pickle_protocol_version import PICKLE_PROTOCOL_VERSION
 
 from .analysis_models import CompletedAnalysis
 from .analysis_memcache import MemoryCache
@@ -289,7 +290,9 @@ class CompletedAnalysisStore:
 def _serialize_completed_analysis_to_pickle(
     completed_analysis: CompletedAnalysis,
 ) -> bytes:
-    return legacy_pickle.dumps(completed_analysis.dict())
+    return legacy_pickle.dumps(
+        completed_analysis.dict(), protocol=PICKLE_PROTOCOL_VERSION
+    )
 
 
 def _serialize_completed_analysis_to_json(completed_analysis: CompletedAnalysis) -> str:


### PR DESCRIPTION
# Overview

This is a change to make it easier for us to debug and do autopsies on robot-server databases. This helps when debugging issues like RQA-1473.

There are [several versions](https://docs.python.org/3/library/pickle.html#data-stream-format) of the `pickle` data format. Currently, the version that robot-server uses changes depending on its environment:

| Environment | Python version | `pickle` protocol version |
|-------------|----------------|-----------------------------------|
| Local dev   | 3.7            | 4                                 |
| OT-2        | 3.7            | 4                                 |
| Flex        | 3.8            | 5                                 |

This is annoying because it means if you save `/var/lib/opentrons-robot-server` from a Flex, you can't just point a local dev server to it with `make -C robot-server dev OT_ROBOT_SERVER_PERSISTENCE_DIRECTORY=...`. Our local dev servers run Python 3.7, so they'll raise errors when they try to read the pickle v5 records.

To fix that, this PR normalizes all robot-server environments to use pickle protocol v4, the least common denominator.

# Test Plan

* [x] Make sure existing run records on Flexes are still returned without error. i.e. we should still be able to *read* the pickle v5 records even though we're not adding new ones.

# Review requests

None in particular.

# Risk assessment

There's some risk that this will harm performance because with the v5 format, ["one copy is avoided on the serialization path".](https://peps.python.org/pep-0574/#improved-in-band-performance)


