### PR TITLE
fix(app): default module calibration in progress animation to spinner

### DIFF
--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-import probing1 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_1.webm'
-import probing8 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_8.webm'
-import probing96 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_96.webm'
 import attachProbe1 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_1.webm'
 import attachProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_8.webm'
 import attachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_96.webm'
@@ -67,21 +64,18 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
 
   const attachedPipetteChannels = attachedPipette.data.channels
-  let pipetteAttachProbeVideoSource, pipetteProbingVideoSource, i18nKey
+  let pipetteAttachProbeVideoSource, i18nKey
   switch (attachedPipetteChannels) {
     case 1:
       pipetteAttachProbeVideoSource = attachProbe1
-      pipetteProbingVideoSource = probing1
       i18nKey = 'install_probe'
       break
     case 8:
       pipetteAttachProbeVideoSource = attachProbe8
-      pipetteProbingVideoSource = probing8
       i18nKey = 'install_probe_8_channel'
       break
     case 96:
       pipetteAttachProbeVideoSource = attachProbe96
-      pipetteProbingVideoSource = probing96
       i18nKey = 'install_probe_96_channel'
       break
   }
@@ -98,24 +92,6 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         controls={false}
       >
         <source src={pipetteAttachProbeVideoSource} />
-      </video>
-    </Flex>
-  )
-
-  // TODO: add assets for probing actual module calibration adapters (ND 8/25/23)
-  const pipetteProbingVid = (
-    <Flex height="10.2rem" paddingTop={SPACING.spacing4}>
-      <video
-        css={css`
-          max-width: 100%;
-          max-height: 100%;
-        `}
-        autoPlay={true}
-        loop={true}
-        controls={false}
-        data-testid={pipetteProbingVideoSource}
-      >
-        <source src={pipetteProbingVideoSource} />
       </video>
     </Flex>
   )
@@ -139,7 +115,8 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   if (isRobotMoving)
     return (
       <InProgressModal
-        alternativeSpinner={isExiting ? null : pipetteProbingVid}
+        // TODO ND: 9/6/23 use spinner until animations are made
+        alternativeSpinner={null}
         description={
           isExiting
             ? t('stand_back')


### PR DESCRIPTION
# Overview

closes [RQA-1476](https://opentrons.atlassian.net/browse/RQA-1476)

# Test Plan

Verify that animation during module calibration probing (contained within AttachProbe wizard tile) displays the InProgressSpinner modal.
<img width="753" alt="Screen Shot 2023-09-06 at 1 23 46 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/8728e1af-0678-451d-8227-ab599a80f9b0">


# Changelog

- set robot moving in progress modal alternative spinner to null (to render spinner)

# Risk assessment

low

[RQA-1476]: https://opentrons.atlassian.net/browse/RQA-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