### PR TITLE
fix(app): disable instrument card controls when run is active

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -204,6 +204,7 @@ export function InstrumentsAndModules({
                 pipetteIs96Channel={is96ChannelAttached}
                 pipetteIsBad={badLeftPipette != null}
                 updatePipette={() => setSubsystemToUpdate('pipette_left')}
+                isRunActive={currentRunId != null && !isRunTerminal}
               />
               {isOT3 && (
                 <GripperCard
@@ -213,6 +214,7 @@ export function InstrumentsAndModules({
                     attachedGripper?.data?.calibratedOffset != null
                   }
                   setSubsystemToUpdate={setSubsystemToUpdate}
+                  isRunActive={currentRunId != null && !isRunTerminal}
                 />
               )}
               {leftColumnModules.map((module, index) => (
@@ -252,6 +254,7 @@ export function InstrumentsAndModules({
                   pipetteIs96Channel={false}
                   pipetteIsBad={badRightPipette != null}
                   updatePipette={() => setSubsystemToUpdate('pipette_right')}
+                  isRunActive={currentRunId != null && !isRunTerminal}
                 />
               )}
               {rightColumnModules.map((module, index) => (

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -26,6 +26,7 @@ interface PipetteOverflowMenuProps {
   handleAboutSlideout: () => void
   handleSettingsSlideout: () => void
   isPipetteCalibrated: boolean
+  isRunActive: boolean
 }
 
 export const PipetteOverflowMenu = (
@@ -40,6 +41,7 @@ export const PipetteOverflowMenu = (
     handleAboutSlideout,
     handleSettingsSlideout,
     isPipetteCalibrated,
+    isRunActive,
   } = props
 
   const pipetteName =
@@ -65,6 +67,7 @@ export const PipetteOverflowMenu = (
           <MenuItem
             key={`${String(pipetteDisplayName)}_${mount}_attach_pipette`}
             onClick={() => handleChangePipette()}
+            disabled={isRunActive}
             data-testid={`pipetteOverflowMenu_attach_pipette_btn_${String(
               pipetteDisplayName
             )}_${mount}`}
@@ -77,6 +80,7 @@ export const PipetteOverflowMenu = (
               <MenuItem
                 key={`${pipetteDisplayName}_${mount}_calibrate_offset`}
                 onClick={() => handleCalibrate()}
+                disabled={isRunActive}
                 data-testid={`pipetteOverflowMenu_calibrate_offset_btn_${pipetteDisplayName}_${mount}`}
               >
                 {t(
@@ -89,6 +93,7 @@ export const PipetteOverflowMenu = (
             <MenuItem
               key={`${String(pipetteDisplayName)}_${mount}_detach`}
               onClick={() => handleChangePipette()}
+              disabled={isRunActive}
               data-testid={`pipetteOverflowMenu_detach_pipette_btn_${String(
                 pipetteDisplayName
               )}_${mount}`}

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -81,6 +81,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     when(mockUseIsOT3).calledWith(mockRobotName).mockReturnValue(false)
     when(mockAboutPipettesSlideout).mockReturnValue(
@@ -121,6 +122,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('left Mount')
@@ -136,6 +138,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText, getByRole } = render(props)
     getByText('Both Mounts')
@@ -156,6 +159,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('right Mount')
@@ -170,6 +174,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('right Mount')
@@ -184,6 +189,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('left Mount')
@@ -199,6 +205,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { queryByText } = render(props)
     expect(queryByText('Calibrate now')).toBeNull()
@@ -213,6 +220,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('Calibrate now')
@@ -226,6 +234,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: false,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByRole, getByText, queryByText } = render(props)
 
@@ -248,6 +257,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: true,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('Right mount')
@@ -268,6 +278,7 @@ describe('PipetteCard', () => {
       isPipetteCalibrated: false,
       pipetteIsBad: true,
       updatePipette: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('Right mount')

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -41,6 +41,7 @@ describe('PipetteOverflowMenu', () => {
       handleAboutSlideout: jest.fn(),
       handleSettingsSlideout: jest.fn(),
       isPipetteCalibrated: false,
+      isRunActive: false,
     }
   })
   afterEach(() => {
@@ -69,6 +70,7 @@ describe('PipetteOverflowMenu', () => {
       handleAboutSlideout: jest.fn(),
       handleSettingsSlideout: jest.fn(),
       isPipetteCalibrated: false,
+      isRunActive: false,
     }
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Attach pipette' })
@@ -87,6 +89,7 @@ describe('PipetteOverflowMenu', () => {
       handleAboutSlideout: jest.fn(),
       handleSettingsSlideout: jest.fn(),
       isPipetteCalibrated: true,
+      isRunActive: false,
     }
     const { getByRole } = render(props)
     const recalibrate = getByRole('button', {

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -54,6 +54,7 @@ interface PipetteCardProps {
   pipetteIs96Channel: boolean
   pipetteIsBad: boolean
   updatePipette: () => void
+  isRunActive: boolean
 }
 const BANNER_LINK_CSS = css`
   text-decoration: underline;
@@ -73,6 +74,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     pipetteIs96Channel,
     pipetteIsBad,
     updatePipette,
+    isRunActive,
   } = props
   const {
     menuOverlay,
@@ -323,6 +325,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               handleAboutSlideout={handleAboutSlideout}
               handleCalibrate={handleCalibrate}
               isPipetteCalibrated={isPipetteCalibrated}
+              isRunActive={isRunActive}
             />
           </Box>
           {menuOverlay}

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -207,6 +207,7 @@ export function RobotUpdateProgressModal({
     <LegacyModal
       title={`${t('updating')} ${robotName}`}
       width="40rem"
+      height="18.4rem"
       onClose={completedUpdating ? completeRobotUpdateHandler : undefined}
       footer={
         completedUpdating ? (

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -42,11 +42,16 @@ function SuccessOrError({ errorMessage }: SuccessOrErrorProps): JSX.Element {
   let renderedImg: JSX.Element
   if (!errorMessage)
     renderedImg = (
-      <img alt={IMAGE_ALT} src={successIcon} height="50%" width="50%" />
+      <img alt={IMAGE_ALT} src={successIcon} height="208px" width="250px" />
     )
   else
     renderedImg = (
-      <Icon name="alert-circle" size="25%" color={COLORS.errorEnabled} />
+      <Icon
+        name="alert-circle"
+        height="40px"
+        color={COLORS.errorEnabled}
+        margin={SPACING.spacing24}
+      />
     )
 
   return (
@@ -104,6 +109,7 @@ function RobotUpdateProgressFooter({
           onClick={installUpdate}
           marginRight={SPACING.spacing8}
           css={FOOTER_BUTTON_STYLE}
+          border="none"
         >
           {t('try_again')}
         </NewSecondaryBtn>
@@ -207,7 +213,6 @@ export function RobotUpdateProgressModal({
     <LegacyModal
       title={`${t('updating')} ${robotName}`}
       width="40rem"
-      height="18.4rem"
       onClose={completedUpdating ? completeRobotUpdateHandler : undefined}
       footer={
         completedUpdating ? (
@@ -219,26 +224,26 @@ export function RobotUpdateProgressModal({
         ) : null
       }
     >
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        alignItems={ALIGN_CENTER}
-        padding={SPACING.spacing48}
-      >
-        {completedUpdating ? (
+      {completedUpdating ? (
+        <Flex flexDirection={DIRECTION_COLUMN} alignItems={ALIGN_CENTER}>
           <SuccessOrError errorMessage={error} />
-        ) : (
-          <>
-            <StyledText>{modalBodyText}</StyledText>
-            <ProgressBar
-              percentComplete={progressPercent.current}
-              outerStyles={UPDATE_PROGRESS_BAR_STYLE}
-            />
-            <StyledText css={dontTurnOffMessage}>
-              {t('do_not_turn_off')}
-            </StyledText>
-          </>
-        )}
-      </Flex>
+        </Flex>
+      ) : (
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          alignItems={ALIGN_CENTER}
+          padding={SPACING.spacing48}
+        >
+          <StyledText>{modalBodyText}</StyledText>
+          <ProgressBar
+            percentComplete={progressPercent.current}
+            outerStyles={UPDATE_PROGRESS_BAR_STYLE}
+          />
+          <StyledText css={dontTurnOffMessage}>
+            {t('do_not_turn_off')}
+          </StyledText>
+        </Flex>
+      )}
     </LegacyModal>
   )
 }

--- a/app/src/organisms/GripperCard/__tests__/GripperCard.test.tsx
+++ b/app/src/organisms/GripperCard/__tests__/GripperCard.test.tsx
@@ -46,6 +46,7 @@ describe('GripperCard', () => {
       } as GripperData,
       isCalibrated: true,
       setSubsystemToUpdate: jest.fn(),
+      isRunActive: false,
     }
     mockGripperWizardFlows.mockReturnValue(<>wizard flow launched</>)
     mockAboutGripperSlideout.mockReturnValue(<>about gripper</>)
@@ -87,6 +88,7 @@ describe('GripperCard', () => {
       } as GripperData,
       isCalibrated: false,
       setSubsystemToUpdate: jest.fn(),
+      isRunActive: false,
     }
 
     const { getByText } = render(props)
@@ -127,6 +129,7 @@ describe('GripperCard', () => {
       attachedGripper: null,
       isCalibrated: false,
       setSubsystemToUpdate: jest.fn(),
+      isRunActive: false,
     }
     const { getByText, getByRole } = render(props)
     const overflowButton = getByRole('button', {
@@ -144,6 +147,7 @@ describe('GripperCard', () => {
       } as any,
       isCalibrated: false,
       setSubsystemToUpdate: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('Extension mount')
@@ -162,6 +166,7 @@ describe('GripperCard', () => {
       } as any,
       isCalibrated: true,
       setSubsystemToUpdate: jest.fn(),
+      isRunActive: false,
     }
     const { getByText } = render(props)
     getByText('Extension mount')

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -17,6 +17,7 @@ interface GripperCardProps {
   attachedGripper: GripperData | BadGripper | null
   isCalibrated: boolean
   setSubsystemToUpdate: (subsystem: Subsystem | null) => void
+  isRunActive: boolean
 }
 const BANNER_LINK_CSS = css`
   text-decoration: underline;
@@ -29,6 +30,7 @@ export function GripperCard({
   attachedGripper,
   isCalibrated,
   setSubsystemToUpdate,
+  isRunActive,
 }: GripperCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
   const [
@@ -63,7 +65,7 @@ export function GripperCard({
       ? [
           {
             label: t('attach_gripper'),
-            disabled: attachedGripper != null,
+            disabled: attachedGripper != null || isRunActive,
             onClick: handleAttach,
           },
         ]
@@ -73,12 +75,12 @@ export function GripperCard({
               attachedGripper.data.calibratedOffset?.last_modified != null
                 ? t('recalibrate_gripper')
                 : t('calibrate_gripper'),
-            disabled: attachedGripper == null,
+            disabled: attachedGripper == null || isRunActive,
             onClick: handleCalibrate,
           },
           {
             label: t('detach_gripper'),
-            disabled: attachedGripper == null,
+            disabled: attachedGripper == null || isRunActive,
             onClick: handleDetach,
           },
           {

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -9,7 +9,7 @@ import {
   RESPONSIVENESS,
   TYPOGRAPHY,
 } from '@opentrons/components'
-
+import { SmallButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import type { ModuleCalibrationWizardStepProps } from './types'
 
@@ -25,13 +25,20 @@ export const BODY_STYLE = css`
 export const Success = (
   props: ModuleCalibrationWizardStepProps
 ): JSX.Element | null => {
-  const { proceed, attachedModule, isRobotMoving } = props
+  const { proceed, attachedModule, isRobotMoving, isOnDevice } = props
   const { t } = useTranslation('module_wizard_flows')
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
 
   const handleOnClick = (): void => {
     proceed()
   }
+  const button = isOnDevice ? (
+    <SmallButton onClick={handleOnClick} buttonText={t('exit')} />
+  ) : (
+    <PrimaryButton disabled={isRobotMoving} onClick={handleOnClick}>
+      {t('exit')}
+    </PrimaryButton>
+  )
 
   return (
     <SimpleWizardBody
@@ -41,9 +48,7 @@ export const Success = (
       isSuccess
       justifyContentForOddButton={JUSTIFY_FLEX_END}
     >
-      <PrimaryButton disabled={isRobotMoving} onClick={handleOnClick}>
-        {t('exit')}
-      </PrimaryButton>
+      {button}
     </SimpleWizardBody>
   )
 }

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -4,6 +4,7 @@ import { css } from 'styled-components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
   COLORS,
+  JUSTIFY_FLEX_END,
   PrimaryButton,
   RESPONSIVENESS,
   TYPOGRAPHY,
@@ -38,6 +39,7 @@ export const Success = (
       // TODO: iconColor unused, change SimpleWizardBody props interface
       iconColor={COLORS.errorEnabled}
       isSuccess
+      justifyContentForOddButton={JUSTIFY_FLEX_END}
     >
       <PrimaryButton disabled={isRobotMoving} onClick={handleOnClick}>
         {t('exit')}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
This PR fixes a few small bugs for release 7.0.1:
RQA-1380, RQA-1515, and RQA-1575
# Test Plan
1. Look at instrument card overflow menu when a run is active and see that the controls are disabled
2. Calibrate a module on ODD and see that the exit button is right aligned
3. After updating the robot, see the height of the update success screen is now accurate

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Disable pipette and gripper card overflow menu items that launch wizard flows when a run is in progress
2. Right align exit button for module calibration success screen on ODD, use SmallButton if on device
3. Edit icon size and padding for the Robot Update success screen according to the figma designs

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Ensure code looks sound
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
