### PR TITLE
fix(app): fix gripper calibration overflowmenu visible issue

### DIFF
--- a/app/src/organisms/RobotSettingsCalibration/RobotSettingsGripperCalibration.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/RobotSettingsGripperCalibration.tsx
@@ -66,6 +66,12 @@ export function RobotSettingsGripperCalibration(
   const [showWizardFlow, setShowWizardFlow] = React.useState<boolean>(false)
   const gripperCalibrationLastModified =
     gripper?.data.calibratedOffset?.last_modified
+
+  const handleCalibrate = (): void => {
+    setShowOverflowMenu(false)
+    setShowWizardFlow(true)
+  }
+
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
@@ -136,7 +142,7 @@ export function RobotSettingsGripperCalibration(
                       right={0}
                       flexDirection={DIRECTION_COLUMN}
                     >
-                      <MenuItem onClick={() => setShowWizardFlow(true)}>
+                      <MenuItem onClick={handleCalibrate}>
                         {t(
                           gripperCalibrationLastModified == null
                             ? 'calibrate_gripper'


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix gripper calibration overflowmenu visible issue
close RQA-1581
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Go to RobotSettings Calibration tab
Try to gripper calibration and check when the wizard shows up, the overflow menu item is dismissed
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update RobotSettingsGripperCalibration component's onClick
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
