### PR TITLE
refactor(app): copy update for tip length calibration

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -123,7 +123,7 @@
   "tip_length_calibration": "Tip Length Calibration",
   "tip_length_invalidates_pipette_offset": "Recalibrating tip length will clear pipette offset data.",
   "tip_length": "tip length calibration",
-  "tip_pick_up_instructions": "<block>Using the controls below or your keyboard, jog the pipette until the nozzle closest to you is centered above the A1 position and level with the top of the tip.</block><br/><block>When the pipette is aligned, you’re ready to test picking up the tip.</block>",
+  "tip_pick_up_instructions": "<block>Using the controls below or your keyboard, jog the pipette until the nozzle closest to you is centered above the A1 position and level with the top of the tip.</block><br/><block>When the pipette is properly aligned, pick up the tip.</block>",
   "title": "robot calibration",
   "to_check": "To check the {{mount}} pipette:",
   "unknown_custom_tiprack": "unknown custom tip rack",


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Removes language about "testing" picking up a tip — the next stage in the calibration process is to just pick it up.

Closes [RQA-1547](https://opentrons.atlassian.net/browse/RQA-1547).

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Tested with dev app and dev robot-server.

<img width="796" alt="Screenshot 2023-09-13 at 4 30 12 PM" src="https://github.com/Opentrons/opentrons/assets/1958332/4e4c5cb3-f570-4c10-af24-159dc090ca10">

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Localization string change only
- No tests because there weren't any before 🙃 

# Review requests

<!--
Describe any requests for your reviewers here.
-->

- Do we like the new words?
- Make sure this doesn't accidentally affect any other workflow screens.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Low, just a copy change.

[RQA-1547]: https://opentrons.atlassian.net/browse/RQA-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