### PR TITLE
fix(api): New protocols print a JSON "run log" from opentrons_execute and opentrons.execute.execute() 

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -58,7 +58,6 @@ from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
 from opentrons.protocol_api.protocol_context import ProtocolContext
 
 from opentrons.protocol_engine import (
-    Command as ProtocolEngineCommand,
     Config,
     DeckType,
     EngineStatus,

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -738,7 +738,7 @@ def _adapt_protocol_source(
 
 def _adapt_command(event: pe_command_monitor.Event) -> command_types.CommandMessage:
     """Convert a Protocol Engine command event to an old-school command_types.CommandMesage."""
-    before_or_after = (
+    before_or_after: command_types.MessageSequenceId = (
         "before" if isinstance(event, pe_command_monitor.RunningEvent) else "after"
     )
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -743,6 +743,9 @@ def _adapt_command(event: pe_command_monitor.Event) -> command_types.CommandMess
     )
 
     message: command_types.CommentMessage = {
+        # TODO(mm, 2023-09-26): If we can without breaking the public API, remove the requirement
+        # to supply a "name" here. If we can't do that, consider adding a special name value
+        # so we don't have to lie and call every command a comment.
         "name": "command.COMMENT",
         "id": event.command.id,
         "$": before_or_after,
@@ -750,6 +753,10 @@ def _adapt_command(event: pe_command_monitor.Event) -> command_types.CommandMess
         # to match behavior from before Protocol Engine.
         # https://opentrons.atlassian.net/browse/RSS-320
         "payload": {"text": event.command.json()},
+        # As far as I know, "error" is not part of the public-facing API, so it doesn't matter
+        # what we put here. Leaving it as `None` to avoid difficulties in converting between
+        # the Protocol Engine `ErrorOccurrence` model and the regular Python `Exception` type
+        # that this field expects.
         "error": None,
     }
     return message

--- a/api/src/opentrons/protocol_engine/command_monitor.py
+++ b/api/src/opentrons/protocol_engine/command_monitor.py
@@ -1,3 +1,6 @@
+"""Monitor the execution of commands in a `ProtocolEngine`."""
+
+
 from dataclasses import dataclass
 import typing
 import contextlib
@@ -8,44 +11,20 @@ from opentrons.protocol_engine import Command, ProtocolEngine
 
 @dataclass
 class RunningEvent:
+    """Emitted when a command starts running."""
+
     command: Command
 
 
 @dataclass
 class NoLongerRunningEvent:
+    """Emitted when a command stops running--either because it succeeded, or failed."""
+
     command: Command
 
 
 Event = typing.Union[RunningEvent, NoLongerRunningEvent]
-
-
 Callback = typing.Callable[[Event], None]
-
-
-class _Monitor:
-    def __init__(self, engine: ProtocolEngine, callback: Callback):
-        self._engine = engine
-        self._callback = callback
-        self._last_running_id: typing.Optional[str] = None
-
-    def handle_state_update(self) -> None:
-        running_id = self._engine.state_view.commands.get_running()
-        last_running_id = self._last_running_id
-
-        if running_id != last_running_id:
-            if last_running_id is not None:
-                self._callback(
-                    NoLongerRunningEvent(
-                        self._engine.state_view.commands.get(last_running_id)
-                    )
-                )
-
-            if running_id is not None:
-                self._callback(
-                    RunningEvent(self._engine.state_view.commands.get(running_id))
-                )
-
-        self._last_running_id = running_id
 
 
 @contextlib.contextmanager
@@ -53,6 +32,34 @@ def monitor_commands(
     protocol_engine: ProtocolEngine,
     callback: Callback,
 ) -> typing.Generator[None, None, None]:
-    monitor = _Monitor(protocol_engine, callback)
-    with protocol_engine.on_state_update(monitor.handle_state_update):
+    """Monitor the execution of commands in `protocol_engine`.
+
+    While this context manager is open, `callback` will be called any time `protocol_engine`
+    starts or stops a command.
+    """
+    # Subscribe to all state updates in protocol_engine.
+    # On every update, diff the new state against the last state and see if the currently
+    # running command has changed. If it has, emit the appropriate events.
+
+    last_running_id: typing.Optional[str] = None
+
+    def handle_state_update() -> None:
+        nonlocal last_running_id
+
+        running_id = protocol_engine.state_view.commands.get_running()
+        if running_id != last_running_id:
+            if last_running_id is not None:
+                callback(
+                    NoLongerRunningEvent(
+                        protocol_engine.state_view.commands.get(last_running_id)
+                    )
+                )
+
+            if running_id is not None:
+                callback(
+                    RunningEvent(protocol_engine.state_view.commands.get(running_id))
+                )
+        last_running_id = running_id
+
+    with protocol_engine.on_state_update(handle_state_update):
         yield

--- a/api/src/opentrons/protocol_engine/command_monitor.py
+++ b/api/src/opentrons/protocol_engine/command_monitor.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+import typing
+import contextlib
+
+
+from opentrons.protocol_engine import Command, ProtocolEngine
+
+
+@dataclass
+class RunningEvent:
+    command: Command
+
+
+@dataclass
+class NoLongerRunningEvent:
+    command: Command
+
+
+Event = typing.Union[RunningEvent, NoLongerRunningEvent]
+
+
+Callback = typing.Callable[[Event], None]
+
+
+class _Monitor:
+    def __init__(self, engine: ProtocolEngine, callback: Callback):
+        self._engine = engine
+        self._callback = callback
+        self._last_running_id: typing.Optional[str] = None
+
+    def handle_state_update(self) -> None:
+        running_id = self._engine.state_view.commands.get_running()
+        last_running_id = self._last_running_id
+
+        if running_id != last_running_id:
+            if last_running_id is not None:
+                self._callback(
+                    NoLongerRunningEvent(
+                        self._engine.state_view.commands.get(last_running_id)
+                    )
+                )
+
+            if running_id is not None:
+                self._callback(
+                    RunningEvent(self._engine.state_view.commands.get(running_id))
+                )
+
+        self._last_running_id = running_id
+
+
+@contextlib.contextmanager
+def monitor_commands(
+    protocol_engine: ProtocolEngine,
+    callback: Callback,
+) -> typing.Generator[None, None, None]:
+    monitor = _Monitor(protocol_engine, callback)
+    with protocol_engine.on_state_update(monitor.handle_state_update):
+        yield

--- a/api/src/opentrons/protocol_engine/command_monitor.py
+++ b/api/src/opentrons/protocol_engine/command_monitor.py
@@ -43,7 +43,7 @@ def monitor_commands(
 
     last_running_id: typing.Optional[str] = None
 
-    def handle_state_update() -> None:
+    def handle_state_update(_message_from_broker: None) -> None:
         nonlocal last_running_id
 
         running_id = protocol_engine.state_view.commands.get_running()
@@ -61,5 +61,5 @@ def monitor_commands(
                 )
         last_running_id = running_id
 
-    with protocol_engine.on_state_update(handle_state_update):
+    with protocol_engine.state_update_broker.subscribed(handle_state_update):
         yield

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -1,8 +1,7 @@
 """ProtocolEngine class definition."""
 from contextlib import AsyncExitStack
-import contextlib
 from logging import getLogger
-from typing import Callable, Dict, Generator, Optional, Union
+from typing import Dict, Optional, Union
 
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
@@ -12,6 +11,8 @@ from opentrons_shared_data.errors import (
     ErrorCodes,
     EnumeratedError,
 )
+
+from opentrons.util.broker import ReadOnlyBroker
 
 from .errors import ProtocolCommandFailedError, ErrorOccurrence
 from .errors.exceptions import EStopActivatedError
@@ -130,6 +131,36 @@ class ProtocolEngine:
         """Get an interface to retrieve calculated state values."""
         return self._state_store
 
+    @property
+    def state_update_broker(self) -> ReadOnlyBroker[None]:
+        """Return a broker that you can use to get notified of all state updates.
+
+        For example, you can use this to do something any time a new command starts running.
+
+        `ProtocolEngine` will publish a message to this broker (with the placeholder value `None`)
+        any time its state updates. Then, when you receive that message, you can get the latest
+        state through `state_view` and inspect it to see whether something happened that you care
+        about.
+
+        Warning:
+            Use this mechanism sparingly, because it has several footguns:
+
+            * Your callbacks will run synchronously, on every state update.
+              If they take a long time, they will harm analysis and run speed.
+
+            * Your callbacks will run in the thread and asyncio event loop that own this
+              `ProtocolEngine`. (See the concurrency notes in the `ProtocolEngine` docstring.)
+              If your callbacks interact with things in other threads or event loops,
+              take appropriate precautions to keep them concurrency-safe.
+
+            * Currently, if your callback raises an exception, it will propagate into
+              `ProtocolEngine` and be treated like any other internal error. This will probably
+              stop the run. If you expect your code to raise exceptions and don't want
+              that to happen, consider catching and logging them at the top level of your callback,
+              before they propagate into `ProtocolEngine`.
+        """
+        return self._state_store.update_broker
+
     def add_plugin(self, plugin: AbstractPlugin) -> None:
         """Add a plugin to the engine to customize behavior."""
         self._plugin_starter.start(plugin)
@@ -203,14 +234,6 @@ class ProtocolEngine:
             self._state_store.commands.get_command_is_final,
             command_id=command_id,
         )
-
-    # TODO: Work out multithreading concerns.
-    @contextlib.contextmanager
-    def on_state_update(
-        self, callback: Callable[[], None]
-    ) -> Generator[None, None, None]:
-        with self._state_store.on_state_update(callback):
-            yield
 
     async def add_and_execute_command(
         self, request: commands.CommandCreate

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -1,7 +1,8 @@
 """ProtocolEngine class definition."""
 from contextlib import AsyncExitStack
+import contextlib
 from logging import getLogger
-from typing import Dict, Optional, Union
+from typing import Callable, Dict, Generator, Optional, Union
 
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
@@ -202,6 +203,14 @@ class ProtocolEngine:
             self._state_store.commands.get_command_is_final,
             command_id=command_id,
         )
+
+    # TODO: Work out multithreading concerns.
+    @contextlib.contextmanager
+    def on_state_update(
+        self, callback: Callable[[], None]
+    ) -> Generator[None, None, None]:
+        with self._state_store.on_state_update(callback):
+            yield
 
     async def add_and_execute_command(
         self, request: commands.CommandCreate

--- a/api/src/opentrons/protocol_engine/state/change_notifier.py
+++ b/api/src/opentrons/protocol_engine/state/change_notifier.py
@@ -1,5 +1,9 @@
 """Simple state change notification interface."""
 import asyncio
+from contextlib import contextmanager
+from typing import Callable, Generator
+
+from opentrons.util.broker import Broker
 
 
 class ChangeNotifier:
@@ -8,12 +12,30 @@ class ChangeNotifier:
     def __init__(self) -> None:
         """Initialize the ChangeNotifier with an internal Event."""
         self._event = asyncio.Event()
+        self._broker = Broker[None]()
 
     def notify(self) -> None:
         """Notify all `wait`'ers that the state has changed."""
         self._event.set()
+        self._broker.publish(None)
 
     async def wait(self) -> None:
         """Wait until the next state change notification."""
         self._event.clear()
         await self._event.wait()
+
+    @contextmanager
+    def on_change(self, callback: Callable[[], None]) -> Generator[None, None, None]:
+        def wrapped_callback(_: None) -> None:
+            # TODO: Exception safety?
+            # TODO: Is this a good approach or is there a way to use async generators?
+            # What does Seth's subsystem thing do?
+            # Maybe add a CM to EquipmentBroker?
+            # Maybe give EquipmentBroker a read-only interface?
+            callback()
+
+        unsubscribe = self._broker.subscribe(wrapped_callback)
+        try:
+            yield
+        finally:
+            unsubscribe()

--- a/api/src/opentrons/protocol_engine/state/change_notifier.py
+++ b/api/src/opentrons/protocol_engine/state/change_notifier.py
@@ -1,9 +1,7 @@
 """Simple state change notification interface."""
 import asyncio
-from contextlib import contextmanager
-from typing import Callable, Generator
 
-from opentrons.util.broker import Broker
+from opentrons.util.broker import Broker, ReadOnlyBroker
 
 
 class ChangeNotifier:
@@ -24,18 +22,10 @@ class ChangeNotifier:
         self._event.clear()
         await self._event.wait()
 
-    @contextmanager
-    def on_change(self, callback: Callable[[], None]) -> Generator[None, None, None]:
-        def wrapped_callback(_: None) -> None:
-            # TODO: Exception safety?
-            # TODO: Is this a good approach or is there a way to use async generators?
-            # What does Seth's subsystem thing do?
-            # Maybe add a CM to EquipmentBroker?
-            # Maybe give EquipmentBroker a read-only interface?
-            callback()
+    @property
+    def broker(self) -> ReadOnlyBroker[None]:
+        """Return a broker that you can use to get notified of all changes.
 
-        unsubscribe = self._broker.subscribe(wrapped_callback)
-        try:
-            yield
-        finally:
-            unsubscribe()
+        This is an alternative interface to `wait()`.
+        """
+        return self._broker

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -507,13 +507,17 @@ class CommandView(HasState[CommandState]):
         else:
             return run_error or finish_error
 
+    def get_running(self) -> Optional[str]:
+        """Return the ID of the command that's currently running, if any."""
+        return self._state.running_command_id
+
     def get_current(self) -> Optional[CurrentCommand]:
         """Return the "current" command, if any.
 
         The "current" command is the command that is currently executing,
         or the most recent command to have completed.
         """
-        if self._state.running_command_id:
+        if self._state.running_command_id is not None:
             entry = self._state.commands_by_id[self._state.running_command_id]
             return CurrentCommand(
                 command_id=entry.command.id,

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -1,13 +1,14 @@
 """Protocol engine state management."""
 from __future__ import annotations
-from contextlib import contextmanager
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, TypeVar
-from opentrons.protocol_engine.types import ModuleOffsetVector
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
+
+from opentrons.protocol_engine.types import ModuleOffsetVector
+from opentrons.util.broker import ReadOnlyBroker
 
 from ..resources import DeckFixedLabware
 from ..actions import Action, ActionHandler
@@ -239,12 +240,16 @@ class StateStore(StateView, ActionHandler):
 
         return is_done
 
-    @contextmanager
-    def on_state_update(
-        self, callback: Callable[[], None]
-    ) -> Generator[None, None, None]:
-        with self._change_notifier.on_change(callback):
-            yield
+    # We return ReadOnlyBroker[None] instead of ReadOnlyBroker[StateView] in order to avoid
+    # confusion with state mutability. If a caller needs to know the new state, they can
+    # retrieve it explicitly with `ProtocolEngine.state_view`.
+    @property
+    def update_broker(self) -> ReadOnlyBroker[None]:
+        """Return a broker that you can use to get notified of all state updates.
+
+        This is an alternative interface to `wait_for()`.
+        """
+        return self._change_notifier.broker
 
     def _get_next_state(self) -> State:
         """Get a new instance of the state value object."""

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -1,9 +1,10 @@
 """Protocol engine state management."""
 from __future__ import annotations
+from contextlib import contextmanager
 
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, TypeVar
 from opentrons.protocol_engine.types import ModuleOffsetVector
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
@@ -237,6 +238,13 @@ class StateStore(StateView, ActionHandler):
             is_done = predicate()
 
         return is_done
+
+    @contextmanager
+    def on_state_update(
+        self, callback: Callable[[], None]
+    ) -> Generator[None, None, None]:
+        with self._change_notifier.on_change(callback):
+            yield
 
     def _get_next_state(self) -> State:
         """Get a new instance of the state value object."""

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -8,7 +8,7 @@ from typing import Optional
 from opentrons.commands.types import CommandMessage as LegacyCommand
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.protocol_engine import AbstractPlugin, actions as pe_actions
-from opentrons.util.broker import Broker
+from opentrons.util.broker import ReadOnlyBroker
 
 from .legacy_wrappers import LegacyLoadInfo
 from .legacy_command_mapper import LegacyCommandMapper
@@ -37,7 +37,7 @@ class LegacyContextPlugin(AbstractPlugin):
     def __init__(
         self,
         broker: LegacyBroker,
-        equipment_broker: Broker[LegacyLoadInfo],
+        equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
         legacy_command_mapper: Optional[LegacyCommandMapper] = None,
     ) -> None:
         """Initialize the plugin with its dependencies."""

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -78,10 +78,11 @@ class LegacyContextPlugin(AbstractPlugin):
             )
             exit_stack.callback(command_broker_unsubscribe)
 
-            equipment_broker_unsubscribe = self._equipment_broker.subscribe(
-                callback=self._handle_equipment_loaded
+            exit_stack.enter_context(
+                self._equipment_broker.subscribed(
+                    callback=self._handle_equipment_loaded
+                )
             )
-            exit_stack.callback(equipment_broker_unsubscribe)
 
             # All subscriptions succeeded.
             # Save the exit stack so our teardown method can use it later

--- a/api/tests/opentrons/protocol_engine/state/test_change_notifier.py
+++ b/api/tests/opentrons/protocol_engine/state/test_change_notifier.py
@@ -19,8 +19,8 @@ async def test_single_subscriber() -> None:
     await result
 
 
-@pytest.mark.parametrize("count", range(10))
-async def test_multiple_subscribers(count: int) -> None:
+@pytest.mark.parametrize("_test_repetition", range(10))
+async def test_multiple_subscribers(_test_repetition: int) -> None:
     """Test that multiple subscribers can wait for a notification.
 
     This test checks that the subscribers are awoken in the order they
@@ -54,3 +54,20 @@ async def test_multiple_subscribers(count: int) -> None:
     await asyncio.gather(task_1, task_2, task_3)
 
     assert results == [1, 2, 3]
+
+
+@pytest.mark.parametrize("notify_count", [0, 5])
+async def test_broker(notify_count: int) -> None:
+    """Test that notifications are available synchronously through `ChangeNotifier.broker`."""
+    subject = ChangeNotifier()
+    received = 0
+
+    def callback(_message_from_broker: None) -> None:
+        nonlocal received
+        received += 1
+
+    with subject.broker.subscribed(callback):
+        for _ in range(notify_count):
+            subject.notify()
+
+    assert received == notify_count

--- a/api/tests/opentrons/protocol_engine/state/test_change_notifier.py
+++ b/api/tests/opentrons/protocol_engine/state/test_change_notifier.py
@@ -56,9 +56,10 @@ async def test_multiple_subscribers(_test_repetition: int) -> None:
     assert results == [1, 2, 3]
 
 
-@pytest.mark.parametrize("notify_count", [0, 5])
-async def test_broker(notify_count: int) -> None:
+async def test_broker() -> None:
     """Test that notifications are available synchronously through `ChangeNotifier.broker`."""
+    notify_count = 5
+
     subject = ChangeNotifier()
     received = 0
 
@@ -67,7 +68,6 @@ async def test_broker(notify_count: int) -> None:
         received += 1
 
     with subject.broker.subscribed(callback):
-        for _ in range(notify_count):
+        for notify_number in range(notify_count):
             subject.notify()
-
-    assert received == notify_count
+            assert received == notify_number + 1

--- a/api/tests/opentrons/protocol_engine/state/test_command_monitor.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_monitor.py
@@ -1,0 +1,92 @@
+"""Unit tests for `opentrons.protocol_engine.command_monitor`."""
+
+
+from datetime import datetime
+from typing import List
+
+from decoy import Decoy, matchers
+
+from opentrons.protocol_engine import CommandStatus, ProtocolEngine, commands
+from opentrons.protocol_engine.command_monitor import (
+    Event,
+    NoLongerRunningEvent,
+    RunningEvent,
+    monitor_commands as subject,
+)
+
+
+def _make_dummy_command(id: str, completed: bool) -> commands.Command:
+    if completed:
+        return commands.Comment(
+            id=id,
+            key=id,
+            status=CommandStatus.SUCCEEDED,
+            createdAt=datetime(2023, 9, 26),
+            params=commands.CommentParams(message=""),
+            result=None,
+        )
+    else:
+        return commands.Comment(
+            id=id,
+            key=id,
+            status=CommandStatus.RUNNING,
+            createdAt=datetime(2023, 9, 26),
+            completedAt=datetime(2023, 9, 26),
+            params=commands.CommentParams(message=""),
+            result=commands.CommentResult(),
+        )
+
+
+def test_monitor_commands(decoy: Decoy) -> None:
+    """Test that it translates state updates into command running/no-longer-running events."""
+    mock_protocol_engine = decoy.mock(cls=ProtocolEngine)
+    mock_command_view = mock_protocol_engine.state_view.commands
+    callback_captor = matchers.Captor()
+    decoy.when(mock_protocol_engine.on_state_update(callback_captor)).then_enter_with(
+        None
+    )
+
+    command_1_running = _make_dummy_command(id="command-1", completed=False)
+    command_1_completed = _make_dummy_command(id="command-1", completed=True)
+    command_2_running = _make_dummy_command(id="command-2", completed=False)
+    command_2_completed = _make_dummy_command(id="command-2", completed=True)
+
+    received_events: List[Event] = []
+
+    def callback(event: Event) -> None:
+        received_events.append(event)
+
+    with subject(mock_protocol_engine, callback):
+        trigger_callback = callback_captor.value
+
+        # Feed the subject these states, in sequence:
+        #   1. No running command
+        #   2. "command-1" running
+        #   3. "command-2" running
+        #   4. No command running
+        # Between each state, notify the subject by triggering its callback.
+
+        decoy.when(mock_command_view.get_running()).then_return(None)
+        trigger_callback()
+
+        decoy.when(mock_command_view.get_running()).then_return("command-1")
+        decoy.when(mock_command_view.get("command-1")).then_return(command_1_running)
+        trigger_callback()
+
+        decoy.when(mock_command_view.get_running()).then_return("command-2")
+        decoy.when(mock_command_view.get("command-1")).then_return(command_1_completed)
+        decoy.when(mock_command_view.get("command-2")).then_return(command_2_running)
+        trigger_callback()
+
+        decoy.when(mock_command_view.get_running()).then_return(None)
+        decoy.when(mock_command_view.get("command-2")).then_return(command_2_completed)
+        trigger_callback()
+
+    # Make sure the callback converted the sequence of state updates into the expected sequence
+    # of events.
+    assert received_events == [
+        RunningEvent(command_1_running),
+        NoLongerRunningEvent(command_1_completed),
+        RunningEvent(command_2_running),
+        NoLongerRunningEvent(command_2_completed),
+    ]

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -660,6 +660,15 @@ def test_get_okay_to_clear(subject: CommandView, expected_is_okay: bool) -> None
     assert subject.get_is_okay_to_clear() is expected_is_okay
 
 
+def test_get_running() -> None:
+    """It should return the command that's currently running."""
+    subject = get_command_view(running_command_id=None)
+    assert subject.get_running() is None
+
+    subject = get_command_view(running_command_id="command-id")
+    assert subject.get_running() == "command-id"
+
+
 def test_get_current() -> None:
     """It should return the "current" command."""
     subject = get_command_view(

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -12,7 +12,7 @@ from opentrons.protocol_engine import (
     commands as pe_commands,
 )
 from opentrons.legacy_broker import LegacyBroker
-from opentrons.util.broker import Broker
+from opentrons.util.broker import ReadOnlyBroker
 
 from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandMapper
 from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
@@ -30,14 +30,14 @@ from opentrons_shared_data.labware.dev_types import (
 
 @pytest.fixture
 def mock_legacy_broker(decoy: Decoy) -> LegacyBroker:
-    """Get a mocked out LegacyProtocolContext dependency."""
+    """Get a mocked out `broker: LegacyBroker` dependency."""
     return decoy.mock(cls=LegacyBroker)
 
 
 @pytest.fixture
-def mock_broker(decoy: Decoy) -> Broker[LegacyLoadInfo]:
-    """Get a mocked out LegacyProtocolContext dependency."""
-    return decoy.mock(cls=Broker[LegacyLoadInfo])
+def mock_equipment_broker(decoy: Decoy) -> ReadOnlyBroker[LegacyLoadInfo]:
+    """Get a mocked out `equipment_broker: Broker` dependency."""
+    return decoy.mock(cls=ReadOnlyBroker[LegacyLoadInfo])
 
 
 @pytest.fixture
@@ -61,7 +61,7 @@ def mock_action_dispatcher(decoy: Decoy) -> pe_actions.ActionDispatcher:
 @pytest.fixture
 def subject(
     mock_legacy_broker: LegacyBroker,
-    mock_broker: Broker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_state_view: StateView,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
@@ -69,42 +69,58 @@ def subject(
     """Get a configured LegacyContextPlugin with its dependencies mocked out."""
     plugin = LegacyContextPlugin(
         broker=mock_legacy_broker,
-        equipment_broker=mock_broker,
+        equipment_broker=mock_equipment_broker,
         legacy_command_mapper=mock_legacy_command_mapper,
     )
     plugin._configure(state=mock_state_view, action_dispatcher=mock_action_dispatcher)
     return plugin
 
 
+class _ContextManager:
+    """A placeholder in the shape of a context manager, to pass as a template to `decoy.mock()`."""
+
+    def __enter__(self) -> None:
+        raise NotImplementedError()
+
+    def __exit__(self, type: object, value: object, traceback: object) -> None:
+        raise NotImplementedError()
+
+
 async def test_broker_subscribe_unsubscribe(
     decoy: Decoy,
     mock_legacy_broker: LegacyBroker,
-    mock_broker: Broker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
     subject: LegacyContextPlugin,
 ) -> None:
     """It should subscribe to the brokers on setup and unsubscribe on teardown."""
     command_broker_unsubscribe: Callable[[], None] = decoy.mock()
-    equipment_broker_unsubscribe: Callable[[], None] = decoy.mock()
+    equipment_broker_subscription_context = decoy.mock(cls=_ContextManager)
 
     decoy.when(
         mock_legacy_broker.subscribe(topic="command", handler=matchers.Anything())
     ).then_return(command_broker_unsubscribe)
 
-    decoy.when(mock_broker.subscribe(callback=matchers.Anything())).then_return(
-        equipment_broker_unsubscribe
-    )
+    decoy.when(
+        mock_equipment_broker.subscribed(callback=matchers.Anything())
+    ).then_return(equipment_broker_subscription_context)
 
     subject.setup()
     await subject.teardown()
 
     decoy.verify(command_broker_unsubscribe())
-    decoy.verify(equipment_broker_unsubscribe())
+
+    decoy.verify(
+        [
+            equipment_broker_subscription_context.__enter__(),  # type: ignore[func-returns-value]
+            equipment_broker_subscription_context.__exit__(None, None, None),  # type: ignore[func-returns-value]
+        ]
+    )
 
 
 async def test_command_broker_messages(
     decoy: Decoy,
     mock_legacy_broker: LegacyBroker,
-    mock_broker: Broker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
     subject: LegacyContextPlugin,
@@ -117,9 +133,9 @@ async def test_command_broker_messages(
     decoy.when(
         mock_legacy_broker.subscribe(topic="command", handler=command_handler_captor)
     ).then_return(decoy.mock())
-    decoy.when(mock_broker.subscribe(callback=matchers.Anything())).then_return(
-        decoy.mock()
-    )
+    decoy.when(
+        mock_equipment_broker.subscribed(callback=matchers.Anything())
+    ).then_enter_with(None)
 
     subject.setup()
 
@@ -158,7 +174,7 @@ async def test_command_broker_messages(
 async def test_equipment_broker_messages(
     decoy: Decoy,
     mock_legacy_broker: LegacyBroker,
-    mock_broker: Broker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
     subject: LegacyContextPlugin,
@@ -166,15 +182,13 @@ async def test_equipment_broker_messages(
 ) -> None:
     """It should dispatch commands from equipment broker messages."""
     # Capture the function that the plugin sets up as its labware load callback.
-    # Also, ensure that all subscribe calls return an actual unsubscribe callable
-    # (instead of Decoy's default `None`) so subject.teardown() works.
     labware_handler_captor = matchers.Captor()
     decoy.when(
         mock_legacy_broker.subscribe(topic="command", handler=matchers.Anything())
     ).then_return(decoy.mock())
-    decoy.when(mock_broker.subscribe(callback=labware_handler_captor)).then_return(
-        decoy.mock()
-    )
+    decoy.when(
+        mock_equipment_broker.subscribed(callback=labware_handler_captor)
+    ).then_enter_with(None)
 
     subject.setup()
 

--- a/api/tests/opentrons/util/test_broker.py
+++ b/api/tests/opentrons/util/test_broker.py
@@ -6,7 +6,32 @@ from typing import List
 from opentrons.util.broker import Broker
 
 
-def test_broker() -> None:
+def test_context_manager_subscriptions() -> None:
+    """Test subscribing, receiving messages, and unsubscribing."""
+    subject = Broker[int]()
+
+    received_by_a: List[int] = []
+    received_by_b: List[int] = []
+
+    def callback_a(message: int) -> None:
+        received_by_a.append(message)
+
+    def callback_b(message: int) -> None:
+        received_by_b.append(message)
+
+    subject.publish(1)
+    with subject.subscribed(callback_a):
+        subject.publish(2)
+        with subject.subscribed(callback_b):
+            subject.publish(3)
+        subject.publish(4)
+    subject.publish(5)
+
+    assert received_by_a == [2, 3, 4]
+    assert received_by_b == [3]
+
+
+def test_non_context_manager_subscriptions() -> None:
     """Test subscribing, receiving messages, and unsubscribing."""
     subject = Broker[int]()
 


### PR DESCRIPTION
# Overview

Closes RSS-283.

When running PAPIv≥2.14 or JSONv≥6 protocols, `opentrons_execute` will now output a "run log" to stdout like this:

```
{"id": "056a8b70-0f46-43ca-b0eb-847671d31eff", "createdAt": "2023-09-27T18:33:48.154347+00:00", "commandType": "custom", "key": "3ca2f4eb308dc93ebab03777f50b0d85", "status": "running", "params": {"legacyCommandType": "command.COMMENT", "legacyCommandText": "Hello, world!"}, "result": null, "error": null, "startedAt": "2023-09-27T18:33:48.155772+00:00", "completedAt": null, "intent": null}
{"id": "f4d94b1d-6278-45ca-a525-8f811bbdcaa4", "createdAt": "2023-09-27T18:33:48.166984+00:00", "commandType": "loadPipette", "key": "72836212bea2e508afa3f07b3c296c6c", "status": "running", "params": {"pipetteName": "p20_multi_gen2", "mount": "left", "pipetteId": null}, "result": null, "error": null, "startedAt": "2023-09-27T18:33:48.168365+00:00", "completedAt": null, "intent": null}
```

And the same objects are exposed by `opentrons.execute.execute()`'s `emit_runlog` callback.

# Test Plan

* [x] Test this on a Flex by running `python3 -m opentrons.execute path_to_some_protocol.py` with a protocol that specifies `"apiLevel": "2.15"`.
* [x] Test this on an OT-2 by running `opentrons_execute path_to_some_protocol.py` with a protocol that specifies `"apiLevel": "2.14"` or above.

# Changelog

* Add a new helper to allow monitoring a `ProtocolEngine` for ongoing commands.

  This works by subscribing to every state update and seeing if the currently running command has changed since the last one. If it has, we emit a "command running" or "command no longer running" event. Conceptually, that event structure matches the "before" and "after" messages that [the Python Protocol API has long published](https://github.com/Opentrons/opentrons/blob/504588f84da5be81ff567b54b60d3fb9eb9425a9/api/src/opentrons/protocol_api/instrument_context.py#L424-L432).
* Wire that helper up to the `opentrons_execute` CLI and the `opentrons.execute.execute()` function.

  `opentrons.execute.execute()` has [a quirky interface](https://docs.opentrons.com/v2/new_protocol_api.html?highlight=execute#module-opentrons.execute:~:text=The%20format%20of%20the%20runlog%20entries%20is%20as%20follows%3A) that we need to preserve for now, so this takes some shoehorning. For this ticket, I'm not concerned about how the protocol's activity gets printed—just that it gets printed *somehow.* So I'm doing that by reporting each command as a "comment" where the message is the command's JSON text. There's obviously a lot of room for improvement here. RSS-320 tracks making these messages more nicely human-readable. And if there's a use case for it, we could also go the other way, officially exposing the command in a machine-readable way.

# Review requests

* Is this compatible with existing public-facing interfaces, in the sense that it won't outright break any code?
* See my inline comments.

# Risk assessment

Low. This is tricky to test, but it's also fairly nonintrusive.
