### PR TITLE
fix(api): raise an error when loading a 96c pipette when another pipette is attached

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,5 +1,4 @@
 """ProtocolEngine-based Protocol API core implementation."""
-from typing_extensions import Literal
 from typing import Dict, Optional, Type, Union, List, Tuple
 
 from opentrons.protocol_engine.commands import LoadModuleResult
@@ -408,10 +407,8 @@ class ProtocolCore(
                 load_module_result=load_module_result, model=model
             )
 
-    # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
-    # https://opentrons.atlassian.net/browse/RLIQ-255
     def load_instrument(
-        self, instrument_name: Union[PipetteNameType, Literal["p1000_96"]], mount: Mount
+        self, instrument_name: PipetteNameType, mount: Mount
     ) -> InstrumentCore:
         """Load an instrument into the protocol.
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -773,12 +773,12 @@ class ProtocolContext(CommandPublisher):
 
         tip_racks = tip_racks or []
 
-        if is_96_channel and self._instruments[Mount.RIGHT] is not None:
-            loaded_instrument = self._instruments[Mount.RIGHT]
-            assert loaded_instrument is not None
+        # TODO (tz, 9-12-23): move validation into PE
+        on_right_mount = self._instruments[Mount.RIGHT]
+        if is_96_channel and on_right_mount is not None:
             raise RuntimeError(
                 f"Instrument already present on right:"
-                f" {loaded_instrument.name}. In order to load a 96 channel pipette both mounts need to be available."
+                f" {on_right_mount.name}. In order to load a 96 channel pipette both mounts need to be available."
             )
 
         existing_instrument = self._instruments[checked_mount]

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -785,8 +785,6 @@ class ProtocolContext(CommandPublisher):
             f"Loading {checked_instrument_name} on {checked_mount.name.lower()} mount"
         )
 
-        # TODO (tz, 11-22-22): was added to support 96 channel pipette.
-        #  Should remove when working on https://opentrons.atlassian.net/browse/RLIQ-255
         instrument_core = self._core.load_instrument(
             instrument_name=checked_instrument_name,
             mount=checked_mount,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -773,6 +773,14 @@ class ProtocolContext(CommandPublisher):
 
         tip_racks = tip_racks or []
 
+        if is_96_channel and self._instruments[Mount.RIGHT] is not None:
+            loaded_instrument = self._instruments[Mount.RIGHT]
+            assert loaded_instrument is not None
+            raise RuntimeError(
+                f"Instrument already present on right:"
+                f" {loaded_instrument.name}. In order to load a 96 channel pipette both mounts need to be available."
+            )
+
         existing_instrument = self._instruments[checked_mount]
         if existing_instrument is not None and not replace:
             # TODO(mc, 2022-08-25): create specific exception type

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -1,7 +1,6 @@
 """Control a `ProtocolEngine` without async/await."""
 
-from typing import cast, List, Optional, Union, Dict
-from typing_extensions import Literal
+from typing import cast, List, Optional, Dict
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.labware.dev_types import LabwareUri
@@ -141,11 +140,9 @@ class SyncClient:
 
         return cast(commands.MoveLabwareResult, result)
 
-    # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
-    # https://opentrons.atlassian.net/browse/RLIQ-255
     def load_pipette(
         self,
-        pipette_name: Union[PipetteNameType, Literal["p1000_96"]],
+        pipette_name: PipetteNameType,
         mount: MountType,
     ) -> commands.LoadPipetteResult:
         """Execute a LoadPipette command and return the result."""

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -1,7 +1,7 @@
 """Load pipette command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
@@ -19,9 +19,7 @@ LoadPipetteCommandType = Literal["loadPipette"]
 class LoadPipetteParams(BaseModel):
     """Payload needed to load a pipette on to a mount."""
 
