### PR TITLE
fix(api): raise an error on analysis when dispensing invalid volume

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -776,7 +776,7 @@ class InvalidDispenseVolumeError(ProtocolEngineError):
         details: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a InvalidPushOutVolumeError."""
+        """Build a InvalidDispenseVolumeError."""
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -767,6 +767,19 @@ class InvalidPushOutVolumeError(ProtocolEngineError):
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
+class InvalidDispenseVolumeError(ProtocolEngineError):
+    """Raised when attempting to dispense a volume that was not aspirated."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a InvalidPushOutVolumeError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
 class InvalidAxisForRobotType(ProtocolEngineError):
     """Raised when attempting to use an axis that is not present on the given type of robot."""
 

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -10,6 +10,7 @@ from ..errors.exceptions import (
     TipNotAttachedError,
     InvalidPipettingVolumeError,
     InvalidPushOutVolumeError,
+    InvalidDispenseVolumeError,
 )
 
 
@@ -216,6 +217,11 @@ class VirtualPipettingHandler(PipettingHandler):
                 "push out value cannot have a negative value."
             )
         self._validate_tip_attached(pipette_id=pipette_id, command_name="dispense")
+        aspirate_volume = self._state_view.pipettes.get_aspirated_volume(pipette_id)
+        if not aspirate_volume:
+            raise InvalidDispenseVolumeError(
+                "Cannot dispense a volume that is not aspirated."
+            )
         return volume
 
     async def blow_out_in_place(

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -217,7 +217,7 @@ class VirtualPipettingHandler(PipettingHandler):
                 "push out value cannot have a negative value."
             )
         self._validate_tip_attached(pipette_id=pipette_id, command_name="dispense")
-        self._validate_dispense_volume(pipette_id=pipette_id, dispnese_volume=volume)
+        self._validate_dispense_volume(pipette_id=pipette_id, dispense_volume=volume)
         return volume
 
     async def blow_out_in_place(
@@ -237,16 +237,18 @@ class VirtualPipettingHandler(PipettingHandler):
             )
 
     def _validate_dispense_volume(
-        self, pipette_id: str, dispnese_volume: float
+        self, pipette_id: str, dispense_volume: float
     ) -> None:
         """Validate dispense volume."""
         aspirate_volume = self._state_view.pipettes.get_aspirated_volume(pipette_id)
-        if not aspirate_volume:
+        if aspirate_volume is None:
             raise InvalidDispenseVolumeError(
-                "Cannot preform a dispense if there is no volume in attached tip."
+                "Cannot perform a dispense if there is no volume in attached tip."
             )
-        if aspirate_volume and aspirate_volume < dispnese_volume:
-            raise InvalidDispenseVolumeError("Cannot dispense more than tip volume")
+        elif dispense_volume > aspirate_volume:
+            raise InvalidDispenseVolumeError(
+                f"Cannot dispense {dispense_volume} µL when only {aspirate_volume} µL has been aspirated."
+            )
 
 
 def create_pipetting_handler(

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -217,11 +217,7 @@ class VirtualPipettingHandler(PipettingHandler):
                 "push out value cannot have a negative value."
             )
         self._validate_tip_attached(pipette_id=pipette_id, command_name="dispense")
