### PR TITLE
feat(hardware): pass move ack id as part of the move complete info

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -139,7 +139,7 @@ from opentrons_hardware.hardware_control.motion import (
     MoveStopCondition,
     MoveGroup,
 )
-from opentrons_hardware.hardware_control.types import NodeMap
+from opentrons_hardware.hardware_control.types import NodeMap, MotorPositionStatus
 from opentrons_hardware.hardware_control.tools import types as ohc_tool_types
 
 from opentrons_hardware.hardware_control.tool_sensors import (
@@ -487,11 +487,11 @@ class OT3Controller:
 
     def _handle_motor_status_response(
         self,
-        response: NodeMap[Tuple[float, float, bool, bool]],
+        response: NodeMap[MotorPositionStatus],
     ) -> None:
         for axis, pos in response.items():
-            self._position.update({axis: pos[0]})
-            self._encoder_position.update({axis: pos[1]})
+            self._position.update({axis: pos.motor_position})
+            self._encoder_position.update({axis: pos.encoder_position})
             # TODO (FPS 6-01-2023): Remove this once the Feature Flag to ignore stall detection is removed.
             # This check will latch the motor status for an axis at "true" if it was ever set to true.
             # To account for the case where a motor axis has its power reset, we also depend on the
@@ -505,7 +505,8 @@ class OT3Controller:
             self._motor_status.update(
                 {
                     axis: MotorStatus(
-                        motor_ok=(pos[2] or motor_ok_latch), encoder_ok=pos[3]
+                        motor_ok=(pos.motor_ok or motor_ok_latch),
+                        encoder_ok=pos.encoder_ok,
                     )
                 }
             )
@@ -687,7 +688,7 @@ class OT3Controller:
         positions = await runner.run(can_messenger=self._messenger)
         if NodeId.pipette_left in positions:
             self._gear_motor_position = {
-                NodeId.pipette_left: positions[NodeId.pipette_left][0]
+                NodeId.pipette_left: positions[NodeId.pipette_left].motor_position
             }
         else:
             log.debug("no position returned from NodeId.pipette_left")
@@ -705,7 +706,7 @@ class OT3Controller:
         positions = await runner.run(can_messenger=self._messenger)
         if NodeId.pipette_left in positions:
             self._gear_motor_position = {
-                NodeId.pipette_left: positions[NodeId.pipette_left][0]
+                NodeId.pipette_left: positions[NodeId.pipette_left].motor_position
             }
         else:
             log.debug("no position returned from NodeId.pipette_left")
@@ -1168,8 +1169,8 @@ class OT3Controller:
             sensor_id_for_instrument(probe),
         )
         for node, point in positions.items():
-            self._position.update({node: point[0]})
-            self._encoder_position.update({node: point[1]})
+            self._position.update({node: point.motor_position})
+            self._encoder_position.update({node: point.encoder_position})
         return self._position
 
     async def capacitive_probe(

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -697,8 +697,9 @@ class OT3Simulator:
         speed_mm_per_s: float,
         sensor_threshold_pf: float,
         probe: InstrumentProbeType,
-    ) -> None:
+    ) -> bool:
         self._position[axis_to_node(moving)] += distance_mm
