### PR TITLE
fix(app): dismiss app update toast when update modal appears

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -107,28 +107,29 @@ export const DesktopApp = (): JSX.Element => {
           }}
         >
           <Box width="100%">
-            <Switch>
-              {desktopRoutes.map(({ Component, exact, path }: RouteProps) => {
-                return (
-                  <Route key={path} exact={exact} path={path}>
-                    <Breadcrumbs />
-                    <Box
-                      position={POSITION_RELATIVE}
-                      width="100%"
-                      height="100%"
-                      backgroundColor={COLORS.fundamentalsBackground}
-                      overflow={OVERFLOW_AUTO}
-                    >
-                      <ModalPortalRoot />
-                      <Component />
-                    </Box>
-                  </Route>
-                )
-              })}
-              <Redirect exact from="/" to="/protocols" />
-            </Switch>
-            <RobotControlTakeover />
-            <Alerts />
+            <Alerts>
+              <Switch>
+                {desktopRoutes.map(({ Component, exact, path }: RouteProps) => {
+                  return (
+                    <Route key={path} exact={exact} path={path}>
+                      <Breadcrumbs />
+                      <Box
+                        position={POSITION_RELATIVE}
+                        width="100%"
+                        height="100%"
+                        backgroundColor={COLORS.fundamentalsBackground}
+                        overflow={OVERFLOW_AUTO}
+                      >
+                        <ModalPortalRoot />
+                        <Component />
+                      </Box>
+                    </Route>
+                  )
+                })}
+                <Redirect exact from="/" to="/protocols" />
+              </Switch>
+              <RobotControlTakeover />
+            </Alerts>
           </Box>
         </EmergencyStopContext.Provider>
       </ToasterOven>

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -13,7 +13,7 @@ import { ProtocolsLanding } from '../../pages/Protocols/ProtocolsLanding'
 import { ProtocolRunDetails } from '../../pages/Devices/ProtocolRunDetails'
 import { RobotSettings } from '../../pages/Devices/RobotSettings'
 import { GeneralSettings } from '../../pages/AppSettings/GeneralSettings'
-import { AlertsModal } from '../../organisms/Alerts/AlertsModal'
+import { AlertsModal } from '../../organisms/Alerts'
 import { useIsOT3 } from '../../organisms/Devices/hooks'
 import { useSoftwareUpdatePoll } from '../hooks'
 import { DesktopApp } from '../DesktopApp'
@@ -28,7 +28,7 @@ jest.mock('../../pages/Protocols/ProtocolsLanding')
 jest.mock('../../pages/Devices/ProtocolRunDetails')
 jest.mock('../../pages/Devices/RobotSettings')
 jest.mock('../hooks')
-jest.mock('../../organisms/Alerts/AlertsModal')
+jest.mock('../../organisms/Alerts')
 
 const mockCalibrationDashboard = CalibrationDashboard as jest.MockedFunction<
   typeof CalibrationDashboard

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -13,12 +13,11 @@ import { ProtocolsLanding } from '../../pages/Protocols/ProtocolsLanding'
 import { ProtocolRunDetails } from '../../pages/Devices/ProtocolRunDetails'
 import { RobotSettings } from '../../pages/Devices/RobotSettings'
 import { GeneralSettings } from '../../pages/AppSettings/GeneralSettings'
-import { Alerts } from '../../organisms/Alerts'
+import { AlertsModal } from '../../organisms/Alerts/AlertsModal'
 import { useIsOT3 } from '../../organisms/Devices/hooks'
 import { useSoftwareUpdatePoll } from '../hooks'
 import { DesktopApp } from '../DesktopApp'
 
-jest.mock('../../organisms/Alerts')
 jest.mock('../../organisms/Breadcrumbs')
 jest.mock('../../organisms/Devices/hooks')
 jest.mock('../../pages/AppSettings/GeneralSettings')
@@ -29,6 +28,7 @@ jest.mock('../../pages/Protocols/ProtocolsLanding')
 jest.mock('../../pages/Devices/ProtocolRunDetails')
 jest.mock('../../pages/Devices/RobotSettings')
 jest.mock('../hooks')
+jest.mock('../../organisms/Alerts/AlertsModal')
 
 const mockCalibrationDashboard = CalibrationDashboard as jest.MockedFunction<
   typeof CalibrationDashboard
