### PR TITLE
fix(app): fix open door alert modal display condition

### DIFF
--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -310,6 +310,7 @@ interface PrepareToRunProps {
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
   confirmAttachment: () => void
   play: () => void
+  setupScreen: SetupScreens
 }
 
 function PrepareToRun({
@@ -317,6 +318,7 @@ function PrepareToRun({
   setSetupScreen,
   confirmAttachment,
   play,
+  setupScreen,
 }: PrepareToRunProps): JSX.Element {
   const { t, i18n } = useTranslation(['protocol_setup', 'shared'])
   const history = useHistory()
@@ -491,10 +493,11 @@ function PrepareToRun({
   const isDoorOpen =
     doorStatus?.data.status === 'open' &&
     doorStatus?.data.doorRequiredClosedForProtocol
-
   return (
     <>
-      {isReadyToRun && isDoorOpen ? <OpenDoorAlertModal /> : null}
+      {isReadyToRun && isDoorOpen && setupScreen === 'prepare to run' ? (
+        <OpenDoorAlertModal />
+      ) : null}
       {/* Empty box to detect scrolling */}
       <Flex ref={scrollRef} />
       {/* Protocol Setup Header */}
@@ -667,6 +670,7 @@ export function ProtocolSetup(): JSX.Element {
         setSetupScreen={setSetupScreen}
         confirmAttachment={confirmAttachment}
         play={play}
+        setupScreen={setupScreen}
       />
     ),
     instruments: (


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Currently the ODD app shows the modal when the ODD app displays the following screens.

Instruments in ProtocolSetup
Modules in ProtocolSetup
Labware in ProtocolSetup
Liquids in ProtocolSetup

This PR narrows down the condition to display the modal.

The modal only shows up when a user open Prepare to run screen and LPC wizard.


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Prepare to run screen and open/close the door

For the following cases, the modal shouldn't show up
Instruments in ProtocolSetup
Modules in ProtocolSetup
Labware in ProtocolSetup
Liquids in ProtocolSetup

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
update ProtocolSetup components to narrow down the condition to display the modal
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
