### PR TITLE
feat(protocol-designer): remove unused enable OT-3 FF and clean up i1…

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -19,7 +19,6 @@ const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
-  OT_PD_ENABLE_OT_3: process.env.OT_PD_ENABLE_OT_3 === '1' || false,
   OT_PD_ALLOW_ALL_TIPRACKS:
     process.env.OT_PD_ALLOW_ALL_TIPRACKS === '1' || false,
 }

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -15,10 +15,6 @@ export const getDisableModuleRestrictions: Selector<
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
-export const getEnabledOT3: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_OT_3 ?? false
-)
 export const getAllowAllTipracks: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ALLOW_ALL_TIPRACKS ?? false

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -19,12 +19,12 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_HEATER_SHAKER',
   'OT_PD_ENABLE_THERMOCYCLER_GEN_2',
   'OT_PD_ENABLE_LIQUID_COLOR_ENHANCEMENTS',
+  'OT_PD_ENABLE_OT_3',
 ]
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
-  | 'OT_PD_ENABLE_OT_3'
   | 'OT_PD_ALLOW_ALL_TIPRACKS'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -8,18 +8,6 @@
     "description_1": "Turn off all restrictions on module placement and related pipette crash guidance.",
     "description_2": "NOT recommended! Switching from default positions may cause crashes and the Protocol Designer cannot yet give guidance on what to expect. Use at your own discretion. "
   },
-  "OT_PD_ENABLE_BATCH_EDIT_MIX": {
-    "title": "Enable mix batch edit",
-    "description": "Allow users to batch edit mix forms"
-  },
-  "OT_PD_ENABLE_SCHEMA_V6": {
-    "title": "Enable schema v6 support",
-    "description": "Allow users to migrate older protocols to schema v6"
-  },
-  "OT_PD_ENABLE_OT_3": {
-    "title": "Enable OT-3 support",
-    "description": "Allow users to enable OT-3 support in protocol designer"
-  },
   "OT_PD_ALLOW_ALL_TIPRACKS": {
     "title": "Allow all tip rack options",
     "description": "Enable selection of all tip racks for each pipette."


### PR DESCRIPTION
…8n keys

closes RAUT-692

# Overview

Cleans up the Protocol designer feature flag components. 

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_delete-unused-ff-stuff/

Go to the settings tab in protocol-designer. Make sure that there are 2 experimental settings available (these are customer facing):
1. Allow all tipracks
2. Disable module placement restrictions

Turn on the internal feature flags by typing `enablePrereleaseMode()` in console and refresh. There should be 1 feature flag under internal use ff:
1. Use prerelease mode


# Changelog

- delete enable ot-3 feature flag since it isn't being used and deprecate flag name
- delete unused feature-flag i18n keys from past feature flags

# Review requests

see test plan

# Risk assessment

low