### PR TITLE
fix(api,shared-data): Reference stable deck slot IDs instead of unstable enum names

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -750,7 +750,7 @@ class LabwareView(HasState[LabwareState]):
     ) -> Optional[LabwareMovementOffsetData]:
         """Get the labware's gripper offsets of the specified type."""
         parsed_offsets = self.get_definition(labware_id).gripperOffsets
-        offset_key = slot_name.name if slot_name else "default"
+        offset_key = slot_name.id if slot_name else "default"
 
         if parsed_offsets is None or offset_key not in parsed_offsets:
             return None

--- a/shared-data/labware/definitions/2/opentrons_universal_flat_adapter/1.json
+++ b/shared-data/labware/definitions/2/opentrons_universal_flat_adapter/1.json
@@ -51,7 +51,7 @@
         "z": 0
       }
     },
-    "SLOT_A1": {
+    "A1": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -63,7 +63,7 @@
         "z": 0
       }
     },
-    "SLOT_B1": {
+    "B1": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -75,7 +75,7 @@
         "z": 0
       }
     },
-    "SLOT_C1": {
+    "C1": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -87,7 +87,7 @@
         "z": 0
       }
     },
-    "SLOT_D1": {
+    "D1": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -99,7 +99,7 @@
         "z": 0
       }
     },
-    "SLOT_A3": {
+    "A3": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -111,7 +111,7 @@
         "z": 0
       }
     },
-    "SLOT_B3": {
+    "B3": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -123,7 +123,7 @@
         "z": 0
       }
     },
-    "SLOT_C3": {
+    "C3": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,
@@ -135,7 +135,7 @@
         "z": 0
       }
     },
-    "SLOT_D3": {
+    "D3": {
       "pickUpOffset": {
         "x": 0,
         "y": 0,


### PR DESCRIPTION
# Overview

Labware definitions can adjust their gripper offsets depending on which slot they're in.

Currently, they specify this with names like `SLOT_D3`. But those names are internal and unstable. This PR switches them to be like `D3`, which is more stable, and exactly matches the keys in the deck definition.

# Test Plan

* [x] Confirm the offsets still apply.

# Review requests

None in particular.

# Risk assessment

Low.