### PR TITLE
feat(app): status bar Update animation during update installation

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -15,6 +15,7 @@ import {
   SPACING,
   BORDERS,
 } from '@opentrons/components'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 
 import { StyledText } from '../../../../atoms/text'
 import { LegacyModal } from '../../../../molecules/LegacyModal'
@@ -26,6 +27,7 @@ import {
 } from '../../../../redux/robot-update'
 import successIcon from '../../../../assets/images/icon_success.png'
 
+import type { SetStatusBarCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/incidental'
 import type { Dispatch } from '../../../../redux/types'
 import type { UpdateStep } from '.'
 import type { RobotUpdateAction } from '../../../../redux/robot-update/types'
@@ -76,6 +78,26 @@ function RobotUpdateProgressFooter({
     dispatch(startRobotUpdate(robotName))
   }, [robotName])
 
+  const { createLiveCommand } = useCreateLiveCommandMutation()
+  const idleCommand: SetStatusBarCreateCommand = {
+    commandType: 'setStatusBar',
+    params: { animation: 'idle' },
+  }
+
+  // Called if the update fails
+  const startIdleAnimationIfFailed = (): void => {
+    if (errorMessage) {
+      createLiveCommand({
+        command: idleCommand,
+        waitUntilComplete: false,
+      }).catch((e: Error) =>
+        console.warn(`cannot run status bar animation: ${e.message}`)
+      )
+    }
+  }
+
+  React.useEffect(startIdleAnimationIfFailed, [])
+
   return (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>
       {errorMessage && (
@@ -124,12 +146,31 @@ export function RobotUpdateProgressModal({
     return dispatch(clearRobotUpdateSession())
   }
 
+  const { createLiveCommand } = useCreateLiveCommandMutation()
+  const updatingCommand: SetStatusBarCreateCommand = {
+    commandType: 'setStatusBar',
+    params: { animation: 'updating' },
+  }
+
+  // Called when the first step of the update begins
+  const startUpdatingAnimation = (): void => {
+    createLiveCommand({
+      command: updatingCommand,
+      waitUntilComplete: false,
+    }).catch((e: Error) =>
+      console.warn(`cannot run status bar animation: ${e.message}`)
+    )
+  }
+
   let modalBodyText = t('downloading_update')
   if (updateStep === 'install') {
     modalBodyText = t('installing_update')
   } else if (updateStep === 'restart') {
     modalBodyText = t('restarting_robot')
   }
+
+  // Make sure to start the animation when this modal first pops up
+  React.useEffect(startUpdatingAnimation, [])
 
   // Account for update methods that do not require download & decreasing percent oddities.
   React.useEffect(() => {

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
@@ -2,8 +2,18 @@ import * as React from 'react'
 import { i18n } from '../../../../../i18n'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
+import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
+
+import type { SetStatusBarCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV7/command/incidental'
 
 import { RobotUpdateProgressModal } from '../RobotUpdateProgressModal'
+
+jest.mock('@opentrons/react-api-client')
+jest.mock('@opentrons/shared-data/protocol/types/schemaV7/command/incidental')
+
+const mockUseCreateLiveCommandMutation = useCreateLiveCommandMutation as jest.MockedFunction<
+  typeof useCreateLiveCommandMutation
+>
 
 const render = (
   props: React.ComponentProps<typeof RobotUpdateProgressModal>
@@ -15,8 +25,11 @@ const render = (
 
 describe('DownloadUpdateModal', () => {
   let props: React.ComponentProps<typeof RobotUpdateProgressModal>
+  let mockCreateLiveCommand = jest.fn()
 
   beforeEach(() => {
+    mockCreateLiveCommand = jest.fn()
+    mockCreateLiveCommand.mockResolvedValue(null)
     props = {
       robotName: 'testRobot',
       updateStep: 'download',
@@ -24,6 +37,9 @@ describe('DownloadUpdateModal', () => {
       stepProgress: 50,
       closeUpdateBuildroot: jest.fn(),
     }
+    mockUseCreateLiveCommandMutation.mockReturnValue({
+      createLiveCommand: mockCreateLiveCommand,
+    } as any)
   })
 
   afterEach(() => {
@@ -34,6 +50,20 @@ describe('DownloadUpdateModal', () => {
     const [{ getByText }] = render(props)
 
     expect(getByText('Updating testRobot')).toBeInTheDocument()
+  })
+
+  it('activates the Update animation when first rendered', () => {
+    render(props)
+    const updatingCommand: SetStatusBarCreateCommand = {
+      commandType: 'setStatusBar',
+      params: { animation: 'updating' },
+    }
+
+    expect(mockUseCreateLiveCommandMutation).toBeCalledWith()
+    expect(mockCreateLiveCommand).toBeCalledWith({
+      command: updatingCommand,
+      waitUntilComplete: false,
+    })
   })
 
   it('renders the correct text when downloading the robot update with no close button', () => {
@@ -89,11 +119,16 @@ describe('DownloadUpdateModal', () => {
 
     expect(getByText('Robot software successfully updated')).toBeInTheDocument()
     expect(exitButton).toBeInTheDocument()
+    expect(mockCreateLiveCommand).toBeCalledTimes(1)
     fireEvent.click(exitButton)
     expect(props.closeUpdateBuildroot).toHaveBeenCalled()
   })
 
   it('renders an error modal and exit button if an error occurs', () => {
+    const idleCommand: SetStatusBarCreateCommand = {
+      commandType: 'setStatusBar',
+      params: { animation: 'idle' },
+    }
     props = {
       ...props,
       error: 'test error',
@@ -106,5 +141,12 @@ describe('DownloadUpdateModal', () => {
     fireEvent.click(exitButton)
     expect(getByText('Try again')).toBeInTheDocument()
     expect(props.closeUpdateBuildroot).toHaveBeenCalled()
+
+    expect(mockUseCreateLiveCommandMutation).toBeCalledWith()
+    expect(mockCreateLiveCommand).toBeCalledTimes(2)
+    expect(mockCreateLiveCommand).toBeCalledWith({
+      command: idleCommand,
+      waitUntilComplete: false,
+    })
   })
 })


### PR DESCRIPTION


# Overview

This should be the last missing status bar animation. Without this PR, the robot server will start running the Update animation when it starts up after an update and starts updating the firmware images on the robot. However, we want the status bar to pulse while the robot is updating its _software_, which starts well before the robot has restarted.

This PR adds a couple of simple hooks in the `RobotUpdateProgressModal` to start the Updating animation on a Flex that is being updated. If an error occurs, the app changes to the "idle" animation.

# Test Plan

* Updated an OT-2 to make sure that the `setStatusBar` command fails silently instead of interfering with operation
* Updated FlexyFace from a .zip file. The status bar pulsed as soon as the app start uploading the file, and pulsed during the restart.
* Updated FlexyFace and then killed the Update Server during the .zip file upload. The app turned off the pulsing animation.

# Changelog

* When the RobotUpdateProgressModal is first rendered, send a command to the robot to start the Updating animation (pulsing white) on the status bar
* When there is an error during an update, send a command to the robot to display the Idle animation (solid white) on the status bar

# Review requests

* I ended up taking basically the same approach here as with the "disco" animation during first-time setup, mostly because I don't know enough typescript to know if there's a better way to do this. If this is a silly method and/or location to add these hooks then please point me in the right direction :) 

# Risk assessment

Pretty low _as long as_ my understanding of javascript `catch` is correct - when updating a robot with software old enough to not recognize the animation commands, they should just be ignored. 

Otherwise, the biggest risk is some possibility of weird animation states on the robot if you start an update and then close your app in the middle of it. I think the only alternative here would be to manage this through the Update Server instead of the app. I'm a little wary about integrating this kind of functionality in the Update Server unless absolutely necessary, but I could be convinced.