### PR TITLE
feat(app): add deck configuration feature flag

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,4 +1,5 @@
 {
+  "__dev_internal__enableDeckConfiguration": "Enable Deck Configuration",
   "__dev_internal__enableExtendedHardware": "Enable Extended Hardware",
   "__dev_internal__lpcWithProbe": "Golden Tip LPC",
   "add_folder_button": "Add labware source folder",

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -5,6 +5,7 @@ export const CONFIG_VERSION_LATEST: 1 = 1
 export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'enableExtendedHardware',
   'lpcWithProbe',
+  'enableDeckConfiguration',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -7,7 +7,10 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 
 export type DiscoveryCandidates = string[]
 
-export type DevInternalFlag = 'enableExtendedHardware' | 'lpcWithProbe'
+export type DevInternalFlag =
+  | 'enableExtendedHardware'
+  | 'lpcWithProbe'
+  | 'enableDeckConfiguration'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 


### PR DESCRIPTION
# Overview

the feature flag to put all app desktop/ODD deck config work behind

closes RAUT-701

# Test Plan

# Changelog

 - Adds deck config feature flag

# Review requests

# Risk assessment

low