-    # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
-    # https://opentrons.atlassian.net/browse/RLIQ-255
-    pipetteName: Union[PipetteNameType, Literal["p1000_96"]] = Field(
+    pipetteName: PipetteNameType = Field(
         ...,
         description="The load name of the pipette to be required.",
     )

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -1,7 +1,6 @@
 """Equipment command side-effect logic."""
 from dataclasses import dataclass
-from typing import Optional, overload, Union
-from typing_extensions import Literal
+from typing import Optional, overload
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
@@ -155,7 +154,7 @@ class EquipmentHandler:
 
     async def load_pipette(
         self,
-        pipette_name: Union[PipetteNameType, Literal["p1000_96"]],
+        pipette_name: PipetteNameType,
         mount: MountType,
         pipette_id: Optional[str],
     ) -> LoadedPipetteData:

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -177,9 +177,7 @@ class LoadedPipette(BaseModel):
     """A pipette that has been loaded."""
 
     id: str
-    # TODO (tz, 11-23-22): remove Union when refactoring load_pipette for 96 channels.
-    # https://opentrons.atlassian.net/browse/RLIQ-255
-    pipetteName: Union[PipetteNameType, Literal["p1000_96"]]
+    pipetteName: PipetteNameType
     mount: MountType
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -47,14 +47,14 @@ async def test_load_pipette_implementation_96_channel(
     subject = LoadPipetteImplementation(equipment=equipment)
 
     data = LoadPipetteParams(
-        pipetteName="p1000_96",
+        pipetteName=PipetteNameType.P1000_96,
         mount=MountType.LEFT,
         pipetteId="some id",
     )
 
     decoy.when(
         await equipment.load_pipette(
-            pipette_name="p1000_96",
+            pipette_name=PipetteNameType.P1000_96,
             mount=MountType.LEFT,
             pipette_id="some id",
         )

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -674,7 +674,7 @@ async def test_load_pipette_96_channels(
     )
 
     result = await subject.load_pipette(
-        pipette_name="p1000_96",
+        pipette_name=PipetteNameType.P1000_96,
         mount=MountType.LEFT,
         pipette_id=None,
     )

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -163,11 +163,7 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "type": "string"
     },
     "WellOffset": {
@@ -252,21 +248,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup"
-      ],
+      "enum": ["protocol", "setup"],
       "type": "string"
     },
     "AspirateCreate": {
@@ -277,9 +264,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": [
-            "aspirate"
-          ],
+          "enum": ["aspirate"],
           "type": "string"
         },
         "params": {
@@ -299,9 +284,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -326,11 +309,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -340,9 +319,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": [
-            "aspirateInPlace"
-          ],
+          "enum": ["aspirateInPlace"],
           "type": "string"
         },
         "params": {
@@ -362,9 +339,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -377,9 +352,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ]
+      "required": ["message"]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -389,9 +362,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": [
-            "comment"
-          ],
+          "enum": ["comment"],
           "type": "string"
         },
         "params": {
@@ -411,9 +382,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -429,9 +398,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": [
-            "custom"
-          ],
+          "enum": ["custom"],
           "type": "string"
         },
         "params": {
@@ -451,9 +418,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -502,13 +467,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -518,9 +477,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": [
-            "dispense"
-          ],
+          "enum": ["dispense"],
           "type": "string"
         },
         "params": {
@@ -540,9 +497,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -572,11 +527,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -586,9 +537,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": [
-            "dispenseInPlace"
-          ],
+          "enum": ["dispenseInPlace"],
           "type": "string"
         },
         "params": {
@@ -608,9 +557,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -648,12 +595,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -663,9 +605,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": [
-            "blowout"
-          ],
+          "enum": ["blowout"],
           "type": "string"
         },
         "params": {
@@ -685,9 +625,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -706,10 +644,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -719,9 +654,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": [
-            "blowOutInPlace"
-          ],
+          "enum": ["blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -741,19 +674,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -815,11 +741,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ]
+      "required": ["pipetteId", "labwareId", "wellName"]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -829,9 +751,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": [
-            "dropTip"
-          ],
+          "enum": ["dropTip"],
           "type": "string"
         },
         "params": {
@@ -851,9 +771,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -871,9 +789,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -883,9 +799,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": [
-            "dropTipInPlace"
-          ],
+          "enum": ["dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -905,9 +819,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -946,9 +858,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": [
-            "home"
-          ],
+          "enum": ["home"],
           "type": "string"
         },
         "params": {
@@ -968,9 +878,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -986,9 +894,7 @@
           ]
         }
       },
