### PR TITLE
fix(api): Allow right mount Z to home/retract when a 96-chan pipette is attached

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -544,6 +544,14 @@ class OT3Simulator:
         """Save the current."""
         yield
 
+    @asynccontextmanager
+    async def restore_z_r_run_current(self) -> AsyncIterator[None]:
+        """
+        Temporarily restore the active current ONLY when homing or
+        retracting the Z_R axis while the 96-channel is attached.
+        """
+        yield
+
     @ensure_yield
     async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         new_mods_at_ports = [

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -165,7 +165,7 @@ AXES_IN_HOMING_ORDER: Tuple[Axis, Axis, Axis, Axis, Axis, Axis, Axis, Axis, Axis
 Wrapped = TypeVar("Wrapped", bound=Callable[..., Awaitable[Any]])
 
 
-def adjust_high_throughput_z_current(func: Wrapped) -> Wrapped:
+def _adjust_high_throughput_z_current(func: Wrapped) -> Wrapped:
     """
     A decorator that temproarily and conditionally changes the active current (based on the axis input)
     before a function is executed and the cleans up afterwards
@@ -1354,7 +1354,7 @@ class OT3API(
         target_pos.update({axis: self._backend.home_position()[axis]})
         return origin, target_pos
 
-    @adjust_high_throughput_z_current
+    @_adjust_high_throughput_z_current
     async def _home_axis(self, axis: Axis) -> None:
         """
         Perform home; base on axis motor/encoder statuses, shorten homing time
@@ -1501,7 +1501,7 @@ class OT3API(
         await self.retract_axis(Axis.by_mount(mount))
 
     @ExecutionManagerProvider.wait_for_running
-    @adjust_high_throughput_z_current
+    @_adjust_high_throughput_z_current
     async def retract_axis(self, axis: Axis) -> None:
         """
         Move an axis to its home position, without engaging the limit switch,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1442,13 +1442,14 @@ class OT3API(
             checked_axes.append(Axis.Q)
             # NOTE: Z_R current is dropped very low when 96CH attached,
             #       so trying to home it would cause timeout error
-            if not axes:
-                checked_axes.remove(Axis.Z_R)
-            elif Axis.Z_R in axes:
-                raise RuntimeError(
-                    f"unable to home {Axis.Z_R.name} axis"
-                    f"with {self.gantry_load.name} gantry load"
+            if axes and Axis.Z_R in axes:
+                self._log.warning(
+                    f"unable to home {Axis.Z_R.name} axis with"
+                    f" {self.gantry_load.name} gantry load, skipping axis"
                 )
+
+            if Axis.Z_R in checked_axes:
+                checked_axes.remove(Axis.Z_R)
 
         if skip:
             checked_axes = [ax for ax in checked_axes if ax not in skip]
@@ -1501,10 +1502,13 @@ class OT3API(
         will call home if the stepper position is inaccurate.
         """
         if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and axis == Axis.Z_R:
-            raise RuntimeError(
+            # NOTE: Z_R current is dropped very low when 96CH attached,
+            #       so trying to retract it would cause timeout error
+            self._log.warning(
                 f"unable to retract {Axis.Z_R.name} axis"
-                f"with {self.gantry_load.name} gantry load"
+                f"with {self.gantry_load.name} gantry load, skipping"
             )
+            return
 
         motor_ok = self._backend.check_motor_status([axis])
         encoder_ok = self._backend.check_encoder_status([axis])

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1,7 +1,7 @@
 import asyncio
 from concurrent.futures import Future
 import contextlib
-from functools import partial, lru_cache
+from functools import partial, lru_cache, wraps
 from dataclasses import replace
 import logging
 from copy import deepcopy
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Tuple,
     Mapping,
+    Awaitable,
 )
 from opentrons.hardware_control.modules.module_calibration import (
     ModuleCalibrationOffset,
@@ -160,6 +161,24 @@ AXES_IN_HOMING_ORDER: Tuple[Axis, Axis, Axis, Axis, Axis, Axis, Axis, Axis, Axis
     Axis.G,
     Axis.Q,
 )
+
+Wrapped = TypeVar("Wrapped", bound=Callable[..., Awaitable[Any]])
+
+
+def adjust_high_throughput_z_current(func: Wrapped) -> Wrapped:
+    """
+    A decorator that temproarily and conditionally changes the active current (based on the axis input)
+    before a function is executed and the cleans up afterwards
+    """
+    # only home and retract should be wrappeed by this decorator
+    @wraps(func)
+    async def wrapper(self: Any, axis: Axis, *args: Any, **kwargs: Any) -> Any:
+        async with contextlib.AsyncExitStack() as stack:
+            if axis == Axis.Z_R and self.gantry_load == GantryLoad.HIGH_THROUGHPUT:
+                await stack.enter_async_context(self._backend.restore_z_r_run_current())
+            return await func(self, axis, *args, **kwargs)
+
+    return cast(Wrapped, wrapper)
 
 
 class OT3API(
@@ -1335,6 +1354,7 @@ class OT3API(
         target_pos.update({axis: self._backend.home_position()[axis]})
         return origin, target_pos
 
+    @adjust_high_throughput_z_current
     async def _home_axis(self, axis: Axis) -> None:
         """
         Perform home; base on axis motor/encoder statuses, shorten homing time
@@ -1440,17 +1460,6 @@ class OT3API(
             checked_axes = [ax for ax in Axis if ax != Axis.Q]
         if self.gantry_load == GantryLoad.HIGH_THROUGHPUT:
             checked_axes.append(Axis.Q)
-            # NOTE: Z_R current is dropped very low when 96CH attached,
-            #       so trying to home it would cause timeout error
-            if axes and Axis.Z_R in axes:
-                self._log.warning(
-                    f"unable to home {Axis.Z_R.name} axis with"
-                    f" {self.gantry_load.name} gantry load, skipping axis"
-                )
-
-            if Axis.Z_R in checked_axes:
-                checked_axes.remove(Axis.Z_R)
-
         if skip:
             checked_axes = [ax for ax in checked_axes if ax not in skip]
         self._log.info(f"Homing {axes}")
@@ -1492,6 +1501,7 @@ class OT3API(
         await self.retract_axis(Axis.by_mount(mount))
 
     @ExecutionManagerProvider.wait_for_running
+    @adjust_high_throughput_z_current
     async def retract_axis(self, axis: Axis) -> None:
         """
         Move an axis to its home position, without engaging the limit switch,
@@ -1501,15 +1511,6 @@ class OT3API(
         the behaviors between the two robots similar, retract_axis on the FLEX
         will call home if the stepper position is inaccurate.
         """
-        if self.gantry_load == GantryLoad.HIGH_THROUGHPUT and axis == Axis.Z_R:
-            # NOTE: Z_R current is dropped very low when 96CH attached,
-            #       so trying to retract it would cause timeout error
-            self._log.warning(
-                f"unable to retract {Axis.Z_R.name} axis"
-                f"with {self.gantry_load.name} gantry load, skipping"
-            )
-            return
-
         motor_ok = self._backend.check_motor_status([axis])
         encoder_ok = self._backend.check_encoder_status([axis])
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When a 96-channel pipette is attached, the right mount doesn't really need to do anything other than to home/retract. Instead of disabling all movement for the right mount, we should allow it to home and retract. I've created a decorator that wraps these two functions in the hardware controller and temporarily updates the run current for the Z_R axis to allow it to move, and restores the old current once the motion is complete.

