### PR TITLE
feat(api): add settings option to reset ssh authorized keys

### DIFF
--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -15,6 +15,7 @@ from opentrons.calibration_storage import (
 
 
 DATA_BOOT_D = Path("/data/boot.d")
+AUTHORIZED_KEYS = Path(os.path.expanduser("~/.ssh/authorized_keys"))
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class ResetOptionId(str, Enum):
     runs_history = "runsHistory"
     on_device_display = "onDeviceDisplay"
     module_calibration = "moduleCalibration"
+    authorized_keys = "authorizedKeys"
 
 
 _OT_2_RESET_OPTIONS = [
@@ -55,6 +57,7 @@ _FLEX_RESET_OPTIONS = [
     ResetOptionId.runs_history,
     ResetOptionId.on_device_display,
     ResetOptionId.module_calibration,
+    ResetOptionId.authorized_keys,
 ]
 
 _settings_reset_options = {
@@ -91,6 +94,9 @@ _settings_reset_options = {
     ),
     ResetOptionId.module_calibration: CommonResetOption(
         name="Module Calibrations", description="Clear module offset calibrations"
+    ),
+    ResetOptionId.authorized_keys: CommonResetOption(
+        name="SSH Authorized Keys", description="Clear the ssh authorized keys"
     ),
 }
 
@@ -132,6 +138,9 @@ def reset(options: Set[ResetOptionId]) -> None:
     if ResetOptionId.module_calibration in options:
         reset_module_calibration()
 
+    if ResetOptionId.authorized_keys in options:
+        reset_authorized_keys()
+
 
 def reset_boot_scripts() -> None:
     if IS_ROBOT:
@@ -170,3 +179,9 @@ def reset_module_calibration() -> None:
         clear_module_offset_calibrations()
     except ImportError:
         log.warning("Tried to clear module offset calibrations on an OT-2")
+
+
+def reset_authorized_keys() -> None:
+    if IS_ROBOT and os.path.exists(AUTHORIZED_KEYS):
+        with open(AUTHORIZED_KEYS, "w") as fh:
+            fh.write("")

--- a/robot-server/tests/integration/test_settings_reset_options_flex.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options_flex.tavern.yaml
@@ -30,6 +30,9 @@ stages:
           - id: moduleCalibration
             name: Module Calibrations
             description: !re_search 'Clear module offset calibrations'
+          - id: authorizedKeys
+            name: SSH Authorized Keys
+            description: !re_search 'Clear the ssh authorized keys'
 
   - name: POST Reset gripperOffsetCalibrations true on OT-3
     request:


### PR DESCRIPTION
# Overview

We need to be able to reset the SSH authorized keys file, so we don't ship robots with internal public keys

# Test Plan

- [x] Make sure you can ssh to the Flex by using the `/server/ssh_keys/from_local` endpoint
- [x] Make sure that GET `/settings/reset/options` includes `authorizedKeys` key in the response.
- [x] Make sure that you CAN'T SSH when we POST to `/settings/reset` with the new `authorizedKeys` option

# Changelog

- Add authorizedKeys option to the list of robot settings that can be reset

# Review requests

# Risk assessment
Low
