### PR TITLE
fix(app, app-shell): add dynamic alerts given update channel state

### DIFF
--- a/app-shell/src/__tests__/update.test.ts
+++ b/app-shell/src/__tests__/update.test.ts
@@ -63,7 +63,11 @@ describe('update', () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       type: 'shell:CHECK_UPDATE_RESULT',
-      payload: { error: { name: 'Error', message: 'AH' } },
+      payload: {
+        error: { name: 'Error', message: 'AH' },
+        available: false,
+        info: null,
+      },
     })
   })
 

--- a/app-shell/src/update.ts
+++ b/app-shell/src/update.ts
@@ -39,8 +39,9 @@ function checkUpdate(dispatch: Dispatch): void {
   const onNotAvailable = (info: UpdateInfo): void => {
     done({ info, available: false })
   }
+
   const onError = (error: Error): void => {
-    done({ error: PlainObjectError(error) })
+    done({ error: PlainObjectError(error), info: null, available: false })
   }
 
   updater.once('update-available', onAvailable)
@@ -53,7 +54,7 @@ function checkUpdate(dispatch: Dispatch): void {
   updater.checkForUpdates()
 
   function done(payload: {
-    info?: UpdateInfo
+    info?: UpdateInfo | null
     available?: boolean
     error?: PlainError
   }): void {

--- a/app/src/organisms/Alerts/__tests__/Alerts.test.tsx
+++ b/app/src/organisms/Alerts/__tests__/Alerts.test.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
+import { when } from 'jest-when'
 
 import { mountWithStore } from '@opentrons/components'
 import * as AppAlerts from '../../../redux/alerts'
+import { getAvailableShellUpdate } from '../../../redux/shell'
 import { TOAST_ANIMATION_DURATION } from '../../../atoms/Toast'
 import { Alerts } from '..'
 import { AnalyticsSettingsModal } from '../../AnalyticsSettingsModal'
@@ -14,19 +16,20 @@ import type { AlertId } from '../../../redux/alerts/types'
 jest.mock('../../AnalyticsSettingsModal', () => ({
   AnalyticsSettingsModal: () => <></>,
 }))
-
 jest.mock('../U2EDriverOutdatedAlert', () => ({
   U2EDriverOutdatedAlert: () => <></>,
 }))
-
 jest.mock('../../UpdateAppModal', () => ({
   UpdateAppModal: () => <></>,
 }))
-
 jest.mock('../../../redux/alerts/selectors')
+jest.mock('../../../redux/shell')
 
 const getActiveAlerts = AppAlerts.getActiveAlerts as jest.MockedFunction<
   typeof AppAlerts.getActiveAlerts
+>
+const mockGetAvailableShellUpdate = getAvailableShellUpdate as jest.MockedFunction<
+  typeof getAvailableShellUpdate
 >
 
 const MOCK_STATE: State = { mockState: true } as any
@@ -47,6 +50,7 @@ describe('app-wide Alerts component', () => {
 
   beforeEach(() => {
     stubActiveAlerts([])
+    when(mockGetAvailableShellUpdate).mockReturnValue('true')
   })
 
   afterEach(() => {
@@ -119,6 +123,13 @@ describe('app-wide Alerts component', () => {
     wrapper.setProps({ initialState: updatedState })
     setTimeout(() => {
       expect(wrapper.contains('successfully updated')).toBe(true)
+    }, TOAST_ANIMATION_DURATION)
+  })
+  it('should not render an app update toast if a software update is no longer available', () => {
+    when(mockGetAvailableShellUpdate).mockReturnValue('false')
+    const { wrapper } = render()
+    setTimeout(() => {
+      expect(wrapper.contains('View Update')).toBe(false)
     }, TOAST_ANIMATION_DURATION)
   })
 })

--- a/app/src/redux/shell/__tests__/update.test.ts
+++ b/app/src/redux/shell/__tests__/update.test.ts
@@ -72,10 +72,20 @@ describe('shell/update', () => {
         name: 'handles shell:CHECK_UPDATE_RESULT with error',
         action: {
           type: 'shell:CHECK_UPDATE_RESULT',
-          payload: { error: { message: 'AH' } },
+          payload: { error: { message: 'AH' }, available: false, info: null },
         },
-        initialState: { checking: true, error: null } as any,
-        expected: { checking: false, error: { message: 'AH' } },
+        initialState: {
+          checking: true,
+          error: null,
+          available: false,
+          info: undefined,
+        } as any,
+        expected: {
+          checking: false,
+          error: { message: 'AH' },
+          available: false,
+          info: null,
+        },
       },
       {
         name: 'handles shell:DOWNLOAD_UPDATE',

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -34,7 +34,7 @@ export type ShellUpdateAction =
   | { type: 'shell:CHECK_UPDATE'; meta: { shell: true } }
   | {
       type: 'shell:CHECK_UPDATE_RESULT'
-      payload: { available?: boolean; info?: UpdateInfo; error?: Error }
+      payload: { available?: boolean; info?: UpdateInfo | null; error?: Error }
     }
   | { type: 'shell:DOWNLOAD_UPDATE'; meta: { shell: true } }
   | { type: 'shell:DOWNLOAD_UPDATE_RESULT'; payload: { error?: Error } }


### PR DESCRIPTION
Closes RQA-1560

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes conditional rendering when switching app update channels for update alert banners and toasts. 

Current app-shell behavior does not properly error handle when switching from one channel to another that throws an error -certain redux store properties that are utilized to determine app update logic are not properly reset. 

Additionally, top level update Alerts utilized AppAlerts, which does not adequately respond to switching channels. The getAvailableShellUpdate() selector is used instead. 

Test Build: https://builds.opentrons.com/app/Opentrons-v7.0.0-alpha.8-mac-b34680-TEST_APP_SHELL-app-build.dmg

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/c551ae4b-4e94-4255-acfc-09044871bc93

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/22028b3e-cb7e-4fd3-9ad4-ed1bc5053281

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Download build from link above.
- Follow steps outlined in videos.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Added working error logic passed from the shell layer to the redux store.
- Refactored the top-level Alerts component to utilize selectors for triggering proper toast renders.
- Added additional testing to Alerts.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
