### PR TITLE
fix(update-server): check that total rootfs size is greater and not equal to the partition size.

### DIFF
--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -127,7 +127,7 @@ class RootFSInterface:
 
             # check that the uncompressed size is greater than the partition size
             partition_size = PartitionManager.get_partition_size(part.path)
-            if total_size >= partition_size:
+            if total_size > partition_size:
                 msg = f"Write failed, update size ({total_size}) is larger than partition size {part.path} ({partition_size})."
                 LOG.error(msg)
                 return False, msg


### PR DESCRIPTION
# Overview

The rootfs size is equal to the partition size, so let's make sure we only fail if the new rootfs is greater than the partition size.


# Test Plan

- [x] Create a build larger than the rootfs partition size and make sure the update fails
- [x] Create a build smaller or equal to the rootfs partition size and make sure the update passes 


# Changelog

- Check that rootfs size is greater and not greater than or equal to rootfs partition size

# Review requests

# Risk assessment
Low
