### PR TITLE
fix(app): fix SetupModuleList's initial jsx element and condition

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModules/SetupModulesList.tsx
@@ -68,7 +68,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
     remainingAttachedModules,
   } = useUnmatchedModulesForProtocol(robotName, runId)
 
-  const isOt3 = useIsOT3(robotName)
+  const isOT3 = useIsOT3(robotName)
 
   const calibrationStatus = useRunCalibrationStatus(robotName, runId)
 
@@ -176,7 +176,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
                     ? moduleRenderInfoForProtocolById[moduleId]
                     : null
                 }
-                isOt3={isOt3}
+                isOT3={isOT3}
                 calibrationStatus={calibrationStatus}
               />
             )
@@ -193,7 +193,7 @@ interface ModulesListItemProps {
   slotName: string
   attachedModuleMatch: AttachedModule | null
   heaterShakerModuleFromProtocol: ModuleRenderInfoForProtocol | null
-  isOt3: boolean
+  isOT3: boolean
   calibrationStatus: ProtocolCalibrationStatus
 }
 
@@ -203,7 +203,7 @@ export function ModulesListItem({
   slotName,
   attachedModuleMatch,
   heaterShakerModuleFromProtocol,
-  isOt3,
+  isOT3,
   calibrationStatus,
 }: ModulesListItemProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'module_wizard_flows'])
@@ -292,37 +292,43 @@ export function ModulesListItem({
   }
 
   let renderModuleStatus: JSX.Element = (
-    <>
-      <TertiaryButton
-        {...targetProps}
-        onClick={handleCalibrateClick}
-        disabled={!calibrationStatus?.complete || isModuleTooHot}
-      >
-        {t('calibrate_now')}
-      </TertiaryButton>
-      {(!calibrationStatus?.complete && calibrationStatus?.reason != null) ||
-      isModuleTooHot ? (
-        <Tooltip tooltipProps={tooltipProps}>{calibrateDisabledReason}</Tooltip>
-      ) : null}
-    </>
+    <StatusLabel
+      status={moduleConnectionStatus}
+      backgroundColor={COLORS.successBackgroundLight}
+      iconColor={COLORS.successEnabled}
+      textColor={COLORS.successText}
+    />
   )
 
-  if (attachedModuleMatch == null) {
+  if (
+    isOT3 &&
+    attachedModuleMatch != null &&
+    attachedModuleMatch.moduleOffset?.last_modified == null
+  ) {
+    renderModuleStatus = (
+      <>
+        <TertiaryButton
+          {...targetProps}
+          onClick={handleCalibrateClick}
+          disabled={!calibrationStatus?.complete || isModuleTooHot}
+        >
+          {t('calibrate_now')}
+        </TertiaryButton>
+        {(!calibrationStatus?.complete && calibrationStatus?.reason != null) ||
+        isModuleTooHot ? (
+          <Tooltip tooltipProps={tooltipProps}>
+            {calibrateDisabledReason}
+          </Tooltip>
+        ) : null}
+      </>
+    )
+  } else if (attachedModuleMatch == null) {
     renderModuleStatus = (
       <StatusLabel
         status={moduleConnectionStatus}
         backgroundColor={COLORS.warningBackgroundLight}
         iconColor={COLORS.warningEnabled}
         textColor={COLORS.warningText}
-      />
-    )
-  } else if (attachedModuleMatch.moduleOffset?.last_modified != null) {
-    renderModuleStatus = (
-      <StatusLabel
-        status={moduleConnectionStatus}
-        backgroundColor={COLORS.successBackgroundLight}
-        iconColor={COLORS.successEnabled}
-        textColor={COLORS.successText}
       />
     )
   }
@@ -377,7 +383,7 @@ export function ModulesListItem({
             {t('slot_location', {
               slotName:
                 getModuleType(moduleModel) === 'thermocyclerModuleType'
-                  ? isOt3
+                  ? isOT3
                     ? TC_MODULE_LOCATION_OT3
                     : TC_MODULE_LOCATION_OT2
                   : slotName,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue was that the implementation couldn't handle OT-2 case since the initial renderModuleStatus was the button. Update the initial renderModuleStatus and update the conditions.

close RQA-1549

after
![Screenshot 2023-09-21 at 5 57 12 PM](https://github.com/Opentrons/opentrons/assets/474225/38fbffb7-3aa1-4da1-ae8e-7637cc60f9a3)

![Screenshot 2023-09-21 at 5 58 22 PM](https://github.com/Opentrons/opentrons/assets/474225/89f1f86c-5656-42a4-b6cc-392dc8dd6bf8)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Protocol setup with OT-2/Flex
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update moduleStatus's initial value and conditions for it
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
