### PR TITLE
fix(shared-data): Migrate units for mutable configs

### DIFF
--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -140,6 +140,8 @@ class MutableConfig:
         max: float,
         name: str,
     ) -> "MutableConfig":
+        if units == "mm/sec":
+            units = "mm/s"
         return cls(
             value=value,
             default=default,

--- a/shared-data/python/tests/pipette/test_mutable_configurations.py
+++ b/shared-data/python/tests/pipette/test_mutable_configurations.py
@@ -249,3 +249,18 @@ def test_load_with_overrides(
         assert updated_configurations_dict == dict_loaded_configs
     else:
         assert updated_configurations == loaded_base_configurations
+
+
+def test_build_mutable_config_using_old_units() -> None:
+    """Test that MutableConfigs can build with old units."""
+    old_units_config = {
+        "value": 5,
+        "default": 5.0,
+        "units": "mm/s",
+        "type": "float",
+        "min": 0.01,
+        "max": 30,
+    }
+    assert (
+        types.MutableConfig.build(**old_units_config, name="dropTipSpeed") is not None
+    )


### PR DESCRIPTION
# Overview

In the older pipette config code, there was a mix of `mm/s` and `mm/sec` as units. If someone had an older file that contained `mm/sec`, it would fail because the enum was expecting exact string match.

This PR fixes that issue and adds a small test.