### PR TITLE
chore: add releases.json manifest for app

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -449,7 +449,7 @@ jobs:
       - name: 'update internal-releases releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         run: |
-          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
+          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
           node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
 
       - name: 'update release releases.json'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -416,10 +416,13 @@ jobs:
 
       - name: 'pull repo for scripts'
         uses: 'actions/checkout@v3'
+        with:
+          path: ./monorepo
       # https://github.com/actions/checkout/issues/290
       - name: 'Fix actions/checkout odd handling of tags'
         if: startsWith(github.ref, 'refs/tags')
         run: |
+          cd ./monorepo
           git fetch -f origin ${{ github.ref }}:${{ github.ref }}
           git checkout ${{ github.ref }}
       - uses: 'actions/setup-node@v3'
@@ -432,7 +435,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
+            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/monorepo/.github/workflows/utils.js`)
             buildComplexEnvVars(core, context)
       - name: 'cache yarn cache'
         uses: actions/cache@v3
@@ -445,17 +448,18 @@ jobs:
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
+          cd monorepo
           make setup-js
       - name: 'update internal-releases releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
-          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
+          node ./monorepo/scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
           aws --profile=deploy s3 cp ./to_upload_internal-release/releases.json s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json
 
       - name: 'update release releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
-          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
+          node ./monorepo/scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
           aws --profile=deploy s3 cp ./to_upload_release/releases.json s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -416,9 +416,6 @@ jobs:
 
       - name: 'pull repo for scripts'
         uses: 'actions/checkout@v3'
-      - uses: 'actions/setup-node@v3'
-        with:
-          node-version: '16'
       # https://github.com/actions/checkout/issues/290
       - name: 'Fix actions/checkout odd handling of tags'
         if: startsWith(github.ref, 'refs/tags')
@@ -428,6 +425,15 @@ jobs:
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16'
+      - name: 'install udev'
+        run: sudo apt-get update && sudo apt-get install libudev-dev
+      - name: 'set complex environment variables'
+        id: 'set-vars'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
+            buildComplexEnvVars(core, context)
       - name: 'cache yarn cache'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -318,11 +318,6 @@ jobs:
     needs: ['js-unit-test', 'backend-unit-test', 'build-app', 'determine-build-type']
     if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'release') || contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
     steps:
-      - name: 'pull repo for scripts'
-        uses: 'actions/checkout@v3'
-      - uses: 'actions/setup-node@v3'
-        with:
-          node-version: '16'
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'
         with:
@@ -419,6 +414,32 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_ROBOTSTACK_SLACK_NOTIFICATION_WEBHOOK_URL }}
           _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}/${{env._APP_DEPLOY_FOLDER_ROBOTSTACK}}
 
+      - name: 'pull repo for scripts'
+        uses: 'actions/checkout@v3'
+      - uses: 'actions/setup-node@v3'
+        with:
+          node-version: '16'
+      # https://github.com/actions/checkout/issues/290
+      - name: 'Fix actions/checkout odd handling of tags'
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git checkout ${{ github.ref }}
+      - uses: 'actions/setup-node@v3'
+        with:
+          node-version: '16'
+      - name: 'cache yarn cache'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/.npm-cache/_prebuild
+            ${{ github.workspace }}/.yarn-cache
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+      - name: 'setup-js'
+        run: |
+          npm config set cache ${{ github.workspace }}/.npm-cache
+          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
+          make setup-js
       - name: 'update internal-releases releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         run: |

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -357,13 +357,13 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
-          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release
+          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
 
       - name: 'update release releases.json'
         if: needs.determine-build-type.outputs.type == 'release'
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
-          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release
+          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
 
       - name: 'upload windows artifacts to GH release'
         uses: 'ncipollo/release-action@v1.12.0'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -357,13 +357,13 @@ jobs:
         if: needs.determine-build-type.outputs.type == 'release'
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
-          node ./scripts/update-releases.json ./to_upload_internal-release/releases.json ot3 $(find to_upload_internal-release/*.exe) $(find to_upload_internal-release/*.dmg) $(find to_upload_internal-release/*.AppImage)
+          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release
 
       - name: 'update release releases.json'
         if: needs.determine-build-type.outputs.type == 'release'
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
-          node ./scripts/update-releases.json ./to_upload_release/releases.json robot-stack $(find to_upload_release/*.exe) $(find to_upload_release/*.dmg) $(find to_upload_release/*.AppImage)
+          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release
 
       - name: 'upload windows artifacts to GH release'
         uses: 'ncipollo/release-action@v1.12.0'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -353,17 +353,6 @@ jobs:
       - name: 'deploy internal-release release builds to s3'
         run: |
           aws s3 --profile=deploy sync --acl=public-read to_upload_internal-release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
-      - name: 'update internal-releases releases.json'
-        if: needs.determine-build-type.outputs.type == 'release'
-        run: |
-          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
-          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
-
-      - name: 'update release releases.json'
-        if: needs.determine-build-type.outputs.type == 'release'
-        run: |
-          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
-          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
 
       - name: 'upload windows artifacts to GH release'
         uses: 'ncipollo/release-action@v1.12.0'
@@ -429,3 +418,15 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_ROBOTSTACK_SLACK_NOTIFICATION_WEBHOOK_URL }}
           _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}/${{env._APP_DEPLOY_FOLDER_ROBOTSTACK}}
+
+      - name: 'update internal-releases releases.json'
+        if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
+        run: |
+          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
+          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
+
+      - name: 'update release releases.json'
+        if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
+        run: |
+          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
+          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -451,9 +451,11 @@ jobs:
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
           node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
+          aws --profile=deploy s3 cp ./to_upload_internal-release/releases.json s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json
 
       - name: 'update release releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
           node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
+          aws --profile=deploy s3 cp ./to_upload_release/releases.json s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -318,6 +318,11 @@ jobs:
     needs: ['js-unit-test', 'backend-unit-test', 'build-app', 'determine-build-type']
     if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'release') || contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
     steps:
+      - name: 'pull repo for scripts'
+        uses: 'actions/checkout@v3'
+      - uses: 'actions/setup-node@v3'
+        with:
+          node-version: '16'
       - name: 'download run app builds'
         uses: 'actions/download-artifact@v3'
         with:
@@ -348,6 +353,18 @@ jobs:
       - name: 'deploy internal-release release builds to s3'
         run: |
           aws s3 --profile=deploy sync --acl=public-read to_upload_internal-release/ s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}
+      - name: 'update internal-releases releases.json'
+        if: needs.determine-build-type.outputs.type == 'release'
+        run: |
+          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
+          node ./scripts/update-releases.json ./to_upload_internal-release/releases.json ot3 $(find to_upload_internal-release/*.exe) $(find to_upload_internal-release/*.dmg) $(find to_upload_internal-release/*.AppImage)
+
+      - name: 'update release releases.json'
+        if: needs.determine-build-type.outputs.type == 'release'
+        run: |
+          aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
+          node ./scripts/update-releases.json ./to_upload_release/releases.json robot-stack $(find to_upload_release/*.exe) $(find to_upload_release/*.dmg) $(find to_upload_release/*.AppImage)
+
       - name: 'upload windows artifacts to GH release'
         uses: 'ncipollo/release-action@v1.12.0'
         if: needs.determine-build-type.outputs.type == 'release'

--- a/scripts/update-releases-json.js
+++ b/scripts/update-releases-json.js
@@ -7,15 +7,16 @@ const fs = require('fs/promises')
 const versionFinder = require('./git-version')
 
 const parseArgs = require('./deploy/lib/parseArgs')
-const USAGE = '\nUsage:\n node ./scripts/update-releases-json <releases-json-path> <project> <artifact-dir>'
+const USAGE =
+  '\nUsage:\n node ./scripts/update-releases-json <releases-json-path> <project> <artifact-dir>'
 
 async function readOrDefaultReleases(releasesPath) {
   try {
     const releasesFile = await fs.readFile(releasesPath)
     return JSON.parse(releasesFile)
-  } catch(error) {
+  } catch (error) {
     console.log(`Could not read releases file: ${error}, defaulting`)
-    return {production: {}}
+    return { production: {} }
   }
 }
 
@@ -25,41 +26,49 @@ const FILES_IN_RELEASE_JSON = [
   /Opentrons.*\.AppImage$/,
   /latest.*yml$/,
   /alpha.*yml$/,
-  /beta.*yml$/
+  /beta.*yml$/,
 ]
 
 function artifactNameToObj(artifactName) {
   if (artifactName.search(/Opentrons.*\.exe$/) !== -1) {
-    return {'Opentrons.exe': artifactName}
+    return { 'Opentrons.exe': artifactName }
   } else if (artifactName.search(/Opentrons.*\.dmg$/) !== -1) {
-    return {'Opentrons.dmg': artifactName}
+    return { 'Opentrons.dmg': artifactName }
   } else if (artifactName.search(/Opentrons.*\.AppImage$/) !== -1) {
-    return {'Opentrons.AppImage': artifactName}
+    return { 'Opentrons.AppImage': artifactName }
   } else if (artifactName.search(/(latest|alpha|beta).*yml$/) !== -1) {
-    return {[artifactName]: artifactName}
+    return { [artifactName]: artifactName }
   } else {
     throw new Error(`Unmatched artifact ${artifactName}`)
   }
 }
 
 async function artifactsFromDir(artifactDirPath) {
-  const files = await fs.readdir(artifactDirPath, {withFileTypes: true})
-  return files.filter(dirent => dirent.isFile() && FILES_IN_RELEASE_JSON.some(re => dirent.name.search(re) !== -1))
-      .map(dirent => artifactNameToObj(dirent.name))
-      .reduce((prev, current) => ({...prev, ...current}))
+  const files = await fs.readdir(artifactDirPath, { withFileTypes: true })
+  return files
+    .filter(
+      dirent =>
+        dirent.isFile() &&
+        FILES_IN_RELEASE_JSON.some(re => dirent.name.search(re) !== -1)
+    )
+    .map(dirent => artifactNameToObj(dirent.name))
+    .reduce((prev, current) => ({ ...prev, ...current }))
 }
 
 async function main() {
-  const {args}= parseArgs(process.argv.slice(2))
+  const { args } = parseArgs(process.argv.slice(2))
   const [releasesPath, project, artifactDirPath] = args
   if (!releasesPath || !project || !artifactDirPath) {
     throw new Error(USAGE)
   }
   const releasesData = await readOrDefaultReleases(releasesPath)
   const version = await versionFinder.versionForProject(project)
-  releasesData.production[version] = {...(await artifactsFromDir(artifactDirPath)), revoked: false} ;
+  releasesData.production[version] = {
+    ...(await artifactsFromDir(artifactDirPath)),
+    revoked: false,
+  }
 
-  (await fs.open(releasesPath, 'w')).writeFile(JSON.stringify(releasesData))
+  ;(await fs.open(releasesPath, 'w')).writeFile(JSON.stringify(releasesData))
 }
 
 if (require.main === module) {

--- a/scripts/update-releases-json.js
+++ b/scripts/update-releases-json.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const fs = require('fs/promises')
+
+// Updates a releases historical manifest with a release's version.
+
+const versionFinder = require('./git-version')
+
+const parseArgs = require('./deploy/lib/parseArgs')
+const USAGE = '\nUsage:\n node ./scripts/update-releases-json <releases-json-path> <project> <windows-path> <mac-path> <linux-path>'
+
+async function readOrDefaultReleases(releasesPath) {
+  try {
+    const releasesFile = await fs.readFile(releasesPath)
+    return JSON.parse(releasesFile)
+  } catch(error) {
+    console.log(`Could not read releases file: ${error}, defaulting`)
+    return {production: {}}
+  }
+}
+
+async function main() {
+  const {args}= parseArgs(process.argv.slice(2))
+  const [releasesPath, project, windowsPath, macPath, linuxPath] = args
+  if (!releasesPath || !project || !windowsPath || !macPath || !linuxPath) {
+    throw new Error(USAGE)
+  }
+  const releasesData = await readOrDefaultReleases(releasesPath)
+  const version = await versionFinder.versionForProject(project)
+  releasesData.production[version] = {
+    'Opentrons.exe': windowsPath,
+    'Opentrons.dmg': macPath,
+    'Opentrons.AppImage': linuxPath,
+    revoked: false
+  } ;
+  (await fs.open(releasesPath, 'w')).writeFile(JSON.stringify(releasesData))
+}
+
+if (require.main === module) {
+  main()
+    .then(() => {
+      console.log('release file updated')
+    })
+    .catch(error => {
+      console.error('Release file update failed:', error)
+      process.exitCode = -1
+    })
+}

--- a/scripts/update-releases-json.js
+++ b/scripts/update-releases-json.js
@@ -52,7 +52,7 @@ async function artifactsFromDir(artifactDirPath, urlBase) {
         FILES_IN_RELEASE_JSON.some(re => dirent.name.search(re) !== -1)
     )
     .map(dirent => artifactNameToObj(dirent.name, urlBase))
-    .reduce((prev, current) => ({ ...prev, ...current }))
+    .reduce((prev, current) => ({ ...prev, ...current }), {})
 }
 
 async function main() {

--- a/scripts/update-releases-json.js
+++ b/scripts/update-releases-json.js
@@ -7,7 +7,7 @@ const fs = require('fs/promises')
 const versionFinder = require('./git-version')
 
 const parseArgs = require('./deploy/lib/parseArgs')
-const USAGE = '\nUsage:\n node ./scripts/update-releases-json <releases-json-path> <project> <windows-path> <mac-path> <linux-path>'
+const USAGE = '\nUsage:\n node ./scripts/update-releases-json <releases-json-path> <project> <artifact-dir>'
 
 async function readOrDefaultReleases(releasesPath) {
   try {
@@ -19,20 +19,46 @@ async function readOrDefaultReleases(releasesPath) {
   }
 }
 
+const FILES_IN_RELEASE_JSON = [
+  /Opentrons.*\.exe$/,
+  /Opentrons.*\.dmg$/,
+  /Opentrons.*\.AppImage$/,
+  /latest.*yml$/,
+  /alpha.*yml$/,
+  /beta.*yml$/
+]
+
+function artifactNameToObj(artifactName) {
+  if (artifactName.search(/Opentrons.*\.exe$/) !== -1) {
+    return {'Opentrons.exe': artifactName}
+  } else if (artifactName.search(/Opentrons.*\.dmg$/) !== -1) {
+    return {'Opentrons.dmg': artifactName}
+  } else if (artifactName.search(/Opentrons.*\.AppImage$/) !== -1) {
+    return {'Opentrons.AppImage': artifactName}
+  } else if (artifactName.search(/(latest|alpha|beta).*yml$/) !== -1) {
+    return {[artifactName]: artifactName}
+  } else {
+    throw new Error(`Unmatched artifact ${artifactName}`)
+  }
+}
+
+async function artifactsFromDir(artifactDirPath) {
+  const files = await fs.readdir(artifactDirPath, {withFileTypes: true})
+  return files.filter(dirent => dirent.isFile() && FILES_IN_RELEASE_JSON.some(re => dirent.name.search(re) !== -1))
+      .map(dirent => artifactNameToObj(dirent.name))
+      .reduce((prev, current) => ({...prev, ...current}))
+}
+
 async function main() {
   const {args}= parseArgs(process.argv.slice(2))
-  const [releasesPath, project, windowsPath, macPath, linuxPath] = args
-  if (!releasesPath || !project || !windowsPath || !macPath || !linuxPath) {
+  const [releasesPath, project, artifactDirPath] = args
+  if (!releasesPath || !project || !artifactDirPath) {
     throw new Error(USAGE)
   }
   const releasesData = await readOrDefaultReleases(releasesPath)
   const version = await versionFinder.versionForProject(project)
-  releasesData.production[version] = {
-    'Opentrons.exe': windowsPath,
-    'Opentrons.dmg': macPath,
-    'Opentrons.AppImage': linuxPath,
-    revoked: false
-  } ;
+  releasesData.production[version] = {...(await artifactsFromDir(artifactDirPath)), revoked: false} ;
+
   (await fs.open(releasesPath, 'w')).writeFile(JSON.stringify(releasesData))
 }
 

--- a/scripts/update-releases-json.js
+++ b/scripts/update-releases-json.js
@@ -61,8 +61,10 @@ async function main() {
   if (!releasesPath || !project || !artifactDirPath || !urlBase) {
     throw new Error(USAGE)
   }
+  console.log(`Updating ${releasesPath} with artifacts from ${artifactDirPath}`)
   const releasesData = await readOrDefaultReleases(releasesPath)
   const version = await versionFinder.versionForProject(project)
+  console.log(`Adding data for ${version}`)
   releasesData.production[version] = {
     ...(await artifactsFromDir(
       artifactDirPath,
@@ -70,6 +72,9 @@ async function main() {
     )),
     revoked: false,
   }
+  console.log(
+    `Added ${Object.keys(releasesData.production[version]).length} artifacts`
+  )
   ;(await fs.open(releasesPath, 'w')).writeFile(JSON.stringify(releasesData))
 }
 


### PR DESCRIPTION
This adds a file that lives in the deploy bucket that tracks past releases of the app. We can use this for autogenerating previous-release pages and is a good thing to have. We can also use it for release revocation if we want.

## Testing
- we'll have to run some builds, i'll make some internal-release alphas or something. check that the releases.json is there
- but it's not actually used for anything yet