### PR TITLE
feat(shared-data): add temperature module aluminum flat plate adapter

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -30,6 +30,8 @@ _APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
     "nest_96_wellplate_200ul_flat": 2,
     "nest_96_wellplate_2ml_deep": 2,
     "opentrons_96_wellplate_200ul_pcr_full_skirt": 2,
+    "corning_6_wellplate_16.8ml_flat": 2,
+    "corning_24_wellplate_3.4ml_flat": 2,
 }
 
 

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -3729,7 +3729,12 @@
       "schemaVersion": 2,
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 },
       "stackingOffsetWithLabware": {
-        "opentrons_96_flat_bottom_adapter": { "x": 0, "y": 0, "z": 6.7 }
+        "opentrons_96_flat_bottom_adapter": { "x": 0, "y": 0, "z": 6.7 },
+        "opentrons_aluminum_flat_bottom_plate": {
+          "x": 0,
+          "y": 0,
+          "z": 2.3
+        }
       }
     },
     "opentrons/opentrons_1_trash_1100ml_fixed/1": {

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -3733,7 +3733,7 @@
         "opentrons_aluminum_flat_bottom_plate": {
           "x": 0,
           "y": 0,
-          "z": 2.3
+          "z": 5.55
         }
       }
     },

--- a/shared-data/labware/definitions/2/corning_12_wellplate_6.9ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_12_wellplate_6.9ml_flat/2.json
@@ -169,5 +169,12 @@
     "x": 0,
     "y": 0,
     "z": 0
+  },
+  "stackingOffsetWithLabware": {
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 1.25
+    }
   }
 }

--- a/shared-data/labware/definitions/2/corning_12_wellplate_6.9ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_12_wellplate_6.9ml_flat/2.json
@@ -174,7 +174,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 1.25
+      "z": 4.5
     }
   }
 }

--- a/shared-data/labware/definitions/2/corning_24_wellplate_3.4ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_24_wellplate_3.4ml_flat/2.json
@@ -1,0 +1,300 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1"],
+    ["A2", "B2", "C2", "D2"],
+    ["A3", "B3", "C3", "D3"],
+    ["A4", "B4", "C4", "D4"],
+    ["A5", "B5", "C5", "D5"],
+    ["A6", "B6", "C6", "D6"]
+  ],
+  "brand": {
+    "brand": "Corning",
+    "brandId": ["3337", "3524", "3526", "3527", "3473", "3738", "3987"],
+    "links": [
+      "https://ecatalog.corning.com/life-sciences/b2c/US/en/Microplates/Assay-Microplates/96-Well-Microplates/Costar%C2%AE-Multiple-Well-Cell-Culture-Plates/p/3738"
+    ]
+  },
+  "schemaVersion": 2,
+  "version": 1,
+  "namespace": "opentrons",
+  "metadata": {
+    "displayName": "Corning 24 Well Plate 3.4 mL Flat",
+    "displayVolumeUnits": "mL",
+    "displayCategory": "wellPlate",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.47,
+    "zDimension": 20.27
+  },
+  "wells": {
+    "D1": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 17.48,
+      "y": 13.77,
+      "z": 2.87
+    },
+    "C1": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 17.48,
+      "y": 33.07,
+      "z": 2.87
+    },
+    "B1": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 17.48,
+      "y": 52.37,
+      "z": 2.87
+    },
+    "A1": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 17.48,
+      "y": 71.67,
+      "z": 2.87
+    },
+    "D2": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 36.78,
+      "y": 13.77,
+      "z": 2.87
+    },
+    "C2": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 36.78,
+      "y": 33.07,
+      "z": 2.87
+    },
+    "B2": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 36.78,
+      "y": 52.37,
+      "z": 2.87
+    },
+    "A2": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 36.78,
+      "y": 71.67,
+      "z": 2.87
+    },
+    "D3": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 56.08,
+      "y": 13.77,
+      "z": 2.87
+    },
+    "C3": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 56.08,
+      "y": 33.07,
+      "z": 2.87
+    },
+    "B3": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 56.08,
+      "y": 52.37,
+      "z": 2.87
+    },
+    "A3": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 56.08,
+      "y": 71.67,
+      "z": 2.87
+    },
+    "D4": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 75.38,
+      "y": 13.77,
+      "z": 2.87
+    },
+    "C4": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 75.38,
+      "y": 33.07,
+      "z": 2.87
+    },
+    "B4": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 75.38,
+      "y": 52.37,
+      "z": 2.87
+    },
+    "A4": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 75.38,
+      "y": 71.67,
+      "z": 2.87
+    },
+    "D5": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 94.68,
+      "y": 13.77,
+      "z": 2.87
+    },
+    "C5": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 94.68,
+      "y": 33.07,
+      "z": 2.87
+    },
+    "B5": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 94.68,
+      "y": 52.37,
+      "z": 2.87
+    },
+    "A5": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 94.68,
+      "y": 71.67,
+      "z": 2.87
+    },
+    "D6": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 113.98,
+      "y": 13.77,
+      "z": 2.87
+    },
+    "C6": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 113.98,
+      "y": 33.07,
+      "z": 2.87
+    },
+    "B6": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 113.98,
+      "y": 52.37,
+      "z": 2.87
+    },
+    "A6": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 16.26,
+      "totalLiquidVolume": 3400,
+      "x": 113.98,
+      "y": 71.67,
+      "z": 2.87
+    }
+  },
+  "parameters": {
+    "format": "irregular",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "corning_24_wellplate_3.4ml_flat"
+  },
+  "groups": [
+    {
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "A6",
+        "B6",
+        "C6",
+        "D6"
+      ],
+      "metadata": {
+        "wellBottomShape": "flat"
+      }
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "stackingOffsetWithLabware": {
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 0.9
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/corning_24_wellplate_3.4ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_24_wellplate_3.4ml_flat/2.json
@@ -15,7 +15,7 @@
     ]
   },
   "schemaVersion": 2,
