### PR TITLE
fix(app): Module card overflow menu module cal fix

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import {
   COLORS,
   Flex,
@@ -10,6 +11,50 @@ import {
 import { StyledText } from '../../../atoms/text'
 import { ModuleCard } from '../../ModuleCard'
 import { useModuleRenderInfoForProtocolById } from '../hooks'
+import type { BadPipette, PipetteData } from '@opentrons/api-client'
+
+interface PipetteStatus {
+  attachPipetteRequired: boolean
+  updatePipetteFWRequired: boolean
+}
+
+const usePipetteIsReady = (): PipetteStatus => {
+  const EQUIPMENT_POLL_MS = 5000
+
+  const { data: attachedInstruments } = useInstrumentsQuery({
+    refetchInterval: EQUIPMENT_POLL_MS,
+  })
+  const attachedLeftPipette =
+    attachedInstruments?.data?.find(
+      (i): i is PipetteData =>
+        i.instrumentType === 'pipette' && i.ok && i.mount === 'left'
+    ) ?? null
+  const leftPipetteRequiresFWUpdate =
+    attachedInstruments?.data?.find(
+      (i): i is BadPipette =>
+        i.instrumentType === 'pipette' &&
+        !i.ok &&
+        i.subsystem === 'pipette_left'
+    ) ?? null
+  const attachedRightPipette =
+    attachedInstruments?.data?.find(
+      (i): i is PipetteData =>
+        i.instrumentType === 'pipette' && i.ok && i.mount === 'right'
+    ) ?? null
+  const rightPipetteFWRequired =
+    attachedInstruments?.data?.find(
+      (i): i is BadPipette =>
+        i.instrumentType === 'pipette' &&
+        !i.ok &&
+        i.subsystem === 'pipette_right'
+    ) ?? null
+
+  const attachPipetteRequired =
+    attachedLeftPipette == null && attachedRightPipette == null
+  const updatePipetteFWRequired =
+    leftPipetteRequiresFWUpdate != null || rightPipetteFWRequired != null
+  return { attachPipetteRequired, updatePipetteFWRequired }
+}
 
 interface ProtocolRunModuleControlsProps {
   robotName: string
@@ -21,6 +66,9 @@ export const ProtocolRunModuleControls = ({
   runId,
 }: ProtocolRunModuleControlsProps): JSX.Element => {
   const { t } = useTranslation('protocol_details')
+
+  const { attachPipetteRequired, updatePipetteFWRequired } = usePipetteIsReady()
+
   const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
     robotName,
     runId
@@ -67,6 +115,8 @@ export const ProtocolRunModuleControls = ({
               module={module.attachedModuleMatch}
               slotName={module.slotName}
               isLoadedInRun={true}
+              attachPipetteRequired={attachPipetteRequired}
+              updatePipetteFWRequired={updatePipetteFWRequired}
             />
           ) : null
         )}
@@ -85,6 +135,8 @@ export const ProtocolRunModuleControls = ({
               module={module.attachedModuleMatch}
               slotName={module.slotName}
               isLoadedInRun={true}
+              attachPipetteRequired={attachPipetteRequired}
+              updatePipetteFWRequired={updatePipetteFWRequired}
             />
           ) : null
         )}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunModuleControls.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunModuleControls.test.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react'
 import { resetAllWhenMocks, when } from 'jest-when'
 import { i18n } from '../../../../i18n'
-import {
-  componentPropsMatcher,
-  renderWithProviders,
-} from '@opentrons/components'
+import { renderWithProviders } from '@opentrons/components'
 import {
   CompletedProtocolAnalysis,
   ModuleModel,
   ModuleType,
 } from '@opentrons/shared-data'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { ProtocolRunModuleControls } from '../ProtocolRunModuleControls'
 import { ModuleCard } from '../../../ModuleCard'
 import {
@@ -24,6 +22,7 @@ import {
 } from '../../../../redux/modules/__fixtures__'
 import fixtureAnalysis from '../../../../organisms/RunDetails/__fixtures__/analysis.json'
 
+jest.mock('@opentrons/react-api-client')
 jest.mock('../../../ModuleCard')
 jest.mock('../../hooks')
 
@@ -33,6 +32,9 @@ const mockUseModuleRenderInfoForProtocolById = useModuleRenderInfoForProtocolByI
 >
 const mockUseProtocolDetailsForRun = useProtocolDetailsForRun as jest.MockedFunction<
   typeof useProtocolDetailsForRun
+>
+const mockUseInstrumentsQuery = useInstrumentsQuery as jest.MockedFunction<
+  typeof useInstrumentsQuery
 >
 
 const _fixtureAnalysis = (fixtureAnalysis as unknown) as CompletedProtocolAnalysis
@@ -83,6 +85,9 @@ describe('ProtocolRunModuleControls', () => {
       protocolKey: 'fakeProtocolKey',
       robotType: 'OT-2 Standard',
     })
+    when(mockUseInstrumentsQuery).mockReturnValue({
+      data: { data: [] },
+    } as any)
   })
 
   afterEach(() => {
@@ -106,16 +111,7 @@ describe('ProtocolRunModuleControls', () => {
           attachedModuleMatch: mockMagneticModuleGen2,
         },
       } as any)
-    when(mockModuleCard)
-      .calledWith(
-        componentPropsMatcher({
-          robotName: 'otie',
-          module: mockMagneticModuleGen2,
-          runId: 'test123',
-          isLoadedInRun: true, // this can never be false in this component since isModuleControl true is hardcoded in
-        })
-      )
-      .mockReturnValue(<div>mock Magnetic Module Card</div>)
+    when(mockModuleCard).mockReturnValue(<div>mock Magnetic Module Card</div>)
     const { getByText } = render({
       robotName: 'otie',
       runId: 'test123',
@@ -140,16 +136,9 @@ describe('ProtocolRunModuleControls', () => {
           attachedModuleMatch: mockTemperatureModuleGen2,
         },
       } as any)
-    when(mockModuleCard)
-      .calledWith(
-        componentPropsMatcher({
-          robotName: 'otie',
-          module: mockTemperatureModuleGen2,
-          runId: 'test123',
-          isLoadedInRun: true,
-        })
-      )
-      .mockReturnValue(<div>mock Temperature Module Card</div>)
+    when(mockModuleCard).mockReturnValue(
+      <div>mock Temperature Module Card</div>
+    )
     const { getByText } = render({
       robotName: 'otie',
       runId: 'test123',
@@ -175,16 +164,9 @@ describe('ProtocolRunModuleControls', () => {
         },
       } as any)
 
-    when(mockModuleCard)
-      .calledWith(
-        componentPropsMatcher({
-          robotName: 'otie',
-          module: mockThermocycler,
-          runId: 'test123',
-          isLoadedInRun: true,
-        })
-      )
-      .mockReturnValue(<div>mock Thermocycler Module Card</div>)
+    when(mockModuleCard).mockReturnValue(
+      <div>mock Thermocycler Module Card</div>
+    )
 
     const { getByText } = render({
       robotName: 'otie',
@@ -210,16 +192,9 @@ describe('ProtocolRunModuleControls', () => {
           attachedModuleMatch: mockHeaterShaker,
         },
       } as any)
-    when(mockModuleCard)
-      .calledWith(
-        componentPropsMatcher({
-          robotName: 'otie',
-          module: mockHeaterShaker,
-          runId: 'test123',
-          isLoadedInRun: true,
-        })
-      )
-      .mockReturnValue(<div>mock Heater-Shaker Module Card</div>)
+    when(mockModuleCard).mockReturnValue(
+      <div>mock Heater-Shaker Module Card</div>
+    )
 
     const { getByText } = render({
       robotName: 'otie',

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -23,6 +23,7 @@ interface ModuleOverflowMenuProps {
   handleInstructionsClick: () => void
   handleCalibrateClick: () => void
   isLoadedInRun: boolean
+  isPipetteReady: boolean
   robotName: string
   runId?: string
 }
@@ -40,6 +41,7 @@ export const ModuleOverflowMenu = (
     handleInstructionsClick,
     handleCalibrateClick,
     isLoadedInRun,
+    isPipetteReady,
   } = props
 
   const { t, i18n } = useTranslation('module_wizard_flows')
@@ -75,7 +77,7 @@ export const ModuleOverflowMenu = (
   return (
     <Flex position={POSITION_RELATIVE}>
       <MenuList>
-        <MenuItem onClick={handleCalibrateClick}>
+        <MenuItem onClick={handleCalibrateClick} disabled={!isPipetteReady}>
           {i18n.format(
             module.moduleOffset?.last_modified != null
               ? t('recalibrate')

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -190,6 +190,7 @@ describe('ModuleOverflowMenu', () => {
       handleInstructionsClick: jest.fn(),
       handleCalibrateClick: jest.fn(),
       isLoadedInRun: false,
+      isPipetteReady: true,
     }
   })
 
@@ -205,14 +206,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders the correct temperature module menu', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockTemperatureModuleGen2,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const buttonSetting = getByRole('button', {
@@ -226,14 +221,8 @@ describe('ModuleOverflowMenu', () => {
   })
   it('renders the correct TC module menu', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockThermocycler,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const buttonSettingLid = getByRole('button', {
@@ -253,14 +242,8 @@ describe('ModuleOverflowMenu', () => {
   })
   it('renders the correct Heater Shaker module menu', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockHeaterShaker,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     getByRole('button', {
@@ -279,14 +262,8 @@ describe('ModuleOverflowMenu', () => {
   })
   it('renders heater shaker show attachment instructions button and when clicked, launches hs wizard', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockHeaterShaker,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Show attachment instructions' })
@@ -296,14 +273,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders heater shaker labware latch button and is disabled when status is not idle', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockMovingHeaterShaker,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     expect(
@@ -315,14 +286,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders heater shaker labware latch button and when clicked, moves labware latch open', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockCloseLatchHeaterShaker,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -336,14 +301,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders heater shaker labware latch button and when clicked, moves labware latch close', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockHeaterShaker,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
 
@@ -356,14 +315,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders heater shaker overflow menu and deactivates heater when status changes', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockDeactivateHeatHeaterShaker,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -377,14 +330,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders temperature module overflow menu and deactivates heat when status changes', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockTemperatureModuleHeating,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -398,14 +345,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders magnetic module overflow menu and disengages when status changes', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockMagDeckEngaged,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -419,14 +360,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders thermocycler overflow menu and deactivates block when status changes', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockTCBlockHeating,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
 
     const { getByRole } = render(props)
@@ -447,13 +382,8 @@ describe('ModuleOverflowMenu', () => {
       isRunIdle: true,
     })
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockTCBlockHeating,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
       isLoadedInRun: true,
       runId: 'id',
     }
@@ -469,13 +399,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('should disable overflow menu buttons for thermocycler gen 1 when the robot is an OT-3', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockTCBlockHeating,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
       isLoadedInRun: true,
       runId: 'id',
     }
@@ -506,14 +431,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders the correct Thermocycler gen 2 menu', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockThermocyclerGen2,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const setLid = getByRole('button', {
@@ -534,14 +453,8 @@ describe('ModuleOverflowMenu', () => {
 
   it('renders the correct Thermocycler gen 2 menu with the lid closed', () => {
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockThermocyclerGen2LidClosed,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const setLid = getByRole('button', {
@@ -570,14 +483,8 @@ describe('ModuleOverflowMenu', () => {
     })
 
     props = {
-      robotName: 'otie',
+      ...props,
       module: mockThermocyclerGen2LidClosed,
-      handleSlideoutClick: jest.fn(),
-      handleAboutClick: jest.fn(),
-      handleTestShakeClick: jest.fn(),
-      handleInstructionsClick: jest.fn(),
-      handleCalibrateClick: jest.fn(),
-      isLoadedInRun: false,
     }
     const { getByRole } = render(props)
     const setLid = getByRole('button', {
@@ -592,5 +499,16 @@ describe('ModuleOverflowMenu', () => {
     expect(changeLid).toBeDisabled()
     expect(setBlock).toBeDisabled()
     expect(about).not.toBeDisabled()
+  })
+
+  it('renders a disabled calibrate button if the pipettes are not attached or need a firmware update', () => {
+    props = {
+      ...props,
+      isPipetteReady: false,
+    }
+    const { getByRole } = render(props)
+
+    const calibrate = getByRole('button', { name: 'Calibrate' })
+    expect(calibrate).toBeDisabled()
   })
 })

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -74,8 +74,8 @@ interface ModuleCardProps {
   module: AttachedModule
   robotName: string
   isLoadedInRun: boolean
-  attachPipetteRequired?: boolean
-  updatePipetteFWRequired?: boolean
+  attachPipetteRequired: boolean
+  updatePipetteFWRequired: boolean
   runId?: string
   slotName?: string
 }
@@ -120,6 +120,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     },
   })
   const requireModuleCalibration = module.moduleOffset == null
+  const isPipetteReady =
+    (!attachPipetteRequired ?? false) && (!updatePipetteFWRequired ?? false)
   const latestRequestId = last(requestIds)
   const latestRequest = useSelector<State, RequestState | null>(state =>
     latestRequestId ? getRequestById(state, latestRequestId) : null
@@ -432,6 +434,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               robotName={robotName}
               runId={runId}
               isLoadedInRun={isLoadedInRun}
+              isPipetteReady={isPipetteReady}
               handleSlideoutClick={handleMenuItemClick}
               handleTestShakeClick={handleTestShakeClick}
               handleInstructionsClick={handleInstructionsClick}


### PR DESCRIPTION
Closes RQA-1477

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a bug where pipettes are calibrated but not attached, the calibrate/recalibrate buttons within the module card overflow menu are enabled. Because module cards always render a calibrate button, it makes sense to require pipetteattachment/firmware status as props.

https://github.com/Opentrons/opentrons/assets/64858653/511a20e9-bf17-40ff-8d1c-fee8617f51b1

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Verified on a physical flex that the fix works given the above bug conditions.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added necessary network request for pipettes.
- Added disabled state for calibrate/recalibrate button based on pipette status.
- Lightly refactored some test code.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low