### PR TITLE
feat(api,robot-server): check pipette offset consistency

### DIFF
--- a/api-client/src/instruments/types.ts
+++ b/api-client/src/instruments/types.ts
@@ -5,11 +5,11 @@ type Mount = 'left' | 'right' | 'extension'
 
 export interface InconsistentCalibrationFailure {
   kind: 'inconsistent-pipette-offset'
-  offsets: Map<'left'|'right', {x: number, y: number, z: number}>
+  offsets: Map<'left' | 'right', { x: number; y: number; z: number }>
   limit: number
 }
 
-export type CalibrationReasonabilityCheckFailure = |InconsistentCalibrationFailure
+export type CalibrationReasonabilityCheckFailure = InconsistentCalibrationFailure
 
 export interface SharedInstrumentData {
   mount: Mount

--- a/api-client/src/instruments/types.ts
+++ b/api-client/src/instruments/types.ts
@@ -3,6 +3,14 @@ export type InstrumentData = PipetteData | GripperData | BadPipette | BadGripper
 // pipettes module already exports type `Mount`
 type Mount = 'left' | 'right' | 'extension'
 
+export interface InconsistentCalibrationFailure {
+  kind: 'inconsistent-pipette-offset'
+  offsets: Map<'left'|'right', {x: number, y: number, z: number}>
+  limit: number
+}
+
+export type CalibrationReasonabilityCheckFailure = |InconsistentCalibrationFailure
+
 export interface SharedInstrumentData {
   mount: Mount
 }
@@ -13,6 +21,7 @@ export interface GripperData {
       offset: { x: number; y: number; z: number }
       source: string
       last_modified?: string
+      reasonability_check_failures?: null[]
     }
   }
   firmwareVersion?: string
@@ -32,6 +41,7 @@ export interface PipetteData {
       offset: { x: number; y: number; z: number }
       source: string
       last_modified?: string
+      reasonability_check_failures?: CalibrationReasonabilityCheckFailure[]
     }
   }
   firmwareVersion?: string

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -1,5 +1,6 @@
 import typing
-from dataclasses import dataclass
+from typing_extensions import Literal, Final
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from opentrons.config import feature_flags as ff
@@ -20,6 +21,18 @@ from opentrons.calibration_storage import (
 )
 from opentrons.hardware_control.types import OT3Mount
 
+PIPETTE_OFFSET_CONSISTENCY_LIMIT: Final = 1.5
+
+
+@dataclass
+class InconsistentPipetteOffsets:
+    kind: Literal["inconsistent-pipette-offset"]
+    offsets: typing.Dict[Mount, Point]
+    limit: float
+
+
+ReasonabilityCheckFailure = typing.Union[InconsistentPipetteOffsets]
+
 
 @dataclass
 class PipetteOffsetByPipetteMount:
@@ -31,6 +44,11 @@ class PipetteOffsetByPipetteMount:
     source: cal_top_types.SourceType
     status: cal_top_types.CalibrationStatus
     last_modified: typing.Optional[datetime] = None
+
+
+@dataclass
+class PipetteOffsetSummary(PipetteOffsetByPipetteMount):
+    reasonability_check_failures: typing.List[ReasonabilityCheckFailure] = field(default_factory=list)
 
 
 @dataclass
@@ -122,3 +140,25 @@ def save_gripper_calibration_offset(
 ) -> None:
     if gripper_id and ff.enable_ot3_hardware_controller():
         ot3_gripper_offset.save_gripper_calibration(delta, gripper_id)
