### PR TITLE
refactor(api): add idle gripper method to ot3api

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -120,7 +120,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
     @property
     def default_grip_force(self) -> float:
         return self.grip_force_profile.default_grip_force
-    
+
     @property
     def default_idle_force(self) -> float:
         return self.grip_force_profile.default_idle_force

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -120,6 +120,10 @@ class Gripper(AbstractInstrument[GripperDefinition]):
     @property
     def default_grip_force(self) -> float:
         return self.grip_force_profile.default_grip_force
+    
+    @property
+    def default_idle_force(self) -> float:
+        return self.grip_force_profile.default_idle_force
 
     @property
     def default_home_force(self) -> float:

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -137,6 +137,15 @@ class GripperHandler:
         gripper = self.get_gripper()
         if gripper.state == GripperJawState.UNHOMED:
             raise GripError("Gripper jaw must be homed before moving")
+        
+    def is_ready_for_idle(self) -> bool:
+        """Raise an exception if it is not currently valid to idle the jaw."""
+        gripper = self.get_gripper()
+        if gripper.state == GripperJawState.UNHOMED:
+            self._log.warning(
+                "Gripper jaw is not homed and cannot move to idle position."
+            )
+        return gripper.state == GripperJawState.GRIPPING
 
     def is_ready_for_jaw_home(self) -> bool:
         """Raise an exception if it is not currently valid to home the jaw."""

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -137,7 +137,7 @@ class GripperHandler:
         gripper = self.get_gripper()
         if gripper.state == GripperJawState.UNHOMED:
             raise GripError("Gripper jaw must be homed before moving")
