### PR TITLE
fix(app): fix random white spaces in robot list when sending a protocol

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -223,26 +223,24 @@ export function ChooseRobotSlideout(
               selectedRobot != null && selectedRobot.ip === robot.ip
             return (
               <>
-                <Flex key={robot.ip} flexDirection={DIRECTION_COLUMN}>
-                  <AvailableRobotOption
-                    key={robot.ip}
-                    robot={robot}
-                    // TODO: generalize to a disabled/reset prop
-                    onClick={() => {
-                      if (!isCreatingRun) {
-                        resetCreateRun?.()
-                        setSelectedRobot(robot)
-                      }
-                    }}
-                    isError={runCreationError != null}
-                    isSelected={isSelected}
-                    isOnDifferentSoftwareVersion={
-                      isSelectedRobotOnWrongVersionOfSoftware
+                <AvailableRobotOption
+                  key={robot.ip}
+                  robot={robot}
+                  // TODO: generalize to a disabled/reset prop
+                  onClick={() => {
+                    if (!isCreatingRun) {
+                      resetCreateRun?.()
+                      setSelectedRobot(robot)
                     }
-                    showIdleOnly={showIdleOnly}
-                    registerRobotBusyStatus={registerRobotBusyStatus}
-                  />
-                </Flex>
+                  }}
+                  isError={runCreationError != null}
+                  isSelected={isSelected}
+                  isOnDifferentSoftwareVersion={
+                    isSelectedRobotOnWrongVersionOfSoftware
+                  }
+                  showIdleOnly={showIdleOnly}
+                  registerRobotBusyStatus={registerRobotBusyStatus}
+                />
                 {runCreationError != null && isSelected && (
                   <StyledText
                     as="label"


### PR DESCRIPTION
Closes RQA-1580

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Recent CSS changes to ChooseRobotSlideout error text created a superfluous Flex component for each AvailableRobot option. This component coupled with the logic of healthyReachableRobots renders an empty Flex, thus creating the white spacing. Because robots may be reordered when re-rendering the slideout, the behavior appears random.

Removing the unneeded Flex component fixes the issue.

### Current Behavior

![current behavior](https://github.com/Opentrons/opentrons/assets/64858653/6adeb257-f665-4872-b4a2-94a4597867ff)

### Fixed Behavior

![fixed behavior](https://github.com/Opentrons/opentrons/assets/64858653/69d515cc-d8ba-455d-a89d-6a7ae706038f)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- On ProtocolDashboard, click the overflow menu for a protocol and click Send to Opentrons Flex. Style consistency should match that of the "fixed behavior" image above.
- Repeat a few times, as white spacing errors are inconsistent.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
