### PR TITLE
fix(app): modify display for disabled protocol setup steps in ODD

### DIFF
--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -174,7 +174,7 @@ export function ProtocolSetupStep({
             {subDetail}
           </StyledText>
         </Flex>
-        {!disabled && (
+        {disabled ? null : (
           <Icon
             marginLeft={SPACING.spacing8}
             name="more"

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -174,13 +174,15 @@ export function ProtocolSetupStep({
             {subDetail}
           </StyledText>
         </Flex>
-        <Icon
-          marginLeft={SPACING.spacing8}
-          name="more"
-          size="3rem"
-          // Required to prevent inconsistent component height.
-          style={{ backgroundColor: disabled ? 'transparent' : 'initial' }}
-        />
+        {!disabled && (
+          <Icon
+            marginLeft={SPACING.spacing8}
+            name="more"
+            size="3rem"
+            // Required to prevent inconsistent component height.
+            style={{ backgroundColor: disabled ? 'transparent' : 'initial' }}
+          />
+        )}
       </Flex>
     </Btn>
   )


### PR DESCRIPTION
closes [RQA-1512](https://opentrons.atlassian.net/browse/RQA-1512)

# Overview

We want to remove the arrow for disabled ProtocolSetupStep buttons.

# Test Plan

- Ensure disabled ProtocolSetupSteps do not render an arrow, and that the details align right.
<img width="1215" alt="Screen Shot 2023-09-08 at 2 46 35 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/7de37c06-c9ee-47d3-8cab-ce7c89af2806">

# Changelog

- conditionally render arrow Icon based on whether button is disabled or not

# Risk assessment
low


[RQA-1512]: https://opentrons.atlassian.net/browse/RQA-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