### PR TITLE
fix(app): show usb icon for OT-2 usb connection

### DIFF
--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -22,6 +22,7 @@ import {
 import { QuaternaryButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { Tooltip } from '../../atoms/Tooltip'
+import { useIsOT3 } from '../../organisms/Devices/hooks'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../organisms/RunTimeControl/hooks'
 import {
@@ -51,6 +52,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   const [targetProps, tooltipProps] = useHoverTooltip()
   const dispatch = useDispatch<Dispatch>()
 
+  const isOT3 = useIsOT3(name)
   const currentRunId = useCurrentRunId()
   const currentRunStatus = useCurrentRunStatus()
   const { data: runRecord } = useRunQuery(currentRunId, { staleTime: Infinity })
@@ -94,14 +96,17 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   )
 
   const wifiAddress = addresses.find(addr => addr.ip === wifi?.ipAddress)
-  const isOT3ConnectedViaWifi =
+  const isConnectedViaWifi =
     wifiAddress != null && wifiAddress.healthStatus === HEALTH_STATUS_OK
 
   const ethernetAddress = addresses.find(
     addr => addr.ip === ethernet?.ipAddress
   )
+  // do not show ethernet connection for OT-2
   const isOT3ConnectedViaEthernet =
-    ethernetAddress != null && ethernetAddress.healthStatus === HEALTH_STATUS_OK
+    isOT3 &&
+    ethernetAddress != null &&
+    ethernetAddress.healthStatus === HEALTH_STATUS_OK
 
   const usbAddress = addresses.find(addr => addr.ip === OPENTRONS_USB)
   const isOT3ConnectedViaUSB =
@@ -112,7 +117,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   if (isOT3ConnectedViaEthernet) {
     iconName = 'ethernet'
     tooltipTranslationKey = 'device_settings:ethernet'
-  } else if (isOT3ConnectedViaWifi) {
+  } else if (isConnectedViaWifi) {
     iconName = 'wifi'
     tooltipTranslationKey = 'device_settings:wifi'
   } else if ((local != null && local) || isOT3ConnectedViaUSB) {

--- a/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../redux/discovery'
 import { getNetworkInterfaces } from '../../../redux/networking'
 
+import { useIsOT3 } from '../hooks'
 import { RobotStatusHeader } from '../RobotStatusHeader'
 
 import type { DiscoveryClientRobotAddress } from '../../../redux/discovery/types'
@@ -45,6 +46,7 @@ const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
 const mockGetRobotAddressesByName = getRobotAddressesByName as jest.MockedFunction<
   typeof getRobotAddressesByName
 >
+const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
 const MOCK_OTIE = {
   name: 'otie',
@@ -118,6 +120,7 @@ describe('RobotStatusHeader', () => {
           healthStatus: HEALTH_STATUS_OK,
         } as DiscoveryClientRobotAddress,
       ])
+    when(mockUseIsOT3).calledWith('otie').mockReturnValue(true)
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -201,6 +204,19 @@ describe('RobotStatusHeader', () => {
     const [{ getByLabelText }] = render(props)
 
     getByLabelText('wifi')
+  })
+
+  it('renders a usb icon when OT-2 connected locally via USB-ethernet adapter', () => {
+    when(mockGetNetworkInterfaces)
+      .calledWith({} as State, 'otie')
+      .mockReturnValue({
+        wifi: null,
+        ethernet: { ipAddress: ETHERNET_IP } as SimpleInterfaceStatus,
+      })
+    when(mockUseIsOT3).calledWith('otie').mockReturnValue(false)
+    const [{ getByLabelText }] = render(props)
+
+    getByLabelText('usb')
   })
 
   it('renders a usb icon when only connected locally', () => {


### PR DESCRIPTION

# Overview

fixes a reversion introduced by the Flex icon priority changes. since an OT-2 usb connection is actually an ethernet connection inside the frame of the OT-2, we need to only render the ethernet icon for the Flex.

closes RQA-1556

# Test Plan

 - updated unit tests for icon

# Changelog

 -  Shows usb icon for OT-2 usb connection

# Review requests

check for usb icon on physically connected OT-2 not connected to wifi

# Risk assessment

low
