### PR TITLE
fix(app): hide module calibrate menu button when a robot is OT-2

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -77,14 +77,16 @@ export const ModuleOverflowMenu = (
   return (
     <Flex position={POSITION_RELATIVE}>
       <MenuList>
-        <MenuItem onClick={handleCalibrateClick} disabled={!isPipetteReady}>
-          {i18n.format(
-            module.moduleOffset?.last_modified != null
-              ? t('recalibrate')
-              : t('calibrate'),
-            'capitalize'
-          )}
-        </MenuItem>
+        {isOT3 ? (
+          <MenuItem onClick={handleCalibrateClick} disabled={!isPipetteReady}>
+            {i18n.format(
+              module.moduleOffset?.last_modified != null
+                ? t('recalibrate')
+                : t('calibrate'),
+              'capitalize'
+            )}
+          </MenuItem>
+        ) : null}
         {menuOverflowItemsByModuleType[module.moduleType].map(
           (item: any, index: number) => {
             return (

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -501,7 +501,19 @@ describe('ModuleOverflowMenu', () => {
     expect(about).not.toBeDisabled()
   })
 
+  it('not render calibrate button when a robot is OT-2', () => {
+    props = {
+      ...props,
+      isPipetteReady: false,
+    }
+    const { queryByRole } = render(props)
+
+    const calibrate = queryByRole('button', { name: 'Calibrate' })
+    expect(calibrate).not.toBeInTheDocument()
+  })
+
   it('renders a disabled calibrate button if the pipettes are not attached or need a firmware update', () => {
+    mockUseIsOT3.mockReturnValue(true)
     props = {
       ...props,
       isPipetteReady: false,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
hide module calibrate menu button when a robot is OT-2

### before
![Screenshot 2023-09-11 at 7 56 26 PM](https://github.com/Opentrons/opentrons/assets/474225/d826cc19-a35f-496e-bf0d-ec8e0f52af7b)


### after
![Screenshot 2023-09-11 at 7 55 56 PM](https://github.com/Opentrons/opentrons/assets/474225/700531b3-d812-4104-8538-879c74ad71d3)

Flex shows calibrate buttons
![Screenshot 2023-09-11 at 7 57 56 PM](https://github.com/Opentrons/opentrons/assets/474225/f0e0fa84-e397-4fc2-898b-2f9deba564bd)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
OT-2
run robot-server `make -C robot-server dev`
1. go to opentrons-dev Device Details page
2. click overflow menu
there is no calibrate button in each overflow menu

Flex
run robot-server `make -C robot-server dev OT_API_FF_enableOT3HardwareController="true" DEV_ROBOT_NAME="FlexDev" OT_ROBOT_SERVER_simulator_configuration_file_path="simulators/test-flex.json"`
1. go to FlexDev Device Details page
2. click overflow menu
there is calibrate buttons in each overflow menu

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update overflowmenu components and tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
