### PR TITLE
feat(api): add configure_for_volume

### DIFF
--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -331,7 +331,7 @@ In a protocol that handles many different volumes, it's a good practice to call 
     for i in range(8):
         pipette50.pick_up_tip()
         pipette50.configure_for_volume(volumes[i])
-        pipette50.aspirate(volume=volume, location=sources[i])
+        pipette50.aspirate(volume=volumes[i], location=sources[i])
         pipette50.dispense(location=destinations[i])
         pipette50.drop_tip()
 

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -303,6 +303,41 @@ The OT-2 works with the GEN1 and GEN2 pipette models. The newer GEN2 pipettes ha
 
 The single- and multi-channel P50 GEN1 pipettes are the exceptions here. If your protocol uses a P50 GEN1 pipette, there is no backward compatibility with a related GEN2 pipette. To replace a P50 GEN1 with a corresponding GEN2 pipette, edit your protocol to load a P20 Single-Channel GEN2 (for volumes below 20 µL) or a P300 Single-Channel GEN2 (for volumes between 20 and 50 µL).
 
+.. _pipette-volume-modes:
+
+Volume Modes
+============
+
+The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a low-volume mode to accurately dispense 1 µL of liquid. Set low-volume mode by calling :py:meth:`.InstrumentContext.configure_for_volume` with the amount of liquid you plan to aspirate, in µL::
+
+    pipette50.configure_for_volume(1)
+    pipette50.pick_up_tip()
+    pipette50.aspirate(1, plate["A1"])
+    
+.. versionadded:: 2.15
+
+.. note::
+    The pipette must not contain liquid when you call ``configure_for_volume()``, or the API will raise an error.
+    
+    Also, if the pipette is in a well location that may contain liquid, it will move upward to ensure it is not immersed in liquid before changing its mode.
+
+In a protocol that handles many different volumes, it's a good practice to call this function immediately before each :py:meth:`.transfer` or :py:meth:`.aspirate`, specifying the volume that you are about to handle. When operating with a list of volumes, nest ``configure_for_volume()`` inside a ``for`` loop to ensure that the pipette is properly configured for each volume:
+
+.. code-block:: python
+    
+    volumes = [1, 2, 3, 4, 1, 5, 2, 8]
+    sources = plate.columns()[0]
+    destinations = plate.columns()[1]
+    for i in range(8):
+        pipette50.pick_up_tip()
+        pipette50.configure_for_volume(volumes[i])
+        pipette50.aspirate(volume=volume, location=sources[i])
+        pipette50.dispense(location=destinations[i])
+        pipette50.drop_tip()
+
+If you know that all your liquid handling will take place in a specific mode, then you can call ``configure_for_volume()`` just once with a nominal volume. Or if all the volumes correspond to the pipette's default mode, you don't have to call ``configure_for_volume()`` at all.
+
+
 .. _new-plunger-flow-rates:
 
 Pipette Flow Rates
@@ -343,9 +378,13 @@ Now let's change the flow rates for each action::
         pipette.aspirate(200, plate['A1'])  #  50 µL/s
         pipette.dispense(200, plate['A2'])  # 100 µL/s
         pipette.blow_out()                  #  75 µL/s
+        
+These flow rates will remain in effect until you change the ``flow_rate`` attribute again *or* call ``configure_for_volume()``. Calling ``configure_for_volume()`` always resets all pipette flow rates to the defaults for the mode that it sets.
+
+.. TODO add mode ranges and flow defaults to sections below
 
 .. note::
-    In API version 2.13 and earlier, :py:obj:`.InstrumentContext.speed` offered similar functionality. It attempted to set the plunger speed in mm/s. Due to technical limitations, that speed could only be approximate. You must use ``.flow_rate`` in version 2.14 and later, and you should consider replacing older code that sets ``.speed``.
+    In API version 2.13 and earlier, :py:obj:`.InstrumentContext.speed` offered similar functionality to ``.flow_rate``. It attempted to set the plunger speed in mm/s. Due to technical limitations, that speed could only be approximate. You must use ``.flow_rate`` in version 2.14 and later, and you should consider replacing older code that sets ``.speed``.
 
 .. versionadded:: 2.0
 

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -526,3 +526,8 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         if blow_out is not None:
             assert blow_out > 0
             self._blow_out_flow_rate = blow_out
