### PR TITLE
fix(app):  Update conditional calibration banner rendering

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -196,7 +196,8 @@ export function InstrumentsAndModules({
                 }
                 isPipetteCalibrated={
                   isOT3 && attachedLeftPipette?.ok
-                    ? attachedLeftPipette?.data?.calibratedOffset != null
+                    ? attachedLeftPipette?.data?.calibratedOffset
+                        ?.last_modified != null
                     : leftMountOffsetCalibration != null
                 }
                 mount={LEFT}
@@ -210,7 +211,8 @@ export function InstrumentsAndModules({
                   attachedGripper={attachedGripper}
                   isCalibrated={
                     attachedGripper?.ok === true &&
-                    attachedGripper?.data?.calibratedOffset != null
+                    attachedGripper?.data?.calibratedOffset?.last_modified !=
+                      null
                   }
                   setSubsystemToUpdate={setSubsystemToUpdate}
                 />
@@ -244,7 +246,8 @@ export function InstrumentsAndModules({
                   }
                   isPipetteCalibrated={
                     isOT3 && attachedRightPipette?.ok
-                      ? attachedRightPipette?.data?.calibratedOffset != null
+                      ? attachedRightPipette?.data?.calibratedOffset
+                          ?.last_modified != null
                       : rightMountOffsetCalibration != null
                   }
                   mount={RIGHT}

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -175,7 +175,7 @@ export function RobotOverview({
           </Box>
         </Flex>
       </Flex>
-      {robotModel === 'OT-2' && !isRobotBusy ? (
+      {robotModel === 'OT-2' && !isRobotBusy && isRobotViewable ? (
         <CalibrationStatusBanner robotName={robotName} />
       ) : null}
       <Flex

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -29,6 +29,7 @@ import {
   useLights,
   useRobot,
   useRunStatuses,
+  useIsRobotViewable,
 } from '../hooks'
 import {
   expectedBadDeckTaskList,
@@ -124,11 +125,12 @@ const mockGetRobotModelByName = getRobotModelByName as jest.MockedFunction<
 const mockGetRobotAddressesByName = getRobotAddressesByName as jest.MockedFunction<
   typeof getRobotAddressesByName
 >
-
 const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
-
 const mockUseAuthorization = useAuthorization as jest.MockedFunction<
   typeof useAuthorization
+>
+const mockUseIsRobotViewable = useIsRobotViewable as jest.MockedFunction<
+  typeof useIsRobotViewable
 >
 
 const mockToggleLights = jest.fn()
@@ -196,6 +198,7 @@ describe('RobotOverview', () => {
         authorizationToken: { token: 'my.authorization.jwt' },
         registrationToken: { token: 'my.registration.jwt' },
       })
+    when(mockUseIsRobotViewable).mockReturnValue(true)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -250,6 +253,18 @@ describe('RobotOverview', () => {
     expect(calibrationDashboardLink.getAttribute('href')).toEqual(
       '/devices/opentrons-robot-name/robot-settings/calibration'
     )
+  })
+
+  it('does not render a missing calibration status label when the robot is not viewable', () => {
+    mockUseCalibrationTaskList.mockReturnValue(
+      expectedIncompleteDeckCalTaskList
+    )
+    mockUseFeatureFlag.mockReturnValue(true)
+    when(mockUseIsRobotViewable).mockReturnValue(false)
+    const [{ queryByText }] = render(props)
+    expect(
+      queryByText('Robot is missing calibration data')
+    ).not.toBeInTheDocument()
   })
 
   it('renders a recommended recalibration status label when the deck is bad and calibration wizard feature flag is set', () => {

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -123,7 +123,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       }
     },
   })
-  const requireModuleCalibration = module.moduleOffset == null
+  const requireModuleCalibration = module.moduleOffset?.last_modified == null
   const isPipetteReady =
     (!attachPipetteRequired ?? false) && (!updatePipetteFWRequired ?? false)
   const latestRequestId = last(requestIds)


### PR DESCRIPTION
Closes RQA-1708, RQA-1393
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:
 
https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests
 
To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
# Overview

This PR fixes two bugs related to calibration banner rendering.

### Flex Pipette/Gripper banners not rendering after clearing offsets

Clearing pipette/gripper calibration now sets the calibrated offsets to zero instead of clearing the calibrated offsets property. Checking the date last calibrated property is the easiest and most accurate way to determine if a calibration is necessary.
 
**FIXED**

![fixed cal banners](https://github.com/Opentrons/opentrons/assets/64858653/eb50dc60-f2c1-4c5a-9581-dd445a243ad4)
 
### OT-2 Calibration banners still rendering when robot offline
 
Adds a conditional check to make sure that the robot is viewable before rendering the banner. "isRobotViewable" is the same conditional check used for other elements rendered on the DeviceDetails page.

**BEFORE**

<img width="818" alt="Screenshot 2023-08-24 at 10 29 54 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/52b23301-44b8-4b03-a31e-9ee162240a11">

**AFTER**

![ot-2 cal banner fix](https://github.com/Opentrons/opentrons/assets/64858653/2ac60da6-3e0d-4f31-bf18-3a10823562c7)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
# Test Plan
- For the Flex, clear pipette/gripper calibration settings via Advanced Settings and select pipette/gripper calibration. On restart, the banners should properly render. 
- For the OT-2, clear pipette calibration data. Note that the calibration banner on Devices > Robot should no longer render when the robot is not viewable (power off the robot).

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.
 
OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.
 
Note: It can be helpful to write a test plan before doing development
 
Example Test Plan (HTTP API Change)
 
- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct
 
-->

# Changelog
- Pipette/Gripper card now uses offset date to determine if there's need for calibration.
- OT-2 calibration banner conditionally checks if robot is viewable before rendering.
- Added relevant testing. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.
Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported
 
IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Risk assessment
 low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.
 
Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