-        aspirate_volume = self._state_view.pipettes.get_aspirated_volume(pipette_id)
-        if not aspirate_volume:
-            raise InvalidDispenseVolumeError(
-                "Cannot dispense a volume that is not aspirated."
-            )
+        self._validate_dispense_volume(pipette_id=pipette_id, dispnese_volume=volume)
         return volume
 
     async def blow_out_in_place(
@@ -239,6 +235,18 @@ class VirtualPipettingHandler(PipettingHandler):
             raise TipNotAttachedError(
                 f"Cannot perform {command_name} without a tip attached"
             )
+
+    def _validate_dispense_volume(
+        self, pipette_id: str, dispnese_volume: float
+    ) -> None:
+        """Validate dispense volume."""
+        aspirate_volume = self._state_view.pipettes.get_aspirated_volume(pipette_id)
+        if not aspirate_volume:
+            raise InvalidDispenseVolumeError(
+                "Cannot preform a dispense if there is no volume in attached tip."
+            )
+        if aspirate_volume and aspirate_volume < dispnese_volume:
+            raise InvalidDispenseVolumeError("Cannot dispense more than tip volume")
 
 
 def create_pipetting_handler(

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -1,5 +1,5 @@
 """Pipetting execution handler."""
-from typing import cast
+from typing import cast, Optional
 
 import pytest
 from decoy import Decoy
@@ -19,6 +19,7 @@ from opentrons.protocol_engine.errors.exceptions import (
     TipNotAttachedError,
     InvalidPipettingVolumeError,
     InvalidPushOutVolumeError,
+    InvalidDispenseVolumeError,
 )
 
 
@@ -362,6 +363,10 @@ async def test_dispense_in_place_virtual(
         TipGeometry(length=1, diameter=2, volume=3)
     )
 
+    decoy.when(mock_state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(
+        3
+    )
+
     result = await subject.dispense_in_place(
         pipette_id="pipette-id", volume=3, flow_rate=5, push_out=None
     )
@@ -378,9 +383,34 @@ async def test_dispense_in_place_virtual_raises_invalid_push_out(
         TipGeometry(length=1, diameter=2, volume=3)
     )
 
+    decoy.when(mock_state_view.pipettes.get_attached_tip("pipette-id")).then_return(
+        TipGeometry(length=1, diameter=2, volume=3)
+    )
+
     with pytest.raises(InvalidPushOutVolumeError):
         await subject.dispense_in_place(
             pipette_id="pipette-id", volume=3, flow_rate=5, push_out=-7
+        )
+
+
+@pytest.mark.parametrize("aspirated_volume", [(None), (1)])
+async def test_dispense_in_place_virtual_raises_invalid_dispense(
+    decoy: Decoy, mock_state_view: StateView, aspirated_volume: Optional[float]
+) -> None:
+    """Should raise an InvalidDispenseVolumeError."""
+    subject = VirtualPipettingHandler(state_view=mock_state_view)
+
+    decoy.when(mock_state_view.pipettes.get_attached_tip("pipette-id")).then_return(
+        TipGeometry(length=1, diameter=2, volume=3)
+    )
+
+    decoy.when(mock_state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(
+        aspirated_volume
+    )
+
+    with pytest.raises(InvalidDispenseVolumeError):
+        await subject.dispense_in_place(
+            pipette_id="pipette-id", volume=3, flow_rate=5, push_out=7
         )
 
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RSS-330.
added validation for dispense in analysis - make sure there was an aspirate before dispensing. 

# Test Plan

Upload the following protocol and make sure it fails analysis. Should happen for both OT-2 and OT-3 with api version above 2.14.

```
#APIv2

requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.15",
}


def run(protocol_context):
	tiprack1 = protocol_context.load_labware("opentrons_96_tiprack_300ul", "1")
	pipette = protocol_context.load_instrument(
		"p300_single_gen2", mount="right", tip_racks=[tiprack1]
	)
	pipette.pick_up_tip(tiprack1.wells()[0])
	well_plate = protocol_context.load_labware("nest_96_wellplate_200ul_flat", "2")
	# pipette.aspirate(20, well_plate.wells()[0])
	pipette.dispense(20, well_plate.wells()[0])

```

Tested on dev server - works as expected! needs to be tested on the robot.

# Changelog

- Added validation to the dispense command. check if there was an aspiration before dispensing and that the volume is correct. 

# Review requests

are these checks sufficient? I don't think we can check the plunger position without the h/w api unless I am wrong.
Should I add this in the docs?

# Risk assessment

low. raising an exception while analyzing dispense command without aspirating before.