-      "required": [
-        "axis"
-      ]
+      "required": ["axis"]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -998,9 +904,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": [
-            "retractAxis"
-          ],
+          "enum": ["retractAxis"],
           "type": "string"
         },
         "params": {
@@ -1020,9 +924,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1068,9 +970,7 @@
           ]
         }
       },
-      "required": [
-        "slotName"
-      ]
+      "required": ["slotName"]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1083,9 +983,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1098,9 +996,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1121,9 +1017,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             }
           ]
@@ -1154,12 +1048,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ]
+      "required": ["location", "loadName", "namespace", "version"]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1169,9 +1058,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": [
-            "loadLabware"
-          ],
+          "enum": ["loadLabware"],
           "type": "string"
         },
         "params": {
@@ -1191,9 +1078,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1219,11 +1104,7 @@
           }
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ]
+      "required": ["liquidId", "labwareId", "volumeByWell"]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1233,9 +1114,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": [
-            "loadLiquid"
-          ],
+          "enum": ["loadLiquid"],
           "type": "string"
         },
         "params": {
@@ -1255,9 +1134,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1302,10 +1179,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ]
+      "required": ["model", "location"]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1315,9 +1189,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": [
-            "loadModule"
-          ],
+          "enum": ["loadModule"],
           "type": "string"
         },
         "params": {
@@ -1337,9 +1209,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1368,11 +1238,7 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "type": "string"
     },
     "LoadPipetteParams": {
@@ -1402,10 +1268,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ]
+      "required": ["pipetteName", "mount"]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1415,9 +1278,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": [
-            "loadPipette"
-          ],
+          "enum": ["loadPipette"],
           "type": "string"
         },
         "params": {
@@ -1437,18 +1298,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1469,11 +1324,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1499,9 +1350,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             }
           ]
@@ -1533,11 +1382,7 @@
           ]
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ]
+      "required": ["labwareId", "newLocation", "strategy"]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1547,9 +1392,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": [
-            "moveLabware"
-          ],
+          "enum": ["moveLabware"],
           "type": "string"
         },
         "params": {
@@ -1569,18 +1412,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1607,11 +1444,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ]
+      "required": ["pipetteId", "axis", "distance"]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1621,9 +1454,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": [
-            "moveRelative"
-          ],
+          "enum": ["moveRelative"],
           "type": "string"
         },
         "params": {
@@ -1643,9 +1474,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1665,11 +1494,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1707,10 +1532,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ]
+      "required": ["pipetteId", "coordinates"]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1720,9 +1542,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": [
-            "moveToCoordinates"
-          ],
+          "enum": ["moveToCoordinates"],
           "type": "string"
         },
         "params": {
@@ -1742,9 +1562,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -1792,11 +1610,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -1806,9 +1620,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": [
-            "moveToWell"
-          ],
+          "enum": ["moveToWell"],
           "type": "string"
         },
         "params": {
@@ -1828,9 +1640,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -1852,10 +1662,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "type": "string"
         },
         "params": {
@@ -1875,9 +1682,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -1895,9 +1700,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "seconds"
-      ]
+      "required": ["seconds"]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -1907,9 +1710,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": [
-            "waitForDuration"
-          ],
+          "enum": ["waitForDuration"],
           "type": "string"
         },
         "params": {
@@ -1929,9 +1730,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -1963,11 +1762,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -1977,9 +1772,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": [
-            "pickUpTip"
-          ],
+          "enum": ["pickUpTip"],
           "type": "string"
         },
         "params": {
@@ -1999,9 +1792,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2019,9 +1810,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2031,9 +1820,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": [
-            "savePosition"
-          ],
+          "enum": ["savePosition"],
           "type": "string"
         },
         "params": {
@@ -2053,9 +1840,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2068,9 +1853,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ]
+      "required": ["on"]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2080,9 +1863,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": [
-            "setRailLights"
-          ],
+          "enum": ["setRailLights"],
           "type": "string"
         },
         "params": {
@@ -2102,9 +1883,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2147,11 +1926,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2161,9 +1936,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": [
-            "touchTip"
-          ],
+          "enum": ["touchTip"],
           "type": "string"
         },
         "params": {
@@ -2183,20 +1956,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ]
+      "enum": ["idle", "confirm", "updating", "disco", "off"]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2212,9 +1977,7 @@
           ]
         }
       },
