### PR TITLE
fix(app): add modal close logic for remote run deletion for LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -7,6 +7,7 @@ import { LabwareOffsetCreateData } from '@opentrons/api-client'
 import {
   useCreateLabwareOffsetMutation,
   useCreateMaintenanceCommandMutation,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 import {
   CompletedProtocolAnalysis,
@@ -37,6 +38,7 @@ import type { Axis, Sign, StepSize } from '../../molecules/JogControls/types'
 import type { RegisterPositionAction, WorkingOffset } from './types'
 import { getGoldenCheckSteps } from './utils/getGoldenCheckSteps'
 
+const RUN_REFETCH_INTERVAL = 5000
 const JOG_COMMAND_TIMEOUT = 10000 // 10 seconds
 interface LabwarePositionCheckModalProps {
   onCloseClick: () => unknown
@@ -45,6 +47,7 @@ interface LabwarePositionCheckModalProps {
   mostRecentAnalysis: CompletedProtocolAnalysis | null
   existingOffsets: LabwareOffset[]
   caughtError?: Error
+  setMaintenanceRunId: (id: string | null) => void
 }
 
 export const LabwarePositionCheckComponent = (
@@ -56,10 +59,46 @@ export const LabwarePositionCheckComponent = (
     existingOffsets,
     runId,
     maintenanceRunId,
+    setMaintenanceRunId,
   } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const isOnDevice = useSelector(getIsOnDevice)
   const protocolData = mostRecentAnalysis
+
+  // we should start checking for run deletion only after the maintenance run is created
+  // and the useCurrentRun poll has returned that created id
+  const [
+    monitorMaintenanceRunForDeletion,
+    setMonitorMaintenanceRunForDeletion,
+  ] = React.useState<boolean>(false)
+
+  const { data: maintenanceRunData } = useCurrentMaintenanceRun({
+    refetchInterval: RUN_REFETCH_INTERVAL,
+    enabled: maintenanceRunId != null,
+  })
+
+  // this will close the modal in case the run was deleted by the terminate
+  // activity modal on the ODD
+  React.useEffect(() => {
+    if (
+      maintenanceRunId !== null &&
+      maintenanceRunData?.data.id === maintenanceRunId
+    ) {
+      setMonitorMaintenanceRunForDeletion(true)
+    }
+    if (
+      maintenanceRunData?.data.id !== maintenanceRunId &&
+      monitorMaintenanceRunForDeletion
+    ) {
+      setMaintenanceRunId(null)
+    }
+  }, [
+    maintenanceRunData?.data.id,
+    maintenanceRunId,
+    monitorMaintenanceRunForDeletion,
+    setMaintenanceRunId,
+  ])
+
   const [fatalError, setFatalError] = React.useState<string | null>(null)
   const [
     { workingOffsets, tipPickUpOffset },

--- a/app/src/organisms/LabwarePositionCheck/__tests__/useLaunchLPC.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/useLaunchLPC.test.tsx
@@ -80,7 +80,7 @@ describe('useLaunchLPC hook', () => {
       Promise.resolve({ data: { definitionUri: 'fakeDefUri' } })
     )
     mockDeleteMaintenanceRun = jest.fn((_data, opts) => {
-      opts?.onSuccess()
+      opts?.onSettled()
     })
     const store = mockStore({ isOnDevice: false })
     wrapper = ({ children }) => (
@@ -184,7 +184,7 @@ describe('useLaunchLPC hook', () => {
     expect(mockDeleteMaintenanceRun).toHaveBeenCalledWith(
       MOCK_MAINTENANCE_RUN_ID,
       {
-        onSuccess: expect.any(Function),
+        onSettled: expect.any(Function),
       }
     )
     expect(result.current.LPCWizard).toBeNull()

--- a/app/src/organisms/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/index.tsx
@@ -13,6 +13,7 @@ interface LabwarePositionCheckModalProps {
   existingOffsets: LabwareOffset[]
   mostRecentAnalysis: CompletedProtocolAnalysis | null
   caughtError?: Error
+  setMaintenanceRunId: (id: string | null) => void
 }
 
 // We explicitly wrap LabwarePositionCheckComponent in an ErrorBoundary because an error might occur while pulling in

--- a/app/src/organisms/LabwarePositionCheck/useLaunchLPC.tsx
+++ b/app/src/organisms/LabwarePositionCheck/useLaunchLPC.tsx
@@ -29,7 +29,7 @@ export function useLaunchLPC(
   const handleCloseLPC = (): void => {
     if (maintenanceRunId != null) {
       deleteMaintenanceRun(maintenanceRunId, {
-        onSuccess: () => {
+        onSettled: () => {
           setMaintenanceRunId(null)
         },
       })

--- a/app/src/organisms/LabwarePositionCheck/useLaunchLPC.tsx
+++ b/app/src/organisms/LabwarePositionCheck/useLaunchLPC.tsx
@@ -70,6 +70,7 @@ export function useLaunchLPC(
           mostRecentAnalysis={mostRecentAnalysis}
           existingOffsets={runRecord?.data?.labwareOffsets ?? []}
           maintenanceRunId={maintenanceRunId}
+          setMaintenanceRunId={setMaintenanceRunId}
         />
       ) : null,
   }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We need to add logic to the LPC modal that will cause it to close if the procedure is terminated remotely
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Run LPC on desktop, terminate the procedure on ODD, see that within 5-10 seconds the desktop modal closes.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Mimic logic we have in other maintenance run modals to track the `currentMaintenanceRun` and close the modal if that run is no longer present
2. Close the LPC modal even if run deletion fails, so that if the desktop modal is manually exited after the run is deleted from ODD but before we detect that, it won't get stuck in an infinite spinner

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test this out!
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
