### PR TITLE
fix(app): refactor instrument cards for bad instruments

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -42,6 +42,7 @@
   "firmware_update_available_now": "Firmware update available. <updateLink>Update now</updateLink>",
   "firmware_update_failed": "Failed to update module firmware",
   "firmware_update_installation_successful": "Installation successful",
+  "firmware_update_occurring": "Firmware update in progress...",
   "got_it": "Got it",
   "have_not_run": "No recent runs",
   "have_not_run_description": "After you run some protocols, they will appear here.",

--- a/app/src/assets/localization/en/firmware_update.json
+++ b/app/src/assets/localization/en/firmware_update.json
@@ -1,10 +1,17 @@
 {
   "download_logs": "Download the robot logs from the Opentrons App and send them to support@opentrons.com for assistance.",
   "firmware_out_of_date": "The firmware for <bold>{{mount}} {{instrument}}</bold> is out of date. You need to update it before running protocols that use this instrument.",
+  "gantry_x": "Gantry X",
+  "gantry_y": "Gantry Y",
+  "gripper": "Gripper",
+  "head": "Head",
+  "pipette_left": "Left Pipette",
+  "pipette_right": "Right Pipette",
   "ready_to_use": "Your <bold>{{instrument}}</bold> is ready to use!",
+  "rear_panel": "Rear Panel",
   "successful_update": "Successful update!",
   "update_failed": "Update failed",
   "update_firmware": "Update firmware",
   "update_needed": "Instrument firmware update needed",
-  "updating_firmware": "Updating firmware..."
+  "updating_firmware": "Updating {{subsystem}} firmware..."
 }

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -23,8 +23,6 @@ import {
 
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
-import { UpdateBanner } from '../../molecules/UpdateBanner'
-import { InstrumentCard } from '../../molecules/InstrumentCard'
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { ModuleCard } from '../ModuleCard'
 import { FirmwareUpdateModal } from '../FirmwareUpdateModal'
@@ -74,11 +72,7 @@ export function InstrumentsAndModules({
 
   const attachedGripper =
     (attachedInstruments?.data ?? []).find(
-      (i): i is GripperData => i.instrumentType === 'gripper' && i.ok
-    ) ?? null
-  const badGripper =
-    (attachedInstruments?.data ?? []).find(
-      (i): i is BadGripper => i.subsystem === 'gripper' && !i.ok
+      (i): i is GripperData | BadGripper => i.subsystem === 'gripper'
     ) ?? null
   const attachedLeftPipette =
     attachedInstruments?.data?.find(
@@ -193,68 +187,32 @@ export function InstrumentsAndModules({
               flexDirection={DIRECTION_COLUMN}
               gridGap={SPACING.spacing8}
             >
-              {badLeftPipette == null ? (
-                <PipetteCard
-                  pipetteId={attachedPipettes.left?.id}
-                  pipetteInfo={
-                    attachedPipettes.left?.model != null
-                      ? getPipetteModelSpecs(attachedPipettes.left?.model) ??
-                        null
-                      : null
-                  }
-                  isPipetteCalibrated={
-                    isOT3
-                      ? attachedLeftPipette?.data?.calibratedOffset != null
-                      : leftMountOffsetCalibration != null
-                  }
-                  mount={LEFT}
-                  robotName={robotName}
-                  is96ChannelAttached={is96ChannelAttached}
-                />
-              ) : (
-                <InstrumentCard
-                  label={t('mount', { side: 'left' })}
-                  description={t('instrument_attached')}
-                  banner={
-                    <UpdateBanner
-                      robotName={robotName}
-                      serialNumber={
-                        attachedLeftPipette != null
-                          ? attachedLeftPipette.serialNumber
-                          : 'no_left_pipette'
-                      }
-                      setShowBanner={() => null}
-                      updateType="firmware_important"
-                      handleUpdateClick={() =>
-                        setSubsystemToUpdate('pipette_left')
-                      }
-                    />
-                  }
-                />
-              )}
-              {isOT3 && badGripper == null && (
+              <PipetteCard
+                pipetteId={attachedPipettes.left?.id}
+                pipetteModelSpecs={
+                  attachedPipettes.left?.model != null
+                    ? getPipetteModelSpecs(attachedPipettes.left?.model) ?? null
+                    : null
+                }
+                isPipetteCalibrated={
+                  isOT3 && attachedLeftPipette?.ok
+                    ? attachedLeftPipette?.data?.calibratedOffset != null
+                    : leftMountOffsetCalibration != null
+                }
+                mount={LEFT}
+                robotName={robotName}
+                pipetteIs96Channel={is96ChannelAttached}
+                pipetteIsBad={badLeftPipette != null}
+                updatePipette={() => setSubsystemToUpdate('pipette_left')}
+              />
+              {isOT3 && (
                 <GripperCard
                   attachedGripper={attachedGripper}
-                  isCalibrated={attachedGripper?.data?.calibratedOffset != null}
-                />
-              )}
-              {isOT3 && badGripper != null && (
-                <InstrumentCard
-                  label={t('shared:extension_mount')}
-                  description={t('instrument_attached')}
-                  banner={
-                    <UpdateBanner
-                      robotName={robotName}
-                      serialNumber={
-                        attachedGripper != null
-                          ? attachedGripper.serialNumber
-                          : 'no_gripper'
-                      }
-                      setShowBanner={() => null}
-                      updateType="firmware"
-                      handleUpdateClick={() => setSubsystemToUpdate('gripper')}
-                    />
+                  isCalibrated={
+                    attachedGripper?.ok === true &&
+                    attachedGripper?.data?.calibratedOffset != null
                   }
+                  setSubsystemToUpdate={setSubsystemToUpdate}
                 />
               )}
               {leftColumnModules.map((module, index) => (
@@ -275,42 +233,25 @@ export function InstrumentsAndModules({
               flexDirection={DIRECTION_COLUMN}
               gridGap={SPACING.spacing8}
             >
-              {!Boolean(is96ChannelAttached) && badRightPipette == null && (
+              {!Boolean(is96ChannelAttached) && (
                 <PipetteCard
                   pipetteId={attachedPipettes.right?.id}
-                  pipetteInfo={
+                  pipetteModelSpecs={
                     attachedPipettes.right?.model != null
                       ? getPipetteModelSpecs(attachedPipettes.right?.model) ??
                         null
                       : null
                   }
                   isPipetteCalibrated={
-                    isOT3
+                    isOT3 && attachedRightPipette?.ok
                       ? attachedRightPipette?.data?.calibratedOffset != null
                       : rightMountOffsetCalibration != null
                   }
                   mount={RIGHT}
                   robotName={robotName}
-                  is96ChannelAttached={false}
-                />
-              )}
-              {badRightPipette != null && (
-                <InstrumentCard
-                  label={t('mount', { side: 'error' })}
-                  description={t('instrument_attached')}
-                  banner={
-                    <UpdateBanner
-                      robotName={robotName}
-                      serialNumber={
-                        attachedRightPipette != null
-                          ? attachedRightPipette.serialNumber
-                          : 'no_right_pipette'
-                      }
-                      setShowBanner={() => null}
-                      updateType="firmware_important"
-                      handleUpdateClick={() => setSubsystemToUpdate('gripper')}
-                    />
-                  }
+                  pipetteIs96Channel={false}
+                  pipetteIsBad={badRightPipette != null}
+                  updatePipette={() => setSubsystemToUpdate('pipette_right')}
                 />
               )}
               {rightColumnModules.map((module, index) => (

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -3,6 +3,7 @@ import { resetAllWhenMocks, when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { LEFT, RIGHT } from '@opentrons/shared-data'
+import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
 import { getHasCalibrationBlock } from '../../../../redux/config'
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
@@ -28,6 +29,7 @@ jest.mock('../../../CalibrateTipLength')
 jest.mock('../../hooks')
 jest.mock('../AboutPipetteSlideout')
 jest.mock('../../../../redux/robot-api')
+jest.mock('@opentrons/react-api-client')
 
 const mockPipetteOverflowMenu = PipetteOverflowMenu as jest.MockedFunction<
   typeof PipetteOverflowMenu
@@ -51,6 +53,9 @@ const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
   typeof useDispatchApiRequest
 >
 const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
+const mockUseCurrentSubsystemUpdateQuery = useCurrentSubsystemUpdateQuery as jest.MockedFunction<
+  typeof useCurrentSubsystemUpdateQuery
+>
 
 const render = (props: React.ComponentProps<typeof PipetteCard>) => {
   return renderWithProviders(<PipetteCard {...props} />, {
@@ -62,10 +67,21 @@ const mockRobotName = 'mockRobotName'
 describe('PipetteCard', () => {
   let startWizard: any
   let dispatchApiRequest: DispatchApiRequestType
+  let props: React.ComponentProps<typeof PipetteCard>
 
   beforeEach(() => {
     startWizard = jest.fn()
     dispatchApiRequest = jest.fn()
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
+      mount: LEFT,
+      robotName: mockRobotName,
+      pipetteId: 'id',
+      pipetteIs96Channel: false,
+      isPipetteCalibrated: false,
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
     when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(false)
     when(mockAboutPipettesSlideout).mockReturnValue(
       <div>mock about slideout</div>
@@ -86,6 +102,9 @@ describe('PipetteCard', () => {
       dispatchApiRequest,
       ['id'],
     ])
+    mockUseCurrentSubsystemUpdateQuery.mockReturnValue({
+      data: undefined,
+    } as any)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -93,26 +112,32 @@ describe('PipetteCard', () => {
   })
 
   it('renders information for a left pipette', () => {
-    const { getByText } = render({
-      pipetteInfo: mockLeftSpecs,
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
     getByText('left Mount')
     getByText('Left Pipette')
   })
   it('renders information for a 96 channel pipette with overflow menu button not disabled', () => {
-    const { getByText, getByRole } = render({
-      pipetteInfo: mockLeftSpecs,
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      is96ChannelAttached: true,
+      pipetteIs96Channel: true,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByText, getByRole } = render(props)
     getByText('Both Mounts')
     const overflowButton = getByRole('button', {
       name: /overflow/i,
@@ -122,69 +147,87 @@ describe('PipetteCard', () => {
     getByText('mock pipette overflow menu')
   })
   it('renders information for a right pipette', () => {
-    const { getByText } = render({
-      pipetteInfo: mockRightSpecs,
+    props = {
+      pipetteModelSpecs: mockRightSpecs,
       mount: RIGHT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
     getByText('right Mount')
     getByText('Right Pipette')
   })
   it('renders information for no pipette on right Mount', () => {
-    const { getByText } = render({
-      pipetteInfo: null,
+    props = {
+      pipetteModelSpecs: null,
       mount: RIGHT,
       robotName: mockRobotName,
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
     getByText('right Mount')
     getByText('Empty')
   })
   it('renders information for no pipette on left Mount', () => {
-    const { getByText } = render({
-      pipetteInfo: null,
+    props = {
+      pipetteModelSpecs: null,
       mount: LEFT,
       robotName: mockRobotName,
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
     getByText('left Mount')
     getByText('Empty')
   })
   it('does not render banner to calibrate for ot2 pipette if not calibrated', () => {
     when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(false)
-    const { queryByText } = render({
-      pipetteInfo: mockLeftSpecs,
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
       mount: LEFT,
       robotName: mockRobotName,
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { queryByText } = render(props)
     expect(queryByText('Calibrate now')).toBeNull()
   })
   it('renders banner to calibrate for ot3 pipette if not calibrated', () => {
     when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(true)
-    const { getByText } = render({
-      pipetteInfo: { ...mockLeftSpecs, name: 'p300_single_flex' },
+    props = {
+      pipetteModelSpecs: { ...mockLeftSpecs, name: 'p300_single_flex' },
       mount: LEFT,
       robotName: mockRobotName,
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
     getByText('Calibrate now')
   })
   it('renders kebab icon, opens and closes overflow menu on click', () => {
-    const { getByRole, getByText, queryByText } = render({
-      pipetteInfo: mockRightSpecs,
+    props = {
+      pipetteModelSpecs: mockRightSpecs,
       mount: RIGHT,
       robotName: mockRobotName,
-      is96ChannelAttached: false,
+      pipetteIs96Channel: false,
       isPipetteCalibrated: false,
-    })
+      pipetteIsBad: false,
+      updatePipette: jest.fn(),
+    }
+    const { getByRole, getByText, queryByText } = render(props)
 
     const overflowButton = getByRole('button', {
       name: /overflow/i,
@@ -195,5 +238,40 @@ describe('PipetteCard', () => {
     const overflowMenu = getByText('mock pipette overflow menu')
     overflowMenu.click()
     expect(queryByText('mock pipette overflow menu')).toBeNull()
+  })
+  it('renders firmware update needed state if pipette is bad', () => {
+    props = {
+      pipetteModelSpecs: mockRightSpecs,
+      mount: RIGHT,
+      robotName: mockRobotName,
+      pipetteIs96Channel: false,
+      isPipetteCalibrated: false,
+      pipetteIsBad: true,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
+    getByText('Right mount')
+    getByText('Instrument attached')
+    getByText('Firmware update available.')
+    getByText('Update now').click()
+    expect(props.updatePipette).toHaveBeenCalled()
+  })
+  it('renders firmware update in progress state if pipette is bad and update in progress', () => {
+    when(mockUseCurrentSubsystemUpdateQuery).mockReturnValue({
+      data: { data: { updateProgress: 50 } as any },
+    } as any)
+    props = {
+      pipetteModelSpecs: mockRightSpecs,
+      mount: RIGHT,
+      robotName: mockRobotName,
+      pipetteIs96Channel: false,
+      isPipetteCalibrated: false,
+      pipetteIsBad: true,
+      updatePipette: jest.fn(),
+    }
+    const { getByText } = render(props)
+    getByText('Right mount')
+    getByText('Instrument attached')
+    getByText('Firmware update in progress...')
   })
 })

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -297,7 +297,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
                     <StyledText
                       as="p"
                       css={BANNER_LINK_CSS}
-                      onClick={updatePipette()}
+                      onClick={updatePipette}
                     />
                   ),
                 }}

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -281,7 +281,10 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
           label={i18n.format(t('mount', { side: mount }), 'capitalize')}
           description={t('instrument_attached')}
           banner={
-            <Banner type="error" marginBottom={SPACING.spacing4}>
+            <Banner
+              type={subsystemUpdateData != null ? 'warning' : 'error'}
+              marginBottom={SPACING.spacing4}
+            >
               <Trans
                 t={t}
                 i18nKey={

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -199,7 +199,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
           >
             <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing8}>
               <Flex alignItems={ALIGN_START}>
-                {pipetteModelSpecs === null ? null : (
+                {pipetteModelSpecs !== null ? (
                   <InstrumentDiagram
                     pipetteSpecs={pipetteModelSpecs}
                     mount={mount}
@@ -208,7 +208,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
                     size="3.125rem"
                     transformOrigin={isOt3 ? '-50% -10%' : '20% -10%'}
                   />
-                )}
+                ) : null}
               </Flex>
               <Flex
                 flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -19,10 +19,13 @@ import {
   NINETY_SIX_CHANNEL,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
+import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
 import { LEFT } from '../../../redux/pipettes'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { StyledText } from '../../../atoms/text'
+import { Banner } from '../../../atoms/Banner'
 import { useMenuHandleClickOutside } from '../../../atoms/MenuList/hooks'
+import { InstrumentCard } from '../../../molecules/InstrumentCard'
 import { ChangePipette } from '../../ChangePipette'
 import { FLOWS } from '../../PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../../PipetteWizardFlows'
@@ -41,26 +44,35 @@ import type {
   PipetteWizardFlow,
   SelectablePipettes,
 } from '../../PipetteWizardFlows/types'
-import { Banner } from '../../../atoms/Banner'
 
 interface PipetteCardProps {
-  pipetteInfo: PipetteModelSpecs | null
+  pipetteModelSpecs: PipetteModelSpecs | null
   pipetteId?: AttachedPipette['id'] | null
   isPipetteCalibrated: boolean
   mount: Mount
   robotName: string
-  is96ChannelAttached: boolean
+  pipetteIs96Channel: boolean
+  pipetteIsBad: boolean
+  updatePipette: () => void
 }
+const BANNER_LINK_CSS = css`
+  text-decoration: underline;
+  cursor: pointer;
+  margin-left: ${SPACING.spacing8};
+`
+const SUBSYSTEM_UPDATE_POLL_MS = 3000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
-  const { t } = useTranslation(['device_details', 'protocol_setup'])
+  const { t, i18n } = useTranslation(['device_details', 'protocol_setup'])
   const {
-    pipetteInfo,
+    pipetteModelSpecs,
     isPipetteCalibrated,
     mount,
     robotName,
     pipetteId,
-    is96ChannelAttached,
+    pipetteIs96Channel,
+    pipetteIsBad,
+    updatePipette,
   } = props
   const {
     menuOverlay,
@@ -69,9 +81,9 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
   const isOt3 = useIsOT3(robotName)
-  const pipetteName = pipetteInfo?.name
+  const pipetteName = pipetteModelSpecs?.name
   const isOT3PipetteAttached = isOT3Pipette(pipetteName as PipetteName)
-  const pipetteDisplayName = pipetteInfo?.displayName
+  const pipetteDisplayName = pipetteModelSpecs?.displayName
   const pipetteOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
   })
@@ -83,6 +95,14 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   ] = React.useState<PipetteWizardFlow | null>(null)
   const [showAttachPipette, setShowAttachPipette] = React.useState(false)
   const [showAboutSlideout, setShowAboutSlideout] = React.useState(false)
+  const subsystem = mount === LEFT ? 'pipette_left' : 'pipette_right'
+  const { data: subsystemUpdateData } = useCurrentSubsystemUpdateQuery(
+    subsystem,
+    {
+      enabled: pipetteIsBad,
+      refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
+    }
+  )
 
   const [
     selectedPipette,
@@ -153,98 +173,136 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
           closeModal={() => setChangePipette(false)}
         />
       )}
-      {showSlideout && pipetteInfo != null && pipetteId != null && (
+      {showSlideout && pipetteModelSpecs != null && pipetteId != null && (
         <PipetteSettingsSlideout
           robotName={robotName}
-          pipetteName={pipetteInfo.displayName}
+          pipetteName={pipetteModelSpecs.displayName}
           onCloseClick={() => setShowSlideout(false)}
           isExpanded={true}
           pipetteId={pipetteId}
         />
       )}
-      {showAboutSlideout && pipetteInfo != null && pipetteId != null && (
+      {showAboutSlideout && pipetteModelSpecs != null && pipetteId != null && (
         <AboutPipetteSlideout
           pipetteId={pipetteId}
-          pipetteName={pipetteInfo.displayName}
+          pipetteName={pipetteModelSpecs.displayName}
           mount={mount}
           onCloseClick={() => setShowAboutSlideout(false)}
           isExpanded={true}
         />
       )}
-      <Box padding={`${SPACING.spacing16} ${SPACING.spacing8}`} width="100%">
-        <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing8}>
-          <Flex alignItems={ALIGN_START}>
-            {pipetteInfo === null ? null : (
-              <InstrumentDiagram
-                pipetteSpecs={pipetteInfo}
-                mount={mount}
-                //  pipette images for Flex are slightly smaller so need to be scaled accordingly
-                transform={isOt3 ? 'scale(0.4)' : 'scale(0.3)'}
-                size="3.125rem"
-                transformOrigin={isOt3 ? '-50% -10%' : '20% -10%'}
-              />
-            )}
-          </Flex>
-          <Flex
-            flexDirection={DIRECTION_COLUMN}
-            flex="100%"
-            paddingLeft={SPACING.spacing8}
+      {!pipetteIsBad && (
+        <>
+          <Box
+            padding={`${SPACING.spacing16} ${SPACING.spacing8}`}
+            width="100%"
           >
-            {isOT3PipetteAttached && !isPipetteCalibrated ? (
-              <Banner type="error" marginBottom={SPACING.spacing4}>
-                <Trans
-                  t={t}
-                  i18nKey="calibration_needed"
-                  components={{
-                    calLink: (
-                      <StyledText
-                        as="p"
-                        css={css`
-                          text-decoration: underline;
-                          cursor: pointer;
-                          margin-left: 0.5rem;
-                        `}
-                        onClick={handleCalibrate}
-                      />
-                    ),
-                  }}
-                />
-              </Banner>
-            ) : null}
-            <StyledText
-              textTransform={TYPOGRAPHY.textTransformUppercase}
-              color={COLORS.darkGreyEnabled}
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-              fontSize={TYPOGRAPHY.fontSizeH6}
-              paddingBottom={SPACING.spacing4}
-              data-testid={`PipetteCard_mount_${String(pipetteDisplayName)}`}
-            >
-              {is96ChannelAttached
-                ? t('both_mounts')
-                : t('mount', {
-                    side: mount === LEFT ? t('left') : t('right'),
-                  })}
-            </StyledText>
-            <Flex
-              paddingBottom={SPACING.spacing4}
-              data-testid={`PipetteCard_display_name_${String(
-                pipetteDisplayName
-              )}`}
-            >
-              <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
-                {pipetteDisplayName ?? t('empty')}
-              </StyledText>
+            <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing8}>
+              <Flex alignItems={ALIGN_START}>
+                {pipetteModelSpecs === null ? null : (
+                  <InstrumentDiagram
+                    pipetteSpecs={pipetteModelSpecs}
+                    mount={mount}
+                    //  pipette images for Flex are slightly smaller so need to be scaled accordingly
+                    transform={isOt3 ? 'scale(0.4)' : 'scale(0.3)'}
+                    size="3.125rem"
+                    transformOrigin={isOt3 ? '-50% -10%' : '20% -10%'}
+                  />
+                )}
+              </Flex>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                flex="100%"
+                paddingLeft={SPACING.spacing8}
+              >
+                {isOT3PipetteAttached && !isPipetteCalibrated ? (
+                  <Banner type="error" marginBottom={SPACING.spacing4}>
+                    <Trans
+                      t={t}
+                      i18nKey="calibration_needed"
+                      components={{
+                        calLink: (
+                          <StyledText
+                            as="p"
+                            css={css`
+                              text-decoration: underline;
+                              cursor: pointer;
+                              margin-left: 0.5rem;
+                            `}
+                            onClick={handleCalibrate}
+                          />
+                        ),
+                      }}
+                    />
+                  </Banner>
+                ) : null}
+                <StyledText
+                  textTransform={TYPOGRAPHY.textTransformUppercase}
+                  color={COLORS.darkGreyEnabled}
+                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                  fontSize={TYPOGRAPHY.fontSizeH6}
+                  paddingBottom={SPACING.spacing4}
+                  data-testid={`PipetteCard_mount_${String(
+                    pipetteDisplayName
+                  )}`}
+                >
+                  {pipetteIs96Channel
+                    ? t('both_mounts')
+                    : t('mount', {
+                        side: mount === LEFT ? t('left') : t('right'),
+                      })}
+                </StyledText>
+                <Flex
+                  paddingBottom={SPACING.spacing4}
+                  data-testid={`PipetteCard_display_name_${String(
+                    pipetteDisplayName
+                  )}`}
+                >
+                  <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
+                    {pipetteDisplayName ?? t('empty')}
+                  </StyledText>
+                </Flex>
+              </Flex>
             </Flex>
-          </Flex>
-        </Flex>
-      </Box>
-      <Box
-        alignSelf={ALIGN_START}
-        padding={SPACING.spacing4}
-        data-testid={`PipetteCard_overflow_btn_${String(pipetteDisplayName)}`}
-      >
-        <OverflowBtn aria-label="overflow" onClick={handleOverflowClick} />
-      </Box>
+          </Box>
+          <Box
+            alignSelf={ALIGN_START}
+            padding={SPACING.spacing4}
+            data-testid={`PipetteCard_overflow_btn_${String(
+              pipetteDisplayName
+            )}`}
+          >
+            <OverflowBtn aria-label="overflow" onClick={handleOverflowClick} />
+          </Box>
+        </>
+      )}
+      {pipetteIsBad && (
+        <InstrumentCard
+          label={i18n.format(t('mount', { side: mount }), 'capitalize')}
+          description={t('instrument_attached')}
+          banner={
+            <Banner type="error" marginBottom={SPACING.spacing4}>
+              <Trans
+                t={t}
+                i18nKey={
+                  subsystemUpdateData != null
+                    ? 'firmware_update_occurring'
+                    : 'firmware_update_available_now'
+                }
+                components={{
+                  updateLink: (
+                    <StyledText
+                      as="p"
+                      css={BANNER_LINK_CSS}
+                      onClick={updatePipette()}
+                    />
+                  ),
+                }}
+              />
+            </Banner>
+          }
+        />
+      )}
       {showOverflowMenu && (
         <>
           <Box
@@ -255,7 +313,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
             onClick={() => setShowOverflowMenu(false)}
           >
             <PipetteOverflowMenu
-              pipetteSpecs={pipetteInfo}
+              pipetteSpecs={pipetteModelSpecs}
               mount={mount}
               handleChangePipette={handleChangePipette}
               handleSettingsSlideout={handleSettingsSlideout}

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -72,12 +72,16 @@ export function FirmwareUpdateTakeover(): JSX.Element {
     isUnboxingFlowOngoing,
     externalSubsystemUpdateExists,
   ])
+  const memoizedSubsystem = React.useMemo(
+    () => subsystemUpdateInstrument?.subsystem,
+    []
+  )
 
   return (
     <>
-      {subsystemUpdateInstrument != null && showUpdateNeededModal ? (
+      {memoizedSubsystem != null && showUpdateNeededModal ? (
         <UpdateNeededModal
-          subsystem={subsystemUpdateInstrument.subsystem}
+          subsystem={memoizedSubsystem}
           setShowUpdateModal={setShowUpdateNeededModal}
           setInitiatedSubsystemUpdate={setInitiatedSubsystemUpdate}
         />

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -82,12 +82,11 @@ export function FirmwareUpdateTakeover(): JSX.Element {
           setInitiatedSubsystemUpdate={setInitiatedSubsystemUpdate}
         />
       ) : null}
-      {externalSubsystemUpdate != null ? (
+      {externalsubsystemUpdateData != null ? (
         <Portal level="top">
           <UpdateInProgressModal
-            percentComplete={
-              externalsubsystemUpdateData?.data.updateProgress ?? 0
-            }
+            percentComplete={externalsubsystemUpdateData.data.updateProgress}
+            subsystem={externalsubsystemUpdateData.data.subsystem}
           />
         </Portal>
       ) : null}

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -6,12 +6,12 @@ import {
   useCurrentAllSubsystemUpdatesQuery,
   useSubsystemUpdateQuery,
 } from '@opentrons/react-api-client'
-
+import { Portal } from '../../App/portal'
 import { useIsUnboxingFlowOngoing } from '../RobotSettingsDashboard/NetworkSettings/hooks'
 import { UpdateInProgressModal } from './UpdateInProgressModal'
-
 import { UpdateNeededModal } from './UpdateNeededModal'
 import type { Subsystem } from '@opentrons/api-client'
+
 const POLL_INTERVAL_5000_MS = 5000
 
 export function FirmwareUpdateTakeover(): JSX.Element {
@@ -83,11 +83,13 @@ export function FirmwareUpdateTakeover(): JSX.Element {
         />
       ) : null}
       {externalSubsystemUpdate != null ? (
-        <UpdateInProgressModal
-          percentComplete={
-            externalsubsystemUpdateData?.data.updateProgress ?? 0
-          }
-        />
+        <Portal level="top">
+          <UpdateInProgressModal
+            percentComplete={
+              externalsubsystemUpdateData?.data.updateProgress ?? 0
+            }
+          />
+        </Portal>
       ) : null}
     </>
   )

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -41,16 +41,10 @@ export function FirmwareUpdateTakeover(): JSX.Element {
   } = useCurrentAllSubsystemUpdatesQuery({
     refetchInterval: POLL_INTERVAL_5000_MS,
   })
-  const externalSubsystemUpdateExists =
-    currentSubsystemsUpdatesData?.data.some(
-      update =>
-        (update.updateStatus === 'queued' ||
-          update.updateStatus === 'updating') &&
-        update.subsystem !== initiatedSubsystemUpdate
-    ) ?? false
   const externalSubsystemUpdate = currentSubsystemsUpdatesData?.data.find(
     update =>
-      update.updateStatus === 'updating' &&
+      (update.updateStatus === 'queued' ||
+        update.updateStatus === 'updating') &&
       update.subsystem !== initiatedSubsystemUpdate
   )
   const { data: externalsubsystemUpdateData } = useSubsystemUpdateQuery(
@@ -62,7 +56,7 @@ export function FirmwareUpdateTakeover(): JSX.Element {
       subsystemUpdateInstrument != null &&
       maintenanceRunData == null &&
       !isUnboxingFlowOngoing &&
-      !externalSubsystemUpdateExists
+      externalSubsystemUpdate == null
     ) {
       setShowUpdateNeededModal(true)
     }
@@ -70,7 +64,7 @@ export function FirmwareUpdateTakeover(): JSX.Element {
     subsystemUpdateInstrument,
     maintenanceRunData,
     isUnboxingFlowOngoing,
-    externalSubsystemUpdateExists,
+    externalSubsystemUpdate,
   ])
   const memoizedSubsystem = React.useMemo(
     () => subsystemUpdateInstrument?.subsystem,

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -12,7 +12,7 @@ import { UpdateInProgressModal } from './UpdateInProgressModal'
 import { UpdateNeededModal } from './UpdateNeededModal'
 import type { Subsystem } from '@opentrons/api-client'
 
-const POLL_INTERVAL_5000_MS = 5000
+const POLL_INTERVAL_MS = 5000
 
 export function FirmwareUpdateTakeover(): JSX.Element {
   const [
@@ -25,21 +25,21 @@ export function FirmwareUpdateTakeover(): JSX.Element {
   ] = React.useState<Subsystem | null>(null)
 
   const instrumentsData = useInstrumentsQuery({
-    refetchInterval: POLL_INTERVAL_5000_MS,
+    refetchInterval: POLL_INTERVAL_MS,
   }).data?.data
   const subsystemUpdateInstrument = instrumentsData?.find(
     instrument => instrument.ok === false
   )
 
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
-    refetchInterval: POLL_INTERVAL_5000_MS,
+    refetchInterval: POLL_INTERVAL_MS,
   })
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
   const {
     data: currentSubsystemsUpdatesData,
   } = useCurrentAllSubsystemUpdatesQuery({
-    refetchInterval: POLL_INTERVAL_5000_MS,
+    refetchInterval: POLL_INTERVAL_MS,
   })
   const externalSubsystemUpdate = currentSubsystemsUpdatesData?.data.find(
     update =>

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -3,41 +3,90 @@ import * as React from 'react'
 import {
   useInstrumentsQuery,
   useCurrentMaintenanceRun,
+  useCurrentAllSubsystemUpdatesQuery,
+  useSubsystemUpdateQuery,
 } from '@opentrons/react-api-client'
 
 import { useIsUnboxingFlowOngoing } from '../RobotSettingsDashboard/NetworkSettings/hooks'
-import { UpdateNeededModal } from './UpdateNeededModal'
+import { UpdateInProgressModal } from './UpdateInProgressModal'
 
-const INSTRUMENT_POLL_INTERVAL = 5000
+import { UpdateNeededModal } from './UpdateNeededModal'
+import type { Subsystem } from '@opentrons/api-client'
+const POLL_INTERVAL_5000_MS = 5000
 
 export function FirmwareUpdateTakeover(): JSX.Element {
   const [
     showUpdateNeededModal,
     setShowUpdateNeededModal,
   ] = React.useState<boolean>(false)
+  const [
+    initiatedSubsystemUpdate,
+    setInitiatedSubsystemUpdate,
+  ] = React.useState<Subsystem | null>(null)
+
   const instrumentsData = useInstrumentsQuery({
-    refetchInterval: INSTRUMENT_POLL_INTERVAL,
+    refetchInterval: POLL_INTERVAL_5000_MS,
   }).data?.data
-  const { data: maintenanceRunData } = useCurrentMaintenanceRun()
   const subsystemUpdateInstrument = instrumentsData?.find(
     instrument => instrument.ok === false
   )
+
+  const { data: maintenanceRunData } = useCurrentMaintenanceRun({
+    refetchInterval: POLL_INTERVAL_5000_MS,
+  })
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
+  const {
+    data: currentSubsystemsUpdatesData,
+  } = useCurrentAllSubsystemUpdatesQuery({
+    refetchInterval: POLL_INTERVAL_5000_MS,
+  })
+  const externalSubsystemUpdateExists =
+    currentSubsystemsUpdatesData?.data.some(
+      update =>
+        (update.updateStatus === 'queued' ||
+          update.updateStatus === 'updating') &&
+        update.subsystem !== initiatedSubsystemUpdate
+    ) ?? false
+  const externalSubsystemUpdate = currentSubsystemsUpdatesData?.data.find(
+    update =>
+      update.updateStatus === 'updating' &&
+      update.subsystem !== initiatedSubsystemUpdate
+  )
+  const { data: externalsubsystemUpdateData } = useSubsystemUpdateQuery(
+    externalSubsystemUpdate?.id ?? null
+  )
+
   React.useEffect(() => {
-    if (subsystemUpdateInstrument != null && maintenanceRunData == null) {
+    if (
+      subsystemUpdateInstrument != null &&
+      maintenanceRunData == null &&
+      !isUnboxingFlowOngoing &&
+      !externalSubsystemUpdateExists
+    ) {
       setShowUpdateNeededModal(true)
     }
-  }, [subsystemUpdateInstrument, maintenanceRunData])
+  }, [
+    subsystemUpdateInstrument,
+    maintenanceRunData,
+    isUnboxingFlowOngoing,
+    externalSubsystemUpdateExists,
+  ])
 
   return (
     <>
-      {subsystemUpdateInstrument != null &&
-      showUpdateNeededModal &&
-      !isUnboxingFlowOngoing ? (
+      {subsystemUpdateInstrument != null && showUpdateNeededModal ? (
         <UpdateNeededModal
           subsystem={subsystemUpdateInstrument.subsystem}
           setShowUpdateModal={setShowUpdateNeededModal}
+          setInitiatedSubsystemUpdate={setInitiatedSubsystemUpdate}
+        />
+      ) : null}
+      {externalSubsystemUpdate != null ? (
+        <UpdateInProgressModal
+          percentComplete={
+            externalsubsystemUpdateData?.data.updateProgress ?? 0
+          }
         />
       ) : null}
     </>

--- a/app/src/organisms/FirmwareUpdateModal/UpdateInProgressModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateInProgressModal.tsx
@@ -13,9 +13,11 @@ import {
 import { ProgressBar } from '../../atoms/ProgressBar'
 import { StyledText } from '../../atoms/text'
 import { Modal } from '../../molecules/Modal'
+import { Subsystem } from '@opentrons/api-client'
 
 interface UpdateInProgressModalProps {
   percentComplete: number
+  subsystem: Subsystem
 }
 
 const OUTER_STYLES = css`
@@ -26,8 +28,8 @@ const OUTER_STYLES = css`
 export function UpdateInProgressModal(
   props: UpdateInProgressModalProps
 ): JSX.Element {
-  const { percentComplete } = props
-  const { i18n, t } = useTranslation('firmware_update')
+  const { percentComplete, subsystem } = props
+  const { t } = useTranslation('firmware_update')
 
   return (
     <Modal>
@@ -47,7 +49,7 @@ export function UpdateInProgressModal(
           marginBottom={SPACING.spacing4}
           fontWeight={TYPOGRAPHY.fontWeightBold}
         >
-          {i18n.format(t('updating_firmware'), 'capitalize')}
+          {t('updating_firmware', { subsystem: t(subsystem) })}
         </StyledText>
         <ProgressBar
           percentComplete={percentComplete}

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -21,10 +21,11 @@ import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 interface UpdateNeededModalProps {
   setShowUpdateModal: React.Dispatch<React.SetStateAction<boolean>>
   subsystem: Subsystem
+  setInitiatedSubsystemUpdate: (subsystem: Subsystem | null) => void
 }
 
 export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
-  const { setShowUpdateModal, subsystem } = props
+  const { setShowUpdateModal, subsystem, setInitiatedSubsystemUpdate } = props
   const { t } = useTranslation('firmware_update')
   const [updateId, setUpdateId] = React.useState('')
   const {
@@ -43,6 +44,12 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
 
   const { data: updateData } = useSubsystemUpdateQuery(updateId)
   const status = updateData?.data.updateStatus
+  React.useEffect(() => {
+    if (status === 'done') {
+      setInitiatedSubsystemUpdate(null)
+    }
+  }, [status, setInitiatedSubsystemUpdate])
+
   const percentComplete = updateData?.data.updateProgress ?? 0
   const updateError = updateData?.data.updateError
   const instrumentType = subsystem === 'gripper' ? 'gripper' : 'pipette'
@@ -73,7 +80,10 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
           />
         </StyledText>
         <SmallButton
-          onClick={() => updateSubsystem(subsystem)}
+          onClick={() => {
+            setInitiatedSubsystemUpdate(subsystem)
+            updateSubsystem(subsystem)
+          }}
           buttonText={t('update_firmware')}
           width="100%"
         />

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -91,7 +91,12 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
     </Modal>
   )
   if (status === 'updating' || status === 'queued') {
-    modalContent = <UpdateInProgressModal percentComplete={percentComplete} />
+    modalContent = (
+      <UpdateInProgressModal
+        percentComplete={percentComplete}
+        subsystem={subsystem}
+      />
+    )
   } else if (status === 'done' || instrument?.ok) {
     modalContent = (
       <UpdateResultsModal

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateTakeover.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateTakeover.test.tsx
@@ -121,6 +121,15 @@ describe('FirmwareUpdateTakeover', () => {
         ],
       },
     } as any)
+    mockUseSubsystemUpdateQuery.mockReturnValue({
+      data: {
+        data: {
+          subsystem: 'pipette_right',
+          updateStatus: 20,
+        } as any,
+      },
+    } as any)
+
     const { queryByText, getByText } = render()
     expect(queryByText('Mock Update Needed Modal')).not.toBeInTheDocument()
     getByText('Mock Update In Progress Modal')

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateTakeover.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateTakeover.test.tsx
@@ -3,15 +3,19 @@ import { renderWithProviders } from '@opentrons/components'
 import {
   useInstrumentsQuery,
   useCurrentMaintenanceRun,
+  useCurrentAllSubsystemUpdatesQuery,
+  useSubsystemUpdateQuery,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
 import { UpdateNeededModal } from '../UpdateNeededModal'
+import { UpdateInProgressModal } from '../UpdateInProgressModal'
 import { useIsUnboxingFlowOngoing } from '../../RobotSettingsDashboard/NetworkSettings/hooks'
 import { FirmwareUpdateTakeover } from '../FirmwareUpdateTakeover'
 import type { BadPipette, PipetteData } from '@opentrons/api-client'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../UpdateNeededModal')
+jest.mock('../UpdateInProgressModal')
 jest.mock('../../RobotSettingsDashboard/NetworkSettings/hooks')
 
 const mockUseInstrumentQuery = useInstrumentsQuery as jest.MockedFunction<
@@ -25,6 +29,15 @@ const mockUpdateNeededModal = UpdateNeededModal as jest.MockedFunction<
 >
 const mockUseIsUnboxingFlowOngoing = useIsUnboxingFlowOngoing as jest.MockedFunction<
   typeof useIsUnboxingFlowOngoing
+>
+const mockUseCurrentAllSubsystemUpdateQuery = useCurrentAllSubsystemUpdatesQuery as jest.MockedFunction<
+  typeof useCurrentAllSubsystemUpdatesQuery
+>
+const mockUseSubsystemUpdateQuery = useSubsystemUpdateQuery as jest.MockedFunction<
+  typeof useSubsystemUpdateQuery
+>
+const mockUpdateInProgressModal = UpdateInProgressModal as jest.MockedFunction<
+  typeof UpdateInProgressModal
 >
 
 const render = () => {
@@ -48,6 +61,15 @@ describe('FirmwareUpdateTakeover', () => {
     mockUpdateNeededModal.mockReturnValue(<>Mock Update Needed Modal</>)
     mockUseCurrentMaintenanceRun.mockReturnValue({ data: undefined } as any)
     mockUseIsUnboxingFlowOngoing.mockReturnValue(false)
+    mockUseCurrentAllSubsystemUpdateQuery.mockReturnValue({
+      data: undefined,
+    } as any)
+    mockUseSubsystemUpdateQuery.mockReturnValue({
+      data: undefined,
+    } as any)
+    mockUpdateInProgressModal.mockReturnValue(
+      <>Mock Update In Progress Modal</>
+    )
   })
 
   it('renders update needed modal when an instrument is not ok', () => {
@@ -67,7 +89,7 @@ describe('FirmwareUpdateTakeover', () => {
       },
     } as any)
     const { queryByText } = render()
-    expect(queryByText('Mock Update In Progress Modal')).not.toBeInTheDocument()
+    expect(queryByText('Mock Update Needed Modal')).not.toBeInTheDocument()
   })
 
   it('does not render modal when a maintenance run is active', () => {
@@ -77,12 +99,30 @@ describe('FirmwareUpdateTakeover', () => {
       },
     } as any)
     const { queryByText } = render()
-    expect(queryByText('Mock Update In Progress Modal')).not.toBeInTheDocument()
+    expect(queryByText('Mock Update Needed Modal')).not.toBeInTheDocument()
   })
 
-  it('should not render modal when unboxing flow is not done', () => {
+  it('does not not render modal when unboxing flow is not done', () => {
     mockUseIsUnboxingFlowOngoing.mockReturnValue(true)
     const { queryByText } = render()
-    expect(queryByText('Mock Update In Progress Modal')).not.toBeInTheDocument()
+    expect(queryByText('Mock Update Needed Modal')).not.toBeInTheDocument()
+  })
+
+  it('does not render modal when another update is in progress', () => {
+    mockUseCurrentAllSubsystemUpdateQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: '123',
+            createdAt: 'today',
+            subsystem: 'pipette_right',
+            updateStatus: 'updating',
+          },
+        ],
+      },
+    } as any)
+    const { queryByText, getByText } = render()
+    expect(queryByText('Mock Update Needed Modal')).not.toBeInTheDocument()
+    getByText('Mock Update In Progress Modal')
   })
 })

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateInProgressModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateInProgressModal.test.tsx
@@ -19,12 +19,13 @@ describe('UpdateInProgressModal', () => {
   beforeEach(() => {
     props = {
       percentComplete: 12,
+      subsystem: 'pipette_right',
     }
     mockProgressBar.mockReturnValue('12' as any)
   })
   it('renders test and progress bar', () => {
     const { getByText } = render(props)
-    getByText('Updating firmware...')
+    getByText('Updating Right Pipette firmware...')
     getByText('12')
   })
 })

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateNeededModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateNeededModal.test.tsx
@@ -48,6 +48,7 @@ describe('UpdateNeededModal', () => {
     props = {
       setShowUpdateModal: jest.fn(),
       subsystem: 'pipette_left',
+      setInitiatedSubsystemUpdate: jest.fn(),
     }
     mockUseInstrumentQuery.mockReturnValue({
       data: {

--- a/app/src/organisms/GripperCard/__tests__/GripperCard.test.tsx
+++ b/app/src/organisms/GripperCard/__tests__/GripperCard.test.tsx
@@ -1,24 +1,26 @@
 import * as React from 'react'
 import { resetAllWhenMocks } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
+import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
 import { fireEvent } from '@testing-library/react'
 import { i18n } from '../../../i18n'
-import { Banner } from '../../../atoms/Banner'
 import { GripperWizardFlows } from '../../GripperWizardFlows'
 import { AboutGripperSlideout } from '../AboutGripperSlideout'
 import { GripperCard } from '../'
 import type { GripperData } from '@opentrons/api-client'
 
-jest.mock('../../../atoms/Banner')
 jest.mock('../../GripperWizardFlows')
 jest.mock('../AboutGripperSlideout')
+jest.mock('@opentrons/react-api-client')
 
-const mockBanner = Banner as jest.MockedFunction<typeof Banner>
 const mockGripperWizardFlows = GripperWizardFlows as jest.MockedFunction<
   typeof GripperWizardFlows
 >
 const mockAboutGripperSlideout = AboutGripperSlideout as jest.MockedFunction<
   typeof AboutGripperSlideout
+>
+const mockUseCurrentSubsystemUpdateQuery = useCurrentSubsystemUpdateQuery as jest.MockedFunction<
+  typeof useCurrentSubsystemUpdateQuery
 >
 
 const render = (props: React.ComponentProps<typeof GripperCard>) => {
@@ -35,6 +37,7 @@ describe('GripperCard', () => {
         instrumentModel: 'gripperV1.1',
         serialNumber: '123',
         firmwareVersion: '12',
+        ok: true,
         data: {
           calibratedOffset: {
             last_modified: '12/2/4',
@@ -42,10 +45,13 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: true,
+      setSubsystemToUpdate: jest.fn(),
     }
-    mockBanner.mockReturnValue(<>calibration needed</>)
     mockGripperWizardFlows.mockReturnValue(<>wizard flow launched</>)
     mockAboutGripperSlideout.mockReturnValue(<>about gripper</>)
+    mockUseCurrentSubsystemUpdateQuery.mockReturnValue({
+      data: undefined,
+    } as any)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -72,6 +78,7 @@ describe('GripperCard', () => {
         instrumentModel: 'gripperV1.1',
         serialNumber: '123',
         firmwareVersion: '12',
+        ok: true,
         data: {
           calibratedOffset: {
             last_modified: undefined,
@@ -79,10 +86,11 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: false,
+      setSubsystemToUpdate: jest.fn(),
     }
 
     const { getByText } = render(props)
-    getByText('calibration needed')
+    getByText('Calibration needed.')
   })
   it('opens the about gripper slideout when button is pressed', () => {
     const { getByText, getByRole } = render(props)
@@ -118,6 +126,7 @@ describe('GripperCard', () => {
     props = {
       attachedGripper: null,
       isCalibrated: false,
+      setSubsystemToUpdate: jest.fn(),
     }
     const { getByText, getByRole } = render(props)
     const overflowButton = getByRole('button', {
@@ -127,5 +136,36 @@ describe('GripperCard', () => {
     const attachGripperButton = getByText('Attach gripper')
     attachGripperButton.click()
     getByText('wizard flow launched')
+  })
+  it('renders firmware update needed state if gripper is bad', () => {
+    props = {
+      attachedGripper: {
+        ok: false,
+      } as any,
+      isCalibrated: false,
+      setSubsystemToUpdate: jest.fn(),
+    }
+    const { getByText } = render(props)
+    getByText('Extension mount')
+    getByText('Instrument attached')
+    getByText('Firmware update available.')
+    getByText('Update now').click()
+    expect(props.setSubsystemToUpdate).toHaveBeenCalledWith('gripper')
+  })
+  it('renders firmware update in progress state if gripper is bad and update in progress', () => {
+    mockUseCurrentSubsystemUpdateQuery.mockReturnValue({
+      data: { data: { updateProgress: 50 } as any },
+    } as any)
+    props = {
+      attachedGripper: {
+        ok: false,
+      } as any,
+      isCalibrated: true,
+      setSubsystemToUpdate: jest.fn(),
+    }
+    const { getByText } = render(props)
+    getByText('Extension mount')
+    getByText('Instrument attached')
+    getByText('Firmware update in progress...')
   })
 })

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -127,7 +127,10 @@ export function GripperCard({
           label={i18n.format(t('mount', { side: 'extension' }), 'capitalize')}
           description={t('instrument_attached')}
           banner={
-            <Banner type="error" marginBottom={SPACING.spacing4}>
+            <Banner
+              type={subsystemUpdateData != null ? 'warning' : 'error'}
+              marginBottom={SPACING.spacing4}
+            >
               <Trans
                 t={t}
                 i18nKey={

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -1,27 +1,36 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
-import { GripperData } from '@opentrons/api-client'
 import { SPACING } from '@opentrons/components'
 import { getGripperDisplayName, GripperModel } from '@opentrons/shared-data'
+import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
 import { Banner } from '../../atoms/Banner'
 import { StyledText } from '../../atoms/text'
 import { InstrumentCard } from '../../molecules/InstrumentCard'
 import { GripperWizardFlows } from '../GripperWizardFlows'
 import { AboutGripperSlideout } from './AboutGripperSlideout'
 import { GRIPPER_FLOW_TYPES } from '../GripperWizardFlows/constants'
+import type { BadGripper, GripperData, Subsystem } from '@opentrons/api-client'
 import type { GripperWizardFlowType } from '../GripperWizardFlows/types'
 
 interface GripperCardProps {
-  attachedGripper: GripperData | null
+  attachedGripper: GripperData | BadGripper | null
   isCalibrated: boolean
+  setSubsystemToUpdate: (subsystem: Subsystem | null) => void
 }
+const BANNER_LINK_CSS = css`
+  text-decoration: underline;
+  cursor: pointer;
+  margin-left: ${SPACING.spacing8};
+`
+const SUBSYSTEM_UPDATE_POLL_MS = 3000
 
 export function GripperCard({
   attachedGripper,
   isCalibrated,
+  setSubsystemToUpdate,
 }: GripperCardProps): JSX.Element {
-  const { t } = useTranslation(['device_details', 'shared'])
+  const { t, i18n } = useTranslation(['device_details', 'shared'])
   const [
     openWizardFlowType,
     setOpenWizardFlowType,
@@ -42,9 +51,15 @@ export function GripperCard({
   const handleCalibrate: React.MouseEventHandler<HTMLButtonElement> = () => {
     setOpenWizardFlowType(GRIPPER_FLOW_TYPES.RECALIBRATE)
   }
-
+  const { data: subsystemUpdateData } = useCurrentSubsystemUpdateQuery(
+    'gripper',
+    {
+      enabled: attachedGripper != null && !attachedGripper.ok,
+      refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
+    }
+  )
   const menuOverlayItems =
-    attachedGripper == null
+    attachedGripper == null || !attachedGripper.ok
       ? [
           {
             label: t('attach_gripper'),
@@ -74,41 +89,66 @@ export function GripperCard({
         ]
   return (
     <>
-      <InstrumentCard
-        description={
-          attachedGripper != null
-            ? getGripperDisplayName(
-                attachedGripper.instrumentModel as GripperModel
-              )
-            : t('shared:empty')
-        }
-        banner={
-          attachedGripper != null && !isCalibrated ? (
+      {attachedGripper == null || attachedGripper.ok ? (
+        <InstrumentCard
+          description={
+            attachedGripper != null
+              ? getGripperDisplayName(
+                  attachedGripper.instrumentModel as GripperModel
+                )
+              : t('shared:empty')
+          }
+          banner={
+            attachedGripper?.ok && !isCalibrated ? (
+              <Banner type="error" marginBottom={SPACING.spacing4}>
+                <Trans
+                  t={t}
+                  i18nKey="calibration_needed"
+                  components={{
+                    calLink: (
+                      <StyledText
+                        as="p"
+                        css={BANNER_LINK_CSS}
+                        onClick={handleCalibrate}
+                      />
+                    ),
+                  }}
+                />
+              </Banner>
+            ) : null
+          }
+          isGripperAttached={attachedGripper != null}
+          label={t('shared:extension_mount')}
+          menuOverlayItems={menuOverlayItems}
+        />
+      ) : null}
+      {attachedGripper?.ok === false ? (
+        <InstrumentCard
+          label={i18n.format(t('mount', { side: 'extension' }), 'capitalize')}
+          description={t('instrument_attached')}
+          banner={
             <Banner type="error" marginBottom={SPACING.spacing4}>
               <Trans
                 t={t}
-                i18nKey="calibration_needed"
+                i18nKey={
+                  subsystemUpdateData != null
+                    ? 'firmware_update_occurring'
+                    : 'firmware_update_available_now'
+                }
                 components={{
-                  calLink: (
+                  updateLink: (
                     <StyledText
                       as="p"
-                      css={css`
-                        text-decoration: underline;
-                        cursor: pointer;
-                        margin-left: 0.5rem;
-                      `}
-                      onClick={handleCalibrate}
+                      css={BANNER_LINK_CSS}
+                      onClick={setSubsystemToUpdate('gripper')}
                     />
                   ),
                 }}
               />
             </Banner>
-          ) : null
-        }
-        isGripperAttached={attachedGripper != null}
-        label={t('shared:extension_mount')}
-        menuOverlayItems={menuOverlayItems}
-      />
+          }
+        />
+      ) : null}
       {openWizardFlowType != null ? (
         <GripperWizardFlows
           flowType={openWizardFlowType}
@@ -116,7 +156,7 @@ export function GripperCard({
           closeFlow={() => setOpenWizardFlowType(null)}
         />
       ) : null}
-      {attachedGripper != null && showAboutGripperSlideout && (
+      {attachedGripper?.ok && showAboutGripperSlideout && (
         <AboutGripperSlideout
           serialNumber={attachedGripper.serialNumber}
           firmwareVersion={attachedGripper.firmwareVersion}

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -143,7 +143,7 @@ export function GripperCard({
                     <StyledText
                       as="p"
                       css={BANNER_LINK_CSS}
-                      onClick={setSubsystemToUpdate('gripper')}
+                      onClick={() => setSubsystemToUpdate('gripper')}
                     />
                   ),
                 }}


### PR DESCRIPTION
fix RQA-1478, RQA-1315, RQA-1252

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Instrument cards for bad instruments were rendered outside of the `GripperCard` and `PipetteCard` components, which is where attachment flows are rendered. This caused flows to close when an instrument that needed a subsystem update was attached during a flow. 
This PR refactors `GripperCard` and `PipetteCard` to handle instruments that need subsystem updates so that no longer happens and reflects in progress updates on both desktop and ODD.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Go through an attachment flow with an instrument that will need a firmware update. See that the attachment flow no longer closes. See that an in progress modal appears on the ODD.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Refactor `GripperCard` and `PipetteCard` to handle instruments that need subsystem updates
2. Show dynamic text and color for subsystem update banner if an update is already in progress
3. Show ODD in progress modal anytime an externally initiated update is in progress

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Ensure refactor looks sound
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