+
+    def configure_for_volume(self, volume: float) -> None:
+        return self._engine_client.configure_for_volume(
+            pipette_id=self._pipette_id, volume=volume
+        )

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -528,6 +528,6 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             self._blow_out_flow_rate = blow_out
 
     def configure_for_volume(self, volume: float) -> None:
-        return self._engine_client.configure_for_volume(
+        self._engine_client.configure_for_volume(
             pipette_id=self._pipette_id, volume=volume
         )

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -228,5 +228,13 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
     ) -> None:
         ...
 
+    def configure_for_volume(self, volume: float) -> None:
+        """Configure the pipette for a specific volume.
+
+        Args:
+            volume: The volume to preppare to handle.
+        """
+        ...
+
 
 InstrumentCoreType = TypeVar("InstrumentCoreType", bound=AbstractInstrument[Any])

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -507,3 +507,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
                     to_loc=location,
                     is_multichannel=self.get_channels() > 1,
                 )
+
+    def configure_for_volume(self, volume: float) -> None:
+        """This will never be called because it was added in API 2.15."""
+        pass

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -417,3 +417,7 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
         """Raise TipAttachedError if tip."""
         if self.has_tip():
             raise TipAttachedError(f"Cannot {action} with a tip attached")
+
+    def configure_for_volume(self, volume: float) -> None:
+        """This will never be called because it was added in API 2.15."""
+        pass

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1585,77 +1585,30 @@ class InstrumentContext(publisher.CommandPublisher):
 
     @requires_version(2, 15)
     def configure_for_volume(self, volume: float) -> None:
-        """Configure the pipette to handle a specific volume of liquid.
+        """Configure a pipette to handle a specific volume of liquid, specified in µL. Depending on the
+        volume, the pipette will enter a certain pipetting mode. Changing pipette modes alters properties
+        of the instance of :py:class:`.InstrumentContext`, such as default flow rate, minimum volume, and
+        maximum volume. The pipette will remain in the mode set by this function until it is called again.
 
-        Some pipettes have multiples of operation to handle certain volumes of liquid accurately.
-        For instance, the 50 µL GEN3 Single and Eight Channel pipettes must be placed in a low
-        volume mode to accurately dispense 1 µL of liquid. This function sets the mode of a pipette
-        - if applicable - appropriately for the specified volume.
+        The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a low-volume mode
+        to accurately dispense 1 µL of liquid. Low-volume mode can only be set by calling this function.
 
-        The function can only be called when no liquid is aspirated into the pipette. It can be called
-        whether or not a tip is present, though when the pipette is in a certain mode some tips may be
-        unavailable.
-
-        The function must be called to put the pipette in the proper mode for a later aspiration. The
-        mode then persists until the next time the function is called.
-
-        Pipette modes also determine other properties of the pipette such as default flow rates and
-        maximum or minimum handlable volumes. The properties of this object may change when you change
-        modes.
+        For more information on available modes for certain pipettes, see :ref:`pipette-volume-modes`.
 
         .. note ::
 
-            Changing a pipette's mode will reset its flowrates.
+            Changing a pipette's mode will reset its :ref:`flow rates <new-plunger-flow-rates>`.
 
-        If you are executing a protocol with many different volumes, it's a good practice to call this
-        function immediately before every distinct transfer or aspirate, using the volumes that you are
-        about to transfer or aspirate. This style also means the mode will always be correct when
-        executing from a volume list:
+        This function will raise an error if called when the pipette's tip contains liquid. It won't
+        raise an error if no tip is attached, but changing modes may affect which tips the pipette can
+        subsequently pick up without raising an error.
 
