### PR TITLE
fix(app): sort current offsets by date to ensure order

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -21,7 +21,7 @@ import { useLPCDisabledReason, useStoredProtocolAnalysis } from '../../hooks'
 import { CurrentOffsetsTable } from './CurrentOffsetsTable'
 import { useLaunchLPC } from '../../../LabwarePositionCheck/useLaunchLPC'
 import { StyledText } from '../../../../atoms/text'
-import { LabwareOffset } from '@opentrons/api-client'
+import type { LabwareOffset } from '@opentrons/api-client'
 
 interface SetupLabwarePositionCheckProps {
   expandLabwareStep: () => void


### PR DESCRIPTION
closes RAUT-722 and RQA-1608

# Overview

The data fetched from the runQuery hook does guarantee that the current offsets return in the same order. To fix this, I added sorting via `createdAt` from the offsets key

# Test Plan

see the ticket attached, basically run LPC on desktop with offsets already in the table. Make sure they don't reorder during LPC. The reordering starts after the initial page of the LPC flow and ends when you complete LPC

# Changelog

added sorting of the current offsets

# Review requests

see test plan

# Risk assessment

low