### PR TITLE
feat(protocol-designer): remove touchTip from incompatible labwares

### DIFF
--- a/protocol-designer/cypress/integration/batchEdit.spec.js
+++ b/protocol-designer/cypress/integration/batchEdit.spec.js
@@ -98,7 +98,7 @@ function importProtocol() {
     cy.get('[data-test="ComputingSpinner"]').should('exist')
     cy.get('div')
       .contains(
-        'We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior'
+        'Your protocol will be automatically updated to the latest version.'
       )
       .should('exist')
     cy.get('button').contains('ok', { matchCase: false }).click()

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -26,7 +26,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       expectedExportFixture:
         '../../fixtures/protocol/7/doItAllV3MigratedToV7.json',
       unusedPipettes: false,
-      migrationModal: 'noBehaviorChange',
+      migrationModal: 'generic',
     },
     {
       title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 7.0.x, schema 7',
@@ -34,7 +34,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       expectedExportFixture:
         '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
       unusedPipettes: false,
-      migrationModal: 'noBehaviorChange',
+      migrationModal: 'generic',
     },
     {
       title: 'doItAllV6 (schema 6, PD version 6.1.0) -> PD 7.0.x, schema 7',
@@ -42,7 +42,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       expectedExportFixture:
         '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
       unusedPipettes: false,
-      migrationModal: 'noBehaviorChange',
+      migrationModal: 'generic',
     },
     {
       title:
@@ -58,7 +58,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
         'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 7.0.x, schema 7',
       importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
       expectedExportFixture: '../../fixtures/protocol/7/mix_7_0_0.json',
-      migrationModal: 'noBehaviorChange',
+      migrationModal: 'generic',
       unusedPipettes: false,
     },
     {

--- a/protocol-designer/cypress/integration/mixSettings.spec.js
+++ b/protocol-designer/cypress/integration/mixSettings.spec.js
@@ -13,7 +13,7 @@ function importProtocol() {
     cy.get('[data-test="ComputingSpinner"]').should('exist')
     cy.get('div')
       .contains(
-        'We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior'
+        'Your protocol will be automatically updated to the latest version.'
       )
       .should('exist')
     cy.get('button').contains('ok', { matchCase: false }).click()

--- a/protocol-designer/cypress/integration/transferSettings.spec.js
+++ b/protocol-designer/cypress/integration/transferSettings.spec.js
@@ -14,7 +14,7 @@ function importProtocol() {
       cy.get('[data-test="ComputingSpinner"]').should('exist')
       cy.get('div')
         .contains(
-          'We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior'
+          'Your protocol will be automatically updated to the latest version.'
         )
         .should('exist')
       cy.get('button').contains('ok', { matchCase: false }).click()

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/__tests__/modalContents.test.ts
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/__tests__/modalContents.test.ts
@@ -17,7 +17,7 @@ describe('modalContents', () => {
         )
       })
     })
