### PR TITLE
fix(robot-server): Say "Flex" instead of "OT-3 Standard" in upload error message

### DIFF
--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -224,9 +224,9 @@ async def create_protocol(
     if source.robot_type != robot_type:
         raise ProtocolRobotTypeMismatch(
             detail=(
-                f"This protocol is for {source.robot_type} robots."
+                f"This protocol is for {_user_facing_robot_type(source.robot_type)} robots."
                 f" It can't be analyzed or run on this robot,"
-                f" which is an {robot_type}."
+                f" which is {_user_facing_robot_type(robot_type, include_article=True)}."
             )
         ).as_error(status.HTTP_422_UNPROCESSABLE_ENTITY)
 
@@ -557,3 +557,12 @@ async def get_protocol_analysis_as_document(
         ) from error
 
     return PlainTextResponse(content=analysis, media_type="application/json")
+
+
+def _user_facing_robot_type(
+    robot_type: RobotType, include_article: bool = False
+) -> str:
+    if robot_type == "OT-2 Standard":
+        return "an OT-2" if include_article else "OT-2"
+    elif robot_type == "OT-3 Standard":
+        return "a Flex" if include_article else "Flex"

--- a/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
@@ -22,7 +22,7 @@ stages:
         errors:
           - id: ProtocolRobotTypeMismatch
             title: Protocol For Different Robot Type
-            detail: "This protocol is for OT-3 Standard robots. It can't be analyzed or run on this robot, which is an OT-2 Standard."
+            detail: "This protocol is for Flex robots. It can't be analyzed or run on this robot, which is an OT-2."
             errorCode: '4000'
 
 # TODO(mm, 2022-12-12): Also make sure an OT-3 server rejects OT-2 protocols.

--- a/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
@@ -30,6 +30,7 @@ stages:
 test_name: Make sure an OT-3 server rejects OT-2 protocols.
 
 marks:
+  - ot3_only
   - usefixtures:
     - ot3_server_base_url
   - parametrize:

--- a/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_robot_type_rejection.tavern.yaml
@@ -25,4 +25,31 @@ stages:
             detail: "This protocol is for Flex robots. It can't be analyzed or run on this robot, which is an OT-2."
             errorCode: '4000'
 
-# TODO(mm, 2022-12-12): Also make sure an OT-3 server rejects OT-2 protocols.
+---
+
+test_name: Make sure an OT-3 server rejects OT-2 protocols.
+
+marks:
+  - usefixtures:
+    - ot3_server_base_url
+  - parametrize:
+      key: protocol_file_path
+      vals:
+        - 'tests/integration/protocols/empty_ot2.json'
+        - 'tests/integration/protocols/empty_ot2.py'
+
+stages:
+  - name: Upload the protocol.
+    request:
+      url: '{ot3_server_base_url}/protocols'
+      method: POST
+      files:
+        files: "{protocol_file_path}"
+    response:
+      status_code: 422
+      json:
+        errors:
+          - id: ProtocolRobotTypeMismatch
+            title: Protocol For Different Robot Type
+            detail: "This protocol is for OT-2 robots. It can't be analyzed or run on this robot, which is a Flex."
+            errorCode: '4000'

--- a/robot-server/tests/integration/protocols/empty_ot2.json
+++ b/robot-server/tests/integration/protocols/empty_ot2.json
@@ -1,0 +1,16 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/6",
+  "schemaVersion": 6,
+  "metadata": {},
+  "robot": {
+    "model": "OT-2 Standard",
+    "deckId": "ot2_standard"
+  },
+  "pipettes": {},
+  "modules": {},
+  "labware": {},
+  "liquids": {},
+  "labwareDefinitions": {},
+  "commands": [],
+  "commandAnnotations": []
+}

--- a/robot-server/tests/integration/protocols/empty_ot2.py
+++ b/robot-server/tests/integration/protocols/empty_ot2.py
@@ -1,0 +1,8 @@
+requirements = {
+    "robotType": "OT-2",
+    "apiLevel": "2.15",
+}
+
+
+def run(protocol):
+    pass


### PR DESCRIPTION
# Overview

Closes RQA-1673.

# Test Plan

See steps to reproduce in RQA-1673.

# Changelog

* Map the internal string "OT-3 Standard" to the user-facing string "Flex", and the internal string "OT-2 Standard" to the user-facing string "OT-2." Take care to use the proper indefinite articles: "a Flex" and "an OT-2," not "an Flex" or "a OT-2."
* Update our integration tests for this.
* Resolve an old todo comment in those integration tests about checking OT-2 -> Flex uploads, not just Flex -> OT-2 uploads.

# Review requests

None in particular.

# Risk assessment

Low.