### PR TITLE
fix(api, app-testing): Removal of ot3 to flex load name resolution and calls 7 chore

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -35,29 +35,8 @@ _APILEVEL_2_14_OT_DEFAULT_VERSIONS: Dict[str, int] = {
 }
 
 
-_MAP_OT3_TO_FLEX_LOAD_NAMES: Dict[str, str] = {
-    "opentrons_ot3_96_tiprack_50ul": "opentrons_flex_96_tiprack_50ul",
-    "opentrons_ot3_96_tiprack_200ul": "opentrons_flex_96_tiprack_200ul",
-    "opentrons_ot3_96_tiprack_1000ul": "opentrons_flex_96_tiprack_1000ul",
-}
-
-
 class AmbiguousLoadLabwareParamsError(RuntimeError):
     """Error raised when specific labware parameters cannot be found due to multiple matching labware definitions."""
-
-
-def resolve_loadname(load_name: str) -> str:
-    """Temporarily check for old Flex tiprack loadnames so that an error is not raised.
-
-    REMOVE FOR LAUNCH.
-    Args:
-        load_name: Load name of the labware.
-
-    Returns:
-        Either the updated loadname or the original loadname if no match.
-
-    """
-    return _MAP_OT3_TO_FLEX_LOAD_NAMES.get(load_name, load_name)
 
 
 def resolve(

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -147,19 +147,15 @@ class ProtocolCore(
         """Load a labware using its identifying parameters."""
         load_location = self._convert_labware_location(location=location)
 
-        # TODO (lc 06-27-2023) Let's keep this around up to launch to
-        # make the user-facing name switching a bit easier for everyone.
-        mapped_load_name = load_labware_params.resolve_loadname(load_name)
-
         custom_labware_params = (
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
         namespace, version = load_labware_params.resolve(
-            mapped_load_name, namespace, version, custom_labware_params
+            load_name, namespace, version, custom_labware_params
         )
 
         load_result = self._engine_client.load_labware(
-            load_name=mapped_load_name,
+            load_name=load_name,
             location=load_location,
             namespace=namespace,
             version=version,

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -272,12 +272,6 @@ def test_load_labware(
     ).then_return(("some_namespace", 9001))
 
     decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
-
-    decoy.when(
         mock_engine_client.load_labware(
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
             load_name="some_labware",
@@ -345,14 +339,8 @@ def test_load_labware_on_labware(
     ).then_return([EngineLabwareLoadParams("hello", "world", 654)])
 
     decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("labware_some")
-
-    decoy.when(
         load_labware_params.resolve(
-            "labware_some",
+            "some_labware",
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
@@ -362,7 +350,7 @@ def test_load_labware_on_labware(
     decoy.when(
         mock_engine_client.load_labware(
             location=OnLabwareLocation(labwareId="labware-id"),
-            load_name="labware_some",
+            load_name="some_labware",
             display_name="some_display_name",
             namespace="some_namespace",
             version=9001,
@@ -425,12 +413,6 @@ def test_load_labware_off_deck(
             [EngineLabwareLoadParams("hello", "world", 654)],
         )
     ).then_return(("some_namespace", 9001))
-
-    decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
 
     decoy.when(
         mock_engine_client.load_labware(
@@ -693,12 +675,6 @@ def test_load_labware_on_module(
     ).then_return(("some_namespace", 9001))
 
     decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
-
-    decoy.when(
         mock_engine_client.load_labware(
             location=ModuleLocation(moduleId="module-id"),
             load_name="some_labware",
@@ -771,12 +747,6 @@ def test_load_labware_on_non_connected_module(
             [EngineLabwareLoadParams("hello", "world", 654)],
         )
     ).then_return(("some_namespace", 9001))
-
-    decoy.when(
-        load_labware_params.resolve_loadname(
-            "some_labware",
-        )
-    ).then_return("some_labware")
 
     decoy.when(
         mock_engine_client.load_labware(

--- a/app-testing/files/protocols/py/OT3_P1000MLeft_P50MRight_HS_MM_TC_TM_2_15_ABR3_Illumina_DNA_Enrichment.py
+++ b/app-testing/files/protocols/py/OT3_P1000MLeft_P50MRight_HS_MM_TC_TM_2_15_ABR3_Illumina_DNA_Enrichment.py
@@ -45,17 +45,17 @@ def run(protocol: protocol_api.ProtocolContext):
     # ========== FIRST ROW ===========
     heatershaker = protocol.load_module("heaterShakerModuleV1", "1")
     sample_plate_2 = heatershaker.load_labware("nest_96_wellplate_2ml_deep")
-    tiprack_200_1 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "2")
+    tiprack_200_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "2")
     temp_block = protocol.load_module("temperature module gen2", "3")
     reagent_plate = temp_block.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
     # ========== SECOND ROW ==========
     MAG_PLATE_SLOT = protocol.load_module("magneticBlockV1", "4")
     reservoir = protocol.load_labware("nest_96_wellplate_2ml_deep", "5")
-    tiprack_200_2 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "6")
+    tiprack_200_2 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "6")
     # ========== THIRD ROW ===========
     thermocycler = protocol.load_module("thermocycler module gen2")
     sample_plate_1 = thermocycler.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
-    tiprack_20 = protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "9")
+    tiprack_20 = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "9")
     # ========== FOURTH ROW ==========
 
     # reagent

--- a/app-testing/files/protocols/py/OT3_P1000MLeft_P50MRight_HS_MM_TC_TM_2_15_ABR3_Illumina_DNA_Enrichment_v4.py
+++ b/app-testing/files/protocols/py/OT3_P1000MLeft_P50MRight_HS_MM_TC_TM_2_15_ABR3_Illumina_DNA_Enrichment_v4.py
@@ -69,15 +69,15 @@ def run(protocol: protocol_api.ProtocolContext):
     reagent_plate = temp_block.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
     # ========== SECOND ROW ==========
     MAG_PLATE_SLOT = 4
-    tiprack_200_1 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "5")
-    tiprack_50_1 = protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "6")
+    tiprack_200_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "5")
+    tiprack_50_1 = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "6")
     # ========== THIRD ROW ===========
     thermocycler = protocol.load_module("thermocycler module gen2")
     sample_plate_1 = thermocycler.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
-    tiprack_200_2 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "8")
-    tiprack_50_2 = protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "9")
+    tiprack_200_2 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "8")
+    tiprack_50_2 = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "9")
     # ========== FOURTH ROW ==========
-    tiprack_200_3 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "11")
+    tiprack_200_3 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "11")
 
     # reagent
     AMPure = reservoir["A1"]