+
+
+def check_instrument_offset_reasonability(
+    left_offset: Point, right_offset: Point
+) -> typing.List[ReasonabilityCheckFailure]:
+    if (
+        not left_offset
+        or left_offset == Point(0, 0, 0)
+        or not right_offset
+        or right_offset == Point(0, 0, 0)
+    ):
+        return []
+    diff = left_offset - right_offset
+    if any(abs(d) > PIPETTE_OFFSET_CONSISTENCY_LIMIT for d in diff):
+        return [
+            InconsistentPipetteOffsets(
+                "inconsistent-pipette-offset",
+                {Mount.LEFT: left_offset, Mount.RIGHT: right_offset},
+                PIPETTE_OFFSET_CONSISTENCY_LIMIT,
+            )
+        ]
+    return []

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -48,7 +48,9 @@ class PipetteOffsetByPipetteMount:
 
 @dataclass
 class PipetteOffsetSummary(PipetteOffsetByPipetteMount):
-    reasonability_check_failures: typing.List[ReasonabilityCheckFailure] = field(default_factory=list)
+    reasonability_check_failures: typing.List[ReasonabilityCheckFailure] = field(
+        default_factory=list
+    )
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -201,7 +201,7 @@ class OT3PipetteHandler:
         offset_data: PipetteOffsetByPipetteMount,
     ) -> PipetteOffsetSummary:
         if mount == OT3Mount.LEFT:
-            other_pipette = self.get_pipette(OT3Mount.RIGHT)
+            other_pipette = self._attached_instruments.get(OT3Mount.RIGHT, None)
             if other_pipette:
                 other_offset = other_pipette.pipette_offset.offset
             else:
@@ -210,7 +210,7 @@ class OT3PipetteHandler:
                 offset_data.offset, other_offset
             )
         else:
-            other_pipette = self.get_pipette(OT3Mount.LEFT)
+            other_pipette = self._attached_instruments.get(OT3Mount.LEFT, None)
             if other_pipette:
                 other_offset = other_pipette.pipette_offset.offset
             else:

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -45,7 +45,11 @@ from opentrons.hardware_control.constants import (
 
 from opentrons.hardware_control.dev_types import PipetteDict
 from .pipette import Pipette
-from .instrument_calibration import PipetteOffsetByPipetteMount
+from .instrument_calibration import (
+    PipetteOffsetSummary,
+    PipetteOffsetByPipetteMount,
+    check_instrument_offset_reasonability,
+)
 
 
 MOD_LOG = logging.getLogger(__name__)
@@ -159,16 +163,16 @@ class OT3PipetteHandler:
         else:
             _reset(mount)
 
-    def get_instrument_offset(
-        self, mount: OT3Mount
-    ) -> Optional[PipetteOffsetByPipetteMount]:
+    def get_instrument_offset(self, mount: OT3Mount) -> Optional[PipetteOffsetSummary]:
         """Get the specified pipette's offset."""
         assert mount != OT3Mount.GRIPPER, "Wrong mount type to fetch pipette offset"
         try:
             pipette = self.get_pipette(mount)
         except top_types.PipetteNotAttachedError:
             return None
-        return pipette.pipette_offset
+        return self._return_augmented_offset_data(
+            pipette, mount, pipette.pipette_offset
+        )
 
     def reset_instrument_offset(self, mount: OT3Mount, to_default: bool) -> None:
         """
@@ -180,14 +184,47 @@ class OT3PipetteHandler:
 
     def save_instrument_offset(
         self, mount: OT3Mount, delta: top_types.Point
-    ) -> PipetteOffsetByPipetteMount:
+    ) -> PipetteOffsetSummary:
         """
         Save a new instrument offset the pipette offset to a particular value.
         :param mount: Modify the given mount.
         :param delta: The offset to set for the pipette.
         """
         pipette = self.get_pipette(mount)
-        return pipette.save_pipette_offset(mount, delta)
+        offset_data = pipette.save_pipette_offset(mount, delta)
+        return self._return_augmented_offset_data(pipette, mount, offset_data)
+
+    def _return_augmented_offset_data(
+        self,
+        pipette: Pipette,
+        mount: OT3Mount,
+        offset_data: PipetteOffsetByPipetteMount,
+    ) -> PipetteOffsetSummary:
+        if mount == OT3Mount.LEFT:
+            other_pipette = self.get_pipette(OT3Mount.RIGHT)
+            if other_pipette:
+                other_offset = other_pipette.pipette_offset.offset
+            else:
+                other_offset = top_types.Point(0, 0, 0)
+            reasonability = check_instrument_offset_reasonability(
+                offset_data.offset, other_offset
+            )
+        else:
+            other_pipette = self.get_pipette(OT3Mount.LEFT)
+            if other_pipette:
+                other_offset = other_pipette.pipette_offset.offset
+            else:
+                other_offset = top_types.Point(0, 0, 0)
+            reasonability = check_instrument_offset_reasonability(
+                other_offset, offset_data.offset
+            )
+        return PipetteOffsetSummary(
+            offset=offset_data.offset,
+            source=offset_data.source,
+            status=offset_data.status,
+            last_modified=offset_data.last_modified,
+            reasonability_check_failures=reasonability,
+        )
 
     # TODO(mc, 2022-01-11): change returned map value type to `Optional[PipetteDict]`
     # instead of potentially returning an empty dict

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -62,7 +62,7 @@ from .instruments.ot3.pipette import (
 from .instruments.ot3.gripper import compare_gripper_config_and_check_skip, Gripper
 from .instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
-    PipetteOffsetByPipetteMount,
+    PipetteOffsetSummary,
 )
 from .backends.ot3controller import OT3Controller
 from .backends.ot3simulator import OT3Simulator
@@ -2040,7 +2040,7 @@ class OT3API(
 
     def get_instrument_offset(
         self, mount: OT3Mount
-    ) -> Union[GripperCalibrationOffset, PipetteOffsetByPipetteMount, None]:
+    ) -> Union[GripperCalibrationOffset, PipetteOffsetSummary, None]:
         """Get instrument calibration data."""
         # TODO (spp, 2023-04-19): We haven't introduced a 'calibration_offset' key in
         #  PipetteDict because the dict is shared with OT2 pipettes which have
@@ -2066,7 +2066,7 @@ class OT3API(
 
     async def save_instrument_offset(
         self, mount: Union[top_types.Mount, OT3Mount], delta: top_types.Point
-    ) -> Union[GripperCalibrationOffset, PipetteOffsetByPipetteMount]:
+    ) -> Union[GripperCalibrationOffset, PipetteOffsetSummary]:
         """Save a new offset for a given instrument."""
         checked_mount = OT3Mount.from_mount(mount)
         if checked_mount == OT3Mount.GRIPPER:

--- a/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
@@ -16,10 +16,13 @@ from opentrons_shared_data.labware.labware_definition import (
 )
 
 
-from opentrons import calibration_storage
+from opentrons import calibration_storage, types as top_types
 from opentrons.calibration_storage import helpers as calibration_storage_helpers
 from opentrons.calibration_storage.ot2.models import v1 as v1_models
 from opentrons.hardware_control.instruments.ot2 import instrument_calibration as subject
+from opentrons.hardware_control.instruments.ot3 import (
+    instrument_calibration as subject_ot3,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -110,3 +113,35 @@ def test_load_tip_length(
             markedAt=datetime(year=2023, month=2, day=2),
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "left,right,ok",
+    [
+        # If either point is all 0 (uncalibrated) then the check should pass
+        (top_types.Point(0, 0, 0), top_types.Point(0, 0, 2), True),
+        (top_types.Point(0, 0, 2), top_types.Point(0, 0, 0), True),
+        (top_types.Point(0, 0, 0), top_types.Point(0, 0, 0), True),
+        # If both points are non-zero but all values are within the range the
+        # check should pass
+        (top_types.Point(0, 1.0, 1.5), top_types.Point(-1, 0, 0.2), True),
+        # If both points are non-zero but at least one element is more than
+        # the range different the test should fail
+        (top_types.Point(0.1, -1, 1.5), top_types.Point(1.7, 0, 0.2), False),
+        (top_types.Point(0.1, -1, 1.5), top_types.Point(0.6, 0.6, 1.3), False),
+        (top_types.Point(0.1, -1, 1.5), top_types.Point(-0.2, -0.1, 5), False),
+    ],
+)
+def test_instrument_consistency_check_ot3(
+    left: top_types.Point, right: top_types.Point, ok: bool
+) -> None:
+    result = subject_ot3.check_instrument_offset_reasonability(left, right)
+    if ok:
+        assert result == []
+    else:
+        assert result[0].kind == "inconsistent-pipette-offset"
+        assert result[0].offsets == {
+            top_types.Mount.LEFT: left,
+            top_types.Mount.RIGHT: right,
+        }
+        assert result[0].limit == 1.5

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -16,7 +16,7 @@ from opentrons.hardware_control.dev_types import (
 )
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
-    PipetteOffsetByPipetteMount,
+    PipetteOffsetSummary,
 )
 from opentrons.hardware_control.types import GripperJawState, OT3Mount
 from opentrons.protocol_engine.types import Vec3f
@@ -187,21 +187,23 @@ async def test_get_all_attached_instruments(
         rehearse_instrument_retrievals
     )
     decoy.when(ot3_hardware_api.get_instrument_offset(mount=OT3Mount.LEFT)).then_return(
-        PipetteOffsetByPipetteMount(
+        PipetteOffsetSummary(
             offset=Point(1, 2, 3),
             source=SourceType.default,
             status=CalibrationStatus(),
             last_modified=None,
+            reasonability_check_failures=[],
         )
     )
     decoy.when(
         ot3_hardware_api.get_instrument_offset(mount=OT3Mount.RIGHT)
     ).then_return(
-        PipetteOffsetByPipetteMount(
+        PipetteOffsetSummary(
             offset=Point(4, 5, 6),
             source=SourceType.default,
             status=CalibrationStatus(),
             last_modified=None,
+            reasonability_check_failures=[],
         )
     )
     result = await get_attached_instruments(hardware=ot3_hardware_api)
@@ -224,6 +226,7 @@ async def test_get_all_attached_instruments(
                     offset=Vec3f(x=1, y=2, z=3),
                     source=SourceType.default,
                     last_modified=None,
+                    reasonability_check_failures=[],
                 ),
             ),
             state=PipetteState(tip_detected=True),
@@ -245,6 +248,7 @@ async def test_get_all_attached_instruments(
                     offset=Vec3f(x=4, y=5, z=6),
                     source=SourceType.default,
                     last_modified=None,
+                    reasonability_check_failures=[],
                 ),
             ),
             state=PipetteState(tip_detected=False),
@@ -263,6 +267,7 @@ async def test_get_all_attached_instruments(
                     offset=Vec3f(x=1, y=2, z=3),
                     source=SourceType.default,
                     last_modified=None,
+                    reasonability_check_failures=[],
                 ),
             ),
         ),


### PR DESCRIPTION
Add a basic instrument offset consistency check to drive UI indicating that an instrument may be miscalibrated and the user should run calibration.

This checks the consistency between the calibrated pipette offsets of the left and right pipettes. It detects a problem if
- There are two pipettes
- Both are calibrated
- Their calibration offsets differ by more than 1.5mm in any axis (this is tunable)

In other situations they succeed.

The outcome of this check shouldn't be treated as definitely meaning a calibration is bad; rather, it can serve as a hint that a user might want to retry calibration (so for instance if we display a banner on this it should be dismissable).

Closes RAUT-738

## Testing
- [x] Check that a robot with two pipettes with similar offsets passes
- [x] Check that a robot with two pipettes with different enough offsets fails
- [x] Check that a robot with one pipette passes
- [x] Take an inventory of robots and see if 1.5 is appropriate