+        return True
 
     @ensure_yield
     async def capacitive_pass(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2357,7 +2357,7 @@ class OT3API(
         pass_settings: CapacitivePassSettings,
         retract_after: bool = True,
         probe: Optional[InstrumentProbeType] = None,
-    ) -> float:
+    ) -> Tuple[float, bool]:
         """Determine the position of something using the capacitive sensor.
 
         This function orchestrates detecting the position of a collision between the
@@ -2418,7 +2418,7 @@ class OT3API(
             else:
                 # default to primary (rear) probe
                 probe = InstrumentProbeType.PRIMARY
-        await self._backend.capacitive_probe(
+        contact = await self._backend.capacitive_probe(
             mount,
             moving_axis,
             machine_pass_distance,
@@ -2429,7 +2429,7 @@ class OT3API(
         end_pos = await self.gantry_position(mount, refresh=True)
         if retract_after:
             await self.move_to(mount, pass_start_pos)
-        return moving_axis.of_point(end_pos)
+        return moving_axis.of_point(end_pos), contact
 
     async def capacitive_sweep(
         self,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -702,7 +702,7 @@ async def test_capacitive_probe(
 ) -> None:
     await ot3_hardware.home()
     here = await ot3_hardware.gantry_position(mount)
-    res = await ot3_hardware.capacitive_probe(mount, moving, 2, fake_settings)
+    res, _ = await ot3_hardware.capacitive_probe(mount, moving, 2, fake_settings)
     # in reality, this value would be the previous position + the value
     # updated in ot3controller.capacitive_probe, and it kind of is here, but that
     # previous position is always 0. This is a test of ot3api though and checking

--- a/hardware-testing/hardware_testing/examples/capacitive_probe_ot3.py
+++ b/hardware-testing/hardware_testing/examples/capacitive_probe_ot3.py
@@ -66,7 +66,7 @@ async def _probe_sequence(
         await helpers_ot3.wait_for_stable_capacitance_ot3(
             api, mount, threshold_pf=STABLE_CAP_PF, duration=1.0
         )
-    found_z = await api.capacitive_probe(
+    found_z, _ = await api.capacitive_probe(
         mount, z_ax, ASSUMED_Z_LOCATION.z, PROBE_SETTINGS_Z_AXIS
     )
     print(f"Found deck Z location = {found_z} mm")
@@ -85,7 +85,7 @@ async def _probe_sequence(
         await helpers_ot3.wait_for_stable_capacitance_ot3(
             api, mount, threshold_pf=STABLE_CAP_PF, duration=1.0
         )
-    found_x_left = await api.capacitive_probe(
+    found_x_left, _ = await api.capacitive_probe(
         mount,
         types.Axis.X,
         ASSUMED_XY_LOCATION.x - half_cutout,
@@ -95,7 +95,7 @@ async def _probe_sequence(
         await helpers_ot3.wait_for_stable_capacitance_ot3(
             api, mount, threshold_pf=STABLE_CAP_PF, duration=1.0
         )
-    found_x_right = await api.capacitive_probe(
+    found_x_right, _ = await api.capacitive_probe(
         mount,
         types.Axis.X,
         ASSUMED_XY_LOCATION.x + half_cutout,
@@ -106,7 +106,7 @@ async def _probe_sequence(
         await helpers_ot3.wait_for_stable_capacitance_ot3(
             api, mount, threshold_pf=STABLE_CAP_PF, duration=1.0
         )
-    found_y_front = await api.capacitive_probe(
+    found_y_front, _ = await api.capacitive_probe(
         mount,
         types.Axis.Y,
         ASSUMED_XY_LOCATION.y - half_cutout,
@@ -116,7 +116,7 @@ async def _probe_sequence(
         await helpers_ot3.wait_for_stable_capacitance_ot3(
             api, mount, threshold_pf=STABLE_CAP_PF, duration=1.0
         )
-    found_y_back = await api.capacitive_probe(
+    found_y_back, _ = await api.capacitive_probe(
         mount,
         types.Axis.Y,
         ASSUMED_XY_LOCATION.y + half_cutout,

--- a/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_probe.py
+++ b/hardware-testing/hardware_testing/production_qc/gripper_assembly_qc_ot3/test_probe.py
@@ -146,7 +146,9 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
         # move to 5 mm above the deck
         await api.move_to(mount, probe_pos._replace(z=PROBE_PREP_HEIGHT_MM))
         z_ax = Axis.by_mount(mount)
-        found_pos = await api.capacitive_probe(mount, z_ax, probe_pos.z, pass_settings)
+        found_pos, _ = await api.capacitive_probe(
+            mount, z_ax, probe_pos.z, pass_settings
+        )
         print(f"Found deck height: {found_pos}")
 
         # check against max overrun

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_capacitance.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_capacitance.py
@@ -167,7 +167,7 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
         async def _probe(distance: float, speed: float) -> float:
             if api.is_simulator:
                 return 0.0
-            pos, _ = await capacitive_probe(
+            pos = await capacitive_probe(
                 api._backend._messenger,  # type: ignore[union-attr]
                 NodeId.pipette_left,
                 NodeId.head_l,
@@ -176,7 +176,7 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
                 sensor_id=sensor_id,
                 relative_threshold_pf=default_probe_cfg.sensor_threshold_pf,
             )
-            return pos
+            return pos.motor_position
 
         if not api.is_simulator:
             ui.get_user_ready("about to probe the DECK")

--- a/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_instruments.py
+++ b/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_instruments.py
@@ -108,7 +108,7 @@ async def _probe_mount_and_record_result(
     if not api.is_simulator:
         ui.get_user_ready("about to probe DOWN")
     print("touch with your finger to stop the probing motion")
-    height_of_probe_stopped = await api.capacitive_probe(
+    height_of_probe_stopped, _ = await api.capacitive_probe(
         mount, z_ax, height_of_probe_full_travel, PROBE_SETTINGS
     )
 

--- a/hardware-testing/hardware_testing/scripts/gripper_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_ot3.py
@@ -291,7 +291,7 @@ async def _probe_labware_corners(
     for corner in nominal_corners:
         current_pos = await api.gantry_position(PROBE_MOUNT)
         await api.move_to(PROBE_MOUNT, corner._replace(z=current_pos.z))
-        found_z = await api.capacitive_probe(
+        found_z, _ = await api.capacitive_probe(
             PROBE_MOUNT,
             types.Axis.by_mount(PROBE_MOUNT),
             corner.z,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -229,8 +229,8 @@ class MoveCompletedPayload(MoveGroupResponsePayload):
 class MotorPositionResponse(EmptyPayload):
     """Read Encoder Position."""
 
-    current_position: utils.UInt32Field
-    encoder_position: utils.Int32Field
+    current_position_um: utils.UInt32Field
+    encoder_position_um: utils.Int32Field
     position_flags: MotorPositionFlagsField
 
 

--- a/hardware/opentrons_hardware/hardware_control/motor_position_status.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_position_status.py
@@ -42,6 +42,7 @@ _MotorStatusMoves = Union[
 
 
 def extract_motor_status_info(msg: _MotorStatusMoves) -> MotorPositionStatus:
+    """Extract motor position status from CAN responses."""
     move_ack: Optional[MoveCompleteAck] = None
     if isinstance(msg, MoveCompleted) or isinstance(msg, TipActionResponse):
         move_ack = MoveCompleteAck(msg.payload.ack_id.value)

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -73,7 +73,7 @@ from opentrons_hardware.firmware_bindings.messages.fields import (
 )
 from opentrons_hardware.hardware_control.motion import MoveStopCondition
 
-from .types import NodeDict
+from .types import NodeDict, MotorPositionStatus
 
 log = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ class MoveGroupRunner:
 
     async def execute(
         self, can_messenger: CanMessenger
-    ) -> NodeDict[Tuple[float, float, bool, bool]]:
+    ) -> NodeDict[MotorPositionStatus]:
         """Execute a pre-prepared move group. The second thing that run() does.
 
         prep() and execute() can be used to replace a single call to run() to
