### PR TITLE
fix(hardware-testing): Explicitely add the commit hash to the test version string

### DIFF
--- a/hardware-testing/hardware_testing/data/__init__.py
+++ b/hardware-testing/hardware_testing/data/__init__.py
@@ -22,7 +22,7 @@ def _build_git_description_string() -> str:
     raw_hash = _git("rev-parse", "--short", "HEAD")
     description_split = raw_description.split("-")
     description = "_".join(description_split)
-    desc_with_hash = description + "_" + raw_hash
+    desc_with_hash = description + "-" + raw_hash
     mods = _git("ls-files", "-m").replace("\n", " ")
     if not mods:
         return desc_with_hash

--- a/hardware-testing/hardware_testing/data/__init__.py
+++ b/hardware-testing/hardware_testing/data/__init__.py
@@ -19,13 +19,14 @@ def _build_git_description_string() -> str:
     if IS_ROBOT:
         raise RuntimeError("unable to run git describe on robot")
     raw_description = _git("describe")
+    raw_hash = _git("rev-parse", "--short", "HEAD")
     description_split = raw_description.split("-")
-    # separate everything but git hash with an underscore
-    description = "_".join(description_split[:-1]) + "-" + description_split[-1]
+    description = "_".join(description_split)
+    desc_with_hash = description + "_" + raw_hash
     mods = _git("ls-files", "-m").replace("\n", " ")
     if not mods:
-        return description
-    return f"{description}-[{mods}]"
+        return desc_with_hash
+    return f"{desc_with_hash}-[{mods}]"
 
 
 def get_git_description() -> str:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR explicitly places the commit has at the end of the test version string stored in the CSV file.

The test version string that is generated for QC tests uses the output of `git describe` and writes it to the CSV file. We rely on the commit hash in that output to make the data traceable to a specific software version.

A recent tag was generated that, for some reason, makes the output of `git describe` not include the commit hash.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
