### PR TITLE
fix(api): do not block refresh positions

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -111,11 +111,12 @@ class Gripper(AbstractInstrument[GripperDefinition]):
     @current_jaw_displacement.setter
     def current_jaw_displacement(self, mm: float) -> None:
         max_mm = self._max_jaw_displacement() + 2.0
-        assert mm <= max_mm, (
-            f"jaw displacement {round(mm, 1)} mm exceeds max expected value: "
-            f"{max_mm} mm"
-        )
-        self._current_jaw_displacement = mm
+        if mm > max_mm:
+            self._log.warning(
+                f"jaw displacement {round(mm, 1)} mm exceeds max expected value: "
+                f"{max_mm} mm, setting value to max value instead."
+            )
+        self._current_jaw_displacement = min(mm, max_mm)
 
     @property
     def default_grip_force(self) -> float:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Just found out that if the gripper jaw is reporting a value greater than the max jaw value for whatever reason, we won't be able to home/move any axes. 

This is because we have this sanity check that raises an error whenever we try to set the jaw displacement. This is an issue for us now because whenever we home an axis, we first cache the motor positions for all available motors-- which also sets the jaw displacement value based on the jaw encoder position. 

To fix this, instead of raising an error whenever the encoder value is out-of-bound, we're just going to show a warning and set the displacement to the max value to not block any motion. 