@@ -144,9 +144,7 @@ class MoveGroupRunner:
         move_completion_data = await self._move(can_messenger, self._start_at_index)
         return self._accumulate_move_completions(move_completion_data)
 
-    async def run(
-        self, can_messenger: CanMessenger
-    ) -> NodeDict[Tuple[float, float, bool, bool]]:
+    async def run(self, can_messenger: CanMessenger) -> NodeDict[MotorPositionStatus]:
         """Run the move group.
 
         Args:
@@ -170,7 +168,7 @@ class MoveGroupRunner:
     @staticmethod
     def _accumulate_move_completions(
         completions: _Completions,
-    ) -> NodeDict[Tuple[float, float, bool, bool]]:
+    ) -> NodeDict[MotorPositionStatus]:
         position: NodeDict[
             List[Tuple[Tuple[int, int], float, float, bool, bool]]
         ] = defaultdict(list)

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -32,6 +32,7 @@ from opentrons_hardware.hardware_control.motion import (
     MoveGroupStep,
 )
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
+from opentrons_hardware.hardware_control.types import MoveStatus
 
 LOG = getLogger(__name__)
 PipetteProbeTarget = Literal[NodeId.pipette_left, NodeId.pipette_right]
@@ -73,7 +74,7 @@ async def liquid_probe(
     auto_zero_sensor: bool = True,
     num_baseline_reads: int = 10,
     sensor_id: SensorId = SensorId.S0,
-) -> Dict[NodeId, Tuple[float, float, bool, bool]]:
+) -> Dict[NodeId, MoveStatus]:
     """Move the mount and pipette simultaneously while reading from the pressure sensor."""
     sensor_driver = SensorDriver()
     threshold_fixed_point = threshold_pascals * sensor_fixed_point_conversion
@@ -197,7 +198,7 @@ async def capacitive_probe(
         do_log=log_sensor_values,
     ):
         position = await runner.run(can_messenger=messenger)
-        return position[mover][:2]
+        return position[mover].get_positions_only()
 
 
 async def capacitive_pass(

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -161,7 +161,7 @@ async def capacitive_probe(
     sensor_id: SensorId = SensorId.S0,
     relative_threshold_pf: float = 1.0,
     log_sensor_values: bool = False,
-) -> Tuple[float, float]:
+) -> MotorPositionStatus:
     """Move the specified tool down until its capacitive sensor triggers.
 
     Moves down by the specified distance at the specified speed until the
