### PR TITLE
refactor(protocol-designer): allow multiple off deck labware at once

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
@@ -20,11 +20,15 @@ export function LabwareLocationField(
   const labwareEntities = useSelector(getLabwareEntities)
   const robotState = useSelector(getRobotStateAtActiveItem)
   const moduleEntities = useSelector(getModuleEntities)
+  const isLabwarOffDeck =
+    props.labware != null
+      ? robotState?.labware[props.labware]?.slot === 'offDeck'
+      : false
 
   let unoccupiedLabwareLocationsOptions =
     useSelector(getUnocuppiedLabwareLocationOptions) ?? []
 
-  if (props.useGripper) {
+  if (props.useGripper || isLabwarOffDeck) {
     unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
       option => option.value !== 'offDeck'
     )

--- a/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
@@ -20,7 +20,7 @@ export function LabwareLocationField(
   const labwareEntities = useSelector(getLabwareEntities)
   const robotState = useSelector(getRobotStateAtActiveItem)
   const moduleEntities = useSelector(getModuleEntities)
-  const isLabwarOffDeck =
+  const isLabwareOffDeck =
     props.labware != null
       ? robotState?.labware[props.labware]?.slot === 'offDeck'
       : false
@@ -28,7 +28,7 @@ export function LabwareLocationField(
   let unoccupiedLabwareLocationsOptions =
     useSelector(getUnocuppiedLabwareLocationOptions) ?? []
 
-  if (props.useGripper || isLabwarOffDeck) {
+  if (props.useGripper || isLabwareOffDeck) {
     unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
       option => option.value !== 'offDeck'
     )

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -182,26 +182,14 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
       )
       .map(slotId => ({ name: slotId, value: slotId }))
 
-    const offDeckSlot = Object.values(labware)
-      .map(lw => lw.slot)
-      .find(slot => slot === 'offDeck')
-    const offDeck =
-      offDeckSlot !== 'offDeck' ? { name: 'Off Deck', value: 'offDeck' } : null
+    const offDeck = { name: 'Off Deck', value: 'offDeck' }
 
-    if (offDeck == null) {
-      return [
-        ...unoccupiedAdapterOptions,
-        ...unoccupiedModuleOptions,
-        ...unoccupiedSlotOptions,
-      ]
-    } else {
-      return [
-        ...unoccupiedAdapterOptions,
-        ...unoccupiedModuleOptions,
-        ...unoccupiedSlotOptions,
-        offDeck,
-      ]
-    }
+    return [
+      ...unoccupiedAdapterOptions,
+      ...unoccupiedModuleOptions,
+      ...unoccupiedSlotOptions,
+      offDeck,
+    ]
   }
 )
 


### PR DESCRIPTION
closes RQA-1589

# Overview

Noticed that the current code in the repo doesn't allow for multiple off deck labware at the same time. This PR fixes that so you can have an infinite amount of off deck labware.

# Test Plan

in PD, create either a Flex or OT-2 protocol. Add several labware to the deck. Can be whatever kind of labware you want as long as its not an adapter. Add a move labware step and select the New Location to be `off deck`. Add a another move labware step, select a New Location for a labware that is on deck, see that `off deck` is an option. If you change to trying to move a labware that is off deck, make sure that the `off deck` option is NOT available in the New Location dropdown.


# Changelog

- instead of filtering the off deck labware option in the selector, filter it out in the parent component by grabbing the selected labware's location

# Review requests

see test plan

# Risk assessment

low