### PR TITLE
fix(app): Fix overeager maintenance run takeover modal

### DIFF
--- a/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
+++ b/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
@@ -51,7 +51,7 @@ export function MaintenanceRunTakeoverModal(
   }
 
   React.useEffect(() => {
-    if (currentRunId == null && status === 'success') {
+    if (currentRunId == null) {
       setIsLoading(false)
       setShowConfirmTerminateModal(false)
       reset()

--- a/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
+++ b/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
@@ -37,11 +37,7 @@ export function MaintenanceRunTakeoverModal(
   const desktopMaintenanceRunInProgress =
     isMaintenanceRunCurrent && oddRunId !== currentRunId
 
-  const {
-    deleteMaintenanceRun,
-    status,
-    reset,
-  } = useDeleteMaintenanceRunMutation()
+  const { deleteMaintenanceRun, reset } = useDeleteMaintenanceRunMutation()
 
   const handleCloseAndTerminate = (): void => {
     if (currentRunId != null) {
@@ -56,7 +52,7 @@ export function MaintenanceRunTakeoverModal(
       setShowConfirmTerminateModal(false)
       reset()
     }
-  }, [currentRunId, status])
+  }, [currentRunId])
 
   return (
     <>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes hanging maintenance run takeover modals after a delete maintenance run request has been sent to the server. Awaiting a successful response is redundant, since the currentRunId is polled and will be null upon successful deletion. Checking the status introduces odd edge cases where the currentRunId clears, but the takeover modal hangs unnecessarily.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Bug identified on the physical flex. While recreating the exact conditions in which this bug appeared are difficult, it has been confirmed that this change does not impact normal functionality.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Removed deleteMaintenanceRun status check.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low