### PR TITLE
feat(api): add command to configure pipette volume in Protocol Engine

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -193,6 +193,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         return self._liquid_class
 
     @property
+    def liquid_class_name(self) -> pip_types.LiquidClasses:
+        return self._liquid_class_name
+
+    @property
     def nozzle_offset(self) -> List[float]:
         return self._nozzle_offset
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -136,28 +136,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         else:
             self._pipetting_function_version = PIPETTING_FUNCTION_LATEST_VERSION
 
-    def get_liquid_class_for_volume(self, volume: float) -> str:
-        """Get the liquid class required for the specified volume.
-        Some pipettes have different liquid classes for different volumes. If applicable,
-        and if the volume is in the different range, this will return that liquid class.
-        Otherwise, it will return the current liquid class.
-        This function takes into account the current liquid class to provide hysteresis.
-        """
-        # For now, until we add more liquid classes, we're going to hardcode the default
-        # and lowVolumeDefault liquid classes as the ones to switch between.
-        has_lvd = (
-            pip_types.LiquidClasses.lowVolumeDefault in self._config.liquid_properties
-        )
-        if not has_lvd:
-            return self._liquid_class_name.name
-        if self._liquid_class_name == pip_types.LiquidClasses.lowVolumeDefault:
-            if volume > (self.liquid_class.max_volume * 0.75):
-                return pip_types.LiquidClasses.default.name
-        if self._liquid_class_name == pip_types.LiquidClasses.default:
-            if volume < (self.liquid_class.max_volume * 0.5):
-                return pip_types.LiquidClasses.lowVolumeDefault.name
-        return self._liquid_class_name.name
-
     @property
     def config(self) -> PipetteConfigurations:
         return self._config
@@ -165,6 +143,10 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     @property
     def liquid_class(self) -> PipetteLiquidPropertiesDefinition:
         return self._liquid_class
+
+    @property
+    def liquid_class_name(self) -> pip_types.LiquidClasses:
+        return self._liquid_class_name
 
     @property
     def channels(self) -> pip_types.PipetteChannelType:

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -16,6 +16,7 @@ from opentrons_shared_data.pipette.pipette_definition import (
     PipetteNameType,
     PipetteModelVersionType,
     PipetteLiquidPropertiesDefinition,
+    default_tip_for_liquid_class,
 )
 from opentrons_shared_data.errors.exceptions import (
     InvalidLiquidClassName,
@@ -110,9 +111,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         )
         self.ready_to_aspirate = False
 
-        self._active_tip_setting_name = pip_types.PipetteTipType(
-            self._liquid_class.max_volume
-        )
+        self._active_tip_setting_name = default_tip_for_liquid_class(self._liquid_class)
         self._active_tip_settings = self._liquid_class.supported_tips[
             self._active_tip_setting_name
         ]
@@ -231,7 +230,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self.ready_to_aspirate = False
         #: True if ready to aspirate
         self.set_liquid_class_by_name("default")
