### PR TITLE
fix(app-shell): delete protocols across both protocol storages 

### DIFF
--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -201,14 +201,22 @@ export function registerProtocolStorage(dispatch: Dispatch): Dispatch {
           })
         break
       }
-
+      // TODO(jh, 2023-09-15): remove the secondary removeProtocolByKey() after
+      // OT-2 parity work is completed.
       case ProtocolStorageActions.REMOVE_PROTOCOL: {
         FileSystem.removeProtocolByKey(
           action.payload.protocolKey,
           FileSystem.PROTOCOLS_DIRECTORY_PATH
-        ).then(() =>
-          fetchProtocols(dispatch, ProtocolStorageActions.PROTOCOL_ADDITION)
         )
+          .then(() =>
+            FileSystem.removeProtocolByKey(
+              action.payload.protocolKey,
+              FileSystem.OLD_PROTOCOLS_DIRECTORY_PATH
+            )
+          )
+          .then(() =>
+            fetchProtocols(dispatch, ProtocolStorageActions.PROTOCOL_ADDITION)
+          )
         break
       }
 

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -209,13 +209,13 @@ export function registerProtocolStorage(dispatch: Dispatch): Dispatch {
           FileSystem.PROTOCOLS_DIRECTORY_PATH
         )
           .then(() =>
+            fetchProtocols(dispatch, ProtocolStorageActions.PROTOCOL_ADDITION)
+          )
+          .then(() =>
             FileSystem.removeProtocolByKey(
               action.payload.protocolKey,
               FileSystem.OLD_PROTOCOLS_DIRECTORY_PATH
             )
-          )
-          .then(() =>
-            fetchProtocols(dispatch, ProtocolStorageActions.PROTOCOL_ADDITION)
           )
         break
       }


### PR DESCRIPTION
Closes RQA-1600

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Removes protocol files from both versions of the app to prevent protocol re-migration upon navigation to the ProtocolDashboard. This is part of the pre-parity stop-gap work for the app and will be removed after parity.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/e8dc4c75-3c90-4448-b9d0-e76a364f9960

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/2fa0a088-05ba-478c-b92c-972ad409f150


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- From the app, delete any protocol that exists within the ~/Library/Application Support/Opentrons/protocols and protocols_v7.0-supported directories.
- Navigate away from ProtocolDashboard and return. Note that the protocol is now properly deleted.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Add support for deleting protocols from the old protocols directory if they exist.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low