### PR TITLE
fix(api): OT3 use retract target in pick up tip function

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1848,6 +1848,8 @@ class OT3API(
         for rel_point, speed in spec.shake_off_list:
             await self.move_rel(realmount, rel_point, speed=speed)
 
+        await self.move_rel(realmount, top_types.Point(z=spec.retract_target))
+
         # TODO: implement tip-detection sequence during pick-up-tip for 96ch,
         #       but not with DVT pipettes because those can only detect drops
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1848,6 +1848,8 @@ class OT3API(
         for rel_point, speed in spec.shake_off_list:
             await self.move_rel(realmount, rel_point, speed=speed)
 
+        # fixme: really only need this during labware position check so user
+        # can verify if a tip is properly attached
         await self.move_rel(realmount, top_types.Point(z=spec.retract_target))
 
         # TODO: implement tip-detection sequence during pick-up-tip for 96ch,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We haven't been retracting the pipette during `pick_up_tip()` in ot3api, which makes it hard for user to verify whether if tip is picked up or not during LPC. This fixes that. 

Now the behavior of pick up tip should match that of the OT2. One problem is that now we're going to retract _every time_ we pick up a tip, even outside of LPC. We really only need to do this when someone needs to physically verify if a tip is attached. I think eventually, we should move the retract call out of pick up tip and have the client move the pipette up only during LPC. 
