### PR TITLE
fix(app,robot-server): Display less error barf

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/RunFailedModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/RunFailedModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import isEmpty from 'lodash/isEmpty'
 import { useTranslation } from 'react-i18next'
 import {
   ALIGN_CENTER,
@@ -95,11 +94,6 @@ export function RunFailedModal({
           <StyledText as="p" textAlign={TYPOGRAPHY.textAlignLeft}>
             {highestPriorityError.detail}
           </StyledText>
-          {!isEmpty(highestPriorityError.errorInfo) && (
-            <StyledText as="p" textAlign={TYPOGRAPHY.textAlignLeft}>
-              {JSON.stringify(highestPriorityError.errorInfo)}
-            </StyledText>
-          )}
         </Flex>
         <StyledText as="p">
           {t('run_failed_modal_description_desktop')}

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunFailedModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunFailedModal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
-import isEmpty from 'lodash/isEmpty'
 import { css } from 'styled-components'
 
 import {
@@ -98,11 +97,6 @@ export function RunFailedModal({
               <StyledText as="p" textAlign={TYPOGRAPHY.textAlignLeft}>
                 {highestPriorityError.detail}
               </StyledText>
-              {!isEmpty(highestPriorityError.errorInfo) && (
-                <StyledText as="p" textAlign={TYPOGRAPHY.textAlignLeft}>
-                  {JSON.stringify(highestPriorityError.errorInfo)}
-                </StyledText>
-              )}
             </Flex>
           </Flex>
           <StyledText as="p" textAlign={TYPOGRAPHY.textAlignLeft}>


### PR DESCRIPTION
# Overview

This removes the more verbose error details from run failures.

Before this PR:

![4cc079c9-9647-4b2f-a563-814447935329](https://github.com/Opentrons/opentrons/assets/3236864/eb031811-5572-41d7-8789-01da6ee3ce7b)

With this PR: 

![IMG_6568](https://github.com/Opentrons/opentrons/assets/3236864/f120a9f2-8e10-417b-b66e-b86026fb42c8)

Different error, but you get the idea. The `JSON.stringify(.errorInfo)` part has been removed.


Closes RQA-1491.

# Test Plan

I've tested this on a Flex on-device display. It should work exactly the same on the desktop app.

# Changelog

* On-device display: Don't show the `errorInfo` field.
* Desktop app: Don't show the `errorInfo` field.
* HTTP API: More specifically specify the fields of our error model.

  Going forward, reporting errors in a consistently good way will depend on us having a strong interface contract for them. This is an attempt to define that.

  The new specification does not necessarily match the robot's current behavior. In particular, I think the `detail` string sometimes be a gross concatenated frankenstein that redundantly includes the `errorCode` and `errorType`. Going forward, we would treat those contract/behavior mismatches as behavioral robot server bugs.


# Review requests

* Do we agree with these new specifications of `detail`, etc.?
* Can the new specifications of `detail`, etc. be made more specific?
* Any thoughts on the `# todo` comments for `errorType`?

# Risk assessment

Medium. This may inadvertently stop displaying information that people need, which would be frustrating.
