### PR TITLE
fix(api): Report Python protocol line numbers for errors from Protocol Engine

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -14,8 +14,8 @@ warn_untyped_fields = True
 
 # TODO(mc, 2021-09-08): fix and remove any / all of the
 # overrides below whenever able
-# ~125 errors
-[mypy-opentrons.protocols.advanced_control.*,opentrons.protocols.api_support.*,opentrons.protocols.duration.*,opentrons.protocols.execution.*,opentrons.protocols.geometry.*,opentrons.protocols.models.*,opentrons.protocols.labware.*]
+# ~115 errors
+[mypy-opentrons.protocols.advanced_control.*,opentrons.protocols.api_support.*,opentrons.protocols.duration.*,opentrons.protocols.execution.dev_types,opentrons.protocols.execution.execute_json_v4,opentrons.protocols.execution.execute_python,opentrons.protocols.geometry.*,opentrons.protocols.models.*,opentrons.protocols.labware.*]
 disallow_any_generics = False
 disallow_untyped_defs = False
 disallow_untyped_calls = False

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -347,8 +347,8 @@ class ProtocolEngine:
             # By the time E-stop error has gotten to us, it may have been wrapped in other errors,
             # so we need to unwrap them to uncover the E-stop error's inner beauty.
             #
-            # TODO(mm, 2023-09-12): Do we need to scan the exception tree like this? Instead, can we
-            # directly inspect the E-stop state through self._hardware_api.get_estop_state()?
+            # We don't use self._hardware_api.get_estop_state() because the E-stop may have been
+            # released by the time we get here.
             if isinstance(error, EnumeratedError) and self._code_in_error_tree(
                 root_error=error, code=ErrorCodes.E_STOP_ACTIVATED
             ):

--- a/api/src/opentrons/protocols/execution/errors.py
+++ b/api/src/opentrons/protocols/execution/errors.py
@@ -19,16 +19,22 @@ class ExceptionInProtocolError(GeneralError):
     ) -> None:
         self.original_exc = original_exc
         self.original_tb = original_tb
-        self.message = message
         self.line = line
         super().__init__(
             wrapping=[original_exc],
-            message="{}{}: {}".format(
-                self.original_exc.__class__.__name__,
-                " [line {}]".format(self.line) if self.line else "",
-                self.message,
+            message=_build_message(
+                exception_class_name=self.original_exc.__class__.__name__,
+                line_number=self.line,
+                message=message,
             ),
         )
 
     def __str__(self) -> str:
         return self.message
+
+
+def _build_message(
+    exception_class_name: str, line_number: Optional[int], message: str
+) -> str:
+    line_number_part = f" [line {line_number}]" if line_number is not None else ""
+    return f"{exception_class_name}{line_number_part}: {message}"

--- a/api/src/opentrons/protocols/execution/errors.py
+++ b/api/src/opentrons/protocols/execution/errors.py
@@ -1,3 +1,6 @@
+from types import TracebackType
+from typing import Optional
+
 from opentrons_shared_data.errors.exceptions import GeneralError
 
 
@@ -7,7 +10,13 @@ class ExceptionInProtocolError(GeneralError):
     we can properly figure out formatting
     """
 
-    def __init__(self, original_exc, original_tb, message, line):
+    def __init__(
+        self,
+        original_exc: Exception,
+        original_tb: Optional[TracebackType],
+        message: str,
+        line: Optional[int],
+    ) -> None:
         self.original_exc = original_exc
         self.original_tb = original_tb
         self.message = message
@@ -21,5 +30,5 @@ class ExceptionInProtocolError(GeneralError):
             ),
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message

--- a/api/src/opentrons/protocols/execution/execute.py
+++ b/api/src/opentrons/protocols/execution/execute.py
@@ -16,7 +16,7 @@ from opentrons.protocols.api_support.types import APIVersion
 MODULE_LOG = logging.getLogger(__name__)
 
 
-def run_protocol(protocol: Protocol, context: ProtocolContext):
+def run_protocol(protocol: Protocol, context: ProtocolContext) -> None:
     """Run a protocol.
 
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -63,7 +63,6 @@ def run_python(proto: PythonProtocol, context: ProtocolContext):
         SmoothieAlarm,
         asyncio.CancelledError,
         ExecutionCancelledError,
-        ProtocolCommandFailedError,
     ):
         # this is a protocol cancel and shouldn't have special logging
         raise

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -10,7 +10,6 @@ from opentrons.protocol_api import ProtocolContext
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
 from opentrons.protocols.types import PythonProtocol, MalformedPythonProtocolError
 from opentrons.hardware_control import ExecutionCancelledError
-from opentrons.protocol_engine.errors import ProtocolCommandFailedError
 
 MODULE_LOG = logging.getLogger(__name__)
 

--- a/api/src/opentrons/protocols/execution/json_dispatchers.py
+++ b/api/src/opentrons/protocols/execution/json_dispatchers.py
@@ -66,7 +66,7 @@ temperature_module_command_map: "JsonV4TemperatureModuleDispatch" = {
 }
 
 
-def tc_do_nothing(module: ThermocyclerContext, params) -> None:
+def tc_do_nothing(module: ThermocyclerContext, params: object) -> None:
     pass
 
 

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -229,9 +229,10 @@ def test_strict_metatada_requirements_validation(tmp_path: Path) -> None:
         # TODO: PAPIv<2.15?
     ],
 )
-def test_error_context(
+def test_python_error_line_numbers(
     tmp_path: Path, python_protocol_source: str, expected_detail: str
 ) -> None:
+    """Test that error messages from Python protocols have line numbers."""
     protocol_source_file = tmp_path / "protocol.py"
     protocol_source_file.write_text(python_protocol_source, encoding="utf-8")
 


### PR DESCRIPTION
# Overview

Fixes RSS-317.

# Test Plan

* [x] E-stop a physical run on a Flex and make sure the desktop app and ODD respond correctly.
* [x] Import the protocol from RSS-317 and make sure it shows a line number now.

# Changelog

* **Bug fix:** When an exception bubbles out of the Python protocol `exec()`, do *not* handle it specially just because that exception passed through Protocol Engine. Handle it like any other exception. This lets us attach the protocol line number to it.

  We were handling it specially before because, I guess, we wanted it to collude with [this `isinstance` check up in `ProtocolEngine.finish()`](https://github.com/Opentrons/opentrons/blob/3ffe41c25ae3deb822942019543480aba206ac02/api/src/opentrons/protocol_engine/protocol_engine.py#L337). Apparently this was unnecessary, because the `ExceptionInProtocolError` that we would wrap it with passes the `isinstance` check just the same.

* Add some analysis integration tests that make sure the line number shows up.

* Resolve some type-checking exclusions in `opentrons.protocols.execute`.

# Review requests

* Do the comments make sense?
* Do we have a reasonable way of inducing E-stop errors in CI tests?

# Risk assessment

Probably medium-high. The special E-stop handling is hard to reason about and unit-test because it works by several far-away places colluding with each other.
