### PR TITLE
fix(app): OT-2 pipette flow success img resize

### DIFF
--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -16,11 +16,12 @@ import {
   POSITION_ABSOLUTE,
   JUSTIFY_FLEX_START,
 } from '@opentrons/components'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import SuccessIcon from '../../assets/images/icon_success.png'
 import { getIsOnDevice } from '../../redux/config'
 import { StyledText } from '../../atoms/text'
 import { Skeleton } from '../../atoms/Skeleton'
-import { FLEX_ROBOT_TYPE, RobotType } from '@opentrons/shared-data'
+import type { RobotType } from '@opentrons/shared-data'
 
 interface Props extends StyleProps {
   iconColor: string

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -20,6 +20,7 @@ import SuccessIcon from '../../assets/images/icon_success.png'
 import { getIsOnDevice } from '../../redux/config'
 import { StyledText } from '../../atoms/text'
 import { Skeleton } from '../../atoms/Skeleton'
+import { FLEX_ROBOT_TYPE, RobotType } from '@opentrons/shared-data'
 
 interface Props extends StyleProps {
   iconColor: string
@@ -28,6 +29,7 @@ interface Props extends StyleProps {
   children?: React.ReactNode
   subHeader?: string | JSX.Element
   isPending?: boolean
+  robotType?: RobotType
   /**
    *  this prop is to change justifyContent of OnDeviceDisplay buttons
    *  TODO(jr, 8/9/23): this SHOULD be refactored so the
@@ -87,6 +89,7 @@ export function SimpleWizardBody(props: Props): JSX.Element {
     subHeader,
     isSuccess,
     isPending,
+    robotType = FLEX_ROBOT_TYPE,
     ...styleProps
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
@@ -144,8 +147,8 @@ export function SimpleWizardBody(props: Props): JSX.Element {
           <>
             {isSuccess ? (
               <img
-                width="250px"
-                height="208px"
+                width={robotType === FLEX_ROBOT_TYPE ? '250px' : '160px'}
+                height={robotType === FLEX_ROBOT_TYPE ? '208px' : '120px'}
                 src={SuccessIcon}
                 alt="Success Icon"
               />

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -13,10 +13,11 @@ import { CheckPipettesButton } from './CheckPipettesButton'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { LevelPipette } from './LevelPipette'
 
-import type {
+import {
   PipetteNameSpecs,
   PipetteModelSpecs,
   PipetteDisplayCategory,
+  OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import type { PipetteOffsetCalibration } from '../../redux/calibration/types'
 import type { Mount } from '../../redux/pipettes/types'
@@ -129,6 +130,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
       header={header}
       subHeader={subHeader}
       isSuccess={success || isWrongWantedPipette || confirmPipetteLevel}
+      robotType={OT2_ROBOT_TYPE}
     >
       <>
         {!success && !wrongWantedPipette && !confirmPipetteLevel && (


### PR DESCRIPTION
closes RQA-1214

# Overview

Resize the success image of the OT-2 pipette flow 

# Test Plan

Test an attach or detach pipette flow on an OT-2. See that hte success screen image is small and doesn't overlap with the buttons.

# Changelog

- extend prop to `SimpleWizardBody` to include robot type. defaulting to flex robot type since this component is mainly used in the flex flows and not the ot-2
- add prop to `ConfirmPipette`

# Review requests

see test plan

# Risk assessment

low