-        .. code-block:: python
+        This function will also raise an error if ``volume`` is outside the :ref:`overall minimum and
+        maximum capacities <new-pipette-models>` of the pipette (e.g., setting ``volume=1`` for a Flex
+        1000 µL pipette).
 
-            tiprack = protocol.load_labware('opentrons_flex_96_tiprack_50ul', 'D1')
-            sample_plate = protocol.load_labware('nest_1_reservoir_195ml', 'D2')
-            instr = protocol.load_instrument('p50_single_gen3', 'left', tip_racks=[tiprack])
-            # this list might have been loaded from a CSV
-            for volume in [1, 2, 3, 4, 1, 5, 2, 8]:
-                instr.pick_up_tip()
-                # configuring for each volume before aspiration ensures the pipette is always in the
-                # right mode
-                instr.configure_for_volume(volume)
-                instr.aspirate(volume=volume, location=sample_plate['A1'])
-                instr.dispense(location=sample_plate['A1'])
-                instr.drop_tip()
-
-        However, if you know that all your liquid handling will take place in a specific mode, then you
-        can call the function just once with a nominal volume ahead of time, or - if the mode is the default
-        one - not call the function at all:
-
-        .. code-block:: python
-
-            # A p300_multi_gen2 has only a default mode; you do not need to call this function
-            tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
-            sample_plate = protocol.load_labware('nest_1_reservoir_195ml', '2')
-            instr = protocol.load_instrument('p300_multi_gen2', 'left', tip_racks=[tiprack])
-            for volume in [50, 10, 25, 300, 8]:
-                instr.pick_up_tip()
-                instr.aspirate(volume=volume, location=sample_plate['A1'])
-                instr.drop_tip()
-
-        For more information on what pipettes have what modes, see the Pipettes page.
-
-        .. note::
-
-            Changing the mode of a pipette may require a plunger movement. The pipette may move to ensure it
-            is not immersed in liquid.
-
-        :param volume:  - The volume to configure the pipette to handle
+        :param volume: The volume, in µL, that the pipette will prepare to handle.
         :type volume: float
-
-        :raises CommandPreconditionViolated: If called when liquid is held in the pipette
-        :raises CommandParameterLimitViolated: If called with a negative volume or a volume that the pipette
-                                               cannot handle in any mode.
-
         """
         if self._core.get_current_volume():
             raise CommandPreconditionViolated(

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -260,8 +260,17 @@ class SyncClient:
         result = self._transport.execute_command(request=request)
         return cast(commands.DropTipResult, result)
 
-    def configure_for_volume(self, pipette_id: str, volume: float) -> None:
-        pass
+    def configure_for_volume(
+        self, pipette_id: str, volume: float
+    ) -> commands.ConfigureForVolumeResult:
+        """Execute a ConfigureForVolume command."""
+        request = commands.ConfigureForVolumeCreate(
+            params=commands.ConfigureForVolumeParams(
+                pipetteId=pipette_id, volume=volume
+            )
+        )
+        result = self._transport.execute_command(request=request)
+        return cast(commands.ConfigureForVolumeResult, result)
 
     def aspirate(
         self,

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -260,6 +260,9 @@ class SyncClient:
         result = self._transport.execute_command(request=request)
         return cast(commands.DropTipResult, result)
 
+    def configure_for_volume(self, pipette_id: str, volume: float) -> None:
+        pass
+
     def aspirate(
         self,
         pipette_id: str,


### PR DESCRIPTION
This function configures a pipette in the appropriate mode to handle a specific volume. It's needed for p50 gen3 pipettes to handle very low volumes by changing a number of settings, and needs to be exposed as a separate function because it can cause motion like prepare_for_aspirate().

## Testing

- Run on a robot! Make sure that the low volume pipetting profile gets selected.
Note: this will be tested on hardware much more... extensively.