### PR TITLE
feat(hardware-testing): save the generated gravimetric reports to the matching run_id directory

### DIFF
--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -289,19 +289,16 @@ sync-ot3: sync-sw-ot3 sync-fw-ot3
 push-ot3-gravimetric:
 	$(MAKE) apply-patches-gravimetric
 	-$(MAKE) sync-sw-ot3
+	scp $(ssh_helper_ot3) -r hardware_testing/labware root@$(host):/data/labware/v2/custom_definitions/custom_beta/
 	$(MAKE) remove-patches-gravimetric
-	scp $(ssh_helper_ot3) -r hardware_testing/labware/opentrons_flex_96_tiprack_50ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	scp $(ssh_helper_ot3) -r hardware_testing/labware/opentrons_flex_96_tiprack_200ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	scp $(ssh_helper_ot3) -r hardware_testing/labware/opentrons_flex_96_tiprack_1000ul_adp/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	scp $(ssh_helper_ot3) -r hardware_testing/labware/radwag_pipette_calibration_vial/ root@$(host):/data/labware/v2/custom_definitions/custom_beta/
 
 .PHONY: apply-patches-gravimetric
 apply-patches-gravimetric:
-	cd ../ && git apply ./hardware-testing/hardware_testing/gravimetric/overrides/*.patch --allow-empty
+	cd ../ && git apply ./hardware-testing/hardware_testing/gravimetric/overrides/*.patch --allow-empty || true
 
 .PHONY: remove-patches-gravimetric
 remove-patches-gravimetric:
-	cd ../ && git apply ./hardware-testing/hardware_testing/gravimetric/overrides/*.patch --reverse --allow-empty
+	cd ../ && git apply ./hardware-testing/hardware_testing/gravimetric/overrides/*.patch --reverse --allow-empty || true
 
 upstream ?= origin/edge
 .PHONY: update-patches-gravimetric

--- a/hardware-testing/hardware_testing/data/README.md
+++ b/hardware-testing/hardware_testing/data/README.md
@@ -14,10 +14,12 @@ file_name = data.create_file_name(test_name=test_name,
                                   tag=tag)
 # write entire file contents at once
 data.dump_data_to_file(test_name=test_name,
+                       run_id=run_id,
                        file_name=file_name,
                        data="some,data,to,record\ncan,be,entire,file,at,once\n")
 # optionally, continue to append to that same file
 data.append_data_to_file(test_name=test_name,
+                         run_id=run_id,
                          file_name=file_name,
                          data="or,you,can,continue,appending,new,data\n")
 ```

--- a/hardware-testing/hardware_testing/data/__init__.py
+++ b/hardware-testing/hardware_testing/data/__init__.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from subprocess import check_output
 from time import time
-from typing import Tuple
+from typing import Tuple, Union
 
 from opentrons.config import infer_config_base_dir, IS_ROBOT
 
@@ -69,7 +69,7 @@ def create_test_name_from_file(f: str) -> str:
     return os.path.basename(f).replace("_", "-").replace(".py", "")
 
 
-def create_folder_for_test_data(test_name: str) -> Path:
+def create_folder_for_test_data(test_name: Union[str, Path]) -> Path:
     """Create a folder for test data."""
     base = _initialize_testing_data_base_dir()
     test_path = base / test_name
@@ -99,28 +99,34 @@ def create_file_name(
     return f"{test_name}_{run_id}_{tag}.{extension}"
 
 
-def _save_data(test_name: str, file_name: str, data: str, perm: str = "w+") -> Path:
+def _save_data(
+    test_name: str, run_id: str, file_name: str, data: str, perm: str = "w+"
+) -> Path:
     test_path = create_folder_for_test_data(test_name)
-    data_path = test_path / file_name
+    run_path = create_folder_for_test_data(test_path / run_id)
+    data_path = test_path / run_path / file_name
     with open(data_path, perm) as f:
         f.write(data)
     return data_path
 
 
-def dump_data_to_file(test_name: str, file_name: str, data: str) -> Path:
+def dump_data_to_file(test_name: str, run_id: str, file_name: str, data: str) -> Path:
     """Save entire file contents to a file on disk."""
-    return _save_data(test_name, file_name, data, perm="w+")
+    return _save_data(test_name, run_id, file_name, data, perm="w+")
 
 
-def append_data_to_file(test_name: str, file_name: str, data: str) -> Path:
+def append_data_to_file(test_name: str, run_id: str, file_name: str, data: str) -> Path:
     """Append new content to an already existing file on disk."""
-    return _save_data(test_name, file_name, data, perm="a+")
+    return _save_data(test_name, run_id, file_name, data, perm="a+")
 
 
-def insert_data_to_file(test_name: str, file_name: str, data: str, line: int) -> None:
+def insert_data_to_file(
+    test_name: str, run_id: str, file_name: str, data: str, line: int
+) -> None:
     """Insert new data at a specified line."""
     test_path = create_folder_for_test_data(test_name)
-    data_path = test_path / file_name
+    run_path = create_folder_for_test_data(run_id)
+    data_path = test_path / run_path / file_name
     # read data from file, insert line, then overwrite previous file
     with open(data_path, "r") as f:
         contents = f.readlines()

--- a/hardware-testing/hardware_testing/data/__init__.py
+++ b/hardware-testing/hardware_testing/data/__init__.py
@@ -125,8 +125,8 @@ def insert_data_to_file(
 ) -> None:
     """Insert new data at a specified line."""
     test_path = create_folder_for_test_data(test_name)
-    run_path = create_folder_for_test_data(run_id)
-    data_path = test_path / run_path / file_name
+    run_path = create_folder_for_test_data(test_path / run_id)
+    data_path = run_path / file_name
     # read data from file, insert line, then overwrite previous file
     with open(data_path, "r") as f:
         contents = f.readlines()

--- a/hardware-testing/hardware_testing/data/csv_report.py
+++ b/hardware-testing/hardware_testing/data/csv_report.py
@@ -484,7 +484,7 @@ class CSVReport:
         _report_str = str(self)
         assert self._file_name, "must set tag before saving to disk"
         return data_io.dump_data_to_file(
-            self._test_name, self._file_name, _report_str + "\n"
+            self._test_name, self._run_id, self._file_name, _report_str + "\n"
         )
 
     def print_results(self) -> None:

--- a/hardware-testing/hardware_testing/data/csv_report.py
+++ b/hardware-testing/hardware_testing/data/csv_report.py
@@ -411,7 +411,8 @@ class CSVReport:
     @property
     def parent(self) -> Path:
         """Parent directory of this report file."""
-        return data_io.create_folder_for_test_data(self._test_name)
+        test_path = data_io.create_folder_for_test_data(self._test_name)
+        return data_io.create_folder_for_test_data(test_path / self._run_id)
 
     @property
     def tag(self) -> str:
@@ -423,8 +424,7 @@ class CSVReport:
         """Get file-path."""
         if not self._file_name:
             raise RuntimeError("must set tag of report using `Report.set_tag()`")
-        test_path = data_io.create_folder_for_test_data(self._test_name)
-        return test_path / self._file_name
+        return self.parent / self._file_name
 
     def _cache_start_time(self, start_time: Optional[float] = None) -> None:
         checked_start_time = start_time if start_time else time()

--- a/hardware-testing/hardware_testing/examples/data.py
+++ b/hardware-testing/hardware_testing/examples/data.py
@@ -12,12 +12,14 @@ def _main() -> None:
     # write
     data.dump_data_to_file(
         test_name,
+        run_id,
         file_name,
         "some,data,to,record\ncan,be,entire,file,at,once\n",
     )
     # append
     data.append_data_to_file(
         test_name,
+        run_id,
         file_name,
         "or,you,can,continue,appending,new,data\n",
     )

--- a/hardware-testing/hardware_testing/gravimetric/measurement/record.py
+++ b/hardware-testing/hardware_testing/gravimetric/measurement/record.py
@@ -496,14 +496,22 @@ class GravimetricRecorder:
             new_sample = recording[-1]
             csv_line = new_sample.as_csv(_start_time)
             append_data_to_file(
-                str(self._cfg.test_name), _file_name, csv_line + "\n"
+                str(self._cfg.test_name),
+                str(self._cfg.run_id),
+                _file_name,
+                csv_line + "\n",
             )  # type: ignore[arg-type]
 
         # add the header to the CSV file
         dump_data_to_file(
-            self._cfg.test_name, self._file_name, GravimetricSample.csv_header() + "\n"
+            self._cfg.test_name,
+            self._cfg.run_id,
+            self._file_name,
+            GravimetricSample.csv_header() + "\n",
         )
         _rec = self._record_samples(timeout=timeout, on_new_sample=_on_new_sample)
         # add a final newline character to the CSV file
-        append_data_to_file(self._cfg.test_name, self._file_name, "\n")
+        append_data_to_file(
+            self._cfg.test_name, self._cfg.run_id, self._file_name, "\n"
+        )
         return _rec

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -1430,8 +1430,9 @@ def _create_csv_and_get_callbacks(
     run_id = data.create_run_id()
     test_name = Path(__file__).parent.name.replace("_", "-")
     folder_path = data.create_folder_for_test_data(test_name)
+    run_path = data.create_folder_for_test_data(folder_path / run_id)
     file_name = data.create_file_name(test_name, run_id, pipette_sn)
-    csv_display_name = os.path.join(folder_path, file_name)
+    csv_display_name = os.path.join(run_path, file_name)
     print(f"CSV: {csv_display_name}")
     start_time = time()
 

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -1448,9 +1448,11 @@ def _create_csv_and_get_callbacks(
             data_list = [first_row_value] + data_list
         data_str = ",".join([str(d) for d in data_list])
         if line_number is None:
-            data.append_data_to_file(test_name, file_name, data_str + "\n")
+            data.append_data_to_file(test_name, run_id, file_name, data_str + "\n")
         else:
-            data.insert_data_to_file(test_name, file_name, data_str + "\n", line_number)
+            data.insert_data_to_file(
+                test_name, run_id, file_name, data_str + "\n", line_number
+            )
 
     def _cache_pressure_data_callback(
         d: List[Any], first_row_value: Optional[str] = None

--- a/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
@@ -144,9 +144,11 @@ def _create_csv_and_get_callbacks(sn: str) -> Tuple[CSVProperties, CSVCallbacks]
             data_list = [first_row_value] + data_list
         data_str = ",".join([str(d) for d in data_list])
         if line_number is None:
-            data.append_data_to_file(test_name, file_name, data_str + "\n")
+            data.append_data_to_file(test_name, run_id, file_name, data_str + "\n")
         else:
-            data.insert_data_to_file(test_name, file_name, data_str + "\n", line_number)
+            data.insert_data_to_file(
+                test_name, run_id, file_name, data_str + "\n", line_number
+            )
 
     return (
         CSVProperties(id=run_id, name=test_name, path=csv_display_name),

--- a/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
@@ -125,9 +125,10 @@ def _create_csv_and_get_callbacks(sn: str) -> Tuple[CSVProperties, CSVCallbacks]
     """Create CSV and get callback functions."""
     run_id = data.create_run_id()
     test_name = data.create_test_name_from_file(__file__)
-    folder_path = data.create_folder_for_test_data(test_name)
+    test_path = data.create_folder_for_test_data(test_name)
+    run_path = data.create_folder_for_test_data(test_path / run_id)
     file_name = data.create_file_name(test_name=test_name, run_id=run_id, tag=sn)
-    csv_display_name = os.path.join(folder_path, file_name)
+    csv_display_name = os.path.join(run_path, file_name)
     print(f"CSV: {csv_display_name}")
     start_time = time.time()
 


### PR DESCRIPTION
# Overview

The gravimetric script generates a lot of data in the form of CSV files, these files are written to the `testing_data/test_name` directory alongside other camera files. Since we generate new CSV files whenever the script is run, it can become unwieldy to manage hundreds of files over time. So instead of dumping all the files in the same location, let's create another directory with the run_id of the current run like `testing_data/test_name/run_id`.

The directory structure will now look like this for example
`testing_data/gravimetric-ot3-p1000-96/run-23-09-21-20-52-56`

Where now the last dir contains the generated reports like this one
`gravimetric-ot3-p1000-96_run-23-09-21-20-52-56_CSVReport-None-qc.csv`

# Test Plan

- [x] run simulated gravimetric tests and make sure the generated CSV files are dumped in the run_id dir
- [ ] run gravimetric test on a Flex and make sure everything still works
- [ ] run photometric test on flex and make sure everything still works

# Changelog

- added run_id arg to functions that create/append/insert to CSV files
- don't fail on appy/remove patches
- simplify hardware-testing labware scp

# Review requests

# Risk assessment
low
