### PR TITLE
feat(app): add open door check for odd

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -26,6 +26,7 @@
   "current_step": "Current Step",
   "current_temperature": "Current: {{temperature}} °C",
   "data_out_of_date": "This data is likely out of date",
+  "door_is_open": "Robot door is open",
   "door_open_pause": "Current Step - Paused - Door Open",
   "download_run_log": "Download run log",
   "downloading_run_log": "Downloading run log",

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -241,7 +241,6 @@ export function ProtocolRunHeader({
               robotName={robotName}
             />
           )}
-
         <Flex>
           {protocolKey != null ? (
             <Link to={`/protocols/${protocolKey}`}>
@@ -268,7 +267,11 @@ export function ProtocolRunHeader({
         {runStatus === RUN_STATUS_STOPPED ? (
           <Banner type="warning">{t('run_canceled')}</Banner>
         ) : null}
-        {isDoorOpen ? (
+        {/* Note: This banner is for before running a protocol */}
+        {isDoorOpen &&
+        runStatus !== RUN_STATUS_BLOCKED_BY_OPEN_DOOR &&
+        runStatus != null &&
+        CANCELLABLE_STATUSES.includes(runStatus) ? (
           <Banner type="warning">{t('shared:close_robot_door')}</Banner>
         ) : null}
         {isRunCurrent ? (

--- a/app/src/organisms/OpenDoorAlertModal/__tests__/OpenDoorAlertModal.test.tsx
+++ b/app/src/organisms/OpenDoorAlertModal/__tests__/OpenDoorAlertModal.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+import { renderWithProviders } from '@opentrons/components'
+
+import { i18n } from '../../../i18n'
+
+import { OpenDoorAlertModal } from '..'
+
+const render = () => {
+  return renderWithProviders(<OpenDoorAlertModal />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('OpenDoorAlertModal', () => {
+  it('should render text', () => {
+    const [{ getByText }] = render()
+    getByText('Robot door is open')
+    getByText('Close robot door to resume run')
+  })
+})

--- a/app/src/organisms/OpenDoorAlertModal/index.tsx
+++ b/app/src/organisms/OpenDoorAlertModal/index.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_CENTER,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { Portal } from '../../App/portal'
+import { StyledText } from '../../atoms/text'
+import { Modal } from '../../molecules/Modal'
+
+export function OpenDoorAlertModal(): JSX.Element {
+  const { t } = useTranslation('run_details')
+  return (
+    <Portal level="top">
+      <Modal>
+        <Flex
+          backgroundColor={COLORS.darkBlack20}
+          borderRadius={BORDERS.borderRadiusSize3}
+          flexDirection={DIRECTION_COLUMN}
+          padding={SPACING.spacing24}
+          alignItems={ALIGN_CENTER}
+          gridGap={SPACING.spacing16}
+          width="100%"
+          justifyContent={JUSTIFY_CENTER}
+        >
+          <Icon name="ot-alert" size="2.5rem" />
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            gridGap={SPACING.spacing4}
+            alignItems={ALIGN_CENTER}
+            width="100%"
+          >
+            <StyledText as="h4" fontWeight={TYPOGRAPHY.fontWeightBold}>
+              {t('door_is_open')}
+            </StyledText>
+            <StyledText
+              as="p"
+              textAlign={TYPOGRAPHY.textAlignCenter}
+              color={COLORS.darkBlack90}
+            >
+              {t('close_door_to_resume')}
+            </StyledText>
+          </Flex>
+        </Flex>
+      </Modal>
+    </Portal>
+  )
+}

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -16,7 +16,6 @@ import { getDeckDefFromRobotType } from '@opentrons/shared-data'
 import ot3StandardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot3_standard.json'
 
 import { i18n } from '../../../../i18n'
-import { useToaster } from '../../../../organisms/ToasterOven'
 import { mockRobotSideAnalysis } from '../../../../organisms/CommandText/__fixtures__'
 import {
   useAttachedModules,
@@ -37,6 +36,7 @@ import {
 } from '../../../../organisms/RunTimeControl/hooks'
 import { useIsHeaterShakerInProtocol } from '../../../../organisms/ModuleCard/hooks'
 import { ConfirmAttachedModal } from '../ConfirmAttachedModal'
+import { OpenDoorAlertModal } from '../../../../organisms/OpenDoorAlertModal'
 import { ProtocolSetup } from '..'
 
 import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
@@ -72,7 +72,7 @@ jest.mock('../../../../organisms/ProtocolSetupLiquids')
 jest.mock('../../../../organisms/ModuleCard/hooks')
 jest.mock('../../../../redux/config')
 jest.mock('../ConfirmAttachedModal')
-jest.mock('../../../../organisms/ToasterOven')
+jest.mock('../../../../organisms/OpenDoorAlertModal')
 
 const mockGetDeckDefFromRobotType = getDeckDefFromRobotType as jest.MockedFunction<
   typeof getDeckDefFromRobotType
@@ -132,7 +132,9 @@ const mockConfirmAttachedModal = ConfirmAttachedModal as jest.MockedFunction<
 const mockUseDoorQuery = useDoorQuery as jest.MockedFunction<
   typeof useDoorQuery
 >
-const mockUseToaster = useToaster as jest.MockedFunction<typeof useToaster>
+const mockOpenDoorAlertModal = OpenDoorAlertModal as jest.MockedFunction<
+  typeof OpenDoorAlertModal
+>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -198,7 +200,6 @@ const mockDoorStatus = {
     doorRequiredClosedForProtocol: true,
   },
 }
-const MOCK_MAKE_SNACKBAR = jest.fn()
 
 describe('ProtocolSetup', () => {
   let mockLaunchLPC: jest.Mock
@@ -279,11 +280,7 @@ describe('ProtocolSetup', () => {
       <div>mock ConfirmAttachedModal</div>
     )
     mockUseDoorQuery.mockReturnValue({ data: mockDoorStatus } as any)
-    when(mockUseToaster)
-      .calledWith()
-      .mockReturnValue(({
-        makeSnackbar: MOCK_MAKE_SNACKBAR,
-      } as unknown) as any)
+    mockOpenDoorAlertModal.mockReturnValue(<div>mock OpenDoorAlertModal</div>)
   })
 
   afterEach(() => {
@@ -375,7 +372,7 @@ describe('ProtocolSetup', () => {
     expect(getAllByTestId('Skeleton').length).toBeGreaterThan(0)
   })
 
-  it('should render toast and make a button disabled when a robot door is open', () => {
+  it('should render open door alert modal when door is open', () => {
     const mockOpenDoorStatus = {
       data: {
         status: 'open',
@@ -383,11 +380,7 @@ describe('ProtocolSetup', () => {
       },
     }
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
-    const [{ getByRole }] = render(`/runs/${RUN_ID}/setup/`)
-    expect(MOCK_MAKE_SNACKBAR).toBeCalledWith(
-      'Close the robot door before starting the run.',
-      7000
-    )
-    expect(getByRole('button', { name: 'play' })).toBeDisabled()
+    const [{ getByText }] = render(`/runs/${RUN_ID}/setup/`)
+    getByText('mock OpenDoorAlertModal')
   })
 })

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -73,12 +73,12 @@ import {
 } from '../../../redux/analytics'
 import { getIsHeaterShakerAttached } from '../../../redux/config'
 import { ConfirmAttachedModal } from './ConfirmAttachedModal'
+import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
+import { OpenDoorAlertModal } from '../../../organisms/OpenDoorAlertModal'
 
 import type { OnDeviceRouteParams } from '../../../App/types'
-import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
 
 const FETCH_DOOR_STATUS_MS = 5000
-const SNACK_BAR_DURATION_MS = 7000
 interface ProtocolSetupStepProps {
   onClickSetupStep: () => void
   status: 'ready' | 'not ready' | 'general'
@@ -491,16 +491,10 @@ function PrepareToRun({
   const isDoorOpen =
     doorStatus?.data.status === 'open' &&
     doorStatus?.data.doorRequiredClosedForProtocol
-  React.useEffect(() => {
-    // Note show snackbar when instruments and modules are all green
-    // but the robot door is open
-    if (isReadyToRun && isDoorOpen) {
-      makeSnackbar(t('shared:close_robot_door'), SNACK_BAR_DURATION_MS)
-    }
-  }, [isDoorOpen])
 
   return (
     <>
+      {isReadyToRun && isDoorOpen ? <OpenDoorAlertModal /> : null}
       {/* Empty box to detect scrolling */}
       <Flex ref={scrollRef} />
       {/* Protocol Setup Header */}

--- a/app/src/pages/OnDeviceDisplay/RunningProtocol.tsx
+++ b/app/src/pages/OnDeviceDisplay/RunningProtocol.tsx
@@ -21,7 +21,10 @@ import {
   useRunQuery,
   useRunActionMutations,
 } from '@opentrons/react-api-client'
-import { RUN_STATUS_STOP_REQUESTED } from '@opentrons/api-client'
+import {
+  RUN_STATUS_STOP_REQUESTED,
+  RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
+} from '@opentrons/api-client'
 
 import { StepMeter } from '../../atoms/StepMeter'
 import { useMostRecentCompletedAnalysis } from '../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
@@ -44,6 +47,7 @@ import {
 import { CancelingRunModal } from '../../organisms/OnDeviceDisplay/RunningProtocol/CancelingRunModal'
 import { ConfirmCancelRunModal } from '../../organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal'
 import { getLocalRobot } from '../../redux/discovery'
+import { OpenDoorAlertModal } from '../../organisms/OpenDoorAlertModal'
 
 import type { OnDeviceRouteParams } from '../../App/types'
 
@@ -147,6 +151,9 @@ export function RunningProtocol(): JSX.Element {
 
   return (
     <>
+      {runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ? (
+        <OpenDoorAlertModal />
+      ) : null}
       {runStatus === RUN_STATUS_STOP_REQUESTED ? <CancelingRunModal /> : null}
       <Flex
         flexDirection={DIRECTION_COLUMN}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
- add OpenDoorAlertModal [design](https://www.figma.com/file/0kuPeCi1t2Auu2GPMnqRb2/Primary%3A-Opentrons-Flex-Touchscreen?type=design&node-id=8342-129925&mode=design&t=jGjuZ6Xf3yotUDst-0)
- Had a conversation on Snackbar for open door status with Rob and Seth and we decided to display the above modal instead Snackbar
- add open door status check to display open door alert modal for odd 

- fix protocol run header banner rendering banner issue desktop app.
The latest alpha, if the door is open, the app shows banner. 
The banner `close door before start running protocol` modal only shows up before running a protocol.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Set up a protocol and open the door
Desktop app shows the banner 
ODD shows the modal

2. run a protocol on Desktop and ODD then open door 
Desktop show up the banner  but that is different from the above banner
ODD shows the modal

3. close the door and resume a run

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add OpenDoorAlert components and test
- update ProtocolSetup component to remove snackbar and hook up the modal to the component and update tests
- update ProtocolRunHeader component to fix banner rendering issue
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