-      "required": [
-        "animation"
-      ]
+      "required": ["animation"]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2224,9 +1987,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": [
-            "setStatusBar"
-          ],
+          "enum": ["setStatusBar"],
           "type": "string"
         },
         "params": {
@@ -2246,9 +2007,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2266,9 +2025,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2278,9 +2035,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": [
-            "heaterShaker/waitForTemperature"
-          ],
+          "enum": ["heaterShaker/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -2300,9 +2055,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2320,10 +2073,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2333,9 +2083,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": [
-            "heaterShaker/setTargetTemperature"
-          ],
+          "enum": ["heaterShaker/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -2355,9 +2103,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -2370,9 +2116,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -2382,9 +2126,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": [
-            "heaterShaker/deactivateHeater"
-          ],
+          "enum": ["heaterShaker/deactivateHeater"],
           "type": "string"
         },
         "params": {
@@ -2404,9 +2146,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -2424,10 +2164,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ]
+      "required": ["moduleId", "rpm"]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -2437,9 +2174,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": [
-            "heaterShaker/setAndWaitForShakeSpeed"
-          ],
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "type": "string"
         },
         "params": {
@@ -2459,9 +2194,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -2474,9 +2207,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -2486,9 +2217,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": [
-            "heaterShaker/deactivateShaker"
-          ],
+          "enum": ["heaterShaker/deactivateShaker"],
           "type": "string"
         },
         "params": {
@@ -2508,9 +2237,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -2523,9 +2250,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -2535,9 +2260,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": [
-            "heaterShaker/openLabwareLatch"
-          ],
+          "enum": ["heaterShaker/openLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -2557,9 +2280,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -2572,9 +2293,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -2584,9 +2303,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": [
-            "heaterShaker/closeLabwareLatch"
-          ],
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -2606,9 +2323,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -2621,9 +2336,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -2633,9 +2346,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": [
-            "magneticModule/disengage"
-          ],
+          "enum": ["magneticModule/disengage"],
           "type": "string"
         },
         "params": {
@@ -2655,9 +2366,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -2675,10 +2384,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ]
+      "required": ["moduleId", "height"]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -2688,9 +2394,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": [
-            "magneticModule/engage"
-          ],
+          "enum": ["magneticModule/engage"],
           "type": "string"
         },
         "params": {
@@ -2710,9 +2414,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2730,10 +2432,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2743,9 +2442,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": [
-            "temperatureModule/setTargetTemperature"
-          ],
+          "enum": ["temperatureModule/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -2765,9 +2462,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2785,9 +2480,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2797,9 +2490,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": [
-            "temperatureModule/waitForTemperature"
-          ],
+          "enum": ["temperatureModule/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -2819,9 +2510,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -2834,9 +2523,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -2846,9 +2533,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": [
-            "temperatureModule/deactivate"
-          ],
+          "enum": ["temperatureModule/deactivate"],
           "type": "string"
         },
         "params": {
@@ -2868,9 +2553,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -2898,10 +2581,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -2911,9 +2591,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": [
-            "thermocycler/setTargetBlockTemperature"
-          ],
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -2933,9 +2611,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -2948,9 +2624,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -2960,9 +2634,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": [
-            "thermocycler/waitForBlockTemperature"
-          ],
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -2982,9 +2654,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -3002,10 +2672,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -3015,9 +2682,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": [
-            "thermocycler/setTargetLidTemperature"
-          ],
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -3037,9 +2702,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -3052,9 +2715,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -3064,9 +2725,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": [
-            "thermocycler/waitForLidTemperature"
-          ],
+          "enum": ["thermocycler/waitForLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -3086,9 +2745,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -3101,9 +2758,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -3113,9 +2768,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": [
-            "thermocycler/deactivateBlock"
-          ],
+          "enum": ["thermocycler/deactivateBlock"],
           "type": "string"
         },
         "params": {
@@ -3135,9 +2788,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -3150,9 +2801,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -3162,9 +2811,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": [
-            "thermocycler/deactivateLid"
-          ],
+          "enum": ["thermocycler/deactivateLid"],
           "type": "string"
         },
         "params": {
@@ -3184,9 +2831,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -3199,9 +2844,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -3211,9 +2854,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": [
-            "thermocycler/openLid"
-          ],
+          "enum": ["thermocycler/openLid"],
           "type": "string"
         },
         "params": {
@@ -3233,9 +2874,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -3248,9 +2887,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -3260,9 +2897,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": [
-            "thermocycler/closeLid"
-          ],
+          "enum": ["thermocycler/closeLid"],
           "type": "string"
         },
         "params": {
@@ -3282,9 +2917,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -3302,10 +2935,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ]
+      "required": ["celsius", "holdSeconds"]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -3331,10 +2961,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ]
+      "required": ["moduleId", "profile"]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -3344,9 +2971,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": [
-            "thermocycler/runProfile"
-          ],
+          "enum": ["thermocycler/runProfile"],
           "type": "string"
         },
         "params": {
@@ -3366,17 +2991,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": [
-        "front",
-        "rear"
-      ]
+      "enum": ["front", "rear"]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -3396,11 +3016,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -3425,9 +3041,7 @@
           ]
         }
       },
