### PR TITLE
fix(api): Removal of OT3 to Flex load name handling

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -38,6 +38,7 @@ _APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
 class AmbiguousLoadLabwareParamsError(RuntimeError):
     """Error raised when specific labware parameters cannot be found due to multiple matching labware definitions."""
 
+
 def resolve(
     load_name: str,
     namespace: Optional[str],

--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -35,30 +35,8 @@ _APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
 }
 
 
-_MAP_OT3_TO_FLEX_LOAD_NAMES: Dict[str, str] = {
-    "opentrons_ot3_96_tiprack_50ul": "opentrons_flex_96_tiprack_50ul",
-    "opentrons_ot3_96_tiprack_200ul": "opentrons_flex_96_tiprack_200ul",
-    "opentrons_ot3_96_tiprack_1000ul": "opentrons_flex_96_tiprack_1000ul",
-}
-
-
 class AmbiguousLoadLabwareParamsError(RuntimeError):
     """Error raised when specific labware parameters cannot be found due to multiple matching labware definitions."""
-
-
-def resolve_loadname(load_name: str) -> str:
-    """Temporarily check for old Flex tiprack loadnames so that an error is not raised.
-
-    REMOVE FOR LAUNCH.
-    Args:
-        load_name: Load name of the labware.
-
-    Returns:
-        Either the updated loadname or the original loadname if no match.
-
-    """
-    return _MAP_OT3_TO_FLEX_LOAD_NAMES.get(load_name, load_name)
-
 
 def resolve(
     load_name: str,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -146,19 +146,15 @@ class ProtocolCore(
         """Load a labware using its identifying parameters."""
         load_location = self._convert_labware_location(location=location)
 
-        # TODO (lc 06-27-2023) Let's keep this around up to launch to
-        # make the user-facing name switching a bit easier for everyone.
-        mapped_load_name = load_labware_params.resolve_loadname(load_name)
-
         custom_labware_params = (
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
         namespace, version = load_labware_params.resolve(
-            mapped_load_name, namespace, version, custom_labware_params
+            load_name, namespace, version, custom_labware_params
         )
 
         load_result = self._engine_client.load_labware(
-            load_name=mapped_load_name,
+            load_name=load_name,
             location=load_location,
             namespace=namespace,
             version=version,

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -272,12 +272,6 @@ def test_load_labware(
     ).then_return(("some_namespace", 9001))
 
     decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
-
-    decoy.when(
         mock_engine_client.load_labware(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
             load_name="some_labware",
@@ -345,14 +339,8 @@ def test_load_labware_on_labware(
     ).then_return([EngineLabwareLoadParams("hello", "world", 654)])
 
     decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("labware_some")
-
-    decoy.when(
         load_labware_params.resolve(
-            "labware_some",
+            "some_labware",
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
@@ -362,7 +350,7 @@ def test_load_labware_on_labware(
     decoy.when(
         mock_engine_client.load_labware(
             location=OnLabwareLocation(labwareId="labware-id"),
-            load_name="labware_some",
+            load_name="some_labware",
             display_name="some_display_name",
             namespace="some_namespace",
             version=9001,
@@ -425,12 +413,6 @@ def test_load_labware_off_deck(
             [EngineLabwareLoadParams("hello", "world", 654)],
         )
     ).then_return(("some_namespace", 9001))
-
-    decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
 
     decoy.when(
         mock_engine_client.load_labware(
@@ -693,12 +675,6 @@ def test_load_labware_on_module(
     ).then_return(("some_namespace", 9001))
 
     decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
-
-    decoy.when(
         mock_engine_client.load_labware(
             location=ModuleLocation(moduleId="module-id"),
             load_name="some_labware",
@@ -771,12 +747,6 @@ def test_load_labware_on_non_connected_module(
             [EngineLabwareLoadParams("hello", "world", 654)],
         )
     ).then_return(("some_namespace", 9001))
-
-    decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
 
     decoy.when(
         mock_engine_client.load_labware(


### PR DESCRIPTION
Older naming conventions for tipracks supported load names utilizing "OT3" as an alias for "Flex", which this removes the definitions and handlers for.

# Overview
OT3 tiprack naming convention support removed to satisfy launch naming conventions. Required removal of all interactions with resolve_loadname handler alongside the relevant dictionary of names. 

Mapped names removed and reference to standard loaded name used instead. Load_name test data under test_protocol_core adjusted.

Of note, issue found in test_protocol_core under **test_load_labware_on_labware**. Originally, load_name provided was "labware_some" and was given to the resolution handler. This passed in unmodified build. Removal of references to resolve_loadname cause this test to fail, as the name "labware_some" would result in the following error:

**TypeError: cannot unpack non-iterable NoneType object**

This is corrected by adjusting the test case name to "some_labware" to prevent inconsistency between subject call and load name expectations, allowing the test to pass.

