### PR TITLE
refactor(protocol-designer): edit module section fixes

### DIFF
--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -74,7 +74,7 @@ export function ModuleRow(props: Props): JSX.Element {
   // If this Module is a TC deck slot and spanning
   // populate all 4 slots individually
   if (slot === SPAN7_8_10_11_SLOT) {
-    slotDisplayName = 'Slot 7'
+    slotDisplayName = 'Slot 7,8,10,11'
     occupiedSlotsForMap = ['7', '8', '10', '11']
     //  TC on Flex
   } else if (isFlex && type === THERMOCYCLER_MODULE_TYPE && slot === 'B1') {

--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -78,6 +78,7 @@ export function ModuleRow(props: Props): JSX.Element {
     occupiedSlotsForMap = ['7', '8', '10', '11']
     //  TC on Flex
   } else if (isFlex && type === THERMOCYCLER_MODULE_TYPE && slot === 'B1') {
+    slotDisplayName = 'Slot A1+B1'
     occupiedSlotsForMap = ['A1', 'B1']
   }
   // If collisionSlots are populated, check which slot is occupied

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -140,20 +140,8 @@ const HEATER_SHAKER_SLOTS_OT2: DropdownOption[] = [
 ]
 const HS_AND_TEMP_SLOTS_FLEX: DropdownOption[] = [
   {
-    name: 'Slot D1',
-    value: 'D1',
-  },
-  {
-    name: 'Slot D3',
-    value: 'D3',
-  },
-  {
-    name: 'Slot C1',
-    value: 'C1',
-  },
-  {
-    name: 'Slot C3',
-    value: 'C3',
+    name: 'Slot A1',
+    value: 'A1',
   },
   {
     name: 'Slot B1',
@@ -164,35 +152,31 @@ const HS_AND_TEMP_SLOTS_FLEX: DropdownOption[] = [
     value: 'B3',
   },
   {
-    name: 'Slot A1',
-    value: 'A1',
+    name: 'Slot C1',
+    value: 'C1',
   },
-]
-
-const MAG_BLOCK_SLOTS_FLEX: DropdownOption[] = [
+  {
+    name: 'Slot C3',
+    value: 'C3',
+  },
   {
     name: 'Slot D1',
     value: 'D1',
   },
   {
-    name: 'Slot D2',
-    value: 'D2',
-  },
-  {
     name: 'Slot D3',
     value: 'D3',
   },
+]
+
+const MAG_BLOCK_SLOTS_FLEX: DropdownOption[] = [
   {
-    name: 'Slot C1',
-    value: 'C1',
+    name: 'Slot A1',
+    value: 'A1',
   },
   {
-    name: 'Slot C2',
-    value: 'C2',
-  },
-  {
-    name: 'Slot C3',
-    value: 'C3',
+    name: 'Slot A2',
+    value: 'A2',
   },
   {
     name: 'Slot B1',
@@ -207,12 +191,28 @@ const MAG_BLOCK_SLOTS_FLEX: DropdownOption[] = [
     value: 'B3',
   },
   {
-    name: 'Slot A1',
-    value: 'A1',
+    name: 'Slot C1',
+    value: 'C1',
   },
   {
-    name: 'Slot A2',
-    value: 'A2',
+    name: 'Slot C2',
+    value: 'C2',
+  },
+  {
+    name: 'Slot C3',
+    value: 'C3',
+  },
+  {
+    name: 'Slot D1',
+    value: 'D1',
+  },
+  {
+    name: 'Slot D2',
+    value: 'D2',
+  },
+  {
+    name: 'Slot D3',
+    value: 'D3',
   },
 ]
 export function getAllModuleSlotsByType(


### PR DESCRIPTION
closes RQA-1131 and RQA-1077

# Overview

Changes up a few things in edit module section in PD
1. change the text for TC GEN2 to say "A1 + B1" instead of "B1" and GEN1 should say "Slot 7,8,10,11" instead of "Slot 7" - these changes match the app
2. change order of slot drop down in edit module modal to go from D1 -> A1 to A1 -> D1

# Test Plan

Create a protocol on the Flex with a TC GEN2, look at the position in the module section, should say `A1+B1` for the slot. Add another module, make sure in the slot dropdown, the slots are listed alphabetically from top to bottom and that the correct slot position is highlighted on the map.

<img width="888" alt="Screen Shot 2023-09-18 at 3 44 27 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/78fc3bad-3eeb-47f5-8fc7-36b5e940cf23">
<img width="1118" alt="Screen Shot 2023-09-18 at 3 45 00 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/8f0fdbcf-6d0a-4fd9-8666-ead24ffb96bd">


# Changelog

- changed the order of listed slots for modules
- change slot display name for TCGEN2

# Review requests

see test plan

# Risk assessment

low