### PR TITLE
fix(api): disengage gripper z when not in use at maintenance position

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -107,6 +107,11 @@ class MoveToMaintenancePositionImplementation(
             )
 
         if params.mount != MountType.EXTENSION:
+
+            # disable z since we don't need it
+            if ot3_api.has_gripper():
+                await ot3_api.disengage_axes([Axis.Z_G])
+
             if params.maintenancePosition == MaintenancePosition.ATTACH_INSTRUMENT:
                 mount_to_axis = Axis.by_mount(params.mount.to_hw_mount())
                 await ot3_api.move_axes(

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -108,7 +108,9 @@ class MoveToMaintenancePositionImplementation(
 
         if params.mount != MountType.EXTENSION:
 
-            # disable z since we don't need it
+            # disengage the gripper z to enable the e-brake, this prevents the gripper
+            # z from dropping when the right mount carriage gets released from the
+            # mount during 96-channel detach flow
             if ot3_api.has_gripper():
                 await ot3_api.disengage_axes([Axis.Z_G])
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Gripper Z drops during the 96-channel pipette detach flow when the right mount Z carriage gets released from the mount. Turns out it's because the gripper z hold current is too low and vibration from right mount caused it to fall. We can fix this by disengaging the z, which engages the e-brake so this will never happen.