### PR TITLE
feat(app): add module calibration data to download

### DIFF
--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDataDownload.tsx
@@ -12,7 +12,10 @@ import {
   TYPOGRAPHY,
   DIRECTION_COLUMN,
 } from '@opentrons/components'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import {
+  useInstrumentsQuery,
+  useModulesQuery,
+} from '@opentrons/react-api-client'
 import { TertiaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import {
@@ -55,20 +58,14 @@ export function CalibrationDataDownload({
   const pipetteOffsetCalibrations = usePipetteOffsetCalibrations()
   const tipLengthCalibrations = useTipLengthCalibrations()
   const { data: attachedInstruments } = useInstrumentsQuery({ enabled: isOT3 })
+  const { data: attachedModules } = useModulesQuery({ enabled: isOT3 })
 
-  const downloadIsPossible =
+  const ot2DownloadIsPossible =
     deckCalibrationData.isDeckCalibrated &&
     pipetteOffsetCalibrations != null &&
     pipetteOffsetCalibrations.length > 0 &&
     tipLengthCalibrations != null &&
     tipLengthCalibrations.length > 0
-
-  const ot3DownloadIsPossible =
-    isOT3 &&
-    attachedInstruments?.data.some(
-      instrument =>
-        instrument.ok && instrument.data.calibratedOffset?.last_modified != null
-    )
 
   const onClickSaveAs: React.MouseEventHandler = e => {
     e.preventDefault()
@@ -81,6 +78,7 @@ export function CalibrationDataDownload({
         isOT3
           ? JSON.stringify({
               instrumentData: attachedInstruments,
+              moduleData: attachedModules,
             })
           : JSON.stringify({
               deck: deckCalibrationData,
@@ -124,7 +122,7 @@ export function CalibrationDataDownload({
         ) : (
           <StyledText as="p">
             {t(
-              downloadIsPossible
+              ot2DownloadIsPossible
                 ? 'robot_calibration:download_calibration_data_available'
                 : 'robot_calibration:download_calibration_data_unavailable'
             )}
@@ -133,7 +131,7 @@ export function CalibrationDataDownload({
       </Flex>
       <TertiaryButton
         onClick={onClickSaveAs}
-        disabled={isOT3 ? !ot3DownloadIsPossible : !downloadIsPossible}
+        disabled={isOT3 ? false : !ot2DownloadIsPossible} // always enable download on Flex
       >
         <Flex alignItems={ALIGN_CENTER}>
           <Icon name="download" size="0.75rem" marginRight={SPACING.spacing8} />

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -3,7 +3,10 @@ import { saveAs } from 'file-saver'
 import { when, resetAllWhenMocks } from 'jest-when'
 
 import { renderWithProviders } from '@opentrons/components'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import {
+  useInstrumentsQuery,
+  useModulesQuery,
+} from '@opentrons/react-api-client'
 import { instrumentsResponseFixture } from '@opentrons/api-client'
 
 import { i18n } from '../../../i18n'
@@ -54,6 +57,9 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
 const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUseInstrumentsQuery = useInstrumentsQuery as jest.MockedFunction<
   typeof useInstrumentsQuery
+>
+const mockUseModulesQuery = useModulesQuery as jest.MockedFunction<
+  typeof useModulesQuery
 >
 
 let mockTrackEvent: jest.Mock
@@ -111,6 +117,9 @@ describe('CalibrationDataDownload', () => {
         mockTipLengthCalibration3,
       ])
     mockUseInstrumentsQuery.mockReturnValue({
+      data: { data: [] },
+    } as any)
+    mockUseModulesQuery.mockReturnValue({
       data: { data: [] },
     } as any)
   })
@@ -221,7 +230,7 @@ describe('CalibrationDataDownload', () => {
     const downloadButton = getByRole('button', {
       name: 'Download calibration data',
     })
-    expect(downloadButton).toBeDisabled()
+    expect(downloadButton).toBeEnabled() // allow download for empty cal data
   })
 
   it('renders disabled button when tip lengths are not calibrated', () => {


### PR DESCRIPTION
closes [RAUT-702](https://opentrons.atlassian.net/browse/RAUT-702)

# Overview

We need to add module calibration data to the .json download from the robot settings page.

# Test Plan

- verify that Flex calibration data download includes module calibration data (even if empty)

# Changelog

- add module calibration data to downloaded calibration data by querying modules endpoint
- enable calibration data download button at all times for Flex

# Risk assessment

low

[RAUT-702]: https://opentrons.atlassian.net/browse/RAUT-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