### PR TITLE
chore: Fix outdated team names in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,18 +9,17 @@
 /webpack-config @Opentrons/js
 
 # subprojects - those with clear team ownership should have appropriate notifications
-/protocol-designer @Opentrons/spddrs
-/labware-designer @Opentrons/spddrs
-/labware-library @Opentrons/spddrs
-/protocol-library-kludge @Opentrons/spddrs
-/update-server @Opentrons/cpx
-/api/src/opentrons @Opentrons/hmg
-/discovery-client @Opentrons/cpx
-/shared-data/pipette @Opentrons/hmg
-/shared-data/protocol @Opentrons/spddrs
-/shared-data/module @Opentrons/hmg
-/shared-data/deck @Opentrons/hmg
-/shared-data/labware @Opentrons/hmg
+/protocol-designer @Opentrons/app-and-uis
+/labware-designer @Opentrons/app-and-uis
+/labware-library @Opentrons/app-and-uis
+/protocol-library-kludge @Opentrons/app-and-uis
+/update-server @Opentrons/robot-svcs
+/discovery-client @Opentrons/robot-svcs @Opentrons/app-and-uis
+/shared-data/pipette @Opentrons/embedded-sw
+/shared-data/protocol @Opentrons/robot-svcs @Opentrons/app-and-uis
+/shared-data/module @Opentrons/embedded-sw
+/shared-data/deck @Opentrons/embedded-sw
+/shared-data/labware @Opentrons/embedded-sw
 
 # subprojects by language - some subprojects are shared by teams but united by a
 # language community (including makefiles and config) so mark them appropriately


### PR DESCRIPTION
# Overview

Fix some broken references in our GitHub CODEOWNERS file because of outdated team names.

# Changelog

* `hmg` -> `embedded-sw`
* `cpx` -> `robot-svcs`
* `spddrs` -> `app-and-uis`
* `discovery-client` is now jointly owned by `app-and-uis` and `robot-svcs`
* `shared-data/protocol` is now jointly owned by `app-and-uis` and `robot-svcs`
* Removed `api/src/opentrons` because I think its ownership is more mixed these days, and better decided by per-PR review requests.

# Review requests

Do we agree with these ownerships? Anything we want to remove or add?