### PR TITLE
chore(api): disable legacy calibration accessors on flex

### DIFF
--- a/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
@@ -91,7 +91,7 @@ def get_pipette_offset(
         log.debug(f"Calibrations for {pipette_id} on {mount} does not exist.")
         return None
     except (json.JSONDecodeError, ValidationError):
-        log.debug(
+        log.warning(
             f"Malformed calibrations for {pipette_id} on {mount}. Please factory reset your calibrations."
         )
         # TODO: Delete the bad calibration here maybe?

--- a/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
@@ -88,12 +88,13 @@ def get_pipette_offset(
             **io.read_cal_file(pipette_calibration_filepath)
         )
     except FileNotFoundError:
-        log.warning(f"Calibrations for {pipette_id} on {mount} does not exist.")
+        log.debug(f"Calibrations for {pipette_id} on {mount} does not exist.")
         return None
     except (json.JSONDecodeError, ValidationError):
-        log.warning(
+        log.debug(
             f"Malformed calibrations for {pipette_id} on {mount}. Please factory reset your calibrations."
         )
+        # TODO: Delete the bad calibration here maybe?
         return None
 
 

--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -50,7 +50,7 @@ def tip_lengths_for_pipette(
                 pass
         return tip_lengths
     except FileNotFoundError:
-        log.warning(f"Tip length calibrations not found for {pipette_id}")
+        log.debug(f"Tip length calibrations not found for {pipette_id}")
         return tip_lengths
 
 

--- a/api/src/opentrons/calibration_storage/ot3/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/pipette_offset.py
@@ -85,7 +85,7 @@ def get_pipette_offset(
             **io.read_cal_file(pipette_calibration_filepath)
         )
     except FileNotFoundError:
-        log.warning(f"Calibrations for {pipette_id} on {mount} does not exist.")
+        log.debug(f"Calibrations for {pipette_id} on {mount} does not exist.")
         return None
     except (json.JSONDecodeError, ValidationError):
         log.warning(

--- a/api/src/opentrons/calibration_storage/ot3/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot3/tip_length.py
@@ -37,19 +37,22 @@ def tip_lengths_for_pipette(
 ) -> typing.Dict[str, v1.TipLengthModel]:
     tip_lengths = {}
     try:
+        # While you technically could drop some data in for tip length calibration on the flex,
+        # it is not necessary and there is no UI frontend for it, so this code will mostly be
+        # taking the FileNotFoundError path.
         tip_length_filepath = config.get_tip_length_cal_path() / f"{pipette_id}.json"
         all_tip_lengths_for_pipette = io.read_cal_file(tip_length_filepath)
         for tiprack, data in all_tip_lengths_for_pipette.items():
             try:
                 tip_lengths[tiprack] = v1.TipLengthModel(**data)
             except (json.JSONDecodeError, ValidationError):
-                log.warning(
+                log.debug(
                     f"Tip length calibration is malformed for {tiprack} on {pipette_id}"
                 )
                 pass
         return tip_lengths
     except FileNotFoundError:
-        log.warning(f"Tip length calibrations not found for {pipette_id}")
+        # this is the overwhelmingly common case
         return tip_lengths
 
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -10,10 +10,12 @@ from opentrons.config.robot_configs import (
 from opentrons.types import Point, Mount
 
 # TODO change this when imports are fixed
-from opentrons.calibration_storage.ot3.pipette_offset import save_pipette_calibration
+from opentrons.calibration_storage.ot3.pipette_offset import (
+    save_pipette_calibration,
+    get_pipette_offset,
+)
 from opentrons.calibration_storage import (
     types as cal_top_types,
-    get_pipette_offset,
     ot3_gripper_offset,
 )
 from opentrons.hardware_control.types import OT3Mount

--- a/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
@@ -82,5 +82,5 @@ class LabwareDataProvider:
                 f"No calibrated tip length found for {pipette_serial},"
                 f" using nominal fallback value of {nominal_fallback}"
             )
-            log.warning(message, exc_info=e)
+            log.debug(message, exc_info=e)
             return nominal_fallback

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -1,14 +1,17 @@
 from starlette import status
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from typing import Optional
 
 from opentrons.calibration_storage import types as cal_types
 from opentrons.calibration_storage.ot2 import tip_length, models
 
+from robot_server.hardware import get_ot2_hardware
 from robot_server.errors import ErrorBody
 from robot_server.service.tip_length import models as tl_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.shared_models import calibration as cal_model
+
+from opentrons.hardware_control import API
 
 
 router = APIRouter()
@@ -48,6 +51,7 @@ async def get_all_tip_length_calibrations(
     tiprack_hash: Optional[str] = None,
     pipette_id: Optional[str] = None,
     tiprack_uri: Optional[str] = None,
+    _: API = Depends(get_ot2_hardware),
 ) -> tl_models.MultipleCalibrationsResponse:
     all_calibrations = tip_length.get_all_tip_length_calibrations()
     if not all_calibrations:
@@ -79,7 +83,9 @@ async def get_all_tip_length_calibrations(
     "serial and tiprack hash",
     responses={status.HTTP_404_NOT_FOUND: {"model": ErrorBody}},
 )
-async def delete_specific_tip_length_calibration(tiprack_hash: str, pipette_id: str):
+async def delete_specific_tip_length_calibration(
+    tiprack_hash: str, pipette_id: str, _: API = Depends(get_ot2_hardware)
+):
     try:
         tip_length.delete_tip_length_calibration(tiprack_hash, pipette_id)
     except cal_types.TipLengthCalNotFound:

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -30,7 +30,7 @@ from opentrons.protocol_api import labware
 from opentrons.types import Point, Mount
 
 from robot_server import app
-from robot_server.hardware import get_hardware
+from robot_server.hardware import get_hardware, get_ot2_hardware
 from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
 from robot_server.service.session.manager import SessionManager
 from robot_server.persistence import get_sql_engine, create_sql_engine
@@ -140,10 +140,22 @@ def _override_version_with_mock(versions: MagicMock) -> Iterator[None]:
 
 
 @pytest.fixture
+def _override_ot2_hardware_with_mock(hardware: MagicMock) -> Iterator[None]:
+    async def get_ot2_hardware_override() -> API:
+        """Override for the get_ot2_hardware FastAPI dependency."""
+        return MagicMock(spec=API)
+
+    app.dependency_overrides[get_ot2_hardware] = get_ot2_hardware_override
+    yield
+    del app.dependency_overrides[get_ot2_hardware]
+
+
+@pytest.fixture
 def api_client(
     _override_hardware_with_mock: None,
     _override_sql_engine_with_mock: None,
     _override_version_with_mock: None,
+    _override_ot2_hardware_with_mock: None,
 ) -> TestClient:
     client = TestClient(app)
     client.headers.update({API_VERSION_HEADER: LATEST_API_VERSION_HEADER_VALUE})

--- a/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
+++ b/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
@@ -124,3 +124,26 @@ stages:
         mount: 'right'
     response:
         status_code: 200
+
+---
+test_name: Pipette calibrations inaccessible on flex
+marks:
+  - usefixtures:
+    - ot3_server_base_url
+    - set_up_pipette_offset_temp_directory
+stages:
+  - name: GET request 403s
+    request:
+      url: "{ot3_server_base_url}/calibration/pipette_offset"
+      method: GET
+    response:
+      status_code: 403
+  - name: DELETE request 403s
+    request:
+      url: "{ot3_server_base_url}/calibration/pipette_offset"
+      method: DELETE
+      params:
+        pipette_id: '321'
+        mount: 'right'
+    response:
+        status_code: 403

--- a/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
+++ b/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
@@ -128,6 +128,7 @@ stages:
 ---
 test_name: Pipette calibrations inaccessible on flex
 marks:
+  - ot3_only
   - usefixtures:
     - ot3_server_base_url
     - set_up_pipette_offset_temp_directory

--- a/robot-server/tests/integration/test_tip_length_access.tavern.yaml
+++ b/robot-server/tests/integration/test_tip_length_access.tavern.yaml
@@ -159,3 +159,22 @@ stages:
       method: DELETE
     response:
         status_code: 404
+---
+test_name: Tip length inaccessible on flex
+marks:
+  - ot3_only
+  - usefixtures:
+    - ot3_server_base_url
+stages:
+  - name: GET request 403s
+    request:
+      url: "{ot3_server_base_url}/calibration/tip_length"
+      method: GET
+    response:
+      status_code: 403
+  - name: DELETE request 403s
+    request:
+      url: "{ot3_server_base_url}/calibration/tip_length"
+      method: DELETE
+    response:
+        status_code: 403


### PR DESCRIPTION
We had a lot of spammy logs in the api log about missing or malformed pipette and tip length calibration.

The missing calibrations should not be logged at info level - these are polled and this is a level state, so it just ends up being spammy. The malformed calibrations though should be, and it's weird that we were getting them.

The culprit is that <7.0.0 apps poll routes to get pipette offset and tip length because that's what you do on the ot2, and the implementations of those routes hardcode the ot2 calibration models - reasonable, since we completely replaced them for the flex. So you'd only get those logs if an old app was polling the robot.

To fix that, I made the routes shortcircuit with a 403 forbidden / not allowed on hardware error. This won't affect the flex because the app doesn't check that route on flex.
