### PR TITLE
fix(shared-data): add type ignore in test

### DIFF
--- a/shared-data/python/tests/pipette/test_mutable_configurations.py
+++ b/shared-data/python/tests/pipette/test_mutable_configurations.py
@@ -262,5 +262,5 @@ def test_build_mutable_config_using_old_units() -> None:
         "max": 30,
     }
     assert (
-        types.MutableConfig.build(**old_units_config, name="dropTipSpeed") is not None
+        types.MutableConfig.build(**old_units_config, name="dropTipSpeed") is not None  # type: ignore
     )


### PR DESCRIPTION
This is testing a splat that loses types and just doesn't really work with type annotations sadly. Removing the types fixes the issue.