--- a/app-testing/files/protocols/py/OT3_P1000MLeft_P50MRight_HS_TM_MM_TC_2_15_ABR4_Illumina_DNA_Prep_24x.py
+++ b/app-testing/files/protocols/py/OT3_P1000MLeft_P50MRight_HS_TM_MM_TC_2_15_ABR4_Illumina_DNA_Prep_24x.py
@@ -40,16 +40,16 @@ def run(protocol: protocol_api.ProtocolContext):
     # ========== FIRST ROW ===========
     heatershaker = protocol.load_module("heaterShakerModuleV1", "1")
     sample_plate_1 = heatershaker.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
-    tiprack_200_1 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "2")
+    tiprack_200_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "2")
     temp_block = protocol.load_module("temperature module gen2", "3")
     reagent_plate = temp_block.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
     # ========== SECOND ROW ==========
     mag_block = protocol.load_module("magneticBlockV1", 4)
     reservoir = protocol.load_labware("nest_96_wellplate_2ml_deep", "5")
-    tiprack_200_2 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "6")
+    tiprack_200_2 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "6")
     # ========== THIRD ROW ===========
     thermocycler = protocol.load_module("thermocycler module gen2")
-    tiprack_20 = protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "9")
+    tiprack_20 = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "9")
     # ========== FOURTH ROW ==========
 
     # =========== RESERVOIR ==========

