### PR TITLE
feat(protocol-designer): create 96-channel feature flag

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -21,6 +21,7 @@ const initialFlags: Flags = {
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
   OT_PD_ALLOW_ALL_TIPRACKS:
     process.env.OT_PD_ALLOW_ALL_TIPRACKS === '1' || false,
+  OT_PD_ALLOW_96_CHANNEL: process.env.OT_PD_ALLOW_96_CHANNEL === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -19,3 +19,7 @@ export const getAllowAllTipracks: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ALLOW_ALL_TIPRACKS ?? false
 )
+export const getAllow96Channel: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ALLOW_96_CHANNEL ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -26,6 +26,7 @@ export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ALLOW_ALL_TIPRACKS'
+  | 'OT_PD_ALLOW_96_CHANNEL'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -11,5 +11,9 @@
   "OT_PD_ALLOW_ALL_TIPRACKS": {
     "title": "Allow all tip rack options",
     "description": "Enable selection of all tip racks for each pipette."
+  },
+  "OT_PD_ALLOW_96_CHANNEL": {
+    "title": "Enable 96-channel pipette",
+    "description": "Allow users to select 96-channel pipette"
   }
 }


### PR DESCRIPTION
closese RAUT-691

# Overview

This creates a feature flag for 96-channel support

# Test Plan

you'll need to launch the PD dev environment: `make -C protocol-designer dev`. In console, type `enablePrereleaseMode()`. Restart and go to settings in PD, you should see the `Enable 96-channel pipette` feature flag. It should turn off and on when you click the toggle.

# Changelog

- add ff to selector, reducer, types, and i18n

# Review requests

see test plan

# Risk assessment

low