@@ -198,7 +198,7 @@ async def capacitive_probe(
         do_log=log_sensor_values,
     ):
         position = await runner.run(can_messenger=messenger)
-        return position[mover].positions_only()
+        return position[mover]
 
 
 async def capacitive_pass(

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -32,7 +32,7 @@ from opentrons_hardware.hardware_control.motion import (
     MoveGroupStep,
 )
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
-from opentrons_hardware.hardware_control.types import MoveStatus
+from opentrons_hardware.hardware_control.types import MotorPositionStatus
 
 LOG = getLogger(__name__)
 PipetteProbeTarget = Literal[NodeId.pipette_left, NodeId.pipette_right]
@@ -74,7 +74,7 @@ async def liquid_probe(
     auto_zero_sensor: bool = True,
     num_baseline_reads: int = 10,
     sensor_id: SensorId = SensorId.S0,
-) -> Dict[NodeId, MoveStatus]:
+) -> Dict[NodeId, MotorPositionStatus]:
     """Move the mount and pipette simultaneously while reading from the pressure sensor."""
     sensor_driver = SensorDriver()
     threshold_fixed_point = threshold_pascals * sensor_fixed_point_conversion
@@ -198,7 +198,7 @@ async def capacitive_probe(
         do_log=log_sensor_values,
     ):
         position = await runner.run(can_messenger=messenger)