-        self.set_tip_type_by_volume(self.liquid_class.max_volume)
+        self.set_tip_type(default_tip_for_liquid_class(self._liquid_class))
 
         self._aspirate_flow_rate = (
             self._active_tip_settings.default_aspirate_flowrate.default

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -899,3 +899,11 @@ class OT3PipetteHandler:
     async def set_liquid_class(self, mount: OT3Mount, liquid_class: str) -> None:
         pip = self.get_pipette(mount)
         pip.set_liquid_class_by_name(liquid_class)
+
+    async def configure_for_volume(self, mount: OT3Mount, volume: float) -> None:
+        pip = self.get_pipette(mount)
+        if pip.current_volume > 0:
+            # Switching liquid classes can't happen when there's already liquid
+            return
+        new_class = pip.get_liquid_class_for_volume(volume + pip.current_volume)
+        pip.set_liquid_class_by_name(new_class)

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -16,9 +16,13 @@ from typing import (
 from typing_extensions import Final
 import numpy
 from opentrons_shared_data.pipette.dev_types import UlPerMmAction
+
 from opentrons_shared_data.errors.exceptions import (
     CommandPreconditionViolated,
     CommandParameterLimitViolated,
+)
+from opentrons_shared_data.pipette.pipette_definition import (
+    liquid_class_for_volume_between_default_and_defaultlowvolume,
 )
 
 from opentrons import types as top_types
@@ -905,5 +909,9 @@ class OT3PipetteHandler:
         if pip.current_volume > 0:
             # Switching liquid classes can't happen when there's already liquid
             return
-        new_class = pip.get_liquid_class_for_volume(volume + pip.current_volume)
-        pip.set_liquid_class_by_name(new_class)
+        new_class_name = liquid_class_for_volume_between_default_and_defaultlowvolume(
+            volume,
+            pip.liquid_class_name,
+            pip.config.liquid_properties,
+        )
+        pip.set_liquid_class_by_name(new_class_name.name)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1575,6 +1575,12 @@ class OT3API(
             acquire_lock=acquire_lock,
         )
 
+    async def configure_for_volume(
+        self, mount: Union[top_types.Mount, OT3Mount], volume: float
+    ) -> None:
+        checked_mount = OT3Mount.from_mount(mount)
+        await self._pipette_handler.configure_for_volume(checked_mount, volume)
+
     async def set_liquid_class(
         self, mount: Union[top_types.Mount, OT3Mount], liquid_class: str
     ) -> None:

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -24,7 +24,6 @@ from .actions import (
     DoorChangeAction,
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
-    AddPipetteConfigAction,
 )
 
 __all__ = [
@@ -49,7 +48,6 @@ __all__ = [
     "DoorChangeAction",
     "ResetTipsAction",
     "SetPipetteMovementSpeedAction",
-    "AddPipetteConfigAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -25,6 +25,7 @@ from .actions import (
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     AddPipetteConfigAction,
+    UpdateLiquidClassAction,
 )
 
 __all__ = [
@@ -50,6 +51,7 @@ __all__ = [
     "ResetTipsAction",
     "SetPipetteMovementSpeedAction",
     "AddPipetteConfigAction",
+    "UpdateLiquidClassAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -25,7 +25,6 @@ from .actions import (
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     AddPipetteConfigAction,
-    UpdateLiquidClassAction,
 )
 
 __all__ = [
@@ -51,7 +50,6 @@ __all__ = [
     "ResetTipsAction",
     "SetPipetteMovementSpeedAction",
     "AddPipetteConfigAction",
-    "UpdateLiquidClassAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -14,8 +14,7 @@ from opentrons.hardware_control.modules import LiveData
 
 from opentrons_shared_data.errors import EnumeratedError
 
-from ..resources import pipette_data_provider
-from ..commands import Command, CommandCreate
+from ..commands import Command, CommandCreate, CommandPrivateResult
 from ..types import LabwareOffsetCreate, ModuleDefinition, Liquid
 
 
@@ -111,6 +110,7 @@ class UpdateCommandAction:
     """Update a given command."""
 
     command: Command
+    private_result: CommandPrivateResult
 
 
 @dataclass(frozen=True)
@@ -180,15 +180,6 @@ class SetPipetteMovementSpeedAction:
     speed: Optional[float]
 
 
-@dataclass(frozen=True)
-class AddPipetteConfigAction:
-    """Adds a pipette's static config to the state store."""
-
-    pipette_id: str
-    serial_number: str
-    config: pipette_data_provider.LoadedStaticPipetteData
-
-
 Action = Union[
     PlayAction,
     PauseAction,
@@ -205,5 +196,4 @@ Action = Union[
     AddLiquidAction,
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
-    AddPipetteConfigAction,
 ]

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -189,15 +189,6 @@ class AddPipetteConfigAction:
     config: pipette_data_provider.LoadedStaticPipetteData
 
 
-@dataclass(frozen=True)
-class UpdateLiquidClassAction:
-    """Update a pipette's current static config class based on a new liquid class."""
-
-    pipette_id: str
-    serial_number: str
-    config: pipette_data_provider.LoadedStaticPipetteData
-
-
 Action = Union[
     PlayAction,
     PauseAction,
@@ -215,5 +206,4 @@ Action = Union[
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     AddPipetteConfigAction,
-    UpdateLiquidClassAction,
 ]

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -189,6 +189,15 @@ class AddPipetteConfigAction:
     config: pipette_data_provider.LoadedStaticPipetteData
 
 
+@dataclass(frozen=True)
+class UpdateLiquidClassAction:
+    """Update a pipette's current static config class based on a new liquid class."""
+
+    pipette_id: str
+    serial_number: str
+    config: pipette_data_provider.LoadedStaticPipetteData
+
+
 Action = Union[
     PlayAction,
     PauseAction,
@@ -206,4 +215,5 @@ Action = Union[
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     AddPipetteConfigAction,
+    UpdateLiquidClassAction,
 ]

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -256,6 +256,14 @@ from .retract_axis import (
     RetractAxisCommandType,
 )
 
+from .configure_for_volume import (
+    ConfigureForVolume,
+    ConfigureForVolumeCreate,
+    ConfigureForVolumeParams,
+    ConfigureForVolumeResult,
+    ConfigureForVolumeCommandType,
+)
+
 __all__ = [
     # command type unions
     "Command",
@@ -444,4 +452,10 @@ __all__ = [
     "thermocycler",
     # calibration command bundle
     "calibration",
+    # configure pipette volume command bundle
+    "ConfigureForVolume",
+    "ConfigureForVolumeCreate",
+    "ConfigureForVolumeParams",
+    "ConfigureForVolumeResult",
+    "ConfigureForVolumeCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -36,6 +36,7 @@ from .command_unions import (
     CommandCreate,
     CommandResult,
     CommandType,
+    CommandPrivateResult,
 )
 
 from .aspirate import (
@@ -141,6 +142,7 @@ from .load_pipette import (
     LoadPipetteCreate,
     LoadPipetteResult,
     LoadPipetteCommandType,
+    LoadPipettePrivateResult,
 )
 
 from .move_labware import (
@@ -271,8 +273,10 @@ __all__ = [
     "CommandCreate",
     "CommandResult",
     "CommandType",
+    "CommandPrivateResult",
     # base interfaces
     "AbstractCommandImpl",
+    "AbstractCommandWithPrivateResultImpl",
     "BaseCommand",
     "BaseCommandCreate",
     "CommandStatus",
@@ -359,6 +363,7 @@ __all__ = [
     "LoadPipetteParams",
     "LoadPipetteResult",
     "LoadPipetteCommandType",
+    "LoadPipettePrivateResult",
     # move labware command models
     "MoveLabware",
     "MoveLabwareCreate",

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -25,7 +25,7 @@ CommandParamsT = TypeVar("CommandParamsT", bound=BaseModel)
 
 CommandResultT = TypeVar("CommandResultT", bound=BaseModel)
 
-CommandPrivateResultT = TypeVar("CommandPrivateResultT", bound=BaseModel)
+CommandPrivateResultT = TypeVar("CommandPrivateResultT")
 
 
 class CommandStatus(str, Enum):

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -157,6 +157,10 @@ class AbstractCommandImpl(
 
     - Create a command resource from the request model
     - Execute the command, mapping data from execution into the result model
+
+    This class should be used as the base class for new commands by default. You should only
+    use AbstractCommandWithPrivateResultImpl if you actually need private results to send to
+    the rest of the engine wihtout being published outside of it.
     """
 
     def __init__(
@@ -186,13 +190,18 @@ class AbstractCommandWithPrivateResultImpl(
     ABC,
     Generic[CommandParamsT, CommandResultT, CommandPrivateResultT],
 ):
-    """Abstract command creation and execution implementation.
+    """Abstract command creation and execution implementation if the command has private results.
 
     A given command request should map to a specific command implementation,
     which defines how to:
 
     - Create a command resource from the request model
     - Execute the command, mapping data from execution into the result model
+
+    This class should be used instead of AbstractCommandImpl as a base class if your command needs
+    to send data to result handlers that should not be published outside of the engine.
+
+    Note that this class needs an extra type-parameter for the private result.
     """
 
     def __init__(

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Tuple
 
 from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 CommandParamsT = TypeVar("CommandParamsT", bound=BaseModel)
 
 CommandResultT = TypeVar("CommandResultT", bound=BaseModel)
+
+CommandPrivateResultT = TypeVar("CommandPrivateResultT", bound=BaseModel)
 
 
 class CommandStatus(str, Enum):
@@ -176,5 +178,43 @@ class AbstractCommandImpl(
 
     @abstractmethod
     async def execute(self, params: CommandParamsT) -> CommandResultT:
+        """Execute the command, mapping data from execution into a response model."""
+        ...
+
+
+class AbstractCommandWithPrivateResultImpl(
+    ABC,
+    Generic[CommandParamsT, CommandResultT, CommandPrivateResultT],
+):
+    """Abstract command creation and execution implementation.
+
+    A given command request should map to a specific command implementation,
+    which defines how to:
+
+    - Create a command resource from the request model
+    - Execute the command, mapping data from execution into the result model
+    """
+
+    def __init__(
+        self,
+        state_view: StateView,
+        hardware_api: HardwareControlAPI,
+        equipment: execution.EquipmentHandler,
+        movement: execution.MovementHandler,
+        gantry_mover: execution.GantryMover,
+        labware_movement: execution.LabwareMovementHandler,
+        pipetting: execution.PipettingHandler,
+        tip_handler: execution.TipHandler,
+        run_control: execution.RunControlHandler,
+        rail_lights: execution.RailLightsHandler,
+        status_bar: execution.StatusBarHandler,
+    ) -> None:
+        """Initialize the command implementation with execution handlers."""
+        pass
+
+    @abstractmethod
+    async def execute(
+        self, params: CommandParamsT
+    ) -> Tuple[CommandResultT, CommandPrivateResultT]:
         """Execute the command, mapping data from execution into a response model."""
         ...

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -119,6 +119,7 @@ from .load_pipette import (
     LoadPipetteCreate,
     LoadPipetteResult,
     LoadPipetteCommandType,
+    LoadPipettePrivateResult,
 )
 
 from .move_labware import (
@@ -513,3 +514,5 @@ CommandResult = Union[
     calibration.CalibrateModuleResult,
     calibration.MoveToMaintenancePositionResult,
 ]
+
+CommandPrivateResult = Union[None, LoadPipettePrivateResult]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -225,6 +225,14 @@ from .retract_axis import (
     RetractAxisCommandType,
 )
 
+from .configure_for_volume import (
+    ConfigureForVolume,
+    ConfigureForVolumeParams,
+    ConfigureForVolumeCreate,
+    ConfigureForVolumeResult,
+    ConfigureForVolumeCommandType,
+)
+
 Command = Union[
     Aspirate,
     AspirateInPlace,
@@ -234,6 +242,7 @@ Command = Union[
     DispenseInPlace,
     BlowOut,
     BlowOutInPlace,
+    ConfigureForVolume,
     DropTip,
     DropTipInPlace,
     Home,
@@ -284,6 +293,7 @@ CommandParams = Union[
     AspirateParams,
     AspirateInPlaceParams,
     CommentParams,
+    ConfigureForVolumeParams,
     CustomParams,
     DispenseParams,
     DispenseInPlaceParams,
@@ -340,6 +350,7 @@ CommandType = Union[
     AspirateCommandType,
     AspirateInPlaceCommandType,
     CommentCommandType,
+    ConfigureForVolumeCommandType,
     CustomCommandType,
     DispenseCommandType,
     DispenseInPlaceCommandType,
@@ -395,6 +406,7 @@ CommandCreate = Union[
     AspirateCreate,
     AspirateInPlaceCreate,
     CommentCreate,
+    ConfigureForVolumeCreate,
     CustomCreate,
     DispenseCreate,
     DispenseInPlaceCreate,
@@ -450,6 +462,7 @@ CommandResult = Union[
     AspirateResult,
     AspirateInPlaceResult,
     CommentResult,
+    ConfigureForVolumeResult,
     CustomResult,
     DispenseResult,
     DispenseInPlaceResult,

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -232,6 +232,7 @@ from .configure_for_volume import (
     ConfigureForVolumeCreate,
     ConfigureForVolumeResult,
     ConfigureForVolumeCommandType,
+    ConfigureForVolumePrivateResult,
 )
 
 Command = Union[
@@ -515,4 +516,6 @@ CommandResult = Union[
     calibration.MoveToMaintenancePositionResult,
 ]
 
-CommandPrivateResult = Union[None, LoadPipettePrivateResult]
+CommandPrivateResult = Union[
+    None, LoadPipettePrivateResult, ConfigureForVolumePrivateResult
+]

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -1,6 +1,6 @@
 """Configure for volume command request, result, and implementation models."""
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type, Tuple
 from typing_extensions import Literal
 
@@ -37,10 +37,7 @@ class ConfigureForVolumePrivateResult(PipetteConfigUpdateResultMixin):
 class ConfigureForVolumeResult(BaseModel):
     """Result data from execution of an ConfigureForVolume command."""
 
-    pipetteId: str = Field(
-        ...,
-        description="An ID to reference this pipette in subsequent commands.",
-    )
+    pass
 
 
 class ConfigureForVolumeImplementation(
@@ -64,9 +61,7 @@ class ConfigureForVolumeImplementation(
             volume=params.volume,
         )
 
-        return ConfigureForVolumeResult(
-            pipetteId=pipette_result.pipette_id
-        ), ConfigureForVolumePrivateResult(
+        return ConfigureForVolumeResult(), ConfigureForVolumePrivateResult(
             pipette_id=pipette_result.pipette_id,
             serial_number=pipette_result.serial_number,
             config=pipette_result.static_config,

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -1,0 +1,89 @@
+"""Configure for volume command request, result, and implementation models."""
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING, Optional, Type, Union
+from typing_extensions import Literal
+
+from opentrons.types import MountType
+
+from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from .pipetting_common import (
+    PipetteIdMixin,
+    VolumeMixin,
+)
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+if TYPE_CHECKING:
+    from ..execution import EquipmentHandler
+
+
+ConfigureForVolumeCommandType = Literal["configureForVolume"]
+
+
+class ConfigureForVolumeParams(PipetteIdMixin, VolumeMixin):
+    """Parameters required to configure volume for a specific pipette."""
+
+    # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
+    # https://opentrons.atlassian.net/browse/RLIQ-255
+    pipetteName: Union[PipetteNameType, Literal["p1000_96"]] = Field(
+        ...,
+        description="The load name of the pipette to be required.",
+    )
+    mount: MountType = Field(
+        ...,
+        description="The mount the pipette should be present on.",
+    )
+
+
+class ConfigureForVolumeResult(BaseModel):
+    """Result data from execution of an ConfigureForVolume command."""
+
+    pipetteId: str = Field(
+        ...,
+        description="An ID to reference this pipette in subsequent commands.",
+    )
+
+
+class ConfigureForVolumeImplementation(
+    AbstractCommandImpl[ConfigureForVolumeParams, ConfigureForVolumeResult]
+):
+    """Configure for volume command implementation."""
+
+    def __init__(self, equipment: EquipmentHandler, **kwargs: object) -> None:
+        self._equipment = equipment
+
+    async def execute(
+        self, params: ConfigureForVolumeParams
+    ) -> ConfigureForVolumeResult:
+        """Check that requested pipette can be configured for the given volume."""
+        configured_pipette = await self._equipment.configure_for_volume(
+            pipette_name=params.pipetteName,
+            mount=params.mount,
+            pipette_id=params.pipetteId,
+            volume=params.volume,
+        )
+
+        return ConfigureForVolumeResult(pipetteId=configured_pipette.pipette_id)
+
+
+class ConfigureForVolume(
+    BaseCommand[ConfigureForVolumeParams, ConfigureForVolumeResult]
+):
+    """Configure for volume command model."""
+
+    commandType: ConfigureForVolumeCommandType = "configureForVolume"
+    params: ConfigureForVolumeParams
+    result: Optional[ConfigureForVolumeResult]
+
+    _ImplementationCls: Type[
+        ConfigureForVolumeImplementation
+    ] = ConfigureForVolumeImplementation
+
+
+class ConfigureForVolumeCreate(BaseCommandCreate[ConfigureForVolumeParams]):
+    """Configure for volume command creation request model."""
+
+    commandType: ConfigureForVolumeCommandType = "configureForVolume"
+    params: ConfigureForVolumeParams
+
+    _CommandCls: Type[ConfigureForVolume] = ConfigureForVolume

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -1,14 +1,19 @@
 """Configure for volume command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, Tuple
 from typing_extensions import Literal
 
 from .pipetting_common import (
     PipetteIdMixin,
     VolumeMixin,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import (
+    AbstractCommandWithPrivateResultImpl,
+    BaseCommand,
+    BaseCommandCreate,
+)
+from .configuring_common import PipetteConfigUpdateResultMixin
 
 if TYPE_CHECKING:
     from ..execution import EquipmentHandler
@@ -23,6 +28,12 @@ class ConfigureForVolumeParams(PipetteIdMixin, VolumeMixin):
     pass
 
 
+class ConfigureForVolumePrivateResult(PipetteConfigUpdateResultMixin):
+    """Result sent to the store but not serialized."""
+
+    pass
+
+
 class ConfigureForVolumeResult(BaseModel):
     """Result data from execution of an ConfigureForVolume command."""
 
@@ -33,7 +44,11 @@ class ConfigureForVolumeResult(BaseModel):
 
 
 class ConfigureForVolumeImplementation(
-    AbstractCommandImpl[ConfigureForVolumeParams, ConfigureForVolumeResult]
+    AbstractCommandWithPrivateResultImpl[
+        ConfigureForVolumeParams,
+        ConfigureForVolumeResult,
+        ConfigureForVolumePrivateResult,
+    ]
 ):
     """Configure for volume command implementation."""
 
@@ -42,14 +57,20 @@ class ConfigureForVolumeImplementation(
 
     async def execute(
         self, params: ConfigureForVolumeParams
-    ) -> ConfigureForVolumeResult:
+    ) -> Tuple[ConfigureForVolumeResult, ConfigureForVolumePrivateResult]:
         """Check that requested pipette can be configured for the given volume."""
-        configured_pipette = await self._equipment.configure_for_volume(
+        pipette_result = await self._equipment.configure_for_volume(
             pipette_id=params.pipetteId,
             volume=params.volume,
         )
 
-        return ConfigureForVolumeResult(pipetteId=configured_pipette.pipette_id)
+        return ConfigureForVolumeResult(
+            pipetteId=pipette_result.pipette_id
+        ), ConfigureForVolumePrivateResult(
+            pipette_id=pipette_result.pipette_id,
+            serial_number=pipette_result.serial_number,
+            config=pipette_result.static_config,
+        )
 
 
 class ConfigureForVolume(

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -1,12 +1,9 @@
 """Configure for volume command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from opentrons.types import MountType
-
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from .pipetting_common import (
     PipetteIdMixin,
     VolumeMixin,
@@ -23,16 +20,7 @@ ConfigureForVolumeCommandType = Literal["configureForVolume"]
 class ConfigureForVolumeParams(PipetteIdMixin, VolumeMixin):
     """Parameters required to configure volume for a specific pipette."""
 
-    # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
-    # https://opentrons.atlassian.net/browse/RLIQ-255
-    pipetteName: Union[PipetteNameType, Literal["p1000_96"]] = Field(
-        ...,
-        description="The load name of the pipette to be required.",
-    )
-    mount: MountType = Field(
-        ...,
-        description="The mount the pipette should be present on.",
-    )
+    pass
 
 
 class ConfigureForVolumeResult(BaseModel):
@@ -57,8 +45,6 @@ class ConfigureForVolumeImplementation(
     ) -> ConfigureForVolumeResult:
         """Check that requested pipette can be configured for the given volume."""
         configured_pipette = await self._equipment.configure_for_volume(
-            pipette_name=params.pipetteName,
-            mount=params.mount,
             pipette_id=params.pipetteId,
             volume=params.volume,
         )

--- a/api/src/opentrons/protocol_engine/commands/configuring_common.py
+++ b/api/src/opentrons/protocol_engine/commands/configuring_common.py
@@ -1,10 +1,11 @@
 """Common configuration command base models."""
 
-from pydantic import BaseModel
+from dataclasses import dataclass
 from ..resources import pipette_data_provider
 
 
-class PipetteConfigUpdateResultMixin(BaseModel):
+@dataclass
+class PipetteConfigUpdateResultMixin:
     """A mixin-suitable model for adding pipette config to results."""
 
     pipette_id: str

--- a/api/src/opentrons/protocol_engine/commands/configuring_common.py
+++ b/api/src/opentrons/protocol_engine/commands/configuring_common.py
@@ -1,0 +1,12 @@
+"""Common configuration command base models."""
+
+from pydantic import BaseModel
+from ..resources import pipette_data_provider
+
+
+class PipetteConfigUpdateResultMixin(BaseModel):
+    """A mixin-suitable model for adding pipette config to results."""
+
+    pipette_id: str
+    serial_number: str
+    config: pipette_data_provider.LoadedStaticPipetteData

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -1,19 +1,30 @@
 """Load pipette command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Type, Union, Tuple
 from typing_extensions import Literal
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import (
+    AbstractCommandWithPrivateResultImpl,
+    BaseCommand,
+    BaseCommandCreate,
+)
+from .configuring_common import PipetteConfigUpdateResultMixin
 
 if TYPE_CHECKING:
     from ..execution import EquipmentHandler
 
 
 LoadPipetteCommandType = Literal["loadPipette"]
+
+
+class LoadPipettePrivateResult(PipetteConfigUpdateResultMixin):
+    """The not-to-be-exposed results of a load pipette call."""
+
+    ...
 
 
 class LoadPipetteParams(BaseModel):
@@ -46,14 +57,18 @@ class LoadPipetteResult(BaseModel):
 
 
 class LoadPipetteImplementation(
-    AbstractCommandImpl[LoadPipetteParams, LoadPipetteResult]
+    AbstractCommandWithPrivateResultImpl[
+        LoadPipetteParams, LoadPipetteResult, LoadPipettePrivateResult
+    ]
 ):
     """Load pipette command implementation."""
 
     def __init__(self, equipment: EquipmentHandler, **kwargs: object) -> None:
         self._equipment = equipment
 
-    async def execute(self, params: LoadPipetteParams) -> LoadPipetteResult:
+    async def execute(
+        self, params: LoadPipetteParams
+    ) -> Tuple[LoadPipetteResult, LoadPipettePrivateResult]:
         """Check that requested pipette is attached and assign its identifier."""
         loaded_pipette = await self._equipment.load_pipette(
             pipette_name=params.pipetteName,
@@ -61,7 +76,13 @@ class LoadPipetteImplementation(
             pipette_id=params.pipetteId,
         )
 
-        return LoadPipetteResult(pipetteId=loaded_pipette.pipette_id)
+        return LoadPipetteResult(
+            pipetteId=loaded_pipette.pipette_id
+        ), LoadPipettePrivateResult(
+            pipette_id=loaded_pipette.pipette_id,
+            serial_number=loaded_pipette.serial_number,
+            config=loaded_pipette.static_config,
+        )
 
 
 class LoadPipette(BaseCommand[LoadPipetteParams, LoadPipetteResult]):

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -76,9 +76,9 @@ class LoadPipetteImplementation(
             pipette_id=params.pipetteId,
         )
 
-        return LoadPipetteResult(
+        return LoadPipetteResult.construct(
             pipetteId=loaded_pipette.pipette_id
-        ), LoadPipettePrivateResult(
+        ), LoadPipettePrivateResult.construct(
             pipette_id=loaded_pipette.pipette_id,
             serial_number=loaded_pipette.serial_number,
             config=loaded_pipette.static_config,

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -76,9 +76,9 @@ class LoadPipetteImplementation(
             pipette_id=params.pipetteId,
         )
 
-        return LoadPipetteResult.construct(
+        return LoadPipetteResult(
             pipetteId=loaded_pipette.pipette_id
-        ), LoadPipettePrivateResult.construct(
+        ), LoadPipettePrivateResult(
             pipette_id=loaded_pipette.pipette_id,
             serial_number=loaded_pipette.serial_number,
             config=loaded_pipette.static_config,

--- a/api/src/opentrons/protocol_engine/execution/__init__.py
+++ b/api/src/opentrons/protocol_engine/execution/__init__.py
@@ -7,6 +7,7 @@ from .equipment import (
     LoadedLabwareData,
     LoadedPipetteData,
     LoadedModuleData,
+    LoadedConfigureForVolumeData,
 )
 from .movement import MovementHandler
 from .gantry_mover import GantryMover
@@ -30,6 +31,7 @@ __all__ = [
     "LoadedLabwareData",
     "LoadedPipetteData",
     "LoadedModuleData",
+    "LoadedConfigureForVolumeData",
     "MovementHandler",
     "GantryMover",
     "PipettingHandler",

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -243,7 +243,7 @@ class EquipmentHandler:
                     pipette_name_value, pipette_id
                 )
             )
-        serial = serial_number or ''
+        serial = serial_number or ""
 
         return LoadedPipetteData(
             pipette_id=pipette_id,

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -351,8 +351,7 @@ class EquipmentHandler:
         """Ensure the requested volume can be configured for the given pipette.
 
         Args:
-            pipette_id: An optional identifier to assign the pipette. If None, an
-                identifier will be generated.
+            pipette_id: The identifier for the pipette.
             volume: The volume to configure the pipette for
 
         Returns:

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -243,10 +243,11 @@ class EquipmentHandler:
                     pipette_name_value, pipette_id
                 )
             )
+        serial = serial_number or ''
 
         return LoadedPipetteData(
             pipette_id=pipette_id,
-            serial_number=serial_number,
+            serial_number=serial,
             static_config=static_pipette_config,
         )
 

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -362,7 +362,7 @@ class EquipmentHandler:
         if not use_virtual_pipettes:
             mount = self._state_store.pipettes.get_mount(pipette_id).to_hw_mount()
 
-            self._hardware_api.configure_for_volume(mount, volume)
+            await self._hardware_api.configure_for_volume(mount, volume)
             pipette_dict = self._hardware_api.get_attached_instrument(mount)
 
             serial_number = pipette_dict["pipette_id"]

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -84,8 +84,22 @@ class VirtualPipetteDataProvider:
             pipette_model.pipette_channels,
             pipette_model.pipette_version,
         )
+        try:
+            tip_type = pip_types.PipetteTipType(
+                config.liquid_properties[liquid_class].max_volume
+            )
+        except ValueError:
+            tip_type = sorted(
+                [
+                    tip
+                    for tip in config.liquid_properties[
+                        liquid_class
+                    ].supported_tips.keys()
+                ],
+                key=lambda tt: tt.value,
+            )[0]
         tip_configuration = config.liquid_properties[liquid_class].supported_tips[
-            pip_types.PipetteTipType(config.liquid_properties[liquid_class].max_volume)
+            tip_type
         ]
         return LoadedStaticPipetteData(
             model=str(pipette_model),

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -2,13 +2,14 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from opentrons_shared_data.pipette.dev_types import PipetteName
+from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,
     types as pip_types,
     pipette_definition,
 )
+
 
 from opentrons.hardware_control.dev_types import PipetteDict
 
@@ -33,42 +34,91 @@ class LoadedStaticPipetteData:
     nominal_tip_overlap: Dict[str, float]
 
 
-def get_virtual_pipette_static_config(
-    pipette_name: PipetteName,
-    liquid_class: pip_types.LiquidClasses = pip_types.LiquidClasses.default,
-) -> LoadedStaticPipetteData:
-    """Get the config for a virtual pipette, given only the pipette name."""
-    pipette_model = pipette_load_name.convert_pipette_name(pipette_name)
-    config = load_pipette_data.load_definition(
-        pipette_model.pipette_type,
-        pipette_model.pipette_channels,
-        pipette_model.pipette_version,
-    )
+class VirtualPipetteDataProvider:
+    """Provide pipette data without requiring hardware control."""
 
-    tip_configuration = config.liquid_properties[liquid_class].supported_tips[
-        pip_types.PipetteTipType(config.liquid_properties[liquid_class].max_volume)
-    ]
-    return LoadedStaticPipetteData(
-        model=str(pipette_model),
-        display_name=config.display_name,
-        min_volume=config.liquid_properties[liquid_class].min_volume,
-        max_volume=config.liquid_properties[liquid_class].max_volume,
-        channels=config.channels,
-        home_position=config.mount_configurations.homePosition,
-        nozzle_offset_z=config.nozzle_offset[2],
-        tip_configuration_lookup_table={
-            k.value: v
-            for k, v in config.liquid_properties[liquid_class].supported_tips.items()
-        },
-        flow_rates=FlowRates(
-            default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
-            default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,
-            default_dispense=tip_configuration.default_dispense_flowrate.values_by_api_level,
-        ),
-        nominal_tip_overlap=config.liquid_properties[
-            liquid_class
-        ].tip_overlap_dictionary,
-    )
+    def __init__(self) -> None:
+        """Build a VirtualPipetteDataProvider."""
+        self._liquid_class_by_id: Dict[str, pip_types.LiquidClasses] = {}
+
+    def configure_virtual_pipette_for_volume(
+        self, pipette_id: str, volume: float, pipette_model_string: str
+    ) -> None:
+        """Emulate configure_for_volume with the same logic for changing modes."""
+        if pipette_id not in self._liquid_class_by_id:
+            self._liquid_class_by_id[pipette_id] = pip_types.LiquidClasses.default
+        pipette_model = pipette_load_name.convert_pipette_model(
+            PipetteModel(pipette_model_string)
+        )
+        config = load_pipette_data.load_definition(
+            pipette_model.pipette_type,
+            pipette_model.pipette_channels,
+            pipette_model.pipette_version,
+        )
+
+        liquid_class = pipette_definition.liquid_class_for_volume_between_default_and_defaultlowvolume(
+            volume, self._liquid_class_by_id[pipette_id], config.liquid_properties
+        )
+        self._liquid_class_by_id[pipette_id] = liquid_class
+
+    def get_virtual_pipette_static_config_by_model_string(
+        self, pipette_model_string: str, pipette_id: str
+    ) -> LoadedStaticPipetteData:
+        """Get the config of a pipette when you know its model string (e.g. from state)."""
+        pipette_model = pipette_load_name.convert_pipette_model(
+            PipetteModel(pipette_model_string)
+        )
+        return self._get_virtual_pipette_static_config_by_model(
+            pipette_model, pipette_id
+        )
+
+    def _get_virtual_pipette_static_config_by_model(
+        self, pipette_model: pipette_definition.PipetteModelVersionType, pipette_id: str
+    ) -> LoadedStaticPipetteData:
+        if pipette_id not in self._liquid_class_by_id:
+            self._liquid_class_by_id[pipette_id] = pip_types.LiquidClasses.default
+
+        liquid_class = self._liquid_class_by_id[pipette_id]
+        config = load_pipette_data.load_definition(
+            pipette_model.pipette_type,
+            pipette_model.pipette_channels,
+            pipette_model.pipette_version,
+        )
+        tip_configuration = config.liquid_properties[liquid_class].supported_tips[
+            pip_types.PipetteTipType(config.liquid_properties[liquid_class].max_volume)
+        ]
+        return LoadedStaticPipetteData(
+            model=str(pipette_model),
+            display_name=config.display_name,
+            min_volume=config.liquid_properties[liquid_class].min_volume,
+            max_volume=config.liquid_properties[liquid_class].max_volume,
+            channels=config.channels,
+            home_position=config.mount_configurations.homePosition,
+            nozzle_offset_z=config.nozzle_offset[2],
+            tip_configuration_lookup_table={
+                k.value: v
+                for k, v in config.liquid_properties[
+                    liquid_class
+                ].supported_tips.items()
+            },
+            flow_rates=FlowRates(
+                default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
+                default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,
+                default_dispense=tip_configuration.default_dispense_flowrate.values_by_api_level,
+            ),
+            nominal_tip_overlap=config.liquid_properties[
+                liquid_class
+            ].tip_overlap_dictionary,
+        )
+
+    def get_virtual_pipette_static_config(
+        self, pipette_name: PipetteName, pipette_id: str
+    ) -> LoadedStaticPipetteData:
+        """Get the config for a virtual pipette, given only the pipette name."""
+        pipette_model = pipette_load_name.convert_pipette_name(pipette_name)
+        return self._get_virtual_pipette_static_config_by_model(
+            pipette_model, pipette_id
+        )
 
 
 def get_pipette_static_config(pipette_dict: PipetteDict) -> LoadedStaticPipetteData:

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -35,6 +35,7 @@ class LoadedStaticPipetteData:
 
 def get_virtual_pipette_static_config(
     pipette_name: PipetteName,
+    liquid_class: pip_types.LiquidClasses = pip_types.LiquidClasses.default,
 ) -> LoadedStaticPipetteData:
     """Get the config for a virtual pipette, given only the pipette name."""
     pipette_model = pipette_load_name.convert_pipette_name(pipette_name)
@@ -44,9 +45,6 @@ def get_virtual_pipette_static_config(
         pipette_model.pipette_version,
     )
 
-    # TODO the liquid classes should be made configurable
-    # in a follow-up PR.
-    liquid_class = pip_types.LiquidClasses.default
     tip_configuration = config.liquid_properties[liquid_class].supported_tips[
         pip_types.PipetteTipType(config.liquid_properties[liquid_class].max_volume)
     ]

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -89,18 +89,13 @@ class VirtualPipetteDataProvider:
                 config.liquid_properties[liquid_class].max_volume
             )
         except ValueError:
-            tip_type = sorted(
-                [
-                    tip
-                    for tip in config.liquid_properties[
-                        liquid_class
-                    ].supported_tips.keys()
-                ],
-                key=lambda tt: tt.value,
-            )[0]
+            tip_type = pipette_definition.default_tip_for_liquid_class(
+                config.liquid_properties[liquid_class]
+            )
         tip_configuration = config.liquid_properties[liquid_class].supported_tips[
             tip_type
         ]
+
         return LoadedStaticPipetteData(
             model=str(pipette_model),
             display_name=config.display_name,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -187,6 +187,11 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                         attached_tip.volume
                     ]
                 except KeyError:
+                    # TODO(seth,9/11/2023): this is a bad way of doing defaults but better than max volume.
+                    # we used to look up a default tip config via the pipette max volume, but if that isn't
+                    # tip volume (as it isn't when we're in low-volume mode) then that lookup fails. Using
+                    # the first entry in the table is ok I guess but we really need to generally rethink how
+                    # we identify tip classes - looking things up by volume is not enough.
                     tip_configuration = list(
                         static_config.tip_configuration_lookup_table.values()
                     )[0]
@@ -203,6 +208,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             static_config = self._state.static_config_by_id.get(pipette_id)
             if static_config:
+                # TODO(seth,9/11/2023): bad way to do defaulting, see above.
                 tip_configuration = list(
                     static_config.tip_configuration_lookup_table.values()
                 )[0]

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -42,7 +42,6 @@ from ..actions import (
     SetPipetteMovementSpeedAction,
     UpdateCommandAction,
     AddPipetteConfigAction,
-    UpdateLiquidClassAction,
 )
 from .abstract_store import HasState, HandlesActions
 
@@ -120,21 +119,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SetPipetteMovementSpeedAction):
             self._state.movement_speed_by_id[action.pipette_id] = action.speed
         elif isinstance(action, AddPipetteConfigAction):
-            config = action.config
-            self._state.static_config_by_id[action.pipette_id] = StaticPipetteConfig(
-                serial_number=action.serial_number,
-                model=config.model,
-                display_name=config.display_name,
-                min_volume=config.min_volume,
-                max_volume=config.max_volume,
-                channels=config.channels,
-                tip_configuration_lookup_table=config.tip_configuration_lookup_table,
-                nominal_tip_overlap=config.nominal_tip_overlap,
-                home_position=config.home_position,
-                nozzle_offset_z=config.nozzle_offset_z,
-            )
-            self._state.flow_rates_by_id[action.pipette_id] = config.flow_rates
-        elif isinstance(action, UpdateLiquidClassAction):
             config = action.config
             self._state.static_config_by_id[action.pipette_id] = StaticPipetteConfig(
                 serial_number=action.serial_number,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -42,6 +42,7 @@ from ..actions import (
     SetPipetteMovementSpeedAction,
     UpdateCommandAction,
     AddPipetteConfigAction,
+    UpdateLiquidClassAction,
 )
 from .abstract_store import HasState, HandlesActions
 
@@ -119,6 +120,21 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SetPipetteMovementSpeedAction):
             self._state.movement_speed_by_id[action.pipette_id] = action.speed
         elif isinstance(action, AddPipetteConfigAction):
+            config = action.config
+            self._state.static_config_by_id[action.pipette_id] = StaticPipetteConfig(
+                serial_number=action.serial_number,
+                model=config.model,
+                display_name=config.display_name,
+                min_volume=config.min_volume,
+                max_volume=config.max_volume,
+                channels=config.channels,
+                tip_configuration_lookup_table=config.tip_configuration_lookup_table,
+                nominal_tip_overlap=config.nominal_tip_overlap,
+                home_position=config.home_position,
+                nozzle_offset_z=config.nozzle_offset_z,
+            )
+            self._state.flow_rates_by_id[action.pipette_id] = config.flow_rates
+        elif isinstance(action, UpdateLiquidClassAction):
             config = action.config
             self._state.static_config_by_id[action.pipette_id] = StaticPipetteConfig(
                 serial_number=action.serial_number,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -541,8 +541,9 @@ class PipetteView(HasState[PipetteState]):
         """Return the given pipette's return tip height scale."""
         max_volume = self.get_maximum_volume(pipette_id)
         working_volume = max_volume
-        if self.get_attached_tip(pipette_id):
-            working_volume = self.get_working_volume(pipette_id)
+        tip = self.get_attached_tip(pipette_id)
+        if tip:
+            working_volume = tip.volume
 
         if working_volume in self.get_config(pipette_id).tip_configuration_lookup_table:
             tip_lookup = self.get_config(pipette_id).tip_configuration_lookup_table[

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -36,12 +36,13 @@ from ..commands import (
     TouchTipResult,
     thermocycler,
     heater_shaker,
+    CommandPrivateResult,
 )
+from ..commands.configuring_common import PipetteConfigUpdateResultMixin
 from ..actions import (
     Action,
     SetPipetteMovementSpeedAction,
     UpdateCommandAction,
-    AddPipetteConfigAction,
 )
 from .abstract_store import HasState, HandlesActions
 
@@ -115,13 +116,22 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""
         if isinstance(action, UpdateCommandAction):
-            self._handle_command(action.command)
+            self._handle_command(action.command, action.private_result)
         elif isinstance(action, SetPipetteMovementSpeedAction):
             self._state.movement_speed_by_id[action.pipette_id] = action.speed
-        elif isinstance(action, AddPipetteConfigAction):
-            config = action.config
-            self._state.static_config_by_id[action.pipette_id] = StaticPipetteConfig(
-                serial_number=action.serial_number,
+
+    def _handle_command(  # noqa: C901
+        self, command: Command, private_result: CommandPrivateResult
+    ) -> None:
+        self._update_current_well(command)
+        self._update_deck_point(command)
+
+        if isinstance(private_result, PipetteConfigUpdateResultMixin):
+            config = private_result.config
+            self._state.static_config_by_id[
+                private_result.pipette_id
+            ] = StaticPipetteConfig(
+                serial_number=private_result.serial_number,
                 model=config.model,
                 display_name=config.display_name,
                 min_volume=config.min_volume,
@@ -132,11 +142,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 home_position=config.home_position,
                 nozzle_offset_z=config.nozzle_offset_z,
             )
-            self._state.flow_rates_by_id[action.pipette_id] = config.flow_rates
-
-    def _handle_command(self, command: Command) -> None:  # noqa: ANN101, C901
-        self._update_current_well(command)
-        self._update_deck_point(command)
+            self._state.flow_rates_by_id[private_result.pipette_id] = config.flow_rates
 
         if isinstance(command.result, LoadPipetteResult):
             pipette_id = command.result.pipetteId
@@ -181,9 +187,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                         attached_tip.volume
                     ]
                 except KeyError:
-                    tip_configuration = static_config.tip_configuration_lookup_table[
-                        static_config.max_volume
-                    ]
+                    tip_configuration = list(
+                        static_config.tip_configuration_lookup_table.values()
+                    )[0]
                 self._state.flow_rates_by_id[pipette_id] = FlowRates(
                     default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
                     default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,
@@ -197,9 +203,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             static_config = self._state.static_config_by_id.get(pipette_id)
             if static_config:
-                tip_configuration = static_config.tip_configuration_lookup_table[
-                    static_config.max_volume
-                ]
+                tip_configuration = list(
+                    static_config.tip_configuration_lookup_table.values()
+                )[0]
                 self._state.flow_rates_by_id[pipette_id] = FlowRates(
                     default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
                     default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -593,9 +593,10 @@ class LegacyCommandMapper:
             ),
             result=pe_commands.LoadPipetteResult.construct(pipetteId=pipette_id),
         )
-        pipette_config_result = pe_commands.LoadPipettePrivateResult.construct(
+        serial = instrument_load_info.pipette_dict.get('pipette_id', None) or ''
+        pipette_config_result = pe_commands.LoadPipettePrivateResult(
             pipette_id=pipette_id,
-            serial_number=instrument_load_info.pipette_dict["pipette_id"],
+            serial_number=serial,
             config=pipette_data_provider.get_pipette_static_config(
                 instrument_load_info.pipette_dict
             ),

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -593,7 +593,7 @@ class LegacyCommandMapper:
             ),
             result=pe_commands.LoadPipetteResult.construct(pipetteId=pipette_id),
         )
-        serial = instrument_load_info.pipette_dict.get('pipette_id', None) or ''
+        serial = instrument_load_info.pipette_dict.get("pipette_id", None) or ""
         pipette_config_result = pe_commands.LoadPipettePrivateResult(
             pipette_id=pipette_id,
             serial_number=serial,

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -124,14 +124,13 @@ class LegacyContextPlugin(AbstractPlugin):
     def _handle_equipment_loaded(self, load_info: LegacyLoadInfo) -> None:
         (
             pe_command,
-            pipette_config_action,
+            pe_private_result,
         ) = self._legacy_command_mapper.map_equipment_load(load_info=load_info)
 
-        if pipette_config_action:
-            self._actions_to_dispatch.put(pipette_config_action)
-
         self._actions_to_dispatch.put(
-            pe_actions.UpdateCommandAction(command=pe_command)
+            pe_actions.UpdateCommandAction(
+                command=pe_command, private_result=pe_private_result
+            )
         )
 
     async def _dispatch_all_actions(self) -> None:

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -430,7 +430,7 @@ async def test_configure_ot3(ot3_api_obj):
     mount = types.Mount.LEFT
     await hw_api.pick_up_tip(mount, 20.0)
     hw_api.set_working_volume(mount, 50)
-    await hw_api.set_liquid_class(mount, "default")
+    await hw_api.configure_for_volume(mount, 26)
     await hw_api.prepare_for_aspirate(mount)
     pos = await hw_api.current_position(mount)
     assert pos[Axis.B] == pytest.approx(71.5)

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -1,9 +1,6 @@
 """Test load pipette commands."""
 from decoy import Decoy
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-
-from opentrons.types import MountType
 from opentrons.protocol_engine.execution import (
     LoadedConfigureForVolumeData,
     EquipmentHandler,
@@ -24,16 +21,12 @@ async def test_configure_for_volume_implementation(
     subject = ConfigureForVolumeImplementation(equipment=equipment)
 
     data = ConfigureForVolumeParams(
-        pipetteName="p50_single_flex",
-        mount=MountType.LEFT,
         pipetteId="some id",
         volume=1,
     )
 
     decoy.when(
         await equipment.configure_for_volume(
-            pipette_name="p50_single_flex",
-            mount=MountType.LEFT,
             pipette_id="some id",
             volume=1,
         )

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -61,7 +61,7 @@ async def test_configure_for_volume_implementation(
 
     result, private_result = await subject.execute(data)
 
-    assert result == ConfigureForVolumeResult(pipetteId="pipette-id")
+    assert result == ConfigureForVolumeResult()
     assert private_result == ConfigureForVolumePrivateResult(
         pipette_id="pipette-id", serial_number="some number", config=config
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -1,0 +1,48 @@
+"""Test load pipette commands."""
+from decoy import Decoy
+
+from opentrons_shared_data.pipette.dev_types import PipetteNameType
+
+from opentrons.types import MountType
+from opentrons.protocol_engine.execution import (
+    LoadedConfigureForVolumeData,
+    EquipmentHandler,
+)
+
+from opentrons.protocol_engine.commands.configure_for_volume import (
+    ConfigureForVolumeParams,
+    ConfigureForVolumeResult,
+    ConfigureForVolumeImplementation,
+)
+
+
+async def test_configure_for_volume_implementation(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+) -> None:
+    """A ConfigureForVolume command should have an execution implementation."""
+    subject = ConfigureForVolumeImplementation(equipment=equipment)
+
+    data = ConfigureForVolumeParams(
+        pipetteName="p50_single_flex",
+        mount=MountType.LEFT,
+        pipetteId="some id",
+        volume=1,
+    )
+
+    decoy.when(
+        await equipment.configure_for_volume(
+            pipette_name="p50_single_flex",
+            mount=MountType.LEFT,
+            pipette_id="some id",
+            volume=1,
+        )
+    ).then_return(
+        LoadedConfigureForVolumeData(
+            pipette_id="pipette-id", serial_number="some number", volume=1
+        )
+    )
+
+    result = await subject.execute(data)
+
+    assert result == ConfigureForVolumeResult(pipetteId="pipette-id")

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -4,11 +4,16 @@ from decoy import Decoy
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
 from opentrons.types import MountType
+from opentrons.protocol_engine.types import FlowRates
 from opentrons.protocol_engine.execution import LoadedPipetteData, EquipmentHandler
+from opentrons.protocol_engine.resources.pipette_data_provider import (
+    LoadedStaticPipetteData,
+)
 
 from opentrons.protocol_engine.commands.load_pipette import (
     LoadPipetteParams,
     LoadPipetteResult,
+    LoadPipettePrivateResult,
     LoadPipetteImplementation,
 )
 
@@ -19,7 +24,20 @@ async def test_load_pipette_implementation(
 ) -> None:
     """A LoadPipette command should have an execution implementation."""
     subject = LoadPipetteImplementation(equipment=equipment)
-
+    config_data = LoadedStaticPipetteData(
+        model="some-model",
+        display_name="Hello",
+        min_volume=0,
+        max_volume=251,
+        channels=8,
+        home_position=123.1,
+        nozzle_offset_z=331.0,
+        flow_rates=FlowRates(
+            default_aspirate={}, default_dispense={}, default_blow_out={}
+        ),
+        tip_configuration_lookup_table={},
+        nominal_tip_overlap={},
+    )
     data = LoadPipetteParams(
         pipetteName=PipetteNameType.P300_SINGLE,
         mount=MountType.LEFT,
@@ -32,11 +50,20 @@ async def test_load_pipette_implementation(
             mount=MountType.LEFT,
             pipette_id="some id",
         )
-    ).then_return(LoadedPipetteData(pipette_id="pipette-id"))
+    ).then_return(
+        LoadedPipetteData(
+            pipette_id="some id",
+            serial_number="some-serial-number",
+            static_config=config_data,
+        )
+    )
 
-    result = await subject.execute(data)
+    result, private_result = await subject.execute(data)
 
-    assert result == LoadPipetteResult(pipetteId="pipette-id")
+    assert result == LoadPipetteResult(pipetteId="some id")
+    assert private_result == LoadPipettePrivateResult(
+        pipette_id="some id", serial_number="some-serial-number", config=config_data
+    )
 
 
 async def test_load_pipette_implementation_96_channel(
@@ -51,6 +78,20 @@ async def test_load_pipette_implementation_96_channel(
         mount=MountType.LEFT,
         pipetteId="some id",
     )
+    config_data = LoadedStaticPipetteData(
+        model="p1000_96_v3.3",
+        display_name="Hello",
+        min_volume=0,
+        max_volume=251,
+        channels=96,
+        home_position=123.1,
+        nozzle_offset_z=331.0,
+        flow_rates=FlowRates(
+            default_aspirate={}, default_dispense={}, default_blow_out={}
+        ),
+        tip_configuration_lookup_table={},
+        nominal_tip_overlap={},
+    )
 
     decoy.when(
         await equipment.load_pipette(
@@ -58,8 +99,15 @@ async def test_load_pipette_implementation_96_channel(
             mount=MountType.LEFT,
             pipette_id="some id",
         )
-    ).then_return(LoadedPipetteData(pipette_id="pipette-id"))
+    ).then_return(
+        LoadedPipetteData(
+            pipette_id="pipette-id", serial_number="some id", static_config=config_data
+        )
+    )
 
-    result = await subject.execute(data)
+    result, private_result = await subject.execute(data)
 
     assert result == LoadPipetteResult(pipetteId="pipette-id")
+    assert private_result == LoadPipettePrivateResult(
+        pipette_id="pipette-id", serial_number="some id", config=config_data
+    )

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -271,8 +271,12 @@ async def test_execute(
     await subject.execute("command-id")
 
     decoy.verify(
-        action_dispatcher.dispatch(UpdateCommandAction(command=running_command)),
-        action_dispatcher.dispatch(UpdateCommandAction(command=completed_command)),
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=running_command)
+        ),
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=completed_command)
+        ),
     )
 
 
@@ -392,7 +396,9 @@ async def test_execute_raises_protocol_engine_error(
     await subject.execute("command-id")
 
     decoy.verify(
-        action_dispatcher.dispatch(UpdateCommandAction(command=running_command)),
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=running_command)
+        ),
         action_dispatcher.dispatch(
             FailCommandAction(
                 command_id="command-id",

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -71,25 +71,10 @@ def _make_config(use_virtual_modules: bool) -> Config:
 def patch_mock_pipette_data_provider(
     decoy: Decoy,
     monkeypatch: pytest.MonkeyPatch,
-    virtual_pipette_data_provider: pipette_data_provider.VirtualPipetteDataProvider,
 ) -> None:
-    """Mock out move_types.py functions."""
+    """Mock out pipette_data_provider top level functions."""
     for name, func in inspect.getmembers(pipette_data_provider, inspect.isfunction):
         monkeypatch.setattr(pipette_data_provider, name, decoy.mock(func=func))
-    monkeypatch.setattr(
-        virtual_pipette_data_provider,
-        "get_virtual_pipette_static_config",
-        decoy.mock(
-            func=virtual_pipette_data_provider.get_virtual_pipette_static_config
-        ),
-    )
-    monkeypatch.setattr(
-        virtual_pipette_data_provider,
-        "get_virtual_pipette_static_config_by_model_string",
-        decoy.mock(
-            func=virtual_pipette_data_provider.get_virtual_pipette_static_config_by_model_string
-        ),
-    )
 
 
 @pytest.fixture
@@ -166,9 +151,11 @@ def loaded_static_pipette_data(
 
 
 @pytest.fixture
-def virtual_pipette_data_provider() -> pipette_data_provider.VirtualPipetteDataProvider:
+def virtual_pipette_data_provider(
+    decoy: Decoy,
+) -> pipette_data_provider.VirtualPipetteDataProvider:
     """Virtual pipette data provider."""
-    return pipette_data_provider.VirtualPipetteDataProvider()
+    return decoy.mock(cls=pipette_data_provider.VirtualPipetteDataProvider)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -22,7 +22,7 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.models import LabwareDefinition
 
 from opentrons.protocol_engine import errors
-from opentrons.protocol_engine.actions import ActionDispatcher, AddPipetteConfigAction
+from opentrons.protocol_engine.actions import ActionDispatcher
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     DeckType,
@@ -653,7 +653,11 @@ async def test_load_pipette(
         pipette_id=None,
     )
 
-    assert result == LoadedPipetteData(pipette_id="unique-id")
+    assert result == LoadedPipetteData(
+        pipette_id="unique-id",
+        serial_number="world",
+        static_config=loaded_static_pipette_data,
+    )
 
     decoy.verify(
         await hardware_api.cache_instruments(
@@ -661,13 +665,6 @@ async def test_load_pipette(
                 HwMount.LEFT: PipetteNameType.P300_SINGLE.value,
                 HwMount.RIGHT: PipetteNameType.P300_MULTI.value,
             }
-        ),
-        action_dispatcher.dispatch(
-            AddPipetteConfigAction(
-                pipette_id="unique-id",
-                serial_number="world",
-                config=loaded_static_pipette_data,
-            )
         ),
     )
 
@@ -703,17 +700,10 @@ async def test_load_pipette_96_channels(
         pipette_id=None,
     )
 
-    assert result == LoadedPipetteData(pipette_id="unique-id")
-
-    decoy.verify(
-        await hardware_api.cache_instruments({HwMount.LEFT: "p1000_96"}),
-        action_dispatcher.dispatch(
-            AddPipetteConfigAction(
-                pipette_id="unique-id",
-                serial_number="world",
-                config=loaded_static_pipette_data,
-            )
-        ),
+    assert result == LoadedPipetteData(
+        pipette_id="unique-id",
+        serial_number="world",
+        static_config=loaded_static_pipette_data,
     )
 
 
@@ -742,16 +732,10 @@ async def test_load_pipette_uses_provided_id(
         pipette_id="my-pipette-id",
     )
 
-    assert result == LoadedPipetteData(pipette_id="my-pipette-id")
-
-    decoy.verify(
-        action_dispatcher.dispatch(
-            AddPipetteConfigAction(
-                pipette_id="my-pipette-id",
-                serial_number="world",
-                config=loaded_static_pipette_data,
-            )
-        )
+    assert result == LoadedPipetteData(
+        pipette_id="my-pipette-id",
+        serial_number="world",
+        static_config=loaded_static_pipette_data,
     )
 
 
@@ -782,16 +766,10 @@ async def test_load_pipette_use_virtual(
         pipette_name=PipetteNameType.P300_SINGLE, mount=MountType.LEFT, pipette_id=None
     )
 
-    assert result == LoadedPipetteData(pipette_id="unique-id")
-
-    decoy.verify(
-        action_dispatcher.dispatch(
-            AddPipetteConfigAction(
-                pipette_id="unique-id",
-                serial_number="fake-serial",
-                config=loaded_static_pipette_data,
-            )
-        )
+    assert result == LoadedPipetteData(
+        pipette_id="unique-id",
+        serial_number="fake-serial",
+        static_config=loaded_static_pipette_data,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -1,4 +1,5 @@
 """Test pipette data provider."""
+import pytest
 from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
 from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 
@@ -6,15 +7,24 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_engine.types import FlowRates
 from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
+    VirtualPipetteDataProvider,
 )
 
 from opentrons.protocol_engine.resources import pipette_data_provider as subject
 
 
-def test_get_virtual_pipette_static_config() -> None:
+@pytest.fixture
+def subject_instance() -> VirtualPipetteDataProvider:
+    """Instance of a VirtualPipetteDataProvider for test."""
+    return VirtualPipetteDataProvider()
+
+
+def test_get_virtual_pipette_static_config(
+    subject_instance: VirtualPipetteDataProvider,
+) -> None:
     """It should return config data given a pipette name."""
-    result = subject.get_virtual_pipette_static_config(
-        PipetteNameType.P20_SINGLE_GEN2.value
+    result = subject_instance.get_virtual_pipette_static_config(
+        PipetteNameType.P20_SINGLE_GEN2.value, "some-id"
     )
 
     assert result == LoadedStaticPipetteData(

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -53,6 +53,78 @@ def test_get_virtual_pipette_static_config(
     )
 
 
+def test_configure_virtual_pipette_for_volume(
+    subject_instance: VirtualPipetteDataProvider,
+) -> None:
+    """It should return an updated config if the liquid class changes."""
+    result1 = subject_instance.get_virtual_pipette_static_config(
+        PipetteNameType.P50_SINGLE_FLEX.value, "my-pipette"
+    )
+    assert result1 == LoadedStaticPipetteData(
+        model="p50_single_v3.0",
+        display_name="Flex 1-Channel 50 μL",
+        min_volume=5,
+        max_volume=50.0,
+        channels=1,
+        nozzle_offset_z=-259.15,
+        home_position=230.15,
+        flow_rates=FlowRates(
+            default_blow_out={"2.14": 4.0},
+            default_aspirate={"2.14": 8.0},
+            default_dispense={"2.14": 8.0},
+        ),
+        tip_configuration_lookup_table=result1.tip_configuration_lookup_table,
+        nominal_tip_overlap=result1.nominal_tip_overlap,
+    )
+    subject_instance.configure_virtual_pipette_for_volume(
+        "my-pipette", 1, result1.model
+    )
+    result2 = subject_instance.get_virtual_pipette_static_config(
+        PipetteNameType.P50_SINGLE_FLEX.value, "my-pipette"
+    )
+    assert result2 == LoadedStaticPipetteData(
+        model="p50_single_v3.0",
+        display_name="Flex 1-Channel 50 μL",
+        min_volume=0.5,
+        max_volume=5.0,
+        channels=1,
+        nozzle_offset_z=-259.15,
+        home_position=230.15,
+        flow_rates=FlowRates(
+            default_blow_out={"2.14": 4.0},
+            default_aspirate={"2.14": 8.0},
+            default_dispense={"2.14": 8.0},
+        ),
+        tip_configuration_lookup_table=result2.tip_configuration_lookup_table,
+        nominal_tip_overlap=result2.nominal_tip_overlap,
+    )
+
+
+def test_load_virtual_pipette_by_model_string(
+    subject_instance: VirtualPipetteDataProvider,
+) -> None:
+    """It should return config data given a pipette model."""
+    result = subject_instance.get_virtual_pipette_static_config_by_model_string(
+        "p300_multi_v2.1", "my-pipette"
+    )
+    assert result == LoadedStaticPipetteData(
+        model="p300_multi_v2.1",
+        display_name="P300 8-Channel GEN2",
+        min_volume=20.0,
+        max_volume=300,
+        channels=8,
+        nozzle_offset_z=35.52,
+        home_position=155.75,
+        flow_rates=FlowRates(
+            default_blow_out={"2.0": 94.0},
+            default_aspirate={"2.0": 94.0},
+            default_dispense={"2.0": 94.0},
+        ),
+        tip_configuration_lookup_table=result.tip_configuration_lookup_table,
+        nominal_tip_overlap=result.nominal_tip_overlap,
+    )
+
+
 def test_get_pipette_static_config(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -282,9 +282,11 @@ def test_command_queue_and_unqueue() -> None:
         command_id="command-id-2",
     )
     update_1 = UpdateCommandAction(
+        private_result=None,
         command=create_running_command(command_id="command-id-1"),
     )
     update_2 = UpdateCommandAction(
+        private_result=None,
         command=create_running_command(command_id="command-id-2"),
     )
 
@@ -326,9 +328,11 @@ def test_setup_command_queue_and_unqueue() -> None:
         command_id="command-id-2",
     )
     update_1 = UpdateCommandAction(
+        private_result=None,
         command=create_running_command(command_id="command-id-1"),
     )
     update_2 = UpdateCommandAction(
+        private_result=None,
         command=create_running_command(command_id="command-id-2"),
     )
 
@@ -388,9 +392,11 @@ def test_running_command_id() -> None:
         command_id="command-id-1",
     )
     running_update = UpdateCommandAction(
+        private_result=None,
         command=create_running_command(command_id="command-id-1"),
     )
     completed_update = UpdateCommandAction(
+        private_result=None,
         command=create_succeeded_command(command_id="command-id-1"),
     )
 
@@ -409,9 +415,11 @@ def test_running_command_id() -> None:
 def test_running_command_no_queue() -> None:
     """It should add a running command to state, even if there was no queue action."""
     running_update = UpdateCommandAction(
+        private_result=None,
         command=create_running_command(command_id="command-id-1"),
     )
     completed_update = UpdateCommandAction(
+        private_result=None,
         command=create_succeeded_command(command_id="command-id-1"),
     )
 
@@ -445,6 +453,7 @@ def test_command_failure_clears_queues() -> None:
         command_id="command-id-2",
     )
     running_1 = UpdateCommandAction(
+        private_result=None,
         command=commands.WaitForResume(
             id="command-id-1",
             key="command-key-1",
@@ -452,7 +461,7 @@ def test_command_failure_clears_queues() -> None:
             startedAt=datetime(year=2022, month=2, day=2),
             params=commands.WaitForResumeParams(),
             status=commands.CommandStatus.RUNNING,
-        )
+        ),
     )
     fail_1 = FailCommandAction(
         command_id="command-id-1",
@@ -546,6 +555,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
     )
 
     running_cmd_2 = UpdateCommandAction(
+        private_result=None,
         command=commands.WaitForResume(
             id="command-id-2",
             key="command-key-2",
@@ -554,7 +564,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
             params=commands.WaitForResumeParams(),
             status=commands.CommandStatus.RUNNING,
             intent=commands.CommandIntent.SETUP,
-        )
+        ),
     )
     failed_action_cmd_2 = FailCommandAction(
         command_id="command-id-2",
@@ -622,20 +632,20 @@ def test_command_store_preserves_handle_order() -> None:
 
     subject = CommandStore(is_door_open=False, config=_make_config())
 
-    subject.handle_action(UpdateCommandAction(command=command_a))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command_a))
     assert subject.state.all_command_ids == ["command-id-1"]
     assert subject.state.commands_by_id == {
         "command-id-1": CommandEntry(index=0, command=command_a),
     }
 
-    subject.handle_action(UpdateCommandAction(command=command_b))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command_b))
     assert subject.state.all_command_ids == ["command-id-1", "command-id-2"]
     assert subject.state.commands_by_id == {
         "command-id-1": CommandEntry(index=0, command=command_a),
         "command-id-2": CommandEntry(index=1, command=command_b),
     }
 
-    subject.handle_action(UpdateCommandAction(command=command_c))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command_c))
     assert subject.state.all_command_ids == ["command-id-1", "command-id-2"]
     assert subject.state.commands_by_id == {
         "command-id-1": CommandEntry(index=0, command=command_c),
@@ -1036,7 +1046,7 @@ def test_command_store_handles_command_failed() -> None:
     )
 
     subject = CommandStore(is_door_open=False, config=_make_config())
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
     subject.handle_action(
         FailCommandAction(
             command_id="command-id",

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store.py
@@ -148,7 +148,7 @@ def test_handles_load_labware(
             created_at=datetime(year=2021, month=1, day=2),
         )
     )
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     assert subject.state.labware_by_id["test-labware-id"] == expected_labware_data
 
@@ -195,7 +195,9 @@ def test_handles_move_labware(
             created_at=datetime(year=2021, month=1, day=2),
         )
     )
-    subject.handle_action(UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     move_command = create_move_labware_command(
         labware_id="my-labware-id",
@@ -203,7 +205,9 @@ def test_handles_move_labware(
         offset_id="my-new-offset",
         strategy=LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE,
     )
-    subject.handle_action(UpdateCommandAction(command=move_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_command)
+    )
 
     assert subject.state.labware_by_id["my-labware-id"].location == DeckSlotLocation(
         slotName=DeckSlotName.SLOT_4
@@ -235,13 +239,17 @@ def test_handles_move_labware_off_deck(
             created_at=datetime(year=2021, month=1, day=2),
         )
     )
-    subject.handle_action(UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     move_labware_off_deck_cmd = create_move_labware_command(
         labware_id="my-labware-id",
         new_location=OFF_DECK_LOCATION,
         strategy=LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE,
     )
-    subject.handle_action(UpdateCommandAction(command=move_labware_off_deck_cmd))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_labware_off_deck_cmd)
+    )
     assert subject.state.labware_by_id["my-labware-id"].location == OFF_DECK_LOCATION
     assert subject.state.labware_by_id["my-labware-id"].offsetId is None

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -130,6 +130,7 @@ def test_load_module(
 ) -> None:
     """It should handle a successful LoadModule command."""
     action = actions.UpdateCommandAction(
+        private_result=None,
         command=commands.LoadModule.construct(  # type: ignore[call-arg]
             params=commands.LoadModuleParams(
                 model=params_model,
@@ -141,7 +142,7 @@ def test_load_module(
                 serialNumber="serial-number",
                 definition=module_definition,
             ),
-        )
+        ),
     )
 
     subject = ModuleStore()
@@ -271,8 +272,12 @@ def test_handle_hs_temperature_commands(heater_shaker_v1_def: ModuleDefinition) 
     )
     subject = ModuleStore()
 
-    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
-    subject.handle_action(actions.UpdateCommandAction(command=set_temp_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_module_cmd)
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=set_temp_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -281,7 +286,9 @@ def test_handle_hs_temperature_commands(heater_shaker_v1_def: ModuleDefinition) 
             plate_target_temperature=42,
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=deactivate_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=deactivate_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -316,8 +323,12 @@ def test_handle_hs_shake_commands(heater_shaker_v1_def: ModuleDefinition) -> Non
     )
     subject = ModuleStore()
 
-    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
-    subject.handle_action(actions.UpdateCommandAction(command=set_shake_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_module_cmd)
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=set_shake_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -326,7 +337,9 @@ def test_handle_hs_shake_commands(heater_shaker_v1_def: ModuleDefinition) -> Non
             plate_target_temperature=None,
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=deactivate_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=deactivate_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -363,7 +376,9 @@ def test_handle_hs_labware_latch_commands(
     )
     subject = ModuleStore()
 
-    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_module_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -373,7 +388,9 @@ def test_handle_hs_labware_latch_commands(
         )
     }
 
-    subject.handle_action(actions.UpdateCommandAction(command=close_latch_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=close_latch_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -382,7 +399,9 @@ def test_handle_hs_labware_latch_commands(
             plate_target_temperature=None,
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=open_latch_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=open_latch_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -421,14 +440,20 @@ def test_handle_tempdeck_temperature_commands(
     )
     subject = ModuleStore()
 
-    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
-    subject.handle_action(actions.UpdateCommandAction(command=set_temp_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_module_cmd)
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=set_temp_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": TemperatureModuleSubState(
             module_id=TemperatureModuleId("module-id"), plate_target_temperature=42
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=deactivate_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=deactivate_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": TemperatureModuleSubState(
             module_id=TemperatureModuleId("module-id"), plate_target_temperature=None
@@ -474,8 +499,12 @@ def test_handle_thermocycler_temperature_commands(
     )
     subject = ModuleStore()
 
-    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
-    subject.handle_action(actions.UpdateCommandAction(command=set_block_temp_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_module_cmd)
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=set_block_temp_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -484,7 +513,9 @@ def test_handle_thermocycler_temperature_commands(
             target_lid_temperature=None,
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=set_lid_temp_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=set_lid_temp_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -493,7 +524,9 @@ def test_handle_thermocycler_temperature_commands(
             target_lid_temperature=35.3,
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=deactivate_lid_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=deactivate_lid_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -502,7 +535,9 @@ def test_handle_thermocycler_temperature_commands(
             target_lid_temperature=None,
         )
     }
-    subject.handle_action(actions.UpdateCommandAction(command=deactivate_block_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=deactivate_block_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -541,8 +576,12 @@ def test_handle_thermocycler_lid_commands(
 
     subject = ModuleStore()
 
-    subject.handle_action(actions.UpdateCommandAction(command=load_module_cmd))
-    subject.handle_action(actions.UpdateCommandAction(command=open_lid_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_module_cmd)
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=open_lid_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -552,7 +591,9 @@ def test_handle_thermocycler_lid_commands(
         )
     }
 
-    subject.handle_action(actions.UpdateCommandAction(command=close_lid_cmd))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=close_lid_cmd)
+    )
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -21,7 +21,6 @@ from opentrons.protocol_engine.types import (
 from opentrons.protocol_engine.actions import (
     SetPipetteMovementSpeedAction,
     UpdateCommandAction,
-    AddPipetteConfigAction,
 )
 from opentrons.protocol_engine.state.pipettes import (
     PipetteStore,
@@ -80,7 +79,7 @@ def test_handles_load_pipette(subject: PipetteStore) -> None:
         mount=MountType.LEFT,
     )
 
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     result = subject.state
 
@@ -110,14 +109,20 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
         pipette_id="abc",
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=pick_up_tip_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=pick_up_tip_command)
+    )
     assert subject.state.attached_tip_by_id["abc"] == TipGeometry(
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.aspirated_volume_by_id["abc"] == 0
 
-    subject.handle_action(UpdateCommandAction(command=drop_tip_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=drop_tip_command)
+    )
     assert subject.state.attached_tip_by_id["abc"] is None
     assert subject.state.aspirated_volume_by_id["abc"] is None
 
@@ -138,14 +143,20 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
         pipette_id="xyz",
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=pick_up_tip_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=pick_up_tip_command)
+    )
     assert subject.state.attached_tip_by_id["xyz"] == TipGeometry(
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.aspirated_volume_by_id["xyz"] == 0
 
-    subject.handle_action(UpdateCommandAction(command=drop_tip_in_place_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=drop_tip_in_place_command)
+    )
     assert subject.state.attached_tip_by_id["xyz"] is None
     assert subject.state.aspirated_volume_by_id["xyz"] is None
 
@@ -163,12 +174,18 @@ def test_pipette_volume_adds_aspirate(subject: PipetteStore) -> None:
         flow_rate=1.23,
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_command))
-    subject.handle_action(UpdateCommandAction(command=aspirate_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=aspirate_command)
+    )
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 42
 
-    subject.handle_action(UpdateCommandAction(command=aspirate_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=aspirate_command)
+    )
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 84
 
@@ -182,7 +199,7 @@ def test_handles_blow_out(subject: PipetteStore) -> None:
         flow_rate=1.23,
     )
 
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     result = subject.state
 
@@ -221,17 +238,27 @@ def test_pipette_volume_subtracts_dispense(
         flow_rate=1.23,
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_command))
-    subject.handle_action(UpdateCommandAction(command=aspirate_command))
-    subject.handle_action(UpdateCommandAction(command=dispense_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=aspirate_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=dispense_command)
+    )
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 21
 
-    subject.handle_action(UpdateCommandAction(command=dispense_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=dispense_command)
+    )
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 0
 
-    subject.handle_action(UpdateCommandAction(command=dispense_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=dispense_command)
+    )
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 0
 
@@ -330,8 +357,10 @@ def test_movement_commands_update_current_well(
         mount=MountType.LEFT,
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     assert subject.state.current_well == expected_location
 
@@ -412,9 +441,13 @@ def test_movement_commands_without_well_clear_current_well(
         well_name="well-name",
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=move_command))
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_command)
+    )
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     assert subject.state.current_well is None
 
@@ -461,9 +494,13 @@ def test_heater_shaker_command_without_movement(
         destination=DeckPoint(x=1, y=2, z=3),
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=move_command))
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_command)
+    )
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     assert subject.state.current_well == CurrentWell(
         pipette_id="pipette-id",
@@ -568,10 +605,16 @@ def test_move_labware_clears_current_well(
         well_name="well-name",
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=move_to_well_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_to_well_command)
+    )
 
-    subject.handle_action(UpdateCommandAction(command=move_labware_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_labware_command)
+    )
     assert subject.state.current_well == expected_current_well
 
 
@@ -583,7 +626,9 @@ def test_set_movement_speed(subject: PipetteStore) -> None:
         pipette_name=PipetteNameType.P300_SINGLE,
         mount=MountType.LEFT,
     )
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
     subject.handle_action(
         SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=123.456)
     )
@@ -594,28 +639,35 @@ def test_add_pipette_config(
     subject: PipetteStore,
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
 ) -> None:
-    """It should issue an action to add a pipette config."""
-    subject.handle_action(
-        AddPipetteConfigAction(
-            pipette_id="pipette-id",
-            serial_number="pipette-serial",
-            config=LoadedStaticPipetteData(
-                model="pipette-model",
-                display_name="pipette name",
-                min_volume=1.23,
-                max_volume=4.56,
-                channels=7,
-                flow_rates=FlowRates(
-                    default_aspirate={"a": 1},
-                    default_dispense={"b": 2},
-                    default_blow_out={"c": 3},
-                ),
-                tip_configuration_lookup_table={4: supported_tip_fixture},
-                nominal_tip_overlap={"default": 5},
-                home_position=8.9,
-                nozzle_offset_z=10.11,
+    """It should update state from any pipette config private result."""
+    command = cmd.LoadPipette.construct(  # type: ignore[call-arg]
+        params=cmd.LoadPipetteParams.construct(
+            mount=MountType.LEFT, pipetteName="p300_single"  # type: ignore[arg-type]
+        ),
+        result=cmd.LoadPipetteResult(pipetteId="pipette-id"),
+    )
+    private_result = cmd.LoadPipettePrivateResult(
+        pipette_id="pipette-id",
+        serial_number="pipette-serial",
+        config=LoadedStaticPipetteData(
+            model="pipette-model",
+            display_name="pipette name",
+            min_volume=1.23,
+            max_volume=4.56,
+            channels=7,
+            flow_rates=FlowRates(
+                default_aspirate={"a": 1},
+                default_dispense={"b": 2},
+                default_blow_out={"c": 3},
             ),
-        )
+            tip_configuration_lookup_table={4: supported_tip_fixture},
+            nominal_tip_overlap={"default": 5},
+            home_position=8.9,
+            nozzle_offset_z=10.11,
+        ),
+    )
+    subject.handle_action(
+        UpdateCommandAction(command=command, private_result=private_result)
     )
 
     assert subject.state.static_config_by_id["pipette-id"] == StaticPipetteConfig(
@@ -630,11 +682,9 @@ def test_add_pipette_config(
         home_position=8.9,
         nozzle_offset_z=10.11,
     )
-    assert subject.state.flow_rates_by_id["pipette-id"] == FlowRates(
-        default_aspirate={"a": 1},
-        default_dispense={"b": 2},
-        default_blow_out={"c": 3},
-    )
+    assert subject.state.flow_rates_by_id["pipette-id"].default_aspirate == {"a": 1.0}
+    assert subject.state.flow_rates_by_id["pipette-id"].default_dispense == {"b": 2.0}
+    assert subject.state.flow_rates_by_id["pipette-id"].default_blow_out == {"c": 3.0}
 
 
 @pytest.mark.parametrize(
@@ -708,8 +758,10 @@ def test_movement_commands_update_deck_point(
         mount=MountType.LEFT,
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     assert subject.state.current_deck_point == CurrentDeckPoint(
         mount=MountType.LEFT, deck_point=DeckPoint(x=11, y=22, z=33)
@@ -787,14 +839,18 @@ def test_homing_commands_clear_deck_point(
         destination=DeckPoint(x=1, y=2, z=3),
     )
 
-    subject.handle_action(UpdateCommandAction(command=load_pipette_command))
-    subject.handle_action(UpdateCommandAction(command=move_command))
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        UpdateCommandAction(private_result=None, command=move_command)
+    )
 
     assert subject.state.current_deck_point == CurrentDeckPoint(
         mount=MountType.LEFT, deck_point=DeckPoint(x=1, y=2, z=3)
     )
 
-    subject.handle_action(UpdateCommandAction(command=command))
+    subject.handle_action(UpdateCommandAction(private_result=None, command=command))
 
     assert subject.state.current_deck_point == CurrentDeckPoint(
         mount=None, deck_point=None

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -107,7 +107,9 @@ def test_get_next_tip_returns_none(
     load_labware_command: commands.LoadLabware, subject: TipStore
 ) -> None:
     """It should start at the first tip in the labware."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -123,7 +125,9 @@ def test_get_next_tip_returns_first_tip(
     load_labware_command: commands.LoadLabware, subject: TipStore, input_tip_amount: int
 ) -> None:
     """It should start at the first tip in the labware."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -142,7 +146,9 @@ def test_get_next_tip_used_starting_tip(
     result_well_name: str,
 ) -> None:
     """It should start searching at the given starting tip."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -178,30 +184,40 @@ def test_get_next_tip_skips_picked_up_tip(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
 ) -> None:
     """It should get the next tip in the column if one has been picked up."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
     subject.handle_action(
-        actions.AddPipetteConfigAction(
-            pipette_id="pipette-id",
-            serial_number="pipette-serial",
-            config=LoadedStaticPipetteData(
-                channels=input_tip_amount,
-                max_volume=15,
-                min_volume=3,
-                model="gen a",
-                display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
-                nozzle_offset_z=1.23,
-                home_position=4.56,
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
+    load_pipette_command = commands.LoadPipette.construct(  # type: ignore[call-arg]
+        result=commands.LoadPipetteResult(pipetteId="pipette-id")
+    )
+    load_pipette_private_result = commands.LoadPipettePrivateResult(
+        pipette_id="pipette-id",
+        serial_number="pipette-serial",
+        config=LoadedStaticPipetteData(
+            channels=input_tip_amount,
+            max_volume=15,
+            min_volume=3,
+            model="gen a",
+            display_name="display name",
+            flow_rates=FlowRates(
+                default_aspirate={},
+                default_dispense={},
+                default_blow_out={},
             ),
+            tip_configuration_lookup_table={15: supported_tip_fixture},
+            nominal_tip_overlap={},
+            nozzle_offset_z=1.23,
+            home_position=4.56,
+        ),
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(
+            private_result=load_pipette_private_result, command=load_pipette_command
         )
     )
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(command=pick_up_tip_command, private_result=None)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -217,7 +233,9 @@ def test_get_next_tip_with_starting_tip(
     load_labware_command: commands.LoadLabware,
 ) -> None:
     """It should return the starting tip, and then the following tip after that."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -238,7 +256,9 @@ def test_get_next_tip_with_starting_tip(
         ),
     )
 
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=pick_up_tip)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -254,7 +274,9 @@ def test_get_next_tip_with_starting_tip_8_channel(
     load_labware_command: commands.LoadLabware,
 ) -> None:
     """It should return the starting tip, and then the following tip after that."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -275,7 +297,9 @@ def test_get_next_tip_with_starting_tip_8_channel(
         ),
     )
 
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=pick_up_tip)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -291,7 +315,9 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
     load_labware_command: commands.LoadLabware,
 ) -> None:
     """It should return the starting tip of H12 and then None after that."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -312,7 +338,9 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
         ),
     )
 
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=pick_up_tip)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -328,7 +356,9 @@ def test_get_next_tip_with_column_and_starting_tip(
     load_labware_command: commands.LoadLabware,
 ) -> None:
     """It should return the first tip in a column, taking starting tip into account."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(subject.state).get_next_tip(
         labware_id="cool-labware",
@@ -346,30 +376,42 @@ def test_reset_tips(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
 ) -> None:
     """It should be able to reset tip tracking state."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
     subject.handle_action(
-        actions.AddPipetteConfigAction(
-            pipette_id="pipette-id",
-            serial_number="pipette-serial",
-            config=LoadedStaticPipetteData(
-                channels=8,
-                max_volume=15,
-                min_volume=3,
-                model="gen a",
-                display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
-                nozzle_offset_z=1.23,
-                home_position=4.56,
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
+    load_pipette_command = commands.LoadPipette.construct(  # type: ignore[call-arg]
+        result=commands.LoadPipetteResult(pipetteId="pipette-id")
+    )
+    load_pipette_private_result = commands.LoadPipettePrivateResult(
+        pipette_id="pipette-id",
+        serial_number="pipette-serial",
+        config=LoadedStaticPipetteData(
+            channels=8,
+            max_volume=15,
+            min_volume=3,
+            model="gen a",
+            display_name="display name",
+            flow_rates=FlowRates(
+                default_aspirate={},
+                default_dispense={},
+                default_blow_out={},
             ),
+            tip_configuration_lookup_table={15: supported_tip_fixture},
+            nominal_tip_overlap={},
+            nozzle_offset_z=1.23,
+            home_position=4.56,
+        ),
+    )
+
+    subject.handle_action(
+        actions.UpdateCommandAction(
+            private_result=load_pipette_private_result, command=load_pipette_command
         )
     )
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=pick_up_tip_command)
+    )
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
 
     result = TipView(subject.state).get_next_tip(
@@ -385,26 +427,32 @@ def test_handle_pipette_config_action(
     subject: TipStore, supported_tip_fixture: pipette_definition.SupportedTipsDefinition
 ) -> None:
     """Should add pipette channel to state."""
-    subject.handle_action(
-        actions.AddPipetteConfigAction(
-            pipette_id="pipette-id",
-            serial_number="pipette-serial",
-            config=LoadedStaticPipetteData(
-                channels=8,
-                max_volume=15,
-                min_volume=3,
-                model="gen a",
-                display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
-                nozzle_offset_z=1.23,
-                home_position=4.56,
+    load_pipette_command = commands.LoadPipette.construct(  # type: ignore[call-arg]
+        result=commands.LoadPipetteResult(pipetteId="pipette-id")
+    )
+    load_pipette_private_result = commands.LoadPipettePrivateResult(
+        pipette_id="pipette-id",
+        serial_number="pipette-serial",
+        config=LoadedStaticPipetteData(
+            channels=8,
+            max_volume=15,
+            min_volume=3,
+            model="gen a",
+            display_name="display name",
+            flow_rates=FlowRates(
+                default_aspirate={},
+                default_dispense={},
+                default_blow_out={},
             ),
+            tip_configuration_lookup_table={15: supported_tip_fixture},
+            nominal_tip_overlap={},
+            nozzle_offset_z=1.23,
+            home_position=4.56,
+        ),
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(
+            private_result=load_pipette_private_result, command=load_pipette_command
         )
     )
 
@@ -424,7 +472,9 @@ def test_has_tip_not_tip_rack(
     load_labware_command: commands.LoadLabware, subject: TipStore
 ) -> None:
     """It should return False if labware isn't a tip rack."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(state=subject.state).has_clean_tip("cool-labware", "A1")
 
@@ -435,7 +485,9 @@ def test_has_tip_tip_rack(
     load_labware_command: commands.LoadLabware, subject: TipStore
 ) -> None:
     """It should return False if labware isn't a tip rack."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
 
     result = TipView(state=subject.state).has_clean_tip("cool-labware", "A1")
 
@@ -451,43 +503,60 @@ def test_drop_tip(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
 ) -> None:
     """It should be clear tip length when a tip is dropped."""
-    subject.handle_action(actions.UpdateCommandAction(command=load_labware_command))
     subject.handle_action(
-        actions.AddPipetteConfigAction(
-            pipette_id="pipette-id",
-            serial_number="pipette-serial",
-            config=LoadedStaticPipetteData(
-                channels=8,
-                max_volume=15,
-                min_volume=3,
-                model="gen a",
-                display_name="display name",
-                flow_rates=FlowRates(
-                    default_aspirate={},
-                    default_dispense={},
-                    default_blow_out={},
-                ),
-                tip_configuration_lookup_table={15: supported_tip_fixture},
-                nominal_tip_overlap={},
-                nozzle_offset_z=1.23,
-                home_position=4.56,
+        actions.UpdateCommandAction(private_result=None, command=load_labware_command)
+    )
+    load_pipette_command = commands.LoadPipette.construct(  # type: ignore[call-arg]
+        result=commands.LoadPipetteResult(pipetteId="pipette-id")
+    )
+    load_pipette_private_result = commands.LoadPipettePrivateResult(
+        pipette_id="pipette-id",
+        serial_number="pipette-serial",
+        config=LoadedStaticPipetteData(
+            channels=8,
+            max_volume=15,
+            min_volume=3,
+            model="gen a",
+            display_name="display name",
+            flow_rates=FlowRates(
+                default_aspirate={},
+                default_dispense={},
+                default_blow_out={},
             ),
+            tip_configuration_lookup_table={15: supported_tip_fixture},
+            nominal_tip_overlap={},
+            nozzle_offset_z=1.23,
+            home_position=4.56,
+        ),
+    )
+    subject.handle_action(
+        actions.UpdateCommandAction(
+            private_result=load_pipette_private_result, command=load_pipette_command
         )
     )
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=pick_up_tip_command)
+    )
     result = TipView(subject.state).get_tip_length("pipette-id")
     assert result == 1.23
 
-    subject.handle_action(actions.UpdateCommandAction(command=drop_tip_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=drop_tip_command)
+    )
     result = TipView(subject.state).get_tip_length("pipette-id")
     assert result == 0
 
-    subject.handle_action(actions.UpdateCommandAction(command=pick_up_tip_command))
+    subject.handle_action(
+        actions.UpdateCommandAction(private_result=None, command=pick_up_tip_command)
+    )
     result = TipView(subject.state).get_tip_length("pipette-id")
     assert result == 1.23
 
     subject.handle_action(
-        actions.UpdateCommandAction(command=drop_tip_in_place_command)
+        actions.UpdateCommandAction(
+            private_result=None, command=drop_tip_in_place_command
+        )
     )
     result = TipView(subject.state).get_tip_length("pipette-id")
     assert result == 0

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -324,7 +324,7 @@ def test_map_instrument_load(decoy: Decoy) -> None:
         ),
         result=pe_commands.LoadPipetteResult.construct(pipetteId=pipette_id_captor),
     )
-    assert result[1] == pe_commands.LoadPipettePrivateResult.construct(
+    assert result[1] == pe_commands.LoadPipettePrivateResult(
         pipette_id="pipette-0",
         serial_number="fizzbuzz",
         config=pipette_config,

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -70,7 +70,8 @@ def test_map_before_command() -> None:
 
     assert result == [
         pe_actions.UpdateCommandAction(
-            pe_commands.Custom.construct(
+            private_result=None,
+            command=pe_commands.Custom.construct(
                 id="command.COMMENT-0",
                 key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.RUNNING,
@@ -80,7 +81,7 @@ def test_map_before_command() -> None:
                     legacyCommandType="command.COMMENT",
                     legacyCommandText="hello world",
                 ),
-            )
+            ),
         )
     ]
 
@@ -109,7 +110,8 @@ def test_map_after_command() -> None:
 
     assert result == [
         pe_actions.UpdateCommandAction(
-            pe_commands.Custom.construct(
+            private_result=None,
+            command=pe_commands.Custom.construct(
                 id="command.COMMENT-0",
                 key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.SUCCEEDED,
@@ -121,7 +123,7 @@ def test_map_after_command() -> None:
                     legacyCommandText="hello world",
                 ),
                 result=pe_commands.CustomResult(),
-            )
+            ),
         )
     ]
 
@@ -201,7 +203,8 @@ def test_command_stack() -> None:
 
     assert result == [
         pe_actions.UpdateCommandAction(
-            pe_commands.Custom.construct(
+            private_result=None,
+            command=pe_commands.Custom.construct(
                 id="command.COMMENT-0",
                 key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.RUNNING,
@@ -211,10 +214,11 @@ def test_command_stack() -> None:
                     legacyCommandType="command.COMMENT",
                     legacyCommandText="hello",
                 ),
-            )
+            ),
         ),
         pe_actions.UpdateCommandAction(
-            pe_commands.Custom.construct(
+            private_result=None,
+            command=pe_commands.Custom.construct(
                 id="command.COMMENT-1",
                 key="command.COMMENT-1",
                 status=pe_commands.CommandStatus.RUNNING,
@@ -224,10 +228,11 @@ def test_command_stack() -> None:
                     legacyCommandType="command.COMMENT",
                     legacyCommandText="goodbye",
                 ),
-            )
+            ),
         ),
         pe_actions.UpdateCommandAction(
-            pe_commands.Custom.construct(
+            private_result=None,
+            command=pe_commands.Custom.construct(
                 id="command.COMMENT-0",
                 key="command.COMMENT-0",
                 status=pe_commands.CommandStatus.SUCCEEDED,
@@ -239,7 +244,7 @@ def test_command_stack() -> None:
                     legacyCommandText="hello",
                 ),
                 result=pe_commands.CustomResult(),
-            )
+            ),
         ),
         pe_actions.FailCommandAction(
             command_id="command.COMMENT-1",
@@ -319,8 +324,8 @@ def test_map_instrument_load(decoy: Decoy) -> None:
         ),
         result=pe_commands.LoadPipetteResult.construct(pipetteId=pipette_id_captor),
     )
-    assert result[1] == pe_actions.AddPipetteConfigAction(
-        pipette_id=pipette_id_captor.value,
+    assert result[1] == pe_commands.LoadPipettePrivateResult.construct(
+        pipette_id="pipette-0",
         serial_number="fizzbuzz",
         config=pipette_config,
     )
@@ -437,17 +442,19 @@ def test_map_pause() -> None:
 
     assert result == [
         pe_actions.UpdateCommandAction(
-            pe_commands.WaitForResume.construct(
+            private_result=None,
+            command=pe_commands.WaitForResume.construct(
                 id="command.PAUSE-0",
                 key="command.PAUSE-0",
                 status=pe_commands.CommandStatus.RUNNING,
                 createdAt=matchers.IsA(datetime),
                 startedAt=matchers.IsA(datetime),
                 params=pe_commands.WaitForResumeParams(message="hello world"),
-            )
+            ),
         ),
         pe_actions.UpdateCommandAction(
-            pe_commands.WaitForResume.construct(
+            private_result=None,
+            command=pe_commands.WaitForResume.construct(
                 id="command.PAUSE-0",
                 key="command.PAUSE-0",
                 status=pe_commands.CommandStatus.SUCCEEDED,
@@ -455,7 +462,7 @@ def test_map_pause() -> None:
                 startedAt=matchers.IsA(datetime),
                 completedAt=matchers.IsA(datetime),
                 params=pe_commands.WaitForResumeParams(message="hello world"),
-            )
+            ),
         ),
         pe_actions.PauseAction(source=pe_actions.PauseSource.PROTOCOL),
     ]

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -145,14 +145,16 @@ async def test_command_broker_messages(
 
     decoy.when(
         mock_legacy_command_mapper.map_command(command=legacy_command)
-    ).then_return([pe_actions.UpdateCommandAction(engine_command)])
+    ).then_return([pe_actions.UpdateCommandAction(engine_command, private_result=None)])
 
     await to_thread.run_sync(handler, legacy_command)
 
     await subject.teardown()
 
     decoy.verify(
-        mock_action_dispatcher.dispatch(pe_actions.UpdateCommandAction(engine_command))
+        mock_action_dispatcher.dispatch(
+            pe_actions.UpdateCommandAction(engine_command, private_result=None)
+        )
     )
 
 
@@ -200,21 +202,16 @@ async def test_equipment_broker_messages(
         params=pe_commands.CustomParams(message="hello"),  # type: ignore[call-arg]
     )
 
-    pipette_config_action = pe_actions.AddPipetteConfigAction(
-        pipette_id="pipette-id",
-        serial_number="serial-number",
-        config=cast(LoadedStaticPipetteData, {"config": True}),
-    )
-
     decoy.when(
         mock_legacy_command_mapper.map_equipment_load(load_info=load_info)
-    ).then_return((engine_command, pipette_config_action))
+    ).then_return((engine_command, None))
 
     await to_thread.run_sync(handler, load_info)
 
     await subject.teardown()
 
     decoy.verify(
-        mock_action_dispatcher.dispatch(pipette_config_action),
-        mock_action_dispatcher.dispatch(pe_actions.UpdateCommandAction(engine_command)),
+        mock_action_dispatcher.dispatch(
+            pe_actions.UpdateCommandAction(command=engine_command, private_result=None)
+        ),
     )

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -3,7 +3,7 @@ import pytest
 from anyio import to_thread
 from decoy import Decoy, matchers
 from datetime import datetime
-from typing import Callable, cast
+from typing import Callable
 
 from opentrons.broker import Broker
 from opentrons.equipment_broker import EquipmentBroker
@@ -12,9 +12,6 @@ from opentrons.protocol_engine import (
     StateView,
     actions as pe_actions,
     commands as pe_commands,
-)
-from opentrons.protocol_engine.resources.pipette_data_provider import (
-    LoadedStaticPipetteData,
 )
 
 from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandMapper

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -12,6 +12,9 @@
       "$ref": "#/definitions/CommentCreate"
     },
     {
+      "$ref": "#/definitions/ConfigureForVolumeCreate"
+    },
+    {
       "$ref": "#/definitions/CustomCreate"
     },
     {
@@ -367,6 +370,55 @@
         },
         "params": {
           "$ref": "#/definitions/CommentParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "ConfigureForVolumeParams": {
+      "title": "ConfigureForVolumeParams",
+      "description": "Parameters required to configure volume for a specific pipette.",
+      "type": "object",
+      "properties": {
+        "volume": {
+          "title": "Volume",
+          "description": "Amount of liquid in uL. Must be greater than 0 and less than a pipette-specific maximum volume.",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": ["volume", "pipetteId"]
+    },
+    "ConfigureForVolumeCreate": {
+      "title": "ConfigureForVolumeCreate",
+      "description": "Configure for volume command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "configureForVolume",
+          "enum": ["configureForVolume"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/ConfigureForVolumeParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -394,8 +394,9 @@ def liquid_class_for_volume_between_default_and_defaultlowvolume(
             return pip_types.LiquidClasses.lowVolumeDefault
     return current_liquid_class_name
 
+
 def default_tip_for_liquid_class(
-        liquid_class_config: PipetteLiquidPropertiesDefinition
+    liquid_class_config: PipetteLiquidPropertiesDefinition,
 ) -> pip_types.PipetteTipType:
     """Provide a "default tip", the one with the largest volume."""
     tip_names = liquid_class_config.supported_tips.keys()

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -393,3 +393,10 @@ def liquid_class_for_volume_between_default_and_defaultlowvolume(
         ):
             return pip_types.LiquidClasses.lowVolumeDefault
     return current_liquid_class_name
+
+def default_tip_for_liquid_class(
+        liquid_class_config: PipetteLiquidPropertiesDefinition
+) -> pip_types.PipetteTipType:
+    """Provide a "default tip", the one with the largest volume."""
+    tip_names = liquid_class_config.supported_tips.keys()
+    return sorted(tip_names, key=lambda tip: tip.value)[-1]

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -355,3 +355,31 @@ class PipetteConfigurations(
         cls, v: Dict[str, PipetteLiquidPropertiesDefinition]
     ) -> Dict[pip_types.LiquidClasses, PipetteLiquidPropertiesDefinition]:
         return {pip_types.LiquidClasses[key]: value for key, value in v.items()}
+
+def liquid_class_for_volume_between_default_and_defaultlowvolume(
+        volume: float,
+        current_liquid_class_name: pip_types.LiquidClasses,
+        available_liquid_classes: Dict[pip_types.LiquidClasses, PipetteLiquidPropertiesDefinition]
+) -> pip_types.LiquidClasses:
+    """Determine the appropriate liquid class to use for a volume.
+
+    This function has such a weird name because it is hardcoded to only use the liquid
+    classes default and defaultLowVolume. It should no longer be used when those liquid
+    classes change.
+
+    This function applies hysteresis to avoid frequently switching back and forth between
+    liquid classes unnecessarily.
+    """
+    # For now, until we add more liquid classes, we're going to hardcode the default
+    # and lowVolumeDefault liquid classes as the ones to switch between.
+    has_lvd = pip_types.LiquidClasses.lowVolumeDefault in available_liquid_classes
+
+    if not has_lvd:
+        return pip_types.LiquidClasses.default
+    if current_liquid_class_name == pip_types.LiquidClasses.lowVolumeDefault:
+        if volume > (available_liquid_classes[pip_types.LiquidClasses.lowVolumeDefault].max_volume * 0.75):
+            return pip_types.LiquidClasses.default
+    else:  # LiquidClasses.default
+        if volume < (available_liquid_classes[pip_types.LiquidClasses.default].max_volume * 0.5):
+            return pip_types.LiquidClasses.lowVolumeDefault
+    return current_liquid_class_name

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -356,10 +356,13 @@ class PipetteConfigurations(
     ) -> Dict[pip_types.LiquidClasses, PipetteLiquidPropertiesDefinition]:
         return {pip_types.LiquidClasses[key]: value for key, value in v.items()}
 
+
 def liquid_class_for_volume_between_default_and_defaultlowvolume(
-        volume: float,
-        current_liquid_class_name: pip_types.LiquidClasses,
-        available_liquid_classes: Dict[pip_types.LiquidClasses, PipetteLiquidPropertiesDefinition]
+    volume: float,
+    current_liquid_class_name: pip_types.LiquidClasses,
+    available_liquid_classes: Dict[
+        pip_types.LiquidClasses, PipetteLiquidPropertiesDefinition
+    ],
 ) -> pip_types.LiquidClasses:
     """Determine the appropriate liquid class to use for a volume.
 
@@ -377,9 +380,16 @@ def liquid_class_for_volume_between_default_and_defaultlowvolume(
     if not has_lvd:
         return pip_types.LiquidClasses.default
     if current_liquid_class_name == pip_types.LiquidClasses.lowVolumeDefault:
-        if volume > (available_liquid_classes[pip_types.LiquidClasses.lowVolumeDefault].max_volume * 0.75):
+        if volume > (
+            available_liquid_classes[
+                pip_types.LiquidClasses.lowVolumeDefault
+            ].max_volume
+            * 0.75
+        ):
             return pip_types.LiquidClasses.default
     else:  # LiquidClasses.default
-        if volume < (available_liquid_classes[pip_types.LiquidClasses.default].max_volume * 0.5):
+        if volume < (
+            available_liquid_classes[pip_types.LiquidClasses.default].max_volume * 0.5
+        ):
             return pip_types.LiquidClasses.lowVolumeDefault
     return current_liquid_class_name

--- a/shared-data/python/tests/pipette/test_pipette_definition.py
+++ b/shared-data/python/tests/pipette/test_pipette_definition.py
@@ -1,12 +1,89 @@
 import pytest
-from typing import cast
+from typing import cast, List
 from opentrons_shared_data.pipette.types import (
     PipetteChannelType,
     PipetteModelType,
     PipetteVersionType,
     PipetteModelMajorVersionType,
     PipetteModelMinorVersionType,
+    LiquidClasses,
 )
+from opentrons_shared_data.pipette.pipette_definition import (
+    liquid_class_for_volume_between_default_and_defaultlowvolume,
+    PipetteLiquidPropertiesDefinition,
+    SupportedTipsDefinition,
+)
+
+
+def get_liquid_definition_for(
+    liquid_class: LiquidClasses,
+) -> PipetteLiquidPropertiesDefinition:
+    if liquid_class == LiquidClasses.lowVolumeDefault:
+        return PipetteLiquidPropertiesDefinition.parse_obj(
+            {
+                "supportedTips": {
+                    "t50": SupportedTipsDefinition.parse_obj(
+                        {
+                            "defaultAspirateFlowRate": {
+                                "default": 5,
+                                "valuesByApiLevel": {"2.0": 5},
+                            },
+                            "defaultDispenseFlowRate": {
+                                "default": 5,
+                                "valuesByApiLevel": {"2.0": 5},
+                            },
+                            "defaultBlowOutFlowRate": {
+                                "default": 10,
+                                "valuesByApiLevel": {"2.0": 10},
+                            },
+                            "defaultFlowAcceleration": 100,
+                            "defaultTipLength": 100,
+                            "defaultReturnTipHeight": 0.5,
+                            "defaultPushOutVolume": 5,
+                            "aspirate": {"default": {"1": [[1, 2, 3]]}},
+                            "dispense": {"default": {"1": [[1, 2, 3]]}},
+                        }
+                    )
+                },
+                "defaultTipOverlapDictionary": {},
+                "maxVolume": 30,
+                "minVolume": 1,
+                "defaultTipracks": [],
+            }
+        )
+    else:
+        return PipetteLiquidPropertiesDefinition.parse_obj(
+            {
+                "supportedTips": {
+                    "t50": SupportedTipsDefinition.parse_obj(
+                        {
+                            "defaultAspirateFlowRate": {
+                                "default": 5,
+                                "valuesByApiLevel": {"2.0": 5},
+                            },
+                            "defaultDispenseFlowRate": {
+                                "default": 5,
+                                "valuesByApiLevel": {"2.0": 5},
+                            },
+                            "defaultBlowOutFlowRate": {
+                                "default": 10,
+                                "valuesByApiLevel": {"2.0": 10},
+                            },
+                            "defaultFlowAcceleration": 100,
+                            "defaultTipLength": 100,
+                            "defaultReturnTipHeight": 0.5,
+                            "defaultPushOutVolume": 5,
+                            "aspirate": {"default": {"1": [[1, 2, 3]]}},
+                            "dispense": {"default": {"1": [[1, 2, 3]]}},
+                        }
+                    )
+                },
+                "defaultTipOverlapDictionary": {},
+                "maxVolume": 100,
+                "minVolume": 30,
+                "defaultTipracks": [],
+            }
+        )
 
 
 @pytest.mark.parametrize(
@@ -41,3 +118,48 @@ def test_version_enum(major: int, minor: int) -> None:
         cast(PipetteModelMinorVersionType, minor),
     )
     assert version_type.as_tuple == (major, minor)
+
+
+@pytest.mark.parametrize(
+    argnames=[
+        "all_liquid_classes",
+        "volume",
+        "current_liquid_class",
+        "expected_liquid_class",
+    ],
+    argvalues=[
+        [
+            [LiquidClasses.default],
+            1,
+            LiquidClasses.lowVolumeDefault,
+            LiquidClasses.default,
+        ],
+        [
+            [LiquidClasses.lowVolumeDefault, LiquidClasses.default],
+            1,
+            LiquidClasses.lowVolumeDefault,
+            LiquidClasses.lowVolumeDefault,
+        ],
+        [
+            [LiquidClasses.lowVolumeDefault, LiquidClasses.default],
+            100,
+            LiquidClasses.lowVolumeDefault,
+            LiquidClasses.default,
+        ],
+    ],
+)
+def test_liquid_class_for_volume_between_default_and_defaultlowvolume(
+    all_liquid_classes: List[LiquidClasses],
+    volume: float,
+    current_liquid_class: LiquidClasses,
+    expected_liquid_class: LiquidClasses,
+) -> None:
+    available_liquid_classes = {
+        lc: get_liquid_definition_for(lc) for lc in all_liquid_classes
+    }
+    assert (
+        liquid_class_for_volume_between_default_and_defaultlowvolume(
+            volume, current_liquid_class, available_liquid_classes
+        )
+        == expected_liquid_class
+    )


### PR DESCRIPTION
# Overview

Add the configure for liquid class command to protocol engine and allow virtual configs to return different liquid class configurations.

# Changelog

- Add new command to configure liquid for volume
- Add a new equipment command that will configure the volume in the hardware controller and update the pipette state store
- Update the hardware controller to again have a command to configure liquid for volume (a copy of work @sfoster1 had previously done) 
