### PR TITLE
fix(app): add reinstall support for new robot update flows

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -239,6 +239,8 @@
   "robot_successfully_connected": "Robot successfully connected to {{networkName}}.",
   "robot_system_version": "Robot System Version",
   "robot_system_version_available": "Robot System Version {{releaseVersion}} available",
+  "robot_up_to_date": "Robot is up to date",
+  "robot_up_to_date_description": "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update.",
   "robot_update_available": "Robot Update Available",
   "robot_update_success": "Robot software successfully updated",
   "search_again": "Search again",

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -72,7 +72,6 @@ function RobotUpdateProgressFooter({
 }: RobotUpdateProgressFooterProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const dispatch = useDispatch<Dispatch>()
-  // TODO(jh, 08-30-2023: add reinstall logic for zip file installation)
   const installUpdate = React.useCallback(() => {
     dispatch(clearRobotUpdateSession())
     dispatch(startRobotUpdate(robotName))
@@ -123,7 +122,7 @@ function RobotUpdateProgressFooter({
 interface RobotUpdateProgressModalProps {
   robotName: string
   updateStep: UpdateStep
-  stepProgress?: number | null
+  stepProgress: number | null
   error?: string | null
   closeUpdateBuildroot?: () => void
 }
@@ -162,12 +161,8 @@ export function RobotUpdateProgressModal({
     )
   }
 
-  let modalBodyText = t('downloading_update')
-  if (updateStep === 'install') {
-    modalBodyText = t('installing_update')
-  } else if (updateStep === 'restart') {
-    modalBodyText = t('restarting_robot')
-  }
+  let modalBodyText = t('installing_update')
+  if (updateStep === 'restart') modalBodyText = t('restarting_robot')
 
   // Make sure to start the animation when this modal first pops up
   React.useEffect(startUpdatingAnimation, [])

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -86,9 +86,11 @@ export function UpdateRobotModal({
 
   let heading = ''
   if (updateType === UPGRADE || updateType === DOWNGRADE) {
-    if (systemType === OT2_BALENA)
+    if (systemType === OT2_BALENA) {
       heading = t('robot_operating_update_available')
-    else heading = `${robotName} ${t('update_available')}`
+    } else {
+      heading = `${robotName} ${t('update_available')}`
+    }
   } else if (updateType === REINSTALL) {
     heading = t('robot_up_to_date')
     releaseNotes = t('robot_up_to_date_description')

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -20,6 +20,9 @@ import {
   robotUpdateChangelogSeen,
   startRobotUpdate,
   OT2_BALENA,
+  UPGRADE,
+  REINSTALL,
+  DOWNGRADE,
 } from '../../../../redux/robot-update'
 import { ReleaseNotes } from '../../../../molecules/ReleaseNotes'
 import { useIsRobotBusy } from '../../hooks'
@@ -45,11 +48,13 @@ export const FOOTER_BUTTON_STYLE = css`
     text-transform: uppercase;
   }
 `
+type UpdateType = typeof UPGRADE | typeof DOWNGRADE | typeof REINSTALL | null
 
 export interface UpdateRobotModalProps {
   robotName: string
   releaseNotes: string
-  systemType: RobotSystemType | null
+  systemType: RobotSystemType
+  updateType: UpdateType
   closeModal: () => void
 }
 
@@ -57,6 +62,7 @@ export function UpdateRobotModal({
   robotName,
   releaseNotes,
   systemType,
+  updateType,
   closeModal,
 }: UpdateRobotModalProps): JSX.Element {
   const dispatch = useDispatch<Dispatch>()
@@ -78,10 +84,15 @@ export function UpdateRobotModal({
     dispatch(robotUpdateChangelogSeen(robotName))
   }, [robotName])
 
-  const heading =
-    systemType === OT2_BALENA
-      ? 'Robot Operating System Update'
-      : `${robotName} ${t('update_available')}`
+  let heading = ''
+  if (updateType === UPGRADE || updateType === DOWNGRADE) {
+    if (systemType === OT2_BALENA)
+      heading = t('robot_operating_update_available')
+    else heading = `${robotName} ${t('update_available')}`
+  } else if (updateType === REINSTALL) {
+    heading = t('robot_up_to_date')
+    releaseNotes = t('robot_up_to_date_description')
+  }
 
   const robotUpdateFooter = (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>
@@ -90,7 +101,7 @@ export function UpdateRobotModal({
         marginRight={SPACING.spacing8}
         css={FOOTER_BUTTON_STYLE}
       >
-        {t('remind_me_later')}
+        {updateType === UPGRADE ? t('remind_me_later') : t('not_now')}
       </NewSecondaryBtn>
       <NewPrimaryBtn
         onClick={() => dispatch(startRobotUpdate(robotName))}

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/ViewUpdateModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/ViewUpdateModal.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 
 import {
   OT2_BALENA,
-  UPGRADE,
   getRobotUpdateInfo,
   getRobotUpdateDownloadProgress,
   getRobotUpdateDownloadError,
@@ -54,7 +53,6 @@ export function ViewUpdateModal(
     children: downloadError !== null ? 'close' : 'not now',
   }
 
-  const showReleaseNotes = robotUpdateType === UPGRADE
   let releaseNotes = ''
   if (updateInfo?.releaseNotes) releaseNotes = updateInfo.releaseNotes
 
@@ -85,12 +83,13 @@ export function ViewUpdateModal(
       />
     )
 
-  if (showReleaseNotes)
+  if (robotSystemType != null)
     return (
       <UpdateRobotModal
         robotName={robotName}
         releaseNotes={releaseNotes}
         systemType={robotSystemType}
+        updateType={robotUpdateType}
         closeModal={closeModal}
       />
     )

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
@@ -66,16 +66,6 @@ describe('DownloadUpdateModal', () => {
     })
   })
 
-  it('renders the correct text when downloading the robot update with no close button', () => {
-    const [{ queryByRole, getByText }] = render(props)
-
-    expect(getByText('Downloading update...')).toBeInTheDocument()
-    expect(
-      getByText('Do not turn off the robot while updating')
-    ).toBeInTheDocument()
-    expect(queryByRole('button')).not.toBeInTheDocument()
-  })
-
   it('renders the correct text when installing the robot update with no close button', () => {
     props = {
       ...props,

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
@@ -43,6 +43,7 @@ describe('UpdateRobotModal', () => {
       releaseNotes: 'test notes',
       systemType: 'flex',
       closeModal: jest.fn(),
+      updateType: 'upgrade',
     }
     when(mockGetRobotUpdateDisplayInfo).mockReturnValue({
       autoUpdateAction: 'upgrade',
@@ -56,7 +57,7 @@ describe('UpdateRobotModal', () => {
     jest.resetAllMocks()
   })
 
-  it('renders an update available header if the type is not Balena', () => {
+  it('renders an update available header if the type is not Balena when upgrading', () => {
     const [{ getByText }] = render(props)
     getByText('test robot Update Available')
   })
@@ -67,10 +68,10 @@ describe('UpdateRobotModal', () => {
       systemType: 'ot2-balena',
     }
     const [{ getByText }] = render(props)
-    getByText('Robot Operating System Update')
+    getByText('Robot Operating System Update Available')
   })
 
-  it('renders release notes and a modal header close icon', () => {
+  it('renders release notes and a modal header close icon when upgrading', () => {
     const [{ getByText, getByTestId }] = render(props)
     getByText('test notes')
 
@@ -81,7 +82,7 @@ describe('UpdateRobotModal', () => {
     expect(props.closeModal).toHaveBeenCalled()
   })
 
-  it('renders remind me later and and disabled update robot now buttons', () => {
+  it('renders remind me later and and disabled update robot now buttons when upgrading', () => {
     const [{ getByText }] = render(props)
     getByText('test notes')
 
@@ -90,5 +91,30 @@ describe('UpdateRobotModal', () => {
     expect(updateNow).toBeDisabled()
     fireEvent.click(remindMeLater)
     expect(props.closeModal).toHaveBeenCalled()
+  })
+
+  it('renders proper text when reinstalling', () => {
+    props = {
+      ...props,
+      updateType: 'reinstall',
+    }
+
+    const [{ getByText, queryByText }] = render(props)
+    getByText('Robot is up to date')
+    queryByText('It looks like your robot is already up to date')
+    getByText('Not now')
+    getByText('Update robot now')
+  })
+
+  it('renders proper text when downgrading', () => {
+    props = {
+      ...props,
+      updateType: 'downgrade',
+    }
+
+    const [{ getByText }] = render(props)
+    getByText('test robot Update Available')
+    getByText('Not now')
+    getByText('Update robot now')
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -45,8 +45,10 @@ export function UpdateBuildroot(props: UpdateBuildrootProps): JSX.Element {
 
   const robotSystemType = getRobotSystemType(robot)
 
+  // TODO(jh, 09-14-2023: add download logic to app-shell/redux/progress bar.
   let updateStep: UpdateStep
-  if (step == null) updateStep = 'download'
+  const DOWNLOAD_STEPS = ['getToken']
+  if (step == null || DOWNLOAD_STEPS.includes(step)) updateStep = 'download'
   else if (step === 'finished') updateStep = 'finished'
   else if (step === 'restart' || step === 'restarting') updateStep = 'restart'
   else updateStep = 'install'


### PR DESCRIPTION
Closes RQA-1587

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The recent robot update flows did not include logic for properly handling reinstall and downgrade cases. This PR adds proper support.

https://github.com/Opentrons/opentrons/assets/64858653/096eecd6-6546-447f-83b2-fadbcd0ffcfc

NOTE: "Download" support was removed as there currently is no download progress in the shell/store. This support will be added in a future PR.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Build the branch and run the build.
- Test the reinstall logic under Device Settings > Advanced > Reinstall (app and robot must be on the same version)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added proper modal support for upgrading/downgrading.
- Added testing to cover these cases.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