-      "required": [
-        "jaw"
-      ]
+      "required": ["jaw"]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -3437,9 +3051,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": [
-            "calibration/calibrateGripper"
-          ],
+          "enum": ["calibration/calibrateGripper"],
           "type": "string"
         },
         "params": {
@@ -3459,9 +3071,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -3477,9 +3087,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -3489,9 +3097,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": [
-            "calibration/calibratePipette"
-          ],
+          "enum": ["calibration/calibratePipette"],
           "type": "string"
         },
         "params": {
@@ -3511,9 +3117,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -3539,11 +3143,7 @@
           ]
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ]
+      "required": ["moduleId", "labwareId", "mount"]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -3553,9 +3153,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": [
-            "calibration/calibrateModule"
-          ],
+          "enum": ["calibration/calibrateModule"],
           "type": "string"
         },
         "params": {
@@ -3575,17 +3173,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ]
+      "enum": ["attachPlate", "attachInstrument"]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -3610,9 +3203,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -3622,9 +3213,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": [
-            "calibration/moveToMaintenancePosition"
-          ],
+          "enum": ["calibration/moveToMaintenancePosition"],
           "type": "string"
         },
         "params": {
@@ -3644,9 +3233,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     }
   },
   "$id": "opentronsCommandSchemaV7",

--- a/shared-data/command/schemas/7.json
+++ b/shared-data/command/schemas/7.json
@@ -163,7 +163,11 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
       "type": "string"
     },
     "WellOffset": {
@@ -248,12 +252,21 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup"],
+      "enum": [
+        "protocol",
+        "setup"
+      ],
       "type": "string"
     },
     "AspirateCreate": {
@@ -264,7 +277,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": ["aspirate"],
+          "enum": [
+            "aspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -284,7 +299,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -309,7 +326,11 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -319,7 +340,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": ["aspirateInPlace"],
+          "enum": [
+            "aspirateInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -339,7 +362,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -352,7 +377,9 @@
           "type": "string"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -362,7 +389,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": ["comment"],
+          "enum": [
+            "comment"
+          ],
           "type": "string"
         },
         "params": {
@@ -382,7 +411,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -398,7 +429,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": ["custom"],
+          "enum": [
+            "custom"
+          ],
           "type": "string"
         },
         "params": {
@@ -418,7 +451,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -467,7 +502,13 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -477,7 +518,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": ["dispense"],
+          "enum": [
+            "dispense"
+          ],
           "type": "string"
         },
         "params": {
@@ -497,7 +540,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -527,7 +572,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -537,7 +586,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": ["dispenseInPlace"],
+          "enum": [
+            "dispenseInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -557,7 +608,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -595,7 +648,12 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -605,7 +663,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": ["blowout"],
+          "enum": [
+            "blowout"
+          ],
           "type": "string"
         },
         "params": {
@@ -625,7 +685,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -644,7 +706,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -654,7 +719,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": ["blowOutInPlace"],
+          "enum": [
+            "blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -674,12 +741,19 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -741,7 +815,11 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"]
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -751,7 +829,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": ["dropTip"],
+          "enum": [
+            "dropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -771,7 +851,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -789,7 +871,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -799,7 +883,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": ["dropTipInPlace"],
+          "enum": [
+            "dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -819,7 +905,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -858,7 +946,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": ["home"],
+          "enum": [
+            "home"
+          ],
           "type": "string"
         },
         "params": {
@@ -878,7 +968,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -894,7 +986,9 @@
           ]
         }
       },
-      "required": ["axis"]
+      "required": [
+        "axis"
+      ]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -904,7 +998,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": ["retractAxis"],
+          "enum": [
+            "retractAxis"
+          ],
           "type": "string"
         },
         "params": {
@@ -924,7 +1020,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -970,7 +1068,9 @@
           ]
         }
       },
