### PR TITLE
chore(push): add ssh_key option when using push-ot3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,10 +380,10 @@ ssh-keygen # note the path you save the key to
 make -C robot-server install-key br_ssh_pubkey=/path/to/pubkey host=${some_other_ip_address}
 ```
 
-and subsequently, when you do `make term`, add the `br_ssh_key=/path/to/key` option:
+and subsequently, when you do `make term`, add the `ssh_key=/path/to/key` option:
 
 ```shell
-make term br_ssh_key=/path/to/privkey
+make term ssh_key=/path/to/privkey
 ```
 
 If you create the key as `~/.ssh/robot_key` and `~/.ssh/robot_key.pub` then `make term` and `make install-key` will work without arguments.

--- a/api/Makefile
+++ b/api/Makefile
@@ -49,10 +49,12 @@ test_opts ?=
 pypi_username ?=
 pypi_password ?=
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
+# Helper to safely bundle ssh options
+ssh_helper = $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts)
 
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
@@ -171,24 +173,23 @@ local-shell:
 
 .PHONY: push-no-restart
 push-no-restart: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push
 push: push-no-restart
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),"jupyter-notebook opentrons-robot-server")
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"jupyter-notebook opentrons-robot-server")
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist
 	echo $(sdist_file)
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,opentrons,src,,$(version_file))
-	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && mkdir -p /usr/local/bin"
-	scp $(ssh_opts) ./src/opentrons/hardware_control/scripts/ot3repl root@$(host):/usr/local/bin/ot3repl
-	scp $(ssh_opts) ./src/opentrons/hardware_control/scripts/ot3gripper root@$(host):/usr/local/bin/ot3gripper
-	ssh $(ssh_opts) root@$(host) "mount -o remount,ro /"
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,opentrons,src,,$(version_file))
+	ssh $(ssh_helper) root@$(host) "mount -o remount,rw / && mkdir -p /usr/local/bin"
+	scp $(ssh_helper) ./src/opentrons/hardware_control/scripts/{ot3repl,ot3gripper} root@$(host):/usr/local/bin/
+	ssh $(ssh_helper) root@$(host) "mount -o remount,ro /"
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),,$(ssh_opts),"opentrons-robot-server")
+	$(call restart-server,$(host),$(host),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: simulate
 simulate:
@@ -206,7 +207,7 @@ deploy: wheel
 # User must currently specify host, e.g.: `make term host=169.254.202.176`
 .PHONY: term
 term:
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host)
+	ssh $(ssh_helper) root@$(host)
 
 .PHONY: plot-session
 plot-session:

--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -72,9 +72,9 @@ dist-ot3: package-deps
 .PHONY: push-ot3
 push-ot3: dist-ot3
 	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
-	scp -r $(ssh_opts) ./opentrons-robot-app.tar.gz root@$(host):
-	ssh $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
-	ssh $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app && rm -rf opentrons-robot-app.tar.gz"
+	scp $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) -r ./opentrons-robot-app.tar.gz root@$(host):
+	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
+	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app && rm -rf opentrons-robot-app.tar.gz"
 	rm -rf opentrons-robot-app.tar.gz
 
 # development

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -23,7 +23,7 @@ dist_files = $(if $(filter $(1),robot-stack),"dist/**/Opentrons-*","dist/**/Open
 update_files := "dist/@(alpha|beta|latest)*.@(yml|json)"
 publish_dir := dist/publish
 
-# Other SSH args for buildroot robots
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
 
 # TODO(mc, 2018-03-27): move all this to some sort of envfile

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -25,10 +25,12 @@ tests ?= tests
 cov_opts ?= --cov=hardware_testing --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 test_opts ?=
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
+# Helper to safely bundle ssh options
+ssh_helper = $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts)
 
 # Source discovery
 # For the python sources
@@ -170,32 +172,32 @@ endef
 
 .PHONY: push-plot-webpage-ot3
 push-plot-webpage-ot3:
-	scp -r hardware_testing/tools/plot root@$(host):/data
-	$(call move-plot-webpage-ot3,$(host),$(br_ssh_key),$(ssh_opts))
+	scp $(ssh_helper) -r hardware_testing/tools/plot root@$(host):/data
+	$(call move-plot-webpage-ot3,$(host),$(ssh_key),$(ssh_opts))
 
 .PHONY: push-description-ot3
 push-description-ot3:
 	$(python) -c "from hardware_testing.data import create_git_description_file; create_git_description_file()"
-	scp ./.hardware-testing-description root@$(host):/data/.hardware-testing-description
+	scp $(ssh_helper) ./.hardware-testing-description root@$(host):/data/
 
 .PHONY: restart
 restart:
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),"opentrons-robot-server")
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: push-no-restart
 push-no-restart: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push
 push: push-no-restart restart
 
 .PHONY: restart-ot3
 restart-ot3:
-	$(call restart-server,$(host),,$(ssh_opts),"opentrons-robot-server")
+	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist Pipfile.lock
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"hardware_testing",,,$(version_file))
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"hardware_testing",,,$(version_file))
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3 push-plot-webpage-ot3 push-description-ot3
@@ -205,7 +207,7 @@ push-all: clean wheel push-no-restart push-plot-webpage
 
 .PHONY: term
 term:
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host)
+	ssh $(ssh_helper) root@$(host)
 
 .PHONY: list-ports
 list-ports:
@@ -221,7 +223,7 @@ push-all-and-term: push-all term
 .PHONY: pull-data-ot3
 pull-data-ot3:
 	mkdir -p "./.pulled-data"
-	scp -r "root@$(host):/data/testing_data/$(test)" "./.pulled-data"
+	scp $(ssh_helper) -r "root@$(host):/data/testing_data/$(test)" "./.pulled-data"
 
 define delete-test-data-cmd
 ssh -i $(2) $(3) root@$(1) \
@@ -230,14 +232,14 @@ endef
 
 .PHONY: delete-data-ot3
 delete-data-ot3:
-	$(call delete-test-data-cmd,$(host),$(br_ssh_key),$(ssh_opts),$(test))
+	$(call delete-test-data-cmd,$(host),$(ssh_key),$(ssh_opts),$(test))
 
 define push-and-update-fw
-scp $(2) root@$(1):/tmp
-ssh root@$(1) \
-"function cleanup () { (rm -rf /tmp/$(2) || true) && mount -o remount,ro / ; } ;\
+scp -i $(2) $(3) $(4) root@$(1):/tmp/
+ssh -i $(2) $(3) root@$(1) \
+"function cleanup () { (rm -rf /tmp/$(4) || true) && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
-(unzip -o /tmp/$(2) -d /usr/lib/firmware || cleanup) &&\
+(unzip -o /tmp/$(4) -d /usr/lib/firmware || cleanup) &&\
 python3 -m json.tool /usr/lib/firmware/opentrons-firmware.json &&\
 cleanup"
 endef
@@ -248,7 +250,7 @@ sync-sw-ot3: push-ot3
 
 .PHONY: sync-fw-ot3
 sync-fw-ot3:
-	$(call push-and-update-fw,$(host),$(zip))
+	$(call push-and-update-fw,$(host),$(ssh_key),$(ssh_opts),$(zip))
 
 .PHONY: sync-ot3
 sync-ot3: sync-sw-ot3 sync-fw-ot3
@@ -258,10 +260,10 @@ push-ot3-gravimetric:
 	$(MAKE) apply-patches-gravimetric
 	-$(MAKE) sync-sw-ot3
 	$(MAKE) remove-patches-gravimetric
-	scp -r -O hardware_testing/labware/opentrons_flex_96_tiprack_50ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	scp -r -O hardware_testing/labware/opentrons_flex_96_tiprack_200ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	scp -r -O hardware_testing/labware/opentrons_flex_96_tiprack_1000ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	scp -r -O hardware_testing/labware/radwag_pipette_calibration_vial/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
+	scp $(ssh_helper) -r -O hardware_testing/labware/opentrons_flex_96_tiprack_50ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
+	scp $(ssh_helper) -r -O hardware_testing/labware/opentrons_flex_96_tiprack_200ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
+	scp $(ssh_helper) -r -O hardware_testing/labware/opentrons_flex_96_tiprack_1000ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
+	scp $(ssh_helper) -r -O hardware_testing/labware/radwag_pipette_calibration_vial/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
 
 .PHONY: apply-patches-gravimetric
 apply-patches-gravimetric:
@@ -283,7 +285,7 @@ update-patches-gravimetric:
 
 .PHONY: push-photometric-ot2
 push-photometric-ot2:
-	scp -r -O photometric-ot2/photometric_ot2 root@$(host):/data/user_storage
+	scp $(ssh_helper) -r -O photometric-ot2/photometric_ot2 root@$(host):/data/user_storage
 
 .PHONY: get-latest-tag
 get-latest-tag:

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -36,10 +36,12 @@ test_opts ?=
 pypi_username ?=
 pypi_password ?=
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
+# Helper to safely bundle ssh options
+ssh_helper = $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts)
 
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
@@ -121,19 +123,19 @@ dev:
 
 .PHONY: push-no-restart
 push-no-restart: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push
 push: push-no-restart
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),"jupyter-notebook opentrons-robot-server")
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"jupyter-notebook opentrons-robot-server")
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist Pipfile.lock
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"opentrons_hardware",,,$(version_file))
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,"opentrons_hardware",,,$(version_file))
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),,$(ssh_opts),"opentrons-robot-server")
+	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 
 # Launch the emulator application.

--- a/notify-server/Makefile
+++ b/notify-server/Makefile
@@ -41,11 +41,11 @@ tests ?= tests
 cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 test_opts ?=
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
 # Pubkey location for buildroot robot to install with install-key
-br_ssh_pubkey ?= $(br_ssh_key).pub
-# Other SSH args for buildroot robots
+br_ssh_pubkey ?= $(ssh_key).pub
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
 
 # Source discovery
@@ -128,19 +128,19 @@ local-shell:
 
 .PHONY: push
 push: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
-	$(call push-systemd-unit,$(host),$(br_ssh_key),$(ssh_opts),./opentrons-notify-server.service)
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-notify-server)
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-systemd-unit,$(host),$(ssh_key),$(ssh_opts),./opentrons-notify-server.service)
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-notify-server)
 
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","notify_server",,,$(version_file))
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","notify_server",,,$(version_file))
 
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),,$(ssh_opts),"opentrons-notify-server")
+	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),"opentrons-notify-server")
 
 
 .PHONY: install-key
@@ -152,4 +152,4 @@ install-key:
 # User must currently specify host, e.g.: `make term host=169.254.202.176`
 .PHONY: term
 term:
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host)
+	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host)

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -36,11 +36,11 @@ tests ?= tests
 cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 test_opts ?=
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Pubkey location for buildroot robot to install with install-key
-br_ssh_pubkey ?= $(br_ssh_key).pub
-# Other SSH args for buildroot robots
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Pubkey location for robot to install with install-key
+ssh_pubkey ?= $(ssh_key).pub
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
 
 # Source discovery
@@ -150,19 +150,19 @@ local-shell:
 
 .PHONY: push
 push: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
-	$(call push-systemd-unit,$(host),$(br_ssh_key),$(ssh_opts),./opentrons-robot-server.service)
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-robot-server)
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-systemd-unit,$(host),$(ssh_key),$(ssh_opts),./opentrons-robot-server.service)
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-robot-server)
 
 .PHONY: push-ot3
 push-ot3: sdist
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","robot_server",,,$(version_file))
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","robot_server",,,$(version_file))
 
 .PHONY: install-key
 install-key:
 	curl -X POST $(host):31950/server/ssh_keys\
 		-H "Content-Type: application/json"\
-		-d "{\"key\":\"$(shell cat $(br_ssh_pubkey))\"}"
+		-d "{\"key\":\"$(shell cat $(ssh_pubkey))\"}"
 
 .PHONY: restart
 restart:
@@ -194,7 +194,7 @@ change-left:
 # User must currently specify host, e.g.: `make term host=169.254.202.176`
 .PHONY: term
 term:
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host)
+	ssh -i $(ssh_key) $(ssh_opts) root@$(host)
 
 
 .PHONY: docs

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -1,10 +1,12 @@
 # utilities for pushing things to robots in a reusable fashion
 
 find_robot=$(shell yarn run -s discovery find -i 169.254)
-default_ssh_key := ~/.ssh/robot_key
+default_ssh_key :=
+#default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-version_dict=$(shell ssh $(call id-file-arg,$(2)) $(3) root@$(1) cat /etc/VERSION.json)
-is-ot3=$(findstring OT-3, $(version_dict))
+#version_dict=$(shell ssh $(call id-file-arg,$(2)) $(3) root@$(1) cat /etc/VERSION.json)
+#is-ot3=$(findstring OT-3, $(version_dict))
+is-ot3=$(findstring OT-3, "OT-3")
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -2,11 +2,9 @@
 
 find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key :=
-#default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
-#version_dict=$(shell ssh $(call id-file-arg,$(2)) $(3) root@$(1) cat /etc/VERSION.json)
-#is-ot3=$(findstring OT-3, $(version_dict))
-is-ot3=$(findstring OT-3, "OT-3")
+version_dict=$(shell ssh $(call id-file-arg,$(2)) $(3) root@$(1) cat /etc/VERSION.json)
+is-ot3=$(findstring OT-3, $(version_dict))
 # make version less than 4.4 do not use intcmp
 allowed-ssh-versions="1 2 3 4 5 6 7 8"
 # in order to use comma in a string we have to set it to a var

--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -35,11 +35,11 @@ tests ?= tests
 cov_opts ?= --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 test_opts ?=
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
 # Pubkey location for buildroot robot to install with install-key
-br_ssh_pubkey ?= $(br_ssh_key).pub
-# Other SSH args for buildroot robots
+br_ssh_pubkey ?= $(ssh_key).pub
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
 
 # Source discovery
@@ -111,9 +111,9 @@ local-shell:
 
 .PHONY: push
 push: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push-ot3
 push-ot3: sdist
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),"/opt/opentrons-system-server","server_utils",,,$(version_file))
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","server_utils")
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),"/opt/opentrons-system-server","server_utils",,,$(version_file))
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","server_utils")

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -3,9 +3,9 @@
 include ../../scripts/python.mk
 include ../../scripts/push.mk
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
 ssh_opts ?= $(default_ssh_opts)
 
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
@@ -103,19 +103,19 @@ format:
 
 .PHONY: push-no-restart
 push-no-restart: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push
 push: push-no-restart
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-robot-server)
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-robot-server)
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist
-	$(call push-python-sdist,$(host),,$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,opentrons_shared_data)
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),/opt/opentrons-robot-server,opentrons_shared_data)
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),,$(ssh_opts),opentrons-robot-server)
+	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),opentrons-robot-server)
 
 .PHONY: deploy
 deploy: wheel

--- a/system-server/Makefile
+++ b/system-server/Makefile
@@ -35,10 +35,10 @@ version_file = $(call python_get_git_version,system-server,$(project_ot3_default
 # specified test
 tests ?= tests
 test_opts ?=
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
-br_ssh_opts ?= $(default_ssh_opts)
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
+ssh_opts ?= $(default_ssh_opts)
 
 .PHONY: setup
 setup:
@@ -91,14 +91,14 @@ sdist: clean
 
 .PHONY: push
 push: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
-	$(call push-systemd-unit,$(host),$(br_ssh_key),$(ssh_opts),./opentrons-system-server.service)
-	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-system-server)
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-systemd-unit,$(host),$(ssh_key),$(ssh_opts),./opentrons-system-server.service)
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-system-server)
 
 .PHONY: push-ot3
 push-ot3: sdist
-	$(call push-python-sdist,$(host),,$(br_ssh_opts),dist/$(sdist_file),/opt/opentrons-system-server,system_server,,,$(version_file))
-	$(call restart-service,$(host),,$(br_ssh_opts),opentrons-system-server)
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),dist/$(sdist_file),/opt/opentrons-system-server,system_server,,,$(version_file))
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-system-server)
 
 .PHONY: dev
 dev: export OT_SYSTEM_SERVER_DOT_ENV_PATH ?= dev.env

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -21,10 +21,10 @@ wheel_file = $(call python_get_wheelname,update-server,$(project_rs_default),otu
 sdist_file = $(call python_get_sdistname,update-server,$(project_ot3_default),otupdate)
 # Find the branch, sha, version that will be used to update the VERSION.json file
 version_file = $(call python_get_git_version,update-server,$(project_ot3_default),update-server)
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
-br_ssh_opts ?= $(default_ssh_opts)
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
+ssh_opts ?= $(default_ssh_opts)
 
 
 .PHONY: setup
@@ -93,12 +93,12 @@ restart:
 
 .PHONY: push
 push: wheel
-	$(call push-python-package,$(host),$(br_ssh_key),$(br_ssh_opts),dist/$(wheel_file))
-	$(call push-systemd-unit,$(host),$(br_ssh_key),$(br_ssh_opts),./opentrons-update-server.service)
-	$(call restart-service,$(host),$(br_ssh_key),$(br_ssh_opts),opentrons-update-server)
+	$(call push-python-package,$(host),$(ssh_key),$(ssh_opts),dist/$(wheel_file))
+	$(call push-systemd-unit,$(host),$(ssh_key),$(ssh_opts),./opentrons-update-server.service)
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-update-server)
 
 
 .PHONY: push-ot3
 push-ot3: sdist
-	$(call push-python-sdist,$(host),,$(br_ssh_opts),dist/$(sdist_file),/opt/opentrons-update-server,"otupdate",,,$(version_file))
-	$(call restart-service,$(host),,$(br_ssh_opts),opentrons-update-server)
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),dist/$(sdist_file),/opt/opentrons-update-server,"otupdate",,,$(version_file))
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-update-server)

--- a/usb-bridge/Makefile
+++ b/usb-bridge/Makefile
@@ -26,10 +26,10 @@ sdist_file = $(call python_get_sdistname,usb-bridge,$(project_ot3_default),ot3us
 # Find the branch, sha, version that will be used to update the VERSION.json file
 version_file = $(call python_get_git_version,usb-bridge,$(project_ot3_default),ot3usb)
 
-# Host key location for buildroot robot
-br_ssh_key ?= $(default_ssh_key)
-# Other SSH args for buildroot robots
-br_ssh_opts ?= $(default_ssh_opts)
+# Host key location for robot
+ssh_key ?= $(default_ssh_key)
+# Other SSH args for robot
+ssh_opts ?= $(default_ssh_opts)
 
 .PHONY: setup
 setup:
@@ -74,5 +74,5 @@ sdist: clean
 
 .PHONY: push-ot3
 push-ot3: sdist
-	$(call push-python-sdist,$(host),,$(br_ssh_opts),dist/$(sdist_file),/opt/ot3usb,ot3usb,,,$(version_file))
-	$(call restart-service,$(host),,$(br_ssh_opts),opentrons-usb-bridge)
+	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),dist/$(sdist_file),/opt/ot3usb,ot3usb,,,$(version_file))
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-usb-bridge)


### PR DESCRIPTION
# Overview

We are enabling SSH RSA keys on the Flex, which means you will no longer be able to SSH to a Flex release build without a valid SSH private key added using the new `/server/ssh_keys/from_local` endpoint recently added [here](https://github.com/Opentrons/opentrons/pull/13509). Because of this, we want to make sure developers are not affected and are ready once the robots require SSH keys. In order to support this we need to change our `push-ot3` Makefile script so it now takes in an identity file `ssh_key` as the private key.

# Instructions for adding your SSH key to the Flex

1. Make sure the Flex is powered on
2. Make sure you are running a version of the software that supports the `/server/ssh_keys/from_local` endpoint
3. Copy your valid SSH RSA public key to a USB thumb drive
4. Plug the USB thumb drive into the Flex
5. Using curl or equivalent send a POST request to the `/server/ssh_keys/from_local` endpoint, see below

`curl --location --request POST 'http://10.13.11.96:31950/server/ssh_keys/from_local' --header 'opentrons-version: 3'`

7. If successful, the response status will be a `201` and the message will tell you how many keys were added
`{
    "message": "Added 1 new keys",
    "key_md5": [
        "0ca9f47168c05f6675fe1806f9063084"
    ]
}`
9. If unsuccessful, the response status will be `404`
`{
    "error": "no-key",
    "message": "No valid keys found"
}`

# Test Plan

- [x] Use push-ot3 without `ssh_key` on a robot with ssh keys enabled and make sure you get permission denied
- [x] Use push-ot3 `ssh_key` on a robot with SSH keys enabled and make sure you get permission denied if the private key is invalid
- [x] Use push-ot3 with `ssh_key` on a robot with SSH keys enabled and make sure you can SSH if you have a valid private key.

# Changelog

- Added `ssh_key` option to make-push so It takes in an identity file in order to perform SSH/SCP operations
- Remove the default `default_ssh_key` from `scripts/push.mk` so we can still ssh into a Flex without providing an identity file


# Review requests

- It should be straightforward but would like some thoughts on removing the default `default_ssh_key`, Is anything wrong with this?


# Risk assessment

Medium, this will affect developers directly or anyone needing to use make push-ot3 to SSH/SCP to the robot and if the robot version and local monorepo branch are not in sync it will cause problems.
