### PR TITLE
fix(app): labware render viewbox adjustment

### DIFF
--- a/app/src/organisms/LabwareDetails/Gallery.tsx
+++ b/app/src/organisms/LabwareDetails/Gallery.tsx
@@ -21,13 +21,17 @@ export interface GalleryProps {
 
 export function Gallery(props: GalleryProps): JSX.Element {
   const { definition } = props
-  const { parameters: params, dimensions: dims } = definition
+  const {
+    parameters: params,
+    dimensions: dims,
+    cornerOffsetFromSlot,
+  } = definition
   const [currentImage, setCurrentImage] = React.useState<number>(0)
   const render = (
     <Box width="100%">
       <RobotWorkSpace
         key="center"
-        viewBox={`0 0 ${String(dims.xDimension)} ${String(dims.yDimension)}`}
+        viewBox={`${cornerOffsetFromSlot.x} ${cornerOffsetFromSlot.y} ${dims.xDimension} ${dims.yDimension}`}
       >
         {() => <LabwareRender definition={definition} />}
       </RobotWorkSpace>


### PR DESCRIPTION
# Overview

Noticed that the labware view of adapter in the labware tab's slideouts of the desktop app was not positioned properly for adapters. I must've missed this case when i went through and fixed it for other labware renders.

# Test Plan

Open the desktop app, go to the labware tab. Click on an adapter definition. See that the adapter render in the slideout is positioned properly.

Before:
<img width="931" alt="Screen Shot 2023-09-15 at 4 55 55 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/983efcfe-a48f-4094-9123-f93c21e8a738">

After:
<img width="933" alt="Screen Shot 2023-09-15 at 4 55 33 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/49cd8520-59fa-4284-a153-108ec87df93f">


# Changelog

changed viewbox coordinates

# Review requests

see test plan

# Risk assessment

low