### PR TITLE
feat(protocol-designer): flex deck modification feature flag

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -22,6 +22,8 @@ const initialFlags: Flags = {
   OT_PD_ALLOW_ALL_TIPRACKS:
     process.env.OT_PD_ALLOW_ALL_TIPRACKS === '1' || false,
   OT_PD_ALLOW_96_CHANNEL: process.env.OT_PD_ALLOW_96_CHANNEL === '1' || false,
+  OT_PD_ENABLE_FLEX_DECK_MODIFICATION:
+    process.env.OT_PD_ENABLE_FLEX_DECK_MODIFICATION === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -23,3 +23,7 @@ export const getAllow96Channel: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ALLOW_96_CHANNEL ?? false
 )
+export const getEnableDeckModification: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_FLEX_DECK_MODIFICATION ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -27,6 +27,7 @@ export type FlagTypes =
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ALLOW_ALL_TIPRACKS'
   | 'OT_PD_ALLOW_96_CHANNEL'
+  | 'OT_PD_ENABLE_FLEX_DECK_MODIFICATION'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -17,7 +17,7 @@
     "description": "Allow users to select 96-channel pipette"
   },
   "OT_PD_ENABLE_FLEX_DECK_MODIFICATION": {
-    "title": "Enable waste chute, flex staging, and trash slot modification",
-    "description": "Allow users to select waste chute, flex staging, and modify trash slot"
+    "title": "Enable Flex deck modification",
+    "description": "Allow users to select waste chute, Flex staging, and modify trash slot"
   }
 }

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -15,5 +15,9 @@
   "OT_PD_ALLOW_96_CHANNEL": {
     "title": "Enable 96-channel pipette",
     "description": "Allow users to select 96-channel pipette"
+  },
+  "OT_PD_ENABLE_FLEX_DECK_MODIFICATION": {
+    "title": "Enable waste chute, flex staging, and trash slot modification",
+    "description": "Allow users to select waste chute, flex staging, and modify trash slot"
   }
 }


### PR DESCRIPTION
closes RAUT-705 and RAUT-713

# Overview

This PR creates a feature flag for flex deck modification in PD. The work that will go under the feature flag will include:
1. waste chute
2. flex staging areas
3. trash slot modification

I initially was gonna split up waste chute and flex staging into separate FFs but the trash slot modification I think needs to happen with both of those features, so I decided to combine them into 1 FF.

# Test Plan

Launch the PD dev env (`make -C protocol-designer dev`) and in console, enable the dev FFs by typing in `enablePrereleaseMode()` and restarting the dev env.

Go to the settings and toggle on/off the feature flag for enabling deck modification.

# Changelog

add feature flag selector, on to the reducer, on to the type, and to i18n

# Review requests

see test plan

# Risk assessment

low