### PR TITLE
fix(api): failed ot3api gripper capacitive sweep test

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -188,6 +188,7 @@ class OT3Simulator:
             nodes.add(NodeId.gripper)
         self._present_nodes = nodes
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
+        self._sim_jaw_state = GripperJawState.HOMED_READY
 
     @property
     def initialized(self) -> bool:
@@ -369,12 +370,14 @@ class OT3Simulator:
     ) -> None:
         """Move gripper inward."""
         _ = create_gripper_jaw_grip_group(duty_cycle, stop_condition, stay_engaged)
+        self._sim_jaw_state = GripperJawState.GRIPPING
 
     @ensure_yield
     async def gripper_home_jaw(self, duty_cycle: float) -> None:
         """Move gripper outward."""
         _ = create_gripper_jaw_home_group(duty_cycle)
         self._motor_status[NodeId.gripper_g] = MotorStatus(True, True)
+        self._sim_jaw_state = GripperJawState.HOMED_READY
 
     @ensure_yield
     async def gripper_hold_jaw(
@@ -383,6 +386,7 @@ class OT3Simulator:
     ) -> None:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
+        self._sim_jaw_state = GripperJawState.HOLDING
 
     async def get_tip_present(self, mount: OT3Mount, tip_state: TipStateType) -> None:
         """Raise an error if the given state doesn't match the physical state."""
@@ -394,7 +398,7 @@ class OT3Simulator:
 
     async def get_jaw_state(self) -> GripperJawState:
         """Get the state of the gripper jaw."""
-        return GripperJawState.HOMED_READY
+        return self._sim_jaw_state
 
     async def tip_action(
         self,

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -135,7 +135,7 @@ class LabwareMovementHandler:
 
             for waypoint_data in movement_waypoints:
                 if waypoint_data.jaw_open:
-                    await ot3api.home_gripper_jaw()
+                    await ot3api.ungrip()
                 else:
                     await ot3api.grip(force_newtons=labware_grip_force)
                 await ot3api.move_to(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -129,19 +129,6 @@ def mock_move_to(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_get_jaw_state(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
-    with patch.object(
-        ot3_hardware.managed_obj._backend,
-        "get_jaw_state",
-        AsyncMock(
-            spec=ot3_hardware.managed_obj._backend.get_jaw_state,
-            wraps=ot3_hardware.managed_obj._backend.get_jaw_state,
-        ),
-    ) as mock_get_jaw_state:
-        yield mock_get_jaw_state
-
-
-@pytest.fixture
 def mock_home(ot3_hardware: ThreadManager[OT3API]) -> Iterator[AsyncMock]:
     with patch.object(
         ot3_hardware.managed_obj,
@@ -852,14 +839,12 @@ async def test_gripper_capacitive_sweep(
     distance: float,
     ot3_hardware: ThreadManager[OT3API],
     mock_move_to: AsyncMock,
-    mock_get_jaw_state: AsyncMock,
     mock_backend_capacitive_pass: AsyncMock,
     gripper_present: None,
 ) -> None:
     await ot3_hardware.home()
     await ot3_hardware.grip(5)
     ot3_hardware._gripper_handler.get_gripper().current_jaw_displacement = 5
-    mock_get_jaw_state.return_value = GripperJawState.GRIPPING
     ot3_hardware.add_gripper_probe(probe)
     data = await ot3_hardware.capacitive_sweep(OT3Mount.GRIPPER, axis, begin, end, 3)
     assert data == [1, 2, 3, 4, 5, 6, 8]
@@ -1783,7 +1768,6 @@ async def test_estop_event_deactivate_module(
 async def test_stop_only_home_necessary_axes(
     ot3_hardware: ThreadManager[OT3API],
     mock_home: AsyncMock,
-    # mock_get_jaw_state: AsyncMock,
     mock_reset: AsyncMock,
     jaw_state: GripperJawState,
 ):

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -167,6 +167,9 @@ async def test_move_labware_with_gripper(
 
     decoy.when(state_store.config.use_virtual_gripper).then_return(False)
     decoy.when(ot3_hardware_api.has_gripper()).then_return(True)
+    decoy.when(ot3_hardware_api._gripper_handler.is_ready_for_jaw_home()).then_return(
+        True
+    )
 
     decoy.when(
         await ot3_hardware_api.gantry_position(mount=OT3Mount.GRIPPER)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
I forgot to update the gripper jaw state in the ot3simulator after performing a jaw action. This should fix those broken tests. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
