### PR TITLE
fix(app): exit module calibration copy

### DIFF
--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -39,6 +39,7 @@
   "select_location": "Select module location",
   "select_the_slot": "Select the slot where you installed the {{module}} on the deck map to the right. The location must be correct for successful calibration.",
   "stand_back": "Stand back, calibration in progress",
+  "stand_back_exiting": "Stand back, robot is in motion",
   "start_setup": "Start setup",
   "successfully_calibrated": "{{module}} successfully calibrated"
 }

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -248,7 +248,7 @@ export const ModuleWizardFlows = (
       />
     )
   } else if (isExiting) {
-    modalContent = <InProgressModal description={t('stand_back')} />
+    modalContent = <InProgressModal description={t('stand_back_exiting')} />
   } else if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {
     modalContent = (
       <BeforeBeginning


### PR DESCRIPTION
closes RQA-1653

# Overview

Fix copy from "calibration in progress" to "robot is in motion" to match what the copy says for exiting out of pipette flows

# Test Plan

Start module calibration and early exit. See that the in progress modal says the correct copy.

# Changelog

change i18n key to another key

# Review requests

see test plan

# Risk assessment

low