### PR TITLE
fix(app): Slideout card error text fix

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -205,56 +205,61 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
           selectedProtocol != null &&
           storedProtocol.protocolKey === selectedProtocol.protocolKey
         return (
-          <Flex
-            flexDirection={DIRECTION_COLUMN}
-            key={storedProtocol.protocolKey}
-          >
-            <MiniCard
-              isSelected={isSelected}
-              isError={runCreationError != null}
-              onClick={() => handleSelectProtocol(storedProtocol)}
+          <>
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              key={storedProtocol.protocolKey}
             >
-              <Box display="grid" gridTemplateColumns="1fr 3fr">
-                <Box
-                  marginY={SPACING.spacingAuto}
-                  backgroundColor={isSelected ? COLORS.white : 'inherit'}
-                  marginRight={SPACING.spacing16}
-                  height="4.25rem"
-                  width="4.75rem"
-                >
-                  <DeckThumbnail
-                    commands={storedProtocol.mostRecentAnalysis?.commands ?? []}
-                    labware={storedProtocol.mostRecentAnalysis?.labware ?? []}
-                  />
+              <MiniCard
+                isSelected={isSelected}
+                isError={runCreationError != null}
+                onClick={() => handleSelectProtocol(storedProtocol)}
+              >
+                <Box display="grid" gridTemplateColumns="1fr 3fr">
+                  <Box
+                    marginY={SPACING.spacingAuto}
+                    backgroundColor={isSelected ? COLORS.white : 'inherit'}
+                    marginRight={SPACING.spacing16}
+                    height="4.25rem"
+                    width="4.75rem"
+                  >
+                    <DeckThumbnail
+                      commands={
+                        storedProtocol.mostRecentAnalysis?.commands ?? []
+                      }
+                      labware={storedProtocol.mostRecentAnalysis?.labware ?? []}
+                    />
+                  </Box>
+                  <StyledText
+                    as="p"
+                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                    overflowWrap="anywhere"
+                  >
+                    {storedProtocol.mostRecentAnalysis?.metadata
+                      ?.protocolName ??
+                      first(storedProtocol.srcFileNames) ??
+                      storedProtocol.protocolKey}
+                  </StyledText>
                 </Box>
-                <StyledText
-                  as="p"
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  overflowWrap="anywhere"
-                >
-                  {storedProtocol.mostRecentAnalysis?.metadata?.protocolName ??
-                    first(storedProtocol.srcFileNames) ??
-                    storedProtocol.protocolKey}
-                </StyledText>
-              </Box>
-              {runCreationError != null && isSelected ? (
-                <>
-                  <Box flex="1 1 auto" />
-                  <Icon
-                    name="alert-circle"
-                    size="1.25rem"
-                    color={COLORS.errorEnabled}
-                  />
-                </>
-              ) : null}
-            </MiniCard>
+                {runCreationError != null && isSelected ? (
+                  <>
+                    <Box flex="1 1 auto" />
+                    <Icon
+                      name="alert-circle"
+                      size="1.25rem"
+                      color={COLORS.errorEnabled}
+                    />
+                  </>
+                ) : null}
+              </MiniCard>
+            </Flex>
             {runCreationError != null && isSelected ? (
               <StyledText
                 as="label"
                 color={COLORS.errorText}
                 overflowWrap="anywhere"
                 display={DISPLAY_BLOCK}
-                marginTop={`-${SPACING.spacing4}`}
+                marginTop={`-${SPACING.spacing8}`}
                 marginBottom={SPACING.spacing8}
               >
                 {runCreationErrorCode === 409 ? (
@@ -278,7 +283,7 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                 )}
               </StyledText>
             ) : null}
-          </Flex>
+          </>
         )
       })}
     </Flex>

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -222,32 +222,34 @@ export function ChooseRobotSlideout(
             const isSelected =
               selectedRobot != null && selectedRobot.ip === robot.ip
             return (
-              <Flex key={robot.ip} flexDirection={DIRECTION_COLUMN}>
-                <AvailableRobotOption
-                  key={robot.ip}
-                  robot={robot}
-                  // TODO: generalize to a disabled/reset prop
-                  onClick={() => {
-                    if (!isCreatingRun) {
-                      resetCreateRun?.()
-                      setSelectedRobot(robot)
+              <>
+                <Flex key={robot.ip} flexDirection={DIRECTION_COLUMN}>
+                  <AvailableRobotOption
+                    key={robot.ip}
+                    robot={robot}
+                    // TODO: generalize to a disabled/reset prop
+                    onClick={() => {
+                      if (!isCreatingRun) {
+                        resetCreateRun?.()
+                        setSelectedRobot(robot)
+                      }
+                    }}
+                    isError={runCreationError != null}
+                    isSelected={isSelected}
+                    isOnDifferentSoftwareVersion={
+                      isSelectedRobotOnWrongVersionOfSoftware
                     }
-                  }}
-                  isError={runCreationError != null}
-                  isSelected={isSelected}
-                  isOnDifferentSoftwareVersion={
-                    isSelectedRobotOnWrongVersionOfSoftware
-                  }
-                  showIdleOnly={showIdleOnly}
-                  registerRobotBusyStatus={registerRobotBusyStatus}
-                />
+                    showIdleOnly={showIdleOnly}
+                    registerRobotBusyStatus={registerRobotBusyStatus}
+                  />
+                </Flex>
                 {runCreationError != null && isSelected && (
                   <StyledText
                     as="label"
                     color={COLORS.errorText}
                     overflowWrap="anywhere"
                     display={DISPLAY_INLINE_BLOCK}
-                    marginTop={`-${SPACING.spacing4}`}
+                    marginTop={`-${SPACING.spacing8}`}
                     marginBottom={SPACING.spacing8}
                   >
                     {runCreationErrorCode === 409 ? (
@@ -271,7 +273,7 @@ export function ChooseRobotSlideout(
                     )}
                   </StyledText>
                 )}
-              </Flex>
+              </>
             )
           })
         )}


### PR DESCRIPTION
Closes RQA-1492

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Error text was overly nested inside a <Flex> component, causing text to render within the boundaries of a
sibling component. This PR fixes the issue across all slideouts.

### Before
<img width="305" alt="Screenshot 2023-09-06 at 2 27 44 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/929d44bd-64c5-4ee7-b856-28bc5598e70a">

### After

<img width="1017" alt="error text fix" src="https://github.com/Opentrons/opentrons/assets/64858653/f6fcaf66-763a-4793-9ecc-7b08d3d4ff97">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Verified that protocol/robot related error messages correctly display without overlap.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Re-arranged and adjusted margins for components within ChooseRobotSlide and ChooseProtocolSlideout

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low