-    it('should return the "no behavior change message" when migrating from v5.x to 5.2', () => {
+    it('should return the "no behavior change message" when migrating from v5.x to 6', () => {
       const migrationsList = [
         ['5.0.0'],
         ['5.0.0', '5.1.0'],
@@ -31,12 +31,13 @@ describe('modalContents', () => {
         )
       })
     })
-    it('should return the generic migration modal when a v4 migration is required', () => {
+    it('should return the generic migration modal when a v4 migration or v7 migration is required', () => {
       const migrationsList = [
         ['4.0.0'],
         ['4.0.0', '5.0.0'],
         ['4.0.0', '5.0.0', '5.1.0'],
         ['4.0.0', '5.0.0', '5.1.0, 5.2.0'],
+        ['6.0.0', '6.1.0', '6.2.0', '6.2.1', '6.2.2'],
       ]
       migrationsList.forEach(migrations => {
         expect(JSON.stringify(getMigrationMessage(migrations))).toEqual(

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -125,7 +125,16 @@ export function getMigrationMessage(migrationsRan: string[]): ModalContents {
   if (migrationsRan.includes('3.0.0')) {
     return toV3MigrationMessage
   }
-  if (migrationsRan.includes('4.0.0')) {
+  const noBehaviorMigrations = [
+    ['5.0.0'],
+    ['5.0.0', '5.1.0'],
+    ['5.0.0', '5.1.0', '5.2.0'],
+  ]
+  if (
+    noBehaviorMigrations.some(migrationList =>
+      migrationsRan.every(migration => migrationList.includes(migration))
+    )
+  ) {
     return noBehaviorChangeMessage
   }
   return genericDidMigrateMessage

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import assert from 'assert'
-import semver from 'semver'
 import styles from './modalContents.css'
 import { ModalContents } from './types'
 import { FileUploadMessage } from '../../../load-file'

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -52,8 +52,7 @@ export const genericDidMigrateMessage: ModalContents = {
       </p>
       <p>
         Updating the file may make changes to liquid handling actions. Please
-        review your file in the Protocol Designer as well as with a water run on
-        the robot.
+        review your file in the Protocol Designer.
       </p>
       <p>As always, please contact us with any questions or feedback.</p>
     </>
@@ -126,7 +125,7 @@ export function getMigrationMessage(migrationsRan: string[]): ModalContents {
   if (migrationsRan.includes('3.0.0')) {
     return toV3MigrationMessage
   }
-  if (migrationsRan.every(migration => semver.gt(migration, '4.0.0'))) {
+  if (migrationsRan.includes('4.0.0')) {
     return noBehaviorChangeMessage
   }
   return genericDidMigrateMessage

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -1,3 +1,4 @@
+import mapValues from 'lodash/mapValues'
 import { uuid } from '../../utils'
 import { getOnlyLatestDefs } from '../../labware-defs'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
@@ -23,6 +24,7 @@ import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 // NOTE: this migration removes pipettes, labware, and modules as top level keys and adds necessary
 // params to the load commands. Also, this migrates previous combined
 //  adapter + labware commands to all labware commands and definitions to their commands/definitions split up
+//  as well as removing touch_tip commands from labware where touch_tip is incompatible
 const PD_VERSION = '7.0.0'
 const SCHEMA_VERSION = 7
 interface LabwareLocationUpdate {
@@ -32,8 +34,9 @@ interface LabwareLocationUpdate {
 export const migrateFile = (
   appData: ProtocolFileV6<DesignerApplicationData>
 ): ProtocolFile => {
-  const { commands, labwareDefinitions } = appData
+  const { commands, labwareDefinitions, designerApplication } = appData
   const { pipettes, labware, modules, ...rest } = appData
+  const savedStepForms = designerApplication?.data?.savedStepForms
   const labwareLocationUpdate: LabwareLocationUpdate =
     appData.designerApplication?.data?.savedStepForms[
       INITIAL_DECK_SETUP_STEP_ID
@@ -252,6 +255,65 @@ export const migrateFile = (
   }
   const newLabwareIngreds = getNewLabwareIngreds(ingredLocations)
 
+  const migrateSavedStepForms = (
+    savedStepForms: Record<string, any>
+  ): Record<string, any> => {
+    return mapValues(savedStepForms, stepForm => {
+      if (stepForm.stepType === 'moveLiquid') {
+        const aspirateLabware =
+          newLabwareDefinitions[labware[stepForm.aspirate_labware].definitionId]
+        const aspirateTouchTipIncompatible = aspirateLabware?.parameters.quirks?.includes(
+          'touchTipDisabled'
+        )
+        const dispenseLabware =
+          newLabwareDefinitions[labware[stepForm.dispense_labware].definitionId]
+        const dispenseTouchTipIncompatible = dispenseLabware?.parameters.quirks?.includes(
+          'touchTipDisabled'
+        )
+        return {
+          ...stepForm,
+          aspirate_touchTip_checkbox: aspirateTouchTipIncompatible
+            ? false
+            : stepForm.aspirate_touchTip_checkbox,
+          aspirate_touchTip_mmFromBottom: aspirateTouchTipIncompatible
+            ? null
+            : stepForm.aspirate_touchTip_mmFromBottom,
+          dispense_touchTip_checkbox: dispenseTouchTipIncompatible
+            ? false
+            : stepForm.dispense_touchTip_checkbox,
+          dispense_touchTip_mmFromBottom: dispenseTouchTipIncompatible
+            ? null
+            : stepForm.dispense_touchTip_mmFromBottom,
+        }
+      } else if (stepForm.stepType === 'mix') {
+        const misLabware =
+          newLabwareDefinitions[labware[stepForm.labware].definitionId]
+        const touchTipIncompatible = misLabware?.parameters.quirks?.includes(
+          'touchTipDisabled'
+        )
+        return {
+          ...stepForm,
+          mix_touchTip_checkbox: touchTipIncompatible
+            ? false
+            : stepForm.mix_touchTip_checkbox,
+          mix_touchTip_mmFromBottom: touchTipIncompatible
+            ? null
+            : stepForm.mix_touchTip_mmFromBottom,
+        }
+      }
+
+      return stepForm
+    })
+  }
+  const savedStepFormsWithoutInitialDeckState = Object.fromEntries(
+    Object.entries(savedStepForms ?? {}).filter(
+      ([key, value]) => key !== INITIAL_DECK_SETUP_STEP_ID
+    )
+  )
+  const newSavedStepFormsWithoutInitialDeckState = migrateSavedStepForms(
+    savedStepFormsWithoutInitialDeckState
+  )
+
   return {
     ...rest,
     designerApplication: {
@@ -263,7 +325,7 @@ export const migrateFile = (
           ...newLabwareIngreds,
         },
         savedStepForms: {
-          ...appData.designerApplication?.data?.savedStepForms,
+          ...newSavedStepFormsWithoutInitialDeckState,
           [INITIAL_DECK_SETUP_STEP_ID]: {
             ...appData.designerApplication?.data?.savedStepForms[
               INITIAL_DECK_SETUP_STEP_ID

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -34,9 +34,8 @@ interface LabwareLocationUpdate {
 export const migrateFile = (
   appData: ProtocolFileV6<DesignerApplicationData>
 ): ProtocolFile => {
-  const { commands, labwareDefinitions, designerApplication } = appData
+  const { commands, labwareDefinitions } = appData
   const { pipettes, labware, modules, ...rest } = appData
-  const savedStepForms = designerApplication?.data?.savedStepForms
   const labwareLocationUpdate: LabwareLocationUpdate =
     appData.designerApplication?.data?.savedStepForms[
       INITIAL_DECK_SETUP_STEP_ID
@@ -305,14 +304,12 @@ export const migrateFile = (
       return stepForm
     })
   }
-  const savedStepFormsWithoutInitialDeckState = Object.fromEntries(
-    Object.entries(savedStepForms ?? {}).filter(
-      ([key, value]) => key !== INITIAL_DECK_SETUP_STEP_ID
-    )
+  const filteredavedStepForms = Object.fromEntries(
+    Object.entries(
+      appData.designerApplication?.data?.savedStepForms ?? {}
+    ).filter(([key, value]) => key !== INITIAL_DECK_SETUP_STEP_ID)
   )
-  const newSavedStepFormsWithoutInitialDeckState = migrateSavedStepForms(
-    savedStepFormsWithoutInitialDeckState
-  )
+  const newFilteredavedStepForms = migrateSavedStepForms(filteredavedStepForms)
 
   return {
     ...rest,
@@ -325,7 +322,6 @@ export const migrateFile = (
           ...newLabwareIngreds,
         },
         savedStepForms: {
-          ...newSavedStepFormsWithoutInitialDeckState,
           [INITIAL_DECK_SETUP_STEP_ID]: {
             ...appData.designerApplication?.data?.savedStepForms[
               INITIAL_DECK_SETUP_STEP_ID
@@ -334,6 +330,7 @@ export const migrateFile = (
               ...newLabwareLocationUpdate,
             },
           },
+          ...newFilteredavedStepForms,
         },
       },
     },

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -273,16 +273,16 @@ export const migrateFile = (
           ...stepForm,
           aspirate_touchTip_checkbox: aspirateTouchTipIncompatible
             ? false
-            : stepForm.aspirate_touchTip_checkbox,
+            : stepForm.aspirate_touchTip_checkbox ?? false,
           aspirate_touchTip_mmFromBottom: aspirateTouchTipIncompatible
             ? null
-            : stepForm.aspirate_touchTip_mmFromBottom,
+            : stepForm.aspirate_touchTip_mmFromBottom ?? null,
           dispense_touchTip_checkbox: dispenseTouchTipIncompatible
             ? false
-            : stepForm.dispense_touchTip_checkbox,
+            : stepForm.dispense_touchTip_checkbox ?? false,
           dispense_touchTip_mmFromBottom: dispenseTouchTipIncompatible
             ? null
-            : stepForm.dispense_touchTip_mmFromBottom,
+            : stepForm.dispense_touchTip_mmFromBottom ?? null,
         }
       } else if (stepForm.stepType === 'mix') {
         const mixLabware =
@@ -294,10 +294,10 @@ export const migrateFile = (
           ...stepForm,
           mix_touchTip_checkbox: mixTouchTipIncompatible
             ? false
-            : stepForm.mix_touchTip_checkbox,
+            : stepForm.mix_touchTip_checkbox ?? false,
           mix_touchTip_mmFromBottom: mixTouchTipIncompatible
             ? null
-            : stepForm.mix_touchTip_mmFromBottom,
+            : stepForm.mix_touchTip_mmFromBottom ?? null,
         }
       }
 

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -286,17 +286,17 @@ export const migrateFile = (
             : stepForm.dispense_touchTip_mmFromBottom,
         }
       } else if (stepForm.stepType === 'mix') {
-        const misLabware =
+        const mixLabware =
           newLabwareDefinitions[labware[stepForm.labware].definitionId]
-        const touchTipIncompatible = misLabware?.parameters.quirks?.includes(
+        const mixTouchTipIncompatible = mixLabware?.parameters.quirks?.includes(
           'touchTipDisabled'
         )
         return {
           ...stepForm,
-          mix_touchTip_checkbox: touchTipIncompatible
+          mix_touchTip_checkbox: mixTouchTipIncompatible
             ? false
             : stepForm.mix_touchTip_checkbox,
-          mix_touchTip_mmFromBottom: touchTipIncompatible
+          mix_touchTip_mmFromBottom: mixTouchTipIncompatible
             ? null
             : stepForm.mix_touchTip_mmFromBottom,
         }


### PR DESCRIPTION
closes RQA-1503

# Overview

touchTip is no longer allowed in certain labware. I changed the pipetting advanced settings to disable the touchtip checkbox in transfer and mix but I forgot to migrate old files. This does the migration. 

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_touch-tip-migration/

Import the protocol attached in the ticket to PD. Export. Upload to the app. It should pass protocol analysis

# Changelog

- add to the migration file. We are migrating the transfer and mix stepTypes to change the touchTip checkboxes to false if the labware it is occurring in is incompatible with touchTip.

# Review requests

see test plan

# Risk assessment

low