### PR TITLE
fix(app): ODD redirect to ProtocolDashboard if cancel protocol setup on desktop app

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -2,14 +2,13 @@ import * as React from 'react'
 import difference from 'lodash/difference'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
+import { useRouteMatch } from 'react-router-dom'
 import { useDispatch } from 'react-redux'
 
 import { useInterval } from '@opentrons/components'
 import {
   useAllProtocolIdsQuery,
-  useAllRunsQuery,
   useHost,
-  useRunQuery,
   useCreateLiveCommandMutation,
 } from '@opentrons/react-api-client'
 import {
@@ -22,14 +21,13 @@ import {
   RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 
-import { checkShellUpdate } from '../redux/shell'
+import { useCurrentRun } from '../organisms/ProtocolUpload/hooks'
 import { useToaster } from '../organisms/ToasterOven'
+import { checkShellUpdate } from '../redux/shell'
 
 import type { SetStatusBarCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/incidental'
-import type { Run, Runs } from '@opentrons/api-client'
 import type { Dispatch } from '../redux/types'
 
-const CURRENT_RUN_POLL = 5000
 const UPDATE_RECHECK_INTERVAL_MS = 60000
 const PROTOCOL_IDS_RECHECK_INTERVAL_MS = 3000
 
@@ -126,75 +124,35 @@ export function useProtocolReceiptToast(): void {
 }
 
 export function useCurrentRunRoute(): string | null {
-  const { data: allRuns } = useAllRunsQuery(
-    { pageLength: 1 },
-    { refetchInterval: CURRENT_RUN_POLL }
+  const runRecord = useCurrentRun()
+
+  const isRunSetupRoute = useRouteMatch('/runs/:runId/setup')
+  if (isRunSetupRoute != null && runRecord == null) return '/protocols'
+
+  const runStatus = runRecord?.data.status
+  const runActions = runRecord?.data.actions
+  if (runRecord == null || runStatus == null || runActions == null) return null
+
+  // grabbing run id off of the run query to have all routing info come from one source of truth
+  const runId = runRecord.data.id
+  const hasRunBeenStarted = runActions?.some(
+    action => action.actionType === RUN_ACTION_TYPE_PLAY
   )
-  const runRecord = useGetRunRecord(allRuns)
-  return useRouteBasedOnRunRecord(runRecord)
-
-  function useGetRunRecord(allRuns: Runs | undefined): Run | undefined {
-    const currentRunLink = allRuns?.links?.current ?? null
-    const currentRun =
-      currentRunLink != null &&
-      typeof currentRunLink !== 'string' &&
-      'href' in currentRunLink
-        ? allRuns?.data.find(
-            run => run.id === currentRunLink.href.replace('/runs/', '')
-          ) // trim link path down to only runId
-        : null
-    const currentRunId = currentRun?.id ?? null
-    const { data: runRecord } = useRunQuery(currentRunId, {
-      staleTime: Infinity,
-      enabled: currentRunId != null,
-    })
-    return runRecord
-  }
-
-  function useRouteBasedOnRunRecord(runRecord: Run | undefined): string | null {
-    if (useHasDesktopCancelledProtocolSetup(runRecord)) return '/protocols'
-    else if (runRecord == null) return null
-    else return routeBasedOnRunStatusAndActions(runRecord)
-  }
-
-  function useHasDesktopCancelledProtocolSetup(
-    runRecord: Run | undefined
-  ): boolean {
-    const previouslyStoredRunRecord = React.useRef<Run | null>(null)
-    if (previouslyStoredRunRecord != null && runRecord == null) {
-      previouslyStoredRunRecord.current = null
-      return true
-    } else {
-      previouslyStoredRunRecord.current = runRecord ?? null
-      return false
-    }
-  }
-
-  function routeBasedOnRunStatusAndActions(runRecord: Run): string | null {
-    const runStatus = runRecord.data.status
-    const runActions = runRecord.data.actions
-    if (runStatus == null || runActions == null) return null
-    // grabbing run id off of the run query to have all routing info come from one source of truth
-    const runId = runRecord?.data.id
-    const hasRunBeenStarted = runActions?.some(
-      action => action.actionType === RUN_ACTION_TYPE_PLAY
-    )
-    if (
-      runStatus === RUN_STATUS_SUCCEEDED ||
-      (runStatus === RUN_STATUS_STOPPED && hasRunBeenStarted) ||
-      runStatus === RUN_STATUS_FAILED
-    ) {
-      return `/runs/${runId}/summary`
-    } else if (
-      runStatus === RUN_STATUS_IDLE ||
-      (!hasRunBeenStarted && runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR)
-    ) {
-      return `/runs/${runId}/setup`
-    } else if (hasRunBeenStarted) {
-      return `/runs/${runId}/run`
-    } else {
-      // includes runs cancelled before starting and runs not yet started
-      return null
-    }
+  if (
+    runStatus === RUN_STATUS_SUCCEEDED ||
+    (runStatus === RUN_STATUS_STOPPED && hasRunBeenStarted) ||
+    runStatus === RUN_STATUS_FAILED
+  ) {
+    return `/runs/${runId}/summary`
+  } else if (
+    runStatus === RUN_STATUS_IDLE ||
+    (!hasRunBeenStarted && runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR)
+  ) {
+    return `/runs/${runId}/setup`
+  } else if (hasRunBeenStarted) {
+    return `/runs/${runId}/run`
+  } else {
+    // includes runs cancelled before starting and runs not yet started
+    return null
   }
 }


### PR DESCRIPTION
Closes RAUT-680
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an issue in which Flex users cancelling protocol setup on the desktop app are not redirected on the ODD.

https://github.com/Opentrons/opentrons/assets/64858653/257746fb-fa41-472a-b0e1-ee38e0464959

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Requires testing on the physical ODD

- From the desktop app, Protocols > Send protocol to a Flex (larger protocol required)  > Click cancel run.
- Should see the ODD redirect to ProtocolDashboard a couple seconds after the desktop confirms cancellation. 
- Existing routing logic should work as expected.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added conditional redirect logic for useCurrentRoute()

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

- Test on dev kit or Flex ODD. 

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low