-        return position[mover].get_positions_only()
+        return position[mover].positions_only()
 
 
 async def capacitive_pass(

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -44,6 +44,7 @@ class MotorPositionStatus:
     move_ack: Optional[MoveCompleteAck] = None
 
     def positions_only(self) -> Tuple[float, float]:
+        """Returns motor and encoder positions as a tuple."""
         return (
             self.motor_position,
             self.encoder_position,

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -41,15 +41,9 @@ class MotorPositionStatus:
     encoder_position: float
     motor_ok: bool
     encoder_ok: bool
+    move_ack: Optional[MoveCompleteAck] = None
 
-
-@dataclass
-class MoveStatus(MotorPositionStatus):
-    """Move status: same as MotorPositionStatus, but with an extra move_ack field."""
-
-    move_ack: MoveCompleteAck
-
-    def get_positions_only(self) -> Tuple[float, float]:
+    def positions_only(self) -> Tuple[float, float]:
         return (
             self.motor_position,
             self.encoder_position,

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -44,14 +44,13 @@ class MotorPositionStatus:
 
 
 @dataclass
-class MoveStatus:
+class MoveStatus(MotorPositionStatus):
     """Move status: same as MotorPositionStatus, but with an extra move_ack field."""
 
-    position_status: MotorPositionStatus
     move_ack: MoveCompleteAck
 
     def get_positions_only(self) -> Tuple[float, float]:
         return (
-            self.position_status.motor_position,
-            self.position_status.encoder_position,
+            self.motor_position,
+            self.encoder_position,
         )

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -1,5 +1,5 @@
 """Types and definitions for hardware bindings."""
-from typing import Mapping, TypeVar, Dict, List, Optional
+from typing import Mapping, TypeVar, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 
 from opentrons_hardware.firmware_bindings.constants import NodeId
@@ -11,6 +11,8 @@ NodeMap = Mapping[NodeId, MapPayload]
 NodeList = List[NodeId]
 
 NodeDict = Dict[NodeId, MapPayload]
+
+MotorPositionStatus = Tuple[float, float, bool, bool]
 
 
 @dataclass

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -1,8 +1,9 @@
 """Types and definitions for hardware bindings."""
 from typing import Mapping, TypeVar, Dict, List, Optional, Tuple
 from dataclasses import dataclass
+from enum import Enum
 
-from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.constants import NodeId, MoveAckId
 
 MapPayload = TypeVar("MapPayload")
 
@@ -23,3 +24,12 @@ class PCBARevision:
     #: A combination of primary and secondary used for looking up firmware
     tertiary: Optional[str] = None
     #: An often-not-present tertiary
+
+
+class MoveCompleteAck(Enum):
+    """Move Complete Ack."""
+
+    complete_without_condition = MoveAckId.complete_without_condition.value
+    stopped_by_condition = MoveAckId.stopped_by_condition.value
+    timeout = MoveAckId.timeout.value
+    position_error = MoveAckId.position_error.value

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -13,8 +13,6 @@ NodeList = List[NodeId]
 
 NodeDict = Dict[NodeId, MapPayload]
 
-MotorPositionStatus = Tuple[float, float, bool, bool]
-
 
 @dataclass
 class PCBARevision:
@@ -33,3 +31,27 @@ class MoveCompleteAck(Enum):
     stopped_by_condition = MoveAckId.stopped_by_condition.value
     timeout = MoveAckId.timeout.value
     position_error = MoveAckId.position_error.value
+
+
+@dataclass
+class MotorPositionStatus:
+    """Motor Position Status information."""
+
+    motor_position: float
+    encoder_position: float
+    motor_ok: bool
+    encoder_ok: bool
+
+
+@dataclass
+class MoveStatus:
+    """Move status: same as MotorPositionStatus, but with an extra move_ack field."""
+
+    position_status: MotorPositionStatus
+    move_ack: MoveCompleteAck
+
+    def get_positions_only(self) -> Tuple[float, float]:
+        return (
+            self.position_status.motor_position,
+            self.position_status.encoder_position,
+        )

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -25,6 +25,11 @@ from opentrons_hardware.firmware_bindings.messages.fields import MoveStopConditi
 from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.hardware_control.motion import create_step, create_home_step
+from opentrons_hardware.hardware_control.types import (
+    MoveStatus,
+    MotorPositionStatus,
+    MoveCompleteAck,
+)
 
 
 @pytest.fixture(
@@ -125,7 +130,11 @@ async def test_move_integration(
     home_runner = MoveGroupRunner([home_move])
     position = await home_runner.run(can_messenger)
     assert position == {
-        motor_node: (0.0, 0.0, False, False) for motor_node in all_motor_nodes
+        motor_node: MoveStatus(
+            MotorPositionStatus(0.0, 0.0, False, False),
+            MoveCompleteAck(2),
+        )
+        for motor_node in all_motor_nodes
     }
     # these moves test position accumulation to reasonably realistic values
     # and have to do it over a kind of long time so that the velocities are low
@@ -188,7 +197,7 @@ async def test_move_integration(
     #  Also mypy doesn't like pytest.approx so we have to type ignore it
 
     # We now store the position as a tuple of assumed position + encoder value.
-    assert {k: v[0] for k, v in position.items()} == {  # type: ignore[comparison-overlap]
+    assert {k: v.position_status.motor_position for k, v in position.items()} == {  # type: ignore[comparison-overlap]
         motor_node: pytest.approx(
             motor_node.value, abs=all_motor_node_step_sizes[motor_node] * 3
         )

--- a/hardware/tests/firmware_integration/test_move_groups.py
+++ b/hardware/tests/firmware_integration/test_move_groups.py
@@ -26,7 +26,6 @@ from opentrons_hardware.drivers.can_bus import CanMessenger, WaitableCallback
 from opentrons_hardware.hardware_control.move_group_runner import MoveGroupRunner
 from opentrons_hardware.hardware_control.motion import create_step, create_home_step
 from opentrons_hardware.hardware_control.types import (
-    MoveStatus,
     MotorPositionStatus,
     MoveCompleteAck,
 )
@@ -130,10 +129,7 @@ async def test_move_integration(
     home_runner = MoveGroupRunner([home_move])
     position = await home_runner.run(can_messenger)
     assert position == {
-        motor_node: MoveStatus(
-            MotorPositionStatus(0.0, 0.0, False, False),
-            MoveCompleteAck(2),
-        )
+        motor_node: MotorPositionStatus(0.0, 0.0, False, False, MoveCompleteAck(2))
         for motor_node in all_motor_nodes
     }
     # these moves test position accumulation to reasonably realistic values
@@ -197,7 +193,7 @@ async def test_move_integration(
     #  Also mypy doesn't like pytest.approx so we have to type ignore it
 
     # We now store the position as a tuple of assumed position + encoder value.
-    assert {k: v.position_status.motor_position for k, v in position.items()} == {  # type: ignore[comparison-overlap]
+    assert {k: v.motor_position for k, v in position.items()} == {  # type: ignore[comparison-overlap]
         motor_node: pytest.approx(
             motor_node.value, abs=all_motor_node_step_sizes[motor_node] * 3
         )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motor_position_status.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motor_position_status.py
@@ -21,6 +21,7 @@ from opentrons_hardware.firmware_bindings.arbitration_id import (
 )
 
 from opentrons_hardware.hardware_control import motor_position_status
+from opentrons_hardware.hardware_control.types import MotorPositionStatus
 
 
 def motor_position_response() -> md.MotorPositionResponse:
@@ -78,6 +79,6 @@ async def test_parse_motor_position(waitable_reader: AsyncIter) -> None:
         ),
         1,
     )
-    expected = (0.123, 0.123, True, False)
+    expected = MotorPositionStatus(0.123, 0.123, True, False)
     for n in nodes:
         assert data.get(n) == expected

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -1,6 +1,6 @@
 """Tests for the move scheduler."""
 import pytest
-from typing import List, Any, Tuple
+from typing import List, Any
 from numpy import float64, float32, int32
 from mock import AsyncMock, call, MagicMock, patch
 from opentrons_shared_data.errors.exceptions import (

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -62,7 +62,6 @@ from opentrons_hardware.hardware_control.move_group_runner import (
 
 from opentrons_hardware.hardware_control.types import (
     NodeMap,
-    MoveStatus,
     MotorPositionStatus,
     MoveCompleteAck,
 )
@@ -1025,7 +1024,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.gantry_x),
                     MoveCompleted(
                         payload=MoveCompletedPayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(10000),
@@ -1038,7 +1037,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.gantry_x),
                     MoveCompleted(
                         payload=MoveCompletedPayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(1),
                             current_position_um=UInt32Field(20000),
@@ -1062,8 +1061,8 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                 ),
             ],
             {
-                NodeId.gantry_x: MoveStatus(
-                    MotorPositionStatus(10, 40, False, False), MoveCompleteAck(1)
+                NodeId.gantry_x: MotorPositionStatus(
+                    10, 40, False, False, MoveCompleteAck(1)
                 )
             },
         ),
@@ -1074,7 +1073,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.gantry_x),
                     MoveCompleted(
                         payload=MoveCompletedPayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(10000),
@@ -1111,11 +1110,11 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                 ),
             ],
             {
-                NodeId.gantry_x: MoveStatus(
-                    MotorPositionStatus(10, 40, False, False), MoveCompleteAck(1)
+                NodeId.gantry_x: MotorPositionStatus(
+                    10, 40, False, False, MoveCompleteAck(1)
                 ),
-                NodeId.gantry_y: MoveStatus(
-                    MotorPositionStatus(30, 40, False, False), MoveCompleteAck(1)
+                NodeId.gantry_y: MotorPositionStatus(
+                    30, 40, False, False, MoveCompleteAck(1)
                 ),
             },
         ),
@@ -1139,8 +1138,8 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                 ),
             ],
             {
-                NodeId.pipette_left: MoveStatus(
-                    MotorPositionStatus(10, 0, False, False), MoveCompleteAck(1)
+                NodeId.pipette_left: MotorPositionStatus(
+                    10, 0, False, False, MoveCompleteAck(1)
                 )
             },
         ),
@@ -1153,7 +1152,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
 )
 def test_accumulate_move_completions(
     completions: List[_CompletionPacket],
-    position_map: NodeMap[MoveStatus],
+    position_map: NodeMap[MotorPositionStatus],
 ) -> None:
     """Build correct move results."""
     assert MoveGroupRunner._accumulate_move_completions(completions) == position_map

--- a/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_move_group_runner.py
@@ -60,7 +60,12 @@ from opentrons_hardware.hardware_control.move_group_runner import (
     _CompletionPacket,
 )
 
-from opentrons_hardware.hardware_control.types import NodeMap
+from opentrons_hardware.hardware_control.types import (
+    NodeMap,
+    MoveStatus,
+    MotorPositionStatus,
+    MoveCompleteAck,
+)
 from opentrons_hardware.firmware_bindings.messages import (
     message_definitions as md,
     MessageDefinition,
@@ -1046,7 +1051,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.gantry_x),
                     MoveCompleted(
                         payload=MoveCompletedPayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(1),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(30000),
@@ -1056,7 +1061,11 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     ),
                 ),
             ],
-            {NodeId.gantry_x: (10, 40, False, False)},
+            {
+                NodeId.gantry_x: MoveStatus(
+                    MotorPositionStatus(10, 40, False, False), MoveCompleteAck(1)
+                )
+            },
         ),
         (
             # multiple axes with different numbers of completions
@@ -1078,7 +1087,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.gantry_x),
                     MoveCompleted(
                         payload=MoveCompletedPayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(1),
                             current_position_um=UInt32Field(20000),
@@ -1091,7 +1100,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.gantry_y),
                     MoveCompleted(
                         payload=MoveCompletedPayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(1),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(30000),
@@ -1102,8 +1111,12 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                 ),
             ],
             {
-                NodeId.gantry_x: (10, 40, False, False),
-                NodeId.gantry_y: (30, 40, False, False),
+                NodeId.gantry_x: MoveStatus(
+                    MotorPositionStatus(10, 40, False, False), MoveCompleteAck(1)
+                ),
+                NodeId.gantry_y: MoveStatus(
+                    MotorPositionStatus(30, 40, False, False), MoveCompleteAck(1)
+                ),
             },
         ),
         (
@@ -1112,7 +1125,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     _build_arb(NodeId.pipette_left),
                     md.TipActionResponse(
                         payload=TipActionResponsePayload(
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                             group_id=UInt8Field(2),
                             seq_id=UInt8Field(2),
                             current_position_um=UInt32Field(10000),
@@ -1125,7 +1138,11 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
                     ),
                 ),
             ],
-            {NodeId.pipette_left: (10, 0, False, False)},
+            {
+                NodeId.pipette_left: MoveStatus(
+                    MotorPositionStatus(10, 0, False, False), MoveCompleteAck(1)
+                )
+            },
         ),
         (
             # empty base case
@@ -1136,7 +1153,7 @@ def _build_arb(from_node: NodeId) -> ArbitrationId:
 )
 def test_accumulate_move_completions(
     completions: List[_CompletionPacket],
-    position_map: NodeMap[Tuple[float, float, bool, bool]],
+    position_map: NodeMap[MoveStatus],
 ) -> None:
     """Build correct move results."""
     assert MoveGroupRunner._accumulate_move_completions(completions) == position_map

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -185,7 +185,7 @@ async def test_liquid_probe(
         num_baseline_reads=8,
         sensor_id=SensorId.S0,
     )
