### PR TITLE
feat(api): After overpressure errors, leave the pipette where it is

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1094,9 +1094,8 @@ class OT3Controller:
                     q_msg = _pop_queue()
                     if q_msg:
                         mount = Axis.to_ot3_mount(node_to_axis(q_msg[0]))
-                        raise OverPressureDetected(
-                            f"The pressure sensor on the {mount} mount has exceeded operational limits."
-                        )
+                        raise OverPressureDetected(mount.name)
+
         else:
             yield
 

--- a/api/src/opentrons/hardware_control/errors.py
+++ b/api/src/opentrons/hardware_control/errors.py
@@ -1,3 +1,4 @@
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from .types import OT3Mount
 
 
@@ -61,10 +62,14 @@ class FirmwareUpdateFailed(RuntimeError):
     pass
 
 
-class OverPressureDetected(RuntimeError):
+class OverPressureDetected(PipetteOverpressureError):
     """An error raised when the pressure sensor max value is exceeded."""
 
-    pass
+    def __init__(self, mount: str) -> None:
+        return super().__init__(
+            message=f"The pressure sensor on the {mount} mount has exceeded operational limits.",
+            detail={"mount": mount},
+        )
 
 
 class InvalidPipetteName(KeyError):

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -349,11 +349,18 @@ class ProtocolEngine:
             #
             # We don't use self._hardware_api.get_estop_state() because the E-stop may have been
             # released by the time we get here.
-            if isinstance(error, EnumeratedError) and self._code_in_error_tree(
-                root_error=error, code=ErrorCodes.E_STOP_ACTIVATED
-            ):
-                drop_tips_after_run = False
-                post_run_hardware_state = PostRunHardwareState.DISENGAGE_IN_PLACE
+            if isinstance(error, EnumeratedError):
+                if self._code_in_error_tree(
+                    root_error=error, code=ErrorCodes.E_STOP_ACTIVATED
+                ) or self._code_in_error_tree(
+                    # Request from the hardware team for the v7.0 betas: to help in-house debugging
+                    # of pipette overpressure events, leave the pipette where it was like we do
+                    # for E-stops.
+                    root_error=error,
+                    code=ErrorCodes.PIPETTE_OVERPRESSURE,
+                ):
+                    drop_tips_after_run = False
+                    post_run_hardware_state = PostRunHardwareState.DISENGAGE_IN_PLACE
 
             error_details: Optional[FinishErrorDetails] = FinishErrorDetails(
                 error_id=self._model_utils.generate_id(),


### PR DESCRIPTION
# Overview

Implements a request from the hardware testing team, via @sfoster1.

When a run fails because of a pipette overpressure event, it's easier to investigate it if we handle it sort of like E-stops. Leave the pipette exactly where it is—don't home.

# Test Plan

* [ ] Make sure this doesn't break E-stop handling
* [ ] Manually trigger a pipette overpressure somehow and see that it leaves the pipette in-place?

# Review requests

None in particular.

# Risk assessment

Low.