### PR TITLE
fix(app): commandText for dropTip and adapters

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -1,5 +1,5 @@
 {
-  "adapter_in_mod_in_slot": "{{adapter}} in {{module}} in {{slot}}",
+  "adapter_in_mod_in_slot": "{{adapter}} on {{module}} in {{slot}}",
   "adapter_in_slot": "{{adapter}} in {{slot}}",
   "aspirate": "Aspirating {{volume}} µL from well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
   "blowout": "Blowing out at well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
@@ -36,7 +36,7 @@
   "pause_on": "Pause on {{robot_name}}",
   "pause": "Pause",
   "pickup_tip": "Picking up tip from {{well_name}} of {{labware}} in {{labware_location}}",
-  "return_tip": "Returning tip in {{well_name}} of {{labware}} in {{labware_location}}",
+  "return_tip": "Returning tip to {{well_name}} of {{labware}} in {{labware_location}}",
   "save_position": "Saving position",
   "set_and_await_hs_shake": "Setting Heater-Shaker to shake at {{rpm}} rpm and waiting until reached",
   "setting_hs_temp": "Setting Target Temperature of Heater-Shaker to {{temp}}",

--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -1,4 +1,6 @@
 {
+  "adapter_in_mod_in_slot": "{{adapter}} in {{module}} in {{slot}}",
+  "adapter_in_slot": "{{adapter}} in {{slot}}",
   "aspirate": "Aspirating {{volume}} µL from well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
   "blowout": "Blowing out at well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
   "closing_tc_lid": "Closing Thermocycler lid",
@@ -34,6 +36,7 @@
   "pause_on": "Pause on {{robot_name}}",
   "pause": "Pause",
   "pickup_tip": "Picking up tip from {{well_name}} of {{labware}} in {{labware_location}}",
+  "return_tip": "Returning tip in {{well_name}} of {{labware}} in {{labware_location}}",
   "save_position": "Saving position",
   "set_and_await_hs_shake": "Setting Heater-Shaker to shake at {{rpm}} rpm and waiting until reached",
   "setting_hs_temp": "Setting Target Temperature of Heater-Shaker to {{temp}}",

--- a/app/src/organisms/CommandText/PipettingCommandText.tsx
+++ b/app/src/organisms/CommandText/PipettingCommandText.tsx
@@ -32,6 +32,7 @@ export const PipettingCommandText = ({
   const { labwareId, wellName } = command.params
   const labwareLocation = getLoadedLabware(robotSideAnalysis, labwareId)
     ?.location
+
   const displayLocation =
     labwareLocation != null
       ? getLabwareDisplayLocation(robotSideAnalysis, labwareLocation, t)
@@ -74,11 +75,18 @@ export const PipettingCommandText = ({
       })
     }
     case 'dropTip': {
-      return t('drop_tip', {
-        well_name: wellName,
-        labware: getLabwareName(robotSideAnalysis, labwareId),
-        labware_location: displayLocation,
-      })
+      const labwareDisplayName = getLabwareName(robotSideAnalysis, labwareId)
+
+      return labwareDisplayName === 'Fixed Trash'
+        ? t('drop_tip', {
+            well_name: wellName,
+            labware: getLabwareName(robotSideAnalysis, labwareId),
+          })
+        : t('return_tip', {
+            well_name: wellName,
+            labware: getLabwareName(robotSideAnalysis, labwareId),
+            labware_location: displayLocation,
+          })
     }
     case 'pickUpTip': {
       return t('pickup_tip', {

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -10,7 +10,11 @@ import type {
   LoadLabwareRunTimeCommand,
   LoadLiquidRunTimeCommand,
 } from '@opentrons/shared-data/protocol/types/schemaV7/command/setup'
-import { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+import {
+  LabwareDefinition2,
+  RunTimeCommand,
+  DropTipRunTimeCommand,
+} from '@opentrons/shared-data'
 
 describe('CommandText', () => {
   it('renders correct text for aspirate', () => {
@@ -106,6 +110,28 @@ describe('CommandText', () => {
       )[0]
       getByText('Dropping tip in A1 of Fixed Trash')
     }
+  })
+  it('renders correct text for dropTip into a labware', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        robotSideAnalysis={mockRobotSideAnalysis}
+        command={
+          {
+            commandType: 'dropTip',
+            params: {
+              labwareId: 'c8f42311-f83f-4722-9821-9d2225e4b0b5',
+              wellName: 'A1',
+              wellLocation: { origin: 'top', offset: { x: 0, y: 0, z: 0 } },
+              pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
+            },
+          } as DropTipRunTimeCommand
+        }
+      />,
+      { i18nInstance: i18n }
+    )[0]
+    getByText(
+      'Returning tip in A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1'
+    )
   })
   it('renders correct text for pickUpTip', () => {
     const command = mockRobotSideAnalysis.commands.find(

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -130,7 +130,7 @@ describe('CommandText', () => {
       { i18nInstance: i18n }
     )[0]
     getByText(
-      'Returning tip in A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1'
+      'Returning tip to A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1'
     )
   })
   it('renders correct text for pickUpTip', () => {

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -119,7 +119,7 @@ describe('CommandText', () => {
           {
             commandType: 'dropTip',
             params: {
-              labwareId: 'c8f42311-f83f-4722-9821-9d2225e4b0b5',
+              labwareId: 'b2a40c9d-31b0-4f27-ad4a-c92ced91204d',
               wellName: 'A1',
               wellLocation: { origin: 'top', offset: { x: 0, y: 0, z: 0 } },
               pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
@@ -129,9 +129,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )[0]
-    getByText(
-      'Returning tip to A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1'
-    )
+    getByText('Returning tip to A1 of Opentrons 96 Tip Rack 300 µL in Slot 9')
   })
   it('renders correct text for pickUpTip', () => {
     const command = mockRobotSideAnalysis.commands.find(

--- a/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
@@ -67,7 +67,7 @@ export function getLabwareDisplayLocation(
     } else if ('slotName' in adapter.location) {
       return t('adapter_in_slot', {
         adapter: adapterDisplayName,
-        slot_name: adapter.location.slotName,
+        slot: adapter.location.slotName,
       })
     } else if ('moduleId' in adapter.location) {
       const moduleIdUnderAdapter = adapter.location.moduleId
@@ -82,14 +82,14 @@ export function getLabwareDisplayLocation(
         robotSideAnalysis,
         adapter.location.moduleId
       )
-      return t('adapter_in_module_in_slot', {
+      return t('adapter_in_mod_in_slot', {
         count: getOccludedSlotCountForModule(
           getModuleType(moduleModel),
           robotSideAnalysis.robotType ?? OT2_STANDARD_MODEL
         ),
         module: getModuleDisplayName(moduleModel),
         adapter: adapterDisplayName,
-        slot_name: slotName,
+        slot: slotName,
       })
     } else {
       console.warn(


### PR DESCRIPTION
closes RAUT-698

# Overview

Fixes the copy for returning a tip to a location and adds some missing i18n keys for adapters

# Test Plan

upload a protocol where the drop tip happens in a labware location other than the trash. See in the run log that it displays the text correctly.

# Changelog

- add logic for returning tip to location other than trash
- add back i18n keys that somehow were missing??
- add test

# Review requests

see test plan

# Risk assessment

low