### PR TITLE
fix(engine): fix labware gripperOffsets not allowing only a `default` offset

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -751,8 +751,11 @@ class LabwareView(HasState[LabwareState]):
         """Get the labware's gripper offsets of the specified type."""
         parsed_offsets = self.get_definition(labware_id).gripperOffsets
         offset_key = slot_name.name if slot_name else "default"
-        return (
-            LabwareMovementOffsetData(
+
+        if parsed_offsets is None or offset_key not in parsed_offsets:
+            return None
+        else:
+            return LabwareMovementOffsetData(
                 pickUpOffset=cast(
                     LabwareOffsetVector, parsed_offsets[offset_key].pickUpOffset
                 ),
@@ -760,9 +763,6 @@ class LabwareView(HasState[LabwareState]):
                     LabwareOffsetVector, parsed_offsets[offset_key].dropOffset
                 ),
             )
-            if parsed_offsets
-            else None
-        )
 
     def get_grip_force(self, labware_id: str) -> float:
         """Get the recommended grip force for gripping labware using gripper."""

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -10,6 +10,8 @@ from opentrons_shared_data.labware.labware_definition import (
     Parameters,
     LabwareRole,
     OverlapOffset as SharedDataOverlapOffset,
+    GripperOffsets,
+    OffsetVector,
 )
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName, Point, MountType
@@ -1343,6 +1345,49 @@ def test_get_labware_gripper_offsets(
     ) == LabwareMovementOffsetData(
         pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
         dropOffset=LabwareOffsetVector(x=2, y=0, z=0),
+    )
+
+
+def test_get_labware_gripper_offsets_default_no_slots(
+    well_plate_def: LabwareDefinition,
+    adapter_plate_def: LabwareDefinition,
+) -> None:
+    """It should get the labware's gripper offsets with only a default gripper offset entry."""
+    subject = get_labware_view(
+        labware_by_id={
+            "labware-id": LoadedLabware(
+                id="labware-id",
+                loadName="labware-load-name",
+                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+                definitionUri="some-labware-uri",
+                offsetId=None,
+                displayName="Fancy Labware Name",
+            )
+        },
+        definitions_by_uri={
+            "some-labware-uri": LabwareDefinition.construct(  # type: ignore[call-arg]
+                gripperOffsets={
+                    "default": GripperOffsets(
+                        pickUpOffset=OffsetVector(x=1, y=2, z=3),
+                        dropOffset=OffsetVector(x=4, y=5, z=6),
+                    )
+                }
+            ),
+        },
+    )
+
+    assert (
+        subject.get_labware_gripper_offsets(
+            labware_id="labware-id", slot_name=DeckSlotName.SLOT_D1
+        )
+        is None
+    )
+
+    assert subject.get_labware_gripper_offsets(
+        labware_id="labware-id", slot_name=None
+    ) == LabwareMovementOffsetData(
+        pickUpOffset=LabwareOffsetVector(x=1, y=2, z=3),
+        dropOffset=LabwareOffsetVector(x=4, y=5, z=6),
     )
 
 


### PR DESCRIPTION
# Overview

As introduced in #13186, labware definitions can have a `gripperOffsets` property for providing an offset when picking up and dropping labware to and from that labware. It is required to have a `default` field, used for anything that does not have a specific slot name (e.g. `SLOT_C1`).

It was noticed in testing though that that `default` key, if there was no corresponding slot name key, was producing a `KeyError` because it was always attempting a direct access of the slot name key, regardless if it existed or not. This PR fixes that by first checking for the presence of the key before going for a direct access. This is not currently affecting any existing definition since the only one (`opentrons_universal_flat_adapter`) has all possible slot names it can be in in its `gripperOffsets`

# Test Plan

Tested to make sure that a definition with a `default` only entry worked and did not crash, that gripping to and from a flat adapter still worked as expected, and that gripping to and from a labware with no offset continued to work.

Used this protocol with and without adding a default gripper offset to the aluminum block:

```
metadata = {
    'protocolName': 'Labware GripperOffsets test',
}

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.15"
}


def run(context):
    heater_shaker = context.load_module("heaterShakerModuleV1", location="D1")
    temp_module = context.load_module("temperatureModuleV2", location="D3")

    flat_adapter = heater_shaker.load_adapter("opentrons_universal_flat_adapter")
    aluminum_block = temp_module.load_adapter("opentrons_96_well_aluminum_block")

    corning_plate = context.load_labware("corning_384_wellplate_112ul_flat", location="C1")
    nest_plate = context.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", location="C3")

    heater_shaker.open_labware_latch()

    context.move_labware(corning_plate, new_location=flat_adapter, use_gripper=True)
    context.home()
    heater_shaker.close_labware_latch()
    heater_shaker.open_labware_latch()
    context.move_labware(corning_plate, new_location="C1", use_gripper=True)


    context.move_labware(nest_plate, new_location=aluminum_block, use_gripper=True)
    context.home()
    context.move_labware(nest_plate, new_location="C3", use_gripper=True)
```

```
  "gripperOffsets": {
    "default": {
      "pickUpOffset": {
        "x": 0,
        "y": 0,
        "z": 0
      },
      "dropOffset": {
        "x": 0,
        "y": 0,
        "z": 10
      }
    }
```

# Changelog

- Fixed `get_labware_gripper_offsets` to check for presence of key before accessing it from `parsed_offsets`

# Review requests

# Risk assessment

Low, this fixes an exception that was being raised but otherwise does not change the function's behavior.