### PR TITLE
feat(app): acknowledge animation when Flex receives a new protocol

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -109,7 +109,7 @@ export function useProtocolReceiptToast(): void {
           createLiveCommand({
             command: animationCommand,
           }).catch((e: Error) =>
-            console.warn(`cannot run status bar animtion: ${e.message}`)
+            console.warn(`cannot run status bar animation: ${e.message}`)
           )
         })
         .catch((e: Error) => {

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -9,6 +9,7 @@ import {
   useAllRunsQuery,
   useHost,
   useRunQuery,
+  useCreateLiveCommandMutation,
 } from '@opentrons/react-api-client'
 import {
   getProtocol,
@@ -21,6 +22,7 @@ import {
 } from '@opentrons/api-client'
 import { checkShellUpdate } from '../redux/shell'
 import { useToaster } from '../organisms/ToasterOven'
+import type { SetStatusBarCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/incidental'
 
 import type { Dispatch } from '../redux/types'
 
@@ -50,6 +52,11 @@ export function useProtocolReceiptToast(): void {
   const protocolIds = protocolIdsQuery.data?.data ?? []
   const protocolIdsRef = React.useRef(protocolIds)
   const hasRefetched = React.useRef(true)
+  const { createLiveCommand } = useCreateLiveCommandMutation()
+  const animationCommand: SetStatusBarCreateCommand = {
+    commandType: 'setStatusBar',
+    params: { animation: 'confirm' },
+  }
 
   if (protocolIdsQuery.isRefetching) {
     hasRefetched.current = false
@@ -97,6 +104,13 @@ export function useProtocolReceiptToast(): void {
             .catch((e: Error) =>
               console.error(`error invalidating protocols query: ${e.message}`)
             )
+        })
+        .then(() => {
+          createLiveCommand({
+            command: animationCommand,
+          }).catch((e: Error) =>
+            console.warn(`cannot run status bar animtion: ${e.message}`)
+          )
         })
         .catch((e: Error) => {
           console.error(e)

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -510,3 +510,12 @@ export interface GripperDefinition {
     jawWidth: { min: number; max: number }
   }
 }
+
+export type StatusBarAnimation =
+  | 'idle'
+  | 'confirm'
+  | 'updating'
+  | 'disco'
+  | 'off'
+
+export type StatusBarAnimations = StatusBarAnimation[]

--- a/shared-data/protocol/types/schemaV7/command/incidental.ts
+++ b/shared-data/protocol/types/schemaV7/command/incidental.ts
@@ -1,0 +1,21 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { StatusBarAnimation } from '../../../../js/types'
+
+export type IncidentalCreateCommand = SetStatusBarCreateCommand
+
+export type IncidentalRunTimeCommand = SetStatusBarRunTimeCommand
+
+export interface SetStatusBarCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'setStatusBar'
+  params: SetStatusBarParams
+}
+
+export interface SetStatusBarRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    SetStatusBarCreateCommand {
+  result?: any
+}
+
+interface SetStatusBarParams {
+  animation: StatusBarAnimation
+}

--- a/shared-data/protocol/types/schemaV7/command/index.ts
+++ b/shared-data/protocol/types/schemaV7/command/index.ts
@@ -7,6 +7,10 @@ import type { ModuleRunTimeCommand, ModuleCreateCommand } from './module'
 import type { SetupRunTimeCommand, SetupCreateCommand } from './setup'
 import type { TimingRunTimeCommand, TimingCreateCommand } from './timing'
 import type {
+  IncidentalCreateCommand,
+  IncidentalRunTimeCommand,
+} from './incidental'
+import type {
   AnnotationRunTimeCommand,
   AnnotationCreateCommand,
 } from './annotation'
@@ -51,6 +55,7 @@ export type CreateCommand =
   | TimingCreateCommand // effecting the timing of command execution
   | CalibrationCreateCommand // for automatic pipette calibration
   | AnnotationCreateCommand // annotating command execution
+  | IncidentalCreateCommand // command with only incidental effects (status bar animations)
 
 // commands will be required to have a key, but will not be created with one
 export type RunTimeCommand =
@@ -61,6 +66,7 @@ export type RunTimeCommand =
   | TimingRunTimeCommand // effecting the timing of command execution
   | CalibrationRunTimeCommand // for automatic pipette calibration
   | AnnotationRunTimeCommand // annotating command execution
+  | IncidentalRunTimeCommand // command with only incidental effects (status bar animations)
 
 interface RunCommandError {
   id: string


### PR DESCRIPTION
# Overview

The design spec for the status bar calls for the Confirmation animation to play when a new protocol is uploaded. We already have 1) a [stateless protocol engine command](https://github.com/Opentrons/opentrons/pull/12890) to run that animation, and 2) a hook in the ODD app to detect when a new protocol is uploaded. This PR just glues those two things together.

# Test Plan

Pushed this to Flexy and uploaded a protocol.
* If the robot is idle (status bar is plain white, not running a protocol) when it is uploaded, the animation plays
* If the robot is in the middle of a protocol run, the status bar does _not_ play the animation, instead showing the status of the running protocol

# Changelog

- Added definitions for the Status Bar Animation command to schemaV7 in shared-data
- In the hook listening for new protocol uploads, send a status bar animation command to run the `confirm` animation if a new protocol was uploaded

# Review requests

- Does the command definition stuff in shared-data need to be filled in anywhere else that I'm missing?

# Risk assessment

Pretty low, not core behavior
