### PR TITLE
fix(api): disallow moving a fixed-trash labware

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -92,6 +92,13 @@ class MoveLabwareImplementation(
         )
         definition_uri = current_labware.definitionUri
 
+        if labware_validation.validate_if_labware_is_fixed_trash(
+            current_labware_definition
+        ):
+            raise LabwareMovementNotAllowedError(
+                f"Cannot move fixed trash labware '{current_labware_definition.parameters.loadName}'."
+            )
+
         available_new_location = self._state_view.geometry.ensure_location_not_occupied(
             location=params.newLocation
         )

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -92,9 +92,7 @@ class MoveLabwareImplementation(
         )
         definition_uri = current_labware.definitionUri
 
-        if labware_validation.validate_if_labware_is_fixed_trash(
-            current_labware_definition
-        ):
+        if self._state_view.labware.is_fixed_trash(params.labwareId):
             raise LabwareMovementNotAllowedError(
                 f"Cannot move fixed trash labware '{current_labware_definition.parameters.loadName}'."
             )

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -25,7 +25,7 @@ def validate_labware_can_be_stacked(
 
 
 def validate_gripper_compatible(definition: LabwareDefinition) -> bool:
-    """Validate that the    labware definition does not have a quirk disallowing movement with gripper."""
+    """Validate that the labware definition does not have a quirk disallowing movement with gripper."""
     return (
         definition.parameters.quirks is None
         or "gripperIncompatible" not in definition.parameters.quirks

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -25,16 +25,8 @@ def validate_labware_can_be_stacked(
 
 
 def validate_gripper_compatible(definition: LabwareDefinition) -> bool:
-    """Validate that the labware definition does not have a quirk disallowing movement with gripper."""
+    """Validate that the    labware definition does not have a quirk disallowing movement with gripper."""
     return (
         definition.parameters.quirks is None
         or "gripperIncompatible" not in definition.parameters.quirks
-    )
-
-
-def validate_if_labware_is_fixed_trash(definition: LabwareDefinition) -> bool:
-    """Validate that the labware definition is a fixed trash."""
-    return (
-        definition.parameters.quirks is not None
-        and "fixedTrash" in definition.parameters.quirks
     )

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -30,3 +30,11 @@ def validate_gripper_compatible(definition: LabwareDefinition) -> bool:
         definition.parameters.quirks is None
         or "gripperIncompatible" not in definition.parameters.quirks
     )
+
+
+def validate_if_labware_is_fixed_trash(definition: LabwareDefinition) -> bool:
+    """Validate that the labware definition is a fixed trash."""
+    return (
+        definition.parameters.quirks is not None
+        and "fixedTrash" in definition.parameters.quirks
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -571,9 +571,9 @@ async def test_move_labware_raises_when_moving_fixed_trash_labware(
         state_view.labware.get_definition(labware_id="my-cool-labware-id")
     ).then_return(definition)
 
-    decoy.when(
-        labware_validation.validate_if_labware_is_fixed_trash(definition)
-    ).then_return(True)
+    decoy.when(state_view.labware.is_fixed_trash("my-cool-labware-id")).then_return(
+        True
+    )
 
     with pytest.raises(
         errors.LabwareMovementNotAllowedError,

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -531,3 +531,52 @@ async def test_move_labware_with_gripper_raises_on_ot2(
     )
     with pytest.raises(errors.NotSupportedOnRobotType):
         await subject.execute(data)
+
+
+async def test_move_labware_raises_when_moving_fixed_trash_labware(
+    decoy: Decoy,
+    equipment: EquipmentHandler,
+    labware_movement: LabwareMovementHandler,
+    state_view: StateView,
+    run_control: RunControlHandler,
+) -> None:
+    """It should raise an error when trying to move a fixed trash."""
+    subject = MoveLabwareImplementation(
+        state_view=state_view,
+        equipment=equipment,
+        labware_movement=labware_movement,
+        run_control=run_control,
+    )
+
+    data = MoveLabwareParams(
+        labwareId="my-cool-labware-id",
+        newLocation=DeckSlotLocation(slotName=DeckSlotName.FIXED_TRASH),
+        strategy=LabwareMovementStrategy.USING_GRIPPER,
+    )
+
+    definition = LabwareDefinition.construct(  # type: ignore[call-arg]
+        parameters=Parameters.construct(loadName="My cool labware", quirks=["fixedTrash"]),  # type: ignore[call-arg]
+    )
+
+    decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
+        LoadedLabware(
+            id="my-cool-labware-id",
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+            offsetId=None,
+        )
+    )
+    decoy.when(
+        state_view.labware.get_definition(labware_id="my-cool-labware-id")
+    ).then_return(definition)
+
+    decoy.when(
+        labware_validation.validate_if_labware_is_fixed_trash(definition)
+    ).then_return(True)
+
+    with pytest.raises(
+        errors.LabwareMovementNotAllowedError,
+        match="Cannot move fixed trash labware 'My cool labware'.",
+    ):
+        await subject.execute(data)


### PR DESCRIPTION
# Overview

follow up work for https://github.com/Opentrons/opentrons/pull/13504.
disallow moving a labware if it has a fixed trash quirk. 

# Test Plan

try moving a fixed trash labware. make sure it raises.
try moving a non fixed-trash labware - make sure it works as expected. 

# Changelog

- validate that the movable labware is not a fixed trash. if it is, raise. 

# Risk assessment

low. should only affect fixed-trash labware in move-labware.
