### PR TITLE
feat(hardware): allow variable number of tip presence messages

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from functools import wraps
 import logging
 from copy import deepcopy
-from typing_extensions import Literal
 from typing import (
     Any,
     Awaitable,
@@ -857,12 +856,11 @@ class OT3Controller:
         expected_responses = 2 if expect_multiple_responses else 1
         node = sensor_node_for_mount(OT3Mount(mount.value))
         assert node != NodeId.gripper
-        res = await get_tip_ejector_state(
-            self._messenger, node, expected_responses
-        )
+        res = await get_tip_ejector_state(self._messenger, node, expected_responses)  # type: ignore[arg-type]
         vals = list(res.values())
         if not all([r == vals[0] for r in vals]):
-            raise UnmatchedTipPresenceStates()
+            states = {int(sensor): res[sensor] for sensor in res.keys()}
+            raise UnmatchedTipPresenceStates(states)
         tip_present_state = bool(vals[0]) and bool(vals[-1])
         return tip_present_state
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -836,7 +836,7 @@ class OT3Controller:
         res = await get_limit_switches(self._messenger, motor_nodes)
         return {node_to_axis(node): bool(val) for node, val in res.items()}
 
-    async def get_tip_present(
+    async def check_for_tip_presence(
         self,
         mount: OT3Mount,
         tip_state: TipStateType,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -861,7 +861,7 @@ class OT3Controller:
         if not all([r == vals[0] for r in vals]):
             states = {int(sensor): res[sensor] for sensor in res}
             raise UnmatchedTipPresenceStates(states)
-        tip_present_state = bool(vals[0]) and bool(vals[-1])
+        tip_present_state = bool(vals[0])
         return tip_present_state
 
     @staticmethod

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -855,9 +855,9 @@ class OT3Controller:
         res = await get_tip_ejector_state(
             self._messenger, sensor_node_for_mount(OT3Mount(mount.value)), expected_responses  # type: ignore
         )
-        if res[0] != res[1]:
+        if res[0] != res[-1]:
             raise UnmatchedTipStates()
-        tip_present_state = bool(res[0]) and bool(res[1])
+        tip_present_state = bool(res[0]) and bool(res[-1])
         return tip_present_state
 
     @staticmethod

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -858,11 +858,12 @@ class OT3Controller:
         node = sensor_node_for_mount(OT3Mount(mount.value))
         assert node != NodeId.gripper
         res = await get_tip_ejector_state(
-            self._messenger, node, Literal[expected_responses]
+            self._messenger, node, expected_responses
         )
-        if not all([r == res[0] for r in res]):
+        vals = list(res.values())
+        if not all([r == vals[0] for r in vals]):
             raise UnmatchedTipPresenceStates()
-        tip_present_state = bool(res[0]) and bool(res[-1])
+        tip_present_state = bool(vals[0]) and bool(vals[-1])
         return tip_present_state
 
     @staticmethod

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -860,7 +860,7 @@ class OT3Controller:
         res = await get_tip_ejector_state(
             self._messenger, node, Literal[expected_responses]
         )
-        if res[0] != res[-1]:
+        if not all([r == res[0] for r in res]):
             raise UnmatchedTipPresenceStates()
         tip_present_state = bool(res[0]) and bool(res[-1])
         return tip_present_state

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -859,7 +859,7 @@ class OT3Controller:
         res = await get_tip_ejector_state(self._messenger, node, expected_responses)  # type: ignore[arg-type]
         vals = list(res.values())
         if not all([r == vals[0] for r in vals]):
-            states = {int(sensor): res[sensor] for sensor in res.keys()}
+            states = {int(sensor): res[sensor] for sensor in res}
             raise UnmatchedTipPresenceStates(states)
         tip_present_state = bool(vals[0]) and bool(vals[-1])
         return tip_present_state

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -839,18 +839,18 @@ class OT3Controller:
         self,
         mount: OT3Mount,
         tip_state: TipStateType,
-        is_ninety_six_channel: bool = False,
+        expect_multiple_responses: bool = False,
     ) -> None:
         """Raise an error if the expected tip state does not match the current state."""
-        res = await self.get_tip_present_state(mount, is_ninety_six_channel)
+        res = await self.get_tip_present_state(mount, expect_multiple_responses)
         if res[0] != tip_state.value or res[0] != res[1]:
             raise FailedTipStateCheck(tip_state, res[0])
 
     async def get_tip_present_state(
-        self, mount: OT3Mount, is_ninety_six_channel: bool = False
+        self, mount: OT3Mount, expect_multiple_responses: bool = False
     ) -> List[int]:
         """Get the state of the tip ejector flag for a given mount."""
-        expected_responses = 2 if is_ninety_six_channel else 1
+        expected_responses = 2 if expect_multiple_responses else 1
         res = await get_tip_ejector_state(
             self._messenger, sensor_node_for_mount(OT3Mount(mount.value)), expected_responses  # type: ignore
         )

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -383,7 +383,12 @@ class OT3Simulator:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
 
-    async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> None:
+    async def get_tip_present(
+        self,
+        mount: OT3Mount,
+        tip_state: TipStateType,
+        is_ninety_six_channel: bool = False,
+    ) -> None:
         """Raise an error if the given state doesn't match the physical state."""
         pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -387,7 +387,9 @@ class OT3Simulator:
         """Raise an error if the given state doesn't match the physical state."""
         pass
 
-    async def get_tip_present_state(self, mount: OT3Mount) -> int:
+    async def get_tip_present_state(
+        self, mount: OT3Mount, is_ninety_six_channel: bool = False
+    ) -> int:
         """Get the state of the tip ejector flag for a given mount."""
         pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -394,7 +394,7 @@ class OT3Simulator:
 
     async def get_tip_present_state(
         self, mount: OT3Mount, expect_multiple_responses: bool = False
-    ) -> int:
+    ) -> bool:
         """Get the state of the tip ejector flag for a given mount."""
         pass
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -383,7 +383,7 @@ class OT3Simulator:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
 
-    async def get_tip_present(
+    async def check_for_tip_presence(
         self,
         mount: OT3Mount,
         tip_state: TipStateType,

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -387,13 +387,13 @@ class OT3Simulator:
         self,
         mount: OT3Mount,
         tip_state: TipStateType,
-        is_ninety_six_channel: bool = False,
+        expect_multiple_responses: bool = False,
     ) -> None:
         """Raise an error if the given state doesn't match the physical state."""
         pass
 
     async def get_tip_present_state(
-        self, mount: OT3Mount, is_ninety_six_channel: bool = False
+        self, mount: OT3Mount, expect_multiple_responses: bool = False
     ) -> int:
         """Get the state of the tip ejector flag for a given mount."""
         pass

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2065,9 +2065,9 @@ class OT3API(
         # TODO we should have a PipetteState that can be returned from
         # this function with additional state (such as critical points)
         realmount = OT3Mount.from_mount(mount)
-        is_ninety_six_channel = self._gantry_load == GantryLoad.HIGH_THROUGHPUT
+        expect_multiple_responses = self._gantry_load == GantryLoad.HIGH_THROUGHPUT
         res = await self._backend.get_tip_present_state(
-            realmount, is_ninety_six_channel
+            realmount, expect_multiple_responses
         )
         pipette_state_for_mount: PipetteStateDict = {"tip_detected": bool(res[0])}
         return pipette_state_for_mount

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1926,7 +1926,7 @@ class OT3API(
             self.gantry_load != GantryLoad.HIGH_THROUGHPUT
             and ff.tip_presence_detection_enabled()
         ):
-            await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
+            await self._backend.check_for_tip_presence(realmount, TipStateType.PRESENT)
 
         _add_tip_to_instrs()
 
@@ -2001,7 +2001,7 @@ class OT3API(
             self.gantry_load != GantryLoad.HIGH_THROUGHPUT
             and ff.tip_presence_detection_enabled()
         ):
-            await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
+            await self._backend.check_for_tip_presence(realmount, TipStateType.ABSENT)
 
         # home mount axis
         if home_after:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2066,7 +2066,7 @@ class OT3API(
         # this function with additional state (such as critical points)
         realmount = OT3Mount.from_mount(mount)
         res = await self._backend.get_tip_present_state(realmount)
-        pipette_state_for_mount: PipetteStateDict = {"tip_detected": bool(res[0])}
+        pipette_state_for_mount: PipetteStateDict = {"tip_detected": res}
         return pipette_state_for_mount
 
     def reset_instrument(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2001,7 +2001,7 @@ class OT3API(
             self.gantry_load != GantryLoad.HIGH_THROUGHPUT
             and ff.tip_presence_detection_enabled()
         ):
-            await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
+            await self._backend.get_tip_present(realmount, TipStateType.ABSENT)
 
         # home mount axis
         if home_after:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1922,11 +1922,11 @@ class OT3API(
         # TODO: implement tip-detection sequence during pick-up-tip for 96ch,
         #       but not with DVT pipettes because those can only detect drops
 
-        if ff.tip_presence_detection_enabled():
-            ninety_six_channel_attached = self.gantry_load == GantryLoad.HIGH_THROUGHPUT
-            await self._backend.get_tip_present(
-                realmount, TipStateType.PRESENT, ninety_six_channel_attached
-            )
+        if (
+            self.gantry_load != GantryLoad.HIGH_THROUGHPUT
+            and ff.tip_presence_detection_enabled()
+        ):
+            await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
 
         _add_tip_to_instrs()
 
@@ -1997,11 +1997,11 @@ class OT3API(
 
         await self._backend.set_active_current(spec.ending_current)
         # TODO: implement tip-detection sequence during drop-tip for 96ch
-        if ff.tip_presence_detection_enabled():
-            ninety_six_channel_attached = self.gantry_load == GantryLoad.HIGH_THROUGHPUT
-            await self._backend.get_tip_present(
-                realmount, TipStateType.PRESENT, ninety_six_channel_attached
-            )
+        if (
+            self.gantry_load != GantryLoad.HIGH_THROUGHPUT
+            and ff.tip_presence_detection_enabled()
+        ):
+            await self._backend.get_tip_present(realmount, TipStateType.PRESENT)
 
         # home mount axis
         if home_after:
@@ -2065,10 +2065,7 @@ class OT3API(
         # TODO we should have a PipetteState that can be returned from
         # this function with additional state (such as critical points)
         realmount = OT3Mount.from_mount(mount)
-        expect_multiple_responses = self._gantry_load == GantryLoad.HIGH_THROUGHPUT
-        res = await self._backend.get_tip_present_state(
-            realmount, expect_multiple_responses
-        )
+        res = await self._backend.get_tip_present_state(realmount)
         pipette_state_for_mount: PipetteStateDict = {"tip_detected": bool(res[0])}
         return pipette_state_for_mount
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -642,3 +642,13 @@ class FailedTipStateCheck(RuntimeError):
             f"Failed to correctly determine tip state for tip {str(tip_state_type)} "
             f"received {bool(actual_state)} but expected {bool(tip_state_type.value)}"
         )
+
+
+class UnmatchedTipStates(RuntimeError):
+    """Error raised if a 96 channel pipette receives two differing tip presence statuses."""
+
+    def __init__(self) -> None:
+        """Iniitialize FailedTipStateCheck error."""
+        super().__init__(
+            f"Received two differing tip presence statuses. Pickup motor may need to be homed."
+        )

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -650,5 +650,5 @@ class UnmatchedTipStates(RuntimeError):
     def __init__(self) -> None:
         """Iniitialize FailedTipStateCheck error."""
         super().__init__(
-            f"Received two differing tip presence statuses. Pickup motor may need to be homed."
+            "Received two differing tip presence statuses. Pickup motor may need to be homed."
         )

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -637,18 +637,8 @@ class FailedTipStateCheck(RuntimeError):
     """Error raised if the tip ejector state does not match the expected value."""
 
     def __init__(self, tip_state_type: TipStateType, actual_state: int) -> None:
-        """Iniitialize FailedTipStateCheck error."""
+        """Initialize FailedTipStateCheck error."""
         super().__init__(
             f"Failed to correctly determine tip state for tip {str(tip_state_type)} "
             f"received {bool(actual_state)} but expected {bool(tip_state_type.value)}"
-        )
-
-
-class UnmatchedTipStates(RuntimeError):
-    """Error raised if a 96 channel pipette receives two differing tip presence statuses."""
-
-    def __init__(self) -> None:
-        """Iniitialize FailedTipStateCheck error."""
-        super().__init__(
-            "Received two differing tip presence statuses. Pickup motor may need to be homed."
         )

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1077,7 +1077,7 @@ async def test_monitor_pressure(
 async def test_get_tip_present(
     controller: OT3Controller,
     tip_state_type: TipStateType,
-    mocked_ejector_response: List[int],
+    mocked_ejector_response: Dict[int, int],
     expectation: ContextManager[None],
 ) -> None:
     mount = OT3Mount.LEFT

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1068,16 +1068,16 @@ async def test_monitor_pressure(
 @pytest.mark.parametrize(
     "tip_state_type, mocked_ejector_response, expectation",
     [
-        [TipStateType.PRESENT, 1, does_not_raise()],
-        [TipStateType.ABSENT, 0, does_not_raise()],
-        [TipStateType.PRESENT, 0, pytest.raises(FailedTipStateCheck)],
-        [TipStateType.ABSENT, 1, pytest.raises(FailedTipStateCheck)],
+        [TipStateType.PRESENT, [1, 1], does_not_raise()],
+        [TipStateType.ABSENT, [0, 0], does_not_raise()],
+        [TipStateType.PRESENT, [0, 0], pytest.raises(FailedTipStateCheck)],
+        [TipStateType.ABSENT, [1, 1], pytest.raises(FailedTipStateCheck)],
     ],
 )
 async def test_get_tip_present(
     controller: OT3Controller,
     tip_state_type: TipStateType,
-    mocked_ejector_response: int,
+    mocked_ejector_response: List[int],
     expectation: ContextManager[None],
 ) -> None:
     mount = OT3Mount.LEFT

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1086,7 +1086,7 @@ async def test_get_tip_present(
         return_value=mocked_ejector_response,
     ):
         with expectation:
-            await controller.get_tip_present(mount, tip_state_type)
+            await controller.check_for_tip_presence(mount, tip_state_type)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1068,10 +1068,10 @@ async def test_monitor_pressure(
 @pytest.mark.parametrize(
     "tip_state_type, mocked_ejector_response, expectation",
     [
-        [TipStateType.PRESENT, [1, 1], does_not_raise()],
-        [TipStateType.ABSENT, [0, 0], does_not_raise()],
-        [TipStateType.PRESENT, [0, 0], pytest.raises(FailedTipStateCheck)],
-        [TipStateType.ABSENT, [1, 1], pytest.raises(FailedTipStateCheck)],
+        [TipStateType.PRESENT, {0: 1, 1: 1}, does_not_raise()],
+        [TipStateType.ABSENT, {0: 0, 1: 0}, does_not_raise()],
+        [TipStateType.PRESENT, {0: 0, 1: 0}, pytest.raises(FailedTipStateCheck)],
+        [TipStateType.ABSENT, {0: 1, 1: 1}, pytest.raises(FailedTipStateCheck)],
     ],
 )
 async def test_get_tip_present(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1695,8 +1695,8 @@ async def test_tip_presence_disabled_ninety_six_channel(
     # TODO remove this check once we enable tip presence for 96 chan.
     with patch.object(
         ot3_hardware.managed_obj._backend,
-        "get_tip_present",
-        AsyncMock(spec=ot3_hardware.managed_obj._backend.get_tip_present),
+        "check_for_tip_presence",
+        AsyncMock(spec=ot3_hardware.managed_obj._backend.check_for_tip_presence()),
     ) as tip_present:
         pipette_config = load_pipette_data.load_definition(
             PipetteModelType("p1000"),

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1696,7 +1696,7 @@ async def test_tip_presence_disabled_ninety_six_channel(
     with patch.object(
         ot3_hardware.managed_obj._backend,
         "check_for_tip_presence",
-        AsyncMock(spec=ot3_hardware.managed_obj._backend.check_for_tip_presence()),
+        AsyncMock(spec=ot3_hardware.managed_obj._backend.check_for_tip_presence),
     ) as tip_present:
         pipette_config = load_pipette_data.load_definition(
             PipetteModelType("p1000"),

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -1002,7 +1002,7 @@ async def _jog_for_tip_state(
     async def _matches_state(_state: TipStateType) -> bool:
         try:
             await asyncio.sleep(0.2)
-            await api._backend.get_tip_present(mount, _state)
+            await api._backend.check_for_tip_presence(mount, _state)
             return True
         except FailedTipStateCheck:
             return False

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -3,11 +3,17 @@ import asyncio
 import logging
 
 from typing_extensions import Literal
+from typing import List
+
+from opentrons_shared_data.errors.exceptions import CommandTimedOutError
 
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 
-from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
-from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    MultipleMessagesWaitableCallback,
+    WaitableCallback,
+)
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     TipStatusQueryRequest,
     PushTipPresenceNotification,
@@ -21,21 +27,14 @@ log = logging.getLogger(__name__)
 async def get_tip_ejector_state(
     can_messenger: CanMessenger,
     node: Literal[NodeId.pipette_left, NodeId.pipette_right],
-) -> int:
+    expected_responses: int = 1,
+    timeout: float = 1.0,
+) -> List[int]:
     """Get the state of the tip presence interrupter.
 
     When the tip ejector flag is occuluded, then we
     know that there is a tip on the pipette.
     """
-    tip_ejector_state = 0
-
-    event = asyncio.Event()
-
-    def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
-        nonlocal tip_ejector_state
-        if isinstance(message, PushTipPresenceNotification):
-            event.set()
-            tip_ejector_state = message.payload.ejector_flag_status.value
 
     def _filter(arbitration_id: ArbitrationId) -> bool:
         return (NodeId(arbitration_id.parts.originating_node_id) == node) and (
@@ -43,13 +42,30 @@ async def get_tip_ejector_state(
             == MessageId.tip_presence_notification
         )
 
-    can_messenger.add_listener(_listener, _filter)
-    await can_messenger.send(node_id=node, message=TipStatusQueryRequest())
+    async def gather_responses(reader: WaitableCallback) -> List[int]:
+        data: List[int] = []
+        async for response, _ in reader:
+            assert isinstance(response, PushTipPresenceNotification)
+            tip_ejector_state = response.payload.ejector_flag_status.value
+            data.append(tip_ejector_state)
+        return data
 
-    try:
-        await asyncio.wait_for(event.wait(), 1.0)
-    except asyncio.TimeoutError:
-        log.error("tip ejector state request timed out before expected nodes responded")
-    finally:
-        can_messenger.remove_listener(_listener)
-        return tip_ejector_state
+    with MultipleMessagesWaitableCallback(
+        can_messenger,
+        _filter,
+        number_of_messages=expected_responses,
+    ) as _reader:
+        data_list: List[int] = []
+        await can_messenger.send(node_id=node, message=TipStatusQueryRequest())
+        try:
+
+            data_list = await asyncio.wait_for(
+                gather_responses(_reader),
+                timeout,
+            )
+        except asyncio.TimeoutError as te:
+            msg = f"Tip presence poll of {node} timed out"
+            log.warning(msg)
+            raise CommandTimedOutError(message=msg) from te
+        finally:
+            return data_list

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -12,6 +12,7 @@ from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.drivers.can_bus.can_messenger import (
     CanMessenger,
     MultipleMessagesWaitableCallback,
+    WaitableCallback,
 )
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     TipStatusQueryRequest,
@@ -41,7 +42,9 @@ async def get_tip_ejector_state(
             == MessageId.tip_presence_notification
         )
 
-    async def gather_responses(reader: MultipleMessagesWaitableCallback ) -> Dict[SensorId, int]:
+    async def gather_responses(
+        reader: WaitableCallback,
+    ) -> Dict[SensorId, int]:
         data: Dict[SensorId, int] = {}
         async for response, _ in reader:
             assert isinstance(response, PushTipPresenceNotification)

--- a/hardware/opentrons_hardware/hardware_control/tip_presence.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 from typing_extensions import Literal
-from typing import List
+from typing import List, overload, Tuple, Union
 
 from opentrons_shared_data.errors.exceptions import CommandTimedOutError
 
@@ -24,12 +24,32 @@ from opentrons_hardware.firmware_bindings.constants import MessageId, NodeId
 log = logging.getLogger(__name__)
 
 
+@overload
 async def get_tip_ejector_state(
     can_messenger: CanMessenger,
     node: Literal[NodeId.pipette_left, NodeId.pipette_right],
-    expected_responses: int = 1,
+    expected_responses: Literal[1],
     timeout: float = 1.0,
-) -> List[int]:
+) -> Tuple[int]:
+    ...
+
+
+@overload
+async def get_tip_ejector_state(
+    can_messenger: CanMessenger,
+    node: Literal[NodeId.pipette_left, NodeId.pipette_right],
+    expected_responses: Literal[2],
+    timeout: float = 1.0,
+) -> Tuple[int, int]:
+    ...
+
+
+async def get_tip_ejector_state(
+    can_messenger: CanMessenger,
+    node: Literal[NodeId.pipette_left, NodeId.pipette_right],
+    expected_responses: Union[Literal[1], Literal[2]],
+    timeout: float = 1.0,
+) -> Tuple[int, ...]:
     """Get the state of the tip presence interrupter.
 
     When the tip ejector flag is occuluded, then we
@@ -68,4 +88,4 @@ async def get_tip_ejector_state(
             log.warning(msg)
             raise CommandTimedOutError(message=msg) from te
         finally:
-            return data_list
+            return tuple(data_list)

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
@@ -1,4 +1,5 @@
 """Tests for reading the current status of the tip presence photointerrupter."""
+import pytest
 from mock import AsyncMock
 
 from typing import List, Tuple, cast
@@ -15,6 +16,7 @@ from opentrons_hardware.firmware_bindings.messages.payloads import (
 from opentrons_hardware.firmware_bindings.messages.fields import SensorIdField
 from opentrons_hardware.firmware_bindings.utils import UInt8Field
 from opentrons_hardware.firmware_bindings.constants import NodeId, SensorId
+from opentrons_shared_data.errors.exceptions import CommandTimedOutError
 from tests.conftest import CanLoopback
 
 
@@ -63,9 +65,10 @@ async def test_tip_ejector_state_times_out(mock_messenger: AsyncMock) -> None:
     """Test that a timeout is handled."""
     node = NodeId.pipette_left
 
-    res = await get_tip_ejector_state(
-        mock_messenger,
-        cast(Literal[NodeId.pipette_left, NodeId.pipette_right], node),
-        1,
-    )
-    assert not res
+    with pytest.raises(CommandTimedOutError):
+        res = await get_tip_ejector_state(
+            mock_messenger,
+            cast(Literal[NodeId.pipette_left, NodeId.pipette_right], node),
+            1,
+        )
+        assert not res

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
@@ -46,7 +46,9 @@ async def test_get_tip_ejector_state(
     message_send_loopback.add_responder(responder)
 
     res = await get_tip_ejector_state(
-        mock_messenger, cast(Literal[NodeId.pipette_left, NodeId.pipette_right], node)
+        mock_messenger,
+        cast(Literal[NodeId.pipette_left, NodeId.pipette_right], node),
+        1,
     )
 
     # We should have sent a request
@@ -62,6 +64,8 @@ async def test_tip_ejector_state_times_out(mock_messenger: AsyncMock) -> None:
     node = NodeId.pipette_left
 
     res = await get_tip_ejector_state(
-        mock_messenger, cast(Literal[NodeId.pipette_left, NodeId.pipette_right], node)
+        mock_messenger,
+        cast(Literal[NodeId.pipette_left, NodeId.pipette_right], node),
+        1,
     )
     assert not res

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -181,6 +181,10 @@
     "4003": {
       "detail": "Not supported on this robot type",
       "category": "generalError"
+    },
+    "4004": {
+      "detail": "Unmatched tip presence states",
+      "category": "roboticsControlError"
     }
   }
 }

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -102,6 +102,10 @@
       "detail": "Misaligned Gantry",
       "category": "roboticsControlError"
     },
+    "2012": {
+      "detail": "Unmatched tip presence states",
+      "category": "roboticsControlError"
+    },
     "3000": {
       "detail": "A robotics interaction error occurred.",
       "category": "roboticsInteractionError"
@@ -181,10 +185,6 @@
     "4003": {
       "detail": "Not supported on this robot type",
       "category": "generalError"
-    },
-    "4004": {
-      "detail": "Unmatched tip presence states",
-      "category": "roboticsControlError"
     }
   }
 }

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -55,6 +55,7 @@ class ErrorCodes(Enum):
     EARLY_CAPACITIVE_SENSE_TRIGGER = _code_from_dict_entry("2009")
     INACCURATE_NON_CONTACT_SWEEP = _code_from_dict_entry("2010")
     MISALIGNED_GANTRY = _code_from_dict_entry("2011")
+    UNMATCHED_TIP_PRESENCE_STATES = _code_from_dict_entry("2012")
     ROBOTICS_INTERACTION_ERROR = _code_from_dict_entry("3000")
     LABWARE_DROPPED = _code_from_dict_entry("3001")
     LABWARE_NOT_PICKED_UP = _code_from_dict_entry("3002")
@@ -75,7 +76,6 @@ class ErrorCodes(Enum):
     ROBOT_IN_USE = _code_from_dict_entry("4001")
     API_REMOVED = _code_from_dict_entry("4002")
     NOT_SUPPORTED_ON_ROBOT_TYPE = _code_from_dict_entry("4003")
-    UNMATCHED_TIP_PRESENCE_STATES = _code_from_dict_entry("4004")
 
     @classmethod
     @lru_cache(25)

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -75,6 +75,7 @@ class ErrorCodes(Enum):
     ROBOT_IN_USE = _code_from_dict_entry("4001")
     API_REMOVED = _code_from_dict_entry("4002")
     NOT_SUPPORTED_ON_ROBOT_TYPE = _code_from_dict_entry("4003")
+    UNMATCHED_TIP_PRESENCE_STATES = _code_from_dict_entry("4004")
 
     @classmethod
     @lru_cache(25)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -539,9 +539,13 @@ class UnmatchedTipPresenceStates(RoboticsControlError):
     ) -> None:
         """Build an UnmatchedTipPresenceStatesError."""
         tip_status_by_sensor = {0: "not detected", 1: "detected"}
-        msg = "Received two differing tip presence statuses:" \
-              "\nRear Sensor tips" + tip_status_by_sensor[states[0]] + \
-              "\nFront Sensor tips" + tip_status_by_sensor[states[1]]
+        msg = (
+            "Received two differing tip presence statuses:"
+            "\nRear Sensor tips"
+            + tip_status_by_sensor[states[0]]
+            + "\nFront Sensor tips"
+            + tip_status_by_sensor[states[1]]
+        )
         if detail:
             msg += str(detail)
         super().__init__(

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -533,11 +533,15 @@ class UnmatchedTipPresenceStates(RoboticsControlError):
 
     def __init__(
         self,
+        states: Dict[int, int],
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnmatchedTipPresenceStatesError."""
-        msg = "Received two differing tip presence statuses. Pickup motor may need to be homed."
+        tip_status_by_sensor = {0: "not detected", 1: "detected"}
+        msg = "Received two differing tip presence statuses:" \
+              "\nRear Sensor tips" + tip_status_by_sensor[states[0]] + \
+              "\nFront Sensor tips" + tip_status_by_sensor[states[1]]
         if detail:
             msg += str(detail)
         super().__init__(

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -528,6 +528,26 @@ class MisalignedGantryError(RoboticsControlError):
         )
 
 
+class UnmatchedTipPresenceStates(RoboticsControlError):
+    """An error indicating that a tip presence check resulted in two different response outcomes."""
+
+    def __init__(
+        self,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a MisalignedGantryError."""
+        msg = "Received two differing tip presence statuses. Pickup motor may need to be homed."
+        if detail:
+            msg += str(detail)
+        super().__init__(
+            ErrorCodes.UNMATCHED_TIP_PRESENCE_STATES,
+            msg,
+            detail,
+            wrapping,
+        )
+
+
 class LabwareDroppedError(RoboticsInteractionError):
     """An error indicating that the gripper dropped labware it was holding."""
 

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -529,14 +529,14 @@ class MisalignedGantryError(RoboticsControlError):
 
 
 class UnmatchedTipPresenceStates(RoboticsControlError):
-    """An error indicating that a tip presence check resulted in two different response outcomes."""
+    """An error indicating that a tip presence check resulted in two differing responses."""
 
     def __init__(
         self,
         detail: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a MisalignedGantryError."""
+        """Build an UnmatchedTipPresenceStatesError."""
         msg = "Received two differing tip presence statuses. Pickup motor may need to be homed."
         if detail:
             msg += str(detail)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -538,13 +538,13 @@ class UnmatchedTipPresenceStates(RoboticsControlError):
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnmatchedTipPresenceStatesError."""
-        tip_status_by_sensor = {0: "not detected", 1: "detected"}
+        format_tip_state = {0: "not detected", 1: "detected"}
         msg = (
             "Received two differing tip presence statuses:"
             "\nRear Sensor tips"
-            + tip_status_by_sensor[states[0]]
+            + format_tip_state[states[0]]
             + "\nFront Sensor tips"
-            + tip_status_by_sensor[states[1]]
+            + format_tip_state[states[1]]
         )
         if detail:
             msg += str(detail)


### PR DESCRIPTION
## Overview
Currently, the hardware controller is only able to process one tip presence notification. This changes `tip_presence.py` to wait for and return either 1 or 2 notifications, as a `List[int]` rather than an `int`. 

At the hardware controller level, we check that both responses are the same, and then handle the tip presence status as a single value.