### PR TITLE
fix(app):  enable doorSafetySwitch for OT-2

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -58,6 +58,7 @@ import {
 } from '../../../../redux/analytics'
 import { getRobotUpdateDisplayInfo } from '../../../../redux/robot-update'
 import { getIsHeaterShakerAttached } from '../../../../redux/config'
+import { getRobotSettings } from '../../../../redux/robot-settings'
 
 import {
   useProtocolDetailsForRun,
@@ -111,6 +112,7 @@ jest.mock('../../../../redux/analytics')
 jest.mock('../../../../redux/config')
 jest.mock('../RunFailedModal')
 jest.mock('../../../../redux/robot-update/selectors')
+jest.mock('../../../../redux/robot-settings/selectors')
 
 const mockGetIsHeaterShakerAttached = getIsHeaterShakerAttached as jest.MockedFunction<
   typeof getIsHeaterShakerAttached
@@ -192,6 +194,9 @@ const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUseDoorQuery = useDoorQuery as jest.MockedFunction<
   typeof useDoorQuery
 >
+const mockGetRobotSettings = getRobotSettings as jest.MockedFunction<
+  typeof getRobotSettings
+>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -199,6 +204,13 @@ const CREATED_AT = '03/03/2022 19:08:49'
 const STARTED_AT = '2022-03-03T19:09:40.620530+00:00'
 const COMPLETED_AT = '2022-03-03T19:39:53.620530+00:00'
 const PROTOCOL_NAME = 'A Protocol for Otie'
+const mockSettings = {
+  id: 'enableDoorSafetySwitch',
+  title: 'Enable Door Safety Switch',
+  description: '',
+  value: true,
+  restart_required: false,
+}
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as CompletedProtocolAnalysis
 
@@ -351,10 +363,11 @@ describe('ProtocolRunHeader', () => {
     when(mockUseRunCalibrationStatus)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({ complete: true })
-    mockUseIsOT3.mockReturnValue(true)
+    when(mockUseIsOT3).calledWith(ROBOT_NAME).mockReturnValue(true)
     mockRunFailedModal.mockReturnValue(<div>mock RunFailedModal</div>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
     mockUseDoorQuery.mockReturnValue({ data: mockDoorStatus } as any)
+    mockGetRobotSettings.mockReturnValue([mockSettings])
   })
 
   afterEach(() => {
@@ -849,12 +862,36 @@ describe('ProtocolRunHeader', () => {
     getByLabelText('ot-spinner')
   })
 
-  it('renders banner when the robot door is open', () => {
+  it('renders door close banner when the robot door is open', () => {
     const mockOpenDoorStatus = {
       data: { status: 'open', doorRequiredClosedForProtocol: true },
     }
     mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
     const [{ getByText }] = render()
     getByText('Close the robot door before starting the run.')
+  })
+
+  it('should render door close banner when door is open and enabled safety door switch is on - OT-2', () => {
+    when(mockUseIsOT3).calledWith(ROBOT_NAME).mockReturnValue(false)
+    const mockOpenDoorStatus = {
+      data: { status: 'open', doorRequiredClosedForProtocol: true },
+    }
+    mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
+    const [{ getByText }] = render()
+    getByText('Close the robot door before starting the run.')
+  })
+
+  it('should not render door close banner when door is open and enabled safety door switch is off - OT-2', () => {
+    when(mockUseIsOT3).calledWith(ROBOT_NAME).mockReturnValue(false)
+    const mockOffSettings = { ...mockSettings, value: false }
+    mockGetRobotSettings.mockReturnValue([mockOffSettings])
+    const mockOpenDoorStatus = {
+      data: { status: 'open', doorRequiredClosedForProtocol: true },
+    }
+    mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
+    const [{ queryByText }] = render()
+    expect(
+      queryByText('Close the robot door before starting the run.')
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Update ProtoclRunHeader's door status check that can catch the robot setting for OT-2.

Flex always checks door status 
OT-2 checks door status when the robot setting, `enableDoorSafetySwitch` is on. 

close RQA-1672
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
### OT-2 `switch on`
1. RobotSettings and turn on `enableDoorSafetySwtich`
2. run a protocol
3. open door and the Desktop app shows the banner

### OT-2 `switch off`
1. RobotSettings and turn off `enableDoorSafetySwtich`
2. run a protocol
3. open door and the Desktop app doesn't show the banner

### Flex
1. RobotSettings and turn on `enableDoorSafetySwtich`
2. run a protocol
3. open door and the Desktop app shows the banner

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update ProtocolRunHeader isDoorOpen condition for OT-2 and add tests for OT-2
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