--- a/app-testing/files/protocols/py/OT3_P1000SRight_None_2_15_ABR_Simple_Normalize_Long_Right.py
+++ b/app-testing/files/protocols/py/OT3_P1000SRight_None_2_15_ABR_Simple_Normalize_Long_Right.py
@@ -34,16 +34,16 @@ def run(protocol: protocol_api.ProtocolContext):
     reservoir = protocol.load_labware("nest_12_reservoir_15ml", "1")
     sample_plate_1 = protocol.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", "3")
     # ========== SECOND ROW ==========
-    tiprack_200_1 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "4")
-    tiprack_200_2 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "5")
+    tiprack_200_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "4")
+    tiprack_200_2 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "5")
     sample_plate_2 = protocol.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", "6")
     # ========== THIRD ROW ===========
-    tiprack_200_3 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "7")
-    tiprack_200_4 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "8")
+    tiprack_200_3 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "7")
+    tiprack_200_4 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "8")
     sample_plate_3 = protocol.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", "9")
     # ========== FOURTH ROW ==========
-    tiprack_200_5 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "10")
-    tiprack_200_6 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "11")
+    tiprack_200_5 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "10")
+    tiprack_200_6 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "11")
 
     # reagent
     Dye_1 = reservoir["A1"]

--- a/app-testing/files/protocols/py/OT3_P50MLeft_P1000MRight_None_2_15_ABRKAPALibraryQuantLongv2.py
+++ b/app-testing/files/protocols/py/OT3_P50MLeft_P1000MRight_None_2_15_ABRKAPALibraryQuantLongv2.py
@@ -65,9 +65,9 @@ def run(protocol: protocol_api.ProtocolContext):
     reservoir = protocol.load_labware("nest_12_reservoir_15ml", "2")
     dilution_plate_1 = protocol.load_labware("opentrons_96_aluminumblock_biorad_wellplate_200ul", "3")
 
-    tiprack_50_1 = protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "4")
-    tiprack_200_1 = protocol.load_labware("opentrons_ot3_96_tiprack_200ul", "5")
-    tiprack_50_2 = protocol.load_labware("opentrons_ot3_96_tiprack_50ul", "6")
+    tiprack_50_1 = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "4")
+    tiprack_200_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "5")
+    tiprack_50_2 = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "6")
 
     reagent_plate = protocol.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", "7")  # <--- NEST Strip Tubes
     dilution_plate_2 = protocol.load_labware("opentrons_96_aluminumblock_biorad_wellplate_200ul", "8")


### PR DESCRIPTION
**Special Note**: This is a resubmission of a previous PR, but based off the 7.0.0 Chore release at the advising of RSS team, as well as the addition of removal of obslete OT3 tiprack naming conventions from a multitude of app-testing protocols. Assessment of other protocols utilizing "opentrons_ot3_96_tiprack..." naming convention to be held to ensure consistency.

Older naming conventions for tipracks supported load names utilizing "OT3" as an alias for "Flex", which this removes the definitions and handlers for.

# Overview
OT3 tiprack naming convention support removed to satisfy launch naming conventions. Required removal of all interactions with resolve_loadname handler alongside the relevant dictionary of names. 

Mapped names removed and reference to standard loaded name used instead. Load_name test data under test_protocol_core adjusted.

Of note, issue found in test_protocol_core under **test_load_labware_on_labware**. Originally, load_name provided was "labware_some" and was given to the resolution handler. This passed in unmodified build. Removal of references to resolve_loadname cause this test to fail, as the name "labware_some" would result in the following error:

**TypeError: cannot unpack non-iterable NoneType object**

This is corrected by adjusting the test case name to "some_labware" to prevent inconsistency between subject call and load name expectations, allowing the test to pass.

Additional removal of mention of "opentrons_ot3_96_tiprack..." load n ame conventions removed from a myriad of app-testing files to ensure compliancy with the new/only naming convention of "opentrond_flex_96_tiprack...". This is in line with the "_gen3" naming convention removal edits from a previous naming convention adjustment PR.


