### PR TITLE
fix(hardware): prioritize raising estop errors from failed movements

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -559,10 +559,10 @@ class MoveScheduler:
         Multiple kinds of error messages may arise, but the only one that is important
         to raise is the message about the Estop.
         """
-        estop_errors = list(
-            filter(lambda err: isinstance(err, EStopActivatedError), self._errors)
-        )
-        return estop_errors if len(estop_errors) > 0 else self._errors
+        for err in self._errors:
+            if isinstance(err, EStopActivatedError):
+                return [err]
+        return self._errors
 
     async def _send_stop_if_necessary(
         self, can_messenger: CanMessenger, group_id: int


### PR DESCRIPTION


# Overview

Closes RQA-1528

When the estop is pressed during a movement, it can cause some of the axes to raise errors _other_ than estop failures - most notably, `collision_detected` can be reported by some nodes. The presence of these other errors can obfuscate the actual cause of the error (which is that the estop was pressed), as the app may show an error other than `estop_detected`.

This PR changes the MoveGroupRunner to prioritize Estop-related errors. Pressing the estop during a movement really represents a single logical "error event", but each node independently reports it. Therefore, we will just return a single one of those error messages so that the logged error is not the generic message "Motion failed with multiple errors" but rather a specific Estop-related error message.

# Test Plan

Ran a Flex protocol a few times and pressed the Estop during a movement each time. After each failure, looking at the error details for the run would show an Estop error message.

# Changelog

- MoveGroupRunner will return a single estop error if one exists, instead of returning the entire list of errors.
- Added test that the estop errors are filtered properly

# Review requests


# Risk assessment


