### PR TITLE
feat(protocol-designer): 96 flat bottom adapter support + waitForTemp…

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -78,6 +78,7 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'opentrons_24_aluminumblock_nest_2ml_screwcap',
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
+    'opentrons_aluminum_flat_bottom_plate',
   ],
   [MAGNETIC_MODULE_TYPE]: [
     'nest_96_wellplate_100ul_pcr_full_skirt',

--- a/protocol-designer/src/components/listButtons.css
+++ b/protocol-designer/src/components/listButtons.css
@@ -1,7 +1,7 @@
 @import '@opentrons/components';
 
 .list_item_button {
-  z-index: 10;
+  z-index: 1;
   position: relative;
   padding: 1rem 2rem 1.25rem 2rem;
 }

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -248,12 +248,16 @@ export function getAllModuleSlotsByType(
       moduleType === HEATERSHAKER_MODULE_TYPE ||
       moduleType === TEMPERATURE_MODULE_TYPE
     ) {
-      slot = HS_AND_TEMP_SLOTS_FLEX.filter(
-        s => s.value !== supportedSlotOption[0].value
+      slot = supportedSlotOption.concat(
+        HS_AND_TEMP_SLOTS_FLEX.filter(
+          s => s.value !== supportedSlotOption[0].value
+        )
       )
     } else {
-      slot = MAG_BLOCK_SLOTS_FLEX.filter(
-        s => s.value !== supportedSlotOption[0].value
+      slot = supportedSlotOption.concat(
+        MAG_BLOCK_SLOTS_FLEX.filter(
+          s => s.value !== supportedSlotOption[0].value
+        )
       )
     }
   }

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -474,6 +474,7 @@ describe('steps actions', () => {
           stepType: 'temperature',
           setTemperature: 'true',
           targetTemperature: 10,
+          moduleId: 'mockTemp',
         } as any)
       mockGetUnsavedFormIsPristineSetTempForm.mockReturnValue(true)
       mockGetRobotStateTimeline.mockReturnValue(mockRobotStateTimeline)
@@ -490,6 +491,7 @@ describe('steps actions', () => {
             setTemperature: 'true',
             stepType: 'temperature',
             targetTemperature: 10,
+            moduleId: 'mockTemp',
           },
           type: 'SAVE_STEP_FORM',
         },
@@ -558,6 +560,14 @@ describe('steps actions', () => {
         {
           payload: {
             update: {
+              moduleId: 'mockTemp',
+            },
+          },
+          type: 'CHANGE_FORM_INPUT',
+        },
+        {
+          payload: {
+            update: {
               pauseTemperature: 10,
             },
           },
@@ -568,6 +578,7 @@ describe('steps actions', () => {
             setTemperature: 'true',
             stepType: 'temperature',
             targetTemperature: 10,
+            moduleId: 'mockTemp',
           },
           type: 'SAVE_STEP_FORM',
         },

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -242,11 +242,11 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
       },
     })
   )
-  const tempId = unsavedSetTemperatureForm?.moduleId
+  const tempertureModuleId = unsavedSetTemperatureForm?.moduleId
   dispatch(
     changeFormInput({
       update: {
-        moduleId: tempId,
+        moduleId: tempertureModuleId,
       },
     })
   )

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -242,6 +242,14 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
       },
     })
   )