-      "required": ["slotName"]
+      "required": [
+        "slotName"
+      ]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -983,7 +1083,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -996,7 +1098,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"]
+      "required": [
+        "labwareId"
+      ]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1017,7 +1121,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             }
           ]
@@ -1048,7 +1154,12 @@
           "type": "string"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"]
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1058,7 +1169,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": ["loadLabware"],
+          "enum": [
+            "loadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1078,7 +1191,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1104,7 +1219,11 @@
           }
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"]
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1114,7 +1233,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": ["loadLiquid"],
+          "enum": [
+            "loadLiquid"
+          ],
           "type": "string"
         },
         "params": {
@@ -1134,7 +1255,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1179,7 +1302,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"]
+      "required": [
+        "model",
+        "location"
+      ]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1189,7 +1315,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": ["loadModule"],
+          "enum": [
+            "loadModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -1209,7 +1337,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1238,7 +1368,11 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "type": "string"
     },
     "LoadPipetteParams": {
@@ -1247,15 +1381,10 @@
       "type": "object",
       "properties": {
         "pipetteName": {
-          "title": "Pipettename",
           "description": "The load name of the pipette to be required.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/PipetteNameType"
-            },
-            {
-              "enum": ["p1000_96"],
-              "type": "string"
             }
           ]
         },
@@ -1273,7 +1402,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteName", "mount"]
+      "required": [
+        "pipetteName",
+        "mount"
+      ]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1283,7 +1415,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": ["loadPipette"],
+          "enum": [
+            "loadPipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -1303,12 +1437,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1329,7 +1469,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1355,7 +1499,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             }
           ]
@@ -1387,7 +1533,11 @@
           ]
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"]
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1397,7 +1547,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": ["moveLabware"],
+          "enum": [
+            "moveLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1417,12 +1569,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1449,7 +1607,11 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "axis", "distance"]
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1459,7 +1621,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": ["moveRelative"],
+          "enum": [
+            "moveRelative"
+          ],
           "type": "string"
         },
         "params": {
@@ -1479,7 +1643,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1499,7 +1665,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1537,7 +1707,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "coordinates"]
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1547,7 +1720,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": ["moveToCoordinates"],
+          "enum": [
+            "moveToCoordinates"
+          ],
           "type": "string"
         },
         "params": {
@@ -1567,7 +1742,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -1615,7 +1792,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -1625,7 +1806,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": ["moveToWell"],
+          "enum": [
+            "moveToWell"
+          ],
           "type": "string"
         },
         "params": {
@@ -1645,7 +1828,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -1667,7 +1852,10 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "type": "string"
         },
         "params": {
@@ -1687,7 +1875,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -1705,7 +1895,9 @@
           "type": "string"
         }
       },
