### PR TITLE
refactor(protocol-designer): filter out 96-channel tiprack adapter fo…

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -238,10 +238,13 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
       defs,
       (acc, def: typeof defs[keyof typeof defs]) => {
         const category: string = def.metadata.displayCategory
-        // filter out non-permitted tipracks
+        // filter out non-permitted tipracks +
+        //  temporarily filtering out 96-channel adapter until we support
+        //  96-channel
         if (
-          category === 'tipRack' &&
-          !permittedTipracks.includes(getLabwareDefURI(def))
+          (category === 'tipRack' &&
+            !permittedTipracks.includes(getLabwareDefURI(def))) ||
+          def.parameters.loadName === 'opentrons_flex_96_tiprack_adapter'
         ) {
           return acc
         }

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -238,7 +238,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
       defs,
       (acc, def: typeof defs[keyof typeof defs]) => {
         const category: string = def.metadata.displayCategory
-        // filter out non-permitted tipracks +
+        //  filter out non-permitted tipracks +
         //  temporarily filtering out 96-channel adapter until we support
         //  96-channel
         if (


### PR DESCRIPTION
…r now

# Overview

We don't want the 96-channel tip rack adapter to be selectable right now until we support the 96-channel. So i filtered out the def in `labwareSelectionModal`

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_remove-96-channel-adapter/

Make a protocol for ot-2 or Flex. Go to the design tab, on the deck setup view, add a labware directly to the deck map. Click on the adapter dropdown option in the labware selection modal. Make sure only 1 adapter is available and that it is the 96 well aluminum block. The 96 channel adapter should NOT be available

# Changelog

- filter out adapter

# Review requests

see test plan

# Risk assessment

low