+  const tempId = unsavedSetTemperatureForm?.moduleId
+  dispatch(
+    changeFormInput({
+      update: {
+        moduleId: tempId,
+      },
+    })
+  )
   dispatch(
     changeFormInput({
       update: {

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -40,6 +40,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
     'opentrons_96_well_aluminum_block',
+    'opentrons_aluminum_flat_bottom_plate',
   ],
   [MAGNETIC_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',
@@ -82,6 +83,7 @@ const FLAT_BOTTOM_ADAPTER_LOADNAME = 'opentrons_96_flat_bottom_adapter'
 const PCR_ADAPTER_LOADNAME = 'opentrons_96_pcr_adapter'
 const UNIVERSAL_FLAT_ADAPTER_LOADNAME = 'opentrons_universal_flat_adapter'
 const ALUMINUM_BLOCK_96_LOADNAME = 'opentrons_96_well_aluminum_block'
+const ALUMINUM_FLAT_BOTTOM_PLATE = 'opentrons_aluminum_flat_bottom_plate'
 
 export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   string,
@@ -94,10 +96,20 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
+    'opentrons/nest_96_wellplate_200ul_flat/2',
   ],
   [ALUMINUM_BLOCK_96_LOADNAME]: [
     'opentrons/biorad_96_wellplate_200ul_pcr/2',
     'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',
+  ],
+  [ALUMINUM_FLAT_BOTTOM_PLATE]: [
+    'opentrons/corning_384_wellplate_112ul_flat/2',
+    'opentrons/corning_96_wellplate_360ul_flat/2',
+    'opentrons/corning_48_wellplate_1.6ml_flat/2',
+    'opentrons/corning_24_wellplate_3.4ml_flat/2',
+    'opentrons/corning_12_wellplate_6.9ml_flat/2',
+    'opentrons/corning_6_wellplate_16.8ml_flat/2',
+    'opentrons/nest_96_wellplate_200ul_flat/2',
   ],
 }
 
@@ -123,6 +135,16 @@ export const getAdapterLabwareIsAMatch = (
   const loadName = Object.values(allLabware).find(lab => lab.id === labwareId)
     ?.def.parameters.loadName
 
+  const aluminumFlatBottomLabwares = [
+    'corning_384_wellplate_112ul_flat',
+    'corning_96_wellplate_360ul_flat',
+    'corning_6_wellplate_16.8ml_flat',
+    'corning_384_wellplate_112ul_flat',
+    'corning_96_wellplate_360ul_flat',
+    'corning_6_wellplate_16.8ml_flat',
+    'nest_96_wellplate_200ul_flat',
+  ]
+
   const deepWellPair =
     loadName === DEEP_WELL_ADAPTER_LOADNAME &&
     draggedLabwareLoadname === 'nest_96_wellplate_2ml_deep'
@@ -134,18 +156,23 @@ export const getAdapterLabwareIsAMatch = (
     draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt'
   const universalPair =
     loadName === UNIVERSAL_FLAT_ADAPTER_LOADNAME &&
-    draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat'
+    (draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat' ||
+      draggedLabwareLoadname === 'nest_96_wellplate_200ul_flat')
   const aluminumBlock96Pairs =
     loadName === ALUMINUM_BLOCK_96_LOADNAME &&
     (draggedLabwareLoadname === 'biorad_96_wellplate_200ul_pcr' ||
       draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt')
+  const aluminumFlatBottomPlatePairs =
+    loadName === ALUMINUM_FLAT_BOTTOM_PLATE &&
+    aluminumFlatBottomLabwares.includes(draggedLabwareLoadname)
 
   if (
     deepWellPair ||
     flatBottomPair ||
     pcrPair ||
     universalPair ||
-    aluminumBlock96Pairs
+    aluminumBlock96Pairs ||
+    aluminumFlatBottomPlatePairs
   ) {
     return true
   } else {

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -96,6 +96,11 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
+    'opentrons/corning_96_wellplate_360ul_flat/2',
+    'opentrons/corning_48_wellplate_1.6ml_flat/2',
+    'opentrons/corning_24_wellplate_3.4ml_flat/2',
+    'opentrons/corning_12_wellplate_6.9ml_flat/2',
+    'opentrons/corning_6_wellplate_16.8ml_flat/2',
     'opentrons/nest_96_wellplate_200ul_flat/2',
   ],
   [ALUMINUM_BLOCK_96_LOADNAME]: [
@@ -135,7 +140,7 @@ export const getAdapterLabwareIsAMatch = (
   const loadName = Object.values(allLabware).find(lab => lab.id === labwareId)
     ?.def.parameters.loadName
 
-  const aluminumFlatBottomLabwares = [
+  const flatBottomLabwares = [
     'corning_384_wellplate_112ul_flat',
     'corning_96_wellplate_360ul_flat',
     'corning_6_wellplate_16.8ml_flat',
@@ -156,15 +161,14 @@ export const getAdapterLabwareIsAMatch = (
     draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt'
   const universalPair =
     loadName === UNIVERSAL_FLAT_ADAPTER_LOADNAME &&
-    (draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat' ||
-      draggedLabwareLoadname === 'nest_96_wellplate_200ul_flat')
+    flatBottomLabwares.includes(draggedLabwareLoadname)
   const aluminumBlock96Pairs =
     loadName === ALUMINUM_BLOCK_96_LOADNAME &&
     (draggedLabwareLoadname === 'biorad_96_wellplate_200ul_pcr' ||
       draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt')
   const aluminumFlatBottomPlatePairs =
     loadName === ALUMINUM_FLAT_BOTTOM_PLATE &&
-    aluminumFlatBottomLabwares.includes(draggedLabwareLoadname)
+    flatBottomLabwares.includes(draggedLabwareLoadname)
 
   if (
     deepWellPair ||

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -96,12 +96,13 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
-    'opentrons/corning_96_wellplate_360ul_flat/2',
-    'opentrons/corning_48_wellplate_1.6ml_flat/2',
-    'opentrons/corning_24_wellplate_3.4ml_flat/2',
-    'opentrons/corning_12_wellplate_6.9ml_flat/2',
-    'opentrons/corning_6_wellplate_16.8ml_flat/2',
     'opentrons/nest_96_wellplate_200ul_flat/2',
+    //  TODO(jr, 9/18/23): comment this out
+    // 'opentrons/corning_96_wellplate_360ul_flat/2',
+    // 'opentrons/corning_48_wellplate_1.6ml_flat/2',
+    // 'opentrons/corning_24_wellplate_3.4ml_flat/2',
+    // 'opentrons/corning_12_wellplate_6.9ml_flat/2',
+    // 'opentrons/corning_6_wellplate_16.8ml_flat/2',
   ],
   [ALUMINUM_BLOCK_96_LOADNAME]: [
     'opentrons/biorad_96_wellplate_200ul_pcr/2',
@@ -161,7 +162,8 @@ export const getAdapterLabwareIsAMatch = (
     draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt'
   const universalPair =
     loadName === UNIVERSAL_FLAT_ADAPTER_LOADNAME &&
-    flatBottomLabwares.includes(draggedLabwareLoadname)
+    (draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat' ||
+      draggedLabwareLoadname === 'nest_96_wellplate_200ul_flat')
   const aluminumBlock96Pairs =
     loadName === ALUMINUM_BLOCK_96_LOADNAME &&
     (draggedLabwareLoadname === 'biorad_96_wellplate_200ul_pcr' ||


### PR DESCRIPTION
… command fix

closes RAUT-726, RQA-1544, RQA-1650, RQA-1656

# Overview

Sorry to address multiple things in this PR but basically this:
1. adds support for the 96 flat bottom aluminum block adapter
2. fixes a bug where the `waitForTemperature` command was being assigned to the wrong module
3. fixes a UI issue with the step creation button
4. fixes bug where the module dropdown for which slot to go into when editing modules is wrong

# Test Plan

sandbox: https://sandbox.designer.opentrons.com/pd_96-flat-bottom-adapter-support/

For the adapter stuff:

Create a protocol for Flex or OT-2. Add a temperature module, thermocycler, magnetic module/block, and heater-shaker. In deck setup on the design tab, add the 96 Aluminum flat bottom plate. See that there are 7 options available for labware to put on top of it (6 corning and 1 NEST). Now, directly on the deck, add the 96 Aluminum flat bottom plate. See that those 7 options are also available. Now, check the modules, there SHOULD NOT be the 96 aluminum flat bottom plate option available. Also, mess around with dragging/dropping. Make sure that the only labware that can go on top of the adapter are the compatible labware.

For the `waitForTemperature` bug:

Create a Flex or OT-2 protocol with the heater-shaker and temperature module. Add a temperature command in the timeline for the temperature module and select "build pause now". Do the same thing for the heater-shaker and select "build pause now". Export the protocol. See in the json file that the `waitForTemperature` commands are assigned to the correct modules in the correct order. 

For the Step creation button bug:

Check the screenshots

Before:
<img width="1216" alt="Screen Shot 2023-09-18 at 12 28 19 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/72cd591a-7896-4930-aa6d-056bbaf63082">

After:
<img width="1249" alt="Screen Shot 2023-09-18 at 12 26 49 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/d28964dc-d415-46f8-8e81-efee6b4943b7">

# Changelog

- add compatible labware to the new aluminum block adapter
- change the zIndex on the step creation button
- plug in the moduleId in `saveSetTempFormWithAddedPauseUntilTemp` - we forgot to plug it in so it kept defaulting to the heater-shaker moduleId if both modules were in the protocol or using the temp module if the heater-shaker wasn't present.

# Review requests

see test plan

# Risk assessment

low