-      "required": ["seconds"]
+      "required": [
+        "seconds"
+      ]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -1715,7 +1907,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": ["waitForDuration"],
+          "enum": [
+            "waitForDuration"
+          ],
           "type": "string"
         },
         "params": {
@@ -1735,7 +1929,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -1767,7 +1963,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -1777,7 +1977,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": ["pickUpTip"],
+          "enum": [
+            "pickUpTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1797,7 +1999,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -1815,7 +2019,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -1825,7 +2031,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": ["savePosition"],
+          "enum": [
+            "savePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -1845,7 +2053,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -1858,7 +2068,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"]
+      "required": [
+        "on"
+      ]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -1868,7 +2080,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": ["setRailLights"],
+          "enum": [
+            "setRailLights"
+          ],
           "type": "string"
         },
         "params": {
@@ -1888,7 +2102,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -1931,7 +2147,11 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -1941,7 +2161,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": ["touchTip"],
+          "enum": [
+            "touchTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1961,12 +2183,20 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": ["idle", "confirm", "updating", "disco", "off"]
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -1982,7 +2212,9 @@
           ]
         }
       },
-      "required": ["animation"]
+      "required": [
+        "animation"
+      ]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -1992,7 +2224,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": ["setStatusBar"],
+          "enum": [
+            "setStatusBar"
+          ],
           "type": "string"
         },
         "params": {
@@ -2012,7 +2246,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2030,7 +2266,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2040,7 +2278,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": ["heaterShaker/waitForTemperature"],
+          "enum": [
+            "heaterShaker/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2060,7 +2300,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2078,7 +2320,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2088,7 +2333,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": ["heaterShaker/setTargetTemperature"],
+          "enum": [
+            "heaterShaker/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2108,7 +2355,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -2121,7 +2370,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -2131,7 +2382,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": ["heaterShaker/deactivateHeater"],
+          "enum": [
+            "heaterShaker/deactivateHeater"
+          ],
           "type": "string"
         },
         "params": {
@@ -2151,7 +2404,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -2169,7 +2424,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"]
+      "required": [
+        "moduleId",
+        "rpm"
+      ]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -2179,7 +2437,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
+          "enum": [
+            "heaterShaker/setAndWaitForShakeSpeed"
+          ],
           "type": "string"
         },
         "params": {
@@ -2199,7 +2459,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -2212,7 +2474,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -2222,7 +2486,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": ["heaterShaker/deactivateShaker"],
+          "enum": [
+            "heaterShaker/deactivateShaker"
+          ],
           "type": "string"
         },
         "params": {
@@ -2242,7 +2508,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -2255,7 +2523,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -2265,7 +2535,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": ["heaterShaker/openLabwareLatch"],
+          "enum": [
+            "heaterShaker/openLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -2285,7 +2557,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -2298,7 +2572,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -2308,7 +2584,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": ["heaterShaker/closeLabwareLatch"],
+          "enum": [
+            "heaterShaker/closeLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -2328,7 +2606,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -2341,7 +2621,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -2351,7 +2633,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": ["magneticModule/disengage"],
+          "enum": [
+            "magneticModule/disengage"
+          ],
           "type": "string"
         },
         "params": {
@@ -2371,7 +2655,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -2389,7 +2675,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "height"]
+      "required": [
+        "moduleId",
+        "height"
+      ]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -2399,7 +2688,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": ["magneticModule/engage"],
+          "enum": [
+            "magneticModule/engage"
+          ],
           "type": "string"
         },
         "params": {
@@ -2419,7 +2710,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2437,7 +2730,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2447,7 +2743,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": ["temperatureModule/setTargetTemperature"],
+          "enum": [
+            "temperatureModule/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2467,7 +2765,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2485,7 +2785,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2495,7 +2797,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": ["temperatureModule/waitForTemperature"],
+          "enum": [
+            "temperatureModule/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2515,7 +2819,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -2528,7 +2834,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -2538,7 +2846,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": ["temperatureModule/deactivate"],
+          "enum": [
+            "temperatureModule/deactivate"
+          ],
           "type": "string"
         },
         "params": {
@@ -2558,7 +2868,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -2586,7 +2898,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -2596,7 +2911,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": ["thermocycler/setTargetBlockTemperature"],
+          "enum": [
+            "thermocycler/setTargetBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2616,7 +2933,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -2629,7 +2948,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -2639,7 +2960,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": ["thermocycler/waitForBlockTemperature"],
+          "enum": [
+            "thermocycler/waitForBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2659,7 +2982,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -2677,7 +3002,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -2687,7 +3015,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": ["thermocycler/setTargetLidTemperature"],
+          "enum": [
+            "thermocycler/setTargetLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2707,7 +3037,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -2720,7 +3052,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -2730,7 +3064,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": ["thermocycler/waitForLidTemperature"],
+          "enum": [
+            "thermocycler/waitForLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2750,7 +3086,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -2763,7 +3101,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -2773,7 +3113,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": ["thermocycler/deactivateBlock"],
+          "enum": [
+            "thermocycler/deactivateBlock"
+          ],
           "type": "string"
         },
         "params": {
@@ -2793,7 +3135,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -2806,7 +3150,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -2816,7 +3162,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": ["thermocycler/deactivateLid"],
+          "enum": [
+            "thermocycler/deactivateLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -2836,7 +3184,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -2849,7 +3199,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -2859,7 +3211,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": ["thermocycler/openLid"],
+          "enum": [
+            "thermocycler/openLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -2879,7 +3233,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -2892,7 +3248,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -2902,7 +3260,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": ["thermocycler/closeLid"],
+          "enum": [
+            "thermocycler/closeLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -2922,7 +3282,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -2940,7 +3302,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"]
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -2966,7 +3331,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "profile"]
+      "required": [
+        "moduleId",
+        "profile"
+      ]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -2976,7 +3344,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": ["thermocycler/runProfile"],
+          "enum": [
+            "thermocycler/runProfile"
+          ],
           "type": "string"
         },
         "params": {
@@ -2996,12 +3366,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": ["front", "rear"]
+      "enum": [
+        "front",
+        "rear"
+      ]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -3021,7 +3396,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -3046,7 +3425,9 @@
           ]
         }
       },
-      "required": ["jaw"]
+      "required": [
+        "jaw"
+      ]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -3056,7 +3437,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": ["calibration/calibrateGripper"],
+          "enum": [
+            "calibration/calibrateGripper"
+          ],
           "type": "string"
         },
         "params": {
@@ -3076,7 +3459,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -3092,7 +3477,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -3102,7 +3489,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": ["calibration/calibratePipette"],
+          "enum": [
+            "calibration/calibratePipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -3122,7 +3511,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -3148,7 +3539,11 @@
           ]
         }
       },
-      "required": ["moduleId", "labwareId", "mount"]
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -3158,7 +3553,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": ["calibration/calibrateModule"],
+          "enum": [
+            "calibration/calibrateModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -3178,12 +3575,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"]
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -3208,7 +3610,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -3218,7 +3622,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": ["calibration/moveToMaintenancePosition"],
+          "enum": [
+            "calibration/moveToMaintenancePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -3238,7 +3644,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     }
   },
   "$id": "opentronsCommandSchemaV7",


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RSS-304.
raise an error when trying to load a 96c pipette when another pipette is attached on the right.

# Test Plan

- on a Flex load the following python protocol and make sure there is an exception raised for a pipette attached:

```
requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.15",
}


def run(protocol_context):
	tip_rack_50 = ctx.load_labware("opentrons_ot3_96_tiprack_50ul", 4)
	p300 = protocol_context.load_instrument('p50_single_flex', 'right', [tip_rack_50])
	p300.pick_up_tip()
	p300.drop_tip()

	# should raise an error for a pipette attached on the right
	p1000_96c = protocol_context.load_instrument('flex_96channel_1000', 'left')

```

- should work as expected:

```

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.15",
}

def run(protocol_context):
	tip_rack_50 = ctx.load_labware("opentrons_ot3_96_tiprack_50ul", 4)
	p1000_96c = protocol_context.load_instrument('flex_96channel_1000', 'right', [tip_rack_50])
	p1000_96c.pick_up_tip()
	p1000_96c.drop_tip()
```


# Changelog

- Removed all instances of `Literal[p1000_96]` and accept PipetteNameType.
- Added logic when loading a 96c pipette check the right mount and make sure nothing is attached.

# Review requests

1. Is it sufficient to check the right mount? the left mount will be checked in the following if statement if statment and its not allowed to replace. 
2. do we want raise a specific error as part of this pr? I checked in the rest of the file and the only custom error we are raising is an `APIVersionError`
3. error message raised is fine?

# Risk assessment

low. should not change existing logic. needs to be test on a robot. 
