### PR TITLE
refactor(hardware): SensorIdField fix

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -546,6 +546,8 @@ class GripperErrorTolerancePayload(EmptyPayload):
 
 @dataclass(eq=False)
 class PushTipPresenceNotificationPayload(EmptyPayload):
+    """A notification that the ejector flag status has changed."""
+
     ejector_flag_status: utils.UInt8Field
     sensor_id: SensorIdField
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -545,40 +545,8 @@ class GripperErrorTolerancePayload(EmptyPayload):
 
 
 @dataclass(eq=False)
-class _PushTipPresenceNotificationPayloadBase(EmptyPayload):
+class PushTipPresenceNotificationPayload(EmptyPayload):
     ejector_flag_status: utils.UInt8Field
-
-
-@dataclass(eq=False)
-class PushTipPresenceNotificationPayload(_PushTipPresenceNotificationPayloadBase):
-    """A notification that the ejector flag status has changed."""
-
-    @classmethod
-    def build(cls, data: bytes) -> "PushTipPresenceNotificationPayload":
-        """Build a response payload from incoming bytes."""
-        consumed_by_super = _PushTipPresenceNotificationPayloadBase.get_size()
-        superdict = asdict(_PushTipPresenceNotificationPayloadBase.build(data))
-        message_index = superdict.pop("message_index")
-
-        # we want to parse this by adding extra 0s that may not be necessary,
-        # which is annoying and complex, so let's wrap it in an iterator
-        def _data_for_optionals(consumed: int, buf: bytes) -> Iterator[bytes]:
-            extended = buf + b"\x00\x00"
-            yield extended[consumed:]
-            consumed += 2
-            extended = extended + b"\x00"
-            yield extended[consumed : consumed + 1]
-
-        optionals_yielder = _data_for_optionals(consumed_by_super, data)
-        inst = cls(
-            **superdict,
-            sensor_id=SensorIdField.build(
-                int.from_bytes(next(optionals_yielder), "big")
-            ),
-        )
-        inst.message_index = message_index
-        return inst
-
     sensor_id: SensorIdField
 
 


### PR DESCRIPTION
## Overview
The `build` method that was in the `PushTipPresenceNotificationPayload` causes 16 0's to get added onto the `sensor_id` field of the payload, resulting in the secondary sensor reporting its id as `65536`. Removing this method and handling the `sensor_id` the same way the `SensorPayload` does seems to fix this issue.