### PR TITLE
fix(engine): allow dropping tips in any labware

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -862,8 +862,9 @@ class InstrumentContext(publisher.CommandPublisher):
 
         If no location is passed, the Pipette will drop the tip into its
         :py:attr:`trash_container`, which if not specified defaults to
-        the fixed trash in slot 12.  From API version 2.15 on, the API will default to
-        alternating between two different drop tip locations within the trash container
+        the fixed trash in slot 12.  From API version 2.15 on, if the trash container is
+        the default fixed trash in A3 (slot 12), the API will default to
+        dropping tips in different points within the trash container
         in order to prevent tips from piling up in a single location in the trash.
 
         The location in which to drop the tip can be manually specified with

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -379,15 +379,15 @@ class GeometryView:
                 offset=well_location.offset,
             )
 
-        # return to top if labware is fixed trash
-        if self._labware.get_has_quirk(labware_id=labware_id, quirk="fixedTrash"):
-            z_offset = well_location.offset.z
-        else:
+        if self._labware.get_definition(labware_id).parameters.isTiprack:
             z_offset = self._labware.get_tip_drop_z_offset(
                 labware_id=labware_id,
                 length_scale=self._pipettes.get_return_tip_scale(pipette_id),
                 additional_offset=well_location.offset.z,
             )
+        else:
+            # return to top if labware is not tip rack
+            z_offset = well_location.offset.z
 
         return WellLocation(
             origin=WellOrigin.TOP,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -552,6 +552,8 @@ class GeometryView:
             # In order to avoid the complexity of finding tip drop locations for
             # variety of labware with different well configs, we will allow
             # location cycling only for fixed trash labware right now.
+            # TODO (spp, 2023-09-12): update this to possibly a labware-width based check,
+            #  or a 'trash' quirk check, once movable trash is implemented.
             return DropTipWellLocation(
                 origin=DropTipWellOrigin.DEFAULT,
                 offset=WellOffset(x=0, y=0, z=0),

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -944,8 +944,11 @@ def test_get_tip_drop_location(
     labware_view: LabwareView,
     mock_pipette_view: PipetteView,
     subject: GeometryView,
+    tip_rack_def: LabwareDefinition,
 ) -> None:
     """It should get relative drop tip location for a pipette/labware combo."""
+    decoy.when(labware_view.get_definition("tip-rack-id")).then_return(tip_rack_def)
+
     decoy.when(mock_pipette_view.get_return_tip_scale("pipette-id")).then_return(0.5)
 
     decoy.when(
@@ -966,15 +969,14 @@ def test_get_tip_drop_location(
     assert location == WellLocation(offset=WellOffset(x=1, y=2, z=1337))
 
 
-def test_get_tip_drop_location_with_trash(
+def test_get_tip_drop_location_with_non_tiprack(
     decoy: Decoy,
     labware_view: LabwareView,
     subject: GeometryView,
+    reservoir_def: LabwareDefinition,
 ) -> None:
-    """It should get relative drop tip location for a the fixed trash."""
-    decoy.when(
-        labware_view.get_has_quirk(labware_id="labware-id", quirk="fixedTrash")
-    ).then_return(True)
+    """It should get relative drop tip location for a labware that is not a tiprack."""
+    decoy.when(labware_view.get_definition("labware-id")).then_return(reservoir_def)
 
     location = subject.get_checked_tip_drop_location(
         pipette_id="pipette-id",


### PR DESCRIPTION
Closes RSS-277

# Overview

Fixes a bug introduced in 6.3.0 that unintentionally raises an error when trying to drop tips into labware that is neither a fixed trash nor a tiprack.

Our API documentation clearly states that you can specify an arbitrary tip drop location in `instrument_context.drop_tip()`. Furthermore, the API allows assigning any labware as the designated trash container for a particular pipette, which is treated as the default tip drop location. 
For executing both these cases, the engine needs to allow dropping tips into any labware; not just tiprack or fixed trash.

This is also necessary for the upcoming 'post-run-tip-drop' flow that the app is planning on adding.

# Test Plan

This protocol should drop tips into the fixed trash, the tip rack **and a reservoir** as expected
(Can also be tested on the OT-2 by updating the protocol for OT-2)

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.15"
}

def run(protocol_context):
	# For Flex:
	tiprack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "D2")
	pipette = protocol_context.load_instrument("flex_1channel_50", 'left', tip_racks=[tiprack1])
	
	pipette.pick_up_tip()
	pipette.drop_tip()		# Should drop tip at TOP of fixed trash in A3 (at an alternating location)

        pipette.pick_up_tip()
	pipette.drop_tip()		# Should drop tip at TOP of fixed trash in A3 (at an alternating location)

	pipette.drop_tip(pipette.trash_container['A1'].center())	# Should always drop tip in CENTER of Fixed trash

	trash_labware = protocol_context.load_labware("nest_1_reservoir_195ml", "D1")
	pipette.trash_container = trash_labware

	pipette.pick_up_tip()
	pipette.drop_tip()		# Should drop tip at CENTER TOP of Nest reservoir (NO alternating locations)

	pipette.pick_up_tip()
	pipette.drop_tip(pipette.trash_container['A1'].center())	# Should always drop tip in CENTER of Nest reservoir

	pipette.pick_up_tip()
	pipette.return_tip()	        # Should return tip to tiprack
```

# Changelog

- changed `get_checked_tip_drop_location()` to check if labware is tiprack, else drop tip to TOP of specified labware.
- updated tests

# Review requests

- Make sure I am not messing up any side effects of tip dropping by allowing any arbitrary locations

# Risk assessment

Low. Bug fix.
