### PR TITLE
feat(api-client, app, react-api-client): Feat add robot door status check to desktop and odd

### DIFF
--- a/api-client/src/robot/getDoorStatus.ts
+++ b/api-client/src/robot/getDoorStatus.ts
@@ -1,0 +1,9 @@
+import { GET, request } from '../request'
+
+import type { ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+import type { DoorStatus } from './types'
+
+export function getDoorStatus(config: HostConfig): ResponsePromise<DoorStatus> {
+  return request<DoorStatus>(GET, '/robot/door/status', null, config)
+}

--- a/api-client/src/robot/index.ts
+++ b/api-client/src/robot/index.ts
@@ -1,8 +1,10 @@
+export { getDoorStatus } from './getDoorStatus'
 export { getEstopStatus } from './getEstopStatus'
 export { acknowledgeEstopDisengage } from './acknowledgeEstopDisengage'
 export { getLights } from './getLights'
 export { setLights } from './setLights'
 export type {
+  DoorStatus,
   EstopPhysicalStatus,
   EstopState,
   EstopStatus,

--- a/api-client/src/robot/types.ts
+++ b/api-client/src/robot/types.ts
@@ -1,3 +1,8 @@
+export interface DoorStatus {
+  data: {
+    status: 'open' | 'closed'
+  }
+}
 export type EstopState =
   | 'physicallyEngaged'
   | 'logicallyEngaged'

--- a/api-client/src/robot/types.ts
+++ b/api-client/src/robot/types.ts
@@ -1,6 +1,7 @@
 export interface DoorStatus {
   data: {
     status: 'open' | 'closed'
+    doorRequiredClosedForProtocol: boolean
   }
 }
 export type EstopState =

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -6,7 +6,7 @@
   "browse": "browse",
   "cancel": "cancel",
   "clear_data": "clear data",
-  "close_robot_door": "Close the robot door before starting the run",
+  "close_robot_door": "Close the robot door before starting the run.",
   "close": "close",
   "computer_in_app_is_controlling_robot": "A computer with the Opentrons App is currently controlling this robot.",
   "confirm_placement": "Confirm placement",

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -6,6 +6,7 @@
   "browse": "browse",
   "cancel": "cancel",
   "clear_data": "clear data",
+  "close_robot_door": "Close the robot door before starting the run",
   "close": "close",
   "computer_in_app_is_controlling_robot": "A computer with the Opentrons App is currently controlling this robot.",
   "confirm_placement": "Confirm placement",

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -143,7 +143,7 @@ export function ProtocolRunHeader({
   const { data: doorStatus } = useDoorQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })
-  const isDoorOpen = doorStatus?.data.status === 'open' && doorStatus.?data.doorRequiredClosedForProtocol
+  const isDoorOpen = doorStatus?.data.status === 'open' && doorStatus?.data.doorRequiredClosedForProtocol
 
   React.useEffect(() => {
     if (protocolData != null && !isRobotViewable) {

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -143,7 +143,9 @@ export function ProtocolRunHeader({
   const { data: doorStatus } = useDoorQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })
-  const isDoorOpen = doorStatus?.data.status === 'open' && doorStatus?.data.doorRequiredClosedForProtocol
+  const isDoorOpen =
+    doorStatus?.data.status === 'open' &&
+    doorStatus?.data.doorRequiredClosedForProtocol
 
   React.useEffect(() => {
     if (protocolData != null && !isRobotViewable) {

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -16,7 +16,11 @@ import {
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   RunStatus,
 } from '@opentrons/api-client'
-import { useRunQuery, useModulesQuery } from '@opentrons/react-api-client'
+import {
+  useRunQuery,
+  useModulesQuery,
+  useDoorQuery,
+} from '@opentrons/react-api-client'
 import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
 import {
   Box,
@@ -85,11 +89,11 @@ import { RunTimer } from './RunTimer'
 import { EMPTY_TIMESTAMP } from '../constants'
 import { getHighestPriorityError } from '../../OnDeviceDisplay/RunningProtocol'
 import { RunFailedModal } from './RunFailedModal'
+import { RunProgressMeter } from '../../RunProgressMeter'
 
 import type { Run, RunError } from '@opentrons/api-client'
 import type { State } from '../../../redux/types'
 import type { HeaterShakerModule } from '../../../redux/modules/types'
-import { RunProgressMeter } from '../../RunProgressMeter'
 
 const EQUIPMENT_POLL_MS = 5000
 const CANCELLABLE_STATUSES = [
@@ -113,7 +117,7 @@ export function ProtocolRunHeader({
   runId,
   makeHandleJumpToStep,
 }: ProtocolRunHeaderProps): JSX.Element | null {
-  const { t } = useTranslation('run_details')
+  const { t } = useTranslation(['run_details', 'shared'])
   const history = useHistory()
   const createdAtTimestamp = useRunCreatedAtTimestamp(runId)
   const {
@@ -136,6 +140,10 @@ export function ProtocolRunHeader({
     runRecord?.data.errors?.[0] != null
       ? getHighestPriorityError(runRecord?.data?.errors)
       : null
+  const { data: doorStatus } = useDoorQuery({
+    refetchInterval: EQUIPMENT_POLL_MS,
+  })
+  const isDoorClosed = doorStatus?.data.status === 'closed'
 
   React.useEffect(() => {
     if (protocolData != null && !isRobotViewable) {
@@ -258,6 +266,9 @@ export function ProtocolRunHeader({
         {runStatus === RUN_STATUS_STOPPED ? (
           <Banner type="warning">{t('run_canceled')}</Banner>
         ) : null}
+        {!isDoorClosed ? (
+          <Banner type="warning">{t('shared:close_robot_door')}</Banner>
+        ) : null}
         {isRunCurrent ? (
           <TerminalRunBanner
             {...{
@@ -289,6 +300,7 @@ export function ProtocolRunHeader({
               isProtocolAnalyzing={
                 protocolData == null || !!isProtocolAnalyzing
               }
+              isDoorClosed={isDoorClosed}
             />
           </Flex>
         </Box>
@@ -412,9 +424,16 @@ interface ActionButtonProps {
   robotName: string
   runStatus: RunStatus | null
   isProtocolAnalyzing: boolean
+  isDoorClosed: boolean
 }
 function ActionButton(props: ActionButtonProps): JSX.Element {
-  const { runId, robotName, runStatus, isProtocolAnalyzing } = props
+  const {
+    runId,
+    robotName,
+    runStatus,
+    isProtocolAnalyzing,
+    isDoorClosed,
+  } = props
   const history = useHistory()
   const { t } = useTranslation(['run_details', 'shared'])
   const attachedModules =
@@ -463,7 +482,8 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     isOtherRunCurrent ||
     isProtocolAnalyzing ||
     (runStatus != null && DISABLED_STATUSES.includes(runStatus)) ||
-    isRobotOnWrongVersionOfSoftware
+    isRobotOnWrongVersionOfSoftware ||
+    !isDoorClosed
   const handleProceedToRunClick = (): void => {
     trackEvent({ name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN, properties: {} })
     play()

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -143,7 +143,7 @@ export function ProtocolRunHeader({
   const { data: doorStatus } = useDoorQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })
-  const isDoorClosed = doorStatus?.data.status === 'closed'
+  const isDoorOpen = doorStatus?.data.status === 'open'
 
   React.useEffect(() => {
     if (protocolData != null && !isRobotViewable) {
@@ -266,7 +266,7 @@ export function ProtocolRunHeader({
         {runStatus === RUN_STATUS_STOPPED ? (
           <Banner type="warning">{t('run_canceled')}</Banner>
         ) : null}
-        {!isDoorClosed ? (
+        {isDoorOpen ? (
           <Banner type="warning">{t('shared:close_robot_door')}</Banner>
         ) : null}
         {isRunCurrent ? (
@@ -300,7 +300,7 @@ export function ProtocolRunHeader({
               isProtocolAnalyzing={
                 protocolData == null || !!isProtocolAnalyzing
               }
-              isDoorClosed={isDoorClosed}
+              isDoorOpen={isDoorOpen}
             />
           </Flex>
         </Box>
@@ -424,16 +424,10 @@ interface ActionButtonProps {
   robotName: string
   runStatus: RunStatus | null
   isProtocolAnalyzing: boolean
-  isDoorClosed: boolean
+  isDoorOpen: boolean
 }
 function ActionButton(props: ActionButtonProps): JSX.Element {
-  const {
-    runId,
-    robotName,
-    runStatus,
-    isProtocolAnalyzing,
-    isDoorClosed,
-  } = props
+  const { runId, robotName, runStatus, isProtocolAnalyzing, isDoorOpen } = props
   const history = useHistory()
   const { t } = useTranslation(['run_details', 'shared'])
   const attachedModules =
@@ -483,7 +477,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     isProtocolAnalyzing ||
     (runStatus != null && DISABLED_STATUSES.includes(runStatus)) ||
     isRobotOnWrongVersionOfSoftware ||
-    !isDoorClosed
+    isDoorOpen
   const handleProceedToRunClick = (): void => {
     trackEvent({ name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN, properties: {} })
     play()

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -143,7 +143,7 @@ export function ProtocolRunHeader({
   const { data: doorStatus } = useDoorQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })
-  const isDoorOpen = doorStatus?.data.status === 'open'
+  const isDoorOpen = doorStatus?.data.status === 'open' && doorStatus.?data.doorRequiredClosedForProtocol
 
   React.useEffect(() => {
     if (protocolData != null && !isRobotViewable) {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -855,6 +855,6 @@ describe('ProtocolRunHeader', () => {
     }
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
     const [{ getByText }] = render()
-    getByText('Close the robot door before starting the run')
+    getByText('Close the robot door before starting the run.')
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -242,6 +242,7 @@ const mockEstopStatus = {
 const mockDoorStatus = {
   data: {
     status: 'closed',
+    doorRequiredClosedForProtocol: true,
   },
 }
 
@@ -849,7 +850,9 @@ describe('ProtocolRunHeader', () => {
   })
 
   it('renders banner when the robot door is open', () => {
-    const mockOpenDoorStatus = { data: { status: 'open' } }
+    const mockOpenDoorStatus = {
+      data: { status: 'open', doorRequiredClosedForProtocol: true },
+    }
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
     const [{ getByText }] = render()
     getByText('Close the robot door before starting the run')

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -21,6 +21,7 @@ import {
   usePipettesQuery,
   useDismissCurrentRunMutation,
   useEstopQuery,
+  useDoorQuery,
 } from '@opentrons/react-api-client'
 import _uncastedSimpleV6Protocol from '@opentrons/shared-data/protocol/fixtures/6/simpleV6.json'
 
@@ -188,6 +189,9 @@ const mockUseEstopQuery = useEstopQuery as jest.MockedFunction<
   typeof useEstopQuery
 >
 const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
+const mockUseDoorQuery = useDoorQuery as jest.MockedFunction<
+  typeof useDoorQuery
+>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -233,6 +237,11 @@ const mockEstopStatus = {
     status: DISENGAGED,
     leftEstopPhysicalStatus: DISENGAGED,
     rightEstopPhysicalStatus: NOT_PRESENT,
+  },
+}
+const mockDoorStatus = {
+  data: {
+    status: 'closed',
   },
 }
 
@@ -344,6 +353,7 @@ describe('ProtocolRunHeader', () => {
     mockUseIsOT3.mockReturnValue(true)
     mockRunFailedModal.mockReturnValue(<div>mock RunFailedModal</div>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
+    mockUseDoorQuery.mockReturnValue({ data: mockDoorStatus })
   })
 
   afterEach(() => {
@@ -836,5 +846,12 @@ describe('ProtocolRunHeader', () => {
     const [{ getByText, getByLabelText }] = render()
     getByText('Run completed.')
     getByLabelText('ot-spinner')
+  })
+
+  it('renders banner when the robot door is open', () => {
+    const mockOpenDoorStatus = { data: { status: 'open' } }
+    mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
+    const [{ getByText }] = render()
+    getByText('Close the robot door before starting the run')
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -353,7 +353,7 @@ describe('ProtocolRunHeader', () => {
     mockUseIsOT3.mockReturnValue(true)
     mockRunFailedModal.mockReturnValue(<div>mock RunFailedModal</div>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
-    mockUseDoorQuery.mockReturnValue({ data: mockDoorStatus })
+    mockUseDoorQuery.mockReturnValue({ data: mockDoorStatus } as any)
   })
 
   afterEach(() => {

--- a/app/src/organisms/ToasterOven/ToasterContext.ts
+++ b/app/src/organisms/ToasterOven/ToasterContext.ts
@@ -30,4 +30,8 @@ export const ToasterContext = React.createContext<ToasterContextType>({
 
 export type MakeSnackbarOptions = Omit<SnackbarProps, 'message'>
 
-type MakeSnackbar = (message: string, options?: MakeSnackbarOptions) => void
+type MakeSnackbar = (
+  message: string,
+  duration?: number,
+  options?: MakeSnackbarOptions
+) => void

--- a/app/src/organisms/ToasterOven/ToasterOven.tsx
+++ b/app/src/organisms/ToasterOven/ToasterOven.tsx
@@ -74,8 +74,12 @@ export function ToasterOven({ children }: ToasterOvenProps): JSX.Element {
     return id
   }
 
-  function makeSnackbar(message: string, options?: MakeSnackbarOptions): void {
-    setSnackbar({ message, ...options })
+  function makeSnackbar(
+    message: string,
+    duration?: number,
+    options?: MakeSnackbarOptions
+  ): void {
+    setSnackbar({ message, duration, ...options })
   }
 
   // This function is needed to actually make the snackbar auto-close in the context of the

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -195,6 +195,7 @@ const mockOffset = {
 const mockDoorStatus = {
   data: {
     status: 'closed',
+    doorRequiredClosedForProtocol: true,
   },
 }
 const MOCK_MAKE_SNACKBAR = jest.fn()
@@ -378,6 +379,7 @@ describe('ProtocolSetup', () => {
     const mockOpenDoorStatus = {
       data: {
         status: 'open',
+        doorRequiredClosedForProtocol: true,
       },
     }
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -197,8 +197,7 @@ const mockDoorStatus = {
     status: 'closed',
   },
 }
-const MOCK_MAKE_TOAST = jest.fn()
-const MOCK_EAT_TOAST = jest.fn()
+const MOCK_MAKE_SNACKBAR = jest.fn()
 
 describe('ProtocolSetup', () => {
   let mockLaunchLPC: jest.Mock
@@ -282,9 +281,8 @@ describe('ProtocolSetup', () => {
     when(mockUseToaster)
       .calledWith()
       .mockReturnValue(({
-        makeToast: MOCK_MAKE_TOAST,
-        eatToast: MOCK_EAT_TOAST,
-      } as unknown) as ToasterContextType)
+        makeSnackbar: MOCK_MAKE_SNACKBAR,
+      } as unknown) as any)
   })
 
   afterEach(() => {
@@ -384,13 +382,9 @@ describe('ProtocolSetup', () => {
     }
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
     const [{ getByRole }] = render(`/runs/${RUN_ID}/setup/`)
-    expect(MOCK_MAKE_TOAST).toBeCalledWith(
+    expect(MOCK_MAKE_SNACKBAR).toBeCalledWith(
       'Close the robot door before starting the run',
-      'warning',
-      {
-        closeButton: false,
-        disableTimeout: true,
-      }
+      7000
     )
     expect(getByRole('button', { name: 'play' })).toBeDisabled()
   })

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -9,12 +9,14 @@ import {
   useInstrumentsQuery,
   useRunQuery,
   useProtocolQuery,
+  useDoorQuery,
 } from '@opentrons/react-api-client'
 import { renderWithProviders } from '@opentrons/components'
 import { getDeckDefFromRobotType } from '@opentrons/shared-data'
 import ot3StandardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot3_standard.json'
 
 import { i18n } from '../../../../i18n'
+import { useToaster } from '../../../../organisms/ToasterOven'
 import { mockRobotSideAnalysis } from '../../../../organisms/CommandText/__fixtures__'
 import {
   useAttachedModules,
@@ -70,6 +72,7 @@ jest.mock('../../../../organisms/ProtocolSetupLiquids')
 jest.mock('../../../../organisms/ModuleCard/hooks')
 jest.mock('../../../../redux/config')
 jest.mock('../ConfirmAttachedModal')
+jest.mock('../../../../organisms/ToasterOven')
 
 const mockGetDeckDefFromRobotType = getDeckDefFromRobotType as jest.MockedFunction<
   typeof getDeckDefFromRobotType
@@ -126,6 +129,10 @@ const mockUseIsHeaterShakerInProtocol = useIsHeaterShakerInProtocol as jest.Mock
 const mockConfirmAttachedModal = ConfirmAttachedModal as jest.MockedFunction<
   typeof ConfirmAttachedModal
 >
+const mockUseDoorQuery = useDoorQuery as jest.MockedFunction<
+  typeof useDoorQuery
+>
+const mockUseToaster = useToaster as jest.MockedFunction<typeof useToaster>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -184,6 +191,14 @@ const mockOffset = {
   location: { slotName: 'A1' },
   vector: { x: 1, y: 2, z: 3 },
 }
+
+const mockDoorStatus = {
+  data: {
+    status: 'closed',
+  },
+}
+const MOCK_MAKE_TOAST = jest.fn()
+const MOCK_EAT_TOAST = jest.fn()
 
 describe('ProtocolSetup', () => {
   let mockLaunchLPC: jest.Mock
@@ -263,6 +278,13 @@ describe('ProtocolSetup', () => {
     mockConfirmAttachedModal.mockReturnValue(
       <div>mock ConfirmAttachedModal</div>
     )
+    mockUseDoorQuery.mockReturnValue({ data: mockDoorStatus } as any)
+    when(mockUseToaster)
+      .calledWith()
+      .mockReturnValue(({
+        makeToast: MOCK_MAKE_TOAST,
+        eatToast: MOCK_EAT_TOAST,
+      } as unknown) as ToasterContextType)
   })
 
   afterEach(() => {
@@ -352,5 +374,24 @@ describe('ProtocolSetup', () => {
     mockUseMostRecentCompletedAnalysis.mockReturnValue(null)
     const [{ getAllByTestId }] = render(`/runs/${RUN_ID}/setup/`)
     expect(getAllByTestId('Skeleton').length).toBeGreaterThan(0)
+  })
+
+  it('should render toast and make a button disabled when a robot door is open', () => {
+    const mockOpenDoorStatus = {
+      data: {
+        status: 'open',
+      },
+    }
+    mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
+    const [{ getByRole }] = render(`/runs/${RUN_ID}/setup/`)
+    expect(MOCK_MAKE_TOAST).toBeCalledWith(
+      'Close the robot door before starting the run',
+      'warning',
+      {
+        closeButton: false,
+        disableTimeout: true,
+      }
+    )
+    expect(getByRole('button', { name: 'play' })).toBeDisabled()
   })
 })

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -385,7 +385,7 @@ describe('ProtocolSetup', () => {
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
     const [{ getByRole }] = render(`/runs/${RUN_ID}/setup/`)
     expect(MOCK_MAKE_SNACKBAR).toBeCalledWith(
-      'Close the robot door before starting the run',
+      'Close the robot door before starting the run.',
       7000
     )
     expect(getByRole('button', { name: 'play' })).toBeDisabled()

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -488,7 +488,9 @@ function PrepareToRun({
   const { data: doorStatus } = useDoorQuery({
     refetchInterval: FETCH_DOOR_STATUS_MS,
   })
-  const isDoorOpen = doorStatus?.data.status === 'open'
+  const isDoorOpen =
+    doorStatus?.data.status === 'open' &&
+    doorStatus?.data.doorRequiredClosedForProtocol
   React.useEffect(() => {
     // Note show snackbar when instruments and modules are all green
     // but the robot door is open

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -77,7 +77,8 @@ import { ConfirmAttachedModal } from './ConfirmAttachedModal'
 import type { OnDeviceRouteParams } from '../../../App/types'
 import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
 
-const FETCH_DOOR_STATUS_MS = 5000
+const FETCH_DOOR_STATUS_MS = 10000
+const SNACK_BAR_DURATION_MS = 7000
 interface ProtocolSetupStepProps {
   onClickSetupStep: () => void
   status: 'ready' | 'not ready' | 'general'
@@ -319,8 +320,7 @@ function PrepareToRun({
 }: PrepareToRunProps): JSX.Element {
   const { t, i18n } = useTranslation(['protocol_setup', 'shared'])
   const history = useHistory()
-  const { makeSnackbar, makeToast, eatToast } = useToaster()
-  const toastRef = React.useRef<string | null>(null)
+  const { makeSnackbar } = useToaster()
 
   // Watch for scrolling to toggle dropshadow
   const scrollRef = React.useRef<HTMLDivElement>(null)
@@ -490,13 +490,10 @@ function PrepareToRun({
   })
   const isDoorOpen = doorStatus?.data.status === 'open'
   React.useEffect(() => {
-    if (isDoorOpen) {
-      toastRef.current = makeToast(t('shared:close_robot_door'), 'warning', {
-        closeButton: false,
-        disableTimeout: true,
-      })
-    } else if (!isDoorOpen && toastRef.current != null) {
-      eatToast(toastRef.current)
+    // Note show snackbar when instruments and modules are all green
+    // but the robot door is open
+    if (isReadyToRun && isDoorOpen) {
+      makeSnackbar(t('shared:close_robot_door'), SNACK_BAR_DURATION_MS)
     }
   }, [isDoorOpen])
 
@@ -513,7 +510,7 @@ function PrepareToRun({
         position={POSITION_STICKY}
         top={0}
         backgroundColor={COLORS.white}
-        overflowY="hidden"
+        overflowY="auto"
         marginX={`-${SPACING.spacing32}`}
       >
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -77,7 +77,7 @@ import { ConfirmAttachedModal } from './ConfirmAttachedModal'
 import type { OnDeviceRouteParams } from '../../../App/types'
 import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
 
-const FETCH_DOOR_STATUS_MS = 10000
+const FETCH_DOOR_STATUS_MS = 5000
 const SNACK_BAR_DURATION_MS = 7000
 interface ProtocolSetupStepProps {
   onClickSetupStep: () => void

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -489,7 +489,6 @@ function PrepareToRun({
     refetchInterval: FETCH_DOOR_STATUS_MS,
   })
   const isDoorOpen = doorStatus?.data.status === 'open'
-  console.log('doorStatus', doorStatus?.data.status)
   React.useEffect(() => {
     if (isDoorOpen) {
       toastRef.current = makeToast(t('shared:close_robot_door'), 'warning', {

--- a/react-api-client/src/robot/__tests__/useDoorQuery.test.tsx
+++ b/react-api-client/src/robot/__tests__/useDoorQuery.test.tsx
@@ -18,7 +18,9 @@ const mockGetDoorStatus = getDoorStatus as jest.MockedFunction<
 const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
-const DOOR_RESPONSE: DoorStatus = { data: { status: 'open' } } as DoorStatus
+const DOOR_RESPONSE: DoorStatus = {
+  data: { status: 'open', doorRequiredClosedForProtocol: true },
+} as DoorStatus
 
 describe('useDoorQuery hook', () => {
   let wrapper: React.FunctionComponent<{}>

--- a/react-api-client/src/robot/__tests__/useDoorQuery.test.tsx
+++ b/react-api-client/src/robot/__tests__/useDoorQuery.test.tsx
@@ -3,30 +3,24 @@ import { when } from 'jest-when'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { renderHook } from '@testing-library/react-hooks'
 
-import { getEstopStatus } from '@opentrons/api-client'
+import { getDoorStatus } from '@opentrons/api-client'
 import { useHost } from '../../api'
-import { useEstopQuery } from '..'
+import { useDoorQuery } from '..'
 
-import type { HostConfig, Response, EstopStatus } from '@opentrons/api-client'
+import type { HostConfig, Response, DoorStatus } from '@opentrons/api-client'
 
 jest.mock('@opentrons/api-client')
 jest.mock('../../api/useHost')
 
-const mockGetEstopStatus = getEstopStatus as jest.MockedFunction<
-  typeof getEstopStatus
+const mockGetDoorStatus = getDoorStatus as jest.MockedFunction<
+  typeof getDoorStatus
 >
 const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
-const ESTOP_STATE_RESPONSE: EstopStatus = {
-  data: {
-    status: 'disengaged',
-    leftEstopPhysicalStatus: 'disengaged',
-    rightEstopPhysicalStatus: 'disengaged',
-  },
-}
+const DOOR_RESPONSE: DoorStatus = { data: { status: 'open' } } as DoorStatus
 
-describe('useEstopQuery hook', () => {
+describe('useDoorQuery hook', () => {
   let wrapper: React.FunctionComponent<{}>
 
   beforeEach(() => {
@@ -45,32 +39,30 @@ describe('useEstopQuery hook', () => {
   it('should return no data if no host', () => {
     when(mockUseHost).calledWith().mockReturnValue(null)
 
-    const { result } = renderHook(useEstopQuery, { wrapper })
+    const { result } = renderHook(useDoorQuery, { wrapper })
 
     expect(result.current?.data).toBeUndefined()
   })
 
-  it('should return no data if estop request fails', () => {
+  it('should return no data if lights request fails', () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
-    when(mockGetEstopStatus).calledWith(HOST_CONFIG).mockRejectedValue('oh no')
+    when(mockGetDoorStatus).calledWith(HOST_CONFIG).mockRejectedValue('oh no')
 
-    const { result } = renderHook(useEstopQuery, { wrapper })
+    const { result } = renderHook(useDoorQuery, { wrapper })
 
     expect(result.current?.data).toBeUndefined()
   })
 
-  it('should return estop state response data', async () => {
+  it('should return lights response data', async () => {
     when(mockUseHost).calledWith().mockReturnValue(HOST_CONFIG)
-    when(mockGetEstopStatus)
+    when(mockGetDoorStatus)
       .calledWith(HOST_CONFIG)
-      .mockResolvedValue({
-        data: ESTOP_STATE_RESPONSE,
-      } as Response<EstopStatus>)
+      .mockResolvedValue({ data: DOOR_RESPONSE } as Response<DoorStatus>)
 
-    const { result, waitFor } = renderHook(useEstopQuery, { wrapper })
+    const { result, waitFor } = renderHook(useDoorQuery, { wrapper })
 
     await waitFor(() => result.current?.data != null)
 
-    expect(result.current?.data).toEqual(ESTOP_STATE_RESPONSE)
+    expect(result.current?.data).toEqual(DOOR_RESPONSE)
   })
 })

--- a/react-api-client/src/robot/index.ts
+++ b/react-api-client/src/robot/index.ts
@@ -1,3 +1,4 @@
+export { useDoorQuery } from './useDoorQuery'
 export { useEstopQuery } from './useEstopQuery'
 export { useLightsQuery } from './useLightsQuery'
 export { useAcknowledgeEstopDisengageMutation } from './useAcknowledgeEstopDisengageMutation'

--- a/react-api-client/src/robot/useDoorQuery.ts
+++ b/react-api-client/src/robot/useDoorQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-query'
+import { HostConfig, getDoorStatus } from '@opentrons/api-client'
+import { useHost } from '../api'
+
+import type { UseQueryResult, UseQueryOptions } from 'react-query'
+import type { DoorStatus } from '@opentrons/api-client'
+
+export function useDoorQuery<TError = Error>(
+  options: UseQueryOptions<DoorStatus, TError> = {}
+): UseQueryResult<DoorStatus, TError> {
+  const host = useHost()
+  const query = useQuery<DoorStatus, TError>(
+    [host as HostConfig, '/robot/door/status'],
+    () => getDoorStatus(host as HostConfig).then(response => response.data),
+    { enabled: host !== null, ...options }
+  )
+
+  return query
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add api-client and react-api-client to check door status via `/robot/door/status` endpoint
This PR needs https://github.com/Opentrons/opentrons/pull/13584 (Adding a new endpoint for the robot status)

For Flex, doorRequiredClosedForProtocol is always true, so in this PR the item is used as an alternative of isOT3.
```json
{
  "data": {
    "status": "closed",
    "doorRequiredClosedForProtocol": true
  }
}
```

[design]
Desktop
https://www.figma.com/file/0hYQ4lFJbAAI33jQMRt1Di/Release%3A-Desktop-June-Flex-launch?node-id=22521%3A106668&mode=dev

ODD
https://www.figma.com/file/AoTLAYuWawlaWItB1umOjr/Release%3A-Opentrons-Flex-Touchscreen?node-id=20416%3A122097&mode=dev


when a robot is missing modules/instruments or both -> not display Snackbar
when a robot is ready to run (instruments and modules are attached), but the door is open -> display Snackbar (7sec)


close RQA-1614
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Desktop app
1. Setup protocol
2. Open the robot door
Banner will show up in the header and the run start button is disabled

Touchscreen app
1. Setup protocol
2. Open the robot door
Snackbar will show up and the play button is disabled
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add getDoorStatus to `api-client` and `useDoorQuery` to `react-api-client` for the new endpoint, `/robot/door/status/`
- update ProtocolSetup components for Desktop app and ODD app
- update Snackbar type for passing duration
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
