### PR TITLE
refactor(protocol-designer): remove nest_96_wellplate_200ul_flat from…

### DIFF
--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -96,13 +96,14 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
-    'opentrons/nest_96_wellplate_200ul_flat/2',
-    //  TODO(jr, 9/18/23): comment this out
+    //  TODO(jr, 9/18/23): comment this out for now until these labwares are compatible
+    //  with this adapter from the API side
     // 'opentrons/corning_96_wellplate_360ul_flat/2',
     // 'opentrons/corning_48_wellplate_1.6ml_flat/2',
     // 'opentrons/corning_24_wellplate_3.4ml_flat/2',
     // 'opentrons/corning_12_wellplate_6.9ml_flat/2',
     // 'opentrons/corning_6_wellplate_16.8ml_flat/2',
+    // 'opentrons/nest_96_wellplate_200ul_flat/2',
   ],
   [ALUMINUM_BLOCK_96_LOADNAME]: [
     'opentrons/biorad_96_wellplate_200ul_pcr/2',

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -96,9 +96,9 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
+    'opentrons/corning_96_wellplate_360ul_flat/2',
     //  TODO(jr, 9/18/23): comment this out for now until these labwares are compatible
     //  with this adapter from the API side
-    // 'opentrons/corning_96_wellplate_360ul_flat/2',
     // 'opentrons/corning_48_wellplate_1.6ml_flat/2',
     // 'opentrons/corning_24_wellplate_3.4ml_flat/2',
     // 'opentrons/corning_12_wellplate_6.9ml_flat/2',
@@ -164,7 +164,7 @@ export const getAdapterLabwareIsAMatch = (
   const universalPair =
     loadName === UNIVERSAL_FLAT_ADAPTER_LOADNAME &&
     (draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat' ||
-      draggedLabwareLoadname === 'nest_96_wellplate_200ul_flat')
+      draggedLabwareLoadname === 'corning_96_wellplate_360ul_flat')
   const aluminumBlock96Pairs =
     loadName === ALUMINUM_BLOCK_96_LOADNAME &&
     (draggedLabwareLoadname === 'biorad_96_wellplate_200ul_pcr' ||

--- a/step-generation/src/utils/heaterShakerCollision.ts
+++ b/step-generation/src/utils/heaterShakerCollision.ts
@@ -115,10 +115,11 @@ export const pipetteIntoHeaterShakerWhileShaking = (
   labwareId: string
 ): boolean => {
   const labwareSlot: string = labware[labwareId]?.slot
+  const adapterSlot: string = labware[labwareSlot]?.slot
   const moduleUnderLabware: string | null | undefined =
     modules &&
-    labwareSlot &&
-    Object.keys(modules).find((moduleId: string) => moduleId === labwareSlot)
+    adapterSlot &&
+    Object.keys(modules).find((moduleId: string) => moduleId === adapterSlot)
   const moduleState =
     moduleUnderLabware && modules[moduleUnderLabware].moduleState
   const isShaking: boolean = Boolean(


### PR DESCRIPTION
… adapter compatiblity

# Overview

upon smoke testing PD, I realized that this labware is not compatible with the universal flat adapter in the API and also a bug in the heater-shaker error creator where it didn't extend to support adapters.

# Test Plan

test that the universal flat adapter only has 1 labware available, the corning 384 well. So create a new protocol either OT-2 or Flex and add a heater-shaker. On the deck map, add the universal flat adapter. Add the labware on top and see only 1 is available.

add that labware and add a heater-shaker step to start shaking the heater-shaker. Now, try to add a transfer or mix into that labware on the heater-shaker, you should see a timeline error saying the heater-shaker is shaking.

# Changelog

- comment out the nest 96 well plate flat for now
- extend adapter support to the Heater-shaker collision util for if you're pipetting into a shaking heater-shaker

# Review requests

see test plan

# Risk assessment

low for these changes, but I'm hoping to cut a release candidate off of this branch that will hopefully be the release.