### PR TITLE
docs(tutorial): syntax correction for Flex tutorial tip_racks declaration

### DIFF
--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -192,7 +192,7 @@ Next you’ll specify what pipette to use in the protocol. Loading a pipette is 
 .. code-block:: python
 
         # Flex
-        left_pipette = protocol.load_instrument('flex_1channel_1000', 'left', tip_racks[tips])
+        left_pipette = protocol.load_instrument('flex_1channel_1000', 'left', tip_racks=[tips])
 
 .. code-block:: python
 


### PR DESCRIPTION


# Overview

Flex load_instruments example declared tip_racks variable incorrectly, issue not present on OT-2 tutorial instructions

tip_racks[tips] changed to tip_racks=[tips]