-        
+
     def is_ready_for_idle(self) -> bool:
         """Raise an exception if it is not currently valid to idle the jaw."""
         gripper = self.get_gripper()

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -91,7 +91,6 @@ from .types import (
     OT3AxisKind,
     OT3Mount,
     OT3AxisMap,
-    GripperJawState,
     InstrumentProbeType,
     GripperProbe,
     UpdateStatus,
@@ -1159,9 +1158,10 @@ class OT3API(
     async def idle_gripper(self) -> None:
         """Move gripper to its idle, gripped position."""
         try:
+            gripper = self._gripper_handler.get_gripper()
             if self._gripper_handler.is_ready_for_idle():
                 await self.grip(
-                    force_newtons=self._gripper_handler.gripper.default_idle_force,
+                    force_newtons=gripper.default_idle_force,
                     stay_engaged=False,
                 )
         except GripperNotAttachedError:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1162,7 +1162,7 @@ class OT3API(
             if self._gripper_handler.is_ready_for_idle():
                 await self.grip(
                     force_newtons=self._gripper_handler.gripper.default_idle_force,
-                    stay_engaged=False
+                    stay_engaged=False,
                 )
         except GripperNotAttachedError:
             pass

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -32,7 +32,6 @@ from opentrons_shared_data.pipette.dev_types import (
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
 )
-from opentrons_shared_data.gripper.constants import IDLE_STATE_GRIP_FORCE
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
@@ -1176,7 +1175,7 @@ class OT3API(
                 )
             else:
                 # allows for safer gantry movement at minimum force
-                await self.grip(force_newtons=IDLE_STATE_GRIP_FORCE)
+                await self.grip(force_newtons=self._gripper_handler.gripper.default_grip_force)
 
     def _build_moves(
         self,

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -141,6 +141,9 @@ class LabwareMovementHandler:
                     mount=gripper_mount, abs_position=waypoint_data.position
                 )
 
+            # this makes sure gripper jaw is closed between two labware movement calls
+            await ot3api.idle_gripper()
+
     async def ensure_movement_not_obstructed_by_module(
         self, labware_id: str, new_location: LabwareLocation
     ) -> None:

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING
-from opentrons_shared_data.gripper.constants import IDLE_STATE_GRIP_FORCE
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import OT3Mount, Axis
@@ -141,10 +140,6 @@ class LabwareMovementHandler:
                 await ot3api.move_to(
                     mount=gripper_mount, abs_position=waypoint_data.position
                 )
-
-            # Keep the gripper in idly gripped position to avoid colliding with
-            # things like the thermocycler latches
-            await ot3api.grip(force_newtons=IDLE_STATE_GRIP_FORCE, stay_engaged=False)
 
     async def ensure_movement_not_obstructed_by_module(
         self, labware_id: str, new_location: LabwareLocation

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -141,7 +141,7 @@ class LabwareMovementHandler:
                     mount=gripper_mount, abs_position=waypoint_data.position
                 )
 
-            # this makes sure gripper jaw is closed between two labware movement calls
+            # this makes sure gripper jaw is closed between two move labware calls
             await ot3api.idle_gripper()
 
     async def ensure_movement_not_obstructed_by_module(

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -259,7 +259,7 @@ async def test_move_labware_with_gripper(
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[5]
         ),
-        await ot3_hardware_api.grip(force_newtons=10),
+        await ot3_hardware_api.idle_gripper(),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -8,7 +8,6 @@ from decoy import Decoy, matchers
 from typing import TYPE_CHECKING, Union
 
 from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
-from opentrons_shared_data.gripper.constants import IDLE_STATE_GRIP_FORCE
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.types import DeckSlotName, Point
 
@@ -260,9 +259,7 @@ async def test_move_labware_with_gripper(
         await ot3_hardware_api.move_to(
             mount=gripper, abs_position=expected_waypoints[5]
         ),
-        await ot3_hardware_api.grip(
-            force_newtons=IDLE_STATE_GRIP_FORCE, stay_engaged=False
-        ),
+        await ot3_hardware_api.grip(force_newtons=10),
     )
 
 

--- a/shared-data/gripper/definitions/1/gripperV1.1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.1.json
@@ -10,6 +10,7 @@
       [2, 0.0135956]
     ],
     "defaultGripForce": 15.0,
+    "defaultIdleForce": 10.0,
     "defaultHomeForce": 12.0,
     "min": 2.0,
     "max": 30.0

--- a/shared-data/gripper/definitions/1/gripperV1.2.json
+++ b/shared-data/gripper/definitions/1/gripperV1.2.json
@@ -10,6 +10,7 @@
       [2, 0.0135956]
     ],
     "defaultGripForce": 15.0,
+    "defaultIdleForce": 10.0,
     "defaultHomeForce": 12.0,
     "min": 2.0,
     "max": 30.0

--- a/shared-data/gripper/definitions/1/gripperV1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.json
@@ -9,6 +9,7 @@
       [1, 2.09]
     ],
     "defaultGripForce": 15.0,
+    "defaultIdleForce": 10.0,
     "defaultHomeForce": 12.0,
     "min": 5.0,
     "max": 20.0

--- a/shared-data/gripper/schemas/1.json
+++ b/shared-data/gripper/schemas/1.json
@@ -6,7 +6,9 @@
     "schemaVersion": {
       "title": "Schemaversion",
       "description": "Which schema version a gripper is using",
-      "enum": [1],
+      "enum": [
+        1
+      ],
       "type": "integer"
     },
     "displayName": {
@@ -35,7 +37,11 @@
     "GripperModel": {
       "title": "GripperModel",
       "description": "Gripper models.",
-      "enum": ["gripperV1"],
+      "enum": [
+        "gripperV1",
+        "gripperV1.1",
+        "gripperV1.2"
+      ],
       "type": "string"
     },
     "Geometry": {
@@ -147,6 +153,11 @@
           "minimum": 0.0,
           "type": "number"
         },
+        "defaultIdleForce": {
+          "title": "Defaultidleforce",
+          "minimum": 0.0,
+          "type": "number"
+        },
         "defaultHomeForce": {
           "title": "Defaulthomeforce",
           "minimum": 0.0,
@@ -166,6 +177,7 @@
       "required": [
         "polynomial",
         "defaultGripForce",
+        "defaultIdleForce",
         "defaultHomeForce",
         "min",
         "max"

--- a/shared-data/gripper/schemas/1.json
+++ b/shared-data/gripper/schemas/1.json
@@ -6,9 +6,7 @@
     "schemaVersion": {
       "title": "Schemaversion",
       "description": "Which schema version a gripper is using",
-      "enum": [
-        1
-      ],
+      "enum": [1],
       "type": "integer"
     },
     "displayName": {
@@ -37,11 +35,7 @@
     "GripperModel": {
       "title": "GripperModel",
       "description": "Gripper models.",
-      "enum": [
-        "gripperV1",
-        "gripperV1.1",
-        "gripperV1.2"
-      ],
+      "enum": ["gripperV1", "gripperV1.1", "gripperV1.2"],
       "type": "string"
     },
     "Geometry": {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -499,6 +499,7 @@ export interface GripperDefinition {
     polynomial: [[number, number], [number, number]]
     defaultGripForce: number
     defaultHomeForce: number
+    defaultIdleForce: number
     min: number
     max: number
   }

--- a/shared-data/python/opentrons_shared_data/gripper/constants.py
+++ b/shared-data/python/opentrons_shared_data/gripper/constants.py
@@ -1,6 +1,5 @@
 """Gripper constants and default values."""
 
 LABWARE_GRIP_FORCE = 15.0  # Newtons
-IDLE_STATE_GRIP_FORCE = 10.0  # Newtons
 GRIPPER_DECK_DROP_OFFSET = [-0.5, -0.5, -1.5]
 GRIPPER_MODULE_DROP_OFFSET = [0.0, 0.0, 1.5]

--- a/shared-data/python/opentrons_shared_data/gripper/gripper_definition.py
+++ b/shared-data/python/opentrons_shared_data/gripper/gripper_definition.py
@@ -83,6 +83,7 @@ class GripForceProfile(GripperBaseModel):
         min_items=1,
     )
     default_grip_force: _StrictNonNegativeFloat
+    default_idle_force: _StrictNonNegativeFloat
     default_home_force: _StrictNonNegativeFloat
     min: _StrictNonNegativeFloat
     max: _StrictNonNegativeFloat


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR does:
1. Add gripper default idle force to shared-data gripper definitions & update schema
2. Add `idle_gripper()` to ot3api which uses the default idle force to close the gripper jaw
3. Make protocol engine call `idle_gripper()` instead

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
