### PR TITLE
fix(app, app-shell): Support protocol backwards app compatibility

### DIFF
--- a/app-shell/src/protocol-storage/file-system.ts
+++ b/app-shell/src/protocol-storage/file-system.ts
@@ -24,8 +24,13 @@ import { analyzeProtocolSource } from '../protocol-analysis'
  *  │  ├─ analysis/
  *  │  │  ├─ 1646303906.json
  */
-
-export const PROTOCOLS_DIRECTORY_NAME = 'protocols'
+// TODO(jh, 2023-09-11): remove OLD_PROTOCOLS_DIRECTORY_PATH after
+// OT-2 parity work is completed and move all protocols back to "protocols" directory.
+export const OLD_PROTOCOLS_DIRECTORY_PATH = path.join(
+  app.getPath('userData'),
+  'protocols'
+)
+export const PROTOCOLS_DIRECTORY_NAME = 'protocols_v7.0-supported'
 export const PROTOCOLS_DIRECTORY_PATH = path.join(
   app.getPath('userData'),
   PROTOCOLS_DIRECTORY_NAME

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -66,7 +66,7 @@ function migrateProtocolsToNewDirectory(): () => Promise<void> {
           console.log(
             `Error migrating protocols to ${FileSystem.PROTOCOLS_DIRECTORY_NAME}: ${e}`
           )
-          reject(e)
+          resolve()
         })
     })
   }

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -78,7 +78,7 @@ function migrateProtocolsToNewDirectory(): () => Promise<void> {
         if (!doesSrcExist.isDirectory()) return Promise.resolve()
 
         return fse.readdir(src).then(items => {
-          const protocols: Array<Promise<void>> = items.map(item => {
+          const protocols = items.map(item => {
             const srcItem = path.join(src, item)
             const destItem = path.join(dest, item)
 

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -83,7 +83,9 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   the app to the most recent version to run this protocol.`
 
   const UnknownAttachmentError = (
-    <StyledText>{UNKNOWN_ATTACHMENT_ERROR}</StyledText>
+    <StyledText color={COLORS.errorEnabled}>
+      {UNKNOWN_ATTACHMENT_ERROR}
+    </StyledText>
   )
 
   return (

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import {
   getModuleType,
@@ -55,7 +56,6 @@ interface ProtocolCardProps {
   handleSendProtocolToOT3: (storedProtocolData: StoredProtocolData) => void
   storedProtocolData: StoredProtocolData
 }
-
 export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   const history = useHistory()
   const {
@@ -78,6 +78,14 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
     mostRecentAnalysis
   )
 
+  const UNKNOWN_ATTACHMENT_ERROR = `${protocolDisplayName} protocol uses 
+  instruments  or modules from a future version of the app. Please update 
+  the app to the most recent version to run this protocol.`
+
+  const UnknownAttachmentError = (
+    <StyledText>{UNKNOWN_ATTACHMENT_ERROR}</StyledText>
+  )
+
   return (
     <Box
       backgroundColor={COLORS.white}
@@ -89,13 +97,15 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
       onClick={() => history.push(`/protocols/${protocolKey}`)}
       css={BORDERS.cardOutlineBorder}
     >
-      <AnalysisInfo
-        protocolKey={protocolKey}
-        mostRecentAnalysis={mostRecentAnalysis}
-        protocolDisplayName={protocolDisplayName}
-        isAnalyzing={isAnalyzing}
-        modified={modified}
-      />
+      <ErrorBoundary fallback={UnknownAttachmentError}>
+        <AnalysisInfo
+          protocolKey={protocolKey}
+          mostRecentAnalysis={mostRecentAnalysis}
+          protocolDisplayName={protocolDisplayName}
+          isAnalyzing={isAnalyzing}
+          modified={modified}
+        />
+      </ErrorBoundary>
       <Box
         position={POSITION_ABSOLUTE}
         top={SPACING.spacing4}


### PR DESCRIPTION
Closes RQA-1509

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an issue where users who downgrades their app from v7.0.0 to 6.3.1 or lower whitescreen on startup due to protocols supporting modules not present in previous versions. Because a v6.3.1 and 7.0.0 version of the app must both be supported until OT-2/Flex app parity, there's need for a workaround solution.

### The Immediate Problem

In order to solve this issue without deploying a hotfix for 6.3.1, protocols for version 7.0+ are stored in a new protocols folder (within the same directory as the old). A migration occurs on startup where new protocols added in the 6.3.1 app are copied over for use within the 7.0.0 app. 

Using a copy rather than a simple folder rename prevents users who have both versions of the app from seeing none of their protocols in the v6.3.1 version.

NOTE: Very large protocol files take a while to transfer and may result in a temporary whitescreen on app startup, however, in practice this should not be an issue in practice- only significantly large protocols made with the purpose of testing protocol size will cause noticeable delay. 

### The Future Problem

To prevent the need for a stop-gap solution in the future, a simple error boundary is added.

![Screenshot 2023-09-12 at 8 15 28 AM](https://github.com/Opentrons/opentrons/assets/64858653/e41245e1-afb8-4754-a2ea-419efe4c665d)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Open the app on this branch.
- Observe protocol migration by going to /Users/user_name/Library/Application Support/Opentrons/ and opening the protocols and protocols_v7.0-supported directories. Only protocols before the v6.3.1 release date are present in the former directory, and all protocols are present in the latter directory.
- Use the protocol below, which is for a module that doesn't exist (manually add it to the new protocols directory). Observe the error message upon app restart.
[34564c7z-f57a-4ca6-9e2f-725aedeb1149.zip](https://github.com/Opentrons/opentrons/files/12589099/34564c7z-f57a-4ca6-9e2f-725aedeb1149.zip)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added temporary stop-gap to migrate protocols until app parity.
- Added protocol error boundary to prevent this issue from occurring in the future.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low