### PR TITLE
fix(app): change date formatting to reflect designs

### DIFF
--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -283,7 +283,7 @@ export function ProtocolDetails(
       : t('shared:no_data')
   const lastAnalyzed =
     mostRecentAnalysis?.createdAt != null
-      ? format(new Date(mostRecentAnalysis.createdAt), 'MMM dd yy HH:mm')
+      ? format(new Date(mostRecentAnalysis.createdAt), 'M/d/yy HH:mm')
       : t('shared:no_data')
   const robotType = mostRecentAnalysis?.robotType ?? null
 
@@ -426,7 +426,7 @@ export function ProtocolDetails(
                 <StyledText as="p">
                   {analysisStatus === 'loading'
                     ? t('shared:loading')
-                    : format(new Date(modified), 'MMM dd yy HH:mm')}
+                    : format(new Date(modified), 'M/d/yy HH:mm')}
                 </StyledText>
               </Flex>
               <Flex

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -299,7 +299,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
               <StyledText as="label" color={COLORS.darkGreyEnabled}>
                 {`${t('updated')} ${format(
                   new Date(modified),
-                  'MMM dd yy HH:mm'
+                  'M/d/yy HH:mm'
                 )}`}
               </StyledText>
             </Flex>


### PR DESCRIPTION
closes [RQA-1633](https://opentrons.atlassian.net/browse/RQA-1633)

# Overview

Fix date formatting for protocol updated and analyzed dates

# Test Plan

- Verify that 'Updated' date on protocol cards are formatted as 'm/d/yy HH:mm'
<img width="989" alt="Screen Shot 2023-09-26 at 11 45 38 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/8708d972-4079-48a7-86f5-ec6105c1fa38">

- Verify that 'Last updated' and 'Last analyzed' date on protocol details page are formatted as 'm/d/yy HH:mm'
<img width="1012" alt="Screen Shot 2023-09-26 at 11 46 30 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/45538e51-649a-46b7-9006-49aea3c75640">

# Risk assessment

low

[RQA-1633]: https://opentrons.atlassian.net/browse/RQA-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