### PR TITLE
fix(app): clear previous protocol errors error in choose robot slideout

### DIFF
--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -133,11 +133,13 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
       {selectedProtocol != null ? (
         <>
           <ChooseRobotToRunProtocolSlideout
+            key={selectedProtocol.protocolKey}
             onCloseClick={() => setShowChooseRobotToRunProtocolSlideout(false)}
             showSlideout={showChooseRobotToRunProtocolSlideout}
             storedProtocolData={selectedProtocol}
           />
           <SendProtocolToOT3Slideout
+            key={selectedProtocol.protocolKey}
             isExpanded={showSendProtocolToOT3Slideout}
             onCloseClick={() => setShowSendProtocolToOT3Slideout(false)}
             storedProtocolData={selectedProtocol}


### PR DESCRIPTION
closes [RQA-1493](https://opentrons.atlassian.net/browse/RQA-1493)

# Overview

When attempting to start setup for a protocol that produces an analysis error from the ProtocolsLanding page, the selected device on the ChooseRobotSlideout displays a red error banner as expected. However, when the slideout is closed, and a new valid protocol is selected to run, the slideout still shows the error banner from the previous failed analysis. We need to ensure the slideout re-renders to clear the error banner for a new protocol selection.

# Test Plan

- Verify that an an error from a previous protocol attempt is cleared when a new protocol is selected:
https://github.com/Opentrons/opentrons/assets/47604184/d39064d3-9788-4deb-ad60-484bac7182f8

- Verify that the same issue doesn't exist when choosing a protocol in the ChooseProtocolSlideout from RobotOverview

# Changelog

- Set a protocol-specific key in the ChooseProtocolSlideout instantiation from the ProtocolsList to ensure previous protocol error banner is cleared

# Risk assessment

low

[RQA-1493]: https://opentrons.atlassian.net/browse/RQA-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