-  "version": 1,
+  "version": 2,
   "namespace": "opentrons",
   "metadata": {
     "displayName": "Corning 24 Well Plate 3.4 mL Flat",

--- a/shared-data/labware/definitions/2/corning_24_wellplate_3.4ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_24_wellplate_3.4ml_flat/2.json
@@ -294,7 +294,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 0.9
+      "z": 4.15
     }
   }
 }

--- a/shared-data/labware/definitions/2/corning_384_wellplate_112ul_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_384_wellplate_112ul_flat/2.json
@@ -4707,6 +4707,11 @@
       "x": 0,
       "y": 0,
       "z": 8.32
+    },
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 2.2
     }
   }
 }

--- a/shared-data/labware/definitions/2/corning_384_wellplate_112ul_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_384_wellplate_112ul_flat/2.json
@@ -4711,7 +4711,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 2.2
+      "z": 5.45
     }
   }
 }

--- a/shared-data/labware/definitions/2/corning_48_wellplate_1.6ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_48_wellplate_1.6ml_flat/2.json
@@ -533,5 +533,12 @@
     "x": 0,
     "y": 0,
     "z": 0
+  },
+  "stackingOffsetWithLabware": {
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 1.15
+    }
   }
 }

--- a/shared-data/labware/definitions/2/corning_48_wellplate_1.6ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_48_wellplate_1.6ml_flat/2.json
@@ -538,7 +538,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 1.15
+      "z": 4.4
     }
   }
 }

--- a/shared-data/labware/definitions/2/corning_6_wellplate_16.8ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_6_wellplate_16.8ml_flat/2.json
@@ -1,0 +1,110 @@
+{
+  "ordering": [
+    ["A1", "B1"],
+    ["A2", "B2"],
+    ["A3", "B3"]
+  ],
+  "metadata": {
+    "displayName": "Corning 6 Well Plate 16.8 mL Flat",
+    "displayVolumeUnits": "mL",
+    "displayCategory": "wellPlate",
+    "tags": []
+  },
+  "schemaVersion": 2,
+  "version": 1,
+  "namespace": "opentrons",
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.47,
+    "zDimension": 20.27
+  },
+  "parameters": {
+    "format": "irregular",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "corning_6_wellplate_16.8ml_flat"
+  },
+  "wells": {
+    "B1": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 35.43,
+      "totalLiquidVolume": 16800,
+      "x": 24.76,
+      "y": 23.16,
+      "z": 2.87
+    },
+    "A1": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 35.43,
+      "totalLiquidVolume": 16800,
+      "x": 24.76,
+      "y": 62.28,
+      "z": 2.87
+    },
+    "B2": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 35.43,
+      "totalLiquidVolume": 16800,
+      "x": 63.88,
+      "y": 23.16,
+      "z": 2.87
+    },
+    "A2": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 35.43,
+      "totalLiquidVolume": 16800,
+      "x": 63.88,
+      "y": 62.28,
+      "z": 2.87
+    },
+    "B3": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 35.43,
+      "totalLiquidVolume": 16800,
+      "x": 103,
+      "y": 23.16,
+      "z": 2.87
+    },
+    "A3": {
+      "shape": "circular",
+      "depth": 17.4,
+      "diameter": 35.43,
+      "totalLiquidVolume": 16800,
+      "x": 103,
+      "y": 62.28,
+      "z": 2.87
+    }
+  },
+  "brand": {
+    "brand": "Corning",
+    "brandId": ["3335", "3506", "3516", "3471"],
+    "links": [
+      "https://ecatalog.corning.com/life-sciences/b2c/US/en/Microplates/Assay-Microplates/96-Well-Microplates/Costar%C2%AE-Multiple-Well-Cell-Culture-Plates/p/3335"
+    ]
+  },
+  "groups": [
+    {
+      "wells": ["A1", "B1", "A2", "B2", "A3", "B3"],
+      "metadata": {
+        "wellBottomShape": "flat"
+      }
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "stackingOffsetWithLabware": {
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 1.25
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/corning_6_wellplate_16.8ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_6_wellplate_16.8ml_flat/2.json
@@ -11,7 +11,7 @@
     "tags": []
   },
   "schemaVersion": 2,
-  "version": 1,
+  "version": 2,
   "namespace": "opentrons",
   "dimensions": {
     "xDimension": 127.76,

--- a/shared-data/labware/definitions/2/corning_6_wellplate_16.8ml_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_6_wellplate_16.8ml_flat/2.json
@@ -104,7 +104,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 1.25
+      "z": 4.5
     }
   }
 }

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_flat/2.json
@@ -1047,5 +1047,12 @@
   },
   "namespace": "opentrons",
   "version": 2,
