### PR TITLE
chore(shared-data): liquid class bound updates

### DIFF
--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -85,8 +85,8 @@ def test_configure_virtual_pipette_for_volume(
     assert result2 == LoadedStaticPipetteData(
         model="p50_single_v3.0",
         display_name="Flex 1-Channel 50 μL",
-        min_volume=0.5,
-        max_volume=5.0,
+        min_volume=1,
+        max_volume=30,
         channels=1,
         nozzle_offset_z=-259.15,
         home_position=230.15,

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_0.json
@@ -92,7 +92,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_3.json
@@ -92,7 +92,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_4.json
@@ -92,7 +92,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 50,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/eight_channel/p50/lowVolumeDefault/3_5.json
@@ -92,7 +92,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_0.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_0.json
@@ -92,7 +92,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_3.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_3.json
@@ -92,7 +92,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_4.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_4.json
@@ -94,7 +94,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_5.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_5.json
@@ -94,7 +94,7 @@
     "default": 10.5,
     "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5
   },
-  "maxVolume": 5,
-  "minVolume": 0.5,
+  "maxVolume": 30,
+  "minVolume": 1,
   "defaultTipracks": ["opentrons/opentrons_flex_96_tiprack_50ul/1"]
 }

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -369,9 +369,6 @@ def liquid_class_for_volume_between_default_and_defaultlowvolume(
     This function has such a weird name because it is hardcoded to only use the liquid
     classes default and defaultLowVolume. It should no longer be used when those liquid
     classes change.
-
-    This function applies hysteresis to avoid frequently switching back and forth between
-    liquid classes unnecessarily.
     """
     # For now, until we add more liquid classes, we're going to hardcode the default
     # and lowVolumeDefault liquid classes as the ones to switch between.
@@ -379,20 +376,9 @@ def liquid_class_for_volume_between_default_and_defaultlowvolume(
 
     if not has_lvd:
         return pip_types.LiquidClasses.default
-    if current_liquid_class_name == pip_types.LiquidClasses.lowVolumeDefault:
-        if volume > (
-            available_liquid_classes[
-                pip_types.LiquidClasses.lowVolumeDefault
-            ].max_volume
-            * 0.75
-        ):
-            return pip_types.LiquidClasses.default
-    else:  # LiquidClasses.default
-        if volume < (
-            available_liquid_classes[pip_types.LiquidClasses.default].max_volume * 0.5
-        ):
-            return pip_types.LiquidClasses.lowVolumeDefault
-    return current_liquid_class_name
+    if volume >= available_liquid_classes[pip_types.LiquidClasses.default].min_volume:
+        return pip_types.LiquidClasses.default
+    return pip_types.LiquidClasses.lowVolumeDefault
 
 
 def default_tip_for_liquid_class(

--- a/shared-data/python/tests/pipette/test_pipette_definition.py
+++ b/shared-data/python/tests/pipette/test_pipette_definition.py
@@ -80,7 +80,7 @@ def get_liquid_definition_for(
                 },
                 "defaultTipOverlapDictionary": {},
                 "maxVolume": 100,
-                "minVolume": 30,
+                "minVolume": 5,
                 "defaultTipracks": [],
             }
         )
@@ -139,6 +139,24 @@ def test_version_enum(major: int, minor: int) -> None:
             1,
             LiquidClasses.lowVolumeDefault,
             LiquidClasses.lowVolumeDefault,
+        ],
+        [
+            [LiquidClasses.lowVolumeDefault, LiquidClasses.default],
+            1,
+            LiquidClasses.default,
+            LiquidClasses.lowVolumeDefault,
+        ],
+        [
+            [LiquidClasses.lowVolumeDefault, LiquidClasses.default],
+            5,
+            LiquidClasses.default,
+            LiquidClasses.default,
+        ],
+        [
+            [LiquidClasses.lowVolumeDefault, LiquidClasses.default],
+            5,
+            LiquidClasses.lowVolumeDefault,
+            LiquidClasses.default,
         ],
         [
             [LiquidClasses.lowVolumeDefault, LiquidClasses.default],


### PR DESCRIPTION
Change the bounds for the liquid classes to match what hardware wants and update the selection logic to remove hysteresis and just change based on the low volume of default.