-    assert position[motor_node][0] == 14
+    assert position[motor_node].get_positions_only()[0] == 14
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(
         sensor=sensor_info,
         data=SensorDataType.build(threshold_pascals * 65536, sensor_info.sensor_type),

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -281,11 +281,11 @@ async def test_capacitive_probe(
 
     message_send_loopback.add_responder(move_responder)
 
-    position, encoder_position = await capacitive_probe(
+    status = await capacitive_probe(
         mock_messenger, target_node, motor_node, distance, speed
     )
-    assert position == 10  # this comes from the current_position_um above
-    assert encoder_position == 10
+    assert status.motor_position == 10  # this comes from the current_position_um above
+    assert status.encoder_position == 10
     # this mock assert is annoying because something's __eq__ doesn't work
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(
         sensor=sensor_info,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -185,7 +185,7 @@ async def test_liquid_probe(
         num_baseline_reads=8,
         sensor_id=SensorId.S0,
     )
-    assert position[motor_node].get_positions_only()[0] == 14
+    assert position[motor_node].positions_only()[0] == 14
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(
         sensor=sensor_info,
         data=SensorDataType.build(threshold_pascals * 65536, sensor_info.sensor_type),
@@ -270,7 +270,7 @@ async def test_capacitive_probe(
                             current_position_um=UInt32Field(10000),
                             encoder_position_um=Int32Field(10000),
                             position_flags=MotorPositionFlagsField(0),
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                         )
                     ),
                     motor_node,
@@ -354,7 +354,7 @@ async def test_capacitive_sweep(
                             current_position_um=UInt32Field(10000),
                             encoder_position_um=Int32Field(10000),
                             position_flags=MotorPositionFlagsField(0),
-                            ack_id=UInt8Field(0),
+                            ack_id=UInt8Field(1),
                         )
                     ),
                     motor_node,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_update_motor_estimation.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_update_motor_estimation.py
@@ -21,6 +21,7 @@ from opentrons_hardware.firmware_bindings.arbitration_id import (
 )
 
 from opentrons_hardware.hardware_control import motor_position_status
+from opentrons_hardware.hardware_control.types import MotorPositionStatus
 
 NODE_TO_POS = {NodeId.gantry_x: 1000, NodeId.gantry_y: 2000, NodeId.head: 3000}
 
@@ -93,7 +94,7 @@ async def test_parse_estimation_response(
             ),
             1,
         )
-        assert data == (NODE_TO_POS[node] / 1000, 0.123, True, False)
+        assert data == MotorPositionStatus(NODE_TO_POS[node] / 1000, 0.123, True, False)
     else:
         with pytest.raises(StopAsyncIteration):
             await asyncio.wait_for(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
On the Flex, for each move we command, we expect the following info to be reported from the axis firmware:
1. Motor position in um
2. Encoder position in um (if available)
3. Motor position ok flag
4. Encoder position ok flag
5. Ack ID

We have been checking the Ack id in the hardware move group runner; this tells us whether or not a move had reached the stop condition we set when it completed. For the most part, we want the ack id to match the move's stop condition – a home move should complete with the limit switch triggered, and if it didn't, something is really wrong and we should cancel any other scheduled moves.

But sometimes, it's okay if the ack id doesn't match the stop condition. For instance, while the robot is performing edge finding during calibration, the capacitive probe is _not_ expected to reach the stop condition when it actually finds the edge of the surface. However, when we're calibrating for the Z height, if capacitive probe should make contact with the surface, otherwise, the operation should fail. 

The complexity of the move ack/condition warrants it to be exposed to the hardware controller so the caller of the move can determine what to do with it, instead of leaving the responsibility solely to the move group runner. 


All that is to say - we can now know, for a fact (we used to check the z position at the end of the move against the hardware- limit 😅 ), whether or not the probe touched the deck and can use that info to better our calibration process. 

# Changelog
* Motor position/move complete info is now passed to the hardware controller the form of a new dataclass: `MovePositionStatus` instead of a tuple of ints and bools
* Adding a bool to the `api.capactive_probe` return values that checks if the probe made contact with a surface
