### PR TITLE
feat(app): oDD banners for pipette calibration warning

### DIFF
--- a/app/src/assets/localization/en/instruments_dashboard.json
+++ b/app/src/assets/localization/en/instruments_dashboard.json
@@ -4,6 +4,7 @@
   "firmware_version": "firmware version",
   "last_calibrated": "last calibrated",
   "no_cal_data": "no calibration data",
+  "pipette_calibrations_differ": "<bold>Pipette recalibration recommended</bold> The attached pipettes have very different calibration values. When properly calibrated, the values should be similar.",
   "recalibrate": "recalibrate",
   "serial_number": "serial number"
 }

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -183,11 +183,11 @@ export function InstrumentsAndModules({
           </Flex>
         )}
         {getShowPipetteCalibrationWarning(attachedInstruments) &&
-          (currentRunId == null || isRunTerminal) ? (
-            <Flex paddingBottom={SPACING.spacing16}>
-              <PipetteRecalibrationWarning />
-            </Flex>
-          ): null}
+        (currentRunId == null || isRunTerminal) ? (
+          <Flex paddingBottom={SPACING.spacing16}>
+            <PipetteRecalibrationWarning />
+          </Flex>
+        ) : null}
         {isRobotViewable ? (
           <Flex gridGap={SPACING.spacing8} width="100%">
             <Flex

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { getPipetteModelSpecs, LEFT, RIGHT } from '@opentrons/shared-data'
-import { INCONSISTENT_PIPETTE_OFFSET } from '@opentrons/api-client'
 import {
   useAllPipetteOffsetCalibrationsQuery,
   useModulesQuery,
@@ -32,6 +31,7 @@ import { useIsOT3, useIsRobotViewable, useRunStatuses } from './hooks'
 import {
   getIs96ChannelPipetteAttached,
   getOffsetCalibrationForMount,
+  getShowPipetteCalibrationWarning,
 } from './utils'
 import { PipetteCard } from './PipetteCard'
 import { GripperCard } from '../GripperCard'
@@ -140,16 +140,6 @@ export function InstrumentsAndModules({
     attachedPipettes,
     RIGHT
   )
-  const pipetteCalibrationWarning =
-    attachedInstruments?.data.some((i): i is PipetteData => {
-      const failuresList =
-        i.ok && i.data.calibratedOffset?.reasonability_check_failures != null
-          ? i.data.calibratedOffset?.reasonability_check_failures
-          : []
-      if (failuresList.length > 0) {
-        return failuresList[0]?.kind === INCONSISTENT_PIPETTE_OFFSET
-      } else return false
-    }) ?? false
 
   return (
     <Flex
@@ -192,11 +182,12 @@ export function InstrumentsAndModules({
             <Banner type="warning">{t('robot_control_not_available')}</Banner>
           </Flex>
         )}
-        {pipetteCalibrationWarning && (currentRunId == null || isRunTerminal) && (
-          <Flex paddingBottom={SPACING.spacing16}>
-            <PipetteRecalibrationWarning />
-          </Flex>
-        )}
+        {getShowPipetteCalibrationWarning(attachedInstruments) &&
+          (currentRunId == null || isRunTerminal) && (
+            <Flex paddingBottom={SPACING.spacing16}>
+              <PipetteRecalibrationWarning />
+            </Flex>
+          )}
         {isRobotViewable ? (
           <Flex gridGap={SPACING.spacing8} width="100%">
             <Flex

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -183,11 +183,11 @@ export function InstrumentsAndModules({
           </Flex>
         )}
         {getShowPipetteCalibrationWarning(attachedInstruments) &&
-          (currentRunId == null || isRunTerminal) && (
+          (currentRunId == null || isRunTerminal) ? (
             <Flex paddingBottom={SPACING.spacing16}>
               <PipetteRecalibrationWarning />
             </Flex>
-          )}
+          ): null}
         {isRobotViewable ? (
           <Flex gridGap={SPACING.spacing8} width="100%">
             <Flex

--- a/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
@@ -8,9 +8,9 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { INCONSISTENT_PIPETTE_OFFSET } from '@opentrons/api-client'
 import { StyledText } from '../../../atoms/text'
 import * as PipetteConstants from '../../../redux/pipettes/constants'
+import { getShowPipetteCalibrationWarning } from '../utils'
 import { PipetteRecalibrationWarning } from '../PipetteCard/PipetteRecalibrationWarning'
 import {
   useRunPipetteInfoByMount,
@@ -24,7 +24,7 @@ import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMo
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { isGripperInCommands } from '../../../resources/protocols/utils'
 
-import type { GripperData, PipetteData } from '@opentrons/api-client'
+import type { GripperData } from '@opentrons/api-client'
 import { i18n } from '../../../i18n'
 
 const EQUIPMENT_POLL_MS = 5000
@@ -56,20 +56,12 @@ export function SetupInstrumentCalibration({
         (i): i is GripperData => i.instrumentType === 'gripper'
       ) ?? null
     : null
-  const pipetteCalibrationWarning =
-    instrumentsQueryData?.data.some((i): i is PipetteData => {
-      const failuresList =
-        i.ok && i.data.calibratedOffset?.reasonability_check_failures != null
-          ? i.data.calibratedOffset?.reasonability_check_failures
-          : []
-      if (failuresList.length > 0) {
-        return failuresList[0]?.kind === INCONSISTENT_PIPETTE_OFFSET
-      } else return false
-    }) ?? false
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-      {pipetteCalibrationWarning && <PipetteRecalibrationWarning />}
+      {getShowPipetteCalibrationWarning(instrumentsQueryData) && (
+        <PipetteRecalibrationWarning />
+      )}
       <StyledText
         color={COLORS.black}
         css={TYPOGRAPHY.pSemiBold}

--- a/app/src/organisms/Devices/utils.ts
+++ b/app/src/organisms/Devices/utils.ts
@@ -1,10 +1,15 @@
 import { format, parseISO } from 'date-fns'
+import { INCONSISTENT_PIPETTE_OFFSET } from '@opentrons/api-client'
 import type {
   FetchPipettesResponseBody,
   FetchPipettesResponsePipette,
   Mount,
 } from '../../redux/pipettes/types'
-import type { PipetteOffsetCalibration } from '@opentrons/api-client'
+import type {
+  Instruments,
+  PipetteData,
+  PipetteOffsetCalibration,
+} from '@opentrons/api-client'
 
 /**
  * formats a string if it is in ISO 8601 date format
@@ -67,4 +72,20 @@ export function getOffsetCalibrationForMount(
       ) || null
     )
   }
+}
+
+export function getShowPipetteCalibrationWarning(
+  attachedInstruments?: Instruments
+): boolean {
+  return (
+    attachedInstruments?.data.some((i): i is PipetteData => {
+      const failuresList =
+        i.ok && i.data.calibratedOffset?.reasonability_check_failures != null
+          ? i.data.calibratedOffset?.reasonability_check_failures
+          : []
+      if (failuresList.length > 0) {
+        return failuresList[0]?.kind === INCONSISTENT_PIPETTE_OFFSET
+      } else return false
+    }) ?? false
+  )
 }

--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -27,11 +27,7 @@ import { FLOWS } from '../PipetteWizardFlows/constants'
 import { PipetteWizardFlows } from '../PipetteWizardFlows'
 import { GripperWizardFlows } from '../GripperWizardFlows'
 
-import type {
-  InstrumentData,
-  PipetteOffsetCalibration,
-  GripperData,
-} from '@opentrons/api-client'
+import type { InstrumentData } from '@opentrons/api-client'
 import type { GripperModel } from '@opentrons/shared-data'
 import type { Mount } from '../../redux/pipettes/types'
 
@@ -53,10 +49,6 @@ interface ProtocolInstrumentMountItemProps {
   mount: Mount | 'extension'
   mostRecentAnalysis?: CompletedProtocolAnalysis | null
   attachedInstrument: InstrumentData | null
-  attachedCalibrationData:
-    | PipetteOffsetCalibration
-    | GripperData['data']['calibratedOffset']
-    | null
   speccedName: PipetteName | GripperModel
   instrumentsRefetch?: () => void
 }

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -70,7 +70,6 @@ describe('ProtocolInstrumentMountItem', () => {
     props = {
       mount: LEFT,
       attachedInstrument: null,
-      attachedCalibrationData: null,
       speccedName: 'p1000_multi_flex',
     }
     mockPipetteWizardFlows.mockReturnValue(<div>pipette wizard flow</div>)

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -10,11 +10,10 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import {
-  useAllPipetteOffsetCalibrationsQuery,
-  useInstrumentsQuery,
-} from '@opentrons/react-api-client'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { ODDBackButton } from '../../molecules/ODDBackButton'
+import { PipetteRecalibrationODDWarning } from '../../pages/OnDeviceDisplay/PipetteRealibrationODDWarning'
+import { getShowPipetteCalibrationWarning } from '../Devices/utils'
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { ProtocolInstrumentMountItem } from '../InstrumentMountItem'
 
@@ -34,9 +33,6 @@ export function ProtocolSetupInstruments({
 }: ProtocolSetupInstrumentsProps): JSX.Element {
   const { t, i18n } = useTranslation('protocol_setup')
   const { data: attachedInstruments, refetch } = useInstrumentsQuery()
-  const {
-    data: allPipettesCalibrationData,
-  } = useAllPipetteOffsetCalibrationsQuery()
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
 
   const usesGripper =
@@ -59,6 +55,11 @@ export function ProtocolSetupInstruments({
         label={t('instruments')}
         onClick={() => setSetupScreen('prepare to run')}
       />
+      {getShowPipetteCalibrationWarning(attachedInstruments) && (
+        <Flex paddingBottom={SPACING.spacing16}>
+          <PipetteRecalibrationODDWarning />
+        </Flex>
+      )}
       <Flex
         justifyContent={JUSTIFY_SPACE_BETWEEN}
         alignItems={ALIGN_CENTER}
@@ -85,15 +86,6 @@ export function ProtocolSetupInstruments({
             speccedName={loadedPipette.pipetteName}
             attachedInstrument={attachedPipetteMatch}
             mostRecentAnalysis={mostRecentAnalysis}
-            attachedCalibrationData={
-              attachedPipetteMatch != null
-                ? allPipettesCalibrationData?.data.find(
-                    cal =>
-                      cal.mount === attachedPipetteMatch.mount &&
-                      cal.pipette === attachedPipetteMatch.instrumentName
-                  ) ?? null
-                : null
-            }
             instrumentsRefetch={refetch}
           />
         )
@@ -104,9 +96,6 @@ export function ProtocolSetupInstruments({
           mount="extension"
           speccedName={'gripperV1' as GripperModel}
           attachedInstrument={attachedGripperMatch}
-          attachedCalibrationData={
-            attachedGripperMatch?.data.calibratedOffset ?? null
-          }
         />
       ) : null}
     </Flex>

--- a/app/src/organisms/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
@@ -7,7 +7,6 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { INCONSISTENT_PIPETTE_OFFSET } from '@opentrons/api-client'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 
 import { StyledText } from '../../atoms/text'
@@ -16,10 +15,10 @@ import {
   useIsOT3,
   usePipetteOffsetCalibrations,
 } from '../Devices/hooks'
+import { getShowPipetteCalibrationWarning } from '../Devices/utils'
 import { PipetteRecalibrationWarning } from '../Devices/PipetteCard/PipetteRecalibrationWarning'
 import { PipetteOffsetCalibrationItems } from './CalibrationDetails/PipetteOffsetCalibrationItems'
 
-import type { PipetteData } from '@opentrons/api-client'
 import type { FormattedPipetteOffsetCalibration } from '.'
 
 interface RobotSettingsPipetteOffsetCalibrationProps {
@@ -55,16 +54,6 @@ export function RobotSettingsPipetteOffsetCalibration({
       ot3AttachedRightPipetteOffsetCal != null)
   )
     showPipetteOffsetCalItems = true
-  const pipetteCalibrationWarning =
-    instrumentsData?.data.some((i): i is PipetteData => {
-      const failuresList =
-        i.ok && i.data.calibratedOffset?.reasonability_check_failures != null
-          ? i.data.calibratedOffset?.reasonability_check_failures
-          : []
-      if (failuresList.length > 0) {
-        return failuresList[0]?.kind === INCONSISTENT_PIPETTE_OFFSET
-      } else return false
-    }) ?? false
 
   return (
     <Flex
@@ -80,7 +69,9 @@ export function RobotSettingsPipetteOffsetCalibration({
       {isOT3 ? (
         <StyledText as="p">{t('pipette_calibrations_description')}</StyledText>
       ) : null}
-      {pipetteCalibrationWarning && <PipetteRecalibrationWarning />}
+      {getShowPipetteCalibrationWarning(instrumentsData) && (
+        <PipetteRecalibrationWarning />
+      )}
       {showPipetteOffsetCalItems ? (
         <PipetteOffsetCalibrationItems
           robotName={robotName}

--- a/app/src/pages/OnDeviceDisplay/InstrumentsDashboard.tsx
+++ b/app/src/pages/OnDeviceDisplay/InstrumentsDashboard.tsx
@@ -6,6 +6,8 @@ import { onDeviceDisplayRoutes } from '../../App/OnDeviceDisplayApp'
 import { Navigation } from '../../organisms/Navigation'
 import { AttachedInstrumentMountItem } from '../../organisms/InstrumentMountItem'
 import { GripperWizardFlows } from '../../organisms/GripperWizardFlows'
+import { getShowPipetteCalibrationWarning } from '../../organisms/Devices/utils'
+import { PipetteRecalibrationODDWarning } from './PipetteRealibrationODDWarning'
 import type { GripperData, PipetteData } from '@opentrons/api-client'
 
 const FETCH_PIPETTE_CAL_POLL = 10000
@@ -34,6 +36,11 @@ export const InstrumentsDashboard = (): JSX.Element => {
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing8}
       >
+        {getShowPipetteCalibrationWarning(attachedInstruments) && (
+          <Flex paddingBottom={SPACING.spacing16}>
+            <PipetteRecalibrationODDWarning />
+          </Flex>
+        )}
         {isNinetySixChannel ? (
           <AttachedInstrumentMountItem
             mount="left"

--- a/app/src/pages/OnDeviceDisplay/PipetteRealibrationODDWarning.tsx
+++ b/app/src/pages/OnDeviceDisplay/PipetteRealibrationODDWarning.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { useTranslation, Trans } from 'react-i18next'
+import {
+  Flex,
+  Icon,
+  Btn,
+  SPACING,
+  COLORS,
+  JUSTIFY_SPACE_BETWEEN,
+  ALIGN_CENTER,
+  BORDERS,
+  JUSTIFY_FLEX_START,
+} from '@opentrons/components'
+import { StyledText } from '../../atoms/text'
+
+export const PipetteRecalibrationODDWarning = (): JSX.Element | null => {
+  const { t } = useTranslation('instruments_dashboard')
+  const [showBanner, setShowBanner] = React.useState<boolean>(true)
+  if (!showBanner) return null
+
+  return (
+    <Flex
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      alignItems={ALIGN_CENTER}
+      borderRadius={BORDERS.borderRadiusSize3}
+      backgroundColor={COLORS.yellow3}
+      padding={`${SPACING.spacing12} ${SPACING.spacing16}`}
+      height="5.76rem"
+      width="60rem"
+    >
+      <Flex justifyContent={JUSTIFY_FLEX_START}>
+        <Icon
+          name="alert-circle"
+          color={COLORS.yellow2}
+          width="45px"
+          marginRight={SPACING.spacing12}
+        />
+        <StyledText as="p">
+          <Trans
+            t={t}
+            i18nKey="pipette_calibrations_differ"
+            components={{ bold: <strong /> }}
+          />
+        </StyledText>
+      </Flex>
+      <Btn onClick={() => setShowBanner(false)}>
+        <Icon
+          width={SPACING.spacing32}
+          height={SPACING.spacing32}
+          name="close"
+          aria-label="close_icon"
+        />
+      </Btn>
+    </Flex>
+  )
+}


### PR DESCRIPTION
fix RAUT-737

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add pipette calibration warning to Instruments tab and protocol setup/instruments on ODD
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
This warning should occur on ODD protocol run setup and instruments dashboard if two pipettes are attached that have calibration values differing by more than 1.5mm
I've tested this out with mock data on my dev server, here are screenshots:
![Screen Shot 2023-09-21 at 5 40 53 PM](https://github.com/Opentrons/opentrons/assets/14302493/aca23520-96fe-4e36-ac0d-7c3b133f5572)
![Screen Shot 2023-09-21 at 5 40 38 PM](https://github.com/Opentrons/opentrons/assets/14302493/37fc99ff-6ea6-4a16-8309-40a272048d7d)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Create ODD version of pipette calibration warning banner and display on ODD Instruments Dashboard and Protocol Setup
2. Create util for logic of when to show this warning so it isn't replicated across five locations
3. Removed unused pipette calibration data and prop that I noticed hanging around in `ProtocolInstrumentMountItem`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over the code and test on an ODD if you have time!
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