-  "schemaVersion": 2
+  "schemaVersion": 2,
+  "stackingOffsetWithLabware": {
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 2.2
+    }
+  }
 }

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_flat/2.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_flat/2.json
@@ -1052,7 +1052,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 2.2
+      "z": 5.45
     }
   }
 }

--- a/shared-data/labware/definitions/2/nest_96_wellplate_200ul_flat/2.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_200ul_flat/2.json
@@ -1021,6 +1021,11 @@
       "x": 0,
       "y": 0,
       "z": 6.7
+    },
+    "opentrons_aluminum_flat_bottom_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 2.3
     }
   }
 }

--- a/shared-data/labware/definitions/2/nest_96_wellplate_200ul_flat/2.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_200ul_flat/2.json
@@ -1025,7 +1025,7 @@
     "opentrons_aluminum_flat_bottom_plate": {
       "x": 0,
       "y": 0,
-      "z": 2.3
+      "z": 5.55
     }
   }
 }

--- a/shared-data/labware/definitions/2/opentrons_aluminum_flat_bottom_plate/1.json
+++ b/shared-data/labware/definitions/2/opentrons_aluminum_flat_bottom_plate/1.json
@@ -13,7 +13,7 @@
   "dimensions": {
     "xDimension": 134,
     "yDimension": 92,
-    "zDimension": 7.95
+    "zDimension": 11.2
   },
   "wells": {},
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_aluminum_flat_bottom_plate/1.json
+++ b/shared-data/labware/definitions/2/opentrons_aluminum_flat_bottom_plate/1.json
@@ -1,0 +1,41 @@
+{
+  "ordering": [],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Opentrons Aluminum Flat Bottom Plate",
+    "displayCategory": "adapter",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 134,
+    "yDimension": 92,
+    "zDimension": 7.95
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_aluminum_flat_bottom_plate"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "allowedRoles": ["adapter"],
+  "cornerOffsetFromSlot": {
+    "x": -3,
+    "y": -3,
+    "z": 0
+  }
+}


### PR DESCRIPTION
# Overview

This PR adds the aluminum flat bottom plate for the temperature module (as seen [here](https://shop.opentrons.com/aluminum-block-set/)) and the relevant stacking overlaps for all compatible labware. Measurements were obtained from the DVT extant spreadsheet plus measurements obtained from solidworks.

# Test Plan

Was able to test the Corning 384 Flat Plate and the Nest 96 200ul Flat Plate with the following script, which both moves the pipette to well A1 and picks up the labware to and from the adapter. LPC offsets needed were all below 0.5mm.

```
metadata = {
    'protocolName': 'Temp Module Flat Bottom Adapter Test',
}


requirements = {
	"robotType": "Flex",
	"apiLevel": "2.15"
}


WELL_PLATE_LOAD_NAME = 'corning_384_wellplate_112ul_flat'
#WELL_PLATE_LOAD_NAME = 'nest_96_wellplate_200ul_flat'


def run(context):
    temp_deck = context.load_module('temperatureModuleV2', 'D3')
    flat_plate = temp_deck.load_adapter('opentrons_aluminum_flat_bottom_plate')

    well_plate = context.load_labware(WELL_PLATE_LOAD_NAME, 'D2')

    tiprack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'C3')
    pipette = context.load_instrument("p50_single_flex", "left", tip_racks=[tiprack])

    pipette.pick_up_tip()

    pipette.move_to(well_plate.wells()[0].top())

    context.delay(seconds=5)

    context.move_labware(well_plate, flat_plate, use_gripper=True)

    pipette.move_to(well_plate.wells()[0].top())

    context.delay(seconds=5)

    context.move_labware(well_plate, 'C2', use_gripper=True)

    pipette.return_tip()
```

# Changelog

- Added adapter definition for `opentrons_aluminum_flat_bottom_plate`
- Added `stackingOffsetWithLabware` for compatible flat plate adapters

# Review requests

The name of the new adapter might need some tweaking, and I was only able to get my hands on the Corning 384 Flat Plate and the Nest 96 200ul to physically test, though I calculated all the stacking overlaps the same way from the same source.

# Risk assessment

Low, mostly shared-data definition additions and a small change to protocol API to load the correct versions for new labware definition versions added.