### PR TITLE
fix(api): gripper idling error post protocol run drop tip

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -145,6 +145,7 @@ class GripperHandler:
             self._log.warning(
                 "Gripper jaw is not homed and cannot move to idle position."
             )
+            return False
         return gripper.state != GripperJawState.GRIPPING
 
     def is_ready_for_jaw_home(self) -> bool:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If the gripper is unhomed, we shouldn't try to idle the gripper jaw. We saw an error when the pipette tries to drop tip during the post-protocol cleanup, the jaw had been disengaged and could not idle. 