@@ -48,10 +48,10 @@ const mockProtocolRunDetails = ProtocolRunDetails as jest.MockedFunction<
 const mockRobotSettings = RobotSettings as jest.MockedFunction<
   typeof RobotSettings
 >
-const mockAlerts = Alerts as jest.MockedFunction<typeof Alerts>
 const mockAppSettings = GeneralSettings as jest.MockedFunction<
   typeof GeneralSettings
 >
+const mockAlertsModal = AlertsModal as jest.MockedFunction<typeof AlertsModal>
 const mockBreadcrumbs = Breadcrumbs as jest.MockedFunction<typeof Breadcrumbs>
 const mockUseSoftwareUpdatePoll = useSoftwareUpdatePoll as jest.MockedFunction<
   typeof useSoftwareUpdatePoll
@@ -77,9 +77,9 @@ describe('DesktopApp', () => {
     mockProtocolsLanding.mockReturnValue(<div>Mock ProtocolsLanding</div>)
     mockProtocolRunDetails.mockReturnValue(<div>Mock ProtocolRunDetails</div>)
     mockRobotSettings.mockReturnValue(<div>Mock RobotSettings</div>)
-    mockAlerts.mockReturnValue(<div>Mock Alerts</div>)
     mockAppSettings.mockReturnValue(<div>Mock AppSettings</div>)
     mockBreadcrumbs.mockReturnValue(<div>Mock Breadcrumbs</div>)
+    mockAlertsModal.mockReturnValue(<></>)
     mockUseIsOT3.mockReturnValue(true)
   })
   afterEach(() => {
@@ -127,11 +127,6 @@ describe('DesktopApp', () => {
       '/devices/otie/protocol-runs/95e67900-bc9f-4fbf-92c6-cc4d7226a51b/setup'
     )
     getByText('Mock ProtocolRunDetails')
-  })
-
-  it('should render app-wide Alerts', () => {
-    const [{ getByText }] = render()
-    getByText('Mock Alerts')
   })
 
   it('should poll for software updates', () => {

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -13,7 +13,7 @@ import { ProtocolsLanding } from '../../pages/Protocols/ProtocolsLanding'
 import { ProtocolRunDetails } from '../../pages/Devices/ProtocolRunDetails'
 import { RobotSettings } from '../../pages/Devices/RobotSettings'
 import { GeneralSettings } from '../../pages/AppSettings/GeneralSettings'
-import { AlertsModal } from '../../organisms/Alerts'
+import { AlertsModal } from '../../organisms/Alerts/AlertsModal'
 import { useIsOT3 } from '../../organisms/Devices/hooks'
 import { useSoftwareUpdatePoll } from '../hooks'
 import { DesktopApp } from '../DesktopApp'
@@ -28,7 +28,7 @@ jest.mock('../../pages/Protocols/ProtocolsLanding')
 jest.mock('../../pages/Devices/ProtocolRunDetails')
 jest.mock('../../pages/Devices/RobotSettings')
 jest.mock('../hooks')
-jest.mock('../../organisms/Alerts')
+jest.mock('../../organisms/Alerts/AlertsModal')
 
 const mockCalibrationDashboard = CalibrationDashboard as jest.MockedFunction<
   typeof CalibrationDashboard

--- a/app/src/organisms/Alerts/AlertsModal.tsx
+++ b/app/src/organisms/Alerts/AlertsModal.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import head from 'lodash/head'
+
+import * as AppAlerts from '../../redux/alerts'
+import { getHasJustUpdated, toggleConfigValue } from '../../redux/config'
+import { getAvailableShellUpdate } from '../../redux/shell'
+import { SUCCESS_TOAST, WARNING_TOAST } from '../../atoms/Toast'
+import { useToaster } from '../ToasterOven'
+import { AnalyticsSettingsModal } from '../AnalyticsSettingsModal'
+import { UpdateAppModal } from '../UpdateAppModal'
+import { U2EDriverOutdatedAlert } from './U2EDriverOutdatedAlert'
+import { useRemoveActiveAppUpdateToast } from './useRemoveActiveAppUpdateToast.ts'
+
+import type { State, Dispatch } from '../../redux/types'
+import type { AlertId } from '../../redux/alerts/types'
+import type { MutableRefObject } from 'react'
+
+interface AlertsModalProps {
+  toastIdRef: MutableRefObject<string | null>
+}
+
+export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
+  const dispatch = useDispatch<Dispatch>()
+  const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(false)
+  const { t } = useTranslation('app_settings')
+  const { makeToast } = useToaster()
+  const { removeActiveAppUpdateToast } = useRemoveActiveAppUpdateToast()
+
+  // TODO(mc, 2020-05-07): move head logic to selector with alert priorities
+  const activeAlertId: AlertId | null = useSelector((state: State) => {
+    return head(AppAlerts.getActiveAlerts(state)) ?? null
+  })
+  const isAppUpdateAvailable = Boolean(useSelector(getAvailableShellUpdate))
+
+  const dismissDriverAlert = (remember?: boolean): void => {
+    if (activeAlertId != null) {
+      dispatch(AppAlerts.alertDismissed(activeAlertId, remember))
+    }
+  }
+  const isAppUpdateIgnored = useSelector((state: State) => {
+    return AppAlerts.getAlertIsPermanentlyIgnored(
+      state,
+      AppAlerts.ALERT_APP_UPDATE_AVAILABLE
+    )
+  })
+
+  const hasJustUpdated = useSelector(getHasJustUpdated)
+  const removeToast = !isAppUpdateAvailable || isAppUpdateIgnored
+  const createAppUpdateAvailableToast =
+    isAppUpdateAvailable && !isAppUpdateIgnored
+
+  // Only run this hook on app startup
+  React.useEffect(() => {
+    if (hasJustUpdated) {
+      makeToast(t('opentrons_app_successfully_updated'), SUCCESS_TOAST, {
+        closeButton: true,
+        disableTimeout: true,
+      })
+      dispatch(toggleConfigValue('update.hasJustUpdated'))
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (createAppUpdateAvailableToast) {
+      toastIdRef.current = makeToast(
+        t('opentrons_app_update_available_variation'),
+        WARNING_TOAST,
+        {
+          closeButton: true,
+          disableTimeout: true,
+          linkText: t('view_update'),
+          onLinkClick: () => setShowUpdateModal(true),
+        }
+      )
+    } else if (removeToast && toastIdRef.current) {
+      removeActiveAppUpdateToast()
+    }
+  }, [isAppUpdateAvailable, isAppUpdateIgnored])
+
+  return (
+    <>
+      {/* TODO(mc, 2020-05-07): AnalyticsSettingsModal currently controls its
+            own render; move its logic into `state.alerts` */}
+      <AnalyticsSettingsModal />
+
+      {activeAlertId === AppAlerts.ALERT_U2E_DRIVER_OUTDATED ? (
+        <U2EDriverOutdatedAlert dismissAlert={dismissDriverAlert} />
+      ) : null}
+      {showUpdateModal ? (
+        <UpdateAppModal closeModal={() => setShowUpdateModal(false)} />
+      ) : null}
+    </>
+  )
+}

--- a/app/src/organisms/Alerts/AlertsModal.tsx
+++ b/app/src/organisms/Alerts/AlertsModal.tsx
@@ -11,7 +11,7 @@ import { useToaster } from '../ToasterOven'
 import { AnalyticsSettingsModal } from '../AnalyticsSettingsModal'
 import { UpdateAppModal } from '../UpdateAppModal'
 import { U2EDriverOutdatedAlert } from './U2EDriverOutdatedAlert'
-import { useRemoveActiveAppUpdateToast } from './useRemoveActiveAppUpdateToast.ts'
+import { useRemoveActiveAppUpdateToast } from '.'
 
 import type { State, Dispatch } from '../../redux/types'
 import type { AlertId } from '../../redux/alerts/types'

--- a/app/src/organisms/Alerts/AlertsProvider.tsx
+++ b/app/src/organisms/Alerts/AlertsProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { AlertsModal } from './AlertsModal'
+import { AlertsModal } from '.'
 import { useToaster } from '../ToasterOven'
 
 export interface AlertsContextProps {

--- a/app/src/organisms/Alerts/__tests__/Alerts.test.tsx
+++ b/app/src/organisms/Alerts/__tests__/Alerts.test.tsx
@@ -10,7 +10,7 @@ import { AlertsModal } from '../AlertsModal'
 import { AnalyticsSettingsModal } from '../../AnalyticsSettingsModal'
 import { U2EDriverOutdatedAlert } from '../U2EDriverOutdatedAlert'
 import { UpdateAppModal } from '../../UpdateAppModal'
-import { useRemoveActiveAppUpdateToast } from '../useRemoveActiveAppUpdateToast.ts'
+import { useRemoveActiveAppUpdateToast } from '..'
 
 import type { State } from '../../../redux/types'
 import type { AlertId } from '../../../redux/alerts/types'
@@ -27,7 +27,7 @@ jest.mock('../../UpdateAppModal', () => ({
 jest.mock('../../../redux/alerts/selectors')
 jest.mock('../../../redux/shell')
 jest.mock('../../../redux/config')
-jest.mock('../useRemoveActiveAppUpdateToast.ts')
+jest.mock('..')
 
 const getActiveAlerts = AppAlerts.getActiveAlerts as jest.MockedFunction<
   typeof AppAlerts.getActiveAlerts

--- a/app/src/organisms/Alerts/__tests__/Alerts.test.tsx
+++ b/app/src/organisms/Alerts/__tests__/Alerts.test.tsx
@@ -4,11 +4,13 @@ import { when } from 'jest-when'
 import { mountWithStore } from '@opentrons/components'
 import * as AppAlerts from '../../../redux/alerts'
 import { getAvailableShellUpdate } from '../../../redux/shell'
+import { getHasJustUpdated } from '../../../redux/config'
 import { TOAST_ANIMATION_DURATION } from '../../../atoms/Toast'
-import { Alerts } from '..'
+import { AlertsModal } from '../AlertsModal'
 import { AnalyticsSettingsModal } from '../../AnalyticsSettingsModal'
 import { U2EDriverOutdatedAlert } from '../U2EDriverOutdatedAlert'
 import { UpdateAppModal } from '../../UpdateAppModal'
+import { useRemoveActiveAppUpdateToast } from '../useRemoveActiveAppUpdateToast.ts'
 
 import type { State } from '../../../redux/types'
 import type { AlertId } from '../../../redux/alerts/types'
@@ -24,6 +26,8 @@ jest.mock('../../UpdateAppModal', () => ({
 }))
 jest.mock('../../../redux/alerts/selectors')
 jest.mock('../../../redux/shell')
+jest.mock('../../../redux/config')
+jest.mock('../useRemoveActiveAppUpdateToast.ts')
 
 const getActiveAlerts = AppAlerts.getActiveAlerts as jest.MockedFunction<
   typeof AppAlerts.getActiveAlerts
@@ -31,14 +35,26 @@ const getActiveAlerts = AppAlerts.getActiveAlerts as jest.MockedFunction<
 const mockGetAvailableShellUpdate = getAvailableShellUpdate as jest.MockedFunction<
   typeof getAvailableShellUpdate
 >
+const mockGetHasJustUpdated = getHasJustUpdated as jest.MockedFunction<
+  typeof getHasJustUpdated
+>
+const mockUseRemoveActiveAppUpdateToast = useRemoveActiveAppUpdateToast as jest.MockedFunction<
+  typeof useRemoveActiveAppUpdateToast
+>
 
 const MOCK_STATE: State = { mockState: true } as any
 
 describe('app-wide Alerts component', () => {
+  let props: React.ComponentProps<typeof AlertsModal>
+  const mockUseRef = { current: null }
+
   const render = () => {
-    return mountWithStore<React.ComponentProps<typeof Alerts>>(<Alerts />, {
-      initialState: MOCK_STATE,
-    })
+    return mountWithStore<React.ComponentProps<typeof AlertsModal>>(
+      <AlertsModal {...props} />,
+      {
+        initialState: MOCK_STATE,
+      }
+    )
   }
 
   const stubActiveAlerts = (alertIds: AlertId[]): void => {
@@ -51,6 +67,13 @@ describe('app-wide Alerts component', () => {
   beforeEach(() => {
     stubActiveAlerts([])
     when(mockGetAvailableShellUpdate).mockReturnValue('true')
+    when(mockGetHasJustUpdated).mockReturnValue(false)
+    when(mockUseRemoveActiveAppUpdateToast).calledWith().mockReturnValue({
+      removeActiveAppUpdateToast: jest.fn(),
+    })
+    props = {
+      toastIdRef: mockUseRef,
+    }
   })
 
   afterEach(() => {
@@ -116,11 +139,8 @@ describe('app-wide Alerts component', () => {
   })
   it('should render a success toast if the software update was successful', () => {
     const { wrapper } = render()
-    const updatedState = {
-      hasJustUpdated: true,
-    }
+    when(mockGetHasJustUpdated).mockReturnValue(true)
 
-    wrapper.setProps({ initialState: updatedState })
     setTimeout(() => {
       expect(wrapper.contains('successfully updated')).toBe(true)
     }, TOAST_ANIMATION_DURATION)
@@ -130,6 +150,7 @@ describe('app-wide Alerts component', () => {
     const { wrapper } = render()
     setTimeout(() => {
       expect(wrapper.contains('View Update')).toBe(false)
+      expect(mockUseRemoveActiveAppUpdateToast).toHaveBeenCalled()
     }, TOAST_ANIMATION_DURATION)
   })
 })

--- a/app/src/organisms/Alerts/index.ts
+++ b/app/src/organisms/Alerts/index.ts
@@ -1,0 +1,3 @@
+export * from './AlertsProvider'
+export * from './AlertsModal'
+export * from './useRemoveActiveAppUpdateToast.ts'

--- a/app/src/organisms/Alerts/index.tsx
+++ b/app/src/organisms/Alerts/index.tsx
@@ -1,89 +1,34 @@
 import * as React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
-import { useTranslation } from 'react-i18next'
-import head from 'lodash/head'
-
-import * as AppAlerts from '../../redux/alerts'
-import { getHasJustUpdated, toggleConfigValue } from '../../redux/config'
-import { getAvailableShellUpdate } from '../../redux/shell'
-import { SUCCESS_TOAST, WARNING_TOAST } from '../../atoms/Toast'
+import { AlertsModal } from './AlertsModal'
 import { useToaster } from '../ToasterOven'
-import { AnalyticsSettingsModal } from '../AnalyticsSettingsModal'
-import { UpdateAppModal } from '../UpdateAppModal'
-import { U2EDriverOutdatedAlert } from './U2EDriverOutdatedAlert'
 
-import type { State, Dispatch } from '../../redux/types'
-import type { AlertId } from '../../redux/alerts/types'
+export interface AlertsContextProps {
+  removeActiveAppUpdateToast: () => void
+}
 
-export function Alerts(): JSX.Element {
-  const dispatch = useDispatch<Dispatch>()
-  const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(false)
-  const { t } = useTranslation('app_settings')
-  const { makeToast, eatToast } = useToaster()
+export const AlertsContext = React.createContext<AlertsContextProps>({
+  removeActiveAppUpdateToast: () => null,
+})
+
+interface AlertsProps {
+  children: React.ReactNode
+}
+
+export function Alerts({ children }: AlertsProps): JSX.Element {
   const toastRef = React.useRef<string | null>(null)
+  const { eatToast } = useToaster()
 
-  // TODO(mc, 2020-05-07): move head logic to selector with alert priorities
-  const activeAlertId: AlertId | null = useSelector((state: State) => {
-    return head(AppAlerts.getActiveAlerts(state)) ?? null
-  })
-  const isAppUpdateAvailable = Boolean(useSelector(getAvailableShellUpdate))
-
-  const dismissDriverAlert = (remember?: boolean): void => {
-    if (activeAlertId != null) {
-      dispatch(AppAlerts.alertDismissed(activeAlertId, remember))
-    }
-  }
-  const isAppUpdateIgnored = useSelector((state: State) => {
-    return AppAlerts.getAlertIsPermanentlyIgnored(
-      state,
-      AppAlerts.ALERT_APP_UPDATE_AVAILABLE
-    )
-  })
-
-  const hasJustUpdated = useSelector(getHasJustUpdated)
-  const removeToast = !isAppUpdateAvailable || isAppUpdateIgnored
-
-  // Only run this hook on app startup
-  React.useEffect(() => {
-    if (hasJustUpdated) {
-      makeToast(t('opentrons_app_successfully_updated'), SUCCESS_TOAST, {
-        closeButton: true,
-        disableTimeout: true,
-      })
-      dispatch(toggleConfigValue('update.hasJustUpdated'))
-    }
-  }, [])
-
-  React.useEffect(() => {
-    if (isAppUpdateAvailable && !isAppUpdateIgnored) {
-      toastRef.current = makeToast(
-        t('opentrons_app_update_available_variation'),
-        WARNING_TOAST,
-        {
-          closeButton: true,
-          disableTimeout: true,
-          linkText: t('view_update'),
-          onLinkClick: () => setShowUpdateModal(true),
-        }
-      )
-    } else if (removeToast && toastRef.current) {
+  const removeActiveAppUpdateToast = (): void => {
+    if (toastRef.current) {
       eatToast(toastRef.current)
       toastRef.current = null
     }
-  }, [isAppUpdateAvailable, isAppUpdateIgnored])
+  }
 
   return (
-    <>
-      {/* TODO(mc, 2020-05-07): AnalyticsSettingsModal currently controls its
-          own render; move its logic into `state.alerts` */}
-      <AnalyticsSettingsModal />
-
-      {activeAlertId === AppAlerts.ALERT_U2E_DRIVER_OUTDATED ? (
-        <U2EDriverOutdatedAlert dismissAlert={dismissDriverAlert} />
-      ) : null}
-      {showUpdateModal ? (
-        <UpdateAppModal closeModal={() => setShowUpdateModal(false)} />
-      ) : null}
-    </>
+    <AlertsContext.Provider value={{ removeActiveAppUpdateToast }}>
+      <AlertsModal toastIdRef={toastRef} />
+      {children}
+    </AlertsContext.Provider>
   )
 }

--- a/app/src/organisms/Alerts/useRemoveActiveAppUpdateToast.ts.ts
+++ b/app/src/organisms/Alerts/useRemoveActiveAppUpdateToast.ts.ts
@@ -1,0 +1,7 @@
+import * as React from 'react'
+import { AlertsContext } from '.'
+import type { AlertsContextProps } from '.'
+
+export function useRemoveActiveAppUpdateToast(): AlertsContextProps {
+  return React.useContext(AlertsContext)
+}

--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { i18n } from '../../../i18n'
 import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
-import * as Shell from '../../../redux/shell'
 import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import * as Shell from '../../../redux/shell'
 import { UpdateAppModal, UpdateAppModalProps } from '..'
-import { useRemoveActiveAppUpdateToast } from '../../Alerts/useRemoveActiveAppUpdateToast.ts'
+import { useRemoveActiveAppUpdateToast } from '../../Alerts'
 
 import type { State } from '../../../redux/types'
 import type { ShellUpdateState } from '../../../redux/shell/types'
@@ -21,7 +21,7 @@ jest.mock('react-router-dom', () => ({
     push: jest.fn(),
   }),
 }))
-jest.mock('../../Alerts/useRemoveActiveAppUpdateToast.ts')
+jest.mock('../../Alerts')
 
 const getShellUpdateState = Shell.getShellUpdateState as jest.MockedFunction<
   typeof Shell.getShellUpdateState

--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import { i18n } from '../../../i18n'
+import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import * as Shell from '../../../redux/shell'
 import { renderWithProviders } from '@opentrons/components'
 import { UpdateAppModal, UpdateAppModalProps } from '..'
+import { useRemoveActiveAppUpdateToast } from '../../Alerts/useRemoveActiveAppUpdateToast.ts'
 
 import type { State } from '../../../redux/types'
 import type { ShellUpdateState } from '../../../redux/shell/types'
@@ -19,9 +21,13 @@ jest.mock('react-router-dom', () => ({
     push: jest.fn(),
   }),
 }))
+jest.mock('../../Alerts/useRemoveActiveAppUpdateToast.ts')
 
 const getShellUpdateState = Shell.getShellUpdateState as jest.MockedFunction<
   typeof Shell.getShellUpdateState
+>
+const mockUseRemoveActiveAppUpdateToast = useRemoveActiveAppUpdateToast as jest.MockedFunction<
+  typeof useRemoveActiveAppUpdateToast
 >
 
 const render = (props: React.ComponentProps<typeof UpdateAppModal>) => {
@@ -49,6 +55,9 @@ describe('UpdateAppModal', () => {
           releaseNotes: 'this is a release',
         },
       } as ShellUpdateState
+    })
+    when(mockUseRemoveActiveAppUpdateToast).calledWith().mockReturnValue({
+      removeActiveAppUpdateToast: jest.fn(),
     })
   })
 

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -26,6 +26,7 @@ import { ReleaseNotes } from '../../molecules/ReleaseNotes'
 import { LegacyModal } from '../../molecules/LegacyModal'
 import { Banner } from '../../atoms/Banner'
 import { ProgressBar } from '../../atoms/ProgressBar'
+import { useRemoveActiveAppUpdateToast } from '../Alerts/useRemoveActiveAppUpdateToast.ts'
 
 import type { Dispatch } from '../../redux/types'
 import { StyledText } from '../../atoms/text'
@@ -97,6 +98,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   const releaseNotes = updateInfo?.releaseNotes
   const { t } = useTranslation('app_settings')
   const history = useHistory()
+  const { removeActiveAppUpdateToast } = useRemoveActiveAppUpdateToast()
 
   if (downloaded) setTimeout(() => dispatch(applyShellUpdate()), 5000)
 
@@ -104,6 +106,8 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
     history.push('/app-settings/general')
     closeModal(true)
   }
+
+  removeActiveAppUpdateToast()
 
   const appUpdateFooter = (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -26,7 +26,7 @@ import { ReleaseNotes } from '../../molecules/ReleaseNotes'
 import { LegacyModal } from '../../molecules/LegacyModal'
 import { Banner } from '../../atoms/Banner'
 import { ProgressBar } from '../../atoms/ProgressBar'
-import { useRemoveActiveAppUpdateToast } from '../Alerts/useRemoveActiveAppUpdateToast.ts'
+import { useRemoveActiveAppUpdateToast } from '../Alerts'
 
 import type { Dispatch } from '../../redux/types'
 import { StyledText } from '../../atoms/text'
@@ -80,6 +80,8 @@ const UPDATE_PROGRESS_BAR_STYLE = css`
   background: ${COLORS.medGreyEnabled};
 `
 
+const RESTART_APP_AFTER_TIME = 5000
+
 export interface UpdateAppModalProps {
   closeModal: (arg0: boolean) => void
 }
@@ -100,7 +102,8 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   const history = useHistory()
   const { removeActiveAppUpdateToast } = useRemoveActiveAppUpdateToast()
 
-  if (downloaded) setTimeout(() => dispatch(applyShellUpdate()), 5000)
+  if (downloaded)
+    setTimeout(() => dispatch(applyShellUpdate()), RESTART_APP_AFTER_TIME)
 
   const handleRemindMeLaterClick = (): void => {
     history.push('/app-settings/general')


### PR DESCRIPTION
Closes RQA-1612
# Overview

Resolves a bug in which the app update toast remains visible when clicking on the app update banner.
 
The only real solution is to either prop drill or create context, which seems the lesser of two not great options. When more of our team is back in office, I really would like to push for [this library](https://github.com/eBay/nice-modal-react), which would greatly simplify the way we manage modals and prevent the need for such excessive context/prop drilling in the future plus aid in maintainability. Read the motivation section for an explanation of the benefits.
 
Note that the exit animation for toasts does not properly play when the update banner renders, although this doesn't seem to negatively affect UX. When toasts are refactored (a current to-do item), eatToast() should better account for returning a null Id after the toast exit animation duration, thereby allowing toasts to play while still enabling conditional removal of toasts based on toastId.
 
### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/8bad8f1f-384a-4be8-9018-2b4711f16908

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/a16355ca-dba0-45f2-a135-bd3628c1571a

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
# Test Plan
- Follow test steps as outlined in the video.
 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.
 
OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.
 
Note: It can be helpful to write a test plan before doing development
 
Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct
-->
# Changelog
- Created new context and supporting hook for dismissing app updates.
- Placed hook in UpdateAppModal
- Added supporting testing
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
 
Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Risk assessment
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.
 
Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
low
