### PR TITLE
fix(app, react-api-client): rely on subsystem status before instrument status

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -60,7 +60,7 @@ const BANNER_LINK_CSS = css`
   cursor: pointer;
   margin-left: ${SPACING.spacing8};
 `
-const SUBSYSTEM_UPDATE_POLL_MS = 3000
+const SUBSYSTEM_UPDATE_POLL_MS = 5000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const { t, i18n } = useTranslation(['device_details', 'protocol_setup'])
@@ -99,7 +99,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const { data: subsystemUpdateData } = useCurrentSubsystemUpdateQuery(
     subsystem,
     {
-      enabled: pipetteIsBad,
+      enabled: isOt3,
       refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
     }
   )
@@ -191,7 +191,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
           isExpanded={true}
         />
       )}
-      {!pipetteIsBad && (
+      {!pipetteIsBad && subsystemUpdateData == null && (
         <>
           <Box
             padding={`${SPACING.spacing16} ${SPACING.spacing8}`}
@@ -276,7 +276,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
           </Box>
         </>
       )}
-      {pipetteIsBad && (
+      {(pipetteIsBad || subsystemUpdateData != null) && (
         <InstrumentCard
           label={i18n.format(t('mount', { side: mount }), 'capitalize')}
           description={t('instrument_attached')}

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -14,7 +14,7 @@ import type { Subsystem } from '@opentrons/api-client'
 
 const POLL_INTERVAL_MS = 5000
 
-export function FirmwareUpdateTakeover(): JSX.Element {
+export function FirmwareUpdateTakeover(): React.ReactNode {
   const [
     showUpdateNeededModal,
     setShowUpdateNeededModal,
@@ -54,7 +54,6 @@ export function FirmwareUpdateTakeover(): JSX.Element {
   React.useEffect(() => {
     if (
       subsystemUpdateInstrument != null &&
-      maintenanceRunData == null &&
       !isUnboxingFlowOngoing &&
       externalSubsystemUpdate == null
     ) {
@@ -62,7 +61,6 @@ export function FirmwareUpdateTakeover(): JSX.Element {
     }
   }, [
     subsystemUpdateInstrument,
-    maintenanceRunData,
     isUnboxingFlowOngoing,
     externalSubsystemUpdate,
   ])
@@ -71,6 +69,7 @@ export function FirmwareUpdateTakeover(): JSX.Element {
     []
   )
 
+  if (maintenanceRunData != null) return null
   return (
     <>
       {memoizedSubsystem != null && showUpdateNeededModal ? (

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -14,7 +14,7 @@ import type { Subsystem } from '@opentrons/api-client'
 
 const POLL_INTERVAL_MS = 5000
 
-export function FirmwareUpdateTakeover(): React.ReactNode {
+export function FirmwareUpdateTakeover(): JSX.Element {
   const [
     showUpdateNeededModal,
     setShowUpdateNeededModal,
@@ -54,6 +54,7 @@ export function FirmwareUpdateTakeover(): React.ReactNode {
   React.useEffect(() => {
     if (
       subsystemUpdateInstrument != null &&
+      maintenanceRunData == null &&
       !isUnboxingFlowOngoing &&
       externalSubsystemUpdate == null
     ) {
@@ -61,6 +62,7 @@ export function FirmwareUpdateTakeover(): React.ReactNode {
     }
   }, [
     subsystemUpdateInstrument,
+    maintenanceRunData,
     isUnboxingFlowOngoing,
     externalSubsystemUpdate,
   ])
@@ -69,7 +71,6 @@ export function FirmwareUpdateTakeover(): React.ReactNode {
     []
   )
 
-  if (maintenanceRunData != null) return null
   return (
     <>
       {memoizedSubsystem != null && showUpdateNeededModal ? (
@@ -79,7 +80,7 @@ export function FirmwareUpdateTakeover(): React.ReactNode {
           setInitiatedSubsystemUpdate={setInitiatedSubsystemUpdate}
         />
       ) : null}
-      {externalsubsystemUpdateData != null ? (
+      {externalsubsystemUpdateData != null && maintenanceRunData == null ? (
         <Portal level="top">
           <UpdateInProgressModal
             percentComplete={externalsubsystemUpdateData.data.updateProgress}

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -23,7 +23,7 @@ const BANNER_LINK_CSS = css`
   cursor: pointer;
   margin-left: ${SPACING.spacing8};
 `
-const SUBSYSTEM_UPDATE_POLL_MS = 3000
+const SUBSYSTEM_UPDATE_POLL_MS = 5000
 
 export function GripperCard({
   attachedGripper,
@@ -54,7 +54,6 @@ export function GripperCard({
   const { data: subsystemUpdateData } = useCurrentSubsystemUpdateQuery(
     'gripper',
     {
-      enabled: attachedGripper != null && !attachedGripper.ok,
       refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
     }
   )
@@ -89,7 +88,8 @@ export function GripperCard({
         ]
   return (
     <>
-      {attachedGripper == null || attachedGripper.ok ? (
+      {(attachedGripper == null || attachedGripper.ok) &&
+      subsystemUpdateData == null ? (
         <InstrumentCard
           description={
             attachedGripper != null
@@ -122,7 +122,7 @@ export function GripperCard({
           menuOverlayItems={menuOverlayItems}
         />
       ) : null}
-      {attachedGripper?.ok === false ? (
+      {attachedGripper?.ok === false || subsystemUpdateData != null ? (
         <InstrumentCard
           label={i18n.format(t('mount', { side: 'extension' }), 'capitalize')}
           description={t('instrument_attached')}

--- a/react-api-client/src/subsystems/useCurrentAllSubsystemUpdatesQuery.ts
+++ b/react-api-client/src/subsystems/useCurrentAllSubsystemUpdatesQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery } from 'react-query'
+import { useQuery, useQueryClient } from 'react-query'
 
 import { getCurrentAllSubsystemUpdates } from '@opentrons/api-client'
 import { useHost } from '../api'
@@ -10,6 +10,7 @@ export function useCurrentAllSubsystemUpdatesQuery<TError = Error>(
   options: UseQueryOptions<CurrentSubsystemUpdates, TError> = {}
 ): UseQueryResult<CurrentSubsystemUpdates, TError> {
   const host = useHost()
+  const queryClient = useQueryClient()
   const query = useQuery<CurrentSubsystemUpdates, TError>(
     [host, '/subsystems/updates/current'],
     () =>
@@ -19,6 +20,9 @@ export function useCurrentAllSubsystemUpdatesQuery<TError = Error>(
     {
       ...options,
       enabled: host !== null,
+      onError: () => {
+        queryClient.resetQueries([host, '/subsystems/updates/current'])
+      },
     }
   )
 

--- a/react-api-client/src/subsystems/useCurrentSubsystemUpdateQuery.ts
+++ b/react-api-client/src/subsystems/useCurrentSubsystemUpdateQuery.ts
@@ -26,9 +26,13 @@ export function useCurrentSubsystemUpdateQuery<TError = Error>(
     {
       ...options,
       enabled: host !== null,
-        onError: () => {
-          queryClient.resetQueries([host, '/subsystems/updates/current', subsystem])
-        }
+      onError: () => {
+        queryClient.resetQueries([
+          host,
+          '/subsystems/updates/current',
+          subsystem,
+        ])
+      },
     }
   )
 

--- a/react-api-client/src/subsystems/useCurrentSubsystemUpdateQuery.ts
+++ b/react-api-client/src/subsystems/useCurrentSubsystemUpdateQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery } from 'react-query'
+import { useQuery, useQueryClient } from 'react-query'
 
 import { getCurrentSubsystemUpdate } from '@opentrons/api-client'
 import { useHost } from '../api'
@@ -15,6 +15,7 @@ export function useCurrentSubsystemUpdateQuery<TError = Error>(
   options: UseQueryOptions<SubsystemUpdateProgressData, TError> = {}
 ): UseQueryResult<SubsystemUpdateProgressData, TError> {
   const host = useHost()
+  const queryClient = useQueryClient()
   const query = useQuery<SubsystemUpdateProgressData, TError>(
     [host, '/subsystems/updates/current', subsystem],
     () =>
@@ -25,6 +26,9 @@ export function useCurrentSubsystemUpdateQuery<TError = Error>(
     {
       ...options,
       enabled: host !== null,
+        onError: () => {
+          queryClient.resetQueries([host, '/subsystems/updates/current', subsystem])
+        }
     }
   )
 


### PR DESCRIPTION
fix RQA-1585

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We can't rely on the `/instruments` endpoint response while a subsystem update is ongoing. Instead, we first need to poll for the presence of an update on a given subsystem.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Attach an instrument that needs an update during a firmware update flow. Observe that when after the firmware update takes place, you don't see an "instrument not attached" screen before you see a success screen.
2. Update the firmware of an instrument via the ODD. On desktop, watch the instrument card for the corresponding instrument. The instrument card should display a subsystem update in progress until the update is complete, and then show the instrument card for an attached instrument.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. In the firmware update modal, once the update is `done` refetch the instruments. If the instrument is `ok`, proceed to the results screen. If it is still not `ok`, wait another 10 seconds before proceeding.
2. In the gripper and pipette cards, continuously poll for a subsystem update. If an update is ongoing, rely on that information to show the "bad" instrument card and update banner. If it is not, rely on the `/instruments` endpoint response for what to show.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Run through the test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
