### PR TITLE
fix(app): fix text displayed for Detach Gripper step

### DIFF
--- a/app/src/assets/localization/en/gripper_wizard_flows.json
+++ b/app/src/assets/localization/en/gripper_wizard_flows.json
@@ -22,7 +22,7 @@
   "gripper_successfully_detached": "Flex Gripper successfully detached",
   "gripper": "Gripper",
   "hex_screwdriver": "2.5 mm Hex Screwdriver",
-  "hold_gripper_and_loosen_screws": "Hold the gripper in place and loosen the bottom gripper screw first. After that move onto the bottom screw. (The screws are captive and will not come apart from the gripper.) Then carefully remove the gripper.",
+  "hold_gripper_and_loosen_screws": "Hold the gripper in place and loosen the top gripper screw first. After that move onto the bottom screw. (The screws are captive and will not come apart from the gripper.) Then carefully remove the gripper.",
   "insert_pin_into_front_jaw": "Insert calibration pin in front jaw",
   "insert_pin_into_rear_jaw": "Insert calibration pin in rear jaw",
   "loosen_screws_and_detach": "Loosen screws and detach Flex Gripper",

--- a/app/src/organisms/GripperWizardFlows/__tests__/UnmountGripper.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/UnmountGripper.test.tsx
@@ -85,7 +85,7 @@ describe('UnmountGripper', () => {
     const { getByText } = render()[0]
     getByText('Loosen screws and detach Flex Gripper')
     getByText(
-      'Hold the gripper in place and loosen the bottom gripper screw first. After that move onto the bottom screw. (The screws are captive and will not come apart from the gripper.) Then carefully remove the gripper.'
+      'Hold the gripper in place and loosen the top gripper screw first. After that move onto the bottom screw. (The screws are captive and will not come apart from the gripper.) Then carefully remove the gripper.'
     )
   })
 })


### PR DESCRIPTION
Closes [RQA-1709](https://opentrons.atlassian.net/browse/RQA-1709)

# Overview

When detaching a gripper instrument, the left hand text prompts the user to remove the bottom screw twice without referencing the top screw. This PR changes the first reference of unscrewing the bottom screw to the top screw.

# Test Plan

- verify that both desktop app and ODD Detach Gripper step display proper text 
<img width="1007" alt="Screen Shot 2023-09-25 at 2 08 35 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/9c20844e-abc7-4ff7-9d79-57afdd037529">

# Changelog

- change Detach Gripper step to reference top and bottom screw (in order)
- update tests to reflect this change

# Risk assessment

low 

[RQA-1709]: https://opentrons.atlassian.net/browse/RQA-1709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