### PR TITLE
fix(app) App thermocycler run preview style fix

### DIFF
--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -85,18 +85,18 @@ export function CommandText(props: Props): JSX.Element | null {
       )
       return (
         <Flex flexDirection={DIRECTION_COLUMN} {...styleProps}>
-          <StyledText marginBottom={SPACING.spacing4} {...styleProps}>
+          <StyledText as="p" marginBottom={SPACING.spacing4} {...styleProps}>
             {t('tc_starting_profile', {
               repetitions: Object.keys(steps).length,
             })}
           </StyledText>
-          <Flex marginLeft={SPACING.spacing16}>
+          <StyledText as="p" marginLeft={SPACING.spacing16}>
             <ul>
               {steps.map((step: string, index: number) => (
                 <li key={index}> {step}</li>
               ))}
             </ul>
-          </Flex>
+          </StyledText>
         </Flex>
       )
     }


### PR DESCRIPTION
Closes RQA-747

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes run preview commands involving the thermocycler profile to have styles consistent with other run preview steps.

### Before
![Screenshot 2023-09-13 at 8 48 59 AM](https://github.com/Opentrons/opentrons/assets/64858653/d24247bb-f5a6-4fe7-9850-9e4cba625991)

### After
![Screenshot 2023-09-13 at 8 49 08 AM](https://github.com/Opentrons/opentrons/assets/64858653/d7eb9cc7-0e0a-4ba6-8c3c-e4faa1489ec4)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Upload a protocol that makes use of the thermocycler profile 
(Here is one [ThermocyclerTest.py.zip](https://github.com/Opentrons/opentrons/files/12597592/ThermocyclerTest.py.zip))
- Setup the protocol for running and go to Run Preview.
- Scroll down to the step involving the thermocycler profile. Observe text is now consistent.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Adjusted thermocycler case to stylistically match other run preview commands.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low